### PR TITLE
Re-expose `CardUtils.getPossibleCardBrand`

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/CardUtils.kt
+++ b/payments-core/src/main/java/com/stripe/android/CardUtils.kt
@@ -13,7 +13,9 @@ internal object CardUtils {
      * @return the [CardBrand] that matches the card number based on prefixes,
      * or [CardBrand.Unknown] if it can't be determined
      */
-    internal fun getPossibleCardBrand(cardNumber: String?): CardBrand {
+    @Deprecated("CardInputWidget and CardMultilineWidget handle card brand lookup. This method should not be relied on for determining CardBrand.")
+    @JvmStatic
+    fun getPossibleCardBrand(cardNumber: String?): CardBrand {
         return if (cardNumber.isNullOrBlank()) {
             CardBrand.Unknown
         } else {


### PR DESCRIPTION
# Summary
In the major version upgrade we removed CardUtils.getPossibleCardBrand.  Re-exposing this with the same deprecated annotation.

# Motivation
RUN-397
