### PR TITLE
[1 of 3] Provide a fallback injection mechanisom when app process is killed by system

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -5182,11 +5182,11 @@ public final class com/stripe/android/payments/core/authentication/threeds2/Defa
 }
 
 public final class com/stripe/android/payments/core/authentication/threeds2/Stripe3DS2Authenticator_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3DS2Authenticator_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3DS2Authenticator_Factory;
 	public fun get ()Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3DS2Authenticator;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/PaymentAuthConfig;ZI)Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3DS2Authenticator;
+	public static fun newInstance (Lcom/stripe/android/PaymentAuthConfig;ZILkotlin/jvm/functions/Function0;Ljava/util/Set;)Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3DS2Authenticator;
 }
 
 public final class com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactory_MembersInjector : dagger/MembersInjector {
@@ -5238,10 +5238,16 @@ public final class com/stripe/android/payments/core/injection/DaggerPaymentLaunc
 	public fun inject (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel$Factory;)V
 }
 
+public final class com/stripe/android/payments/core/injection/DaggerStripe3ds2TransactionViewModelFactoryComponent : com/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelFactoryComponent {
+	public static fun builder ()Lcom/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelFactoryComponent$Builder;
+	public fun inject (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactory;)V
+}
+
 public abstract interface annotation class com/stripe/android/payments/core/injection/IOContext : java/lang/annotation/Annotation {
 }
 
 public abstract interface class com/stripe/android/payments/core/injection/Injectable {
+	public abstract fun fallbackInitialize (Ljava/lang/Object;)V
 }
 
 public abstract interface class com/stripe/android/payments/core/injection/Injector {
@@ -5357,11 +5363,11 @@ public final class com/stripe/android/payments/core/injection/PaymentLauncherMod
 }
 
 public final class com/stripe/android/payments/core/injection/PaymentLauncherModule_ProvidePaymentAuthenticatorRegistryFactory : dagger/internal/Factory {
-	public fun <init> (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/PaymentLauncherModule_ProvidePaymentAuthenticatorRegistryFactory;
+	public fun <init> (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/PaymentLauncherModule_ProvidePaymentAuthenticatorRegistryFactory;
 	public fun get ()Lcom/stripe/android/payments/core/authentication/PaymentAuthenticatorRegistry;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun providePaymentAuthenticatorRegistry (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Landroid/content/Context;Lcom/stripe/android/networking/StripeRepository;ZLkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Ljava/util/Map;Lcom/stripe/android/networking/DefaultAnalyticsRequestExecutor;Lcom/stripe/android/networking/AnalyticsRequestFactory;)Lcom/stripe/android/payments/core/authentication/PaymentAuthenticatorRegistry;
+	public static fun providePaymentAuthenticatorRegistry (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Landroid/content/Context;Lcom/stripe/android/networking/StripeRepository;ZLkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Ljava/util/Map;Lcom/stripe/android/networking/DefaultAnalyticsRequestExecutor;Lcom/stripe/android/networking/AnalyticsRequestFactory;Lkotlin/jvm/functions/Function0;Ljava/util/Set;)Lcom/stripe/android/payments/core/authentication/PaymentAuthenticatorRegistry;
 }
 
 public final class com/stripe/android/payments/core/injection/PaymentLauncherModule_ProvidePaymentIntentFlowResultProcessorFactory : dagger/internal/Factory {
@@ -5388,14 +5394,6 @@ public final class com/stripe/android/payments/core/injection/PaymentLauncherMod
 	public static fun provideThreeDs1IntentReturnUrlMap (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;)Ljava/util/Map;
 }
 
-public final class com/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule_Companion_ProvideMessageVersionRegistryFactory : dagger/internal/Factory {
-	public fun <init> ()V
-	public static fun create ()Lcom/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule_Companion_ProvideMessageVersionRegistryFactory;
-	public fun get ()Lcom/stripe/android/stripe3ds2/transaction/MessageVersionRegistry;
-	public synthetic fun get ()Ljava/lang/Object;
-	public static fun provideMessageVersionRegistry ()Lcom/stripe/android/stripe3ds2/transaction/MessageVersionRegistry;
-}
-
 public final class com/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule_Companion_ProvidePaymentAuthConfigFactory : dagger/internal/Factory {
 	public fun <init> ()V
 	public static fun create ()Lcom/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule_Companion_ProvidePaymentAuthConfigFactory;
@@ -5404,12 +5402,49 @@ public final class com/stripe/android/payments/core/injection/Stripe3DSAuthentic
 	public static fun providePaymentAuthConfig ()Lcom/stripe/android/PaymentAuthConfig;
 }
 
-public final class com/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule_Companion_ProvideStripeThreeDs2ServiceFactory : dagger/internal/Factory {
+public final class com/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelModule_Companion_ProvideMessageVersionRegistryFactory : dagger/internal/Factory {
+	public fun <init> ()V
+	public static fun create ()Lcom/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelModule_Companion_ProvideMessageVersionRegistryFactory;
+	public fun get ()Lcom/stripe/android/stripe3ds2/transaction/MessageVersionRegistry;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideMessageVersionRegistry ()Lcom/stripe/android/stripe3ds2/transaction/MessageVersionRegistry;
+}
+
+public final class com/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelModule_Companion_ProvideStripeThreeDs2ServiceFactory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule_Companion_ProvideStripeThreeDs2ServiceFactory;
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelModule_Companion_ProvideStripeThreeDs2ServiceFactory;
 	public fun get ()Lcom/stripe/android/stripe3ds2/service/StripeThreeDs2Service;
 	public synthetic fun get ()Ljava/lang/Object;
 	public static fun provideStripeThreeDs2Service (Landroid/content/Context;ZLkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/stripe3ds2/service/StripeThreeDs2Service;
+}
+
+public final class com/stripe/android/payments/core/injection/StripeRepositoryModule {
+	public static final field $stable I
+	public fun <init> ()V
+}
+
+public final class com/stripe/android/payments/core/injection/StripeRepositoryModule_ProvideAnalyticsRequestExecutor$payments_core_releaseFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/payments/core/injection/StripeRepositoryModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/StripeRepositoryModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/StripeRepositoryModule_ProvideAnalyticsRequestExecutor$payments_core_releaseFactory;
+	public fun get ()Lcom/stripe/android/networking/AnalyticsRequestExecutor;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideAnalyticsRequestExecutor$payments_core_release (Lcom/stripe/android/payments/core/injection/StripeRepositoryModule;ZLkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/networking/AnalyticsRequestExecutor;
+}
+
+public final class com/stripe/android/payments/core/injection/StripeRepositoryModule_ProvideAnalyticsRequestFactory$payments_core_releaseFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/payments/core/injection/StripeRepositoryModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/StripeRepositoryModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/StripeRepositoryModule_ProvideAnalyticsRequestFactory$payments_core_releaseFactory;
+	public fun get ()Lcom/stripe/android/networking/AnalyticsRequestFactory;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideAnalyticsRequestFactory$payments_core_release (Lcom/stripe/android/payments/core/injection/StripeRepositoryModule;Landroid/content/Context;Lkotlin/jvm/functions/Function0;Ljava/util/Set;)Lcom/stripe/android/networking/AnalyticsRequestFactory;
+}
+
+public final class com/stripe/android/payments/core/injection/StripeRepositoryModule_ProvideStripeRepository$payments_core_releaseFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/payments/core/injection/StripeRepositoryModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/StripeRepositoryModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/StripeRepositoryModule_ProvideStripeRepository$payments_core_releaseFactory;
+	public fun get ()Lcom/stripe/android/networking/StripeRepository;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideStripeRepository$payments_core_release (Lcom/stripe/android/payments/core/injection/StripeRepositoryModule;Landroid/content/Context;Lcom/stripe/android/networking/AnalyticsRequestFactory;Lcom/stripe/android/networking/AnalyticsRequestExecutor;Lkotlin/coroutines/CoroutineContext;ZLkotlin/jvm/functions/Function0;)Lcom/stripe/android/networking/StripeRepository;
 }
 
 public abstract interface annotation class com/stripe/android/payments/core/injection/UIContext : java/lang/annotation/Annotation {
@@ -5594,10 +5629,10 @@ public final class com/stripe/android/payments/paymentlauncher/StripePaymentLaun
 }
 
 public final class com/stripe/android/payments/paymentlauncher/StripePaymentLauncher_Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/paymentlauncher/StripePaymentLauncher_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/paymentlauncher/StripePaymentLauncher_Factory;
 	public fun get (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Landroidx/activity/result/ActivityResultLauncher;)Lcom/stripe/android/payments/paymentlauncher/StripePaymentLauncher;
-	public static fun newInstance (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Landroidx/activity/result/ActivityResultLauncher;Landroid/content/Context;ZLkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lcom/stripe/android/networking/StripeRepository;Lcom/stripe/android/networking/AnalyticsRequestFactory;)Lcom/stripe/android/payments/paymentlauncher/StripePaymentLauncher;
+	public static fun newInstance (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Landroidx/activity/result/ActivityResultLauncher;Landroid/content/Context;ZLkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lcom/stripe/android/networking/StripeRepository;Lcom/stripe/android/networking/AnalyticsRequestFactory;Ljava/util/Set;)Lcom/stripe/android/payments/paymentlauncher/StripePaymentLauncher;
 }
 
 public abstract class com/stripe/android/paymentsheet/model/ClientSecret : android/os/Parcelable {

--- a/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -109,6 +109,8 @@ constructor(
             workContext,
             uiContext,
             threeDs1IntentReturnUrlMap,
+            { publishableKeyProvider.get() },
+            analyticsRequestFactory.defaultProductUsageTokens
         )
 
     override fun registerLaunchersWithActivityResultCaller(

--- a/payments-core/src/main/java/com/stripe/android/networking/AnalyticsRequestFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/AnalyticsRequestFactory.kt
@@ -22,10 +22,9 @@ class AnalyticsRequestFactory @VisibleForTesting internal constructor(
     private val packageInfo: PackageInfo?,
     private val packageName: String,
     private val publishableKeyProvider: Provider<String>,
-    private val defaultProductUsageTokens: Set<String> = emptySet()
+    internal val defaultProductUsageTokens: Set<String> = emptySet()
 ) {
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    @VisibleForTesting
     constructor(
         context: Context,
         publishableKey: String,

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultPaymentAuthenticatorRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultPaymentAuthenticatorRegistry.kt
@@ -118,7 +118,7 @@ internal class DefaultPaymentAuthenticatorRegistry @Inject internal constructor(
         paymentBrowserAuthLauncher = null
     }
 
-    override fun inject(injectable: Injectable) {
+    override fun inject(injectable: Injectable<*>) {
         when (injectable) {
             is Stripe3ds2TransactionViewModelFactory -> authenticationComponent.inject(injectable)
         }
@@ -133,7 +133,9 @@ internal class DefaultPaymentAuthenticatorRegistry @Inject internal constructor(
             enableLogging: Boolean,
             workContext: CoroutineContext,
             uiContext: CoroutineContext,
-            threeDs1IntentReturnUrlMap: MutableMap<String, String>
+            threeDs1IntentReturnUrlMap: MutableMap<String, String>,
+            publishableKeyProvider: () -> String,
+            productUsage: Set<String>
         ): PaymentAuthenticatorRegistry {
             val injectorKey = WeakMapInjectorRegistry.nextKey()
             val component = DaggerAuthenticationComponent.builder()
@@ -146,6 +148,8 @@ internal class DefaultPaymentAuthenticatorRegistry @Inject internal constructor(
                 .uiContext(uiContext)
                 .threeDs1IntentReturnUrlMap(threeDs1IntentReturnUrlMap)
                 .injectorKey(injectorKey)
+                .publishableKeyProvider(publishableKeyProvider)
+                .productUsage(productUsage)
                 .build()
             val registry = component.registry
             registry.authenticationComponent = component

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3DS2Authenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3DS2Authenticator.kt
@@ -11,6 +11,8 @@ import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.payments.core.authentication.PaymentAuthenticator
 import com.stripe.android.payments.core.injection.ENABLE_LOGGING
 import com.stripe.android.payments.core.injection.InjectorKey
+import com.stripe.android.payments.core.injection.PRODUCT_USAGE
+import com.stripe.android.payments.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.stripe3ds2.transaction.SdkTransactionId
 import com.stripe.android.view.AuthActivityStarterHost
 import javax.inject.Inject
@@ -25,6 +27,8 @@ internal class Stripe3DS2Authenticator @Inject constructor(
     private val config: PaymentAuthConfig,
     @Named(ENABLE_LOGGING) private val enableLogging: Boolean,
     @InjectorKey private val injectorKey: Int,
+    @Named(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String,
+    @Named(PRODUCT_USAGE) private val productUsage: Set<String>
 ) : PaymentAuthenticator<StripeIntent> {
 
     /**
@@ -70,7 +74,9 @@ internal class Stripe3DS2Authenticator @Inject constructor(
                 requestOptions,
                 enableLogging = enableLogging,
                 host.statusBarColor,
-                injectorKey
+                injectorKey,
+                publishableKeyProvider(),
+                productUsage
             )
         )
     }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionContract.kt
@@ -40,7 +40,9 @@ internal class Stripe3ds2TransactionContract :
         val requestOptions: ApiRequest.Options,
         val enableLogging: Boolean,
         val statusBarColor: Int?,
-        @InjectorKey val injectorKey: Int
+        @InjectorKey val injectorKey: Int,
+        val publishableKey: String,
+        val productUsage: Set<String>
     ) : Parcelable {
         val fingerprint: Stripe3ds2Fingerprint get() = Stripe3ds2Fingerprint(nextActionData)
 

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.AbstractSavedStateViewModelFactory
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.savedstate.SavedStateRegistryOwner
+import com.stripe.android.Logger
 import com.stripe.android.StripePaymentController
 import com.stripe.android.auth.PaymentBrowserAuthContract
 import com.stripe.android.exception.StripeException
@@ -16,14 +17,13 @@ import com.stripe.android.networking.AnalyticsEvent
 import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.AnalyticsRequestFactory
 import com.stripe.android.networking.ApiRequest
-import com.stripe.android.networking.RetryDelaySupplier
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.PaymentFlowResult
+import com.stripe.android.payments.core.injection.DaggerStripe3ds2TransactionViewModelFactoryComponent
 import com.stripe.android.payments.core.injection.IOContext
 import com.stripe.android.payments.core.injection.Injectable
 import com.stripe.android.payments.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.stripe3ds2.service.StripeThreeDs2Service
-import com.stripe.android.stripe3ds2.service.StripeThreeDs2ServiceImpl
 import com.stripe.android.stripe3ds2.transaction.ChallengeParameters
 import com.stripe.android.stripe3ds2.transaction.ChallengeResult
 import com.stripe.android.stripe3ds2.transaction.InitChallengeArgs
@@ -32,6 +32,7 @@ import com.stripe.android.stripe3ds2.transaction.InitChallengeRepositoryFactory
 import com.stripe.android.stripe3ds2.transaction.IntentData
 import com.stripe.android.stripe3ds2.transaction.MessageVersionRegistry
 import com.stripe.android.stripe3ds2.transaction.Transaction
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -290,7 +291,15 @@ internal class Stripe3ds2TransactionViewModelFactory(
     private val applicationSupplier: () -> Application,
     owner: SavedStateRegistryOwner,
     private val argsSupplier: () -> Stripe3ds2TransactionContract.Args,
-) : AbstractSavedStateViewModelFactory(owner, null), Injectable {
+) : AbstractSavedStateViewModelFactory(owner, null),
+    Injectable<Stripe3ds2TransactionViewModelFactory.FallbackInitializeParam> {
+
+    internal data class FallbackInitializeParam(
+        val application: Application,
+        val enableLogging: Boolean,
+        val publishableKey: String,
+        val productUsage: Set<String>
+    )
 
     @Inject
     lateinit var stripeRepository: StripeRepository
@@ -314,6 +323,21 @@ internal class Stripe3ds2TransactionViewModelFactory(
     @IOContext
     lateinit var workContext: CoroutineContext
 
+    /**
+     * Fallback call to initialize dependencies when injection is not available, this might happen
+     * when app process is killed by system and [WeakMapInjectorRegistry] is cleared.
+     */
+    override fun fallbackInitialize(arg: FallbackInitializeParam) {
+        DaggerStripe3ds2TransactionViewModelFactoryComponent.builder()
+            .context(arg.application)
+            .enableLogging(arg.enableLogging)
+            .workContext(Dispatchers.IO)
+            .publishableKeyProvider { arg.publishableKey }
+            .productUsage(arg.productUsage)
+            .build()
+            .inject(this)
+    }
+
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel?> create(
         key: String,
@@ -321,28 +345,34 @@ internal class Stripe3ds2TransactionViewModelFactory(
         handle: SavedStateHandle
     ): T {
         val args = argsSupplier()
-        WeakMapInjectorRegistry.retrieve(args.injectorKey)?.inject(this) ?: run {
-            throw IllegalArgumentException(
-                "Failed to initialize Stripe3ds2TransactionViewModelFactory"
+
+        val application = applicationSupplier()
+
+        val logger = Logger.getInstance(args.enableLogging)
+
+        WeakMapInjectorRegistry.retrieve(args.injectorKey)?.let {
+            logger.info("Injector available, injecting dependencies into Stripe3ds2TransactionViewModelFactory")
+            it.inject(this)
+        } ?: run {
+            logger.info("Injector unavailable, initializing dependencies of Stripe3ds2TransactionViewModelFactory")
+            fallbackInitialize(
+                FallbackInitializeParam(
+                    application,
+                    args.enableLogging,
+                    args.publishableKey,
+                    args.productUsage
+                )
             )
         }
 
-        val application = applicationSupplier()
         return Stripe3ds2TransactionViewModel(
             args,
             stripeRepository,
             analyticsRequestExecutor,
             analyticsRequestFactory,
-            StripeThreeDs2ServiceImpl(application, args.enableLogging, workContext),
-            MessageVersionRegistry(),
-            DefaultStripe3ds2ChallengeResultProcessor(
-                stripeRepository,
-                analyticsRequestExecutor,
-                analyticsRequestFactory,
-                RetryDelaySupplier(),
-                args.enableLogging,
-                workContext
-            ),
+            threeDs2Service,
+            messageVersionRegistry,
+            challengeResultProcessor,
             InitChallengeRepositoryFactory(
                 application,
                 args.stripeIntent.isLiveMode,

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
@@ -63,6 +63,14 @@ internal interface AuthenticationComponent {
         @BindsInstance
         fun injectorKey(@InjectorKey id: Int): Builder
 
+        @BindsInstance
+        fun publishableKeyProvider(
+            @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String
+        ): Builder
+
+        @BindsInstance
+        fun productUsage(@Named(PRODUCT_USAGE) productUsage: Set<String>): Builder
+
         fun build(): AuthenticationComponent
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/Injectable.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/Injectable.kt
@@ -8,4 +8,12 @@ import androidx.annotation.RestrictTo
  * through constructor and need to have them injected through lateinit properties.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) // For paymentsheet
-interface Injectable
+interface Injectable<FallbackInitializeParam> {
+    /**
+     * Fallback initialization logic for the dependencies when [Injector] is not available. This
+     * could happen when the app process is killed and static [Injector]s are cleared up.
+     *
+     * An [Injectable] should check when this happens and calls this function manually.
+     */
+    fun fallbackInitialize(arg: FallbackInitializeParam)
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/Injector.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/Injector.kt
@@ -17,5 +17,5 @@ interface Injector {
     /**
      * Injects into a [Injectable] instance.
      */
-    fun inject(injectable: Injectable)
+    fun inject(injectable: Injectable<*>)
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherComponent.kt
@@ -45,6 +45,9 @@ internal interface PaymentLauncherComponent {
         @BindsInstance
         fun stripeAccountIdProvider(@Named(STRIPE_ACCOUNT_ID) stripeAccountIdProvider: () -> String?): Builder
 
+        @BindsInstance
+        fun productUsage(@Named(PRODUCT_USAGE) productUsage: Set<String>): Builder
+
         fun build(): PaymentLauncherComponent
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherModule.kt
@@ -96,7 +96,9 @@ internal class PaymentLauncherModule {
         @UIContext uiContext: CoroutineContext,
         threeDs1IntentReturnUrlMap: MutableMap<String, String>,
         defaultAnalyticsRequestExecutor: DefaultAnalyticsRequestExecutor,
-        analyticsRequestFactory: AnalyticsRequestFactory
+        analyticsRequestFactory: AnalyticsRequestFactory,
+        @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
+        @Named(PRODUCT_USAGE) productUsage: Set<String>
     ): PaymentAuthenticatorRegistry = DefaultPaymentAuthenticatorRegistry.createInstance(
         context,
         stripeRepository,
@@ -106,5 +108,7 @@ internal class PaymentLauncherModule {
         workContext,
         uiContext,
         threeDs1IntentReturnUrlMap,
+        publishableKeyProvider,
+        productUsage
     )
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule.kt
@@ -1,29 +1,25 @@
 package com.stripe.android.payments.core.injection
 
-import android.content.Context
 import com.stripe.android.PaymentAuthConfig
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.StripeIntent.NextActionData
 import com.stripe.android.payments.core.authentication.PaymentAuthenticator
-import com.stripe.android.payments.core.authentication.threeds2.DefaultStripe3ds2ChallengeResultProcessor
 import com.stripe.android.payments.core.authentication.threeds2.Stripe3DS2Authenticator
-import com.stripe.android.payments.core.authentication.threeds2.Stripe3ds2ChallengeResultProcessor
-import com.stripe.android.stripe3ds2.service.StripeThreeDs2Service
-import com.stripe.android.stripe3ds2.service.StripeThreeDs2ServiceImpl
-import com.stripe.android.stripe3ds2.transaction.MessageVersionRegistry
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoMap
-import javax.inject.Named
 import javax.inject.Singleton
-import kotlin.coroutines.CoroutineContext
 
 /**
  * Provides [PaymentAuthenticator] for [NextActionData.SdkData.Use3DS2].
  * Requires 3ds2 SDK.
  */
-@Module
+@Module(
+    includes = [
+        Stripe3ds2TransactionViewModelModule::class
+    ]
+)
 internal abstract class Stripe3DSAuthenticatorModule {
     @IntentAuthenticatorMap
     @Binds
@@ -33,28 +29,9 @@ internal abstract class Stripe3DSAuthenticatorModule {
         stripe3ds2Authenticator: Stripe3DS2Authenticator
     ): PaymentAuthenticator<StripeIntent>
 
-    @Binds
-    abstract fun bindsStripe3ds2ChallengeResultProcessor(
-        defaultStripe3ds2ChallengeResultProcessor: DefaultStripe3ds2ChallengeResultProcessor
-    ): Stripe3ds2ChallengeResultProcessor
-
     companion object {
         @Provides
         @Singleton
         fun providePaymentAuthConfig() = PaymentAuthConfig.get()
-
-        @Provides
-        @Singleton
-        fun provideMessageVersionRegistry() = MessageVersionRegistry()
-
-        @Provides
-        @Singleton
-        fun provideStripeThreeDs2Service(
-            context: Context,
-            @Named(ENABLE_LOGGING) enableLogging: Boolean,
-            @IOContext workContext: CoroutineContext,
-        ): StripeThreeDs2Service {
-            return StripeThreeDs2ServiceImpl(context, enableLogging, workContext)
-        }
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelFactoryComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelFactoryComponent.kt
@@ -1,0 +1,46 @@
+package com.stripe.android.payments.core.injection
+
+import android.content.Context
+import com.stripe.android.payments.core.authentication.threeds2.Stripe3ds2TransactionViewModelFactory
+import dagger.BindsInstance
+import dagger.Component
+import javax.inject.Named
+import javax.inject.Singleton
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Component to inject [Stripe3ds2TransactionViewModelFactory] when the app process is killed and
+ * there is no [Injector] available.
+ */
+@Singleton
+@Component(
+    modules = [
+        StripeRepositoryModule::class,
+        Stripe3ds2TransactionViewModelModule::class
+    ]
+)
+internal interface Stripe3ds2TransactionViewModelFactoryComponent {
+    fun inject(stripe3ds2TransactionViewModelFactory: Stripe3ds2TransactionViewModelFactory)
+
+    @Component.Builder
+    interface Builder {
+        @BindsInstance
+        fun context(context: Context): Builder
+
+        @BindsInstance
+        fun enableLogging(@Named(ENABLE_LOGGING) enableLogging: Boolean): Builder
+
+        @BindsInstance
+        fun workContext(@IOContext workContext: CoroutineContext): Builder
+
+        @BindsInstance
+        fun publishableKeyProvider(
+            @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String
+        ): Builder
+
+        @BindsInstance
+        fun productUsage(@Named(PRODUCT_USAGE) productUsage: Set<String>): Builder
+
+        fun build(): Stripe3ds2TransactionViewModelFactoryComponent
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelModule.kt
@@ -1,0 +1,43 @@
+package com.stripe.android.payments.core.injection
+
+import android.content.Context
+import com.stripe.android.payments.core.authentication.threeds2.DefaultStripe3ds2ChallengeResultProcessor
+import com.stripe.android.payments.core.authentication.threeds2.Stripe3ds2ChallengeResultProcessor
+import com.stripe.android.payments.core.authentication.threeds2.Stripe3ds2TransactionViewModel
+import com.stripe.android.stripe3ds2.service.StripeThreeDs2Service
+import com.stripe.android.stripe3ds2.service.StripeThreeDs2ServiceImpl
+import com.stripe.android.stripe3ds2.transaction.MessageVersionRegistry
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import javax.inject.Named
+import javax.inject.Singleton
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Provides dependencies for [Stripe3ds2TransactionViewModel].
+ */
+@Module
+internal abstract class Stripe3ds2TransactionViewModelModule {
+    @Binds
+    abstract fun bindsStripe3ds2ChallengeResultProcessor(
+        defaultStripe3ds2ChallengeResultProcessor: DefaultStripe3ds2ChallengeResultProcessor
+    ): Stripe3ds2ChallengeResultProcessor
+
+    companion object {
+
+        @Provides
+        @Singleton
+        fun provideMessageVersionRegistry() = MessageVersionRegistry()
+
+        @Provides
+        @Singleton
+        fun provideStripeThreeDs2Service(
+            context: Context,
+            @Named(ENABLE_LOGGING) enableLogging: Boolean,
+            @IOContext workContext: CoroutineContext,
+        ): StripeThreeDs2Service {
+            return StripeThreeDs2ServiceImpl(context, enableLogging, workContext)
+        }
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/StripeRepositoryModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/StripeRepositoryModule.kt
@@ -1,0 +1,60 @@
+package com.stripe.android.payments.core.injection
+
+import android.content.Context
+import com.stripe.android.Logger
+import com.stripe.android.networking.AnalyticsRequestExecutor
+import com.stripe.android.networking.AnalyticsRequestFactory
+import com.stripe.android.networking.DefaultAnalyticsRequestExecutor
+import com.stripe.android.networking.StripeApiRepository
+import com.stripe.android.networking.StripeRepository
+import dagger.Module
+import dagger.Provides
+import javax.inject.Named
+import javax.inject.Singleton
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * A [Module] to provide [StripeRepository] and its corresponding dependencies.
+ * [Context], [ENABLE_LOGGING], [PUBLISHABLE_KEY], [PRODUCT_USAGE] and [IOContext] need to be
+ * provided elsewhere to use this module.
+ *
+ * TODO: Let [PaymentCommonModule] include this module.
+ */
+@Module
+class StripeRepositoryModule {
+    @Provides
+    @Singleton
+    internal fun provideStripeRepository(
+        appContext: Context,
+        analyticsRequestFactory: AnalyticsRequestFactory,
+        analyticsRequestExecutor: AnalyticsRequestExecutor,
+        @IOContext workContext: CoroutineContext,
+        @Named(ENABLE_LOGGING) enableLogging: Boolean,
+        @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
+    ): StripeRepository = StripeApiRepository(
+        appContext,
+        publishableKeyProvider,
+        logger = Logger.getInstance(enableLogging),
+        workContext = workContext,
+        analyticsRequestFactory = analyticsRequestFactory,
+        analyticsRequestExecutor = analyticsRequestExecutor
+    )
+
+    @Provides
+    @Singleton
+    internal fun provideAnalyticsRequestFactory(
+        appContext: Context,
+        @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
+        @Named(PRODUCT_USAGE) productUsageTokens: Set<String>,
+    ) = AnalyticsRequestFactory(appContext, publishableKeyProvider, productUsageTokens)
+
+    @Provides
+    @Singleton
+    internal fun provideAnalyticsRequestExecutor(
+        @Named(ENABLE_LOGGING) enableLogging: Boolean,
+        @IOContext workContext: CoroutineContext
+    ): AnalyticsRequestExecutor = DefaultAnalyticsRequestExecutor(
+        Logger.getInstance(enableLogging),
+        workContext
+    )
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/WeakMapInjectorRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/WeakMapInjectorRegistry.kt
@@ -8,6 +8,10 @@ import java.util.concurrent.atomic.AtomicInteger
 /**
  * A [InjectorRegistry] implemented with a weak map. An entry from the map will be  will be garbage
  * collected once the [Injector] instance is no longer held elsewhere.
+ *
+ * Note: the weak map will be cleared when app process is killed by system.
+ * [Injectable] implementations are responsible for detecting this and call
+ * [Injectable.fallbackInitialize] accordingly.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) // For paymentsheet
 object WeakMapInjectorRegistry : InjectorRegistry {

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherFactory.kt
@@ -46,21 +46,28 @@ class PaymentLauncherFactory(
     fun create(
         publishableKey: String,
         stripeAccountId: String? = null
-    ): PaymentLauncher = StripePaymentLauncher(
-        { publishableKey },
-        { stripeAccountId },
-        hostActivityLauncher,
-        context,
-        BuildConfig.DEBUG,
-        Dispatchers.IO,
-        Dispatchers.Main,
-        StripeApiRepository(
+    ): PaymentLauncher {
+        val productUsage = setOf("PaymentLauncher")
+        val analyticsRequestFactory = AnalyticsRequestFactory(
             context,
-            { publishableKey }
-        ),
-        AnalyticsRequestFactory(
-            context,
-            { publishableKey }
+            { publishableKey },
+            productUsage
         )
-    )
+        return StripePaymentLauncher(
+            { publishableKey },
+            { stripeAccountId },
+            hostActivityLauncher,
+            context,
+            BuildConfig.DEBUG,
+            Dispatchers.IO,
+            Dispatchers.Main,
+            StripeApiRepository(
+                context,
+                { publishableKey },
+                analyticsRequestFactory = analyticsRequestFactory
+            ),
+            analyticsRequestFactory,
+            productUsage = productUsage
+        )
+    }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -242,7 +242,15 @@ internal class PaymentLauncherViewModel(
         @InjectorKey private val injectorKeyProvider: () -> Int,
         private val authActivityStarterHostProvider: () -> AuthActivityStarterHost,
         private val activityResultCaller: ActivityResultCaller
-    ) : ViewModelProvider.Factory, Injectable {
+    ) : ViewModelProvider.Factory, Injectable<Factory.FallbackInitializeParam> {
+        internal data class FallbackInitializeParam(
+            val enableLogging: Boolean
+        )
+
+        override fun fallbackInitialize(arg: FallbackInitializeParam) {
+            // TODO(ccen) to implement
+        }
+
         @Inject
         lateinit var stripeApiRepository: StripeRepository
 

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncher.kt
@@ -13,6 +13,7 @@ import com.stripe.android.payments.core.injection.IOContext
 import com.stripe.android.payments.core.injection.Injectable
 import com.stripe.android.payments.core.injection.Injector
 import com.stripe.android.payments.core.injection.InjectorKey
+import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.payments.core.injection.PaymentLauncherComponent
 import com.stripe.android.payments.core.injection.STRIPE_ACCOUNT_ID
@@ -37,7 +38,8 @@ class StripePaymentLauncher @AssistedInject internal constructor(
     @IOContext ioContext: CoroutineContext,
     @UIContext uiContext: CoroutineContext,
     stripeRepository: StripeRepository,
-    analyticsRequestFactory: AnalyticsRequestFactory
+    analyticsRequestFactory: AnalyticsRequestFactory,
+    @Named(PRODUCT_USAGE) productUsage: Set<String>
 ) : PaymentLauncher, Injector {
     private val paymentLauncherComponent: PaymentLauncherComponent =
         DaggerPaymentLauncherComponent.builder()
@@ -49,6 +51,7 @@ class StripePaymentLauncher @AssistedInject internal constructor(
             .analyticsRequestFactory(analyticsRequestFactory)
             .publishableKeyProvider(publishableKeyProvider)
             .stripeAccountIdProvider(stripeAccountIdProvider)
+            .productUsage(productUsage)
             .build()
 
     @InjectorKey
@@ -58,7 +61,7 @@ class StripePaymentLauncher @AssistedInject internal constructor(
         WeakMapInjectorRegistry.register(this, injectorKey)
     }
 
-    override fun inject(injectable: Injectable) {
+    override fun inject(injectable: Injectable<*>) {
         when (injectable) {
             is PaymentLauncherViewModel.Factory -> {
                 paymentLauncherComponent.inject(injectable)

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/Stripe3DS2AuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/Stripe3DS2AuthenticatorTest.kt
@@ -36,7 +36,9 @@ class Stripe3DS2AuthenticatorTest {
     private val authenticator = Stripe3DS2Authenticator(
         paymentAuthConfig,
         enableLogging = false,
-        injectorKey = 1
+        injectorKey = 1,
+        publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
+        productUsage = setOf()
     )
 
     @Test

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionActivityTest.kt
@@ -8,32 +8,31 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentAuthConfig
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.payments.PaymentFlowResult
+import com.stripe.android.payments.core.injection.Injectable
+import com.stripe.android.payments.core.injection.Injector
+import com.stripe.android.payments.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.stripe3ds2.init.ui.StripeUiCustomization
 import com.stripe.android.stripe3ds2.transaction.SdkTransactionId
 import com.stripe.android.stripe3ds2.views.ChallengeProgressFragmentFactory
 import com.stripe.android.utils.TestUtils
 import com.stripe.android.utils.injectableActivityScenario
+import org.junit.After
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
-import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertIs
 
 @RunWith(RobolectricTestRunner::class)
 class Stripe3ds2TransactionActivityTest {
 
-    @BeforeTest
-    fun setup() {
-        PaymentConfiguration.init(
-            ApplicationProvider.getApplicationContext(),
-            ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
-        )
+    @After
+    fun cleanUpInjector() {
+        WeakMapInjectorRegistry.staticCacheMap.clear()
     }
 
     @Test
@@ -75,6 +74,49 @@ class Stripe3ds2TransactionActivityTest {
         }
     }
 
+    @Test
+    fun `Stripe3ds2TransactionViewModelFactory gets initialized by Injector when Injector is available`() {
+        val injector = object : Injector {
+            override fun inject(injectable: Injectable<*>) {
+                val factory = injectable as Stripe3ds2TransactionViewModelFactory
+                factory.stripeRepository = mock()
+                factory.analyticsRequestExecutor = mock()
+                factory.analyticsRequestFactory = mock()
+                factory.messageVersionRegistry = mock()
+                factory.threeDs2Service = mock()
+                factory.challengeResultProcessor = mock()
+                factory.workContext = mock()
+            }
+        }
+        WeakMapInjectorRegistry.register(injector, INJECTOR_KEY)
+
+        ActivityScenario.launch<Stripe3ds2TransactionActivity>(
+            Intent(
+                ApplicationProvider.getApplicationContext(),
+                Stripe3ds2TransactionActivity::class.java
+            ).putExtras(
+                ARGS.toBundle()
+            )
+        ).use { activityScenario ->
+            assertThat(activityScenario.state).isEqualTo(Lifecycle.State.RESUMED)
+        }
+    }
+
+    @Test
+    fun `Stripe3ds2TransactionViewModelFactory gets initialized with fallback when no Injector is available`() {
+        WeakMapInjectorRegistry.staticCacheMap.clear()
+        ActivityScenario.launch<Stripe3ds2TransactionActivity>(
+            Intent(
+                ApplicationProvider.getApplicationContext(),
+                Stripe3ds2TransactionActivity::class.java
+            ).putExtras(
+                ARGS.toBundle()
+            )
+        ).use { activityScenario ->
+            assertThat(activityScenario.state).isEqualTo(Lifecycle.State.RESUMED)
+        }
+    }
+
     private fun parseResult(
         activityScenario: ActivityScenario<*>
     ): PaymentFlowResult.Unvalidated {
@@ -83,6 +125,7 @@ class Stripe3ds2TransactionActivityTest {
     }
 
     private companion object {
+        var INJECTOR_KEY = WeakMapInjectorRegistry.nextKey()
         val ARGS = Stripe3ds2TransactionContract.Args(
             SdkTransactionId.create(),
             PaymentAuthConfig.Stripe3ds2Config(
@@ -97,7 +140,9 @@ class Stripe3ds2TransactionActivityTest {
             ApiRequest.Options(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY),
             enableLogging = false,
             statusBarColor = null,
-            injectorKey = 1
+            injectorKey = INJECTOR_KEY,
+            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+            setOf()
         )
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/payments/core/injection/WeakMapInjectorRegistryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/injection/WeakMapInjectorRegistryTest.kt
@@ -65,7 +65,7 @@ class WeakMapInjectorRegistryTest {
     // calling whenever() on a mock will end up holding the mock instance, therefore a real
     // Injector instance is needed to ensure System.gc() works correctly.
     internal class TestInjector : Injector {
-        override fun inject(injectable: Injectable) {
+        override fun inject(injectable: Injectable<*>) {
             // no - op
         }
     }

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncherTest.kt
@@ -23,7 +23,8 @@ class StripePaymentLauncherTest {
         ioContext = mock(),
         uiContext = mock(),
         stripeRepository = mock(),
-        analyticsRequestFactory = mock()
+        analyticsRequestFactory = mock(),
+        productUsage = mock()
     )
 
     @Test

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -144,7 +144,7 @@ internal class PaymentOptionsViewModel(
         @Inject
         @JvmSuppressWildcards
         lateinit var prefsRepositoryFactory:
-                (PaymentSheet.CustomerConfiguration?) -> PrefsRepository
+            (PaymentSheet.CustomerConfiguration?) -> PrefsRepository
 
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -122,7 +122,14 @@ internal class PaymentOptionsViewModel(
     internal class Factory(
         private val applicationSupplier: () -> Application,
         private val starterArgsSupplier: () -> PaymentOptionContract.Args
-    ) : ViewModelProvider.Factory, Injectable {
+    ) : ViewModelProvider.Factory, Injectable<Factory.FallbackInitializeParam> {
+        internal data class FallbackInitializeParam(
+            val enableLogging: Boolean
+        )
+
+        override fun fallbackInitialize(arg: FallbackInitializeParam) {
+            // TODO(ccen) to implement
+        }
 
         @Inject
         lateinit var eventReporter: EventReporter
@@ -137,7 +144,7 @@ internal class PaymentOptionsViewModel(
         @Inject
         @JvmSuppressWildcards
         lateinit var prefsRepositoryFactory:
-            (PaymentSheet.CustomerConfiguration?) -> PrefsRepository
+                (PaymentSheet.CustomerConfiguration?) -> PrefsRepository
 
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -101,7 +101,7 @@ internal class DefaultFlowController @Inject internal constructor(
      */
     lateinit var flowControllerComponent: FlowControllerComponent
 
-    override fun inject(injectable: Injectable) {
+    override fun inject(injectable: Injectable<*>) {
         when (injectable) {
             is PaymentOptionsViewModel.Factory -> {
                 flowControllerComponent.inject(injectable)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAddPaymentMethodFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAddPaymentMethodFragmentTest.kt
@@ -31,7 +31,7 @@ class PaymentOptionsAddPaymentMethodFragmentTest {
     private val eventReporter = mock<EventReporter>()
 
     private val testInjector: Injector = object : Injector {
-        override fun inject(injectable: Injectable) {
+        override fun inject(injectable: Injectable<*>) {
             val factory = (injectable as PaymentOptionsViewModel.Factory)
             factory.eventReporter = eventReporter
             factory.customerRepository = com.stripe.android.paymentsheet.FakeCustomerRepository()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
When the app process is killed by system, `WeakMapInjectorRegistry` will be cleared, all `Injectable`s that rely on it won't have correct `Injector` available. If this happens, `Injectable` needs to bootstrap its own dependency graph.

Most of the files changed are placeholders caused by the interface change, the actual changes in this PR are as follows:
1. add an mandatory `Injectable.fallbackInitialize` method 
2. Implement `Injectable.fallbackInitialize` for `Stripe3ds2TransactionViewModelFactory`
    - Create a `Stripe3ds2TransactionViewModelFactoryComponent` with required dependencies in the fallback
    - Create a dedicated `StripeRepositoryModule` to initialize `StripeRepository`, this will be included into `PaymentCommonModule`
    - Split the original `Stripe3DSAuthenticatorModule` into `Stripe3DSAuthenticatorModule` and `Stripe3ds2TransactionViewModelModule`: the former provides more deps and is used in regular `Injector` case; the later only provides deps for `Stripe3ds2TransactionViewModel` and is used for the fallback case


Fixing #4167


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Currently there are 3 `Injectable` implementations, will address them one with a PR.
1. [Stripe3ds2TransactionViewModelFactory](Stripe3ds2TransactionViewModelFactory) - fixed in this PR
2. [PaymentOptionsViewModel.Factory](https://github.com/stripe/stripe-android/blob/86633d4682cc80a9ea173a70f8f5cb105d6a37b4/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt#L122)
3. [PaymentLauncherViewModel.Factory](https://github.com/stripe/stripe-android/blob/86633d4682cc80a9ea173a70f8f5cb105d6a37b4/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt#L241)


# Testing
<!-- How was the code tested? Be as specific as possible. -->
Note: two tests are added in `Stripe3ds2TransactionActivityTest`, mimicking the case when `Injector` is available and is not avaialble. 
- [x] Added tests
- [x] Modified tests
- [x] Manually verified



