### PR TITLE
[2 of 3] Provide a fallback injection mechanisom when app process is killed by system 

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -5192,6 +5192,11 @@ public final class com/stripe/android/payments/core/injection/DaggerPaymentLaunc
 	public fun inject (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel$Factory;)V
 }
 
+public final class com/stripe/android/payments/core/injection/DaggerPaymentLauncherViewModelFactoryComponent : com/stripe/android/payments/core/injection/PaymentLauncherViewModelFactoryComponent {
+	public static fun builder ()Lcom/stripe/android/payments/core/injection/PaymentLauncherViewModelFactoryComponent$Builder;
+	public fun inject (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel$Factory;)V
+}
+
 public final class com/stripe/android/payments/core/injection/DaggerStripe3ds2TransactionViewModelFactoryComponent : com/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelFactoryComponent {
 	public static fun builder ()Lcom/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelFactoryComponent$Builder;
 	public fun inject (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactory;)V
@@ -5420,23 +5425,35 @@ public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherCo
 
 public abstract class com/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args : android/os/Parcelable {
 	public static final field $stable I
-	public synthetic fun <init> (ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;ZLjava/util/Set;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getEnableLogging ()Z
 	public fun getInjectorKey ()I
+	public fun getProductUsage ()Ljava/util/Set;
+	public fun getPublishableKey ()Ljava/lang/String;
+	public fun getStripeAccountId ()Ljava/lang/String;
 	public final fun toBundle ()Landroid/os/Bundle;
 }
 
 public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$IntentConfirmationArgs : com/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (ILcom/stripe/android/model/ConfirmStripeIntentParams;)V
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;ZLjava/util/Set;Lcom/stripe/android/model/ConfirmStripeIntentParams;)V
 	public final fun component1 ()I
-	public final fun component2 ()Lcom/stripe/android/model/ConfirmStripeIntentParams;
-	public final fun copy (ILcom/stripe/android/model/ConfirmStripeIntentParams;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$IntentConfirmationArgs;
-	public static synthetic fun copy$default (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$IntentConfirmationArgs;ILcom/stripe/android/model/ConfirmStripeIntentParams;ILjava/lang/Object;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$IntentConfirmationArgs;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun component5 ()Ljava/util/Set;
+	public final fun component6 ()Lcom/stripe/android/model/ConfirmStripeIntentParams;
+	public final fun copy (ILjava/lang/String;Ljava/lang/String;ZLjava/util/Set;Lcom/stripe/android/model/ConfirmStripeIntentParams;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$IntentConfirmationArgs;
+	public static synthetic fun copy$default (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$IntentConfirmationArgs;ILjava/lang/String;Ljava/lang/String;ZLjava/util/Set;Lcom/stripe/android/model/ConfirmStripeIntentParams;ILjava/lang/Object;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$IntentConfirmationArgs;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConfirmStripeIntentParams ()Lcom/stripe/android/model/ConfirmStripeIntentParams;
+	public fun getEnableLogging ()Z
 	public fun getInjectorKey ()I
+	public fun getProductUsage ()Ljava/util/Set;
+	public fun getPublishableKey ()Ljava/lang/String;
+	public fun getStripeAccountId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
@@ -5445,15 +5462,23 @@ public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherCo
 public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$PaymentIntentNextActionArgs : com/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (ILjava/lang/String;)V
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;)V
 	public final fun component1 ()I
 	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (ILjava/lang/String;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$PaymentIntentNextActionArgs;
-	public static synthetic fun copy$default (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$PaymentIntentNextActionArgs;ILjava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$PaymentIntentNextActionArgs;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun component5 ()Ljava/util/Set;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (ILjava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$PaymentIntentNextActionArgs;
+	public static synthetic fun copy$default (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$PaymentIntentNextActionArgs;ILjava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$PaymentIntentNextActionArgs;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getEnableLogging ()Z
 	public fun getInjectorKey ()I
 	public final fun getPaymentIntentClientSecret ()Ljava/lang/String;
+	public fun getProductUsage ()Ljava/util/Set;
+	public fun getPublishableKey ()Ljava/lang/String;
+	public fun getStripeAccountId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
@@ -5462,15 +5487,23 @@ public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherCo
 public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$SetupIntentNextActionArgs : com/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (ILjava/lang/String;)V
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;)V
 	public final fun component1 ()I
 	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (ILjava/lang/String;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$SetupIntentNextActionArgs;
-	public static synthetic fun copy$default (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$SetupIntentNextActionArgs;ILjava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$SetupIntentNextActionArgs;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun component5 ()Ljava/util/Set;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (ILjava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$SetupIntentNextActionArgs;
+	public static synthetic fun copy$default (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$SetupIntentNextActionArgs;ILjava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$SetupIntentNextActionArgs;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getEnableLogging ()Z
 	public fun getInjectorKey ()I
+	public fun getProductUsage ()Ljava/util/Set;
+	public fun getPublishableKey ()Ljava/lang/String;
 	public final fun getSetupIntentClientSecret ()Ljava/lang/String;
+	public fun getStripeAccountId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherViewModelFactoryComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherViewModelFactoryComponent.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.payments.core.injection
+
+import android.content.Context
+import com.stripe.android.payments.paymentlauncher.PaymentLauncherViewModel
+import dagger.BindsInstance
+import dagger.Component
+import javax.inject.Named
+import javax.inject.Singleton
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Component to inject [PaymentLauncherViewModel.Factory] when the app process is killed and
+ * there is no [Injector] available.
+ */
+@Singleton
+@Component(
+    modules = [
+        PaymentLauncherModule::class,
+        StripeRepositoryModule::class
+    ]
+)
+internal interface PaymentLauncherViewModelFactoryComponent {
+    fun inject(factory: PaymentLauncherViewModel.Factory)
+
+    @Component.Builder
+    interface Builder {
+        @BindsInstance
+        fun context(context: Context): Builder
+
+        @BindsInstance
+        fun enableLogging(@Named(ENABLE_LOGGING) enableLogging: Boolean): Builder
+
+        @BindsInstance
+        fun ioContext(@IOContext workContext: CoroutineContext): Builder
+
+        @BindsInstance
+        fun uiContext(@UIContext uiContext: CoroutineContext): Builder
+
+        @BindsInstance
+        fun publishableKeyProvider(@Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String): Builder
+
+        @BindsInstance
+        fun stripeAccountIdProvider(@Named(STRIPE_ACCOUNT_ID) stripeAccountIdProvider: () -> String?): Builder
+
+        @BindsInstance
+        fun productUsage(@Named(PRODUCT_USAGE) productUsage: Set<String>): Builder
+
+        fun build(): PaymentLauncherViewModelFactoryComponent
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherContract.kt
@@ -29,26 +29,42 @@ class PaymentLauncherContract :
 
     sealed class Args(
         @InjectorKey open val injectorKey: Int,
+        open val publishableKey: String,
+        open val stripeAccountId: String?,
+        open val enableLogging: Boolean,
+        open val productUsage: Set<String>
     ) : Parcelable {
         fun toBundle() = bundleOf(EXTRA_ARGS to this)
 
         @Parcelize
         data class IntentConfirmationArgs(
             override val injectorKey: Int,
+            override val publishableKey: String,
+            override val stripeAccountId: String?,
+            override val enableLogging: Boolean,
+            override val productUsage: Set<String>,
             val confirmStripeIntentParams: ConfirmStripeIntentParams
-        ) : Args(injectorKey)
+        ) : Args(injectorKey, publishableKey, stripeAccountId, enableLogging, productUsage)
 
         @Parcelize
         data class PaymentIntentNextActionArgs(
             override val injectorKey: Int,
+            override val publishableKey: String,
+            override val stripeAccountId: String?,
+            override val enableLogging: Boolean,
+            override val productUsage: Set<String>,
             val paymentIntentClientSecret: String
-        ) : Args(injectorKey)
+        ) : Args(injectorKey, publishableKey, stripeAccountId, enableLogging, productUsage)
 
         @Parcelize
         data class SetupIntentNextActionArgs(
             override val injectorKey: Int,
+            override val publishableKey: String,
+            override val stripeAccountId: String?,
+            override val enableLogging: Boolean,
+            override val productUsage: Set<String>,
             val setupIntentClientSecret: String
-        ) : Args(injectorKey)
+        ) : Args(injectorKey, publishableKey, stripeAccountId, enableLogging, productUsage)
 
         internal companion object {
             private const val EXTRA_ARGS = "extra_args"

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -1,19 +1,21 @@
 package com.stripe.android.payments.paymentlauncher
 
+import android.app.Application
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.AbstractSavedStateViewModelFactory
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import androidx.savedstate.SavedStateRegistryOwner
+import com.stripe.android.Logger
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.exception.APIException
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
-import com.stripe.android.model.PaymentIntent
-import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.AnalyticsEvent
 import com.stripe.android.networking.AnalyticsRequestFactory
@@ -25,11 +27,13 @@ import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.payments.PaymentIntentFlowResultProcessor
 import com.stripe.android.payments.SetupIntentFlowResultProcessor
 import com.stripe.android.payments.core.authentication.PaymentAuthenticatorRegistry
+import com.stripe.android.payments.core.injection.DaggerPaymentLauncherViewModelFactoryComponent
 import com.stripe.android.payments.core.injection.Injectable
-import com.stripe.android.payments.core.injection.InjectorKey
 import com.stripe.android.payments.core.injection.UIContext
 import com.stripe.android.payments.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.view.AuthActivityStarterHost
+import dagger.Lazy
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -41,18 +45,20 @@ import kotlin.coroutines.CoroutineContext
  */
 
 internal class PaymentLauncherViewModel(
+    private val isPaymentIntent: Boolean,
     private val stripeApiRepository: StripeRepository,
     private val authenticatorRegistry: PaymentAuthenticatorRegistry,
     private val defaultReturnUrl: DefaultReturnUrl,
     private val apiRequestOptionsProvider: Provider<ApiRequest.Options>,
     private val threeDs1IntentReturnUrlMap: MutableMap<String, String>,
-    private val lazyPaymentIntentFlowResultProcessor: dagger.Lazy<PaymentIntentFlowResultProcessor>,
-    private val lazySetupIntentFlowResultProcessor: dagger.Lazy<SetupIntentFlowResultProcessor>,
+    private val lazyPaymentIntentFlowResultProcessor: Lazy<PaymentIntentFlowResultProcessor>,
+    private val lazySetupIntentFlowResultProcessor: Lazy<SetupIntentFlowResultProcessor>,
     private val analyticsRequestExecutor: DefaultAnalyticsRequestExecutor,
     private val analyticsRequestFactory: AnalyticsRequestFactory,
     private val uiContext: CoroutineContext,
     private val authActivityStarterHost: AuthActivityStarterHost,
-    activityResultCaller: ActivityResultCaller
+    activityResultCaller: ActivityResultCaller,
+    private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
     init {
         authenticatorRegistry.onNewActivityResultCaller(
@@ -62,16 +68,25 @@ internal class PaymentLauncherViewModel(
     }
 
     /**
+     * Indicates if the [ViewModel] has complete handling a [StripeIntent].
+     * In cases when an [StripeIntent] is still being handled and the
+     * [PaymentLauncherConfirmationActivity] is recreated(e.g due to process is killed by system),
+     * this value will be set true, preventing [PaymentLauncherConfirmationActivity] to try to
+     * confirm the same [StripeIntent] again.
+     */
+    internal val hasStarted: Boolean
+        get() = savedStateHandle.get(KEY_HAS_STARTED) ?: false
+
+    /**
      * [PaymentResult] live data to be observed.
      */
     internal val paymentLauncherResult = MutableLiveData<PaymentResult>()
-
-    lateinit var stripeIntent: StripeIntent
 
     /**
      * Confirms a payment intent or setup intent
      */
     internal suspend fun confirmStripeIntent(confirmStripeIntentParams: ConfirmStripeIntentParams) {
+        savedStateHandle.set(KEY_HAS_STARTED, true)
         logReturnUrl(confirmStripeIntentParams.returnUrl)
         val returnUrl = confirmStripeIntentParams.returnUrl.takeUnless { it.isNullOrBlank() }
             ?: defaultReturnUrl.value
@@ -86,7 +101,6 @@ internal class PaymentLauncherViewModel(
                         }
                     }
                 }
-                stripeIntent = intent
                 authenticatorRegistry.getAuthenticator(intent).authenticate(
                     authActivityStarterHost,
                     intent,
@@ -132,6 +146,7 @@ internal class PaymentLauncherViewModel(
      * Fetches a [StripeIntent] and handles its next action.
      */
     internal suspend fun handleNextActionForStripeIntent(clientSecret: String) {
+        savedStateHandle.set(KEY_HAS_STARTED, true)
         runCatching {
             requireNotNull(
                 stripeApiRepository.retrieveStripeIntent(
@@ -141,7 +156,6 @@ internal class PaymentLauncherViewModel(
             )
         }.fold(
             onSuccess = { intent ->
-                stripeIntent = intent
                 authenticatorRegistry.getAuthenticator(intent)
                     .authenticate(
                         authActivityStarterHost,
@@ -159,13 +173,10 @@ internal class PaymentLauncherViewModel(
     internal fun onPaymentFlowResult(paymentFlowResult: PaymentFlowResult.Unvalidated) {
         viewModelScope.launch {
             runCatching {
-                when (stripeIntent) {
-                    is PaymentIntent -> {
-                        lazyPaymentIntentFlowResultProcessor.get()
-                    }
-                    is SetupIntent -> {
-                        lazySetupIntentFlowResultProcessor.get()
-                    }
+                if (isPaymentIntent) {
+                    lazyPaymentIntentFlowResultProcessor.get()
+                } else {
+                    lazySetupIntentFlowResultProcessor.get()
                 }.processResult(paymentFlowResult)
             }.fold(
                 onSuccess = {
@@ -239,17 +250,20 @@ internal class PaymentLauncherViewModel(
     }
 
     internal class Factory(
-        @InjectorKey private val injectorKeyProvider: () -> Int,
+        private val argsSupplier: () -> PaymentLauncherContract.Args,
+        private val applicationSupplier: () -> Application,
         private val authActivityStarterHostProvider: () -> AuthActivityStarterHost,
-        private val activityResultCaller: ActivityResultCaller
-    ) : ViewModelProvider.Factory, Injectable<Factory.FallbackInitializeParam> {
+        private val activityResultCaller: ActivityResultCaller,
+        owner: SavedStateRegistryOwner,
+    ) : AbstractSavedStateViewModelFactory(owner, null),
+        Injectable<Factory.FallbackInitializeParam> {
         internal data class FallbackInitializeParam(
-            val enableLogging: Boolean
+            val application: Application,
+            val enableLogging: Boolean,
+            val publishableKey: String,
+            val stripeAccountId: String?,
+            val productUsage: Set<String>
         )
-
-        override fun fallbackInitialize(arg: FallbackInitializeParam) {
-            // TODO(ccen) to implement
-        }
 
         @Inject
         lateinit var stripeApiRepository: StripeRepository
@@ -267,10 +281,10 @@ internal class PaymentLauncherViewModel(
         lateinit var threeDs1IntentReturnUrlMap: MutableMap<String, String>
 
         @Inject
-        lateinit var lazyPaymentIntentFlowResultProcessor: dagger.Lazy<PaymentIntentFlowResultProcessor>
+        lateinit var lazyPaymentIntentFlowResultProcessor: Lazy<PaymentIntentFlowResultProcessor>
 
         @Inject
-        lateinit var lazySetupIntentFlowResultProcessor: dagger.Lazy<SetupIntentFlowResultProcessor>
+        lateinit var lazySetupIntentFlowResultProcessor: Lazy<SetupIntentFlowResultProcessor>
 
         @Inject
         lateinit var analyticsRequestExecutor: DefaultAnalyticsRequestExecutor
@@ -283,12 +297,42 @@ internal class PaymentLauncherViewModel(
         lateinit var uiContext: CoroutineContext
 
         @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-            WeakMapInjectorRegistry.retrieve(injectorKeyProvider())?.inject(this) ?: run {
-                throw IllegalArgumentException("Failed to initialize PaymentLauncherViewModel.Factory")
+        override fun <T : ViewModel?> create(
+            key: String,
+            modelClass: Class<T>,
+            handle: SavedStateHandle
+        ): T {
+            val arg = argsSupplier()
+            val logger = Logger.getInstance(arg.enableLogging)
+            WeakMapInjectorRegistry.retrieve(arg.injectorKey)?.let {
+                logger.info("Injector available, injecting dependencies into PaymentLauncherViewModel.Factory")
+                it.inject(this)
+            } ?: run {
+                logger.info("Injector unavailable, initializing dependencies of PaymentLauncherViewModel.Factory")
+                fallbackInitialize(
+                    FallbackInitializeParam(
+                        applicationSupplier(),
+                        arg.enableLogging,
+                        arg.publishableKey,
+                        arg.stripeAccountId,
+                        arg.productUsage
+                    )
+                )
+            }
+
+            val isPaymentIntent = when (arg) {
+                is PaymentLauncherContract.Args.IntentConfirmationArgs -> {
+                    when (arg.confirmStripeIntentParams) {
+                        is ConfirmPaymentIntentParams -> true
+                        is ConfirmSetupIntentParams -> false
+                    }
+                }
+                is PaymentLauncherContract.Args.PaymentIntentNextActionArgs -> true
+                is PaymentLauncherContract.Args.SetupIntentNextActionArgs -> false
             }
 
             return PaymentLauncherViewModel(
+                isPaymentIntent,
                 stripeApiRepository,
                 authenticatorRegistry,
                 defaultReturnUrl,
@@ -300,8 +344,25 @@ internal class PaymentLauncherViewModel(
                 analyticsRequestFactory,
                 uiContext,
                 authActivityStarterHostProvider(),
-                activityResultCaller
+                activityResultCaller,
+                handle
             ) as T
+        }
+
+        /**
+         * Fallback call to initialize dependencies when injection is not available, this might happen
+         * when app process is killed by system and [WeakMapInjectorRegistry] is cleared.
+         */
+        override fun fallbackInitialize(arg: FallbackInitializeParam) {
+            DaggerPaymentLauncherViewModelFactoryComponent.builder()
+                .context(arg.application)
+                .enableLogging(arg.enableLogging)
+                .ioContext(Dispatchers.IO)
+                .uiContext(Dispatchers.Main)
+                .publishableKeyProvider { arg.publishableKey }
+                .stripeAccountIdProvider { arg.stripeAccountId }
+                .productUsage(arg.productUsage)
+                .build().inject(this)
         }
     }
 
@@ -310,5 +371,8 @@ internal class PaymentLauncherViewModel(
         const val UNKNOWN_ERROR = "Payment fails due to unknown error. \n"
         const val REQUIRED_ERROR = "API request returned an invalid response."
         val EXPAND_PAYMENT_METHOD = listOf("payment_method")
+
+        @VisibleForTesting
+        internal const val KEY_HAS_STARTED = "key_has_started"
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncher.kt
@@ -30,16 +30,16 @@ import kotlin.coroutines.CoroutineContext
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class StripePaymentLauncher @AssistedInject internal constructor(
-    @Assisted(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
-    @Assisted(STRIPE_ACCOUNT_ID) stripeAccountIdProvider: () -> String?,
+    @Assisted(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String,
+    @Assisted(STRIPE_ACCOUNT_ID) private val stripeAccountIdProvider: () -> String?,
     @Assisted private val hostActivityLauncher: ActivityResultLauncher<PaymentLauncherContract.Args>,
     context: Context,
-    @Named(ENABLE_LOGGING) enableLogging: Boolean,
+    @Named(ENABLE_LOGGING) private val enableLogging: Boolean,
     @IOContext ioContext: CoroutineContext,
     @UIContext uiContext: CoroutineContext,
     stripeRepository: StripeRepository,
     analyticsRequestFactory: AnalyticsRequestFactory,
-    @Named(PRODUCT_USAGE) productUsage: Set<String>
+    @Named(PRODUCT_USAGE) private val productUsage: Set<String>
 ) : PaymentLauncher, Injector {
     private val paymentLauncherComponent: PaymentLauncherComponent =
         DaggerPaymentLauncherComponent.builder()
@@ -76,6 +76,10 @@ class StripePaymentLauncher @AssistedInject internal constructor(
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.IntentConfirmationArgs(
                 injectorKey = injectorKey,
+                publishableKey = publishableKeyProvider(),
+                stripeAccountId = stripeAccountIdProvider(),
+                enableLogging = enableLogging,
+                productUsage = productUsage,
                 confirmStripeIntentParams = params
             )
         )
@@ -85,6 +89,10 @@ class StripePaymentLauncher @AssistedInject internal constructor(
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.IntentConfirmationArgs(
                 injectorKey = injectorKey,
+                publishableKey = publishableKeyProvider(),
+                stripeAccountId = stripeAccountIdProvider(),
+                enableLogging = enableLogging,
+                productUsage = productUsage,
                 confirmStripeIntentParams = params
             )
         )
@@ -94,6 +102,10 @@ class StripePaymentLauncher @AssistedInject internal constructor(
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.PaymentIntentNextActionArgs(
                 injectorKey = injectorKey,
+                publishableKey = publishableKeyProvider(),
+                stripeAccountId = stripeAccountIdProvider(),
+                enableLogging = enableLogging,
+                productUsage = productUsage,
                 paymentIntentClientSecret = clientSecret
             )
         )
@@ -103,6 +115,10 @@ class StripePaymentLauncher @AssistedInject internal constructor(
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.SetupIntentNextActionArgs(
                 injectorKey = injectorKey,
+                publishableKey = publishableKeyProvider(),
+                stripeAccountId = stripeAccountIdProvider(),
+                enableLogging = enableLogging,
+                productUsage = productUsage,
                 setupIntentClientSecret = clientSecret
             )
         )

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivityTest.kt
@@ -2,9 +2,14 @@ package com.stripe.android.payments.paymentlauncher
 
 import android.content.Intent
 import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.model.ConfirmStripeIntentParams
+import com.stripe.android.payments.core.injection.Injectable
+import com.stripe.android.payments.core.injection.Injector
+import com.stripe.android.payments.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.TestUtils
 import com.stripe.android.utils.injectableActivityScenario
@@ -35,6 +40,10 @@ class PaymentLauncherConfirmationActivityTest {
             ).putExtras(
                 PaymentLauncherContract.Args.IntentConfirmationArgs(
                     INJECTOR_KEY,
+                    ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                    TEST_STRIPE_ACCOUNT_ID,
+                    false,
+                    PRODUCT_USAGE,
                     confirmStripeIntentParams
                 ).toBundle()
             )
@@ -55,10 +64,7 @@ class PaymentLauncherConfirmationActivityTest {
                 ApplicationProvider.getApplicationContext(),
                 PaymentLauncherConfirmationActivity::class.java
             ).putExtras(
-                PaymentLauncherContract.Args.PaymentIntentNextActionArgs(
-                    INJECTOR_KEY,
-                    CLIENT_SECRET
-                ).toBundle()
+                PAYMENT_INTENT_NEXT_ACTION_ARGS.toBundle()
             )
         ).use {
             it.onActivity {
@@ -79,6 +85,10 @@ class PaymentLauncherConfirmationActivityTest {
             ).putExtras(
                 PaymentLauncherContract.Args.SetupIntentNextActionArgs(
                     INJECTOR_KEY,
+                    ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                    TEST_STRIPE_ACCOUNT_ID,
+                    false,
+                    PRODUCT_USAGE,
                     CLIENT_SECRET
                 ).toBundle()
             )
@@ -99,14 +109,60 @@ class PaymentLauncherConfirmationActivityTest {
                 PaymentLauncherConfirmationActivity::class.java
             )
         ).use { activityScenario ->
-            Truth.assertThat(activityScenario.state)
+            assertThat(activityScenario.state)
                 .isEqualTo(Lifecycle.State.DESTROYED)
             val result =
                 PaymentResult.fromIntent(activityScenario.getResult().resultData) as PaymentResult.Failed
-            Truth.assertThat(result.throwable.message)
+            assertThat(result.throwable.message)
                 .isEqualTo(
                     PaymentLauncherConfirmationActivity.EMPTY_ARG_ERROR
                 )
+        }
+    }
+
+    @Test
+    fun `viewModelFactory gets initialized by Injector when Injector is available`() {
+        val injector = object : Injector {
+            override fun inject(injectable: Injectable<*>) {
+                val factory = injectable as PaymentLauncherViewModel.Factory
+                factory.stripeApiRepository = mock()
+                factory.authenticatorRegistry = mock()
+                factory.defaultReturnUrl = mock()
+                factory.apiRequestOptionsProvider = mock()
+                factory.threeDs1IntentReturnUrlMap = mock()
+                factory.lazyPaymentIntentFlowResultProcessor = mock()
+                factory.lazySetupIntentFlowResultProcessor = mock()
+                factory.analyticsRequestExecutor = mock()
+                factory.analyticsRequestFactory = mock()
+                factory.uiContext = mock()
+            }
+        }
+        WeakMapInjectorRegistry.register(injector, INJECTOR_KEY)
+
+        ActivityScenario.launch<PaymentLauncherConfirmationActivity>(
+            Intent(
+                ApplicationProvider.getApplicationContext(),
+                PaymentLauncherConfirmationActivity::class.java
+            ).putExtras(
+                PAYMENT_INTENT_NEXT_ACTION_ARGS.toBundle()
+            )
+        ).use { activityScenario ->
+            assertThat(activityScenario.state).isEqualTo(Lifecycle.State.RESUMED)
+        }
+        WeakMapInjectorRegistry.staticCacheMap.clear()
+    }
+
+    @Test
+    fun `viewModelFactory gets initialized with fallback when no Injector is available`() {
+        ActivityScenario.launch<PaymentLauncherConfirmationActivity>(
+            Intent(
+                ApplicationProvider.getApplicationContext(),
+                PaymentLauncherConfirmationActivity::class.java
+            ).putExtras(
+                PAYMENT_INTENT_NEXT_ACTION_ARGS.toBundle()
+            )
+        ).use { activityScenario ->
+            assertThat(activityScenario.state).isEqualTo(Lifecycle.State.RESUMED)
         }
     }
 
@@ -122,5 +178,16 @@ class PaymentLauncherConfirmationActivityTest {
     private companion object {
         const val INJECTOR_KEY = 1
         const val CLIENT_SECRET = "clientSecret"
+        const val TEST_STRIPE_ACCOUNT_ID = "accountId"
+        val PRODUCT_USAGE = setOf("TestProductUsage")
+        val PAYMENT_INTENT_NEXT_ACTION_ARGS =
+            PaymentLauncherContract.Args.PaymentIntentNextActionArgs(
+                INJECTOR_KEY,
+                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                TEST_STRIPE_ACCOUNT_ID,
+                false,
+                PRODUCT_USAGE,
+                CLIENT_SECRET
+            )
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
When the app process is killed by system, `WeakMapInjectorRegistry` will be cleared, all `Injectable`s that rely on it won't have correct `Injector` available. If this happens, `Injectable` needs to bootstrap its own dependency graph.

The following changes are made:
1. Implement `Injectable.fallbackInitialize` for `PaymentLauncherViewModel.Factory`
    - Create a `PaymentLauncherViewModelFactoryComponent` with required dependencies in the fallback
    - The component needs `PaymentLauncherModule` and `StripeRepositoryModule`: the former is used for regular [StripePaymentLauncher](https://github.com/stripe/stripe-android/blob/485c76fcfa3579f3c882447108df5ee6d0338035/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncher.kt#L45) injection, where `StripeRepository` is passed as a parameter from outside; the later is needed for self bootstrap to recreate `StripeRepository`


Fixing #4167


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Currently there are 3 `Injectable` implementations, will address them one with a PR.
1. [Stripe3ds2TransactionViewModelFactory](Stripe3ds2TransactionViewModelFactory) - fixed in #4176
2. [PaymentOptionsViewModel.Factory](https://github.com/stripe/stripe-android/blob/86633d4682cc80a9ea173a70f8f5cb105d6a37b4/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt#L122)
3. [PaymentLauncherViewModel.Factory](https://github.com/stripe/stripe-android/blob/86633d4682cc80a9ea173a70f8f5cb105d6a37b4/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt#L241)- fixed in this PR


# Testing
<!-- How was the code tested? Be as specific as possible. -->
Note: two tests are added in `StripePaymentLauncherTest`, mimicking the case when `Injector` is available and is unavailable. 
- [x] Added tests
- [x] Modified tests
- [x] Manually verified



