### PR TITLE
[3 of 3] Provide a fallback injection mechanisom when app process is killed by system

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -537,11 +537,11 @@ public final class com/stripe/android/paymentsheet/flowcontroller/DefaultFlowCon
 }
 
 public final class com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowController_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowController_Factory;
 	public fun get ()Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowController;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lkotlinx/coroutines/CoroutineScope;Landroidx/lifecycle/LifecycleOwner;Lkotlin/jvm/functions/Function0;Lcom/stripe/android/paymentsheet/model/PaymentOptionFactory;Lcom/stripe/android/paymentsheet/PaymentOptionCallback;Lcom/stripe/android/paymentsheet/PaymentSheetResultCallback;Landroidx/activity/result/ActivityResultCaller;ILcom/stripe/android/paymentsheet/flowcontroller/FlowControllerInitializer;Lcom/stripe/android/paymentsheet/analytics/EventReporter;Lcom/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel;Lcom/stripe/android/payments/paymentlauncher/StripePaymentLauncherAssistedFactory;Ldagger/Lazy;Lkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowController;
+	public static fun newInstance (Lkotlinx/coroutines/CoroutineScope;Landroidx/lifecycle/LifecycleOwner;Lkotlin/jvm/functions/Function0;Lcom/stripe/android/paymentsheet/model/PaymentOptionFactory;Lcom/stripe/android/paymentsheet/PaymentOptionCallback;Lcom/stripe/android/paymentsheet/PaymentSheetResultCallback;Landroidx/activity/result/ActivityResultCaller;ILcom/stripe/android/paymentsheet/flowcontroller/FlowControllerInitializer;Lcom/stripe/android/paymentsheet/analytics/EventReporter;Lcom/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel;Lcom/stripe/android/payments/paymentlauncher/StripePaymentLauncherAssistedFactory;Ldagger/Lazy;Lkotlin/coroutines/CoroutineContext;ZLjava/util/Set;)Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowController;
 }
 
 public final class com/stripe/android/paymentsheet/forms/FormViewModel_Factory : dagger/internal/Factory {
@@ -561,6 +561,11 @@ public final class com/stripe/android/paymentsheet/injection/DaggerFlowControlle
 public final class com/stripe/android/paymentsheet/injection/DaggerFormViewModelComponent : com/stripe/android/paymentsheet/injection/FormViewModelComponent {
 	public static fun builder ()Lcom/stripe/android/paymentsheet/injection/FormViewModelComponent$Builder;
 	public fun getViewModel ()Lcom/stripe/android/paymentsheet/forms/FormViewModel;
+}
+
+public final class com/stripe/android/paymentsheet/injection/DaggerPaymentOptionsViewModelFactoryComponent : com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent {
+	public static fun builder ()Lcom/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent$Builder;
+	public fun inject (Lcom/stripe/android/paymentsheet/PaymentOptionsViewModel$Factory;)V
 }
 
 public final class com/stripe/android/paymentsheet/injection/DaggerPaymentSheetViewModelComponent : com/stripe/android/paymentsheet/injection/PaymentSheetViewModelComponent {
@@ -606,6 +611,38 @@ public final class com/stripe/android/paymentsheet/injection/FlowControllerModul
 	public fun get ()Lcom/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
 	public static fun provideViewModel (Landroidx/lifecycle/ViewModelStoreOwner;)Lcom/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel;
+}
+
+public final class com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule_ProvideEventReporterModeFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule;)V
+	public static fun create (Lcom/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule;)Lcom/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule_ProvideEventReporterModeFactory;
+	public fun get ()Lcom/stripe/android/paymentsheet/analytics/EventReporter$Mode;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideEventReporterMode (Lcom/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule;)Lcom/stripe/android/paymentsheet/analytics/EventReporter$Mode;
+}
+
+public final class com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule_ProvidePaymentConfigurationFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule_ProvidePaymentConfigurationFactory;
+	public fun get ()Lcom/stripe/android/PaymentConfiguration;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun providePaymentConfiguration (Lcom/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule;Landroid/content/Context;)Lcom/stripe/android/PaymentConfiguration;
+}
+
+public final class com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule_ProvidePrefsRepositoryFactoryFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule_ProvidePrefsRepositoryFactoryFactory;
+	public synthetic fun get ()Ljava/lang/Object;
+	public fun get ()Lkotlin/jvm/functions/Function1;
+	public static fun providePrefsRepositoryFactory (Lcom/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule;Landroid/content/Context;Lkotlin/coroutines/CoroutineContext;)Lkotlin/jvm/functions/Function1;
+}
+
+public final class com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule_ProvidePublishableKeyFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule_ProvidePublishableKeyFactory;
+	public synthetic fun get ()Ljava/lang/Object;
+	public fun get ()Lkotlin/jvm/functions/Function0;
+	public static fun providePublishableKey (Lcom/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule;Lcom/stripe/android/PaymentConfiguration;)Lkotlin/jvm/functions/Function0;
 }
 
 public final class com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule_Companion_ProvideEnabledLoggingFactory : dagger/internal/Factory {

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -116,6 +116,7 @@ dependencies {
 
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+    testImplementation "org.mockito:mockito-inline:$mockitoCoreVersion"
     testImplementation 'org.robolectric:robolectric:4.6.1'
     testImplementation "androidx.test:core:$androidTestVersion"
     testImplementation 'org.json:json:20210307'

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionContract.kt
@@ -36,7 +36,9 @@ internal class PaymentOptionContract :
         val isGooglePayReady: Boolean,
         val newCard: PaymentSelection.New.Card?,
         @ColorInt val statusBarColor: Int?,
-        @InjectorKey val injectorKey: Int
+        @InjectorKey val injectorKey: Int,
+        val enableLogging: Boolean,
+        val productUsage: Set<String>
     ) : ActivityStarter.Args {
         internal companion object {
             internal fun fromIntent(intent: Intent): Args? {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -6,10 +6,12 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import com.stripe.android.Logger
 import com.stripe.android.payments.core.injection.IOContext
 import com.stripe.android.payments.core.injection.Injectable
 import com.stripe.android.payments.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.injection.DaggerPaymentOptionsViewModelFactoryComponent
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
@@ -124,11 +126,15 @@ internal class PaymentOptionsViewModel(
         private val starterArgsSupplier: () -> PaymentOptionContract.Args
     ) : ViewModelProvider.Factory, Injectable<Factory.FallbackInitializeParam> {
         internal data class FallbackInitializeParam(
-            val enableLogging: Boolean
+            val application: Application,
+            val productUsage: Set<String>
         )
 
         override fun fallbackInitialize(arg: FallbackInitializeParam) {
-            // TODO(ccen) to implement
+            DaggerPaymentOptionsViewModelFactoryComponent.builder()
+                .context(arg.application)
+                .productUsage(arg.productUsage)
+                .build().inject(this)
         }
 
         @Inject
@@ -148,14 +154,26 @@ internal class PaymentOptionsViewModel(
 
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-            WeakMapInjectorRegistry.retrieve(starterArgsSupplier().injectorKey)?.inject(this)
-                ?: run {
-                    throw IllegalArgumentException(
-                        "Failed to initialize PaymentOptionsViewModel.Factory"
-                    )
-                }
-
+            val application = applicationSupplier()
             val starterArgs = starterArgsSupplier()
+
+            val logger = Logger.getInstance(starterArgs.enableLogging)
+            WeakMapInjectorRegistry.retrieve(starterArgsSupplier().injectorKey)?.let {
+                logger.info(
+                    "Injector available, " +
+                        "injecting dependencies into PaymentOptionsViewModel.Factory"
+                )
+                it.inject(this)
+            } ?: run {
+                logger.info(
+                    "Injector unavailable, " +
+                        "initializing dependencies of PaymentOptionsViewModel.Factory"
+                )
+                fallbackInitialize(
+                    FallbackInitializeParam(application, starterArgs.productUsage)
+                )
+            }
+
             return PaymentOptionsViewModel(
                 starterArgs,
                 prefsRepositoryFactory(starterArgs.config?.customer),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -18,9 +18,11 @@ import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContra
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.PaymentIntent
+import com.stripe.android.payments.core.injection.ENABLE_LOGGING
 import com.stripe.android.payments.core.injection.Injectable
 import com.stripe.android.payments.core.injection.Injector
 import com.stripe.android.payments.core.injection.InjectorKey
+import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.core.injection.UIContext
 import com.stripe.android.payments.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.payments.paymentlauncher.PaymentLauncher
@@ -52,6 +54,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
+import javax.inject.Named
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
@@ -76,7 +79,9 @@ internal class DefaultFlowController @Inject internal constructor(
      * stripeAccountId after creating a [DefaultFlowController].
      */
     private val lazyPaymentConfiguration: Lazy<PaymentConfiguration>,
-    @UIContext private val uiContext: CoroutineContext
+    @UIContext private val uiContext: CoroutineContext,
+    @Named(ENABLE_LOGGING) private val enableLogging: Boolean,
+    @Named(PRODUCT_USAGE) private val productUsage: Set<String>
 ) : PaymentSheet.FlowController, Injector {
     private val paymentOptionActivityLauncher: ActivityResultLauncher<PaymentOptionContract.Args>
     private var googlePayActivityLauncher:
@@ -200,7 +205,9 @@ internal class DefaultFlowController @Inject internal constructor(
                 isGooglePayReady = initData.isGooglePayReady,
                 newCard = viewModel.paymentSelection as? PaymentSelection.New.Card,
                 statusBarColor = statusBarColor(),
-                injectorKey = injectorKey
+                injectorKey = injectorKey,
+                enableLogging = enableLogging,
+                productUsage = productUsage
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
@@ -1,0 +1,33 @@
+package com.stripe.android.paymentsheet.injection
+
+import android.content.Context
+import com.stripe.android.payments.core.injection.PRODUCT_USAGE
+import com.stripe.android.payments.core.injection.StripeRepositoryModule
+import com.stripe.android.paymentsheet.PaymentOptionsViewModel
+import dagger.BindsInstance
+import dagger.Component
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+@Component(
+    modules = [
+        StripeRepositoryModule::class,
+        PaymentSheetCommonModule::class,
+        PaymentOptionsViewModelModule::class
+    ]
+)
+internal interface PaymentOptionsViewModelFactoryComponent {
+    fun inject(factory: PaymentOptionsViewModel.Factory)
+
+    @Component.Builder
+    interface Builder {
+        @BindsInstance
+        fun context(context: Context): Builder
+
+        @BindsInstance
+        fun productUsage(@Named(PRODUCT_USAGE) productUsage: Set<String>): Builder
+
+        fun build(): PaymentOptionsViewModelFactoryComponent
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule.kt
@@ -1,0 +1,48 @@
+package com.stripe.android.paymentsheet.injection
+
+import android.content.Context
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.payments.core.injection.IOContext
+import com.stripe.android.payments.core.injection.PUBLISHABLE_KEY
+import com.stripe.android.paymentsheet.DefaultPrefsRepository
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PrefsRepository
+import com.stripe.android.paymentsheet.analytics.EventReporter
+import dagger.Module
+import dagger.Provides
+import javax.inject.Named
+import javax.inject.Singleton
+import kotlin.coroutines.CoroutineContext
+
+@Module
+internal class PaymentOptionsViewModelModule {
+    @Provides
+    fun providePaymentConfiguration(appContext: Context): PaymentConfiguration {
+        return PaymentConfiguration.getInstance(appContext)
+    }
+
+    @Provides
+    @Named(PUBLISHABLE_KEY)
+    fun providePublishableKey(paymentConfiguration: PaymentConfiguration): () -> String {
+        return { paymentConfiguration.publishableKey }
+    }
+
+    @Provides
+    @Singleton
+    fun provideEventReporterMode(): EventReporter.Mode = EventReporter.Mode.Custom
+
+    @Provides
+    @Singleton
+    fun providePrefsRepositoryFactory(
+        appContext: Context,
+        @IOContext workContext: CoroutineContext
+    ): (PaymentSheet.CustomerConfiguration?) -> PrefsRepository = { customerConfig ->
+        customerConfig?.let {
+            DefaultPrefsRepository(
+                appContext,
+                it.id,
+                workContext
+            )
+        } ?: PrefsRepository.Noop()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -305,7 +305,9 @@ class PaymentOptionsActivityTest {
             isGooglePayReady = false,
             newCard = null,
             statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR,
-            injectorKey = 0
+            injectorKey = 0,
+            enableLogging = false,
+            productUsage = mock()
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAddPaymentMethodFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAddPaymentMethodFragmentTest.kt
@@ -70,7 +70,9 @@ class PaymentOptionsAddPaymentMethodFragmentTest {
             isGooglePayReady = false,
             newCard = null,
             statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR,
-            injectorKey = MOCK_INJECTOR_KEY
+            injectorKey = MOCK_INJECTOR_KEY,
+            enableLogging = false,
+            productUsage = mock()
         ),
         fragmentConfig: FragmentConfig? = FragmentConfigFixtures.DEFAULT,
         onReady: (PaymentOptionsAddPaymentMethodFragment, FragmentPaymentsheetAddPaymentMethodBinding) -> Unit

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -1,13 +1,18 @@
 package com.stripe.android.paymentsheet
 
+import android.app.Application
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures.DEFAULT_CARD
 import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.payments.core.injection.Injectable
+import com.stripe.android.payments.core.injection.Injector
+import com.stripe.android.payments.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.paymentsheet.PaymentOptionsViewModel.TransitionTarget
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.FragmentConfigFixtures
@@ -22,7 +27,11 @@ import kotlinx.coroutines.test.runBlockingTest
 import kotlinx.coroutines.test.setMain
 import org.junit.Rule
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argWhere
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.AfterTest
@@ -203,6 +212,72 @@ internal class PaymentOptionsViewModelTest {
         assertThat(transitionTarget).hasSize(2)
     }
 
+    @Test
+    fun `Factory gets initialized by Injector when Injector is available`() {
+        val injector = object : Injector {
+            override fun inject(injectable: Injectable<*>) {
+                val factory = injectable as PaymentOptionsViewModel.Factory
+                factory.eventReporter = mock()
+                factory.customerRepository = mock()
+                factory.workContext = TestCoroutineDispatcher()
+                factory.prefsRepositoryFactory = { mock() }
+            }
+        }
+        val injectorKey = 1
+        WeakMapInjectorRegistry.register(injector, injectorKey)
+        val factory = PaymentOptionsViewModel.Factory(
+            { ApplicationProvider.getApplicationContext() },
+            {
+                PaymentOptionContract.Args(
+                    mock(),
+                    mock(),
+                    null,
+                    false,
+                    null,
+                    null,
+                    injectorKey,
+                    false,
+                    mock()
+                )
+            }
+        )
+        val factorySpy = spy(factory)
+        factorySpy.create(PaymentOptionsViewModel::class.java)
+        verify(factorySpy, times(0)).fallbackInitialize(any())
+
+        WeakMapInjectorRegistry.staticCacheMap.clear()
+    }
+
+    @Test
+    fun `Factory gets initialized with fallback when no Injector is available`() = runBlockingTest {
+        val context = ApplicationProvider.getApplicationContext<Application>()
+        val productUsage = setOf("TestProductUsage")
+        PaymentConfiguration.init(context, "testKey")
+        val factory = PaymentOptionsViewModel.Factory(
+            { context },
+            {
+                PaymentOptionContract.Args(
+                    mock(),
+                    mock(),
+                    null,
+                    false,
+                    null,
+                    null,
+                    1,
+                    false,
+                    productUsage
+                )
+            }
+        )
+        val factorySpy = spy(factory)
+        factorySpy.create(PaymentOptionsViewModel::class.java)
+        verify(factorySpy).fallbackInitialize(
+            argWhere {
+                it.application == context && it.productUsage == productUsage
+            }
+        )
+    }
+
     private companion object {
         private val SELECTION_SAVED_PAYMENT_METHOD = PaymentSelection.Saved(
             PaymentMethodFixtures.CARD_PAYMENT_METHOD
@@ -232,7 +307,9 @@ internal class PaymentOptionsViewModelTest {
             isGooglePayReady = true,
             newCard = null,
             statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR,
-            injectorKey = 0
+            injectorKey = 0,
+            enableLogging = false,
+            productUsage = mock()
         )
         private val PAYMENT_METHOD_REPOSITORY_PARAMS =
             listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -271,7 +271,9 @@ internal class DefaultFlowControllerTest {
                         activity,
                         R.color.stripe_toolbar_color_default_dark
                     ),
-                    injectorKey = INJECTOR_KEY
+                    injectorKey = INJECTOR_KEY,
+                    enableLogging = ENABLE_LOGGING,
+                    productUsage = PRODUCT_USAGE
                 )
             }
 
@@ -661,7 +663,9 @@ internal class DefaultFlowControllerTest {
         ViewModelProvider(activity)[FlowControllerViewModel::class.java],
         paymentLauncherAssistedFactory,
         { PaymentConfiguration.getInstance(activity) },
-        testDispatcher
+        testDispatcher,
+        ENABLE_LOGGING,
+        PRODUCT_USAGE
     )
 
     private class FakeFlowControllerInitializer(
@@ -726,6 +730,8 @@ internal class DefaultFlowControllerTest {
         private val PAYMENT_METHODS =
             listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD) + PaymentMethodFixtures.createCards(5)
 
-        private val INJECTOR_KEY = 0
+        private const val INJECTOR_KEY = 0
+        private const val ENABLE_LOGGING = false
+        private val PRODUCT_USAGE = setOf("TestProductUsage")
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
When the app process is killed by system, `WeakMapInjectorRegistry` will be cleared, all `Injectable`s that rely on it won't have correct `Injector` available. If this happens, `Injectable` needs to bootstrap its own dependency graph.

The following changes are made:
- Implement `Injectable.fallbackInitialize` for `PaymentOptionsViewModel.Factory`
    - Create a `PaymentOptionsViewModelFactoryComponent` with required dependencies in the fallback
        - Needs `StripeRepositoryModule` for `StripeRepository`
        - Reuses `PaymentSheetCommonModule`, note this module creates an [StripeIntentRepository](https://github.com/stripe/stripe-android/blob/8e00cc01f2899fbc1b81eb98ba7874e2b922edf7/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt#L37) that's not used for the Factory, but everything else is needed
        - Creates a new `PaymentOptionsViewModelModule` that provides the rest of deps required


Fixing #4167


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Currently there are 3 `Injectable` implementations, will address them one with a PR.
1. [Stripe3ds2TransactionViewModelFactory](Stripe3ds2TransactionViewModelFactory) - fixed in #4176
2. [PaymentOptionsViewModel.Factory](https://github.com/stripe/stripe-android/blob/86633d4682cc80a9ea173a70f8f5cb105d6a37b4/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt#L122) - fixed in this PR
3. [PaymentLauncherViewModel.Factory](https://github.com/stripe/stripe-android/blob/86633d4682cc80a9ea173a70f8f5cb105d6a37b4/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt#L241) - fixed in #4177


# Testing
<!-- How was the code tested? Be as specific as possible. -->
Note: two tests are added in `PaymentOptionsViewModelTest`, mimicking the case when `Injector` is available and is unavailable. 
- [x] Added tests
- [x] Modified tests
- [x] Manually verified



