### PR TITLE
Post Payment launcher cleanup

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -1143,7 +1143,7 @@ public final class com/stripe/android/googlepaylauncher/GooglePayLauncherModule_
 	public static fun provideGooglePayRepositoryFactory (Lcom/stripe/android/googlepaylauncher/GooglePayLauncherModule;Landroid/content/Context;Lcom/stripe/android/Logger;)Lkotlin/jvm/functions/Function1;
 }
 
-public class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher {
+public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher {
 	public static final field $stable I
 	public static final field Companion Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Companion;
 	public static final field DEVELOPER_ERROR I
@@ -1153,7 +1153,7 @@ public class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher
 	public fun <init> (Landroidx/fragment/app/Fragment;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Config;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$ReadyCallback;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$ResultCallback;)V
 	public final fun present (Ljava/lang/String;)V
 	public final fun present (Ljava/lang/String;I)V
-	public fun present (Ljava/lang/String;ILjava/lang/String;)V
+	public final fun present (Ljava/lang/String;ILjava/lang/String;)V
 	public static synthetic fun present$default (Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher;Ljava/lang/String;ILjava/lang/String;ILjava/lang/Object;)V
 }
 

--- a/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -48,7 +48,6 @@ import kotlin.coroutines.CoroutineContext
  * by the [PaymentIntent] or [SetupIntent] object.
  */
 internal class StripePaymentController
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) // For paymentsheet
 @VisibleForTesting
 constructor(
     context: Context,

--- a/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import androidx.activity.result.ActivityResultCallback
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
-import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.exception.APIConnectionException
 import com.stripe.android.exception.APIException

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -30,7 +30,7 @@ import java.util.Locale
  * See the [Google Pay integration guide](https://stripe.com/docs/google-pay) for more details.
  */
 @JvmSuppressWildcards
-open class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
+class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
     @Assisted lifecycleScope: CoroutineScope,
     @Assisted private val config: Config,
     @Assisted private val readyCallback: ReadyCallback,
@@ -152,7 +152,7 @@ open class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
      * This field is required when you send callbacks to the Google Transaction Events API.
      */
     @JvmOverloads
-    open fun present(
+    fun present(
         currencyCode: String,
         amount: Int = 0,
         transactionId: String? = null

--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
@@ -29,7 +29,7 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
     private val logger = Logger.getInstance(enableLogging)
     private val failureMessageFactory = PaymentFlowFailureMessageFactory(context)
 
-    open suspend fun processResult(
+    suspend fun processResult(
         unvalidatedResult: PaymentFlowResult.Unvalidated
     ): S = withContext(workContext) {
         val result = unvalidatedResult.validate()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FakeCustomerRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FakeCustomerRepository.kt
@@ -3,7 +3,7 @@ package com.stripe.android.paymentsheet
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 
-internal open class FakeCustomerRepository(
+internal class FakeCustomerRepository(
     private val paymentMethods: List<PaymentMethod> = emptyList()
 ) : CustomerRepository {
     lateinit var savedPaymentMethod: PaymentMethod


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Found some classes that are open, that do not need to be open while cleaning up after migration to PaymentLauncher

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
I want to double check these changes are okay and see if anyone has any other suggestions for places to look. I used these two commits to search: 
https://github.com/stripe/stripe-android/commit/6c0a99330a322729e01c3a902681fc4176d3ea2e
https://github.com/stripe/stripe-android/commit/c9dc6aa4a80c55f36396755f1454c6b42ea0d4dc

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

Confirmed building, confirmed unit tests run, and confirmed locally that everything behaves on device.

