### PR TITLE
Create a CoroutineContext module to inject IOContext and UIContext

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -5181,6 +5181,29 @@ public final class com/stripe/android/payments/core/injection/AuthenticationModu
 	public static fun providePaymentRelayStarterFactory (Ldagger/Lazy;)Lkotlin/jvm/functions/Function1;
 }
 
+public final class com/stripe/android/payments/core/injection/CoroutineContextModule {
+	public static final field $stable I
+	public fun <init> ()V
+	public final fun provideUIContext ()Lkotlin/coroutines/CoroutineContext;
+	public final fun provideWorkContext ()Lkotlin/coroutines/CoroutineContext;
+}
+
+public final class com/stripe/android/payments/core/injection/CoroutineContextModule_ProvideUIContextFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/payments/core/injection/CoroutineContextModule;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/CoroutineContextModule;)Lcom/stripe/android/payments/core/injection/CoroutineContextModule_ProvideUIContextFactory;
+	public synthetic fun get ()Ljava/lang/Object;
+	public fun get ()Lkotlin/coroutines/CoroutineContext;
+	public static fun provideUIContext (Lcom/stripe/android/payments/core/injection/CoroutineContextModule;)Lkotlin/coroutines/CoroutineContext;
+}
+
+public final class com/stripe/android/payments/core/injection/CoroutineContextModule_ProvideWorkContextFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/payments/core/injection/CoroutineContextModule;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/CoroutineContextModule;)Lcom/stripe/android/payments/core/injection/CoroutineContextModule_ProvideWorkContextFactory;
+	public synthetic fun get ()Ljava/lang/Object;
+	public fun get ()Lkotlin/coroutines/CoroutineContext;
+	public static fun provideWorkContext (Lcom/stripe/android/payments/core/injection/CoroutineContextModule;)Lkotlin/coroutines/CoroutineContext;
+}
+
 public final class com/stripe/android/payments/core/injection/DaggerAuthenticationComponent : com/stripe/android/payments/core/injection/AuthenticationComponent {
 	public static fun builder ()Lcom/stripe/android/payments/core/injection/AuthenticationComponent$Builder;
 	public fun getRegistry ()Lcom/stripe/android/payments/core/authentication/DefaultPaymentAuthenticatorRegistry;

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel.kt
@@ -32,7 +32,6 @@ import com.stripe.android.stripe3ds2.transaction.InitChallengeRepositoryFactory
 import com.stripe.android.stripe3ds2.transaction.IntentData
 import com.stripe.android.stripe3ds2.transaction.MessageVersionRegistry
 import com.stripe.android.stripe3ds2.transaction.Transaction
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -332,7 +331,6 @@ internal class Stripe3ds2TransactionViewModelFactory(
         DaggerStripe3ds2TransactionViewModelFactoryComponent.builder()
             .context(arg.application)
             .enableLogging(arg.enableLogging)
-            .workContext(Dispatchers.IO)
             .publishableKeyProvider { arg.publishableKey }
             .productUsage(arg.productUsage)
             .build()

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/CoroutineContextModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/CoroutineContextModule.kt
@@ -1,0 +1,20 @@
+package com.stripe.android.payments.core.injection
+
+import dagger.Module
+import dagger.Provides
+import kotlinx.coroutines.Dispatchers
+import javax.inject.Singleton
+import kotlin.coroutines.CoroutineContext
+
+@Module
+class CoroutineContextModule {
+    @Provides
+    @Singleton
+    @IOContext
+    fun provideWorkContext(): CoroutineContext = Dispatchers.IO
+
+    @Provides
+    @Singleton
+    @UIContext
+    fun provideUIContext(): CoroutineContext = Dispatchers.Main
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherViewModelFactoryComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherViewModelFactoryComponent.kt
@@ -6,7 +6,6 @@ import dagger.BindsInstance
 import dagger.Component
 import javax.inject.Named
 import javax.inject.Singleton
-import kotlin.coroutines.CoroutineContext
 
 /**
  * Component to inject [PaymentLauncherViewModel.Factory] when the app process is killed and
@@ -16,7 +15,8 @@ import kotlin.coroutines.CoroutineContext
 @Component(
     modules = [
         PaymentLauncherModule::class,
-        StripeRepositoryModule::class
+        StripeRepositoryModule::class,
+        CoroutineContextModule::class
     ]
 )
 internal interface PaymentLauncherViewModelFactoryComponent {
@@ -29,12 +29,6 @@ internal interface PaymentLauncherViewModelFactoryComponent {
 
         @BindsInstance
         fun enableLogging(@Named(ENABLE_LOGGING) enableLogging: Boolean): Builder
-
-        @BindsInstance
-        fun ioContext(@IOContext workContext: CoroutineContext): Builder
-
-        @BindsInstance
-        fun uiContext(@UIContext uiContext: CoroutineContext): Builder
 
         @BindsInstance
         fun publishableKeyProvider(@Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String): Builder

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelFactoryComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelFactoryComponent.kt
@@ -6,7 +6,6 @@ import dagger.BindsInstance
 import dagger.Component
 import javax.inject.Named
 import javax.inject.Singleton
-import kotlin.coroutines.CoroutineContext
 
 /**
  * Component to inject [Stripe3ds2TransactionViewModelFactory] when the app process is killed and
@@ -16,7 +15,8 @@ import kotlin.coroutines.CoroutineContext
 @Component(
     modules = [
         StripeRepositoryModule::class,
-        Stripe3ds2TransactionViewModelModule::class
+        Stripe3ds2TransactionViewModelModule::class,
+        CoroutineContextModule::class
     ]
 )
 internal interface Stripe3ds2TransactionViewModelFactoryComponent {
@@ -29,9 +29,6 @@ internal interface Stripe3ds2TransactionViewModelFactoryComponent {
 
         @BindsInstance
         fun enableLogging(@Named(ENABLE_LOGGING) enableLogging: Boolean): Builder
-
-        @BindsInstance
-        fun workContext(@IOContext workContext: CoroutineContext): Builder
 
         @BindsInstance
         fun publishableKeyProvider(

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -33,7 +33,6 @@ import com.stripe.android.payments.core.injection.UIContext
 import com.stripe.android.payments.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.view.AuthActivityStarterHost
 import dagger.Lazy
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -357,8 +356,6 @@ internal class PaymentLauncherViewModel(
             DaggerPaymentLauncherViewModelFactoryComponent.builder()
                 .context(arg.application)
                 .enableLogging(arg.enableLogging)
-                .ioContext(Dispatchers.IO)
-                .uiContext(Dispatchers.Main)
                 .publishableKeyProvider { arg.publishableKey }
                 .stripeAccountIdProvider { arg.stripeAccountId }
                 .productUsage(arg.productUsage)

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -669,22 +669,6 @@ public final class com/stripe/android/paymentsheet/injection/PaymentSheetCommonM
 	public static fun provideLogger (Z)Lcom/stripe/android/Logger;
 }
 
-public final class com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule_Companion_ProvideUIContextFactory : dagger/internal/Factory {
-	public fun <init> ()V
-	public static fun create ()Lcom/stripe/android/paymentsheet/injection/PaymentSheetCommonModule_Companion_ProvideUIContextFactory;
-	public synthetic fun get ()Ljava/lang/Object;
-	public fun get ()Lkotlin/coroutines/CoroutineContext;
-	public static fun provideUIContext ()Lkotlin/coroutines/CoroutineContext;
-}
-
-public final class com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule_Companion_ProvideWorkContextFactory : dagger/internal/Factory {
-	public fun <init> ()V
-	public static fun create ()Lcom/stripe/android/paymentsheet/injection/PaymentSheetCommonModule_Companion_ProvideWorkContextFactory;
-	public synthetic fun get ()Ljava/lang/Object;
-	public fun get ()Lkotlin/coroutines/CoroutineContext;
-	public static fun provideWorkContext ()Lkotlin/coroutines/CoroutineContext;
-}
-
 public final class com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_Companion_ProvideClientSecretFactory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;)V
 	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_Companion_ProvideClientSecretFactory;

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/FlowControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/FlowControllerComponent.kt
@@ -5,6 +5,7 @@ import androidx.activity.result.ActivityResultCaller
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelStoreOwner
 import com.stripe.android.googlepaylauncher.GooglePayLauncherModule
+import com.stripe.android.payments.core.injection.CoroutineContextModule
 import com.stripe.android.payments.core.injection.InjectorKey
 import com.stripe.android.payments.core.injection.PaymentCommonModule
 import com.stripe.android.paymentsheet.PaymentOptionCallback
@@ -23,7 +24,8 @@ import javax.inject.Singleton
         PaymentCommonModule::class,
         PaymentSheetCommonModule::class,
         FlowControllerModule::class,
-        GooglePayLauncherModule::class
+        GooglePayLauncherModule::class,
+        CoroutineContextModule::class
     ]
 )
 internal interface FlowControllerComponent {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.injection
 
 import android.content.Context
+import com.stripe.android.payments.core.injection.CoroutineContextModule
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.PaymentOptionsViewModel
@@ -14,7 +15,8 @@ import javax.inject.Singleton
     modules = [
         StripeRepositoryModule::class,
         PaymentSheetCommonModule::class,
-        PaymentOptionsViewModelModule::class
+        PaymentOptionsViewModelModule::class,
+        CoroutineContextModule::class
     ]
 )
 internal interface PaymentOptionsViewModelFactoryComponent {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
@@ -3,8 +3,6 @@ package com.stripe.android.paymentsheet.injection
 import androidx.core.os.LocaleListCompat
 import com.stripe.android.Logger
 import com.stripe.android.payments.core.injection.ENABLE_LOGGING
-import com.stripe.android.payments.core.injection.IOContext
-import com.stripe.android.payments.core.injection.UIContext
 import com.stripe.android.paymentsheet.BuildConfig
 import com.stripe.android.paymentsheet.analytics.DefaultDeviceIdRepository
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
@@ -16,10 +14,8 @@ import com.stripe.android.paymentsheet.repositories.StripeIntentRepository
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
-import kotlinx.coroutines.Dispatchers
 import javax.inject.Named
 import javax.inject.Singleton
-import kotlin.coroutines.CoroutineContext
 
 @Module
 internal abstract class PaymentSheetCommonModule {
@@ -48,16 +44,6 @@ internal abstract class PaymentSheetCommonModule {
         @Singleton
         fun provideLogger(@Named(ENABLE_LOGGING) enableLogging: Boolean) =
             Logger.getInstance(enableLogging)
-
-        @Provides
-        @Singleton
-        @IOContext
-        fun provideWorkContext(): CoroutineContext = Dispatchers.IO
-
-        @Provides
-        @Singleton
-        @UIContext
-        fun provideUIContext(): CoroutineContext = Dispatchers.Main
 
         @Provides
         @Singleton

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelComponent.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.injection
 
 import android.app.Application
 import com.stripe.android.googlepaylauncher.GooglePayLauncherModule
+import com.stripe.android.payments.core.injection.CoroutineContextModule
 import com.stripe.android.payments.core.injection.PaymentCommonModule
 import com.stripe.android.paymentsheet.PaymentSheetContract
 import com.stripe.android.paymentsheet.PaymentSheetViewModel
@@ -15,7 +16,8 @@ import javax.inject.Singleton
         PaymentCommonModule::class,
         PaymentSheetCommonModule::class,
         PaymentSheetViewModelModule::class,
-        GooglePayLauncherModule::class
+        GooglePayLauncherModule::class,
+        CoroutineContextModule::class
     ]
 )
 internal interface PaymentSheetViewModelComponent {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
So that we don't need to pass them as Component params, also makes the file sharable across different Components.

Note: There are two Components that still need them as parameters, [AuthenticationComponent](https://github.com/stripe/stripe-android/blob/b6fdd9280905b39f60af9dde9d69bbb97568ab67/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt#L53) and [PaymentLauncherComponent](https://github.com/stripe/stripe-android/blob/b6fdd9280905b39f60af9dde9d69bbb97568ab67/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherComponent.kt#L43). This is because these two components are used within a hosting object that would get the two CoroutineContexts from its constructor. We should just pass them over in this case to make sure unit test works, where a `TestDispatcher` might be passed as constructor param.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Better injection

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
