### PR TITLE
Fix address pre-populate on line 1

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormFragmentArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormFragmentArguments.kt
@@ -21,8 +21,8 @@ internal fun FormFragmentArguments.getValue(id: IdentifierSpec) =
         IdentifierSpec.Name -> this.billingDetails?.name
         IdentifierSpec.Email -> this.billingDetails?.email
         IdentifierSpec.Phone -> this.billingDetails?.phone
-        IdentifierSpec.Line2 -> this.billingDetails?.address?.line1
-        IdentifierSpec.Line1 -> this.billingDetails?.address?.line2
+        IdentifierSpec.Line1 -> this.billingDetails?.address?.line1
+        IdentifierSpec.Line2 -> this.billingDetails?.address?.line2
         IdentifierSpec.City -> this.billingDetails?.address?.city
         IdentifierSpec.State -> this.billingDetails?.address?.state
         IdentifierSpec.Country -> this.billingDetails?.address?.country


### PR DESCRIPTION
# Summary
When the address was provided in the configuration it was switching line 1 and line 2.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified
