### PR TITLE
pass publishableKey to `PaymentAuthWebViewActivityViewModel` instead of getting it from PaymentConfiguration

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -5104,11 +5104,11 @@ public final class com/stripe/android/payments/core/authentication/PaymentAuthen
 }
 
 public final class com/stripe/android/payments/core/authentication/SourceAuthenticator_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/SourceAuthenticator_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/SourceAuthenticator_Factory;
 	public fun get ()Lcom/stripe/android/payments/core/authentication/SourceAuthenticator;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lcom/stripe/android/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/AnalyticsRequestFactory;ZLkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/payments/core/authentication/SourceAuthenticator;
+	public static fun newInstance (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lcom/stripe/android/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/AnalyticsRequestFactory;ZLkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function0;)Lcom/stripe/android/payments/core/authentication/SourceAuthenticator;
 }
 
 public final class com/stripe/android/payments/core/authentication/UnsupportedAuthenticator_Factory : dagger/internal/Factory {
@@ -5120,11 +5120,11 @@ public final class com/stripe/android/payments/core/authentication/UnsupportedAu
 }
 
 public final class com/stripe/android/payments/core/authentication/WebIntentAuthenticator_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator_Factory;
 	public fun get ()Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lkotlin/jvm/functions/Function1;Lcom/stripe/android/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/AnalyticsRequestFactory;ZLkotlin/coroutines/CoroutineContext;Ljava/util/Map;)Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;
+	public static fun newInstance (Lkotlin/jvm/functions/Function1;Lcom/stripe/android/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/AnalyticsRequestFactory;ZLkotlin/coroutines/CoroutineContext;Ljava/util/Map;Lkotlin/jvm/functions/Function0;)Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;
 }
 
 public final class com/stripe/android/payments/core/authentication/threeds2/DefaultStripe3ds2ChallengeResultProcessor_Factory : dagger/internal/Factory {

--- a/payments-core/src/main/java/com/stripe/android/auth/PaymentBrowserAuthContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/auth/PaymentBrowserAuthContract.kt
@@ -81,7 +81,8 @@ internal class PaymentBrowserAuthContract :
          */
         val shouldCancelIntentOnUserNavigation: Boolean = true,
 
-        val statusBarColor: Int? = null
+        val statusBarColor: Int? = null,
+        val publishableKey: String
     ) : Parcelable {
         /**
          * Pre-requisite for using [StripeBrowserLauncherActivity].

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/SourceAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/SourceAuthenticator.kt
@@ -10,6 +10,7 @@ import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.AnalyticsRequestFactory
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.payments.core.injection.ENABLE_LOGGING
+import com.stripe.android.payments.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.payments.core.injection.UIContext
 import com.stripe.android.view.AuthActivityStarterHost
 import kotlinx.coroutines.withContext
@@ -29,7 +30,8 @@ internal class SourceAuthenticator @Inject constructor(
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,
     private val analyticsRequestFactory: AnalyticsRequestFactory,
     @Named(ENABLE_LOGGING) private val enableLogging: Boolean,
-    @UIContext private val uiContext: CoroutineContext
+    @UIContext private val uiContext: CoroutineContext,
+    @Named(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String
 ) : PaymentAuthenticator<Source> {
 
     override suspend fun authenticate(
@@ -65,7 +67,8 @@ internal class SourceAuthenticator @Inject constructor(
                 url = source.redirect?.url.orEmpty(),
                 returnUrl = source.redirect?.returnUrl,
                 enableLogging = enableLogging,
-                stripeAccountId = requestOptions.stripeAccount
+                stripeAccountId = requestOptions.stripeAccount,
+                publishableKey = publishableKeyProvider()
             )
         )
     }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticator.kt
@@ -10,6 +10,7 @@ import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.AnalyticsRequestFactory
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.payments.core.injection.ENABLE_LOGGING
+import com.stripe.android.payments.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.payments.core.injection.UIContext
 import com.stripe.android.view.AuthActivityStarterHost
 import kotlinx.coroutines.withContext
@@ -30,6 +31,7 @@ internal class WebIntentAuthenticator @Inject constructor(
     @Named(ENABLE_LOGGING) private val enableLogging: Boolean,
     @UIContext private val uiContext: CoroutineContext,
     private val threeDs1IntentReturnUrlMap: MutableMap<String, String>,
+    @Named(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String
 ) : PaymentAuthenticator<StripeIntent> {
 
     override suspend fun authenticate(
@@ -96,7 +98,7 @@ internal class WebIntentAuthenticator @Inject constructor(
         )
     }
 
-    internal suspend fun beginWebAuth(
+    private suspend fun beginWebAuth(
         host: AuthActivityStarterHost,
         stripeIntent: StripeIntent,
         requestCode: Int,
@@ -119,7 +121,8 @@ internal class WebIntentAuthenticator @Inject constructor(
                 enableLogging,
                 stripeAccountId = stripeAccount,
                 shouldCancelSource = shouldCancelSource,
-                shouldCancelIntentOnUserNavigation = shouldCancelIntentOnUserNavigation
+                shouldCancelIntentOnUserNavigation = shouldCancelIntentOnUserNavigation,
+                publishableKey = publishableKeyProvider()
             )
         )
     }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel.kt
@@ -217,7 +217,8 @@ internal class Stripe3ds2TransactionViewModel(
                 enableLogging = args.enableLogging,
                 stripeAccountId = args.requestOptions.stripeAccount,
                 // 3D-Secure requires cancelling the source when the user cancels auth (AUTHN-47)
-                shouldCancelSource = true
+                shouldCancelSource = true,
+                publishableKey = args.publishableKey
             )
         )
     }

--- a/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
@@ -6,7 +6,6 @@ import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.Logger
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.Stripe
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.auth.PaymentBrowserAuthContract
@@ -119,14 +118,13 @@ internal class PaymentAuthWebViewActivityViewModel(
         private val args: PaymentBrowserAuthContract.Args
     ) : ViewModelProvider.Factory {
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-            val publishableKey = PaymentConfiguration.getInstance(application).publishableKey
 
             return PaymentAuthWebViewActivityViewModel(
                 args,
                 DefaultAnalyticsRequestExecutor(logger, Dispatchers.IO),
                 AnalyticsRequestFactory(
                     application,
-                    publishableKey,
+                    args.publishableKey,
                     defaultProductUsageTokens = setOf("PaymentAuthWebViewActivity")
                 )
             ) as T

--- a/payments-core/src/test/java/com/stripe/android/PaymentBrowserAuthStarterTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentBrowserAuthStarterTest.kt
@@ -98,7 +98,8 @@ class PaymentBrowserAuthStarterTest {
             requestCode = 50000,
             clientSecret = "pi_1EceMnCRMbs6FrXfCXdF8dnx_secret_vew0L3IGaO0x9o0eyRMGzKr0k",
             url = "https://hooks.stripe.com/",
-            returnUrl = "stripe://payment-auth"
+            returnUrl = "stripe://payment-auth",
+            publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
         )
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/auth/PaymentBrowserAuthContractTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/auth/PaymentBrowserAuthContractTest.kt
@@ -98,7 +98,8 @@ class PaymentBrowserAuthContractTest {
             objectId = "pi_12345",
             requestCode = 5000,
             url = "https://mybank.com/auth",
-            returnUrl = "myapp://custom"
+            returnUrl = "myapp://custom",
+            publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
         )
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/payments/StripeBrowserLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/StripeBrowserLauncherViewModelTest.kt
@@ -111,7 +111,8 @@ class StripeBrowserLauncherViewModelTest {
             objectId = "pi_1F7J1aCRMbs6FrXfaJcvbxF6",
             requestCode = 50000,
             clientSecret = "pi_1F7J1aCRMbs6FrXfaJcvbxF6_secret_mIuDLsSfoo1m6s",
-            url = "https://bank.com"
+            url = "https://bank.com",
+            publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
         )
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/SourceAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/SourceAuthenticatorTest.kt
@@ -49,7 +49,8 @@ class SourceAuthenticatorTest {
         analyticsRequestExecutor,
         analyticsRequestFactory,
         false,
-        testDispatcher
+        testDispatcher,
+        { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY }
     )
 
     @Test

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticatorTest.kt
@@ -60,7 +60,8 @@ class WebIntentAuthenticatorTest {
         analyticsRequestFactory,
         enableLogging = false,
         testDispatcher,
-        threeDs1IntentReturnUrlMap
+        threeDs1IntentReturnUrlMap,
+        { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY }
     )
 
     @Before

--- a/payments-core/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityTest.kt
@@ -95,7 +95,8 @@ internal class PaymentAuthWebViewActivityTest {
             objectId = "pi_1EceMnCRMbs6FrXfCXdF8dnx",
             requestCode = REQUEST_CODE,
             clientSecret = CLIENT_SECRET,
-            url = "https://example.com"
+            url = "https://example.com",
+            publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
         )
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModelTest.kt
@@ -150,7 +150,8 @@ class PaymentAuthWebViewActivityViewModelTest {
             objectId = "pi_1EceMnCRMbs6FrXfCXdF8dnx",
             requestCode = 100,
             clientSecret = "client_secret",
-            url = "https://example.com"
+            url = "https://example.com",
+            publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
         )
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
`publishableKey` is already available in dagger graph, so pass it over instead of trying to read it from a static method.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

MOBILESDK-360

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
