### PR TITLE
Initialize resource repository on PaymentSheet creation

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -271,11 +271,11 @@ public abstract interface class com/stripe/android/paymentsheet/PaymentSheetResu
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheetViewModel_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/PaymentSheetViewModel_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/PaymentSheetViewModel_Factory;
 	public fun get ()Lcom/stripe/android/paymentsheet/PaymentSheetViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Landroid/app/Application;Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;Lcom/stripe/android/paymentsheet/analytics/EventReporter;Ldagger/Lazy;Lcom/stripe/android/paymentsheet/repositories/StripeIntentRepository;Lcom/stripe/android/paymentsheet/model/StripeIntentValidator;Lcom/stripe/android/paymentsheet/repositories/CustomerRepository;Lcom/stripe/android/paymentsheet/PrefsRepository;Lcom/stripe/android/payments/paymentlauncher/StripePaymentLauncherAssistedFactory;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherFactory;Lcom/stripe/android/Logger;Lkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/paymentsheet/PaymentSheetViewModel;
+	public static fun newInstance (Landroid/app/Application;Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;Lcom/stripe/android/paymentsheet/analytics/EventReporter;Ldagger/Lazy;Lcom/stripe/android/paymentsheet/repositories/StripeIntentRepository;Lcom/stripe/android/paymentsheet/model/StripeIntentValidator;Lcom/stripe/android/paymentsheet/repositories/CustomerRepository;Lcom/stripe/android/paymentsheet/PrefsRepository;Lcom/stripe/android/payments/paymentlauncher/StripePaymentLauncherAssistedFactory;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherFactory;Lcom/stripe/android/paymentsheet/elements/ResourceRepository;Lcom/stripe/android/Logger;Lkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/paymentsheet/PaymentSheetViewModel;
 }
 
 public final class com/stripe/android/paymentsheet/address/AddressFieldElementRepository_Factory : dagger/internal/Factory {
@@ -520,12 +520,10 @@ public final class com/stripe/android/paymentsheet/elements/ComposableSingletons
 	public final fun getLambda-1$paymentsheet_release ()Lkotlin/jvm/functions/Function3;
 }
 
-public final class com/stripe/android/paymentsheet/elements/ResourceRepository_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/elements/ResourceRepository_Factory;
-	public fun get ()Lcom/stripe/android/paymentsheet/elements/ResourceRepository;
-	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/paymentsheet/elements/BankRepository;Lcom/stripe/android/paymentsheet/address/AddressFieldElementRepository;)Lcom/stripe/android/paymentsheet/elements/ResourceRepository;
+public class com/stripe/android/paymentsheet/elements/SingletonHolder {
+	public static final field $stable I
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public final fun getInstance (Ljava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializer_Factory : dagger/internal/Factory {
@@ -537,11 +535,11 @@ public final class com/stripe/android/paymentsheet/flowcontroller/DefaultFlowCon
 }
 
 public final class com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowController_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowController_Factory;
 	public fun get ()Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowController;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lkotlinx/coroutines/CoroutineScope;Landroidx/lifecycle/LifecycleOwner;Lkotlin/jvm/functions/Function0;Lcom/stripe/android/paymentsheet/model/PaymentOptionFactory;Lcom/stripe/android/paymentsheet/PaymentOptionCallback;Lcom/stripe/android/paymentsheet/PaymentSheetResultCallback;Landroidx/activity/result/ActivityResultCaller;ILcom/stripe/android/paymentsheet/flowcontroller/FlowControllerInitializer;Lcom/stripe/android/paymentsheet/analytics/EventReporter;Lcom/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel;Lcom/stripe/android/payments/paymentlauncher/StripePaymentLauncherAssistedFactory;Ldagger/Lazy;Lkotlin/coroutines/CoroutineContext;ZLjava/util/Set;)Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowController;
+	public static fun newInstance (Lkotlinx/coroutines/CoroutineScope;Landroidx/lifecycle/LifecycleOwner;Lkotlin/jvm/functions/Function0;Lcom/stripe/android/paymentsheet/model/PaymentOptionFactory;Lcom/stripe/android/paymentsheet/PaymentOptionCallback;Lcom/stripe/android/paymentsheet/PaymentSheetResultCallback;Landroidx/activity/result/ActivityResultCaller;ILcom/stripe/android/paymentsheet/flowcontroller/FlowControllerInitializer;Lcom/stripe/android/paymentsheet/analytics/EventReporter;Lcom/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel;Lcom/stripe/android/payments/paymentlauncher/StripePaymentLauncherAssistedFactory;Ldagger/Lazy;Lkotlin/coroutines/CoroutineContext;Lcom/stripe/android/paymentsheet/elements/ResourceRepository;ZLjava/util/Set;)Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowController;
 }
 
 public final class com/stripe/android/paymentsheet/forms/FormViewModel_Factory : dagger/internal/Factory {
@@ -605,12 +603,28 @@ public final class com/stripe/android/paymentsheet/injection/FlowControllerModul
 	public static fun provideProductUsageTokens ()Ljava/util/Set;
 }
 
+public final class com/stripe/android/paymentsheet/injection/FlowControllerModule_Companion_ProvideResourceRepositoryFactoryFactory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/injection/FlowControllerModule_Companion_ProvideResourceRepositoryFactoryFactory;
+	public fun get ()Lcom/stripe/android/paymentsheet/elements/ResourceRepository;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideResourceRepositoryFactory (Landroid/content/Context;)Lcom/stripe/android/paymentsheet/elements/ResourceRepository;
+}
+
 public final class com/stripe/android/paymentsheet/injection/FlowControllerModule_Companion_ProvideViewModelFactory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;)V
 	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/injection/FlowControllerModule_Companion_ProvideViewModelFactory;
 	public fun get ()Lcom/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
 	public static fun provideViewModel (Landroidx/lifecycle/ViewModelStoreOwner;)Lcom/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel;
+}
+
+public final class com/stripe/android/paymentsheet/injection/FormViewModelModule_Companion_ProvideResourceRepositoryFactoryFactory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/injection/FormViewModelModule_Companion_ProvideResourceRepositoryFactoryFactory;
+	public fun get ()Lcom/stripe/android/paymentsheet/elements/ResourceRepository;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideResourceRepositoryFactory (Landroid/content/res/Resources;)Lcom/stripe/android/paymentsheet/elements/ResourceRepository;
 }
 
 public final class com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule_ProvideEventReporterModeFactory : dagger/internal/Factory {
@@ -699,6 +713,14 @@ public final class com/stripe/android/paymentsheet/injection/PaymentSheetViewMod
 	public synthetic fun get ()Ljava/lang/Object;
 	public fun get ()Ljava/util/Set;
 	public static fun provideProductUsageTokens ()Ljava/util/Set;
+}
+
+public final class com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_Companion_ProvideResourceRepositoryFactoryFactory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_Companion_ProvideResourceRepositoryFactoryFactory;
+	public fun get ()Lcom/stripe/android/paymentsheet/elements/ResourceRepository;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideResourceRepositoryFactory (Landroid/content/Context;)Lcom/stripe/android/paymentsheet/elements/ResourceRepository;
 }
 
 public final class com/stripe/android/paymentsheet/model/PaymentOption {

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -520,12 +520,6 @@ public final class com/stripe/android/paymentsheet/elements/ComposableSingletons
 	public final fun getLambda-1$paymentsheet_release ()Lkotlin/jvm/functions/Function3;
 }
 
-public class com/stripe/android/paymentsheet/elements/SingletonHolder {
-	public static final field $stable I
-	public fun <init> (Lkotlin/jvm/functions/Function1;)V
-	public final fun getInstance (Ljava/lang/Object;)Ljava/lang/Object;
-}
-
 public final class com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializer_Factory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializer_Factory;

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -102,6 +102,7 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
             )
         )
         viewModel.fetchStripeIntent()
+        viewModel.initializeResourceRepository()
 
         starterArgs.statusBarColor?.let {
             window.statusBarColor = it

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -30,6 +30,7 @@ import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.elements.ResourceRepository
 import com.stripe.android.paymentsheet.injection.DaggerPaymentSheetViewModelComponent
 import com.stripe.android.paymentsheet.model.ConfirmStripeIntentParamsFactory
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
@@ -77,6 +78,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     prefsRepository: PrefsRepository,
     private val paymentLauncherFactory: StripePaymentLauncherAssistedFactory,
     private val googlePayPaymentMethodLauncherFactory: GooglePayPaymentMethodLauncherFactory,
+    private val resourceRepository: ResourceRepository,
     private val logger: Logger,
     @IOContext workContext: CoroutineContext
 ) : BaseSheetViewModel<PaymentSheetViewModel.TransitionTarget>(
@@ -173,6 +175,12 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                     },
                     activityResultLauncher = activityResultLauncher
                 )
+        }
+    }
+
+    fun initializeResourceRepository(){
+        viewModelScope.launch {
+            resourceRepository.init()
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -178,7 +178,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         }
     }
 
-    fun initializeResourceRepository(){
+    fun initializeResourceRepository() {
         viewModelScope.launch {
             resourceRepository.init()
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/ResourceRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/ResourceRepository.kt
@@ -1,19 +1,24 @@
 package com.stripe.android.paymentsheet.elements
 
+import android.content.res.Resources
 import com.stripe.android.paymentsheet.address.AddressFieldElementRepository
-import javax.inject.Inject
-import javax.inject.Singleton
 
 /**
  * This holds all the resources read in from JSON.
  */
-@Singleton
-internal class ResourceRepository @Inject internal constructor(
+internal class ResourceRepository(
     internal val bankRepository: BankRepository,
     internal val addressRepository: AddressFieldElementRepository
 ) {
+    internal constructor(resources: Resources) : this(
+        BankRepository(resources),
+        AddressFieldElementRepository(resources)
+    )
+
     internal fun init() {
         bankRepository.init()
         addressRepository.init()
     }
+
+    companion object : SingletonHolder<ResourceRepository, Resources>(::ResourceRepository)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/ResourceRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/ResourceRepository.kt
@@ -10,14 +10,19 @@ internal class ResourceRepository(
     internal val bankRepository: BankRepository,
     internal val addressRepository: AddressFieldElementRepository
 ) {
+    private var initialized: Boolean = false
+
     internal constructor(resources: Resources) : this(
         BankRepository(resources),
         AddressFieldElementRepository(resources)
     )
 
     internal fun init() {
-        bankRepository.init()
-        addressRepository.init()
+        if (!initialized) {
+            bankRepository.init()
+            addressRepository.init()
+            initialized = true
+        }
     }
 
     companion object : SingletonHolder<ResourceRepository, Resources>(::ResourceRepository)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/SingletonHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/SingletonHolder.kt
@@ -1,0 +1,19 @@
+package com.stripe.android.paymentsheet.elements
+
+open class SingletonHolder<out T, in A>(private val constructor: (A) -> T) {
+
+    @Volatile
+    private var instance: T? = null
+
+    fun getInstance(arg: A): T {
+        return when {
+            instance != null -> instance!!
+            else -> synchronized(this) {
+                if (instance == null) {
+                    instance = constructor(arg)
+                }
+                instance!!
+            }
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/SingletonHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/SingletonHolder.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.paymentsheet.elements
 
-open class SingletonHolder<out T, in A>(private val constructor: (A) -> T) {
+internal open class SingletonHolder<out T, in A>(private val constructor: (A) -> T) {
 
     @Volatile
     private var instance: T? = null

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -37,6 +37,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResult
 import com.stripe.android.paymentsheet.PaymentSheetResultCallback
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.elements.ResourceRepository
 import com.stripe.android.paymentsheet.injection.DaggerFlowControllerComponent
 import com.stripe.android.paymentsheet.injection.FlowControllerComponent
 import com.stripe.android.paymentsheet.model.ClientSecret
@@ -80,6 +81,7 @@ internal class DefaultFlowController @Inject internal constructor(
      */
     private val lazyPaymentConfiguration: Lazy<PaymentConfiguration>,
     @UIContext private val uiContext: CoroutineContext,
+    private val resourceRepository: ResourceRepository,
     @Named(ENABLE_LOGGING) private val enableLogging: Boolean,
     @Named(PRODUCT_USAGE) private val productUsage: Set<String>
 ) : PaymentSheet.FlowController, Injector {
@@ -167,6 +169,7 @@ internal class DefaultFlowController @Inject internal constructor(
         callback: PaymentSheet.FlowController.ConfigCallback
     ) {
         lifecycleScope.launch {
+            resourceRepository.init()
             val result = flowControllerInitializer.init(
                 clientSecret,
                 configuration

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
@@ -32,7 +32,7 @@ import javax.inject.Singleton
 internal class FormViewModel @Inject internal constructor(
     layout: LayoutSpec,
     config: FormFragmentArguments,
-    private val resourceRepository: ResourceRepository
+    resourceRepository: ResourceRepository
 ) : ViewModel() {
     internal class Factory(
         private val resources: Resources,
@@ -56,7 +56,6 @@ internal class FormViewModel @Inject internal constructor(
 
     init {
         viewModelScope.launch {
-            resourceRepository.init()
             elements = transformSpecToElement.transform(layout.items)
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/FlowControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/FlowControllerModule.kt
@@ -10,6 +10,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.FlowController
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.elements.ResourceRepository
 import com.stripe.android.paymentsheet.flowcontroller.DefaultFlowControllerInitializer
 import com.stripe.android.paymentsheet.flowcontroller.FlowControllerInitializer
 import com.stripe.android.paymentsheet.flowcontroller.FlowControllerViewModel
@@ -30,6 +31,12 @@ internal abstract class FlowControllerModule {
     ): FlowControllerInitializer
 
     companion object {
+        @Provides
+        @Singleton
+        fun provideResourceRepositoryFactory(
+            appContext: Context,
+        ) = ResourceRepository.getInstance(appContext.resources)
+
         /**
          * [FlowController]'s clientSecret might be updated multiple times through
          * [FlowController.configureWithSetupIntent] or [FlowController.configureWithPaymentIntent].

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/FormViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/FormViewModelComponent.kt
@@ -1,15 +1,19 @@
 package com.stripe.android.paymentsheet.injection
 
 import android.content.res.Resources
+import com.stripe.android.paymentsheet.elements.LayoutSpec
 import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
-import com.stripe.android.paymentsheet.elements.LayoutSpec
 import dagger.BindsInstance
 import dagger.Component
 import javax.inject.Singleton
 
 @Singleton
-@Component
+@Component(
+    modules = [
+        FormViewModelModule::class,
+    ]
+)
 internal interface FormViewModelComponent {
     val viewModel: FormViewModel
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/FormViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/FormViewModelModule.kt
@@ -1,0 +1,20 @@
+package com.stripe.android.paymentsheet.injection
+
+import android.content.res.Resources
+import com.stripe.android.paymentsheet.elements.ResourceRepository
+import dagger.Module
+import dagger.Provides
+import javax.inject.Singleton
+
+@Module
+internal abstract class FormViewModelModule {
+
+    companion object {
+
+        @Provides
+        @Singleton
+        fun provideResourceRepositoryFactory(
+            resource: Resources,
+        ) = ResourceRepository.getInstance(resource)
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/FormViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/FormViewModelModule.kt
@@ -8,9 +8,7 @@ import javax.inject.Singleton
 
 @Module
 internal abstract class FormViewModelModule {
-
     companion object {
-
         @Provides
         @Singleton
         fun provideResourceRepositoryFactory(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
@@ -8,6 +8,7 @@ import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PaymentSheetContract
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.elements.ResourceRepository
 import com.stripe.android.paymentsheet.model.ClientSecret
 import dagger.Binds
 import dagger.Module
@@ -23,6 +24,13 @@ internal abstract class PaymentSheetViewModelModule {
     abstract fun bindsApplicationForContext(application: Application): Context
 
     companion object {
+
+        @Provides
+        @Singleton
+        fun provideResourceRepositoryFactory(
+            appContext: Context,
+        ) = ResourceRepository.getInstance(appContext.resources)
+
         @Provides
         @Singleton
         fun provideClientSecret(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
@@ -24,7 +24,6 @@ internal abstract class PaymentSheetViewModelModule {
     abstract fun bindsApplicationForContext(application: Application): Context
 
     companion object {
-
         @Provides
         @Singleton
         fun provideResourceRepositoryFactory(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -717,6 +717,7 @@ internal class PaymentSheetActivityTest {
             FakePrefsRepository(),
             stripePaymentLauncherAssistedFactory,
             googlePayPaymentMethodLauncherFactory,
+            mock(),
             Logger.noop(),
             testDispatcher
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -632,7 +632,7 @@ internal class PaymentSheetViewModelTest {
         val viewModel = createViewModel(
             ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP.copy(
                 config = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY.copy(
-                    googlePay = com.stripe.android.paymentsheet.ConfigFixtures.GOOGLE_PAY.copy(
+                    googlePay = ConfigFixtures.GOOGLE_PAY.copy(
                         currencyCode = null
                     )
                 )
@@ -740,6 +740,7 @@ internal class PaymentSheetViewModelTest {
             StripeIntentValidator(),
             customerRepository,
             prefsRepository,
+            mock(),
             mock(),
             mock(),
             Logger.noop(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -664,6 +664,7 @@ internal class DefaultFlowControllerTest {
         paymentLauncherAssistedFactory,
         { PaymentConfiguration.getInstance(activity) },
         testDispatcher,
+        mock(),
         ENABLE_LOGGING,
         PRODUCT_USAGE
     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -295,6 +295,7 @@ internal class FormViewModelTest {
     @Test
     fun `Verify params are set when element address fields are complete`() {
         runBlocking {
+            resourceRepository.init()
             /**
              * Using sepa debit as a complex enough example to test the address portion.
              */
@@ -366,6 +367,7 @@ internal class FormViewModelTest {
     @Test
     fun `Verify params are set when required address fields are complete`() {
         runBlocking {
+            resourceRepository.init()
             /**
              * Using sepa debit as a complex enough example to test the address portion.
              */


### PR DESCRIPTION
# Summary
Initialize resource repository early so that form fragments are not slow to load.  This might make sense if we want to load resources based on the LPMs in the intent.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
