### PR TITLE
Move PaymentSheetViewModel injection to PaymentSheetLauncher

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -214,8 +214,8 @@ public final class com/stripe/android/paymentsheet/PaymentSheetContract$Args : c
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args$Companion;
-	public final fun copy (Lcom/stripe/android/paymentsheet/model/ClientSecret;Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Ljava/lang/Integer;)Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;Lcom/stripe/android/paymentsheet/model/ClientSecret;Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;
+	public final fun copy (Lcom/stripe/android/paymentsheet/model/ClientSecret;Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Ljava/lang/Integer;I)Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;Lcom/stripe/android/paymentsheet/model/ClientSecret;Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Ljava/lang/Integer;IILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getGooglePayConfig ()Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
@@ -276,6 +276,14 @@ public final class com/stripe/android/paymentsheet/PaymentSheetViewModel_Factory
 	public fun get ()Lcom/stripe/android/paymentsheet/PaymentSheetViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
 	public static fun newInstance (Landroid/app/Application;Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;Lcom/stripe/android/paymentsheet/analytics/EventReporter;Ldagger/Lazy;Lcom/stripe/android/paymentsheet/repositories/StripeIntentRepository;Lcom/stripe/android/paymentsheet/model/StripeIntentValidator;Lcom/stripe/android/paymentsheet/repositories/CustomerRepository;Lcom/stripe/android/paymentsheet/PrefsRepository;Lcom/stripe/android/payments/paymentlauncher/StripePaymentLauncherAssistedFactory;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherFactory;Lcom/stripe/android/Logger;Lkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/paymentsheet/PaymentSheetViewModel;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheetViewModel_Factory_MembersInjector : dagger/MembersInjector {
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Ldagger/MembersInjector;
+	public fun injectMembers (Lcom/stripe/android/paymentsheet/PaymentSheetViewModel$Factory;)V
+	public synthetic fun injectMembers (Ljava/lang/Object;)V
+	public static fun injectSubComponentBuilderProvider (Lcom/stripe/android/paymentsheet/PaymentSheetViewModel$Factory;Ljavax/inject/Provider;)V
 }
 
 public final class com/stripe/android/paymentsheet/address/AddressFieldElementRepository_Factory : dagger/internal/Factory {
@@ -568,9 +576,9 @@ public final class com/stripe/android/paymentsheet/injection/DaggerPaymentOption
 	public fun inject (Lcom/stripe/android/paymentsheet/PaymentOptionsViewModel$Factory;)V
 }
 
-public final class com/stripe/android/paymentsheet/injection/DaggerPaymentSheetViewModelComponent : com/stripe/android/paymentsheet/injection/PaymentSheetViewModelComponent {
-	public static fun builder ()Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelComponent$Builder;
-	public fun getViewModel ()Lcom/stripe/android/paymentsheet/PaymentSheetViewModel;
+public final class com/stripe/android/paymentsheet/injection/DaggerPaymentSheetLauncherComponent : com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent {
+	public static fun builder ()Lcom/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent$Builder;
+	public fun inject (Lcom/stripe/android/paymentsheet/PaymentSheetViewModel$Factory;)V
 }
 
 public final class com/stripe/android/paymentsheet/injection/FlowControllerModule_Companion_ProvideClientSecretFactory : dagger/internal/Factory {
@@ -669,36 +677,36 @@ public final class com/stripe/android/paymentsheet/injection/PaymentSheetCommonM
 	public static fun providePublishableKey (Lcom/stripe/android/PaymentConfiguration;)Lkotlin/jvm/functions/Function0;
 }
 
-public final class com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_Companion_ProvideClientSecretFactory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_Companion_ProvideClientSecretFactory;
-	public fun get ()Lcom/stripe/android/paymentsheet/model/ClientSecret;
-	public synthetic fun get ()Ljava/lang/Object;
-	public static fun provideClientSecret (Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;)Lcom/stripe/android/paymentsheet/model/ClientSecret;
-}
-
-public final class com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_Companion_ProvideEventReporterModeFactory : dagger/internal/Factory {
+public final class com/stripe/android/paymentsheet/injection/PaymentSheetLauncherModule_Companion_ProvideEventReporterModeFactory : dagger/internal/Factory {
 	public fun <init> ()V
-	public static fun create ()Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_Companion_ProvideEventReporterModeFactory;
+	public static fun create ()Lcom/stripe/android/paymentsheet/injection/PaymentSheetLauncherModule_Companion_ProvideEventReporterModeFactory;
 	public fun get ()Lcom/stripe/android/paymentsheet/analytics/EventReporter$Mode;
 	public synthetic fun get ()Ljava/lang/Object;
 	public static fun provideEventReporterMode ()Lcom/stripe/android/paymentsheet/analytics/EventReporter$Mode;
 }
 
-public final class com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_Companion_ProvidePrefsRepositoryFactory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_Companion_ProvidePrefsRepositoryFactory;
-	public fun get ()Lcom/stripe/android/paymentsheet/PrefsRepository;
-	public synthetic fun get ()Ljava/lang/Object;
-	public static fun providePrefsRepository (Landroid/content/Context;Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;Lkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/paymentsheet/PrefsRepository;
-}
-
-public final class com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_Companion_ProvideProductUsageTokensFactory : dagger/internal/Factory {
+public final class com/stripe/android/paymentsheet/injection/PaymentSheetLauncherModule_Companion_ProvideProductUsageTokensFactory : dagger/internal/Factory {
 	public fun <init> ()V
-	public static fun create ()Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_Companion_ProvideProductUsageTokensFactory;
+	public static fun create ()Lcom/stripe/android/paymentsheet/injection/PaymentSheetLauncherModule_Companion_ProvideProductUsageTokensFactory;
 	public synthetic fun get ()Ljava/lang/Object;
 	public fun get ()Ljava/util/Set;
 	public static fun provideProductUsageTokens ()Ljava/util/Set;
+}
+
+public final class com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvideArgsFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;)V
+	public static fun create (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;)Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvideArgsFactory;
+	public fun get ()Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideArgs (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;)Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;
+}
+
+public final class com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvidePrefsRepositoryFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule_ProvidePrefsRepositoryFactory;
+	public fun get ()Lcom/stripe/android/paymentsheet/PrefsRepository;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun providePrefsRepository (Lcom/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule;Landroid/content/Context;Lkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/paymentsheet/PrefsRepository;
 }
 
 public final class com/stripe/android/paymentsheet/model/PaymentOption {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetContract.kt
@@ -8,6 +8,7 @@ import androidx.activity.result.contract.ActivityResultContract
 import androidx.annotation.ColorInt
 import androidx.annotation.VisibleForTesting
 import androidx.core.os.bundleOf
+import com.stripe.android.payments.core.injection.InjectorKey
 import com.stripe.android.paymentsheet.model.ClientSecret
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.SetupIntentClientSecret
@@ -40,6 +41,7 @@ class PaymentSheetContract :
         internal val clientSecret: ClientSecret,
         internal val config: PaymentSheet.Configuration?,
         @ColorInt internal val statusBarColor: Int? = null,
+        @InjectorKey internal val injectorKey: Int = NON_INJECTOR_KEY
     ) : ActivityStarter.Args {
         val googlePayConfig: PaymentSheet.GooglePayConfiguration? get() = config?.googlePay
 
@@ -63,6 +65,26 @@ class PaymentSheetContract :
                 SetupIntentClientSecret(clientSecret),
                 config
             )
+
+            internal fun createPaymentIntentArgsWithInjectorKey(
+                clientSecret: String,
+                config: PaymentSheet.Configuration? = null,
+                @InjectorKey injectorKey: Int
+            ) = Args(
+                PaymentIntentClientSecret(clientSecret),
+                config,
+                injectorKey = injectorKey
+            )
+
+            internal fun createSetupIntentArgsWithInjectorKey(
+                clientSecret: String,
+                config: PaymentSheet.Configuration? = null,
+                @InjectorKey injectorKey: Int
+            ) = Args(
+                SetupIntentClientSecret(clientSecret),
+                config,
+                injectorKey = injectorKey
+            )
         }
     }
 
@@ -82,5 +104,9 @@ class PaymentSheetContract :
             "com.stripe.android.paymentsheet.PaymentSheetContract.extra_args"
         private const val EXTRA_RESULT =
             "com.stripe.android.paymentsheet.PaymentSheetContract.extra_result"
+
+        // Indicates no corresponding injector is registered, should only happen when
+        // PaymentSheetContract.Args is created by clients directly
+        private const val NON_INJECTOR_KEY = -1
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.viewModelScope
+import com.stripe.android.BuildConfig
 import com.stripe.android.Logger
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
@@ -25,12 +26,16 @@ import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.core.injection.IOContext
+import com.stripe.android.payments.core.injection.Injectable
+import com.stripe.android.payments.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.payments.paymentlauncher.PaymentLauncher
 import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
 import com.stripe.android.paymentsheet.analytics.EventReporter
-import com.stripe.android.paymentsheet.injection.DaggerPaymentSheetViewModelComponent
+import com.stripe.android.paymentsheet.injection.DaggerPaymentSheetLauncherComponent
+import com.stripe.android.paymentsheet.injection.PaymentSheetViewModelModule
+import com.stripe.android.paymentsheet.injection.PaymentSheetViewModelSubcomponent
 import com.stripe.android.paymentsheet.model.ConfirmStripeIntentParamsFactory
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -45,7 +50,7 @@ import dagger.Lazy
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import javax.inject.Singleton
+import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -63,7 +68,6 @@ internal fun PaymentSheetViewState.convert(): PrimaryButton.State {
     }
 }
 
-@Singleton
 internal class PaymentSheetViewModel @Inject internal constructor(
     // Properties provided through PaymentSheetViewModelComponent.Builder
     application: Application,
@@ -435,18 +439,46 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         ) : TransitionTarget()
     }
 
-    @Suppress("UNCHECKED_CAST")
     internal class Factory(
         private val applicationSupplier: () -> Application,
         private val starterArgsSupplier: () -> PaymentSheetContract.Args
-    ) : ViewModelProvider.Factory {
+    ) : ViewModelProvider.Factory, Injectable<Factory.FallbackInitializeParam> {
+        internal data class FallbackInitializeParam(
+            val application: Application,
+        )
+
+        @Inject
+        lateinit var subComponentBuilderProvider:
+            Provider<PaymentSheetViewModelSubcomponent.Builder>
+
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel?> create(modelClass: Class<T>): T {
-            return DaggerPaymentSheetViewModelComponent.builder()
-                .application(applicationSupplier())
-                .starterArgs(starterArgsSupplier())
-                .build()
-                .viewModel as T
+            val application = applicationSupplier()
+            val args = starterArgsSupplier()
+
+            val logger = Logger.getInstance(BuildConfig.DEBUG)
+
+            WeakMapInjectorRegistry.retrieve(args.injectorKey)?.let {
+                logger.info(
+                    "Injector available, injecting dependencies into " +
+                        "PaymentSheetViewModel.Factory"
+                )
+                it.inject(this)
+            } ?: run {
+                logger.info(
+                    "Injector unavailable, initializing dependencies of " +
+                        "PaymentSheetViewModel.Factory by rebuilding the entire dagger graph"
+                )
+                fallbackInitialize(FallbackInitializeParam(application))
+            }
+            return subComponentBuilderProvider.get().paymentSheetViewModelModule(
+                PaymentSheetViewModelModule(args)
+            ).build().viewModel as T
+        }
+
+        override fun fallbackInitialize(arg: FallbackInitializeParam) {
+            DaggerPaymentSheetLauncherComponent.builder().application(arg.application).build()
+                .inject(this)
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import com.stripe.android.googlepaylauncher.GooglePayLauncherModule
 import com.stripe.android.payments.core.injection.CoroutineContextModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
-import com.stripe.android.paymentsheet.PaymentSheetContract
 import com.stripe.android.paymentsheet.PaymentSheetViewModel
 import dagger.BindsInstance
 import dagger.Component
@@ -15,22 +14,19 @@ import javax.inject.Singleton
     modules = [
         StripeRepositoryModule::class,
         PaymentSheetCommonModule::class,
-        PaymentSheetViewModelModule::class,
+        PaymentSheetLauncherModule::class,
         GooglePayLauncherModule::class,
         CoroutineContextModule::class
     ]
 )
-internal interface PaymentSheetViewModelComponent {
-    val viewModel: PaymentSheetViewModel
+internal interface PaymentSheetLauncherComponent {
+    fun inject(factory: PaymentSheetViewModel.Factory)
 
     @Component.Builder
     interface Builder {
         @BindsInstance
         fun application(application: Application): Builder
 
-        @BindsInstance
-        fun starterArgs(starterArgs: PaymentSheetContract.Args): Builder
-
-        fun build(): PaymentSheetViewModelComponent
+        fun build(): PaymentSheetLauncherComponent
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherModule.kt
@@ -1,0 +1,30 @@
+package com.stripe.android.paymentsheet.injection
+
+import android.app.Application
+import android.content.Context
+import com.stripe.android.payments.core.injection.PRODUCT_USAGE
+import com.stripe.android.paymentsheet.analytics.EventReporter
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Module(
+    subcomponents = [PaymentSheetViewModelSubcomponent::class]
+)
+internal abstract class PaymentSheetLauncherModule {
+    @Binds
+    abstract fun bindsApplicationForContext(application: Application): Context
+
+    companion object {
+        @Provides
+        @Singleton
+        fun provideEventReporterMode(): EventReporter.Mode = EventReporter.Mode.Complete
+
+        @Provides
+        @Singleton
+        @Named(PRODUCT_USAGE)
+        fun provideProductUsageTokens() = setOf("PaymentSheet")
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
@@ -1,59 +1,33 @@
 package com.stripe.android.paymentsheet.injection
 
-import android.app.Application
 import android.content.Context
 import com.stripe.android.payments.core.injection.IOContext
-import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PaymentSheetContract
 import com.stripe.android.paymentsheet.PrefsRepository
-import com.stripe.android.paymentsheet.analytics.EventReporter
-import com.stripe.android.paymentsheet.model.ClientSecret
-import dagger.Binds
 import dagger.Module
 import dagger.Provides
-import javax.inject.Named
-import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
 @Module
-internal abstract class PaymentSheetViewModelModule {
+internal class PaymentSheetViewModelModule(private val starterArgs: PaymentSheetContract.Args) {
 
-    @Binds
-    abstract fun bindsApplicationForContext(application: Application): Context
+    @Provides
+    fun provideArgs(): PaymentSheetContract.Args {
+        return starterArgs
+    }
 
-    companion object {
-        @Provides
-        @Singleton
-        fun provideClientSecret(
-            starterArgs: PaymentSheetContract.Args
-        ): ClientSecret {
-            return starterArgs.clientSecret
-        }
-
-        @Provides
-        @Singleton
-        fun providePrefsRepository(
-            appContext: Context,
-            starterArgs: PaymentSheetContract.Args,
-            @IOContext workContext: CoroutineContext
-        ): PrefsRepository {
-            return starterArgs.config?.customer?.let { (id) ->
-                DefaultPrefsRepository(
-                    appContext,
-                    customerId = id,
-                    workContext = workContext
-                )
-            } ?: PrefsRepository.Noop()
-        }
-
-        @Provides
-        @Singleton
-        fun provideEventReporterMode(): EventReporter.Mode = EventReporter.Mode.Complete
-
-        @Provides
-        @Singleton
-        @Named(PRODUCT_USAGE)
-        fun provideProductUsageTokens() = setOf("PaymentSheet")
+    @Provides
+    fun providePrefsRepository(
+        appContext: Context,
+        @IOContext workContext: CoroutineContext
+    ): PrefsRepository {
+        return starterArgs.config?.customer?.let { (id) ->
+            DefaultPrefsRepository(
+                appContext,
+                customerId = id,
+                workContext = workContext
+            )
+        } ?: PrefsRepository.Noop()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelSubcomponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelSubcomponent.kt
@@ -1,0 +1,20 @@
+package com.stripe.android.paymentsheet.injection
+
+import com.stripe.android.paymentsheet.PaymentSheetViewModel
+import dagger.Subcomponent
+
+@Subcomponent(
+    modules = [PaymentSheetViewModelModule::class]
+)
+internal interface PaymentSheetViewModelSubcomponent {
+    val viewModel: PaymentSheetViewModel
+
+    @Subcomponent.Builder
+    interface Builder {
+        fun paymentSheetViewModelModule(
+            paymentSheetViewModelModule: PaymentSheetViewModelModule
+        ): Builder
+
+        fun build(): PaymentSheetViewModelSubcomponent
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -22,9 +22,13 @@ import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.StripeRepository
+import com.stripe.android.payments.core.injection.Injectable
+import com.stripe.android.payments.core.injection.Injector
+import com.stripe.android.payments.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.PaymentSheetViewModel.CheckoutIdentifier
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.injection.PaymentSheetViewModelSubcomponent
 import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
@@ -50,18 +54,21 @@ import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Captor
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argWhere
 import org.mockito.kotlin.capture
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
-import java.lang.IllegalStateException
+import javax.inject.Provider
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertNotNull
 
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
@@ -719,6 +726,63 @@ internal class PaymentSheetViewModelTest {
         // In a real app, the app name will be used. In tests the package name is returned.
         assertThat(viewModel.merchantName)
             .isEqualTo("com.stripe.android.paymentsheet.test")
+    }
+
+    @Test
+    fun `Factory gets initialized by Injector when Injector is available`() {
+        val mockBuilder = mock<PaymentSheetViewModelSubcomponent.Builder>()
+        val mockSubComponent = mock<PaymentSheetViewModelSubcomponent>()
+        val mockViewModel = mock<PaymentSheetViewModel>()
+
+        whenever(mockBuilder.build()).thenReturn(mockSubComponent)
+        whenever(mockBuilder.paymentSheetViewModelModule(any())).thenReturn(mockBuilder)
+        whenever((mockSubComponent.viewModel)).thenReturn(mockViewModel)
+
+        val injector = object : Injector {
+            override fun inject(injectable: Injectable<*>) {
+                val factory = injectable as PaymentSheetViewModel.Factory
+                factory.subComponentBuilderProvider = Provider { mockBuilder }
+            }
+        }
+        val injectorKey = 1
+        WeakMapInjectorRegistry.register(injector, injectorKey)
+        val factory = PaymentSheetViewModel.Factory(
+            { ApplicationProvider.getApplicationContext() },
+            {
+                PaymentSheetContract.Args.createPaymentIntentArgsWithInjectorKey(
+                    "testSecret",
+                    injectorKey = injectorKey
+                )
+            }
+        )
+        val factorySpy = spy(factory)
+        val createdViewModel = factorySpy.create(PaymentSheetViewModel::class.java)
+        verify(factorySpy, times(0)).fallbackInitialize(any())
+        assertThat(createdViewModel).isEqualTo(mockViewModel)
+
+        WeakMapInjectorRegistry.staticCacheMap.clear()
+    }
+
+    @Test
+    fun `Factory gets initialized with fallback when no Injector is available`() = runBlockingTest {
+        val context = ApplicationProvider.getApplicationContext<Application>()
+        PaymentConfiguration.init(context, ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
+        val factory = PaymentSheetViewModel.Factory(
+            { context },
+            {
+                PaymentSheetContract.Args.createPaymentIntentArgs(
+                    "testSecret",
+                )
+            }
+        )
+        val factorySpy = spy(factory)
+
+        assertNotNull(factorySpy.create(PaymentSheetViewModel::class.java))
+        verify(factorySpy).fallbackInitialize(
+            argWhere {
+                it.application == context
+            }
+        )
     }
 
     private fun createViewModel(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Instead of recreating the entire new graph each time a `PaymentSheetActivity`/`PaymentSheetViewModel` is started, save majority of the dependencies required inside `PaymentSheetLauncher`, and reuse them in `PaymentSheetViewModel`

Now the majority of dependencies (`GooglePayLauncher`, `PaymentLauncher`, `StripeRepository` etc) are saved as `paymentSheetLauncherComponent` in `DefaultPaymentSheetLauncher` and shared with `PaymentSheetViewModel.Factory` through a subcomponent

If Injector is available, `PaymentSheetViewModel.Factory` will get all the dependencies from `paymentSheetLauncherComponent` through a `PaymentSheetViewModelSubcomponent.Builder`, then provides a PaymentIntent-specific `PaymentSheetContract.Args`(different with each `PaymentSheet#presentWithPaymentIntent` call) to build the `subcomponent`.

For fallback, `PaymentSheetViewModel.Factory` will recreate the entire dagger graph, the only required param here is application.


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
There are two benefits by saving the common dependencies in `PaymentSheetLauncher`
* Potential performance gains - as there's no need to reinitialize  heavy objects (`GooglePayLauncher`, `PaymentLauncher`, `StripeRepository` etc.) each time a new `PaymentSheetActivity` is created
* Now with `DefaultPaymentSheetLauncher` being registered as a `Injector`, it is possible to inject dependencies to `Activity`/`Fragment`s created from it.(e.g [FormViewModel](https://github.com/stripe/stripe-android/blob/92340fd40aedaa53f522975a95defd348bc86fbb/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt#L32) started by [ComposeFormDataCollectionFragment](https://github.com/stripe/stripe-android/blob/92340fd40aedaa53f522975a95defd348bc86fbb/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ComposeFormDataCollectionFragment.kt#L24))

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
