### PR TITLE
CardInputWidget.CardValidCallback will consider the postal code in validation.

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/CreateCardSourceActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CreateCardSourceActivity.kt
@@ -2,6 +2,7 @@ package com.stripe.example.activity
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
@@ -10,11 +11,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.stripe.android.ApiResultCallback
 import com.stripe.android.Stripe
-import com.stripe.android.model.CardBrand
-import com.stripe.android.model.CardParams
-import com.stripe.android.model.Source
-import com.stripe.android.model.SourceParams
-import com.stripe.android.model.SourceTypeModel
+import com.stripe.android.model.*
 import com.stripe.example.R
 import com.stripe.example.StripeFactory
 import com.stripe.example.adapter.SourcesAdapter
@@ -50,9 +47,19 @@ class CreateCardSourceActivity : AppCompatActivity() {
         setContentView(viewBinding.root)
 
         viewBinding.createButton.setOnClickListener {
+            // If a field is invalid this will shift focus to that field
             viewBinding.cardWidget.cardParams?.let {
                 createCardSource(it)
             } ?: showSnackbar("Enter a valid card.")
+        }
+
+        viewBinding.cardWidget.setCardValidCallback { isValid, invalidFields -> // We will not call cardParams unless it is valid because
+            // this will cause the inFocus field to change.
+            if (isValid) {
+                Log.e("STRIPE", "Validity: $isValid, ${viewBinding.cardWidget.cardParams}")
+            } else {
+                Log.e("STRIPE", "Validity: $isValid, invalidField: ${invalidFields}")
+            }
         }
 
         viewBinding.recyclerView.setHasFixedSize(true)

--- a/example/src/main/java/com/stripe/example/activity/CreateCardSourceActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/CreateCardSourceActivity.kt
@@ -11,7 +11,11 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.stripe.android.ApiResultCallback
 import com.stripe.android.Stripe
-import com.stripe.android.model.*
+import com.stripe.android.model.CardBrand
+import com.stripe.android.model.CardParams
+import com.stripe.android.model.Source
+import com.stripe.android.model.SourceParams
+import com.stripe.android.model.SourceTypeModel
 import com.stripe.example.R
 import com.stripe.example.StripeFactory
 import com.stripe.example.adapter.SourcesAdapter
@@ -58,7 +62,7 @@ class CreateCardSourceActivity : AppCompatActivity() {
             if (isValid) {
                 Log.e("STRIPE", "Validity: $isValid, ${viewBinding.cardWidget.cardParams}")
             } else {
-                Log.e("STRIPE", "Validity: $isValid, invalidField: ${invalidFields}")
+                Log.e("STRIPE", "Validity: $isValid, invalidField: $invalidFields")
             }
         }
 

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -108,8 +108,7 @@ class CardInputWidget @JvmOverloads constructor(
                     this.cvc == null
                 },
                 CardValidCallback.Fields.Postal.takeIf {
-                    (postalCodeRequired || usZipCodeRequired) &&
-                            postalCodeEditText.postalCode.isNullOrBlank()
+                    isPostalRequired() && postalCodeEditText.postalCode.isNullOrBlank()
                 }
             ).toSet()
         }
@@ -156,7 +155,7 @@ class CardInputWidget @JvmOverloads constructor(
 
     @VisibleForTesting
     @JvmSynthetic
-    internal val requiredFields: MutableSet<StripeEditText> = mutableSetOf()
+    internal val requiredFields: MutableSet<StripeEditText>
     private val allFields: Set<StripeEditText>
 
     /**
@@ -332,13 +331,14 @@ class CardInputWidget @JvmOverloads constructor(
     }
 
     private fun updatePostalRequired() {
-        val isPostalCodeCurrentlyRequired = requiredFields.contains(postalCodeEditText)
-        if ((postalCodeRequired || usZipCodeRequired) && postalCodeEnabled) {
+        if (isPostalRequired()) {
             requiredFields.add(postalCodeEditText)
         } else {
             requiredFields.remove(postalCodeEditText)
         }
     }
+
+    private fun isPostalRequired() = (postalCodeRequired || usZipCodeRequired) && postalCodeEnabled
 
     private val frameStart: Int
         get() {
@@ -362,13 +362,11 @@ class CardInputWidget @JvmOverloads constructor(
 
         frameWidthSupplier = { containerLayout.width }
 
-        requiredFields.addAll(
-            setOf(
+        requiredFields = mutableSetOf(
                 cardNumberEditText,
                 cvcEditText,
                 expiryDateEditText
             )
-        )
         allFields = requiredFields.plus(postalCodeEditText)
 
         initView(attrs)

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -224,7 +224,7 @@ class CardInputWidget @JvmOverloads constructor(
             cvcEditText.shouldShowError = cvc == null
             postalCodeEditText.shouldShowError =
                 (postalCodeRequired || usZipCodeRequired) &&
-                        postalCodeEditText.postalCode.isNullOrBlank()
+                postalCodeEditText.postalCode.isNullOrBlank()
 
             // Announce error messages for accessibility
             currentFields
@@ -363,10 +363,10 @@ class CardInputWidget @JvmOverloads constructor(
         frameWidthSupplier = { containerLayout.width }
 
         requiredFields = mutableSetOf(
-                cardNumberEditText,
-                cvcEditText,
-                expiryDateEditText
-            )
+            cardNumberEditText,
+            cvcEditText,
+            expiryDateEditText
+        )
         allFields = requiredFields.plus(postalCodeEditText)
 
         initView(attrs)

--- a/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -17,7 +17,12 @@ import com.stripe.android.CardNumberFixtures.VISA_WITH_SPACES
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.cards.AccountRangeFixtures
 import com.stripe.android.cards.DefaultCardAccountRangeStore
-import com.stripe.android.model.*
+import com.stripe.android.model.Address
+import com.stripe.android.model.BinFixtures
+import com.stripe.android.model.CardBrand
+import com.stripe.android.model.CardParams
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.testharness.ViewTestUtils
 import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.view.CardInputWidget.Companion.LOGGING_TOKEN
@@ -28,7 +33,7 @@ import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.resetMain
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.util.*
+import java.util.Calendar
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -1310,6 +1315,7 @@ internal class CardInputWidgetTest {
             currentIsValid = isValid
             currentInvalidFields = invalidFields
         }
+
         assertThat(currentIsValid)
             .isFalse()
         assertThat(currentInvalidFields)


### PR DESCRIPTION
# Summary
With this change the CardValidCallback for CardInputWidget will only report isValid = true if CardNumber, CVC, and ExpiryDate are valid, and if either postalCodeRequired or usZipCodeRequired is true and the postalCodeEnabled (aka visible) isValid will only be true if it passes postal code validation.

The cardParams when queried will change focus to any invalid fields.   This is as it is currently designed.  If not wanting focus to change to invalid fields cardParams, paymentMethodCreateParams, and paymentMethodCard should only be called when CardValidCallback returns true (which will not be correctly reported). The comments in the code have been updated to reflect this.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

