### PR TITLE
Replace PaymentOptionsViewModel injection with subcomponent

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -9,15 +9,20 @@ public abstract interface class com/stripe/android/paymentsheet/PaymentOptionCal
 	public abstract fun onPaymentOption (Lcom/stripe/android/paymentsheet/model/PaymentOption;)V
 }
 
+public final class com/stripe/android/paymentsheet/PaymentOptionsViewModel_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/PaymentOptionsViewModel_Factory;
+	public fun get ()Lcom/stripe/android/paymentsheet/PaymentOptionsViewModel;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Lcom/stripe/android/paymentsheet/PaymentOptionContract$Args;Lkotlin/jvm/functions/Function1;Lcom/stripe/android/paymentsheet/analytics/EventReporter;Lcom/stripe/android/paymentsheet/repositories/CustomerRepository;Lkotlin/coroutines/CoroutineContext;Landroid/app/Application;Lcom/stripe/android/Logger;)Lcom/stripe/android/paymentsheet/PaymentOptionsViewModel;
+}
+
 public final class com/stripe/android/paymentsheet/PaymentOptionsViewModel_Factory_MembersInjector : dagger/MembersInjector {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Ldagger/MembersInjector;
-	public static fun injectCustomerRepository (Lcom/stripe/android/paymentsheet/PaymentOptionsViewModel$Factory;Lcom/stripe/android/paymentsheet/repositories/CustomerRepository;)V
-	public static fun injectEventReporter (Lcom/stripe/android/paymentsheet/PaymentOptionsViewModel$Factory;Lcom/stripe/android/paymentsheet/analytics/EventReporter;)V
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Ldagger/MembersInjector;
 	public fun injectMembers (Lcom/stripe/android/paymentsheet/PaymentOptionsViewModel$Factory;)V
 	public synthetic fun injectMembers (Ljava/lang/Object;)V
-	public static fun injectPrefsRepositoryFactory (Lcom/stripe/android/paymentsheet/PaymentOptionsViewModel$Factory;Lkotlin/jvm/functions/Function1;)V
-	public static fun injectWorkContext (Lcom/stripe/android/paymentsheet/PaymentOptionsViewModel$Factory;Lkotlin/coroutines/CoroutineContext;)V
+	public static fun injectSubComponentBuilderProvider (Lcom/stripe/android/paymentsheet/PaymentOptionsViewModel$Factory;Ljavax/inject/Provider;)V
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheet {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/FlowControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/FlowControllerModule.kt
@@ -22,7 +22,9 @@ import javax.inject.Provider
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
-@Module
+@Module(
+    subcomponents = [PaymentOptionsViewModelSubcomponent::class]
+)
 internal abstract class FlowControllerModule {
     @Binds
     abstract fun bindsFlowControllerInitializer(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule.kt
@@ -11,7 +11,9 @@ import dagger.Provides
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
-@Module
+@Module(
+    subcomponents = [PaymentOptionsViewModelSubcomponent::class]
+)
 internal class PaymentOptionsViewModelModule {
 
     @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelSubcomponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelSubcomponent.kt
@@ -1,0 +1,23 @@
+package com.stripe.android.paymentsheet.injection
+
+import android.app.Application
+import com.stripe.android.paymentsheet.PaymentOptionContract
+import com.stripe.android.paymentsheet.PaymentOptionsViewModel
+import dagger.BindsInstance
+import dagger.Subcomponent
+
+@Subcomponent
+internal interface PaymentOptionsViewModelSubcomponent {
+    val viewModel: PaymentOptionsViewModel
+
+    @Subcomponent.Builder
+    interface Builder {
+        @BindsInstance
+        fun application(application: Application): Builder
+
+        @BindsInstance
+        fun args(args: PaymentOptionContract.Args): Builder
+
+        fun build(): PaymentOptionsViewModelSubcomponent
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -290,7 +290,7 @@ class PaymentOptionsActivityTest {
     ): PaymentOptionsViewModel {
         return PaymentOptionsViewModel(
             args = args,
-            prefsRepository = FakePrefsRepository(),
+            prefsRepositoryFactory = { FakePrefsRepository() },
             eventReporter = eventReporter,
             customerRepository = FakeCustomerRepository(),
             workContext = testDispatcher,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAddPaymentMethodFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAddPaymentMethodFragmentTest.kt
@@ -8,8 +8,6 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.model.PaymentIntentFixtures
-import com.stripe.android.payments.core.injection.Injectable
-import com.stripe.android.payments.core.injection.Injector
 import com.stripe.android.payments.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.databinding.FragmentPaymentsheetAddPaymentMethodBinding
@@ -17,7 +15,6 @@ import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.FragmentConfigFixtures
 import com.stripe.android.paymentsheet.ui.PaymentSheetFragmentFactory
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -30,23 +27,12 @@ import org.robolectric.RobolectricTestRunner
 class PaymentOptionsAddPaymentMethodFragmentTest {
     private val eventReporter = mock<EventReporter>()
 
-    private val testInjector: Injector = object : Injector {
-        override fun inject(injectable: Injectable<*>) {
-            val factory = (injectable as PaymentOptionsViewModel.Factory)
-            factory.eventReporter = eventReporter
-            factory.customerRepository = com.stripe.android.paymentsheet.FakeCustomerRepository()
-            factory.workContext = TestCoroutineDispatcher()
-            factory.prefsRepositoryFactory = { mock() }
-        }
-    }
-
     @Before
     fun setup() {
         PaymentConfiguration.init(
             ApplicationProvider.getApplicationContext(),
             ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
         )
-        WeakMapInjectorRegistry.register(testInjector, MOCK_INJECTOR_KEY)
     }
 
     @After
@@ -70,7 +56,7 @@ class PaymentOptionsAddPaymentMethodFragmentTest {
             isGooglePayReady = false,
             newCard = null,
             statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR,
-            injectorKey = MOCK_INJECTOR_KEY,
+            injectorKey = 0,
             enableLogging = false,
             productUsage = mock()
         ),
@@ -92,9 +78,5 @@ class PaymentOptionsAddPaymentMethodFragmentTest {
                 )
             )
         }
-    }
-
-    companion object {
-        private const val MOCK_INJECTOR_KEY = 0
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Replace `PaymentOptionsViewModel.Factory`'s field injection with a Subcomponent.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Instead of listing all injection-required fields one by one, using a subcomponent can simplify the injected fields and allow us to apply subcomponent specific scopes if needed.

All `Injectable` should use the subcomponent instead of field injections for uniformity across the codebase.

`Injectable`s to be refactored:
* [PaymentOptionViewModel.Factory](https://github.com/stripe/stripe-android/blob/17dbb67db41f11056fa1c9fe0ce38d50ed2c9b89/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt#L128) <- changed in this PR
* [PaymentLauncherViewModel.Factory](https://github.com/stripe/stripe-android/blob/e59b24a8bef004e0033f13857e73a4a49a7008fe/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt#L251)
* [Stripe3ds2TransactionViewModelFactory](https://github.com/stripe/stripe-android/blob/e59b24a8bef004e0033f13857e73a4a49a7008fe/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel.kt#L290)




# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
