### PR TITLE
Replace PaymentLancherViewModel injection with subcomponent

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -5329,6 +5329,7 @@ public abstract interface annotation class com/stripe/android/payments/core/inje
 
 public final class com/stripe/android/payments/core/injection/NamedConstantsKt {
 	public static final field ENABLE_LOGGING Ljava/lang/String;
+	public static final field IS_PAYMENT_INTENT Ljava/lang/String;
 	public static final field PRODUCT_USAGE Ljava/lang/String;
 	public static final field PUBLISHABLE_KEY Ljava/lang/String;
 	public static final field STRIPE_ACCOUNT_ID Ljava/lang/String;
@@ -5587,21 +5588,20 @@ public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherFa
 	public static synthetic fun create$default (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherFactory;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher;
 }
 
+public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel_Factory;
+	public fun get ()Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (ZLcom/stripe/android/networking/StripeRepository;Lcom/stripe/android/payments/core/authentication/PaymentAuthenticatorRegistry;Lcom/stripe/android/payments/DefaultReturnUrl;Ljavax/inject/Provider;Ljava/util/Map;Ldagger/Lazy;Ldagger/Lazy;Lcom/stripe/android/networking/DefaultAnalyticsRequestExecutor;Lcom/stripe/android/networking/AnalyticsRequestFactory;Lkotlin/coroutines/CoroutineContext;Lcom/stripe/android/view/AuthActivityStarterHost;Landroidx/activity/result/ActivityResultCaller;Landroidx/lifecycle/SavedStateHandle;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel;
+}
+
 public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel_Factory_MembersInjector : dagger/MembersInjector {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Ldagger/MembersInjector;
-	public static fun injectAnalyticsRequestExecutor (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel$Factory;Lcom/stripe/android/networking/DefaultAnalyticsRequestExecutor;)V
-	public static fun injectAnalyticsRequestFactory (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel$Factory;Lcom/stripe/android/networking/AnalyticsRequestFactory;)V
-	public static fun injectApiRequestOptionsProvider (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel$Factory;Ljavax/inject/Provider;)V
-	public static fun injectAuthenticatorRegistry (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel$Factory;Lcom/stripe/android/payments/core/authentication/PaymentAuthenticatorRegistry;)V
-	public static fun injectDefaultReturnUrl (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel$Factory;Lcom/stripe/android/payments/DefaultReturnUrl;)V
-	public static fun injectLazyPaymentIntentFlowResultProcessor (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel$Factory;Ldagger/Lazy;)V
-	public static fun injectLazySetupIntentFlowResultProcessor (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel$Factory;Ldagger/Lazy;)V
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Ldagger/MembersInjector;
 	public fun injectMembers (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel$Factory;)V
 	public synthetic fun injectMembers (Ljava/lang/Object;)V
-	public static fun injectStripeApiRepository (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel$Factory;Lcom/stripe/android/networking/StripeRepository;)V
-	public static fun injectThreeDs1IntentReturnUrlMap (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel$Factory;Ljava/util/Map;)V
-	public static fun injectUiContext (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel$Factory;Lkotlin/coroutines/CoroutineContext;)V
+	public static fun injectSubComponentBuilderProvider (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel$Factory;Ljavax/inject/Provider;)V
 }
 
 public abstract class com/stripe/android/payments/paymentlauncher/PaymentResult : android/os/Parcelable {

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/NamedConstants.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/NamedConstants.kt
@@ -1,5 +1,9 @@
 package com.stripe.android.payments.core.injection
 
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.SetupIntent
+import com.stripe.android.model.StripeIntent
+
 /**
  * Name for injected boolean to denote if logging is enabled.
  */
@@ -19,3 +23,8 @@ const val PUBLISHABLE_KEY = "publishableKey"
  * Name for user's account id
  */
 const val STRIPE_ACCOUNT_ID = "stripeAccountId"
+
+/**
+ * Name to indicate whether the current [StripeIntent] is a [PaymentIntent] or [SetupIntent].
+ */
+const val IS_PAYMENT_INTENT = "isPaymentIntent"

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherModule.kt
@@ -18,7 +18,9 @@ import javax.inject.Provider
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
-@Module
+@Module(
+    subcomponents = [PaymentLauncherViewModelSubcomponent::class]
+)
 internal class PaymentLauncherModule {
 
     /**

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherViewModelSubcomponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherViewModelSubcomponent.kt
@@ -1,0 +1,31 @@
+package com.stripe.android.payments.core.injection
+
+import androidx.activity.result.ActivityResultCaller
+import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.payments.paymentlauncher.PaymentLauncherViewModel
+import com.stripe.android.view.AuthActivityStarterHost
+import dagger.BindsInstance
+import dagger.Subcomponent
+import javax.inject.Named
+
+@Subcomponent
+internal interface PaymentLauncherViewModelSubcomponent {
+    val viewModel: PaymentLauncherViewModel
+
+    @Subcomponent.Builder
+    interface Builder {
+        @BindsInstance
+        fun isPaymentIntent(@Named(IS_PAYMENT_INTENT) isPaymentIntent: Boolean): Builder
+
+        @BindsInstance
+        fun savedStateHandle(handle: SavedStateHandle): Builder
+
+        @BindsInstance
+        fun authActivityStarterHost(authActivityStarterHost: AuthActivityStarterHost): Builder
+
+        @BindsInstance
+        fun activityResultCaller(activityResultCaller: ActivityResultCaller): Builder
+
+        fun build(): PaymentLauncherViewModelSubcomponent
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
@@ -34,7 +34,8 @@ internal class PaymentLauncherConfirmationActivity : AppCompatActivity() {
             this
         )
 
-    private val viewModel: PaymentLauncherViewModel by viewModels { viewModelFactory }
+    @VisibleForTesting
+    internal val viewModel: PaymentLauncherViewModel by viewModels { viewModelFactory }
 
     @SuppressLint("SourceLockedOrientationActivity")
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivityTest.kt
@@ -2,13 +2,10 @@ package com.stripe.android.payments.paymentlauncher
 
 import android.content.Intent
 import androidx.lifecycle.Lifecycle
-import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.model.ConfirmStripeIntentParams
-import com.stripe.android.payments.core.injection.Injectable
-import com.stripe.android.payments.core.injection.Injector
 import com.stripe.android.payments.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.TestUtils
@@ -117,52 +114,6 @@ class PaymentLauncherConfirmationActivityTest {
                 .isEqualTo(
                     PaymentLauncherConfirmationActivity.EMPTY_ARG_ERROR
                 )
-        }
-    }
-
-    @Test
-    fun `viewModelFactory gets initialized by Injector when Injector is available`() {
-        val injector = object : Injector {
-            override fun inject(injectable: Injectable<*>) {
-                val factory = injectable as PaymentLauncherViewModel.Factory
-                factory.stripeApiRepository = mock()
-                factory.authenticatorRegistry = mock()
-                factory.defaultReturnUrl = mock()
-                factory.apiRequestOptionsProvider = mock()
-                factory.threeDs1IntentReturnUrlMap = mock()
-                factory.lazyPaymentIntentFlowResultProcessor = mock()
-                factory.lazySetupIntentFlowResultProcessor = mock()
-                factory.analyticsRequestExecutor = mock()
-                factory.analyticsRequestFactory = mock()
-                factory.uiContext = mock()
-            }
-        }
-        WeakMapInjectorRegistry.register(injector, INJECTOR_KEY)
-
-        ActivityScenario.launch<PaymentLauncherConfirmationActivity>(
-            Intent(
-                ApplicationProvider.getApplicationContext(),
-                PaymentLauncherConfirmationActivity::class.java
-            ).putExtras(
-                PAYMENT_INTENT_NEXT_ACTION_ARGS.toBundle()
-            )
-        ).use { activityScenario ->
-            assertThat(activityScenario.state).isEqualTo(Lifecycle.State.RESUMED)
-        }
-        WeakMapInjectorRegistry.staticCacheMap.clear()
-    }
-
-    @Test
-    fun `viewModelFactory gets initialized with fallback when no Injector is available`() {
-        ActivityScenario.launch<PaymentLauncherConfirmationActivity>(
-            Intent(
-                ApplicationProvider.getApplicationContext(),
-                PaymentLauncherConfirmationActivity::class.java
-            ).putExtras(
-                PAYMENT_INTENT_NEXT_ACTION_ARGS.toBundle()
-            )
-        ).use { activityScenario ->
-            assertThat(activityScenario.state).isEqualTo(Lifecycle.State.RESUMED)
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Replace `PaymentLauncherViewModel.Factory`'s field injection with a Subcomponent.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Instead of listing all injection-required fields one by one, using a subcomponent can simplify the injected fields and allow us to apply subcomponent specific scopes if needed.

All `Injectable` should use the subcomponent instead of field injections for uniformity across the codebase.

`Injectable`s to be refactored:
* [PaymentOptionViewModel.Factory](https://github.com/stripe/stripe-android/blob/17dbb67db41f11056fa1c9fe0ce38d50ed2c9b89/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt#L128) <- #4205
* [PaymentLauncherViewModel.Factory](https://github.com/stripe/stripe-android/blob/e59b24a8bef004e0033f13857e73a4a49a7008fe/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt#L251) <- changed in this PR
* [Stripe3ds2TransactionViewModelFactory](https://github.com/stripe/stripe-android/blob/e59b24a8bef004e0033f13857e73a4a49a7008fe/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel.kt#L290)




# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
