### PR TITLE
Change @InjectorKey to `String`

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -5217,7 +5217,7 @@ public final class com/stripe/android/payments/core/authentication/threeds2/Stri
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3DS2Authenticator_Factory;
 	public fun get ()Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3DS2Authenticator;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/PaymentAuthConfig;ZILkotlin/jvm/functions/Function0;Ljava/util/Set;)Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3DS2Authenticator;
+	public static fun newInstance (Lcom/stripe/android/PaymentAuthConfig;ZLjava/lang/String;Lkotlin/jvm/functions/Function0;Ljava/util/Set;)Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3DS2Authenticator;
 }
 
 public final class com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactory_MembersInjector : dagger/MembersInjector {
@@ -5317,7 +5317,7 @@ public abstract interface annotation class com/stripe/android/payments/core/inje
 }
 
 public final class com/stripe/android/payments/core/injection/InjectorKt {
-	public static final field DUMMY_INJECTOR_KEY I
+	public static final field DUMMY_INJECTOR_KEY Ljava/lang/String;
 }
 
 public abstract interface annotation class com/stripe/android/payments/core/injection/IntentAuthenticatorKey : java/lang/annotation/Annotation {
@@ -5458,9 +5458,9 @@ public final class com/stripe/android/payments/core/injection/WeakMapInjectorReg
 	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/payments/core/injection/WeakMapInjectorRegistry;
 	public final fun getStaticCacheMap ()Ljava/util/WeakHashMap;
-	public fun nextKey ()I
-	public fun register (Lcom/stripe/android/payments/core/injection/Injector;I)V
-	public fun retrieve (I)Lcom/stripe/android/payments/core/injection/Injector;
+	public fun nextKey (Ljava/lang/String;)Ljava/lang/String;
+	public fun register (Lcom/stripe/android/payments/core/injection/Injector;Ljava/lang/String;)V
+	public fun retrieve (Ljava/lang/String;)Lcom/stripe/android/payments/core/injection/Injector;
 }
 
 public abstract interface class com/stripe/android/payments/paymentlauncher/PaymentLauncher {
@@ -5494,9 +5494,9 @@ public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherCo
 
 public abstract class com/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args : android/os/Parcelable {
 	public static final field $stable I
-	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;ZLjava/util/Set;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getEnableLogging ()Z
-	public fun getInjectorKey ()I
+	public fun getInjectorKey ()Ljava/lang/String;
 	public fun getProductUsage ()Ljava/util/Set;
 	public fun getPublishableKey ()Ljava/lang/String;
 	public fun getStripeAccountId ()Ljava/lang/String;
@@ -5506,20 +5506,20 @@ public abstract class com/stripe/android/payments/paymentlauncher/PaymentLaunche
 public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$IntentConfirmationArgs : com/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (ILjava/lang/String;Ljava/lang/String;ZLjava/util/Set;Lcom/stripe/android/model/ConfirmStripeIntentParams;)V
-	public final fun component1 ()I
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Lcom/stripe/android/model/ConfirmStripeIntentParams;)V
+	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Z
 	public final fun component5 ()Ljava/util/Set;
 	public final fun component6 ()Lcom/stripe/android/model/ConfirmStripeIntentParams;
-	public final fun copy (ILjava/lang/String;Ljava/lang/String;ZLjava/util/Set;Lcom/stripe/android/model/ConfirmStripeIntentParams;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$IntentConfirmationArgs;
-	public static synthetic fun copy$default (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$IntentConfirmationArgs;ILjava/lang/String;Ljava/lang/String;ZLjava/util/Set;Lcom/stripe/android/model/ConfirmStripeIntentParams;ILjava/lang/Object;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$IntentConfirmationArgs;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Lcom/stripe/android/model/ConfirmStripeIntentParams;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$IntentConfirmationArgs;
+	public static synthetic fun copy$default (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$IntentConfirmationArgs;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Lcom/stripe/android/model/ConfirmStripeIntentParams;ILjava/lang/Object;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$IntentConfirmationArgs;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConfirmStripeIntentParams ()Lcom/stripe/android/model/ConfirmStripeIntentParams;
 	public fun getEnableLogging ()Z
-	public fun getInjectorKey ()I
+	public fun getInjectorKey ()Ljava/lang/String;
 	public fun getProductUsage ()Ljava/util/Set;
 	public fun getPublishableKey ()Ljava/lang/String;
 	public fun getStripeAccountId ()Ljava/lang/String;
@@ -5531,19 +5531,19 @@ public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherCo
 public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$PaymentIntentNextActionArgs : com/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (ILjava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;)V
-	public final fun component1 ()I
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Z
 	public final fun component5 ()Ljava/util/Set;
 	public final fun component6 ()Ljava/lang/String;
-	public final fun copy (ILjava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$PaymentIntentNextActionArgs;
-	public static synthetic fun copy$default (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$PaymentIntentNextActionArgs;ILjava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$PaymentIntentNextActionArgs;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$PaymentIntentNextActionArgs;
+	public static synthetic fun copy$default (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$PaymentIntentNextActionArgs;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$PaymentIntentNextActionArgs;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getEnableLogging ()Z
-	public fun getInjectorKey ()I
+	public fun getInjectorKey ()Ljava/lang/String;
 	public final fun getPaymentIntentClientSecret ()Ljava/lang/String;
 	public fun getProductUsage ()Ljava/util/Set;
 	public fun getPublishableKey ()Ljava/lang/String;
@@ -5556,19 +5556,19 @@ public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherCo
 public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$SetupIntentNextActionArgs : com/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (ILjava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;)V
-	public final fun component1 ()I
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Z
 	public final fun component5 ()Ljava/util/Set;
 	public final fun component6 ()Ljava/lang/String;
-	public final fun copy (ILjava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$SetupIntentNextActionArgs;
-	public static synthetic fun copy$default (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$SetupIntentNextActionArgs;ILjava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$SetupIntentNextActionArgs;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$SetupIntentNextActionArgs;
+	public static synthetic fun copy$default (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$SetupIntentNextActionArgs;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$SetupIntentNextActionArgs;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getEnableLogging ()Z
-	public fun getInjectorKey ()I
+	public fun getInjectorKey ()Ljava/lang/String;
 	public fun getProductUsage ()Ljava/util/Set;
 	public fun getPublishableKey ()Ljava/lang/String;
 	public final fun getSetupIntentClientSecret ()Ljava/lang/String;

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -93,7 +93,9 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
         .build()
 
     @InjectorKey
-    private val injectorKey: Int = WeakMapInjectorRegistry.nextKey()
+    private val injectorKey: String = WeakMapInjectorRegistry.nextKey(
+        requireNotNull(GooglePayPaymentMethodLauncher::class.simpleName)
+    )
 
     private val injector = object : Injector {
         override fun inject(injectable: Injectable<*>) {

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContract.kt
@@ -7,6 +7,7 @@ import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.core.os.bundleOf
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.payments.core.injection.InjectorKey
 import kotlinx.parcelize.Parcelize
 
 class GooglePayPaymentMethodLauncherContract :
@@ -77,7 +78,7 @@ class GooglePayPaymentMethodLauncherContract :
 
         @Parcelize
         internal data class InjectionParams(
-            val injectorKey: Int,
+            @InjectorKey val injectorKey: String,
             val productUsage: Set<String>,
             val enableLogging: Boolean,
             val publishableKey: String,

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultPaymentAuthenticatorRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultPaymentAuthenticatorRegistry.kt
@@ -121,6 +121,9 @@ internal class DefaultPaymentAuthenticatorRegistry @Inject internal constructor(
     override fun inject(injectable: Injectable<*>) {
         when (injectable) {
             is Stripe3ds2TransactionViewModelFactory -> authenticationComponent.inject(injectable)
+            else -> {
+                throw IllegalArgumentException("invalid Injectable $injectable requested in $this")
+            }
         }
     }
 
@@ -137,7 +140,8 @@ internal class DefaultPaymentAuthenticatorRegistry @Inject internal constructor(
             publishableKeyProvider: () -> String,
             productUsage: Set<String>
         ): PaymentAuthenticatorRegistry {
-            val injectorKey = WeakMapInjectorRegistry.nextKey()
+            val injectorKey =
+                WeakMapInjectorRegistry.nextKey(requireNotNull(PaymentAuthenticatorRegistry::class.simpleName))
             val component = DaggerAuthenticationComponent.builder()
                 .context(context)
                 .stripeRepository(stripeRepository)

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3DS2Authenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3DS2Authenticator.kt
@@ -26,7 +26,7 @@ import javax.inject.Singleton
 internal class Stripe3DS2Authenticator @Inject constructor(
     private val config: PaymentAuthConfig,
     @Named(ENABLE_LOGGING) private val enableLogging: Boolean,
-    @InjectorKey private val injectorKey: Int,
+    @InjectorKey private val injectorKey: String,
     @Named(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String,
     @Named(PRODUCT_USAGE) private val productUsage: Set<String>
 ) : PaymentAuthenticator<StripeIntent> {

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionContract.kt
@@ -40,7 +40,7 @@ internal class Stripe3ds2TransactionContract :
         val requestOptions: ApiRequest.Options,
         val enableLogging: Boolean,
         val statusBarColor: Int?,
-        @InjectorKey val injectorKey: Int,
+        @InjectorKey val injectorKey: String,
         val publishableKey: String,
         val productUsage: Set<String>
     ) : Parcelable {

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
@@ -61,7 +61,7 @@ internal interface AuthenticationComponent {
         ): Builder
 
         @BindsInstance
-        fun injectorKey(@InjectorKey id: Int): Builder
+        fun injectorKey(@InjectorKey id: String): Builder
 
         @BindsInstance
         fun publishableKeyProvider(

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/Injector.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/Injector.kt
@@ -24,4 +24,4 @@ interface Injector {
  * Dummy key when an [Injector] is not available.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) // For paymentsheet
-const val DUMMY_INJECTOR_KEY = -1
+const val DUMMY_INJECTOR_KEY = "DUMMY_INJECTOR_KEY"

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/InjectorRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/InjectorRegistry.kt
@@ -13,18 +13,18 @@ import dagger.Component
  */
 internal interface InjectorRegistry {
     /**
-     * Registers an [Injector] instance with corresponding [InjectorKey]
+     * Registers an [Injector] instance with corresponding [InjectorKey].
      */
-    fun register(injector: Injector, @InjectorKey key: Int)
+    fun register(injector: Injector, @InjectorKey key: String)
 
     /**
      * Retrieves an [Injector] instance from [InjectorKey].
      */
-    fun retrieve(@InjectorKey injectorKey: Int): Injector?
+    fun retrieve(@InjectorKey injectorKey: String): Injector?
 
     /**
-     * Returns the next key to identify an [Injector]
+     * Returns the next key to identify an [Injector].
      */
     @InjectorKey
-    fun nextKey(): Int
+    fun nextKey(prefix: String): String
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/WeakMapInjectorRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/WeakMapInjectorRegistry.kt
@@ -21,26 +21,27 @@ object WeakMapInjectorRegistry : InjectorRegistry {
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @VisibleForTesting
-    val staticCacheMap = WeakHashMap<Injector, @InjectorKey Int>()
+    val staticCacheMap = WeakHashMap<Injector, @InjectorKey String>()
 
     /**
-     * Global unique monotonically increasing key to be assigned to [Injector]s registered.
+     * Global unique monotonically increasing key to be assigned as a suffixes to
+     * registered [Injector]s.
      */
     @VisibleForTesting
     internal val CURRENT_REGISTER_KEY = AtomicInteger(0)
 
-    override fun register(injector: Injector, @InjectorKey key: Int) {
+    override fun register(injector: Injector, @InjectorKey key: String) {
         staticCacheMap[injector] = key
     }
 
-    override fun retrieve(@InjectorKey injectorKey: Int): Injector? {
+    override fun retrieve(@InjectorKey injectorKey: String): Injector? {
         return staticCacheMap.entries.firstOrNull {
             it.value == injectorKey
         }?.key
     }
 
     @InjectorKey
-    override fun nextKey(): Int {
-        return CURRENT_REGISTER_KEY.incrementAndGet()
+    override fun nextKey(prefix: String): String {
+        return prefix + CURRENT_REGISTER_KEY.incrementAndGet()
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherContract.kt
@@ -28,7 +28,7 @@ class PaymentLauncherContract :
     }
 
     sealed class Args(
-        @InjectorKey open val injectorKey: Int,
+        @InjectorKey open val injectorKey: String,
         open val publishableKey: String,
         open val stripeAccountId: String?,
         open val enableLogging: Boolean,
@@ -38,7 +38,7 @@ class PaymentLauncherContract :
 
         @Parcelize
         data class IntentConfirmationArgs(
-            override val injectorKey: Int,
+            @InjectorKey override val injectorKey: String,
             override val publishableKey: String,
             override val stripeAccountId: String?,
             override val enableLogging: Boolean,
@@ -48,7 +48,7 @@ class PaymentLauncherContract :
 
         @Parcelize
         data class PaymentIntentNextActionArgs(
-            override val injectorKey: Int,
+            @InjectorKey override val injectorKey: String,
             override val publishableKey: String,
             override val stripeAccountId: String?,
             override val enableLogging: Boolean,
@@ -58,7 +58,7 @@ class PaymentLauncherContract :
 
         @Parcelize
         data class SetupIntentNextActionArgs(
-            override val injectorKey: Int,
+            @InjectorKey override val injectorKey: String,
             override val publishableKey: String,
             override val stripeAccountId: String?,
             override val enableLogging: Boolean,

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncher.kt
@@ -55,7 +55,8 @@ class StripePaymentLauncher @AssistedInject internal constructor(
             .build()
 
     @InjectorKey
-    private val injectorKey: Int = WeakMapInjectorRegistry.nextKey()
+    private val injectorKey: String =
+        WeakMapInjectorRegistry.nextKey(requireNotNull(PaymentLauncher::class.simpleName))
 
     init {
         WeakMapInjectorRegistry.register(this, injectorKey)

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
@@ -26,6 +26,7 @@ import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.networking.AbsFakeStripeRepository
 import com.stripe.android.networking.ApiRequest
+import com.stripe.android.payments.core.injection.DUMMY_INJECTOR_KEY
 import com.stripe.android.payments.core.injection.Injectable
 import com.stripe.android.payments.core.injection.Injector
 import com.stripe.android.payments.core.injection.WeakMapInjectorRegistry
@@ -167,7 +168,7 @@ class GooglePayPaymentMethodLauncherViewModelTest {
                     factory.subComponentBuilder = mockBuilder
                 }
             }
-            val injectorKey = 1
+            val injectorKey = "testInjectorKey"
             WeakMapInjectorRegistry.register(injector, injectorKey)
             val factory = GooglePayPaymentMethodLauncherViewModel.Factory(
                 ApplicationProvider.getApplicationContext(),
@@ -216,7 +217,7 @@ class GooglePayPaymentMethodLauncherViewModelTest {
                     1099,
                     null,
                     GooglePayPaymentMethodLauncherContract.Args.InjectionParams(
-                        -1,
+                        DUMMY_INJECTOR_KEY,
                         productUsage,
                         false,
                         publishableKey,

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/Stripe3DS2AuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/Stripe3DS2AuthenticatorTest.kt
@@ -8,6 +8,7 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.payments.core.authentication.threeds2.Stripe3DS2Authenticator
 import com.stripe.android.payments.core.authentication.threeds2.Stripe3ds2TransactionContract
+import com.stripe.android.payments.core.injection.DUMMY_INJECTOR_KEY
 import com.stripe.android.view.AuthActivityStarterHost
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
@@ -36,7 +37,7 @@ class Stripe3DS2AuthenticatorTest {
     private val authenticator = Stripe3DS2Authenticator(
         paymentAuthConfig,
         enableLogging = false,
-        injectorKey = 1,
+        injectorKey = DUMMY_INJECTOR_KEY,
         publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
         productUsage = setOf()
     )

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionActivityTest.kt
@@ -125,7 +125,7 @@ class Stripe3ds2TransactionActivityTest {
     }
 
     private companion object {
-        var INJECTOR_KEY = WeakMapInjectorRegistry.nextKey()
+        var INJECTOR_KEY = WeakMapInjectorRegistry.nextKey("TestPrefix")
         val ARGS = Stripe3ds2TransactionContract.Args(
             SdkTransactionId.create(),
             PaymentAuthConfig.Stripe3ds2Config(

--- a/payments-core/src/test/java/com/stripe/android/payments/core/injection/WeakMapInjectorRegistryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/injection/WeakMapInjectorRegistryTest.kt
@@ -21,11 +21,14 @@ class WeakMapInjectorRegistryTest {
 
     @Test
     fun verifyRegistryRetrievesCorrectObject() {
+
         val injector1 = TestInjector()
-        val keyForInjector1 = WeakMapInjectorRegistry.nextKey()
+        val keyForInjector1 =
+            WeakMapInjectorRegistry.nextKey(requireNotNull(TestInjector::class.simpleName))
 
         val injector2 = TestInjector()
-        val keyForInjector2 = WeakMapInjectorRegistry.nextKey()
+        val keyForInjector2 =
+            WeakMapInjectorRegistry.nextKey(requireNotNull(TestInjector::class.simpleName))
 
         WeakMapInjectorRegistry.register(injector1, keyForInjector1)
         WeakMapInjectorRegistry.register(injector2, keyForInjector2)
@@ -42,7 +45,8 @@ class WeakMapInjectorRegistryTest {
     @Test
     fun verifyCacheIsClearedOnceWeakReferenceIsDeReferenced() {
         var injector1: Injector? = TestInjector()
-        val keyForInjector1 = WeakMapInjectorRegistry.nextKey()
+        val keyForInjector1 =
+            WeakMapInjectorRegistry.nextKey(requireNotNull(TestInjector::class.simpleName))
         WeakMapInjectorRegistry.register(injector1!!, keyForInjector1)
 
         assertNotNull(WeakMapInjectorRegistry.retrieve(keyForInjector1))

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivityTest.kt
@@ -176,7 +176,7 @@ class PaymentLauncherConfirmationActivityTest {
     }
 
     private companion object {
-        const val INJECTOR_KEY = 1
+        val INJECTOR_KEY = WeakMapInjectorRegistry.nextKey("testKey")
         const val CLIENT_SECRET = "clientSecret"
         const val TEST_STRIPE_ACCOUNT_ID = "accountId"
         val PRODUCT_USAGE = setOf("TestProductUsage")

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncherTest.kt
@@ -36,7 +36,7 @@ class StripePaymentLauncherTest {
         verify(mockHostActivityLauncher).launch(
             argWhere { arg ->
                 arg is PaymentLauncherContract.Args.IntentConfirmationArgs &&
-                    arg.injectorKey == WeakMapInjectorRegistry.CURRENT_REGISTER_KEY.get() &&
+                    arg.injectorKey == (PaymentLauncher::class.simpleName + WeakMapInjectorRegistry.CURRENT_REGISTER_KEY.get()) &&
                     arg.confirmStripeIntentParams == params
             }
         )
@@ -51,7 +51,7 @@ class StripePaymentLauncherTest {
         verify(mockHostActivityLauncher).launch(
             argWhere { arg ->
                 arg is PaymentLauncherContract.Args.IntentConfirmationArgs &&
-                    arg.injectorKey == WeakMapInjectorRegistry.CURRENT_REGISTER_KEY.get() &&
+                    arg.injectorKey == (PaymentLauncher::class.simpleName + WeakMapInjectorRegistry.CURRENT_REGISTER_KEY.get()) &&
                     arg.confirmStripeIntentParams == params
             }
         )
@@ -64,7 +64,7 @@ class StripePaymentLauncherTest {
         verify(mockHostActivityLauncher).launch(
             argWhere { arg ->
                 arg is PaymentLauncherContract.Args.PaymentIntentNextActionArgs &&
-                    arg.injectorKey == WeakMapInjectorRegistry.CURRENT_REGISTER_KEY.get() &&
+                    arg.injectorKey == (PaymentLauncher::class.simpleName + WeakMapInjectorRegistry.CURRENT_REGISTER_KEY.get()) &&
                     arg.paymentIntentClientSecret == CLIENT_SECRET
             }
         )
@@ -77,7 +77,7 @@ class StripePaymentLauncherTest {
         verify(mockHostActivityLauncher).launch(
             argWhere { arg ->
                 arg is PaymentLauncherContract.Args.SetupIntentNextActionArgs &&
-                    arg.injectorKey == WeakMapInjectorRegistry.CURRENT_REGISTER_KEY.get() &&
+                    arg.injectorKey == (PaymentLauncher::class.simpleName + WeakMapInjectorRegistry.CURRENT_REGISTER_KEY.get()) &&
                     arg.setupIntentClientSecret == CLIENT_SECRET
             }
         )

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -14,7 +14,7 @@ public final class com/stripe/android/paymentsheet/PaymentOptionsViewModel_Facto
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/PaymentOptionsViewModel_Factory;
 	public fun get ()Lcom/stripe/android/paymentsheet/PaymentOptionsViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/paymentsheet/PaymentOptionContract$Args;Lkotlin/jvm/functions/Function1;Lcom/stripe/android/paymentsheet/analytics/EventReporter;Lcom/stripe/android/paymentsheet/repositories/CustomerRepository;Lkotlin/coroutines/CoroutineContext;Landroid/app/Application;Lcom/stripe/android/Logger;I)Lcom/stripe/android/paymentsheet/PaymentOptionsViewModel;
+	public static fun newInstance (Lcom/stripe/android/paymentsheet/PaymentOptionContract$Args;Lkotlin/jvm/functions/Function1;Lcom/stripe/android/paymentsheet/analytics/EventReporter;Lcom/stripe/android/paymentsheet/repositories/CustomerRepository;Lkotlin/coroutines/CoroutineContext;Landroid/app/Application;Lcom/stripe/android/Logger;Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentOptionsViewModel;
 }
 
 public final class com/stripe/android/paymentsheet/PaymentOptionsViewModel_Factory_MembersInjector : dagger/MembersInjector {
@@ -223,8 +223,8 @@ public final class com/stripe/android/paymentsheet/PaymentSheetContract$Args : c
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args$Companion;
-	public final fun copy (Lcom/stripe/android/paymentsheet/model/ClientSecret;Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Ljava/lang/Integer;I)Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;Lcom/stripe/android/paymentsheet/model/ClientSecret;Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Ljava/lang/Integer;IILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;
+	public final fun copy (Lcom/stripe/android/paymentsheet/model/ClientSecret;Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Ljava/lang/Integer;Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;Lcom/stripe/android/paymentsheet/model/ClientSecret;Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Ljava/lang/Integer;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getGooglePayConfig ()Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
@@ -284,7 +284,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheetViewModel_Factory
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/PaymentSheetViewModel_Factory;
 	public fun get ()Lcom/stripe/android/paymentsheet/PaymentSheetViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Landroid/app/Application;Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;Lcom/stripe/android/paymentsheet/analytics/EventReporter;Ldagger/Lazy;Lcom/stripe/android/paymentsheet/repositories/StripeIntentRepository;Lcom/stripe/android/paymentsheet/model/StripeIntentValidator;Lcom/stripe/android/paymentsheet/repositories/CustomerRepository;Lcom/stripe/android/paymentsheet/PrefsRepository;Lcom/stripe/android/payments/paymentlauncher/StripePaymentLauncherAssistedFactory;Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherFactory;Lcom/stripe/android/Logger;Lkotlin/coroutines/CoroutineContext;I)Lcom/stripe/android/paymentsheet/PaymentSheetViewModel;
+	public static fun newInstance (Landroid/app/Application;Lcom/stripe/android/paymentsheet/PaymentSheetContract$Args;Lcom/stripe/android/paymentsheet/analytics/EventReporter;Ldagger/Lazy;Lcom/stripe/android/paymentsheet/repositories/StripeIntentRepository;Lcom/stripe/android/paymentsheet/model/StripeIntentValidator;Lcom/stripe/android/paymentsheet/repositories/CustomerRepository;Lcom/stripe/android/paymentsheet/PrefsRepository;Lcom/stripe/android/payments/paymentlauncher/StripePaymentLauncherAssistedFactory;Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherFactory;Lcom/stripe/android/Logger;Lkotlin/coroutines/CoroutineContext;Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheetViewModel;
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheetViewModel_Factory_MembersInjector : dagger/MembersInjector {
@@ -558,7 +558,7 @@ public final class com/stripe/android/paymentsheet/flowcontroller/DefaultFlowCon
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowController_Factory;
 	public fun get ()Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowController;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lkotlinx/coroutines/CoroutineScope;Landroidx/lifecycle/LifecycleOwner;Lkotlin/jvm/functions/Function0;Lcom/stripe/android/paymentsheet/model/PaymentOptionFactory;Lcom/stripe/android/paymentsheet/PaymentOptionCallback;Lcom/stripe/android/paymentsheet/PaymentSheetResultCallback;Landroidx/activity/result/ActivityResultCaller;ILcom/stripe/android/paymentsheet/flowcontroller/FlowControllerInitializer;Lcom/stripe/android/paymentsheet/analytics/EventReporter;Lcom/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel;Lcom/stripe/android/payments/paymentlauncher/StripePaymentLauncherAssistedFactory;Ldagger/Lazy;Lkotlin/coroutines/CoroutineContext;ZLjava/util/Set;Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherFactory;)Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowController;
+	public static fun newInstance (Lkotlinx/coroutines/CoroutineScope;Landroidx/lifecycle/LifecycleOwner;Lkotlin/jvm/functions/Function0;Lcom/stripe/android/paymentsheet/model/PaymentOptionFactory;Lcom/stripe/android/paymentsheet/PaymentOptionCallback;Lcom/stripe/android/paymentsheet/PaymentSheetResultCallback;Landroidx/activity/result/ActivityResultCaller;Ljava/lang/String;Lcom/stripe/android/paymentsheet/flowcontroller/FlowControllerInitializer;Lcom/stripe/android/paymentsheet/analytics/EventReporter;Lcom/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel;Lcom/stripe/android/payments/paymentlauncher/StripePaymentLauncherAssistedFactory;Ldagger/Lazy;Lkotlin/coroutines/CoroutineContext;ZLjava/util/Set;Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherFactory;)Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowController;
 }
 
 public final class com/stripe/android/paymentsheet/forms/FormViewModel_Factory : dagger/internal/Factory {
@@ -633,9 +633,9 @@ public final class com/stripe/android/paymentsheet/injection/FlowControllerModul
 public final class com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule_ProvideDummyInjectorKeyFactory : dagger/internal/Factory {
 	public fun <init> (Lcom/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule;)V
 	public static fun create (Lcom/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule;)Lcom/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule_ProvideDummyInjectorKeyFactory;
-	public fun get ()Ljava/lang/Integer;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun provideDummyInjectorKey (Lcom/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule;)I
+	public fun get ()Ljava/lang/String;
+	public static fun provideDummyInjectorKey (Lcom/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule;)Ljava/lang/String;
 }
 
 public final class com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule_ProvideEventReporterModeFactory : dagger/internal/Factory {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncher.kt
@@ -22,7 +22,8 @@ internal class DefaultPaymentSheetLauncher(
     application: Application
 ) : PaymentSheetLauncher, Injector {
     @InjectorKey
-    private val injectorKey: Int = WeakMapInjectorRegistry.nextKey()
+    private val injectorKey: String =
+        WeakMapInjectorRegistry.nextKey(requireNotNull(PaymentSheetLauncher::class.simpleName))
 
     private val paymentSheetLauncherComponent: PaymentSheetLauncherComponent =
         DaggerPaymentSheetLauncherComponent
@@ -104,6 +105,9 @@ internal class DefaultPaymentSheetLauncher(
         when (injectable) {
             is PaymentSheetViewModel.Factory -> {
                 paymentSheetLauncherComponent.inject(injectable)
+            }
+            else -> {
+                throw IllegalArgumentException("invalid Injectable $injectable requested in $this")
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionContract.kt
@@ -36,7 +36,7 @@ internal class PaymentOptionContract :
         val isGooglePayReady: Boolean,
         val newCard: PaymentSelection.New.Card?,
         @ColorInt val statusBarColor: Int?,
-        @InjectorKey val injectorKey: Int,
+        @InjectorKey val injectorKey: String,
         val enableLogging: Boolean,
         val productUsage: Set<String>
     ) : ActivityStarter.Args {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -31,7 +31,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
     @IOContext workContext: CoroutineContext,
     application: Application,
     logger: Logger,
-    @InjectorKey injectorKey: Int
+    @InjectorKey injectorKey: String
 ) : BaseSheetViewModel<PaymentOptionsViewModel.TransitionTarget>(
     config = args.config,
     prefsRepository = prefsRepositoryFactory(args.config?.customer),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetContract.kt
@@ -8,6 +8,7 @@ import androidx.activity.result.contract.ActivityResultContract
 import androidx.annotation.ColorInt
 import androidx.annotation.VisibleForTesting
 import androidx.core.os.bundleOf
+import com.stripe.android.payments.core.injection.DUMMY_INJECTOR_KEY
 import com.stripe.android.payments.core.injection.InjectorKey
 import com.stripe.android.paymentsheet.model.ClientSecret
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
@@ -41,7 +42,7 @@ class PaymentSheetContract :
         internal val clientSecret: ClientSecret,
         internal val config: PaymentSheet.Configuration?,
         @ColorInt internal val statusBarColor: Int? = null,
-        @InjectorKey internal val injectorKey: Int = NON_INJECTOR_KEY
+        @InjectorKey internal val injectorKey: String = DUMMY_INJECTOR_KEY
     ) : ActivityStarter.Args {
         val googlePayConfig: PaymentSheet.GooglePayConfiguration? get() = config?.googlePay
 
@@ -69,7 +70,7 @@ class PaymentSheetContract :
             internal fun createPaymentIntentArgsWithInjectorKey(
                 clientSecret: String,
                 config: PaymentSheet.Configuration? = null,
-                @InjectorKey injectorKey: Int
+                @InjectorKey injectorKey: String
             ) = Args(
                 PaymentIntentClientSecret(clientSecret),
                 config,
@@ -79,7 +80,7 @@ class PaymentSheetContract :
             internal fun createSetupIntentArgsWithInjectorKey(
                 clientSecret: String,
                 config: PaymentSheet.Configuration? = null,
-                @InjectorKey injectorKey: Int
+                @InjectorKey injectorKey: String
             ) = Args(
                 SetupIntentClientSecret(clientSecret),
                 config,
@@ -104,9 +105,5 @@ class PaymentSheetContract :
             "com.stripe.android.paymentsheet.PaymentSheetContract.extra_args"
         private const val EXTRA_RESULT =
             "com.stripe.android.paymentsheet.PaymentSheetContract.extra_result"
-
-        // Indicates no corresponding injector is registered, should only happen when
-        // PaymentSheetContract.Args is created by clients directly
-        private const val NON_INJECTOR_KEY = -1
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -85,7 +85,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     private val googlePayPaymentMethodLauncherFactory: GooglePayPaymentMethodLauncherFactory,
     logger: Logger,
     @IOContext workContext: CoroutineContext,
-    @InjectorKey injectorKey: Int
+    @InjectorKey injectorKey: String
 ) : BaseSheetViewModel<PaymentSheetViewModel.TransitionTarget>(
     application = application,
     config = args.config,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -71,7 +71,7 @@ internal class DefaultFlowController @Inject internal constructor(
     private val paymentOptionCallback: PaymentOptionCallback,
     private val paymentResultCallback: PaymentSheetResultCallback,
     activityResultCaller: ActivityResultCaller,
-    @InjectorKey private val injectorKey: Int,
+    @InjectorKey private val injectorKey: String,
     // Properties provided through injection
     private val flowControllerInitializer: FlowControllerInitializer,
     private val eventReporter: EventReporter,
@@ -103,6 +103,9 @@ internal class DefaultFlowController @Inject internal constructor(
         when (injectable) {
             is PaymentOptionsViewModel.Factory -> {
                 flowControllerComponent.inject(injectable)
+            }
+            else -> {
+                throw IllegalArgumentException("invalid Injectable $injectable requested in $this")
             }
         }
     }
@@ -469,7 +472,10 @@ internal class DefaultFlowController @Inject internal constructor(
             paymentOptionCallback: PaymentOptionCallback,
             paymentResultCallback: PaymentSheetResultCallback
         ): PaymentSheet.FlowController {
-            val injectorKey = WeakMapInjectorRegistry.nextKey()
+            val injectorKey =
+                WeakMapInjectorRegistry.nextKey(
+                    requireNotNull(PaymentSheet.FlowController::class.simpleName)
+                )
             val flowControllerComponent = DaggerFlowControllerComponent.builder()
                 .appContext(appContext)
                 .viewModelStoreOwner(viewModelStoreOwner)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/FlowControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/FlowControllerComponent.kt
@@ -63,7 +63,7 @@ internal interface FlowControllerComponent {
         fun paymentResultCallback(paymentResultCallback: PaymentSheetResultCallback): Builder
 
         @BindsInstance
-        fun injectorKey(@InjectorKey injectorKey: Int): Builder
+        fun injectorKey(@InjectorKey injectorKey: String): Builder
 
         fun build(): FlowControllerComponent
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule.kt
@@ -44,5 +44,5 @@ internal class PaymentOptionsViewModelModule {
      */
     @Provides
     @InjectorKey
-    fun provideDummyInjectorKey(): Int = DUMMY_INJECTOR_KEY
+    fun provideDummyInjectorKey(): String = DUMMY_INJECTOR_KEY
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
@@ -29,7 +29,7 @@ internal interface PaymentSheetLauncherComponent {
         fun application(application: Application): Builder
 
         @BindsInstance
-        fun injectorKey(@InjectorKey injectorKey: Int): Builder
+        fun injectorKey(@InjectorKey injectorKey: String): Builder
 
         fun build(): PaymentSheetLauncherComponent
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -48,7 +48,7 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
     protected val prefsRepository: PrefsRepository,
     protected val workContext: CoroutineContext = Dispatchers.IO,
     protected val logger: Logger,
-    @InjectorKey private val injectorKey: Int
+    @InjectorKey private val injectorKey: String
 ) : AndroidViewModel(application) {
     internal val customerConfig = config?.customer
     internal val merchantName = config?.merchantDisplayName

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -309,7 +309,7 @@ class PaymentOptionsActivityTest {
             isGooglePayReady = false,
             newCard = null,
             statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR,
-            injectorKey = 0,
+            injectorKey = DUMMY_INJECTOR_KEY,
             enableLogging = false,
             productUsage = mock()
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAddPaymentMethodFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAddPaymentMethodFragmentTest.kt
@@ -8,6 +8,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.payments.core.injection.DUMMY_INJECTOR_KEY
 import com.stripe.android.payments.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.databinding.FragmentPaymentsheetAddPaymentMethodBinding
@@ -56,7 +57,7 @@ class PaymentOptionsAddPaymentMethodFragmentTest {
             isGooglePayReady = false,
             newCard = null,
             statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR,
-            injectorKey = 0,
+            injectorKey = DUMMY_INJECTOR_KEY,
             enableLogging = false,
             productUsage = mock()
         ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -243,7 +243,7 @@ internal class PaymentOptionsViewModelTest {
                 factory.subComponentBuilderProvider = Provider { mockBuilder }
             }
         }
-        val injectorKey = 1
+        val injectorKey = WeakMapInjectorRegistry.nextKey("testKey")
         WeakMapInjectorRegistry.register(injector, injectorKey)
         val factory = PaymentOptionsViewModel.Factory(
             { ApplicationProvider.getApplicationContext() },
@@ -284,7 +284,7 @@ internal class PaymentOptionsViewModelTest {
                     false,
                     null,
                     null,
-                    1,
+                    DUMMY_INJECTOR_KEY,
                     false,
                     productUsage
                 )
@@ -328,7 +328,7 @@ internal class PaymentOptionsViewModelTest {
             isGooglePayReady = true,
             newCard = null,
             statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR,
-            injectorKey = 0,
+            injectorKey = DUMMY_INJECTOR_KEY,
             enableLogging = false,
             productUsage = mock()
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -840,7 +840,7 @@ internal class PaymentSheetViewModelTest {
                 factory.subComponentBuilderProvider = Provider { mockBuilder }
             }
         }
-        val injectorKey = 1
+        val injectorKey = WeakMapInjectorRegistry.nextKey("testKey")
         WeakMapInjectorRegistry.register(injector, injectorKey)
         val factory = PaymentSheetViewModel.Factory(
             { ApplicationProvider.getApplicationContext() },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -734,7 +734,7 @@ internal class DefaultFlowControllerTest {
         paymentOptionCallback,
         paymentResultCallback,
         activityResultCaller,
-        0,
+        INJECTOR_KEY,
         flowControllerInitializer,
         eventReporter,
         ViewModelProvider(activity)[FlowControllerViewModel::class.java],
@@ -821,7 +821,7 @@ internal class DefaultFlowControllerTest {
         private val PAYMENT_METHODS =
             listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD) + PaymentMethodFixtures.createCards(5)
 
-        private const val INJECTOR_KEY = 0
+        private const val INJECTOR_KEY = "TestInjectorKey"
         private const val ENABLE_LOGGING = false
         private val PRODUCT_USAGE = setOf("TestProductUsage")
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Change `@InjectorKey` from type `Int` to `String`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
When app is recovered, it is possible that a previously assigned key is now assigned to a different Injector due to the sequence the injector is initialized, causing an wrong Injector to be registered in the registry. E.g

1. `PaymentSheet` is created, the registry now has: {<DefaultPaymentSheetLauncher, `1`>}, 
2. `PaymentSheetActivity` is started, sharing the dagger graph through `InjectorKey` `1`
3. `PaymentLauncher` within `PaymentSheetViewModel` is created, the registry now has: {<DefaultPaymentSheetLauncher, `1`>, <PaymentLauncher, `2`>}
4. User selected to add a new payment method,  `ComposeFormDataCollectionFragment`'s `FormViewModel` is created from `PaymentSheetActivity`, sharing the dagger graph through `InjectorKey` `1`
5. App gets killed and recovered
6. `PaymentSheetActivity` gets recreated **without** dagger graph through fallback, now registry is empty
7. `PaymentLauncher` within `PaymentSheetViewModel` is created, the registry now has: {<PaymentLauncher, `1`>}
8. User selected to add a new payment method,  `ComposeFormDataCollectionFragment`s `FormViewModel` is created from `PaymentSheetActivity`, it's trying to sharing the dagger graph through `InjectorKey` `1`, but now `1` points to `PaymentLauncher`, returning the wrong `Injector` - The correct behavior is `FormViewModel` should **not** find an injector and go through the fallback path

By changing the key to a String we can avoid the problem, because in step 8, the registry now has {<PaymentLauncher, `PaymentLauncher1`>}, but s `FormViewModel` will try to query with key `PaymentSheetLauncher1`, resulting in a no found and therefore correct fallback behavior.




# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
