### PR TITLE
Replace Stripe3ds2TransactionViewModel injection with subcomponent

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -5221,17 +5221,19 @@ public final class com/stripe/android/payments/core/authentication/threeds2/Stri
 }
 
 public final class com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactory_MembersInjector : dagger/MembersInjector {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Ldagger/MembersInjector;
-	public static fun injectAnalyticsRequestExecutor (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactory;Lcom/stripe/android/networking/AnalyticsRequestExecutor;)V
-	public static fun injectAnalyticsRequestFactory (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactory;Lcom/stripe/android/networking/AnalyticsRequestFactory;)V
-	public static fun injectChallengeResultProcessor (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactory;Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2ChallengeResultProcessor;)V
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Ldagger/MembersInjector;
 	public fun injectMembers (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactory;)V
 	public synthetic fun injectMembers (Ljava/lang/Object;)V
-	public static fun injectMessageVersionRegistry (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactory;Lcom/stripe/android/stripe3ds2/transaction/MessageVersionRegistry;)V
-	public static fun injectStripeRepository (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactory;Lcom/stripe/android/networking/StripeRepository;)V
-	public static fun injectThreeDs2Service (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactory;Lcom/stripe/android/stripe3ds2/service/StripeThreeDs2Service;)V
-	public static fun injectWorkContext (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactory;Lkotlin/coroutines/CoroutineContext;)V
+	public static fun injectSubComponentBuilder (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactory;Lcom/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelSubcomponent$Builder;)V
+}
+
+public final class com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel_Factory;
+	public fun get ()Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionContract$Args;Lcom/stripe/android/networking/StripeRepository;Lcom/stripe/android/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/AnalyticsRequestFactory;Lcom/stripe/android/stripe3ds2/service/StripeThreeDs2Service;Lcom/stripe/android/stripe3ds2/transaction/MessageVersionRegistry;Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2ChallengeResultProcessor;Lcom/stripe/android/stripe3ds2/transaction/InitChallengeRepository;Lkotlin/coroutines/CoroutineContext;Landroidx/lifecycle/SavedStateHandle;)Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel;
 }
 
 public final class com/stripe/android/payments/core/injection/AuthenticationModule_Companion_ProvideDefaultReturnUrlFactory : dagger/internal/Factory {
@@ -5398,20 +5400,28 @@ public final class com/stripe/android/payments/core/injection/Stripe3DSAuthentic
 	public static fun providePaymentAuthConfig ()Lcom/stripe/android/PaymentAuthConfig;
 }
 
-public final class com/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelModule_Companion_ProvideMessageVersionRegistryFactory : dagger/internal/Factory {
+public final class com/stripe/android/payments/core/injection/Stripe3ds2TransactionModule_Companion_ProvideMessageVersionRegistryFactory : dagger/internal/Factory {
 	public fun <init> ()V
-	public static fun create ()Lcom/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelModule_Companion_ProvideMessageVersionRegistryFactory;
+	public static fun create ()Lcom/stripe/android/payments/core/injection/Stripe3ds2TransactionModule_Companion_ProvideMessageVersionRegistryFactory;
 	public fun get ()Lcom/stripe/android/stripe3ds2/transaction/MessageVersionRegistry;
 	public synthetic fun get ()Ljava/lang/Object;
 	public static fun provideMessageVersionRegistry ()Lcom/stripe/android/stripe3ds2/transaction/MessageVersionRegistry;
 }
 
-public final class com/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelModule_Companion_ProvideStripeThreeDs2ServiceFactory : dagger/internal/Factory {
+public final class com/stripe/android/payments/core/injection/Stripe3ds2TransactionModule_Companion_ProvideStripeThreeDs2ServiceFactory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelModule_Companion_ProvideStripeThreeDs2ServiceFactory;
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/Stripe3ds2TransactionModule_Companion_ProvideStripeThreeDs2ServiceFactory;
 	public fun get ()Lcom/stripe/android/stripe3ds2/service/StripeThreeDs2Service;
 	public synthetic fun get ()Ljava/lang/Object;
 	public static fun provideStripeThreeDs2Service (Landroid/content/Context;ZLkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/stripe3ds2/service/StripeThreeDs2Service;
+}
+
+public final class com/stripe/android/payments/core/injection/Stripe3dsTransactionViewModelModule_ProvidesInitChallengeRepositoryFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/payments/core/injection/Stripe3dsTransactionViewModelModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/Stripe3dsTransactionViewModelModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/Stripe3dsTransactionViewModelModule_ProvidesInitChallengeRepositoryFactory;
+	public fun get ()Lcom/stripe/android/stripe3ds2/transaction/InitChallengeRepository;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun providesInitChallengeRepository (Lcom/stripe/android/payments/core/injection/Stripe3dsTransactionViewModelModule;Landroid/app/Application;Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionContract$Args;Lkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/stripe3ds2/transaction/InitChallengeRepository;
 }
 
 public final class com/stripe/android/payments/core/injection/StripeRepositoryModule {

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3DSAuthenticatorModule.kt
@@ -17,7 +17,7 @@ import javax.inject.Singleton
  */
 @Module(
     includes = [
-        Stripe3ds2TransactionViewModelModule::class
+        Stripe3ds2TransactionModule::class
     ]
 )
 internal abstract class Stripe3DSAuthenticatorModule {

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3ds2TransactionModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3ds2TransactionModule.kt
@@ -3,7 +3,6 @@ package com.stripe.android.payments.core.injection
 import android.content.Context
 import com.stripe.android.payments.core.authentication.threeds2.DefaultStripe3ds2ChallengeResultProcessor
 import com.stripe.android.payments.core.authentication.threeds2.Stripe3ds2ChallengeResultProcessor
-import com.stripe.android.payments.core.authentication.threeds2.Stripe3ds2TransactionViewModel
 import com.stripe.android.stripe3ds2.service.StripeThreeDs2Service
 import com.stripe.android.stripe3ds2.service.StripeThreeDs2ServiceImpl
 import com.stripe.android.stripe3ds2.transaction.MessageVersionRegistry
@@ -15,10 +14,12 @@ import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
 /**
- * Provides dependencies for [Stripe3ds2TransactionViewModel].
+ * Provides dependencies for 3ds2 transaction.
  */
-@Module
-internal abstract class Stripe3ds2TransactionViewModelModule {
+@Module(
+    subcomponents = [Stripe3ds2TransactionViewModelSubcomponent::class]
+)
+internal abstract class Stripe3ds2TransactionModule {
     @Binds
     abstract fun bindsStripe3ds2ChallengeResultProcessor(
         defaultStripe3ds2ChallengeResultProcessor: DefaultStripe3ds2ChallengeResultProcessor

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelFactoryComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelFactoryComponent.kt
@@ -15,7 +15,7 @@ import javax.inject.Singleton
 @Component(
     modules = [
         StripeRepositoryModule::class,
-        Stripe3ds2TransactionViewModelModule::class,
+        Stripe3ds2TransactionModule::class,
         CoroutineContextModule::class
     ]
 )

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelSubcomponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelSubcomponent.kt
@@ -1,0 +1,29 @@
+package com.stripe.android.payments.core.injection
+
+import android.app.Application
+import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.payments.core.authentication.threeds2.Stripe3ds2TransactionContract
+import com.stripe.android.payments.core.authentication.threeds2.Stripe3ds2TransactionViewModel
+import dagger.BindsInstance
+import dagger.Subcomponent
+
+@Subcomponent(
+    modules = [Stripe3dsTransactionViewModelModule::class]
+)
+internal interface Stripe3ds2TransactionViewModelSubcomponent {
+    val viewModel: Stripe3ds2TransactionViewModel
+
+    @Subcomponent.Builder
+    interface Builder {
+        @BindsInstance
+        fun args(args: Stripe3ds2TransactionContract.Args): Builder
+
+        @BindsInstance
+        fun savedStateHandle(handle: SavedStateHandle): Builder
+
+        @BindsInstance
+        fun application(application: Application): Builder
+
+        fun build(): Stripe3ds2TransactionViewModelSubcomponent
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3dsTransactionViewModelModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3dsTransactionViewModelModule.kt
@@ -1,0 +1,26 @@
+package com.stripe.android.payments.core.injection
+
+import android.app.Application
+import com.stripe.android.payments.core.authentication.threeds2.Stripe3ds2TransactionContract
+import com.stripe.android.stripe3ds2.transaction.InitChallengeRepositoryFactory
+import dagger.Module
+import dagger.Provides
+import kotlin.coroutines.CoroutineContext
+
+@Module
+internal class Stripe3dsTransactionViewModelModule {
+    @Provides
+    fun providesInitChallengeRepository(
+        application: Application,
+        args: Stripe3ds2TransactionContract.Args,
+        @UIContext workContext: CoroutineContext
+    ) = InitChallengeRepositoryFactory(
+        application,
+        args.stripeIntent.isLiveMode,
+        args.sdkTransactionId,
+        args.config.uiCustomization.uiCustomization,
+        args.fingerprint.directoryServerEncryption.rootCerts,
+        args.enableLogging,
+        workContext
+    ).create()
+}

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionActivityTest.kt
@@ -12,8 +12,7 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.payments.PaymentFlowResult
-import com.stripe.android.payments.core.injection.Injectable
-import com.stripe.android.payments.core.injection.Injector
+import com.stripe.android.payments.core.injection.DUMMY_INJECTOR_KEY
 import com.stripe.android.payments.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.stripe3ds2.init.ui.StripeUiCustomization
 import com.stripe.android.stripe3ds2.transaction.SdkTransactionId
@@ -74,49 +73,6 @@ class Stripe3ds2TransactionActivityTest {
         }
     }
 
-    @Test
-    fun `Stripe3ds2TransactionViewModelFactory gets initialized by Injector when Injector is available`() {
-        val injector = object : Injector {
-            override fun inject(injectable: Injectable<*>) {
-                val factory = injectable as Stripe3ds2TransactionViewModelFactory
-                factory.stripeRepository = mock()
-                factory.analyticsRequestExecutor = mock()
-                factory.analyticsRequestFactory = mock()
-                factory.messageVersionRegistry = mock()
-                factory.threeDs2Service = mock()
-                factory.challengeResultProcessor = mock()
-                factory.workContext = mock()
-            }
-        }
-        WeakMapInjectorRegistry.register(injector, INJECTOR_KEY)
-
-        ActivityScenario.launch<Stripe3ds2TransactionActivity>(
-            Intent(
-                ApplicationProvider.getApplicationContext(),
-                Stripe3ds2TransactionActivity::class.java
-            ).putExtras(
-                ARGS.toBundle()
-            )
-        ).use { activityScenario ->
-            assertThat(activityScenario.state).isEqualTo(Lifecycle.State.RESUMED)
-        }
-    }
-
-    @Test
-    fun `Stripe3ds2TransactionViewModelFactory gets initialized with fallback when no Injector is available`() {
-        WeakMapInjectorRegistry.staticCacheMap.clear()
-        ActivityScenario.launch<Stripe3ds2TransactionActivity>(
-            Intent(
-                ApplicationProvider.getApplicationContext(),
-                Stripe3ds2TransactionActivity::class.java
-            ).putExtras(
-                ARGS.toBundle()
-            )
-        ).use { activityScenario ->
-            assertThat(activityScenario.state).isEqualTo(Lifecycle.State.RESUMED)
-        }
-    }
-
     private fun parseResult(
         activityScenario: ActivityScenario<*>
     ): PaymentFlowResult.Unvalidated {
@@ -125,7 +81,6 @@ class Stripe3ds2TransactionActivityTest {
     }
 
     private companion object {
-        var INJECTOR_KEY = WeakMapInjectorRegistry.nextKey("TestPrefix")
         val ARGS = Stripe3ds2TransactionContract.Args(
             SdkTransactionId.create(),
             PaymentAuthConfig.Stripe3ds2Config(
@@ -140,7 +95,7 @@ class Stripe3ds2TransactionActivityTest {
             ApiRequest.Options(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY),
             enableLogging = false,
             statusBarColor = null,
-            injectorKey = INJECTOR_KEY,
+            injectorKey = DUMMY_INJECTOR_KEY,
             ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
             setOf()
         )

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactoryTest.kt
@@ -1,0 +1,141 @@
+package com.stripe.android.payments.core.authentication.threeds2
+
+import android.app.Application
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.PaymentAuthConfig
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.networking.ApiRequest
+import com.stripe.android.payments.core.injection.Injectable
+import com.stripe.android.payments.core.injection.Injector
+import com.stripe.android.payments.core.injection.Stripe3ds2TransactionViewModelSubcomponent
+import com.stripe.android.payments.core.injection.WeakMapInjectorRegistry
+import com.stripe.android.stripe3ds2.init.ui.StripeUiCustomization
+import com.stripe.android.stripe3ds2.transaction.SdkTransactionId
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argWhere
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertNotNull
+
+@RunWith(RobolectricTestRunner::class)
+class Stripe3ds2TransactionViewModelFactoryTest {
+    // FragmentScenario is needed to provide SavedStateRegistryOwner required
+    // by Stripe3ds2TransactionViewModelFactory
+    private val scenario = launchFragmentInContainer(initialState = Lifecycle.State.CREATED) {
+        TestFragment()
+    }
+
+    internal class TestFragment : Fragment() {
+        override fun onCreateView(
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?
+        ): View = FrameLayout(inflater.context)
+    }
+
+    @Test
+    fun `Stripe3ds2TransactionViewModelFactory gets initialized by Injector when Injector is available`() {
+        scenario.onFragment { savedStateRegistryOwner ->
+            // The reason the ViewModel cannot be mocked here is because
+            // AbstractSavedStateViewModelFactory will call viewModel.setTagIfAbsent, which accesses
+            // ViewModel.mBagOfTags that's initialized in base class.
+            // Mocking it would leave this field null, causing an NPE.
+            val viewModel = Stripe3ds2TransactionViewModel(
+                mock(), mock(), mock(), mock(), mock(), mock(), mock(), mock(), mock(), mock()
+            )
+            val mockBuilder = mock<Stripe3ds2TransactionViewModelSubcomponent.Builder>()
+            val mockSubcomponent = mock<Stripe3ds2TransactionViewModelSubcomponent>()
+
+            whenever(mockBuilder.build()).thenReturn(mockSubcomponent)
+            whenever(mockBuilder.application(any())).thenReturn(mockBuilder)
+            whenever(mockBuilder.savedStateHandle(any())).thenReturn(mockBuilder)
+            whenever(mockBuilder.args(any())).thenReturn(mockBuilder)
+            whenever(mockSubcomponent.viewModel).thenReturn(viewModel)
+
+            val injector = object : Injector {
+                override fun inject(injectable: Injectable<*>) {
+                    val factory = injectable as Stripe3ds2TransactionViewModelFactory
+                    factory.subComponentBuilder = mockBuilder
+                }
+            }
+            WeakMapInjectorRegistry.register(injector, INJECTOR_KEY)
+
+            val factory = Stripe3ds2TransactionViewModelFactory(
+                { ApplicationProvider.getApplicationContext() },
+                savedStateRegistryOwner,
+                { ARGS }
+            )
+            val factorySpy = spy(factory)
+            val createdViewModel =
+                factorySpy.create(Stripe3ds2TransactionViewModel::class.java)
+            verify(factorySpy, times(0)).fallbackInitialize(any())
+            assertThat(createdViewModel).isEqualTo(viewModel)
+
+            WeakMapInjectorRegistry.staticCacheMap.clear()
+        }
+    }
+
+    @Test
+    fun `Stripe3ds2TransactionViewModelFactory gets initialized with fallback when no Injector is available`() {
+        scenario.onFragment { savedStateRegistryOwner ->
+            val application = ApplicationProvider.getApplicationContext<Application>()
+            val factory = Stripe3ds2TransactionViewModelFactory(
+                { application },
+                savedStateRegistryOwner,
+                { ARGS }
+            )
+            val factorySpy = spy(factory)
+
+            assertNotNull(factorySpy.create(Stripe3ds2TransactionViewModel::class.java))
+            verify(factorySpy).fallbackInitialize(
+                argWhere {
+                    it.application == application &&
+                        it.enableLogging == ENABLE_LOGGING &&
+                        it.productUsage == PRODUCT_USAGE &&
+                        it.publishableKey == ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+                }
+            )
+        }
+    }
+
+    private companion object {
+        val INJECTOR_KEY: String = WeakMapInjectorRegistry.nextKey("TestKey")
+        const val ENABLE_LOGGING = false
+        val PRODUCT_USAGE = setOf("TestProductUsage")
+        val ARGS = Stripe3ds2TransactionContract.Args(
+            SdkTransactionId.create(),
+            PaymentAuthConfig.Stripe3ds2Config(
+                timeout = 5,
+                PaymentAuthConfig.Stripe3ds2UiCustomization(
+                    StripeUiCustomization()
+                )
+            ),
+            PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2,
+            PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2.nextActionData
+                as StripeIntent.NextActionData.SdkData.Use3DS2,
+            ApiRequest.Options(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY),
+            enableLogging = ENABLE_LOGGING,
+            statusBarColor = null,
+            injectorKey = INJECTOR_KEY,
+            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+            PRODUCT_USAGE
+        )
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Replace `Stripe3ds2TransactionViewModelFactory`'s field injection with a Subcomponent.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Instead of listing all injection-required fields one by one, using a subcomponent can simplify the injected fields and allow us to apply subcomponent specific scopes if needed.

All `Injectable` should use the subcomponent instead of field injections for uniformity across the codebase.

`Injectable`s to be refactored:
* [PaymentOptionViewModel.Factory](https://github.com/stripe/stripe-android/blob/17dbb67db41f11056fa1c9fe0ce38d50ed2c9b89/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt#L128) <- #4205
* [PaymentLauncherViewModel.Factory](https://github.com/stripe/stripe-android/blob/e59b24a8bef004e0033f13857e73a4a49a7008fe/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt#L251) <- #4207
* [Stripe3ds2TransactionViewModelFactory](https://github.com/stripe/stripe-android/blob/e59b24a8bef004e0033f13857e73a4a49a7008fe/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel.kt#L290)  <- changed in this PR




# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
