### PR TITLE
Fetch saved payment methods from ViewModel

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
@@ -31,7 +31,6 @@ import com.stripe.android.paymentsheet.paymentdatacollection.TransformToPaymentM
 import com.stripe.android.paymentsheet.ui.AddPaymentMethodsFragmentFactory
 import com.stripe.android.paymentsheet.ui.AnimationConstants
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 internal abstract class BaseAddPaymentMethodFragment(
     private val eventReporter: EventReporter
@@ -67,7 +66,6 @@ internal abstract class BaseAddPaymentMethodFragment(
         )
     }
 
-    @ExperimentalCoroutinesApi
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
@@ -259,7 +257,7 @@ internal abstract class BaseAddPaymentMethodFragment(
                 // checkbox regardless of the payment method until future fix
                 stripeIntent.paymentMethodTypes.forEach {
                     if (SupportedPaymentMethod.fromCode(it)
-                        ?.userRequestedConfirmSaveForFutureSupported == false
+                            ?.userRequestedConfirmSaveForFutureSupported == false
                     ) {
                         saveForFutureUseValue = false
                         saveForFutureUseVisible = false

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
@@ -41,7 +41,7 @@ internal abstract class BasePaymentMethodsListFragment(
         }
         this.config = nullableConfig
 
-        setHasOptionsMenu(config.paymentMethods.isNotEmpty())
+        setHasOptionsMenu(!sheetViewModel.paymentMethods.value.isNullOrEmpty())
         eventReporter.onShowExistingPaymentOptions()
     }
 
@@ -93,7 +93,11 @@ internal abstract class BasePaymentMethodsListFragment(
             viewBinding.recycler.adapter = it
         }
 
-        adapter.update(config, sheetViewModel.selection.value)
+        adapter.setItems(
+            config,
+            sheetViewModel.paymentMethods.value.orEmpty(),
+            sheetViewModel.selection.value
+        )
 
         sheetViewModel.processing.observe(viewLifecycleOwner) { isProcessing ->
             adapter.isEnabled = !isProcessing

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -142,7 +142,7 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
 
         viewModel.fragmentConfig.observe(this) { config ->
             if (config != null) {
-                val target = if (config.paymentMethods.isEmpty()) {
+                val target = if (viewModel.paymentMethods.value.isNullOrEmpty()) {
                     PaymentSheetViewModel.TransitionTarget.AddPaymentMethodSheet(config)
                 } else {
                     PaymentSheetViewModel.TransitionTarget.SelectSavedPaymentMethod(config)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddPaymentMethodFragment.kt
@@ -37,7 +37,7 @@ internal class PaymentSheetAddPaymentMethodFragment(
             BaseSheetActivity.EXTRA_FRAGMENT_CONFIG
         )
         val shouldShowGooglePayButton = config?.let {
-            config.isGooglePayReady && config.paymentMethods.isEmpty()
+            config.isGooglePayReady && sheetViewModel.paymentMethods.value.isNullOrEmpty()
         } ?: false
 
         viewBinding = FragmentPaymentsheetAddPaymentMethodBinding.bind(view)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/FragmentConfig.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/FragmentConfig.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet.model
 
 import android.os.Parcelable
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.BaseAddPaymentMethodFragment
 import com.stripe.android.paymentsheet.BasePaymentMethodsListFragment
@@ -14,30 +13,6 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 internal data class FragmentConfig(
     val stripeIntent: StripeIntent,
-    val paymentMethods: List<PaymentMethod>,
     val isGooglePayReady: Boolean,
     val savedSelection: SavedSelection
-) : Parcelable {
-
-    val sortedPaymentMethods: List<PaymentMethod>
-        get() {
-            val primaryPaymentMethodIndex = when (savedSelection) {
-                is SavedSelection.PaymentMethod -> {
-                    paymentMethods.indexOfFirst {
-                        it.id == savedSelection.id
-                    }
-                }
-                else -> -1
-            }
-            return if (primaryPaymentMethodIndex != -1) {
-                val mutablePaymentMethods = paymentMethods.toMutableList()
-                mutablePaymentMethods.removeAt(primaryPaymentMethodIndex)
-                    .also { primaryPaymentMethod ->
-                        mutablePaymentMethods.add(0, primaryPaymentMethod)
-                    }
-                mutablePaymentMethods
-            } else {
-                paymentMethods
-            }
-        }
-}
+) : Parcelable

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAdapterTest.kt
@@ -4,6 +4,7 @@ import android.widget.FrameLayout
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.FragmentConfigFixtures
@@ -23,6 +24,7 @@ class PaymentOptionsAdapterTest {
     private val paymentSelections = mutableSetOf<PaymentSelection>()
     private val paymentMethodsDeleted =
         mutableListOf<PaymentOptionsAdapter.Item.SavedPaymentMethod>()
+    private val paymentMethods = PaymentMethodFixtures.createCards(6)
     private var addCardClicks = 0
 
     @Test
@@ -108,7 +110,7 @@ class PaymentOptionsAdapterTest {
         val adapter = createConfiguredAdapter(
             CONFIG.copy(
                 isGooglePayReady = true,
-                savedSelection = SavedSelection.PaymentMethod(CONFIG.paymentMethods[1].id!!)
+                savedSelection = SavedSelection.PaymentMethod(paymentMethods[1].id!!)
             )
         )
 
@@ -123,7 +125,7 @@ class PaymentOptionsAdapterTest {
         val adapter = createConfiguredAdapter(
             CONFIG.copy(
                 isGooglePayReady = true,
-                savedSelection = SavedSelection.PaymentMethod(CONFIG.paymentMethods[1].id!!)
+                savedSelection = SavedSelection.PaymentMethod(paymentMethods[1].id!!)
             )
         )
         adapter.isEnabled = false
@@ -161,7 +163,7 @@ class PaymentOptionsAdapterTest {
         val adapter = createConfiguredAdapter(
             CONFIG.copy(
                 isGooglePayReady = true,
-                savedSelection = SavedSelection.PaymentMethod(CONFIG.paymentMethods[1].id!!)
+                savedSelection = SavedSelection.PaymentMethod(paymentMethods[1].id!!)
             )
         )
         adapter.toggleEditing()
@@ -208,13 +210,14 @@ class PaymentOptionsAdapterTest {
 
     @Test
     fun `initial selected item should reflect SavedSelection`() {
-        val savedPaymentMethod = CONFIG.paymentMethods[3]
+        val savedPaymentMethod = paymentMethods[3]
         val adapter = createAdapter().also {
-            it.update(
+            it.setItems(
                 CONFIG.copy(
                     isGooglePayReady = true,
                     savedSelection = SavedSelection.PaymentMethod(savedPaymentMethod.id!!)
-                )
+                ),
+                paymentMethods
             )
         }
 
@@ -226,14 +229,15 @@ class PaymentOptionsAdapterTest {
 
     @Test
     fun `initial selected item should reflect PaymentSelection`() {
-        val savedPaymentMethod = CONFIG.paymentMethods[2]
-        val selectedPaymentMethod = CONFIG.paymentMethods[3]
+        val savedPaymentMethod = paymentMethods[2]
+        val selectedPaymentMethod = paymentMethods[3]
         val adapter = createAdapter().also {
-            it.update(
+            it.setItems(
                 CONFIG.copy(
                     isGooglePayReady = true,
                     savedSelection = SavedSelection.PaymentMethod(savedPaymentMethod.id!!)
                 ),
+                paymentMethods,
                 PaymentSelection.Saved(selectedPaymentMethod)
             )
         }
@@ -246,14 +250,15 @@ class PaymentOptionsAdapterTest {
 
     @Test
     fun `initial selected item should fallback to config when invalid PaymentSelection`() {
-        val savedPaymentMethod = CONFIG.paymentMethods[2]
+        val savedPaymentMethod = paymentMethods[2]
         val selectedPaymentMethod = PaymentMethodFixtures.createCards(1).first()
         val adapter = createAdapter().also {
-            it.update(
+            it.setItems(
                 CONFIG.copy(
                     isGooglePayReady = true,
                     savedSelection = SavedSelection.PaymentMethod(savedPaymentMethod.id!!)
                 ),
+                paymentMethods,
                 PaymentSelection.Saved(selectedPaymentMethod)
             )
         }
@@ -268,9 +273,9 @@ class PaymentOptionsAdapterTest {
     fun `initial selected item should be null when the only item is AddCard`() {
         val adapter = createConfiguredAdapter(
             CONFIG.copy(
-                isGooglePayReady = false,
-                paymentMethods = emptyList()
-            )
+                isGooglePayReady = false
+            ),
+            paymentMethods = emptyList()
         )
         assertThat(adapter.itemCount)
             .isEqualTo(1)
@@ -279,10 +284,11 @@ class PaymentOptionsAdapterTest {
     }
 
     private fun createConfiguredAdapter(
-        fragmentConfig: FragmentConfig = CONFIG
+        fragmentConfig: FragmentConfig = CONFIG,
+        paymentMethods: List<PaymentMethod> = this.paymentMethods
     ): PaymentOptionsAdapter {
         return createAdapter().also {
-            it.update(fragmentConfig)
+            it.setItems(fragmentConfig, paymentMethods)
         }
     }
 
@@ -302,8 +308,6 @@ class PaymentOptionsAdapterTest {
     }
 
     private companion object {
-        private val CONFIG = FragmentConfigFixtures.DEFAULT.copy(
-            paymentMethods = PaymentMethodFixtures.createCards(6)
-        )
+        private val CONFIG = FragmentConfigFixtures.DEFAULT
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -4,8 +4,8 @@ import android.app.Application
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.Logger
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -22,6 +22,7 @@ import com.stripe.android.paymentsheet.model.FragmentConfigFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
+import com.stripe.android.utils.TestUtils.idleLooper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
@@ -224,6 +225,28 @@ internal class PaymentOptionsViewModelTest {
 
         viewModel.resolveTransitionTarget(fragmentConfig)
         assertThat(transitionTarget).hasSize(2)
+    }
+
+
+    @Test
+    fun `removePaymentMethod removes it from payment methods list`() = runBlockingTest {
+        val cards = PaymentMethodFixtures.createCards(3)
+        val viewModel = PaymentOptionsViewModel(
+            args = PAYMENT_OPTION_CONTRACT_ARGS.copy(paymentMethods = cards),
+            prefsRepositoryFactory = { FakePrefsRepository() },
+            eventReporter = eventReporter,
+            customerRepository = customerRepository,
+            workContext = testDispatcher,
+            application = ApplicationProvider.getApplicationContext(),
+            logger = Logger.noop(),
+            injectorKey = DUMMY_INJECTOR_KEY
+        )
+
+        viewModel.removePaymentMethod(cards[1])
+        idleLooper()
+
+        assertThat(viewModel.paymentMethods.value)
+            .containsExactly(cards[0], cards[2])
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/FragmentConfigFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/FragmentConfigFixtures.kt
@@ -6,7 +6,6 @@ internal object FragmentConfigFixtures {
 
     val DEFAULT = FragmentConfig(
         stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-        paymentMethods = emptyList(),
         isGooglePayReady = true,
         savedSelection = SavedSelection.None
     )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Read the list of saved payment methods from the View Model instead of sending them in `FragmentConfig`, so that it can be updated and remain as a single source of truth.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix bug where a deleted payment method would show up again when navigating to another fragment and back.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified