### PR TITLE
Center pay button text within button layout

### DIFF
--- a/paymentsheet/res/layout/primary_button.xml
+++ b/paymentsheet/res/layout/primary_button.xml
@@ -8,6 +8,7 @@
         android:layout_height="wrap_content"
         android:textColor="@color/stripe_paymentsheet_primary_button_text"
         android:gravity="center_horizontal|center_vertical"
+        android:layout_gravity="center"
         android:lineSpacingExtra="5sp"
         android:textSize="16sp"
         android:paddingHorizontal="4dp"


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Centered the text within the pay button vertically. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This came up during dog fooding and now I can't unsee it.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

Cleared with jarvis@ that it's ok that the button is smaller. (we were getting the extra height from the text being off)

# Screenshots
<img src="https://user-images.githubusercontent.com/89166418/134996869-98d31995-c265-4d94-a206-3daccbfb6537.png" alt="" width="350"/>
<img src="https://user-images.githubusercontent.com/89166418/134996876-67c02467-8326-4377-b3f0-b661f9ea1118.png" alt="" width="350"/>
