### PR TITLE
Add padding to options menu button

### DIFF
--- a/paymentsheet/res/layout/activity_payment_sheet.xml
+++ b/paymentsheet/res/layout/activity_payment_sheet.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/coordinator"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -29,7 +30,9 @@
                 android:layout_height="wrap_content"
                 android:background="?colorSurface"
                 app:contentInsetStart="0dp"
-                app:contentInsetStartWithNavigation="0dp">
+                app:contentInsetStartWithNavigation="0dp"
+                android:paddingEnd="12dp"
+                tools:ignore="RtlSymmetry">
 
                 <TextView
                     android:id="@+id/testmode"

--- a/paymentsheet/res/layout/stripe_activity_payment_options.xml
+++ b/paymentsheet/res/layout/stripe_activity_payment_options.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/coordinator"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -28,7 +29,9 @@
                 android:layout_height="wrap_content"
                 android:background="?colorSurface"
                 app:contentInsetStart="0dp"
-                app:contentInsetStartWithNavigation="0dp">
+                app:contentInsetStartWithNavigation="0dp"
+                android:paddingEnd="12dp"
+                tools:ignore="RtlSymmetry">
 
                 <TextView
                     android:id="@+id/testmode"


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add padding to options menu button

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Make right padding match left padding.

# Screenshots
| Before  | After |
| ------------- | ------------- |
| 
![image](https://user-images.githubusercontent.com/77990083/134999346-652bbd8b-80a8-4d9c-bde6-d2f62c444960.png)
  | ![image](https://user-images.githubusercontent.com/77990083/134999363-3d36489f-7075-4abc-ac1d-0d62b9e4635e.png) |
