### PR TITLE
Fix paymentsheet changing heights when you switch to google pay

### DIFF
--- a/paymentsheet/res/layout/activity_payment_sheet.xml
+++ b/paymentsheet/res/layout/activity_payment_sheet.xml
@@ -88,17 +88,14 @@
                     <com.stripe.android.paymentsheet.ui.PrimaryButton
                         android:id="@+id/buy_button"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:layout_margin="@dimen/stripe_paymentsheet_primary_button_margin"
+                        android:layout_height="@dimen/stripe_paymentsheet_primary_button_height"
                         android:text="@string/stripe_paymentsheet_pay_button_label"
-                        android:minHeight="48dp"
                         android:visibility="gone" />
 
                     <com.stripe.android.paymentsheet.ui.GooglePayButton
                         android:id="@+id/google_pay_button"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:minHeight="48dp"
+                        android:layout_height="@dimen/stripe_paymentsheet_primary_button_height"
                         android:visibility="gone" />
                 </FrameLayout>
             </LinearLayout>


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Changed some XML to make the pay button the same size as the google pay button.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

When they are the same size, the layout does not shift when a user toggles between them. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

Confirmed both buttons are 48dp (using layout inspector) height as requested by jarvis@ 

# Screenshots
| Before  | After |
| ------------- | ------------- |
|![changepayments1](https://user-images.githubusercontent.com/89166418/135003961-010f3492-fba0-4ba8-92ee-93aee8b753b8.gif)|![changepayments2](https://user-images.githubusercontent.com/89166418/135003966-979b7d17-0764-41ab-8d6e-11defba67886.gif)|
