### PR TITLE
Add an option to CardInputWidget to make the IME full-screen when in landscape mode

### DIFF
--- a/example/res/layout/create_card_token_activity.xml
+++ b/example/res/layout/create_card_token_activity.xml
@@ -29,7 +29,8 @@
             android:id="@+id/card_input_widget"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:cardTextErrorColor="@android:color/holo_red_dark"/>
+            app:cardTextErrorColor="@android:color/holo_red_dark"
+            app:imeLandscapeFullScreen="true" />
 
         <Button
             android:id="@+id/create_token_button"

--- a/payments-core/res/values/attrs.xml
+++ b/payments-core/res/values/attrs.xml
@@ -4,6 +4,7 @@
         <attr name="cardHintText" format="string" />
         <attr name="cardTint" format="color" />
         <attr name="cardTextErrorColor" format="color" />
+        <attr name="imeLandscapeFullScreen" format="boolean" />
         <attr name="android:focusedByDefault" />
     </declare-styleable>
 

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -681,6 +681,7 @@ class CardInputWidget @JvmOverloads constructor(
         cardBrandView.tintColorInt = cardNumberEditText.hintTextColors.defaultColor
         var cardHintText: String? = null
         var shouldRequestFocus = true
+        var imeLandscapeFullScreen = true
 
         context.withStyledAttributes(
             attrs,
@@ -699,6 +700,10 @@ class CardInputWidget @JvmOverloads constructor(
                 R.styleable.CardInputView_android_focusedByDefault,
                 true
             )
+            imeLandscapeFullScreen = getBoolean(
+                R.styleable.CardInputView_imeLandscapeFullScreen,
+                true
+            )
         }
 
         cardHintText?.let {
@@ -706,6 +711,13 @@ class CardInputWidget @JvmOverloads constructor(
         }
 
         currentFields.forEach { it.setErrorColor(errorColorInt) }
+
+        if (!imeLandscapeFullScreen) {
+            cardNumberEditText.imeOptions = EditorInfo.IME_FLAG_NO_FULLSCREEN
+            expiryDateEditText.imeOptions = EditorInfo.IME_FLAG_NO_FULLSCREEN
+            cvcEditText.imeOptions = EditorInfo.IME_FLAG_NO_FULLSCREEN
+            postalCodeEditText.imeOptions = EditorInfo.IME_FLAG_NO_FULLSCREEN
+        }
 
         cardNumberEditText.internalFocusChangeListeners.add { _, hasFocus ->
             if (hasFocus) {


### PR DESCRIPTION
# Summary

Add an option to CardInputWidget to make the IME full-screen when in landscape mode.

# Motivation

Users cannot check error status when in landscape mode.
I added the `imeLandscapeFullScreen` option.

```xml
<com.stripe.android.view.CardInputWidget
    android:id="@+id/card_input_widget"
    android:layout_width="match_parent"
    android:layout_height="wrap_content"
    app:cardTextErrorColor="@android:color/holo_red_dark"
    app:imeLandscapeFullScreen="false" />
```

If you want to change the name of the option, it's no problem.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before | After |
| ------------- | ------------- |
| imeLandscapeFullScreen=true | imeLandscapeFullScreen=false |
| ![screenshot-210928151159](https://user-images.githubusercontent.com/3386962/135033123-5e6c76b3-29b1-44ae-831b-5fc086c8b899.png)  | ![screenshot-210928151228](https://user-images.githubusercontent.com/3386962/135033059-c91a85d0-0a1c-4522-88df-72e8b92b1cb2.png)|

