### PR TITLE
Add more contrast to test mode indicator for accessibility

### DIFF
--- a/paymentsheet/res/values/colors.xml
+++ b/paymentsheet/res/values/colors.xml
@@ -43,7 +43,7 @@
     <color name="stripe_paymentsheet_googlepay_divider_text">#99000000</color>
 
     <color name="stripe_paymentsheet_testmode_background">#FFDE94</color>
-    <color name="stripe_paymentsheet_testmode_text">#A66912</color>
+    <color name="stripe_paymentsheet_testmode_text">#8E5710</color>
 
     <!-- CardFormView -->
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Changed color on test mode indicator

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
A contrast ratio of at least 4.5:1 is preferred for accessibility.  I darkened the text color slightly to pass this test via the Accessibility Scanner app.  

see here for more info: https://webaim.org/resources/contrastchecker/?fcolor=8E5710&bcolor=FFDE94

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![before1](https://user-images.githubusercontent.com/89166418/135131642-d156f568-8f34-414a-ae1c-de5a0d5841bd.png) | ![after1](https://user-images.githubusercontent.com/89166418/135131705-e144ad9e-87fe-4baf-addf-561f24087c8b.png) |
| ![before2](https://user-images.githubusercontent.com/89166418/135131776-ea6af0e2-d705-40ac-a8e2-16709b78f054.png)| ![after2](https://user-images.githubusercontent.com/89166418/135131792-23a9d10a-465f-41f8-a569-c6d0bb8813d8.png)|
