### PR TITLE
change alpha when google pay button is enabled/disabled

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/GooglePayButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/GooglePayButton.kt
@@ -19,6 +19,8 @@ internal class GooglePayButton @JvmOverloads constructor(
         this
     )
 
+    private var state: PrimaryButton.State? = null
+
     init {
         // Call super so we don't inadvertently effect the primary button as well.
         super.setClickable(true)
@@ -44,10 +46,21 @@ internal class GooglePayButton @JvmOverloads constructor(
     override fun setEnabled(enabled: Boolean) {
         super.setEnabled(enabled)
         viewBinding.primaryButton.isEnabled = enabled
+        updateAlpha()
+    }
+
+    private fun updateAlpha() {
+        viewBinding.googlePayButtonIcon.alpha = if ((state == null || state is PrimaryButton.State.Ready) && !isEnabled) {
+            0.5f
+        } else {
+            1.0f
+        }
     }
 
     fun updateState(state: PrimaryButton.State?) {
         viewBinding.primaryButton.updateState(state)
+        this.state = state
+        updateAlpha()
 
         when (state) {
             is PrimaryButton.State.Ready -> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/GooglePayButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/GooglePayButton.kt
@@ -50,11 +50,12 @@ internal class GooglePayButton @JvmOverloads constructor(
     }
 
     private fun updateAlpha() {
-        viewBinding.googlePayButtonIcon.alpha = if ((state == null || state is PrimaryButton.State.Ready) && !isEnabled) {
-            0.5f
-        } else {
-            1.0f
-        }
+        viewBinding.googlePayButtonIcon.alpha =
+            if ((state == null || state is PrimaryButton.State.Ready) && !isEnabled) {
+                0.5f
+            } else {
+                1.0f
+            }
     }
 
     fun updateState(state: PrimaryButton.State?) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/GooglePayButtonTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/GooglePayButtonTest.kt
@@ -88,23 +88,25 @@ class GooglePayButtonTest {
     }
 
     @Test
-    fun `label alpha is initially 50%`() {
-        assertThat(primaryButton.viewBinding.label.alpha)
+    fun `not setting view state and not enabled should be 50% alpha`() {
+        googlePayButton.isEnabled = false
+        assertThat(googlePayButton.viewBinding.googlePayButtonIcon.alpha)
             .isEqualTo(0.5f)
     }
 
     @Test
-    fun `after viewState ready and disabled, label alpha is 50%`() {
+    fun `ready view state and not enabled should be 50% alpha`() {
         googlePayButton.updateState(PrimaryButton.State.Ready)
-        assertThat(primaryButton.viewBinding.label.alpha)
+        googlePayButton.isEnabled = false
+        assertThat(googlePayButton.viewBinding.googlePayButtonIcon.alpha)
             .isEqualTo(0.5f)
     }
 
     @Test
-    fun `after viewState ready and enabled, label alpha is 100%`() {
+    fun `ready view state and enabled should be 100% alpha`() {
         googlePayButton.updateState(PrimaryButton.State.Ready)
         googlePayButton.isEnabled = true
-        assertThat(primaryButton.viewBinding.label.alpha)
+        assertThat(googlePayButton.viewBinding.googlePayButtonIcon.alpha)
             .isEqualTo(1.0f)
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
The alpha of the google pay button is set to 50% when it is not enabled.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This makes it clear you can't click the google pay button while editing your payment methods. I followed mocks [here](https://www.figma.com/file/2b9r3CJbyeVAmKi1VHV2h9/Payment-Sheet?node-id=3417%3A0). I copied this logic over from [PrimaryButton.kt](https://github.com/stripe/stripe-android/blob/master/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt#L124)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![alphabefore](https://user-images.githubusercontent.com/89166418/135178257-52295401-87d1-4322-8630-fd7e5cb42101.png)| ![alphaafter](https://user-images.githubusercontent.com/89166418/135178272-da32d283-d235-41c7-8c0a-3a0e9279a81e.png)|
