### PR TITLE
[Injection clean up] Add a LoggingModule

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -1387,14 +1387,6 @@ public final class com/stripe/android/googlepaylauncher/injection/GooglePayPayme
 	public static fun provideGooglePayRepository (Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule;Landroid/content/Context;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Config;Lcom/stripe/android/Logger;)Lcom/stripe/android/googlepaylauncher/GooglePayRepository;
 }
 
-public final class com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule_ProvideLoggerFactory : dagger/internal/Factory {
-	public fun <init> (Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule;Ljavax/inject/Provider;)V
-	public static fun create (Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule;Ljavax/inject/Provider;)Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule_ProvideLoggerFactory;
-	public fun get ()Lcom/stripe/android/Logger;
-	public synthetic fun get ()Ljava/lang/Object;
-	public static fun provideLogger (Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule;Z)Lcom/stripe/android/Logger;
-}
-
 public final class com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule_ProvidePaymentsClientFactory : dagger/internal/Factory {
 	public fun <init> (Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
 	public static fun create (Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule_ProvidePaymentsClientFactory;
@@ -5014,6 +5006,14 @@ public final class com/stripe/android/networking/AnalyticsRequestFactory {
 	public final synthetic fun createRequest (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/networking/AnalyticsRequest;
 }
 
+public final class com/stripe/android/networking/AnalyticsRequestFactory_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/networking/AnalyticsRequestFactory_Factory;
+	public fun get ()Lcom/stripe/android/networking/AnalyticsRequestFactory;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Landroid/content/Context;Lkotlin/jvm/functions/Function0;Ljava/util/Set;)Lcom/stripe/android/networking/AnalyticsRequestFactory;
+}
+
 public final class com/stripe/android/networking/ApiRequest : com/stripe/android/networking/StripeRequest {
 	public static final field $stable I
 	public final fun component2 ()Ljava/lang/String;
@@ -5209,7 +5209,7 @@ public final class com/stripe/android/payments/core/authentication/threeds2/Defa
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/threeds2/DefaultStripe3ds2ChallengeResultProcessor_Factory;
 	public fun get ()Lcom/stripe/android/payments/core/authentication/threeds2/DefaultStripe3ds2ChallengeResultProcessor;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/networking/StripeRepository;Lcom/stripe/android/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/AnalyticsRequestFactory;Lcom/stripe/android/networking/RetryDelaySupplier;ZLkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/payments/core/authentication/threeds2/DefaultStripe3ds2ChallengeResultProcessor;
+	public static fun newInstance (Lcom/stripe/android/networking/StripeRepository;Lcom/stripe/android/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/AnalyticsRequestFactory;Lcom/stripe/android/networking/RetryDelaySupplier;Lcom/stripe/android/Logger;Lkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/payments/core/authentication/threeds2/DefaultStripe3ds2ChallengeResultProcessor;
 }
 
 public final class com/stripe/android/payments/core/authentication/threeds2/Stripe3DS2Authenticator_Factory : dagger/internal/Factory {
@@ -5333,6 +5333,20 @@ public abstract interface annotation class com/stripe/android/payments/core/inje
 public abstract interface annotation class com/stripe/android/payments/core/injection/IntentAuthenticatorMap : java/lang/annotation/Annotation {
 }
 
+public final class com/stripe/android/payments/core/injection/LoggingModule {
+	public static final field $stable I
+	public fun <init> ()V
+	public final fun provideLogger (Z)Lcom/stripe/android/Logger;
+}
+
+public final class com/stripe/android/payments/core/injection/LoggingModule_ProvideLoggerFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/payments/core/injection/LoggingModule;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/LoggingModule;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/LoggingModule_ProvideLoggerFactory;
+	public fun get ()Lcom/stripe/android/Logger;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideLogger (Lcom/stripe/android/payments/core/injection/LoggingModule;Z)Lcom/stripe/android/Logger;
+}
+
 public final class com/stripe/android/payments/core/injection/NamedConstantsKt {
 	public static final field ENABLE_LOGGING Ljava/lang/String;
 	public static final field IS_PAYMENT_INTENT Ljava/lang/String;
@@ -5355,14 +5369,6 @@ public final class com/stripe/android/payments/core/injection/PaymentLauncherMod
 	public fun get ()Lcom/stripe/android/payments/DefaultReturnUrl;
 	public synthetic fun get ()Ljava/lang/Object;
 	public static fun provideDefaultReturnUrl (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Landroid/content/Context;)Lcom/stripe/android/payments/DefaultReturnUrl;
-}
-
-public final class com/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideLoggerFactory : dagger/internal/Factory {
-	public fun <init> (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;)V
-	public static fun create (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideLoggerFactory;
-	public fun get ()Lcom/stripe/android/Logger;
-	public synthetic fun get ()Ljava/lang/Object;
-	public static fun provideLogger (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Z)Lcom/stripe/android/Logger;
 }
 
 public final class com/stripe/android/payments/core/injection/PaymentLauncherModule_ProvidePaymentAuthenticatorRegistryFactory : dagger/internal/Factory {
@@ -5429,33 +5435,21 @@ public final class com/stripe/android/payments/core/injection/Stripe3dsTransacti
 	public static fun providesInitChallengeRepository (Lcom/stripe/android/payments/core/injection/Stripe3dsTransactionViewModelModule;Landroid/app/Application;Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionContract$Args;Lkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/stripe3ds2/transaction/InitChallengeRepository;
 }
 
-public final class com/stripe/android/payments/core/injection/StripeRepositoryModule {
+public abstract class com/stripe/android/payments/core/injection/StripeRepositoryModule {
 	public static final field $stable I
+	public static final field Companion Lcom/stripe/android/payments/core/injection/StripeRepositoryModule$Companion;
 	public fun <init> ()V
 }
 
-public final class com/stripe/android/payments/core/injection/StripeRepositoryModule_ProvideAnalyticsRequestExecutor$payments_core_releaseFactory : dagger/internal/Factory {
-	public fun <init> (Lcom/stripe/android/payments/core/injection/StripeRepositoryModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Lcom/stripe/android/payments/core/injection/StripeRepositoryModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/StripeRepositoryModule_ProvideAnalyticsRequestExecutor$payments_core_releaseFactory;
-	public fun get ()Lcom/stripe/android/networking/AnalyticsRequestExecutor;
-	public synthetic fun get ()Ljava/lang/Object;
-	public static fun provideAnalyticsRequestExecutor$payments_core_release (Lcom/stripe/android/payments/core/injection/StripeRepositoryModule;ZLkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/networking/AnalyticsRequestExecutor;
+public final class com/stripe/android/payments/core/injection/StripeRepositoryModule$Companion {
 }
 
-public final class com/stripe/android/payments/core/injection/StripeRepositoryModule_ProvideAnalyticsRequestFactory$payments_core_releaseFactory : dagger/internal/Factory {
-	public fun <init> (Lcom/stripe/android/payments/core/injection/StripeRepositoryModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Lcom/stripe/android/payments/core/injection/StripeRepositoryModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/StripeRepositoryModule_ProvideAnalyticsRequestFactory$payments_core_releaseFactory;
-	public fun get ()Lcom/stripe/android/networking/AnalyticsRequestFactory;
-	public synthetic fun get ()Ljava/lang/Object;
-	public static fun provideAnalyticsRequestFactory$payments_core_release (Lcom/stripe/android/payments/core/injection/StripeRepositoryModule;Landroid/content/Context;Lkotlin/jvm/functions/Function0;Ljava/util/Set;)Lcom/stripe/android/networking/AnalyticsRequestFactory;
-}
-
-public final class com/stripe/android/payments/core/injection/StripeRepositoryModule_ProvideStripeRepository$payments_core_releaseFactory : dagger/internal/Factory {
-	public fun <init> (Lcom/stripe/android/payments/core/injection/StripeRepositoryModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Lcom/stripe/android/payments/core/injection/StripeRepositoryModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/StripeRepositoryModule_ProvideStripeRepository$payments_core_releaseFactory;
+public final class com/stripe/android/payments/core/injection/StripeRepositoryModule_Companion_ProvideStripeRepository$payments_core_releaseFactory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/StripeRepositoryModule_Companion_ProvideStripeRepository$payments_core_releaseFactory;
 	public fun get ()Lcom/stripe/android/networking/StripeRepository;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun provideStripeRepository$payments_core_release (Lcom/stripe/android/payments/core/injection/StripeRepositoryModule;Landroid/content/Context;Lkotlin/jvm/functions/Function0;ZLkotlin/coroutines/CoroutineContext;Ljava/util/Set;Lcom/stripe/android/networking/AnalyticsRequestFactory;Lcom/stripe/android/networking/AnalyticsRequestExecutor;)Lcom/stripe/android/networking/StripeRepository;
+	public static fun provideStripeRepository$payments_core_release (Landroid/content/Context;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/CoroutineContext;Ljava/util/Set;Lcom/stripe/android/networking/AnalyticsRequestFactory;Lcom/stripe/android/networking/AnalyticsRequestExecutor;Lcom/stripe/android/Logger;)Lcom/stripe/android/networking/StripeRepository;
 }
 
 public abstract interface annotation class com/stripe/android/payments/core/injection/UIContext : java/lang/annotation/Annotation {

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherComponent.kt
@@ -7,6 +7,7 @@ import com.stripe.android.networking.AnalyticsRequestFactory
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.core.injection.ENABLE_LOGGING
 import com.stripe.android.payments.core.injection.IOContext
+import com.stripe.android.payments.core.injection.LoggingModule
 import com.stripe.android.payments.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.payments.core.injection.STRIPE_ACCOUNT_ID
 import dagger.BindsInstance
@@ -22,7 +23,8 @@ import kotlin.coroutines.CoroutineContext
 @Singleton
 @Component(
     modules = [
-        GooglePayPaymentMethodLauncherModule::class
+        GooglePayPaymentMethodLauncherModule::class,
+        LoggingModule::class
     ]
 )
 internal abstract class GooglePayPaymentMethodLauncherComponent {

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule.kt
@@ -11,7 +11,6 @@ import com.stripe.android.googlepaylauncher.PaymentsClientFactory
 import com.stripe.android.googlepaylauncher.convert
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.networking.StripeRepository
-import com.stripe.android.payments.core.injection.ENABLE_LOGGING
 import com.stripe.android.payments.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.payments.core.injection.STRIPE_ACCOUNT_ID
 import dagger.Module
@@ -39,11 +38,6 @@ internal class GooglePayPaymentMethodLauncherModule {
         apiKey = publishableKeyProvider(),
         stripeAccount = stripeAccountIdProvider()
     )
-
-    @Provides
-    @Singleton
-    fun provideLogger(@Named(ENABLE_LOGGING) enableLogging: Boolean) =
-        Logger.getInstance(enableLogging)
 
     @Provides
     @Singleton

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherViewModelFactoryComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherViewModelFactoryComponent.kt
@@ -6,6 +6,7 @@ import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherViewMo
 import com.stripe.android.payments.core.injection.CoroutineContextModule
 import com.stripe.android.payments.core.injection.ENABLE_LOGGING
 import com.stripe.android.payments.core.injection.Injector
+import com.stripe.android.payments.core.injection.LoggingModule
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.payments.core.injection.STRIPE_ACCOUNT_ID
@@ -25,7 +26,8 @@ import javax.inject.Singleton
     modules = [
         GooglePayPaymentMethodLauncherModule::class,
         StripeRepositoryModule::class,
-        CoroutineContextModule::class
+        CoroutineContextModule::class,
+        LoggingModule::class
     ]
 )
 internal interface GooglePayPaymentMethodLauncherViewModelFactoryComponent {

--- a/payments-core/src/main/java/com/stripe/android/networking/AnalyticsRequestFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/AnalyticsRequestFactory.kt
@@ -11,7 +11,11 @@ import com.stripe.android.Stripe
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.Source
 import com.stripe.android.model.Token
+import com.stripe.android.payments.core.injection.PRODUCT_USAGE
+import com.stripe.android.payments.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.utils.ContextUtils.packageInfo
+import javax.inject.Inject
+import javax.inject.Named
 import javax.inject.Provider
 
 /**
@@ -39,7 +43,19 @@ class AnalyticsRequestFactory @VisibleForTesting internal constructor(
     internal constructor(
         context: Context,
         publishableKeyProvider: Provider<String>,
-        defaultProductUsageTokens: Set<String> = emptySet(),
+    ) : this(
+        context.applicationContext.packageManager,
+        context.applicationContext.packageInfo,
+        context.applicationContext.packageName.orEmpty(),
+        publishableKeyProvider,
+        emptySet()
+    )
+
+    @Inject
+    internal constructor(
+        context: Context,
+        @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
+        @Named(PRODUCT_USAGE) defaultProductUsageTokens: Set<String>,
     ) : this(
         context.applicationContext.packageManager,
         context.applicationContext.packageInfo,

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -67,7 +67,6 @@ import java.io.IOException
 import java.net.HttpURLConnection
 import java.security.Security
 import java.util.Locale
-import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -75,7 +74,7 @@ import kotlin.coroutines.CoroutineContext
  */
 internal class StripeApiRepository @JvmOverloads internal constructor(
     context: Context,
-    publishableKeyProvider: Provider<String>,
+    publishableKeyProvider: () -> String,
     private val appInfo: AppInfo? = null,
     private val logger: Logger = Logger.noop(),
     private val workContext: CoroutineContext = Dispatchers.IO,

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticator.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.payments.core.authentication
 
-import com.stripe.android.Logger
 import com.stripe.android.PaymentBrowserAuthStarter
 import com.stripe.android.StripePaymentController
 import com.stripe.android.auth.PaymentBrowserAuthContract
@@ -110,7 +109,6 @@ internal class WebIntentAuthenticator @Inject constructor(
         shouldCancelIntentOnUserNavigation: Boolean = true
     ) = withContext(uiContext) {
         val paymentBrowserWebStarter = paymentBrowserAuthStarterFactory(host)
-        Logger.getInstance(enableLogging).debug("PaymentBrowserAuthStarter#start()")
         paymentBrowserWebStarter.start(
             PaymentBrowserAuthContract.Args(
                 objectId = stripeIntent.id.orEmpty(),

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2ChallengeResultProcessor.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2ChallengeResultProcessor.kt
@@ -10,13 +10,11 @@ import com.stripe.android.networking.ApiRequest
 import com.stripe.android.networking.RetryDelaySupplier
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.PaymentFlowResult
-import com.stripe.android.payments.core.injection.ENABLE_LOGGING
 import com.stripe.android.payments.core.injection.IOContext
 import com.stripe.android.stripe3ds2.transaction.ChallengeResult
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
-import javax.inject.Named
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
@@ -30,10 +28,9 @@ internal class DefaultStripe3ds2ChallengeResultProcessor @Inject constructor(
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,
     private val analyticsRequestFactory: AnalyticsRequestFactory,
     private val retryDelaySupplier: RetryDelaySupplier,
-    @Named(ENABLE_LOGGING) enableLogging: Boolean,
+    private val logger: Logger,
     @IOContext private val workContext: CoroutineContext
 ) : Stripe3ds2ChallengeResultProcessor {
-    private val logger = Logger.getInstance(enableLogging)
 
     override suspend fun process(
         challengeResult: ChallengeResult

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
@@ -24,7 +24,8 @@ import kotlin.coroutines.CoroutineContext
     modules = [
         AuthenticationModule::class,
         Stripe3DSAuthenticatorModule::class,
-        WeChatPayAuthenticatorModule::class
+        WeChatPayAuthenticatorModule::class,
+        LoggingModule::class
     ]
 )
 internal interface AuthenticationComponent {

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/LoggingModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/LoggingModule.kt
@@ -1,0 +1,17 @@
+package com.stripe.android.payments.core.injection
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.Logger
+import dagger.Module
+import dagger.Provides
+import javax.inject.Named
+import javax.inject.Singleton
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Module
+class LoggingModule {
+    @Provides
+    @Singleton
+    fun provideLogger(@Named(ENABLE_LOGGING) enableLogging: Boolean) =
+        Logger.getInstance(enableLogging)
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherComponent.kt
@@ -13,7 +13,8 @@ import kotlin.coroutines.CoroutineContext
 @Singleton
 @Component(
     modules = [
-        PaymentLauncherModule::class
+        PaymentLauncherModule::class,
+        LoggingModule::class
     ]
 )
 internal interface PaymentLauncherComponent {

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherModule.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.payments.core.injection
 
 import android.content.Context
-import com.stripe.android.Logger
 import com.stripe.android.networking.AnalyticsRequestFactory
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.networking.DefaultAnalyticsRequestExecutor
@@ -42,11 +41,6 @@ internal class PaymentLauncherModule {
     @Provides
     @Singleton
     fun provideThreeDs1IntentReturnUrlMap() = mutableMapOf<String, String>()
-
-    @Provides
-    @Singleton
-    fun provideLogger(@Named(ENABLE_LOGGING) enableLogging: Boolean) =
-        Logger.getInstance(enableLogging)
 
     @Provides
     @Singleton

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherViewModelFactoryComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherViewModelFactoryComponent.kt
@@ -16,7 +16,8 @@ import javax.inject.Singleton
     modules = [
         PaymentLauncherModule::class,
         StripeRepositoryModule::class,
-        CoroutineContextModule::class
+        CoroutineContextModule::class,
+        LoggingModule::class
     ]
 )
 internal interface PaymentLauncherViewModelFactoryComponent {

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelFactoryComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelFactoryComponent.kt
@@ -16,7 +16,8 @@ import javax.inject.Singleton
     modules = [
         StripeRepositoryModule::class,
         Stripe3ds2TransactionModule::class,
-        CoroutineContextModule::class
+        CoroutineContextModule::class,
+        LoggingModule::class
     ]
 )
 internal interface Stripe3ds2TransactionViewModelFactoryComponent {

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/StripeRepositoryModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/StripeRepositoryModule.kt
@@ -17,7 +17,7 @@ import kotlin.coroutines.CoroutineContext
 
 /**
  * A [Module] to provide [StripeRepository] and its corresponding dependencies.
- * [Context], [ENABLE_LOGGING], [PUBLISHABLE_KEY], [PRODUCT_USAGE] and [IOContext] need to be
+ * [Context], [Logger], [PUBLISHABLE_KEY], [PRODUCT_USAGE] and [IOContext] need to be
  * provided elsewhere to use this module.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/StripeRepositoryModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/StripeRepositoryModule.kt
@@ -1,12 +1,14 @@
 package com.stripe.android.payments.core.injection
 
 import android.content.Context
+import androidx.annotation.RestrictTo
 import com.stripe.android.Logger
 import com.stripe.android.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.AnalyticsRequestFactory
 import com.stripe.android.networking.DefaultAnalyticsRequestExecutor
 import com.stripe.android.networking.StripeApiRepository
 import com.stripe.android.networking.StripeRepository
+import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import javax.inject.Named
@@ -18,43 +20,33 @@ import kotlin.coroutines.CoroutineContext
  * [Context], [ENABLE_LOGGING], [PUBLISHABLE_KEY], [PRODUCT_USAGE] and [IOContext] need to be
  * provided elsewhere to use this module.
  */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Module
-class StripeRepositoryModule {
-    @Provides
-    @Singleton
-    internal fun provideStripeRepository(
-        appContext: Context,
-        @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
-        @Named(ENABLE_LOGGING) enableLogging: Boolean,
-        @IOContext workContext: CoroutineContext,
-        @Named(PRODUCT_USAGE) productUsageTokens: Set<String>,
-        analyticsRequestFactory: AnalyticsRequestFactory,
-        analyticsRequestExecutor: AnalyticsRequestExecutor
-    ): StripeRepository = StripeApiRepository(
-        appContext,
-        publishableKeyProvider,
-        logger = Logger.getInstance(enableLogging),
-        workContext = workContext,
-        productUsageTokens = productUsageTokens,
-        analyticsRequestFactory = analyticsRequestFactory,
-        analyticsRequestExecutor = analyticsRequestExecutor
-    )
+abstract class StripeRepositoryModule {
+    @Binds
+    internal abstract fun bindsAnalyticsRequestExecutor(
+        default: DefaultAnalyticsRequestExecutor
+    ): AnalyticsRequestExecutor
 
-    @Provides
-    @Singleton
-    internal fun provideAnalyticsRequestFactory(
-        appContext: Context,
-        @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
-        @Named(PRODUCT_USAGE) productUsageTokens: Set<String>,
-    ) = AnalyticsRequestFactory(appContext, publishableKeyProvider, productUsageTokens)
-
-    @Provides
-    @Singleton
-    internal fun provideAnalyticsRequestExecutor(
-        @Named(ENABLE_LOGGING) enableLogging: Boolean,
-        @IOContext workContext: CoroutineContext
-    ): AnalyticsRequestExecutor = DefaultAnalyticsRequestExecutor(
-        Logger.getInstance(enableLogging),
-        workContext
-    )
+    companion object {
+        @Provides
+        @Singleton
+        internal fun provideStripeRepository(
+            appContext: Context,
+            @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
+            @IOContext workContext: CoroutineContext,
+            @Named(PRODUCT_USAGE) productUsageTokens: Set<String>,
+            analyticsRequestFactory: AnalyticsRequestFactory,
+            analyticsRequestExecutor: AnalyticsRequestExecutor,
+            logger: Logger
+        ): StripeRepository = StripeApiRepository(
+            appContext,
+            publishableKeyProvider,
+            logger = logger,
+            workContext = workContext,
+            productUsageTokens = productUsageTokens,
+            analyticsRequestFactory = analyticsRequestFactory,
+            analyticsRequestExecutor = analyticsRequestExecutor
+        )
+    }
 }

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/DefaultStripe3ds2ChallengeResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/DefaultStripe3ds2ChallengeResultProcessorTest.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.Logger
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.exception.APIException
 import com.stripe.android.exception.InvalidRequestException
@@ -50,7 +51,7 @@ class DefaultStripe3ds2ChallengeResultProcessorTest {
         analyticsRequestExecutor,
         analyticsRequestFactory,
         RetryDelaySupplier(),
-        enableLogging = false,
+        Logger.noop(),
         testDispatcher
     )
 

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -687,14 +687,6 @@ public final class com/stripe/android/paymentsheet/injection/PaymentSheetCommonM
 	public static fun provideLocale ()Ljava/util/Locale;
 }
 
-public final class com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule_Companion_ProvideLoggerFactory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/injection/PaymentSheetCommonModule_Companion_ProvideLoggerFactory;
-	public fun get ()Lcom/stripe/android/Logger;
-	public synthetic fun get ()Ljava/lang/Object;
-	public static fun provideLogger (Z)Lcom/stripe/android/Logger;
-}
-
 public final class com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule_Companion_ProvidePaymentConfigurationFactory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;)V
 	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/injection/PaymentSheetCommonModule_Companion_ProvidePaymentConfigurationFactory;

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/FlowControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/FlowControllerComponent.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModelStoreOwner
 import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
 import com.stripe.android.payments.core.injection.CoroutineContextModule
 import com.stripe.android.payments.core.injection.InjectorKey
+import com.stripe.android.payments.core.injection.LoggingModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.PaymentOptionCallback
 import com.stripe.android.paymentsheet.PaymentOptionsViewModel
@@ -26,7 +27,8 @@ import javax.inject.Singleton
         PaymentSheetCommonModule::class,
         FlowControllerModule::class,
         GooglePayLauncherModule::class,
-        CoroutineContextModule::class
+        CoroutineContextModule::class,
+        LoggingModule::class
     ]
 )
 internal interface FlowControllerComponent {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.injection
 
 import android.content.Context
 import com.stripe.android.payments.core.injection.CoroutineContextModule
+import com.stripe.android.payments.core.injection.LoggingModule
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.PaymentOptionsViewModel
@@ -16,7 +17,8 @@ import javax.inject.Singleton
         StripeRepositoryModule::class,
         PaymentSheetCommonModule::class,
         PaymentOptionsViewModelModule::class,
-        CoroutineContextModule::class
+        CoroutineContextModule::class,
+        LoggingModule::class
     ]
 )
 internal interface PaymentOptionsViewModelFactoryComponent {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet.injection
 import android.content.Context
 import android.content.res.Resources
 import androidx.core.os.LocaleListCompat
-import com.stripe.android.Logger
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.payments.core.injection.ENABLE_LOGGING
 import com.stripe.android.payments.core.injection.PUBLISHABLE_KEY
@@ -64,8 +63,8 @@ internal abstract class PaymentSheetCommonModule {
 
         @Provides
         @Named(PUBLISHABLE_KEY)
-        fun providePublishableKey(paymentConfiguration: Lazy<PaymentConfiguration>):
-            () -> String = { paymentConfiguration.get().publishableKey }
+        fun providePublishableKey(paymentConfiguration: Lazy<PaymentConfiguration>): () -> String =
+            { paymentConfiguration.get().publishableKey }
 
         @Provides
         @Named(STRIPE_ACCOUNT_ID)
@@ -76,11 +75,6 @@ internal abstract class PaymentSheetCommonModule {
         @Singleton
         @Named(ENABLE_LOGGING)
         fun provideEnabledLogging(): Boolean = BuildConfig.DEBUG
-
-        @Provides
-        @Singleton
-        fun provideLogger(@Named(ENABLE_LOGGING) enableLogging: Boolean) =
-            Logger.getInstance(enableLogging)
 
         @Provides
         @Singleton

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
 import com.stripe.android.payments.core.injection.CoroutineContextModule
 import com.stripe.android.payments.core.injection.InjectorKey
+import com.stripe.android.payments.core.injection.LoggingModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.PaymentSheetViewModel
 import com.stripe.android.paymentsheet.forms.FormViewModel
@@ -18,7 +19,8 @@ import javax.inject.Singleton
         PaymentSheetCommonModule::class,
         PaymentSheetLauncherModule::class,
         GooglePayLauncherModule::class,
-        CoroutineContextModule::class
+        CoroutineContextModule::class,
+        LoggingModule::class
     ]
 )
 internal interface PaymentSheetLauncherComponent {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Clean up the explicit calls of `Logger.getInstance`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Final clean up for dagger in payment SDK, most of the changes are removing explicit constructor/Factory method calls with actual Injection when the call happens in a dagger graph.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
