### PR TITLE
[Injection clean up] inject StripeApiRepository

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -5075,6 +5075,14 @@ public final class com/stripe/android/networking/RetryDelaySupplier_Factory : da
 	public static fun newInstance ()Lcom/stripe/android/networking/RetryDelaySupplier;
 }
 
+public final class com/stripe/android/networking/StripeApiRepository_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/networking/StripeApiRepository_Factory;
+	public fun get ()Lcom/stripe/android/networking/StripeApiRepository;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Landroid/content/Context;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/CoroutineContext;Ljava/util/Set;Lcom/stripe/android/networking/AnalyticsRequestFactory;Lcom/stripe/android/networking/AnalyticsRequestExecutor;Lcom/stripe/android/Logger;)Lcom/stripe/android/networking/StripeApiRepository;
+}
+
 public abstract class com/stripe/android/networking/StripeRepository {
 	public static final field $stable I
 	public fun <init> ()V
@@ -5437,19 +5445,7 @@ public final class com/stripe/android/payments/core/injection/Stripe3dsTransacti
 
 public abstract class com/stripe/android/payments/core/injection/StripeRepositoryModule {
 	public static final field $stable I
-	public static final field Companion Lcom/stripe/android/payments/core/injection/StripeRepositoryModule$Companion;
 	public fun <init> ()V
-}
-
-public final class com/stripe/android/payments/core/injection/StripeRepositoryModule$Companion {
-}
-
-public final class com/stripe/android/payments/core/injection/StripeRepositoryModule_Companion_ProvideStripeRepository$payments_core_releaseFactory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/StripeRepositoryModule_Companion_ProvideStripeRepository$payments_core_releaseFactory;
-	public fun get ()Lcom/stripe/android/networking/StripeRepository;
-	public synthetic fun get ()Ljava/lang/Object;
-	public static fun provideStripeRepository$payments_core_release (Landroid/content/Context;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/CoroutineContext;Ljava/util/Set;Lcom/stripe/android/networking/AnalyticsRequestFactory;Lcom/stripe/android/networking/AnalyticsRequestExecutor;Lcom/stripe/android/Logger;)Lcom/stripe/android/networking/StripeRepository;
 }
 
 public abstract interface annotation class com/stripe/android/payments/core/injection/UIContext : java/lang/annotation/Annotation {

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -59,6 +59,9 @@ import com.stripe.android.model.parsers.SourceJsonParser
 import com.stripe.android.model.parsers.Stripe3ds2AuthResultJsonParser
 import com.stripe.android.model.parsers.StripeFileJsonParser
 import com.stripe.android.model.parsers.TokenJsonParser
+import com.stripe.android.payments.core.injection.IOContext
+import com.stripe.android.payments.core.injection.PRODUCT_USAGE
+import com.stripe.android.payments.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.utils.StripeUrlUtils
 import kotlinx.coroutines.Dispatchers
 import org.json.JSONException
@@ -67,6 +70,8 @@ import java.io.IOException
 import java.net.HttpURLConnection
 import java.security.Security
 import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -94,6 +99,26 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
     apiVersion: String = ApiVersion(betas = betas).code,
     sdkVersion: String = Stripe.VERSION
 ) : StripeRepository() {
+
+    @Inject
+    constructor(
+        appContext: Context,
+        @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
+        @IOContext workContext: CoroutineContext,
+        @Named(PRODUCT_USAGE) productUsageTokens: Set<String>,
+        analyticsRequestFactory: AnalyticsRequestFactory,
+        analyticsRequestExecutor: AnalyticsRequestExecutor,
+        logger: Logger
+    ) : this(
+        context = appContext,
+        publishableKeyProvider = publishableKeyProvider,
+        logger = logger,
+        workContext = workContext,
+        productUsageTokens = productUsageTokens,
+        analyticsRequestFactory = analyticsRequestFactory,
+        analyticsRequestExecutor = analyticsRequestExecutor
+    )
+
     private val apiRequestFactory = ApiRequest.Factory(
         appInfo = appInfo,
         apiVersion = apiVersion,

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/StripeRepositoryModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/StripeRepositoryModule.kt
@@ -4,16 +4,11 @@ import android.content.Context
 import androidx.annotation.RestrictTo
 import com.stripe.android.Logger
 import com.stripe.android.networking.AnalyticsRequestExecutor
-import com.stripe.android.networking.AnalyticsRequestFactory
 import com.stripe.android.networking.DefaultAnalyticsRequestExecutor
 import com.stripe.android.networking.StripeApiRepository
 import com.stripe.android.networking.StripeRepository
 import dagger.Binds
 import dagger.Module
-import dagger.Provides
-import javax.inject.Named
-import javax.inject.Singleton
-import kotlin.coroutines.CoroutineContext
 
 /**
  * A [Module] to provide [StripeRepository] and its corresponding dependencies.
@@ -28,25 +23,8 @@ abstract class StripeRepositoryModule {
         default: DefaultAnalyticsRequestExecutor
     ): AnalyticsRequestExecutor
 
-    companion object {
-        @Provides
-        @Singleton
-        internal fun provideStripeRepository(
-            appContext: Context,
-            @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
-            @IOContext workContext: CoroutineContext,
-            @Named(PRODUCT_USAGE) productUsageTokens: Set<String>,
-            analyticsRequestFactory: AnalyticsRequestFactory,
-            analyticsRequestExecutor: AnalyticsRequestExecutor,
-            logger: Logger
-        ): StripeRepository = StripeApiRepository(
-            appContext,
-            publishableKeyProvider,
-            logger = logger,
-            workContext = workContext,
-            productUsageTokens = productUsageTokens,
-            analyticsRequestFactory = analyticsRequestFactory,
-            analyticsRequestExecutor = analyticsRequestExecutor
-        )
-    }
+    @Binds
+    internal abstract fun bindsStripeRepository(
+        stripeApiRepository: StripeApiRepository
+    ): StripeRepository
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Use constructor injection for `StripeApiRepository`


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Final couple of clean ups for dagger in payment SDK, most of the changes are removing explicit constructor/Factory method calls with actual Injection when the call happens in a dagger graph.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
