### PR TITLE
[Injection clean up] Inject ApiRequest.Options

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -1363,14 +1363,6 @@ public final class com/stripe/android/googlepaylauncher/injection/GooglePayPayme
 	public fun create (Lkotlinx/coroutines/CoroutineScope;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Config;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$ReadyCallback;Landroidx/activity/result/ActivityResultLauncher;Z)Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher;
 }
 
-public final class com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule_ProvideApiRequestOptionsFactory : dagger/internal/Factory {
-	public fun <init> (Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule_ProvideApiRequestOptionsFactory;
-	public fun get ()Lcom/stripe/android/networking/ApiRequest$Options;
-	public synthetic fun get ()Ljava/lang/Object;
-	public static fun provideApiRequestOptions (Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)Lcom/stripe/android/networking/ApiRequest$Options;
-}
-
 public final class com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule_ProvideGooglePayJsonFactoryFactory : dagger/internal/Factory {
 	public fun <init> (Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
 	public static fun create (Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule_ProvideGooglePayJsonFactoryFactory;
@@ -5047,6 +5039,7 @@ public final class com/stripe/android/networking/ApiRequest$Options : android/os
 	public static final field UNDEFINED_PUBLISHABLE_KEY Ljava/lang/String;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
 	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/networking/ApiRequest$Options;
 	public static synthetic fun copy$default (Lcom/stripe/android/networking/ApiRequest$Options;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/networking/ApiRequest$Options;
 	public fun describeContents ()I
@@ -5057,6 +5050,14 @@ public final class com/stripe/android/networking/ApiRequest$Options : android/os
 }
 
 public final class com/stripe/android/networking/ApiRequest$Options$Companion {
+}
+
+public final class com/stripe/android/networking/ApiRequest_Options_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/networking/ApiRequest_Options_Factory;
+	public fun get ()Lcom/stripe/android/networking/ApiRequest$Options;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)Lcom/stripe/android/networking/ApiRequest$Options;
 }
 
 public final class com/stripe/android/networking/DefaultAnalyticsRequestExecutor_Factory : dagger/internal/Factory {
@@ -5353,14 +5354,6 @@ public final class com/stripe/android/payments/core/injection/NamedConstantsKt {
 	public static final field PRODUCT_USAGE Ljava/lang/String;
 	public static final field PUBLISHABLE_KEY Ljava/lang/String;
 	public static final field STRIPE_ACCOUNT_ID Ljava/lang/String;
-}
-
-public final class com/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideApiRequestOptionsFactory : dagger/internal/Factory {
-	public fun <init> (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideApiRequestOptionsFactory;
-	public fun get ()Lcom/stripe/android/networking/ApiRequest$Options;
-	public synthetic fun get ()Ljava/lang/Object;
-	public static fun provideApiRequestOptions (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)Lcom/stripe/android/networking/ApiRequest$Options;
 }
 
 public final class com/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideDefaultReturnUrlFactory : dagger/internal/Factory {

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule.kt
@@ -9,36 +9,17 @@ import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.googlepaylauncher.PaymentsClientFactory
 import com.stripe.android.googlepaylauncher.convert
-import com.stripe.android.networking.ApiRequest
-import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.payments.core.injection.STRIPE_ACCOUNT_ID
 import dagger.Module
 import dagger.Provides
 import javax.inject.Named
-import javax.inject.Provider
 import javax.inject.Singleton
 
 @Module(
     subcomponents = [GooglePayPaymentMethodLauncherViewModelSubcomponent::class]
 )
 internal class GooglePayPaymentMethodLauncherModule {
-    /**
-     * Because [PUBLISHABLE_KEY] and [STRIPE_ACCOUNT_ID] might change, each time a new [ApiRequest]
-     * is to be send through [StripeRepository], a new [ApiRequest.Options]
-     * instance is created with the latest values.
-     *
-     * Should always be used with [Provider] or [Lazy].
-     */
-    @Provides
-    fun provideApiRequestOptions(
-        @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
-        @Named(STRIPE_ACCOUNT_ID) stripeAccountIdProvider: () -> String?
-    ) = ApiRequest.Options(
-        apiKey = publishableKeyProvider(),
-        stripeAccount = stripeAccountIdProvider()
-    )
-
     @Provides
     @Singleton
     fun provideGooglePayRepository(

--- a/payments-core/src/main/java/com/stripe/android/networking/ApiRequest.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/ApiRequest.kt
@@ -7,8 +7,13 @@ import com.stripe.android.ApiVersion
 import com.stripe.android.AppInfo
 import com.stripe.android.Stripe
 import com.stripe.android.exception.InvalidRequestException
+import com.stripe.android.payments.core.injection.PUBLISHABLE_KEY
+import com.stripe.android.payments.core.injection.STRIPE_ACCOUNT_ID
 import kotlinx.parcelize.Parcelize
 import java.io.UnsupportedEncodingException
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Provider
 
 /**
  * A class representing a Stripe API or Analytics request.
@@ -53,6 +58,23 @@ data class ApiRequest internal constructor(
         internal val stripeAccount: String? = null,
         internal val idempotencyKey: String? = null
     ) : Parcelable {
+
+        /**
+         * Dedicated constructor for injection.
+         *
+         * Because [PUBLISHABLE_KEY] and [STRIPE_ACCOUNT_ID] might change, whenever required, a new
+         * [ApiRequest.Options] instance is created with the latest values.
+         * Should always be used with [Provider] or [Lazy].
+         */
+        @Inject
+        constructor(
+            @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
+            @Named(STRIPE_ACCOUNT_ID) stripeAccountIdProvider: () -> String?
+        ) : this(
+            apiKey = publishableKeyProvider(),
+            stripeAccount = stripeAccountIdProvider()
+        )
+
         init {
             ApiKeyValidator().requireValid(apiKey)
         }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherModule.kt
@@ -2,7 +2,6 @@ package com.stripe.android.payments.core.injection
 
 import android.content.Context
 import com.stripe.android.networking.AnalyticsRequestFactory
-import com.stripe.android.networking.ApiRequest
 import com.stripe.android.networking.DefaultAnalyticsRequestExecutor
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.DefaultReturnUrl
@@ -13,7 +12,6 @@ import com.stripe.android.payments.core.authentication.PaymentAuthenticatorRegis
 import dagger.Module
 import dagger.Provides
 import javax.inject.Named
-import javax.inject.Provider
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
@@ -21,23 +19,6 @@ import kotlin.coroutines.CoroutineContext
     subcomponents = [PaymentLauncherViewModelSubcomponent::class]
 )
 internal class PaymentLauncherModule {
-
-    /**
-     * Because [PUBLISHABLE_KEY] and [STRIPE_ACCOUNT_ID] might change, each time a new [ApiRequest]
-     * is to be send through [StripeRepository], a new [ApiRequest.Options]
-     * instance is created with the latest values.
-     *
-     * Should always be used with [Provider] or [Lazy].
-     */
-    @Provides
-    fun provideApiRequestOptions(
-        @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
-        @Named(STRIPE_ACCOUNT_ID) stripeAccountIdProvider: () -> String?
-    ) = ApiRequest.Options(
-        apiKey = publishableKeyProvider(),
-        stripeAccount = stripeAccountIdProvider()
-    )
-
     @Provides
     @Singleton
     fun provideThreeDs1IntentReturnUrlMap() = mutableMapOf<String, String>()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Use constructor injection for `ApiRequest.Options`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Final couple of clean ups for dagger in payment SDK, most of the changes are removing explicit constructor/Factory method calls with actual Injection when the call happens in a dagger graph.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
