### PR TITLE
[Injection clean up] Clean up `GooglePayPaymentMethodLauncherModule`

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -136,6 +136,7 @@ public final class com/stripe/android/GooglePayJsonFactory {
 	public synthetic fun <init> (Landroid/content/Context;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lcom/stripe/android/GooglePayConfig;Z)V
 	public synthetic fun <init> (Lcom/stripe/android/GooglePayConfig;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Config;)V
 	public final fun createIsReadyToPayRequest ()Lorg/json/JSONObject;
 	public final fun createIsReadyToPayRequest (Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters;)Lorg/json/JSONObject;
 	public final fun createIsReadyToPayRequest (Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters;Ljava/lang/Boolean;)Lorg/json/JSONObject;
@@ -236,6 +237,14 @@ public final class com/stripe/android/GooglePayJsonFactory$TransactionInfo$Total
 	public static final field NotCurrentlyKnown Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;
 	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;
 	public static fun values ()[Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;
+}
+
+public final class com/stripe/android/GooglePayJsonFactory_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/GooglePayJsonFactory_Factory;
+	public fun get ()Lcom/stripe/android/GooglePayJsonFactory;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Config;)Lcom/stripe/android/GooglePayJsonFactory;
 }
 
 public final class com/stripe/android/IssuingCardPinService {
@@ -982,6 +991,14 @@ public final class com/stripe/android/exception/StripeException$Companion {
 	public final fun create (Ljava/lang/Throwable;)Lcom/stripe/android/exception/StripeException;
 }
 
+public final class com/stripe/android/googlepaylauncher/DefaultGooglePayRepository_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/googlepaylauncher/DefaultGooglePayRepository_Factory;
+	public fun get ()Lcom/stripe/android/googlepaylauncher/DefaultGooglePayRepository;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Landroid/content/Context;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Config;Lcom/stripe/android/Logger;)Lcom/stripe/android/googlepaylauncher/DefaultGooglePayRepository;
+}
+
 public final class com/stripe/android/googlepaylauncher/GooglePayEnvironment : java/lang/Enum {
 	public static final field Production Lcom/stripe/android/googlepaylauncher/GooglePayEnvironment;
 	public static final field Test Lcom/stripe/android/googlepaylauncher/GooglePayEnvironment;
@@ -1326,6 +1343,14 @@ public final class com/stripe/android/googlepaylauncher/GooglePayRepository$Disa
 	public fun isReady ()Lkotlinx/coroutines/flow/Flow;
 }
 
+public final class com/stripe/android/googlepaylauncher/PaymentsClientFactory_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/googlepaylauncher/PaymentsClientFactory_Factory;
+	public fun get ()Lcom/stripe/android/googlepaylauncher/PaymentsClientFactory;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Landroid/content/Context;)Lcom/stripe/android/googlepaylauncher/PaymentsClientFactory;
+}
+
 public final class com/stripe/android/googlepaylauncher/injection/DaggerGooglePayPaymentMethodLauncherComponent {
 	public static fun builder ()Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherComponent$Builder;
 	public fun inject (Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel$Factory;)V
@@ -1363,28 +1388,12 @@ public final class com/stripe/android/googlepaylauncher/injection/GooglePayPayme
 	public fun create (Lkotlinx/coroutines/CoroutineScope;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Config;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$ReadyCallback;Landroidx/activity/result/ActivityResultLauncher;Z)Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher;
 }
 
-public final class com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule_ProvideGooglePayJsonFactoryFactory : dagger/internal/Factory {
-	public fun <init> (Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule_ProvideGooglePayJsonFactoryFactory;
-	public fun get ()Lcom/stripe/android/GooglePayJsonFactory;
-	public synthetic fun get ()Ljava/lang/Object;
-	public static fun provideGooglePayJsonFactory (Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Config;)Lcom/stripe/android/GooglePayJsonFactory;
-}
-
-public final class com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule_ProvideGooglePayRepositoryFactory : dagger/internal/Factory {
-	public fun <init> (Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule_ProvideGooglePayRepositoryFactory;
-	public fun get ()Lcom/stripe/android/googlepaylauncher/GooglePayRepository;
-	public synthetic fun get ()Ljava/lang/Object;
-	public static fun provideGooglePayRepository (Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule;Landroid/content/Context;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Config;Lcom/stripe/android/Logger;)Lcom/stripe/android/googlepaylauncher/GooglePayRepository;
-}
-
-public final class com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule_ProvidePaymentsClientFactory : dagger/internal/Factory {
-	public fun <init> (Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule_ProvidePaymentsClientFactory;
+public final class com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule_Companion_ProvidePaymentsClientFactory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule_Companion_ProvidePaymentsClientFactory;
 	public fun get ()Lcom/google/android/gms/wallet/PaymentsClient;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun providePaymentsClient (Lcom/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule;Landroid/content/Context;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Config;)Lcom/google/android/gms/wallet/PaymentsClient;
+	public static fun providePaymentsClient (Landroid/content/Context;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Config;Lcom/stripe/android/googlepaylauncher/PaymentsClientFactory;)Lcom/google/android/gms/wallet/PaymentsClient;
 }
 
 public final class com/stripe/android/model/AccountParams : com/stripe/android/model/TokenParams {

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -136,7 +136,6 @@ public final class com/stripe/android/GooglePayJsonFactory {
 	public synthetic fun <init> (Landroid/content/Context;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lcom/stripe/android/GooglePayConfig;Z)V
 	public synthetic fun <init> (Lcom/stripe/android/GooglePayConfig;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Config;)V
 	public final fun createIsReadyToPayRequest ()Lorg/json/JSONObject;
 	public final fun createIsReadyToPayRequest (Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters;)Lorg/json/JSONObject;
 	public final fun createIsReadyToPayRequest (Lcom/stripe/android/GooglePayJsonFactory$BillingAddressParameters;Ljava/lang/Boolean;)Lorg/json/JSONObject;

--- a/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
@@ -48,7 +48,7 @@ class GooglePayJsonFactory constructor(
     )
 
     @Inject
-    constructor(
+    internal constructor(
         @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
         @Named(STRIPE_ACCOUNT_ID) stripeAccountIdProvider: () -> String?,
         googlePayConfig: GooglePayPaymentMethodLauncher.Config

--- a/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
@@ -2,16 +2,24 @@ package com.stripe.android
 
 import android.content.Context
 import android.os.Parcelable
+import com.stripe.android.GooglePayJsonFactory.TransactionInfo.TotalPriceStatus
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
+import com.stripe.android.payments.core.injection.PUBLISHABLE_KEY
+import com.stripe.android.payments.core.injection.STRIPE_ACCOUNT_ID
 import kotlinx.parcelize.Parcelize
 import org.json.JSONArray
 import org.json.JSONObject
 import java.util.Currency
 import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
 
 /**
  * A factory for generating [Google Pay JSON request objects](https://developers.google.com/pay/api/android/reference/request-objects)
  * for Google Pay API version 2.0.
  */
+@Singleton
 class GooglePayJsonFactory constructor(
     private val googlePayConfig: GooglePayConfig,
 
@@ -37,6 +45,16 @@ class GooglePayJsonFactory constructor(
     ) : this(
         googlePayConfig = GooglePayConfig(context),
         isJcbEnabled = isJcbEnabled
+    )
+
+    @Inject
+    constructor(
+        @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
+        @Named(STRIPE_ACCOUNT_ID) stripeAccountIdProvider: () -> String?,
+        googlePayConfig: GooglePayPaymentMethodLauncher.Config
+    ) : this(
+        googlePayConfig = GooglePayConfig(publishableKeyProvider(), stripeAccountIdProvider()),
+        isJcbEnabled = googlePayConfig.isJcbEnabled
     )
 
     /**

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayRepository.kt
@@ -11,6 +11,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flowOf
+import javax.inject.Inject
+import javax.inject.Singleton
 
 fun interface GooglePayRepository {
     fun isReady(): Flow<Boolean>
@@ -24,6 +26,7 @@ fun interface GooglePayRepository {
  * The default implementation of [GooglePayRepository].  Using the individual values as parameters
  * so it can be shared with [GooglePayLauncher] and [GooglePayPaymentMethodLauncher]
  */
+@Singleton
 internal class DefaultGooglePayRepository(
     private val context: Context,
     private val environment: GooglePayEnvironment,
@@ -31,6 +34,20 @@ internal class DefaultGooglePayRepository(
     private val existingPaymentMethodRequired: Boolean,
     private val logger: Logger = Logger.noop()
 ) : GooglePayRepository {
+
+    @Inject
+    constructor(
+        context: Context,
+        googlePayConfig: GooglePayPaymentMethodLauncher.Config,
+        logger: Logger
+    ) : this(
+        context.applicationContext,
+        googlePayConfig.environment,
+        googlePayConfig.billingAddressConfig.convert(),
+        googlePayConfig.existingPaymentMethodRequired,
+        logger
+    )
+
     private val googlePayJsonFactory = GooglePayJsonFactory(context)
 
     private val paymentsClient: PaymentsClient by lazy {

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayRepository.kt
@@ -36,7 +36,7 @@ internal class DefaultGooglePayRepository(
 ) : GooglePayRepository {
 
     @Inject
-    constructor(
+    internal constructor(
         context: Context,
         googlePayConfig: GooglePayPaymentMethodLauncher.Config,
         logger: Logger

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/PaymentsClientFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/PaymentsClientFactory.kt
@@ -3,8 +3,9 @@ package com.stripe.android.googlepaylauncher
 import android.content.Context
 import com.google.android.gms.wallet.PaymentsClient
 import com.google.android.gms.wallet.Wallet
+import javax.inject.Inject
 
-internal class PaymentsClientFactory(
+internal class PaymentsClientFactory @Inject constructor(
     private val context: Context
 ) {
     fun create(

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherModule.kt
@@ -1,54 +1,32 @@
 package com.stripe.android.googlepaylauncher.injection
 
 import android.content.Context
-import com.stripe.android.GooglePayConfig
-import com.stripe.android.GooglePayJsonFactory
-import com.stripe.android.Logger
 import com.stripe.android.googlepaylauncher.DefaultGooglePayRepository
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.googlepaylauncher.PaymentsClientFactory
-import com.stripe.android.googlepaylauncher.convert
-import com.stripe.android.payments.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.payments.core.injection.STRIPE_ACCOUNT_ID
+import dagger.Binds
 import dagger.Module
 import dagger.Provides
-import javax.inject.Named
 import javax.inject.Singleton
 
 @Module(
     subcomponents = [GooglePayPaymentMethodLauncherViewModelSubcomponent::class]
 )
-internal class GooglePayPaymentMethodLauncherModule {
-    @Provides
+internal abstract class GooglePayPaymentMethodLauncherModule {
+    @Binds
     @Singleton
-    fun provideGooglePayRepository(
-        context: Context,
-        googlePayConfig: GooglePayPaymentMethodLauncher.Config,
-        logger: Logger
-    ): GooglePayRepository = DefaultGooglePayRepository(
-        context.applicationContext,
-        googlePayConfig.environment,
-        googlePayConfig.billingAddressConfig.convert(),
-        googlePayConfig.existingPaymentMethodRequired,
-        logger
-    )
+    abstract fun bindsGooglePayRepository(
+        defaultGooglePayRepository: DefaultGooglePayRepository
+    ): GooglePayRepository
 
-    @Provides
-    @Singleton
-    fun provideGooglePayJsonFactory(
-        @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
-        @Named(STRIPE_ACCOUNT_ID) stripeAccountIdProvider: () -> String?,
-        googlePayConfig: GooglePayPaymentMethodLauncher.Config
-    ) = GooglePayJsonFactory(
-        googlePayConfig = GooglePayConfig(publishableKeyProvider(), stripeAccountIdProvider()),
-        isJcbEnabled = googlePayConfig.isJcbEnabled
-    )
-
-    @Provides
-    @Singleton
-    fun providePaymentsClient(
-        context: Context,
-        googlePayConfig: GooglePayPaymentMethodLauncher.Config
-    ) = PaymentsClientFactory(context).create(googlePayConfig.environment)
+    companion object {
+        @Provides
+        @Singleton
+        fun providePaymentsClient(
+            context: Context,
+            googlePayConfig: GooglePayPaymentMethodLauncher.Config,
+            paymentsClientFactory: PaymentsClientFactory
+        ) = paymentsClientFactory.create(googlePayConfig.environment)
+    }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Use constructor injector for `DefaultGooglePayRepository`, `GooglePayJsonFactory` and `PaymentsClientFactory`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Final couple of clean ups for dagger in payment SDK, most of the changes are removing explicit constructor/Factory method calls with actual Injection when the call happens in a dagger graph.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
