### PR TITLE
Sort countries with accents and diacritics correctly

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/view/CountryUtils.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CountryUtils.kt
@@ -1,8 +1,10 @@
 package com.stripe.android.view
 
 import androidx.annotation.RestrictTo
+import androidx.annotation.VisibleForTesting
 import com.stripe.android.model.CountryCode
 import com.stripe.android.model.getCountryCode
+import java.text.Normalizer
 import java.util.Locale
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) // For paymentsheet -- this still auto-completes
@@ -44,9 +46,18 @@ object CountryUtils {
         return listOfNotNull(getCountryByCode(currentLocale.getCountryCode(), currentLocale))
             .plus(
                 localizedCountries(currentLocale)
-                    .sortedBy { it.name.lowercase() }
+                    .sortedBy { formatNameForSorting(it.name) }
                     .filterNot { it.code == currentLocale.getCountryCode() }
             )
+    }
+
+    @VisibleForTesting
+    internal fun formatNameForSorting(name: String): String {
+        // Before normalization: åland islands
+        // After normalization: aºland islands
+        // After regex: aland islands
+        return Normalizer.normalize(name.lowercase(), Normalizer.Form.NFD)
+            .replace("\\p{Mn}+".toRegex(), "")
     }
 
     @Deprecated(

--- a/payments-core/src/test/java/com/stripe/android/view/CountryUtilsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CountryUtilsTest.kt
@@ -68,4 +68,36 @@ class CountryUtilsTest {
         assertThat(germany?.name)
             .isEqualTo("Deutschland")
     }
+
+    @Test
+    fun `formatNameForSorting does nothing to already formatted strings`() {
+        val input = "aland"
+        val expectedOutput = "aland"
+
+        assertThat(CountryUtils.formatNameForSorting(input) == expectedOutput)
+    }
+
+    @Test
+    fun `formatNameForSorting removes accents and diacritics`() {
+        val input = "Dziękuję Åland"
+        val expectedOutput = "dziekuje aland"
+
+        assertThat(CountryUtils.formatNameForSorting(input) == expectedOutput)
+    }
+
+    @Test
+    fun `formatNameForSorting removes capitalization`() {
+        val input = "Aland"
+        val expectedOutput = "aland"
+
+        assertThat(CountryUtils.formatNameForSorting(input) == expectedOutput)
+    }
+
+    @Test
+    fun `formatNameForSorting removes non alphanumeric characters`() {
+        val input = "aºland1!!!"
+        val expectedOutput = "aland"
+
+        assertThat(CountryUtils.formatNameForSorting(input) == expectedOutput)
+    }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Remove accents and diacritics from countries before we sort them to generate the order they're displayed in. 

Note: The removal does not affect how we end up showing the strings, just how we order them. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
If we keep accents and diacritics then countries such as [Åland Islands](https://en.wikipedia.org/wiki/%C3%85land_Islands) will appear near the end of the list of countries. This fix places the country correctly within the A's. 

Here we are using NFD Normalization to remove any diacritic from the letters so they appear sorted within the list. We have to then use a regex to remove the characters because they are added separately to the string by the normalization function.

 See [here](https://stackoverflow.com/questions/51731574/removing-accents-and-diacritics-in-kotlin) for a useful stack overflow post that helped me.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![aland1](https://user-images.githubusercontent.com/89166418/135358416-0ba27ece-4b51-47ad-b605-03c8412dea4f.png)|![aland2](https://user-images.githubusercontent.com/89166418/135358426-d7387528-7a2b-4dca-bfdd-1d07952c3d82.png)|
