### PR TITLE
Supported Payment Methods

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -539,6 +539,22 @@ public final class com/stripe/android/paymentsheet/elements/ComposableSingletons
 	public final fun getLambda-1$paymentsheet_release ()Lkotlin/jvm/functions/Function3;
 }
 
+public final class com/stripe/android/paymentsheet/elements/Requirement : java/lang/Enum {
+	public static final field DelayedSettlementSupport Lcom/stripe/android/paymentsheet/elements/Requirement;
+	public static final field MerchantSelectedSave Lcom/stripe/android/paymentsheet/elements/Requirement;
+	public static final field OneTimeUse Lcom/stripe/android/paymentsheet/elements/Requirement;
+	public static final field ReusableMandateSupport Lcom/stripe/android/paymentsheet/elements/Requirement;
+	public static final field ShippingInIntentAddressCountry Lcom/stripe/android/paymentsheet/elements/Requirement;
+	public static final field ShippingInIntentAddressLine1 Lcom/stripe/android/paymentsheet/elements/Requirement;
+	public static final field ShippingInIntentAddressLine2 Lcom/stripe/android/paymentsheet/elements/Requirement;
+	public static final field ShippingInIntentAddressPostal Lcom/stripe/android/paymentsheet/elements/Requirement;
+	public static final field ShippingInIntentAddressState Lcom/stripe/android/paymentsheet/elements/Requirement;
+	public static final field ShippingInIntentName Lcom/stripe/android/paymentsheet/elements/Requirement;
+	public static final field UserSelectableSave Lcom/stripe/android/paymentsheet/elements/Requirement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/elements/Requirement;
+	public static fun values ()[Lcom/stripe/android/paymentsheet/elements/Requirement;
+}
+
 public final class com/stripe/android/paymentsheet/elements/ResourceRepository_Factory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;)V
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/elements/ResourceRepository_Factory;

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -22,7 +22,6 @@ import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.PaymentIntent
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.core.injection.DUMMY_INJECTOR_KEY
 import com.stripe.android.payments.core.injection.IOContext
@@ -34,7 +33,10 @@ import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.forms.getSupportedPaymentMethods
 import com.stripe.android.paymentsheet.elements.ResourceRepository
+import com.stripe.android.paymentsheet.forms.getAllCapabilities
+import com.stripe.android.paymentsheet.forms.getSupportedSavedCustomerCards
 import com.stripe.android.paymentsheet.injection.DaggerPaymentSheetLauncherComponent
 import com.stripe.android.paymentsheet.injection.PaymentSheetViewModelModule
 import com.stripe.android.paymentsheet.injection.PaymentSheetViewModelSubcomponent
@@ -43,7 +45,6 @@ import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
 import com.stripe.android.paymentsheet.model.StripeIntentValidator
-import com.stripe.android.paymentsheet.model.SupportedPaymentMethod
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.StripeIntentRepository
 import com.stripe.android.paymentsheet.ui.PrimaryButton
@@ -219,34 +220,33 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     /**
      * Fetch the saved payment methods for the customer, if a [PaymentSheet.CustomerConfiguration]
      * was provided.
-     * It will fetch only the payment method types accepted by the [stripeIntent] and defined in
-     * [SupportedPaymentMethod.supportedSavedPaymentMethods].
+     * It will fetch only the payment method types as defined in [getSupportedPaymentMethods].
      */
     @VisibleForTesting
     fun updatePaymentMethods(stripeIntent: StripeIntent) {
         viewModelScope.launch {
             runCatching {
                 customerConfig?.let { customerConfig ->
-                    stripeIntent.paymentMethodTypes.mapNotNull {
-                        PaymentMethod.Type.fromCode(it)
-                    }.filter {
-                        SupportedPaymentMethod.supportedSavedPaymentMethods.contains(it.code)
-                    }.filter {
-                        config?.allowsDelayedPaymentMethods == true || !it.hasDelayedSettlement()
-                    }.let {
-                        customerRepository.getPaymentMethods(
-                            customerConfig,
-                            it
-                        )
-                    }.filter { paymentMethod ->
-                        paymentMethod.hasExpectedDetails().also { valid ->
-                            if (!valid) {
-                                logger.error(
-                                    "Discarding invalid payment method ${paymentMethod.id}"
-                                )
+                    getSupportedSavedCustomerCards(
+                        stripeIntent,
+                        config
+                    ).map {
+                        it.type
+                    }.toList()
+                        .let {
+                            customerRepository.getPaymentMethods(
+                                customerConfig,
+                                it
+                            )
+                        }.filter { paymentMethod ->
+                            paymentMethod.hasExpectedDetails().also { valid ->
+                                if (!valid) {
+                                    logger.error(
+                                        "Discarding invalid payment method ${paymentMethod.id}"
+                                    )
+                                }
                             }
                         }
-                    }
                 }.orEmpty()
             }.fold(
                 onSuccess = {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -35,7 +35,6 @@ import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssisted
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.forms.getSupportedPaymentMethods
 import com.stripe.android.paymentsheet.elements.ResourceRepository
-import com.stripe.android.paymentsheet.forms.getAllCapabilities
 import com.stripe.android.paymentsheet.forms.getSupportedSavedCustomerCards
 import com.stripe.android.paymentsheet.injection.DaggerPaymentSheetLauncherComponent
 import com.stripe.android.paymentsheet.injection.PaymentSheetViewModelModule

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/FormSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/FormSpec.kt
@@ -1,9 +1,45 @@
 package com.stripe.android.paymentsheet.elements
 
 /**
+ * This class defines requirements of the payment method
+ */
+enum class Requirement {
+    DelayedSettlementSupport,
+
+    OneTimeUse,
+    MerchantSelectedSave, // capability if: SetupIntent or PaymentIntent w/setup_future_usage = on/off
+    UserSelectableSave,   // capability if: PaymentIntent w/setup_future_usage off
+
+    /**
+     * Different payment method might require some subset of the address
+     * fields, so they must be individually declared
+     */
+    ShippingInIntentAddressLine1,
+    ShippingInIntentAddressLine2,
+    ShippingInIntentAddressCountry,
+    ShippingInIntentAddressState,
+    ShippingInIntentAddressPostal,
+    ShippingInIntentName,
+
+    /**
+     * ReusableMandateSupport means that a mandate needs to be attached
+     * at confirm time to support the payment method. Currently the api
+     * does not support doing this from the SDK.
+     */
+    ReusableMandateSupport,
+}
+
+/**
  * This class is used to define different forms full of fields.
  */
 internal data class FormSpec(
     val layout: LayoutSpec,
+    val requirements: Set<Requirement>,
+)
+
+internal data class PaymentMethodSpec(
     val paramKey: MutableMap<String, Any?>,
+
+    /** Ordered list of specs in terms of preference **/
+    val specs: List<FormSpec>
 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/FormSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/FormSpec.kt
@@ -4,11 +4,15 @@ package com.stripe.android.paymentsheet.elements
  * This class defines requirements of the payment method
  */
 enum class Requirement {
-    DelayedSettlementSupport,
+    DelayedPaymentMethodSupport,
 
     OneTimeUse,
-    MerchantSelectedSave, // capability if: SetupIntent or PaymentIntent w/setup_future_usage = on/off
-    UserSelectableSave,   // capability if: PaymentIntent w/setup_future_usage off
+
+    // capability if: SetupIntent or PaymentIntent w/setup_future_usage = on/off
+    MerchantRequiresSave,
+
+    // capability if: PaymentIntent w/setup_future_usage off
+    UserSelectableSave,
 
     /**
      * Different payment method might require some subset of the address

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializer.kt
@@ -24,9 +24,9 @@ import kotlin.coroutines.CoroutineContext
 @Singleton
 internal class DefaultFlowControllerInitializer @Inject constructor(
     private val prefsRepositoryFactory: @JvmSuppressWildcards
-        (PaymentSheet.CustomerConfiguration?) -> PrefsRepository,
+    (PaymentSheet.CustomerConfiguration?) -> PrefsRepository,
     private val googlePayRepositoryFactory: @JvmSuppressWildcards
-        (GooglePayEnvironment) -> GooglePayRepository,
+    (GooglePayEnvironment) -> GooglePayRepository,
     private val stripeIntentRepository: StripeIntentRepository,
     private val stripeIntentValidator: StripeIntentValidator,
     private val customerRepository: CustomerRepository,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/AfterpayClearpaySpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/AfterpayClearpaySpec.kt
@@ -50,7 +50,7 @@ private val afterpayClearpaySpec = FormSpec(
         Requirement.ShippingInIntentAddressLine1,
         Requirement.ShippingInIntentAddressCountry,
         Requirement.ShippingInIntentAddressPostal,
-        Requirement.DelayedSettlementSupport, // due to behavior on cancel
+        Requirement.DelayedPaymentMethodSupport, // due to behavior on cancel
         Requirement.OneTimeUse
     )
 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/AfterpayClearpaySpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/AfterpayClearpaySpec.kt
@@ -1,6 +1,17 @@
-package com.stripe.android.paymentsheet.elements
+package com.stripe.android.paymentsheet.forms
 
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.elements.AddressSpec
+import com.stripe.android.paymentsheet.elements.AfterpayClearpayTextSpec
+import com.stripe.android.paymentsheet.elements.EmailSpec
+import com.stripe.android.paymentsheet.elements.FormSpec
+import com.stripe.android.paymentsheet.elements.IdentifierSpec
+import com.stripe.android.paymentsheet.elements.LayoutSpec
+import com.stripe.android.paymentsheet.elements.PaymentMethodSpec
+import com.stripe.android.paymentsheet.elements.Requirement
+import com.stripe.android.paymentsheet.elements.SectionSpec
+import com.stripe.android.paymentsheet.elements.SimpleTextSpec
+import com.stripe.android.paymentsheet.elements.billingParams
 
 internal val afterpayClearpayParamKey: MutableMap<String, Any?> = mutableMapOf(
     "type" to "afterpay_clearpay",
@@ -23,7 +34,7 @@ internal val afterpayClearpayBillingSection = SectionSpec(
     R.string.billing_details
 )
 
-internal val afterpayClearpay = FormSpec(
+private val afterpayClearpaySpec = FormSpec(
     LayoutSpec(
         listOf(
             afterpayClearpayHeader,
@@ -32,5 +43,19 @@ internal val afterpayClearpay = FormSpec(
             afterpayClearpayBillingSection
         )
     ),
-    afterpayClearpayParamKey
+    // We will only require the country and name in the shipping section of
+    // payment intents
+    requirements = setOf(
+        Requirement.ShippingInIntentName,
+        Requirement.ShippingInIntentAddressLine1,
+        Requirement.ShippingInIntentAddressCountry,
+        Requirement.ShippingInIntentAddressPostal,
+        Requirement.DelayedSettlementSupport, // due to behavior on cancel
+        Requirement.OneTimeUse
+    )
+)
+
+internal val afterpayClearpay = PaymentMethodSpec(
+    afterpayClearpayParamKey,
+    listOf(afterpayClearpaySpec)
 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/BancontactSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/BancontactSpec.kt
@@ -7,6 +7,8 @@ import com.stripe.android.paymentsheet.elements.FormSpec
 import com.stripe.android.paymentsheet.elements.IdentifierSpec
 import com.stripe.android.paymentsheet.elements.LayoutSpec
 import com.stripe.android.paymentsheet.elements.MandateTextSpec
+import com.stripe.android.paymentsheet.elements.PaymentMethodSpec
+import com.stripe.android.paymentsheet.elements.Requirement
 import com.stripe.android.paymentsheet.elements.SaveForFutureUseSpec
 import com.stripe.android.paymentsheet.elements.SectionSpec
 import com.stripe.android.paymentsheet.elements.SimpleTextSpec
@@ -28,7 +30,7 @@ internal val bancontactMandate = MandateTextSpec(
     R.string.stripe_paymentsheet_sepa_mandate,
     Color.Gray
 )
-internal val bancontact = FormSpec(
+internal val bancontactUserSelectedSave = FormSpec(
     LayoutSpec(
         listOf(
             bancontactNameSection,
@@ -41,5 +43,38 @@ internal val bancontact = FormSpec(
             bancontactMandate,
         )
     ),
+    // When saved this is a SEPA paymentMethod which requires SEPA requirements
+    requirements = sepaDebitUserSelectedSave.requirements
+        .plus(Requirement.UserSelectableSave),
+)
+internal val bancontactMerchantRequiredSave = FormSpec(
+    LayoutSpec(
+        listOf(
+            bancontactNameSection,
+            bancontactEmailSection,
+            bancontactMandate,
+        )
+    ),
+    // When saved this is a SEPA paymentMethod which requires SEPA requirements
+    requirements = sepaDebitMerchantRequiredSave.requirements
+        .plus(Requirement.MerchantSelectedSave),
+)
+internal val bancontactOneTimeUse = FormSpec(
+    LayoutSpec(
+        listOf(
+            bancontactNameSection,
+        )
+    ),
+    requirements = setOf(
+        Requirement.OneTimeUse
+    )
+)
+
+internal val bancontact = PaymentMethodSpec(
     bancontactParamKey,
+    listOf(
+        bancontactUserSelectedSave,
+        bancontactMerchantRequiredSave,
+        bancontactOneTimeUse
+    )
 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/BancontactSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/BancontactSpec.kt
@@ -57,7 +57,7 @@ internal val bancontactMerchantRequiredSave = FormSpec(
     ),
     // When saved this is a SEPA paymentMethod which requires SEPA requirements
     requirements = sepaDebitMerchantRequiredSave.requirements
-        .plus(Requirement.MerchantSelectedSave),
+        .plus(Requirement.MerchantRequiresSave),
 )
 internal val bancontactOneTimeUse = FormSpec(
     LayoutSpec(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/CardSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/CardSpec.kt
@@ -1,0 +1,17 @@
+package com.stripe.android.paymentsheet.forms
+
+import com.stripe.android.paymentsheet.elements.FormSpec
+import com.stripe.android.paymentsheet.elements.LayoutSpec
+import com.stripe.android.paymentsheet.elements.PaymentMethodSpec
+
+internal val cardFormSpec = FormSpec(
+    LayoutSpec(
+        emptyList() // Not supported in form view
+    ),
+    requirements = emptySet()
+)
+
+internal val card = PaymentMethodSpec(
+    mutableMapOf(),
+    listOf(cardFormSpec)
+)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/EpsSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/EpsSpec.kt
@@ -5,6 +5,8 @@ import com.stripe.android.paymentsheet.elements.BankDropdownSpec
 import com.stripe.android.paymentsheet.elements.FormSpec
 import com.stripe.android.paymentsheet.elements.IdentifierSpec
 import com.stripe.android.paymentsheet.elements.LayoutSpec
+import com.stripe.android.paymentsheet.elements.PaymentMethodSpec
+import com.stripe.android.paymentsheet.elements.Requirement
 import com.stripe.android.paymentsheet.elements.SectionSpec
 import com.stripe.android.paymentsheet.elements.SimpleTextSpec
 import com.stripe.android.paymentsheet.elements.SupportedBankType
@@ -34,12 +36,17 @@ internal val epsBankSection =
         )
     )
 
-internal val eps = FormSpec(
-    LayoutSpec(
-        listOf(
-            epsNameSection,
-            epsBankSection
-        )
-    ),
+internal val eps = PaymentMethodSpec(
     epsParamKey,
+    listOf(
+        FormSpec(
+            LayoutSpec(
+                listOf(
+                    epsNameSection,
+                    epsBankSection
+                )
+            ),
+            requirements = setOf(Requirement.OneTimeUse)
+        )
+    )
 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormPreview.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormPreview.kt
@@ -6,12 +6,13 @@ import com.stripe.android.payments.core.injection.DUMMY_INJECTOR_KEY
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.address.AddressFieldElementRepository
 import com.stripe.android.paymentsheet.address.parseAddressesSchema
-import com.stripe.android.paymentsheet.elements.FormInternal
-import com.stripe.android.paymentsheet.model.Amount
-import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
 import com.stripe.android.paymentsheet.elements.BankRepository
+import com.stripe.android.paymentsheet.elements.FormInternal
+import com.stripe.android.paymentsheet.elements.Requirement
 import com.stripe.android.paymentsheet.elements.ResourceRepository
 import com.stripe.android.paymentsheet.elements.SupportedBankType
+import com.stripe.android.paymentsheet.model.SupportedPaymentMethod
+import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
 import kotlinx.coroutines.flow.MutableStateFlow
 
 /**
@@ -22,7 +23,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 @SuppressLint("VisibleForTests")
 @Composable
 internal fun FormInternalPreview() {
-    val formElements = sofort.layout.items
+    val formElements = sofort.specs.first().layout.items
     val addressFieldElementRepository = AddressFieldElementRepository()
     val bankRepository = BankRepository()
 
@@ -49,20 +50,24 @@ internal fun FormInternalPreview() {
                 addressFieldElementRepository
             ),
             FormFragmentArguments(
-                "Card",
-                saveForFutureUseInitialVisibility = true,
-                saveForFutureUseInitialValue = true,
+                SupportedPaymentMethod.Bancontact,
+                capabilities = setOf(
+                    Requirement.UserSelectableSave,
+                    Requirement.DelayedSettlementSupport,
+                ),
                 merchantName = "Merchant, Inc.",
-                amount = Amount(10, "USD"),
                 billingDetails = PaymentSheet.BillingDetails(
-                    PaymentSheet.Address(
-                        "San Fransciso",
-                        "US",
-                        "123 Main Street",
-                        null,
-                        "94111",
-                        "CA",
-                    )
+                    address = PaymentSheet.Address(
+                        line1 = "123 Main Street",
+                        line2 = null,
+                        city = "San Francisco",
+                        state = "CA",
+                        postalCode = "94111",
+                        country = "DE",
+                    ),
+                    email = "email",
+                    name = "Jenny Rosen",
+                    phone = "+18008675309"
                 ),
                 injectorKey = DUMMY_INJECTOR_KEY
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormPreview.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormPreview.kt
@@ -53,7 +53,7 @@ internal fun FormInternalPreview() {
                 SupportedPaymentMethod.Bancontact,
                 capabilities = setOf(
                     Requirement.UserSelectableSave,
-                    Requirement.DelayedSettlementSupport,
+                    Requirement.DelayedPaymentMethodSupport,
                 ),
                 merchantName = "Merchant, Inc.",
                 billingDetails = PaymentSheet.BillingDetails(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
@@ -80,12 +80,6 @@ internal class FormViewModel @Inject internal constructor(
 
     internal lateinit var elements: List<FormElement>
 
-    private val saveForFutureUseVisible = MutableStateFlow(config.saveForFutureUseInitialVisibility)
-
-    internal fun setSaveForFutureUseVisibility(isVisible: Boolean) {
-        saveForFutureUseVisible.value = isVisible
-    }
-
     internal fun setSaveForFutureUse(value: Boolean) {
         elements
             .filterIsInstance<SaveForFutureUseElement>()
@@ -97,7 +91,7 @@ internal class FormViewModel @Inject internal constructor(
         .firstOrNull()
 
     internal val saveForFutureUse = saveForFutureUseElement?.controller?.saveForFutureUse
-        ?: MutableStateFlow(config.saveForFutureUseInitialValue)
+        ?: MutableStateFlow(false)
 
     private val sectionToFieldIdentifierMap = layout.items
         .filterIsInstance<SectionSpec>()
@@ -108,30 +102,20 @@ internal class FormViewModel @Inject internal constructor(
         }
 
     internal val hiddenIdentifiers =
-        combine(
-            saveForFutureUseVisible,
-            saveForFutureUseElement?.controller?.hiddenIdentifiers
-                ?: MutableStateFlow(emptyList())
-        ) { showFutureUse, hiddenIdentifiers ->
+        (saveForFutureUseElement?.controller?.hiddenIdentifiers ?: MutableStateFlow(emptyList()))
+            .map { hiddenIdentifiers ->
 
-            // For hidden *section* identifiers, list of identifiers of elements in the section
-            val identifiers = sectionToFieldIdentifierMap
-                .filter { idControllerPair ->
-                    hiddenIdentifiers.contains(idControllerPair.key)
-                }
-                .flatMap { sectionToSectionFieldEntry ->
-                    sectionToSectionFieldEntry.value
-                }
-
-            if (!showFutureUse && saveForFutureUseElement != null) {
-                hiddenIdentifiers
-                    .plus(identifiers)
-                    .plus(saveForFutureUseElement.identifier)
-            } else {
-                hiddenIdentifiers
-                    .plus(identifiers)
+                // For hidden *section* identifiers, list of identifiers of elements in the section
+                hiddenIdentifiers.plus(
+                    sectionToFieldIdentifierMap
+                        .filter { idControllerPair ->
+                            hiddenIdentifiers.contains(idControllerPair.key)
+                        }
+                        .flatMap { sectionToSectionFieldEntry ->
+                            sectionToSectionFieldEntry.value
+                        }
+                )
             }
-        }
 
     // Mandate is showing if it is an element of the form and it isn't hidden
     internal val showingMandate = hiddenIdentifiers.map {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/GiropaySpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/GiropaySpec.kt
@@ -3,6 +3,8 @@ package com.stripe.android.paymentsheet.forms
 import com.stripe.android.paymentsheet.elements.FormSpec
 import com.stripe.android.paymentsheet.elements.IdentifierSpec
 import com.stripe.android.paymentsheet.elements.LayoutSpec
+import com.stripe.android.paymentsheet.elements.PaymentMethodSpec
+import com.stripe.android.paymentsheet.elements.Requirement
 import com.stripe.android.paymentsheet.elements.SectionSpec
 import com.stripe.android.paymentsheet.elements.SimpleTextSpec
 import com.stripe.android.paymentsheet.elements.billingParams
@@ -17,11 +19,16 @@ internal val giropayNameSection = SectionSpec(
     SimpleTextSpec.NAME
 )
 
-internal val giropay = FormSpec(
-    LayoutSpec(
-        listOf(
-            giropayNameSection
-        )
-    ),
+internal val giropay = PaymentMethodSpec(
     giropayParamKey,
+    listOf(
+        FormSpec(
+            LayoutSpec(
+                listOf(
+                    giropayNameSection
+                )
+            ),
+            requirements = setOf(Requirement.OneTimeUse)
+        )
+    )
 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/IdealSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/IdealSpec.kt
@@ -8,6 +8,8 @@ import com.stripe.android.paymentsheet.elements.FormSpec
 import com.stripe.android.paymentsheet.elements.IdentifierSpec
 import com.stripe.android.paymentsheet.elements.LayoutSpec
 import com.stripe.android.paymentsheet.elements.MandateTextSpec
+import com.stripe.android.paymentsheet.elements.PaymentMethodSpec
+import com.stripe.android.paymentsheet.elements.Requirement
 import com.stripe.android.paymentsheet.elements.SaveForFutureUseSpec
 import com.stripe.android.paymentsheet.elements.SectionSpec
 import com.stripe.android.paymentsheet.elements.SimpleTextSpec
@@ -42,7 +44,8 @@ internal val idealMandate = MandateTextSpec(
     R.string.stripe_paymentsheet_sepa_mandate,
     Color.Gray
 )
-internal val ideal = FormSpec(
+
+private val idealUserSelectedSave = FormSpec(
     LayoutSpec(
         listOf(
             idealNameSection,
@@ -52,5 +55,40 @@ internal val ideal = FormSpec(
             idealMandate,
         )
     ),
-    idealParamKey,
+    // When saved this is a SEPA paymentMethod which requires SEPA requirements
+    requirements = setOf(Requirement.UserSelectableSave)
+        .plus(sepaDebitUserSelectedSave.requirements)
 )
+private val idealMerchantRequiredSave = FormSpec(
+    LayoutSpec(
+        listOf(
+            idealNameSection,
+            idealEmailSection,
+            idealBankSection,
+            idealMandate,
+        )
+    ),
+    // When saved this is a SEPA paymentMethod which requires SEPA requirements
+    requirements = setOf(Requirement.MerchantSelectedSave)
+        .plus(sepaDebitMerchantRequiredSave.requirements)
+)
+
+private val idealOneTimeUse = FormSpec(
+    LayoutSpec(
+        listOf(
+            idealNameSection,
+            idealBankSection,
+        )
+    ),
+    requirements = setOf(Requirement.OneTimeUse),
+)
+
+internal val ideal = PaymentMethodSpec(
+    idealParamKey,
+    listOf(
+        idealUserSelectedSave,
+        idealMerchantRequiredSave,
+        idealOneTimeUse
+    )
+)
+

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/IdealSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/IdealSpec.kt
@@ -69,7 +69,7 @@ private val idealMerchantRequiredSave = FormSpec(
         )
     ),
     // When saved this is a SEPA paymentMethod which requires SEPA requirements
-    requirements = setOf(Requirement.MerchantSelectedSave)
+    requirements = setOf(Requirement.MerchantRequiresSave)
         .plus(sepaDebitMerchantRequiredSave.requirements)
 )
 
@@ -91,4 +91,3 @@ internal val ideal = PaymentMethodSpec(
         idealOneTimeUse
     )
 )
-

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/P24Spec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/P24Spec.kt
@@ -6,6 +6,8 @@ import com.stripe.android.paymentsheet.elements.EmailSpec
 import com.stripe.android.paymentsheet.elements.FormSpec
 import com.stripe.android.paymentsheet.elements.IdentifierSpec
 import com.stripe.android.paymentsheet.elements.LayoutSpec
+import com.stripe.android.paymentsheet.elements.PaymentMethodSpec
+import com.stripe.android.paymentsheet.elements.Requirement
 import com.stripe.android.paymentsheet.elements.SectionSpec
 import com.stripe.android.paymentsheet.elements.SimpleTextSpec
 import com.stripe.android.paymentsheet.elements.SupportedBankType
@@ -39,13 +41,20 @@ internal val p24BankSection =
         )
     )
 
-internal val p24 = FormSpec(
-    LayoutSpec(
-        listOf(
-            p24NameSection,
-            p24EmailSection,
-            p24BankSection
-        )
-    ),
+internal val p24 = PaymentMethodSpec(
     p24ParamKey,
+    listOf(
+        FormSpec(
+            LayoutSpec(
+                listOf(
+                    p24NameSection,
+                    p24EmailSection,
+                    p24BankSection
+                )
+            ),
+            requirements = setOf(
+                Requirement.OneTimeUse
+            )
+        )
+    )
 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/PaymentMethodSpecKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/PaymentMethodSpecKtx.kt
@@ -46,7 +46,7 @@ internal fun getSupportedPaymentMethods(
             SupportedPaymentMethod.fromCode(it)
         }.filter { supportedPaymentMethod ->
             supportedPaymentMethod.spec.satisfiedBy(capabilities)
-        }//.filter { it == SupportedPaymentMethod.Card }
+        } // .filter { it == SupportedPaymentMethod.Card }
             .toList()
     }
 
@@ -81,7 +81,7 @@ internal fun getAllCapabilities(
     stripeIntent: StripeIntent?,
     config: PaymentSheet.Configuration?
 ) = setOfNotNull(
-    Requirement.DelayedSettlementSupport.takeIf { config?.allowsDelayedPaymentMethods == true },
+    Requirement.DelayedPaymentMethodSupport.takeIf { config?.allowsDelayedPaymentMethods == true },
 )
     .plus(getReusableCapabilities(stripeIntent, config))
     .plus(intentShippingCapabilities(stripeIntent as? PaymentIntent))
@@ -104,11 +104,11 @@ private fun getReusableCapabilities(
                 listOf(Requirement.OneTimeUse)
             }
         } else {
-            listOf(Requirement.MerchantSelectedSave)
+            listOf(Requirement.MerchantRequiresSave)
         }
     }
     is SetupIntent -> {
-        listOf(Requirement.MerchantSelectedSave)
+        listOf(Requirement.MerchantRequiresSave)
     }
     else -> emptyList()
 }
@@ -119,12 +119,24 @@ private fun getReusableCapabilities(
 private fun intentShippingCapabilities(stripeIntent: PaymentIntent?) =
     stripeIntent?.let { paymentIntent ->
         listOfNotNull(
-            Requirement.ShippingInIntentName.takeIf { paymentIntent.shipping?.name != null },
-            Requirement.ShippingInIntentAddressLine1.takeIf { paymentIntent.shipping?.address?.line1 != null },
-            Requirement.ShippingInIntentAddressLine2.takeIf { paymentIntent.shipping?.address?.line1 != null },
-            Requirement.ShippingInIntentAddressCountry.takeIf { paymentIntent.shipping?.address?.country != null },
-            Requirement.ShippingInIntentAddressState.takeIf { paymentIntent.shipping?.address?.state != null },
-            Requirement.ShippingInIntentAddressPostal.takeIf { paymentIntent.shipping?.address?.postalCode != null },
+            Requirement.ShippingInIntentName.takeIf {
+                paymentIntent.shipping?.name != null
+            },
+            Requirement.ShippingInIntentAddressLine1.takeIf {
+                paymentIntent.shipping?.address?.line1 != null
+            },
+            Requirement.ShippingInIntentAddressLine2.takeIf {
+                paymentIntent.shipping?.address?.line1 != null
+            },
+            Requirement.ShippingInIntentAddressCountry.takeIf {
+                paymentIntent.shipping?.address?.country != null
+            },
+            Requirement.ShippingInIntentAddressState.takeIf {
+                paymentIntent.shipping?.address?.state != null
+            },
+            Requirement.ShippingInIntentAddressPostal.takeIf {
+                paymentIntent.shipping?.address?.postalCode != null
+            },
         )
     } ?: emptyList()
 
@@ -162,17 +174,16 @@ private fun allHaveKnownReuseSupport(paymentMethodsInIntent: List<String?>): Boo
 //    )
 }
 
-
-///**
+// /**
 // * List of requirements must match all of the requirements in one of the lists
 // */
-//internal fun ModeConfigurationSpec.getRequirements() = setOfNotNull(
+// internal fun ModeConfigurationSpec.getRequirements() = setOfNotNull(
 //    oneTimeUseSpec?.requirements?.plus(Requirement.OneTimeUse),
 //    merchantRequiredSpec?.requirements?.plus(Requirement.MerchantSelectedSave),
 //    userSelectedSaveSpec?.requirements?.plus(Requirement.UserSelectableSave)
-//)
+// )
 //
-//internal fun ModeConfigurationSpec.getSpecInMode(modeSelector: SaveModeSelector) =
+// internal fun ModeConfigurationSpec.getSpecInMode(modeSelector: SaveModeSelector) =
 //    when (modeSelector) {
 //        SaveModeSelector.OneTimeUse -> oneTimeUseSpec
 //        SaveModeSelector.UserSelectableSave -> userSelectedSaveSpec
@@ -180,11 +191,10 @@ private fun allHaveKnownReuseSupport(paymentMethodsInIntent: List<String?>): Boo
 //        SaveModeSelector.None -> null
 //    }
 
-
-//internal fun getSupportedPaymentMethods(
+// internal fun getSupportedPaymentMethods(
 //    stripeIntent: StripeIntent?,
 //    config: PaymentSheet.Configuration?
-//) {
+// ) {
 //    val supportedPaymentMethod = mutableListOf<SupportedPaymentMethod>()
 //    getPreferredSaveModeSelector(stripeIntent, config).forEach {
 //        supportedPaymentMethod.addAll(
@@ -195,4 +205,4 @@ private fun allHaveKnownReuseSupport(paymentMethodsInIntent: List<String?>): Boo
 //            )
 //        )
 //    }
-//}
+// }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/PaymentMethodSpecKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/PaymentMethodSpecKtx.kt
@@ -1,0 +1,198 @@
+package com.stripe.android.paymentsheet.forms
+
+import androidx.annotation.VisibleForTesting
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.SetupIntent
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.elements.PaymentMethodSpec
+import com.stripe.android.paymentsheet.elements.Requirement
+import com.stripe.android.paymentsheet.model.SupportedPaymentMethod
+
+/**
+ * Get the cards that are supported given the current cpabilities.  For saved cards, this
+ * should never be cards that are only offered for one time use.
+ */
+internal fun getSupportedSavedCustomerCards(
+    stripeIntent: StripeIntent?,
+    config: PaymentSheet.Configuration?
+) = getSupportedPaymentMethods(
+    stripeIntent,
+    config,
+    getAllCapabilities(stripeIntent, config).minus(Requirement.OneTimeUse)
+)
+
+/**
+ * This will get the form layout for the supported method that matches the top pick for the
+ * payment method.
+ */
+internal fun PaymentMethodSpec.getForm(capabilities: Set<Requirement>) =
+    getSpecWithFullfilledRequirements(
+        capabilities
+    )?.layout
+
+/**
+ * This will return a list of payment methods that have a supported form given the capabilities.
+ */
+@VisibleForTesting
+internal fun getSupportedPaymentMethods(
+    stripeIntentParameter: StripeIntent?,
+    config: PaymentSheet.Configuration?,
+    capabilities: Set<Requirement> = getAllCapabilities(stripeIntentParameter, config)
+): List<SupportedPaymentMethod> {
+    stripeIntentParameter?.let { stripeIntent ->
+        return stripeIntent.paymentMethodTypes.asSequence().mapNotNull {
+            SupportedPaymentMethod.fromCode(it)
+        }.filter { supportedPaymentMethod ->
+            supportedPaymentMethod.spec.satisfiedBy(capabilities)
+        }//.filter { it == SupportedPaymentMethod.Card }
+            .toList()
+    }
+
+    return emptyList()
+}
+
+internal fun PaymentMethodSpec.satisfiedBy(
+    capabilities: Set<Requirement>
+) = getSpecWithFullfilledRequirements(capabilities) != null
+
+private fun PaymentMethodSpec.getSpecWithFullfilledRequirements(
+    capabilities: Set<Requirement>
+) = this.specs.firstOrNull {
+    fullfilledRequirements(it.requirements, capabilities)
+}
+
+/**
+ * Capabilities are fulfilled only if all requirements are in the set of capabilities
+ */
+private fun fullfilledRequirements(
+    requirements: Set<Requirement>?,
+    capabilities: Set<Requirement>
+) = requirements?.map { capabilities.contains(it) }
+    ?.contains(false) == false
+
+/**
+ * Capabilities is used to refer to what is supported by the combination of the code base,
+ * configuration, and values in the StripeIntent. (i.e. SetupIntent, PaymentIntent w/SFU,
+ * customer, allowedDelayedSettlement)
+ */
+internal fun getAllCapabilities(
+    stripeIntent: StripeIntent?,
+    config: PaymentSheet.Configuration?
+) = setOfNotNull(
+    Requirement.DelayedSettlementSupport.takeIf { config?.allowsDelayedPaymentMethods == true },
+)
+    .plus(getReusableCapabilities(stripeIntent, config))
+    .plus(intentShippingCapabilities(stripeIntent as? PaymentIntent))
+
+/**
+ * These are the capabilities that define if the intent or configuration requires one time use
+ * merchant requres save through SetupIntent or PaymentIntent with setup_future_usage = on/off session
+ */
+private fun getReusableCapabilities(
+    stripeIntent: StripeIntent?,
+    config: PaymentSheet.Configuration?,
+) = when (stripeIntent) {
+    is PaymentIntent -> {
+        if (stripeIntent.setupFutureUsage == null) {
+            if (config?.customer != null &&
+                allHaveKnownReuseSupport(stripeIntent.paymentMethodTypes)
+            ) {
+                listOf(Requirement.UserSelectableSave, Requirement.OneTimeUse)
+            } else {
+                listOf(Requirement.OneTimeUse)
+            }
+        } else {
+            listOf(Requirement.MerchantSelectedSave)
+        }
+    }
+    is SetupIntent -> {
+        listOf(Requirement.MerchantSelectedSave)
+    }
+    else -> emptyList()
+}
+
+/**
+ * This gets the specific shipping capabilities in the intent
+ */
+private fun intentShippingCapabilities(stripeIntent: PaymentIntent?) =
+    stripeIntent?.let { paymentIntent ->
+        listOfNotNull(
+            Requirement.ShippingInIntentName.takeIf { paymentIntent.shipping?.name != null },
+            Requirement.ShippingInIntentAddressLine1.takeIf { paymentIntent.shipping?.address?.line1 != null },
+            Requirement.ShippingInIntentAddressLine2.takeIf { paymentIntent.shipping?.address?.line1 != null },
+            Requirement.ShippingInIntentAddressCountry.takeIf { paymentIntent.shipping?.address?.country != null },
+            Requirement.ShippingInIntentAddressState.takeIf { paymentIntent.shipping?.address?.state != null },
+            Requirement.ShippingInIntentAddressPostal.takeIf { paymentIntent.shipping?.address?.postalCode != null },
+        )
+    } ?: emptyList()
+
+private fun allHaveKnownReuseSupport(paymentMethodsInIntent: List<String?>): Boolean {
+    // The following PaymentMethods are know to work when PaymentIntent.setup_future_usage = on/off session
+    // This list is different from the PaymentMethod.Type.isReusable
+    // It is expected that this check will be removed soon
+    val knownReusable = setOf(
+        PaymentMethod.Type.Alipay.code,
+        PaymentMethod.Type.Card.code,
+        PaymentMethod.Type.SepaDebit.code,
+        PaymentMethod.Type.AuBecsDebit.code,
+        PaymentMethod.Type.Bancontact.code,
+        PaymentMethod.Type.Sofort.code,
+        PaymentMethod.Type.BacsDebit.code,
+        PaymentMethod.Type.Ideal.code
+    )
+    return paymentMethodsInIntent.filterNot { knownReusable.contains(it) }.isEmpty()
+
+    //    // PaymentMethods that do not work when PaymentIntent.setup_future_usage = on/off session
+//    val notReusable = setOf(
+//        "blik",
+//        "weChatPay",
+//        "grabPay",
+//        "FPX",
+//        "giropay",
+//        "przelewy24",
+//        "EPS",
+//        "netBanking",
+//        "OXXO",
+//        "afterpayClearpay",
+//        "payPal",
+//        "UPI",
+//        "boleto"
+//    )
+}
+
+
+///**
+// * List of requirements must match all of the requirements in one of the lists
+// */
+//internal fun ModeConfigurationSpec.getRequirements() = setOfNotNull(
+//    oneTimeUseSpec?.requirements?.plus(Requirement.OneTimeUse),
+//    merchantRequiredSpec?.requirements?.plus(Requirement.MerchantSelectedSave),
+//    userSelectedSaveSpec?.requirements?.plus(Requirement.UserSelectableSave)
+//)
+//
+//internal fun ModeConfigurationSpec.getSpecInMode(modeSelector: SaveModeSelector) =
+//    when (modeSelector) {
+//        SaveModeSelector.OneTimeUse -> oneTimeUseSpec
+//        SaveModeSelector.UserSelectableSave -> userSelectedSaveSpec
+//        SaveModeSelector.MerchantSelectableSave -> merchantRequiredSpec
+//        SaveModeSelector.None -> null
+//    }
+
+
+//internal fun getSupportedPaymentMethods(
+//    stripeIntent: StripeIntent?,
+//    config: PaymentSheet.Configuration?
+//) {
+//    val supportedPaymentMethod = mutableListOf<SupportedPaymentMethod>()
+//    getPreferredSaveModeSelector(stripeIntent, config).forEach {
+//        supportedPaymentMethod.addAll(
+//            getSupportedPaymentMethods(
+//                stripeIntent,
+//                config,
+//                it
+//            )
+//        )
+//    }
+//}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/SepaDebitSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/SepaDebitSpec.kt
@@ -9,6 +9,8 @@ import com.stripe.android.paymentsheet.elements.IbanSpec
 import com.stripe.android.paymentsheet.elements.IdentifierSpec
 import com.stripe.android.paymentsheet.elements.LayoutSpec
 import com.stripe.android.paymentsheet.elements.MandateTextSpec
+import com.stripe.android.paymentsheet.elements.PaymentMethodSpec
+import com.stripe.android.paymentsheet.elements.Requirement
 import com.stripe.android.paymentsheet.elements.SaveForFutureUseSpec
 import com.stripe.android.paymentsheet.elements.SectionSpec
 import com.stripe.android.paymentsheet.elements.SimpleTextSpec
@@ -46,7 +48,8 @@ internal val sepaBillingSection = SectionSpec(
     AddressSpec(IdentifierSpec.Generic("address")),
     R.string.billing_details
 )
-internal val sepaDebit = FormSpec(
+
+internal val sepaDebitUserSelectedSave = FormSpec(
     LayoutSpec(
         listOf(
             sepaDebitNameSection,
@@ -57,5 +60,51 @@ internal val sepaDebit = FormSpec(
             sepaDebitMandate,
         )
     ),
-    sepaDebitParamKey
+    requirements = setOf(
+        Requirement.DelayedSettlementSupport,
+        Requirement.ReusableMandateSupport,
+        Requirement.UserSelectableSave
+    )
 )
+
+internal val sepaDebitMerchantRequiredSave = FormSpec(
+    LayoutSpec(
+        listOf(
+            sepaDebitNameSection,
+            sepaDebitEmailSection,
+            sepaDebitIbanSection,
+            sepaBillingSection,
+            sepaDebitMandate,
+        )
+    ),
+    requirements = setOf(
+        Requirement.DelayedSettlementSupport,
+        Requirement.ReusableMandateSupport,
+        Requirement.MerchantSelectedSave
+    )
+)
+
+internal val sepaDebitOneTimeUse = FormSpec(
+    LayoutSpec(
+        listOf(
+            sepaDebitNameSection,
+            sepaDebitEmailSection,
+            sepaDebitIbanSection,
+            sepaBillingSection,
+        )
+    ),
+    requirements = setOf(
+        Requirement.DelayedSettlementSupport,
+        Requirement.OneTimeUse
+    )
+)
+
+internal val sepaDebit = PaymentMethodSpec(
+    sepaDebitParamKey,
+    listOf(
+        sepaDebitOneTimeUse,
+        sepaDebitMerchantRequiredSave,
+        sepaDebitUserSelectedSave
+    )
+)
+

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/SepaDebitSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/SepaDebitSpec.kt
@@ -61,7 +61,7 @@ internal val sepaDebitUserSelectedSave = FormSpec(
         )
     ),
     requirements = setOf(
-        Requirement.DelayedSettlementSupport,
+        Requirement.DelayedPaymentMethodSupport,
         Requirement.ReusableMandateSupport,
         Requirement.UserSelectableSave
     )
@@ -78,9 +78,9 @@ internal val sepaDebitMerchantRequiredSave = FormSpec(
         )
     ),
     requirements = setOf(
-        Requirement.DelayedSettlementSupport,
+        Requirement.DelayedPaymentMethodSupport,
         Requirement.ReusableMandateSupport,
-        Requirement.MerchantSelectedSave
+        Requirement.MerchantRequiresSave
     )
 )
 
@@ -94,7 +94,7 @@ internal val sepaDebitOneTimeUse = FormSpec(
         )
     ),
     requirements = setOf(
-        Requirement.DelayedSettlementSupport,
+        Requirement.DelayedPaymentMethodSupport,
         Requirement.OneTimeUse
     )
 )
@@ -107,4 +107,3 @@ internal val sepaDebit = PaymentMethodSpec(
         sepaDebitUserSelectedSave
     )
 )
-

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/SofortSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/SofortSpec.kt
@@ -53,7 +53,7 @@ private val sofortUserSelectedSave = FormSpec(
     ),
     // When saved this is a SEPA paymentMethod which requires SEPA requirements
     requirements = setOf(
-        Requirement.DelayedSettlementSupport,
+        Requirement.DelayedPaymentMethodSupport,
         Requirement.UserSelectableSave
     ).plus(sepaDebitUserSelectedSave.requirements)
 )
@@ -68,8 +68,8 @@ private val sofortMerchantRequiredSave = FormSpec(
     ),
     // When saved this is a SEPA paymentMethod which requires SEPA requirements
     requirements = setOf(
-        Requirement.DelayedSettlementSupport,
-        Requirement.MerchantSelectedSave
+        Requirement.DelayedPaymentMethodSupport,
+        Requirement.MerchantRequiresSave
     ).plus(sepaDebitMerchantRequiredSave.requirements)
 )
 
@@ -80,7 +80,7 @@ private val sofortOneTimeUse = FormSpec(
         )
     ),
     requirements = setOf(
-        Requirement.DelayedSettlementSupport,
+        Requirement.DelayedPaymentMethodSupport,
         Requirement.OneTimeUse
     ),
 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/SofortSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/SofortSpec.kt
@@ -8,6 +8,8 @@ import com.stripe.android.paymentsheet.elements.FormSpec
 import com.stripe.android.paymentsheet.elements.IdentifierSpec
 import com.stripe.android.paymentsheet.elements.LayoutSpec
 import com.stripe.android.paymentsheet.elements.MandateTextSpec
+import com.stripe.android.paymentsheet.elements.PaymentMethodSpec
+import com.stripe.android.paymentsheet.elements.Requirement
 import com.stripe.android.paymentsheet.elements.SaveForFutureUseSpec
 import com.stripe.android.paymentsheet.elements.SectionSpec
 import com.stripe.android.paymentsheet.elements.SimpleTextSpec
@@ -38,7 +40,8 @@ internal val sofortMandate = MandateTextSpec(
     R.string.stripe_paymentsheet_sepa_mandate,
     Color.Gray
 )
-internal val sofort = FormSpec(
+
+private val sofortUserSelectedSave = FormSpec(
     LayoutSpec(
         listOf(
             sofortNameSection,
@@ -48,5 +51,48 @@ internal val sofort = FormSpec(
             sofortMandate,
         )
     ),
+    // When saved this is a SEPA paymentMethod which requires SEPA requirements
+    requirements = setOf(
+        Requirement.DelayedSettlementSupport,
+        Requirement.UserSelectableSave
+    ).plus(sepaDebitUserSelectedSave.requirements)
+)
+private val sofortMerchantRequiredSave = FormSpec(
+    LayoutSpec(
+        listOf(
+            sofortNameSection,
+            sofortEmailSection,
+            sofortCountrySection,
+            sofortMandate,
+        )
+    ),
+    // When saved this is a SEPA paymentMethod which requires SEPA requirements
+    requirements = setOf(
+        Requirement.DelayedSettlementSupport,
+        Requirement.MerchantSelectedSave
+    ).plus(sepaDebitMerchantRequiredSave.requirements)
+)
+
+private val sofortOneTimeUse = FormSpec(
+    LayoutSpec(
+        listOf(
+            sofortCountrySection,
+        )
+    ),
+    requirements = setOf(
+        Requirement.DelayedSettlementSupport,
+        Requirement.OneTimeUse
+    ),
+)
+
+/**
+ * This payment method is authenticated.
+ */
+internal val sofort = PaymentMethodSpec(
     sofortParamKey,
+    listOf(
+        sofortUserSelectedSave,
+        sofortMerchantRequiredSave,
+        sofortOneTimeUse,
+    )
 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethod.kt
@@ -4,9 +4,10 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.R
-import com.stripe.android.paymentsheet.elements.FormSpec
-import com.stripe.android.paymentsheet.elements.afterpayClearpay
+import com.stripe.android.paymentsheet.elements.PaymentMethodSpec
+import com.stripe.android.paymentsheet.forms.afterpayClearpay
 import com.stripe.android.paymentsheet.forms.bancontact
+import com.stripe.android.paymentsheet.forms.card
 import com.stripe.android.paymentsheet.forms.eps
 import com.stripe.android.paymentsheet.forms.giropay
 import com.stripe.android.paymentsheet.forms.ideal
@@ -20,93 +21,74 @@ import com.stripe.android.paymentsheet.forms.sofort
  * FormSpec is optionally null only because Card is not converted to the compose model.
  */
 internal enum class SupportedPaymentMethod(
-    val code: String,
+    // Mandate, isReusable, and hasDelayedSettlement all hidden in here
+    val type: PaymentMethod.Type, // Mandate requirement is hidden in here
     @StringRes val displayNameResource: Int,
     @DrawableRes val iconResource: Int,
-    val formSpec: FormSpec?,
-    val requiresMandate: Boolean,
-    val userRequestedConfirmSaveForFutureSupported: Boolean
+    val spec: PaymentMethodSpec,
 ) {
     Card(
-        "card",
+        PaymentMethod.Type.Card,
         R.string.stripe_paymentsheet_payment_method_card,
         R.drawable.stripe_ic_paymentsheet_pm_card,
-        null,
-        requiresMandate = PaymentMethod.Type.Card.requiresMandate,
-        userRequestedConfirmSaveForFutureSupported = true
+        card
     ),
     Bancontact(
-        "bancontact",
+        PaymentMethod.Type.Bancontact,
         R.string.stripe_paymentsheet_payment_method_bancontact,
         R.drawable.stripe_ic_paymentsheet_pm_bancontact,
-        bancontact,
-        requiresMandate = PaymentMethod.Type.Bancontact.requiresMandate,
-        userRequestedConfirmSaveForFutureSupported = true
+        bancontact
     ),
     Sofort(
-        "sofort",
+        PaymentMethod.Type.Sofort,
         R.string.stripe_paymentsheet_payment_method_sofort,
         R.drawable.stripe_ic_paymentsheet_pm_klarna,
-        sofort,
-        requiresMandate = PaymentMethod.Type.Sofort.requiresMandate,
-        userRequestedConfirmSaveForFutureSupported = true
+        sofort
     ),
     Ideal(
-        "ideal",
+        PaymentMethod.Type.Ideal,
         R.string.stripe_paymentsheet_payment_method_ideal,
         R.drawable.stripe_ic_paymentsheet_pm_ideal,
-        ideal,
-        requiresMandate = PaymentMethod.Type.Ideal.requiresMandate,
-        userRequestedConfirmSaveForFutureSupported = true
+        ideal
     ),
     SepaDebit(
-        "sepa_debit",
+        PaymentMethod.Type.SepaDebit,
         R.string.stripe_paymentsheet_payment_method_sepa_debit,
         R.drawable.stripe_ic_paymentsheet_pm_sepa_debit,
-        sepaDebit,
-        requiresMandate = PaymentMethod.Type.SepaDebit.requiresMandate,
-        userRequestedConfirmSaveForFutureSupported = true
+        sepaDebit
     ),
     Eps(
-        "eps",
+        PaymentMethod.Type.Eps,
         R.string.stripe_paymentsheet_payment_method_eps,
         R.drawable.stripe_ic_paymentsheet_pm_eps,
-        eps,
-        requiresMandate = PaymentMethod.Type.Eps.requiresMandate,
-        userRequestedConfirmSaveForFutureSupported = false
+        eps
     ),
     P24(
-        "p24",
+        PaymentMethod.Type.P24,
         R.string.stripe_paymentsheet_payment_method_p24,
         R.drawable.stripe_ic_paymentsheet_pm_p24,
         p24,
-        requiresMandate = PaymentMethod.Type.P24.requiresMandate,
-        userRequestedConfirmSaveForFutureSupported = false
     ),
     Giropay(
-        "giropay",
+        PaymentMethod.Type.Giropay,
         R.string.stripe_paymentsheet_payment_method_giropay,
         R.drawable.stripe_ic_paymentsheet_pm_giropay,
         giropay,
-        requiresMandate = PaymentMethod.Type.Giropay.requiresMandate,
-        userRequestedConfirmSaveForFutureSupported = false
     ),
     AfterpayClearpay(
-        "afterpay_clearpay",
+        PaymentMethod.Type.AfterpayClearpay,
         R.string.stripe_paymentsheet_payment_method_afterpay_clearpay,
         R.drawable.stripe_ic_paymentsheet_pm_afterpay_clearpay,
-        afterpayClearpay,
-        requiresMandate = PaymentMethod.Type.AfterpayClearpay.requiresMandate,
-        userRequestedConfirmSaveForFutureSupported = true
+        afterpayClearpay
     );
 
     override fun toString(): String {
-        return code
+        return type.code
     }
 
     companion object {
         fun fromCode(code: String?) =
-            values().firstOrNull { it.code == code }
+            values().firstOrNull { it.type.code == code }
 
         /**
          * Defines all types of saved payment method supported on Payment Sheet.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/CardDataCollectionFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/CardDataCollectionFragment.kt
@@ -25,6 +25,7 @@ import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.databinding.FragmentPaymentsheetAddCardBinding
 import com.stripe.android.paymentsheet.databinding.StripeHorizontalDividerBinding
 import com.stripe.android.paymentsheet.databinding.StripeVerticalDividerBinding
+import com.stripe.android.paymentsheet.elements.Requirement
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.BillingAddressView
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
@@ -137,7 +138,7 @@ internal class CardDataCollectionFragment<ViewModelType : BaseSheetViewModel<*>>
         setupSaveCardCheckbox()
     }
 
-    fun updateSelection() {
+    private fun updateSelection() {
         val validCard = if (addCardViewModel.isCardValid) {
             paymentMethodParams?.let { params ->
                 PaymentSelection.New.Card(
@@ -321,8 +322,8 @@ internal class CardDataCollectionFragment<ViewModelType : BaseSheetViewModel<*>>
         requireArguments().getParcelable<FormFragmentArguments>(
             ComposeFormDataCollectionFragment.EXTRA_CONFIG
         )?.let { args ->
-            saveCardCheckbox.isChecked = args.saveForFutureUseInitialValue
-            saveCardCheckbox.isVisible = args.saveForFutureUseInitialVisibility
+            saveCardCheckbox.isChecked = true
+            saveCardCheckbox.isVisible = args.capabilities.contains(Requirement.UserSelectableSave)
         }
         sheetViewModel.newCard?.shouldSavePaymentMethod?.also {
             if (saveCardCheckbox.isVisible) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ComposeFormDataCollectionFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ComposeFormDataCollectionFragment.kt
@@ -15,6 +15,7 @@ import androidx.fragment.app.viewModels
 import com.stripe.android.paymentsheet.StripeTheme
 import com.stripe.android.paymentsheet.elements.Form
 import com.stripe.android.paymentsheet.forms.FormViewModel
+import com.stripe.android.paymentsheet.forms.getForm
 import com.stripe.android.paymentsheet.model.SupportedPaymentMethod
 
 /**
@@ -22,18 +23,24 @@ import com.stripe.android.paymentsheet.model.SupportedPaymentMethod
  * received in the arguments bundle.
  */
 internal class ComposeFormDataCollectionFragment : Fragment() {
-    val formSpec by lazy {
-        requireNotNull(
+    private val formLayout by lazy {
+        val requireNotNull = requireNotNull(
             requireArguments().getParcelable<FormFragmentArguments>(EXTRA_CONFIG)?.let {
-                SupportedPaymentMethod.valueOf(it.supportedPaymentMethodName).formSpec
+                it.supportedPaymentMethod.spec.getForm(it.capabilities)
             }
+        )
+        requireNotNull
+    }
+    val paramKeySpec by lazy {
+        requireNotNull(
+            requireArguments().getParcelable<FormFragmentArguments>(EXTRA_CONFIG)?.supportedPaymentMethod?.spec?.paramKey
         )
     }
 
     val formViewModel: FormViewModel by viewModels {
         FormViewModel.Factory(
             resource = resources,
-            layout = formSpec.layout,
+            layout = formLayout,
             config = requireNotNull(
                 requireArguments().getParcelable(
                     EXTRA_CONFIG

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ComposeFormDataCollectionFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ComposeFormDataCollectionFragment.kt
@@ -33,7 +33,8 @@ internal class ComposeFormDataCollectionFragment : Fragment() {
     }
     val paramKeySpec by lazy {
         requireNotNull(
-            requireArguments().getParcelable<FormFragmentArguments>(EXTRA_CONFIG)?.supportedPaymentMethod?.spec?.paramKey
+            requireArguments().getParcelable<FormFragmentArguments>(EXTRA_CONFIG)
+                ?.supportedPaymentMethod?.spec?.paramKey
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormFragmentArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormFragmentArguments.kt
@@ -4,14 +4,15 @@ import android.os.Parcelable
 import com.stripe.android.payments.core.injection.InjectorKey
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.elements.IdentifierSpec
+import com.stripe.android.paymentsheet.elements.Requirement
 import com.stripe.android.paymentsheet.model.Amount
+import com.stripe.android.paymentsheet.model.SupportedPaymentMethod
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
 internal data class FormFragmentArguments(
-    val supportedPaymentMethodName: String,
-    val saveForFutureUseInitialVisibility: Boolean,
-    val saveForFutureUseInitialValue: Boolean,
+    val supportedPaymentMethod: SupportedPaymentMethod,
+    val capabilities: Set<Requirement>,
     val merchantName: String,
     val amount: Amount? = null,
     val billingDetails: PaymentSheet.BillingDetails? = null,

--- a/paymentsheet/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
@@ -713,7 +713,7 @@ internal object PaymentIntentFixtures {
     val PI_OFF_SESSION = PARSER.parse(
         PI_WITH_SHIPPING_JSON
     )!!.copy(
-        setupFutureUsage = com.stripe.android.model.StripeIntent.Usage.OffSession
+        setupFutureUsage = StripeIntent.Usage.OffSession
     )
 
     val OXXO_REQUIRES_ACTION_JSON = org.json.JSONObject(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormSaveCheckboxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormSaveCheckboxTest.kt
@@ -15,208 +15,213 @@ import kotlinx.serialization.json.Json
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.io.File
 import java.nio.charset.Charset
 
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 class FormSaveCheckboxTest {
-    private val format = Json { prettyPrint = true }
+    private val formatPretty = Json { prettyPrint = true }
+    private val format = Json { prettyPrint = false }
 
     private val expectedMandateRequiredLPMs = listOf("bancontact", "sofort", "ideal", "sepa_debit", "eps", "future_unknown")
     private val paymentMethodSupportsUserRequestedSaveForFutureUsage =
         listOf("card", "bancontact", "sofort", "ideal", "sepa_debit", "afterpay_clearpay", "future_unknown")
-
-    @Test
-    fun `Verify correct list of pms requiring a mandate`() {
-        SupportedPaymentMethod.values().filter {
-            it.requiresMandate
-        }.forEach {
-            assertThat(expectedMandateRequiredLPMs).contains(it.code)
-        }
-        SupportedPaymentMethod.values().filter {
-            !it.requiresMandate
-        }.forEach {
-            assertThat(expectedMandateRequiredLPMs).doesNotContain(it.code)
-        }
-    }
-
-    @Test
-    fun `Verify correct list of pms support user confirm time save for future usage`() {
-        SupportedPaymentMethod.values().filter {
-            it.userRequestedConfirmSaveForFutureSupported
-        }.forEach {
-            assertThat(paymentMethodSupportsUserRequestedSaveForFutureUsage).contains(it.code)
-        }
-
-        SupportedPaymentMethod.values().filter {
-            !it.userRequestedConfirmSaveForFutureSupported
-        }.forEach {
-            assertThat(paymentMethodSupportsUserRequestedSaveForFutureUsage).doesNotContain(it.code)
-        }
-    }
-
-    /**
-     * This "test" will generate test cases with test outputs hard coded
-     * to false, these values will need to be manually set in the json output file.
-     */
-    @Test
-    fun `Output baseline payment intent test inputs`() {
-        println(
-            format.encodeToString(
-                generatePaymentIntentScenarios()
-                    .map {
-                        PaymentIntentTestCase(
-                            it,
-                            TestOutput(
-                                formArgumentFromPaymentIntentTestInput(it).saveForFutureUseInitialValue,
-                                formArgumentFromPaymentIntentTestInput(it).saveForFutureUseInitialVisibility
-                            )
-                        )
-                    }
-            )
-        )
-    }
-
-    /**
-     * This "test" will generate test cases with test outputs hard coded
-     * to false, these values will need to be manually set in the json output file.
-     */
-    @Test
-    fun `Output baseline setup intent test inputs`() {
-        println(
-            format.encodeToString(
-                generateSetupIntentScenarios().map {
-                    SetupIntentTestCase(
-                        it,
-                        TestOutput(
-                            formArgumentFromSetupIntentTestInput(it).saveForFutureUseInitialValue,
-                            formArgumentFromSetupIntentTestInput(it).saveForFutureUseInitialVisibility
-                        )
-                    )
-                }
-            )
-        )
-    }
-
-    private fun generateSetupIntentScenarios(): List<SetupIntentTestInput> {
-        val scenarios = mutableListOf<SetupIntentTestInput>()
-        val customerStates = listOf(true, false)
-        val setupIntentLPM = listOf("card", "ideal", "sepa_debit", "bancontact", "sofort")
-
-        customerStates.forEach { customer ->
-            setupIntentLPM.forEach { lpmCode ->
-                scenarios.add(
-                    SetupIntentTestInput(
-                        hasCustomer = customer,
-                        lpmTypeFormCode = lpmCode,
-                        intentLpms = setupIntentLPM
-                    )
-                )
-            }
-        }
-        return scenarios
-    }
-
-    @Test
-    fun `Verify form argument in setup intent`() {
-        format.decodeFromString<List<SetupIntentTestCase>>(
-            javaClass.classLoader!!.getResource("FormSaveCheckboxSetupIntent.json").readText(Charset.defaultCharset())
-        ).forEach {
-            assertThat(
-                formArgumentFromSetupIntentTestInput(it.testInput)
-            ).isEqualTo(
-                FormFragmentArguments(
-                    SupportedPaymentMethod.fromCode(it.testInput.lpmTypeFormCode)!!.name,
-                    saveForFutureUseInitialVisibility = it.testOutput.expectedSaveCheckboxVisible,
-                    saveForFutureUseInitialValue = it.testOutput.expectedSaveCheckboxValue,
-                    merchantName = "Example, Inc",
-                    injectorKey = DUMMY_INJECTOR_KEY
-                )
-            )
-        }
-    }
-
-    @Test
-    fun `Verify form argument in payment intent`() {
-        format.decodeFromString<List<PaymentIntentTestCase>>(
-            javaClass.classLoader!!.getResource("FormSaveCheckboxPaymentIntent.json").readText(Charset.defaultCharset())
-        ).forEach {
-            assertThat(
-                formArgumentFromPaymentIntentTestInput(it.testInput)
-            ).isEqualTo(
-                FormFragmentArguments(
-                    SupportedPaymentMethod.fromCode(it.testInput.lpmTypeFormCode)!!.name,
-                    saveForFutureUseInitialVisibility = it.testOutput.expectedSaveCheckboxVisible,
-                    saveForFutureUseInitialValue = it.testOutput.expectedSaveCheckboxValue,
-                    merchantName = "Example, Inc",
-                    injectorKey = DUMMY_INJECTOR_KEY
-                )
-            )
-        }
-    }
-
-    private fun generatePaymentIntentScenarios(): List<PaymentIntentTestInput> {
-        val scenarios = mutableListOf<PaymentIntentTestInput>()
-        val customerStates = listOf(true, false)
-        val setupFutureUsage = listOf(StripeIntent.Usage.OffSession, StripeIntent.Usage.OnSession)
-
-        customerStates.forEach { customer ->
-            setupFutureUsage.forEach { usage ->
-                scenarios.addAll(
-                    listOf(
-                        /**
-                         * Save for future use is allowed when card is shown and only card is in the PI
-                         */
-                        PaymentIntentTestInput(
-                            hasCustomer = customer,
-                            lpmTypeFormCode = SupportedPaymentMethod.Card.code,
-                            intentLpms = listOf(SupportedPaymentMethod.Card.code),
-                            intentSetupFutureUsage = usage,
-                        ),
-                        /**
-                         * Save for future use not allowed if the PI contains an LPM that does not support Save for future use on confirm
-                         */
-                        PaymentIntentTestInput(
-                            hasCustomer = customer,
-                            lpmTypeFormCode = SupportedPaymentMethod.Card.code,
-                            intentLpms = listOf(SupportedPaymentMethod.Card.code, SupportedPaymentMethod.Eps.code),
-                            intentSetupFutureUsage = usage,
-                        ),
-                        /**
-                         * Save for future use not allowed if the form requested requires a mandate
-                         */
-                        PaymentIntentTestInput(
-                            hasCustomer = customer,
-                            lpmTypeFormCode = SupportedPaymentMethod.SepaDebit.code,
-                            intentLpms = listOf(SupportedPaymentMethod.Card.code, SupportedPaymentMethod.SepaDebit.code),
-                            intentSetupFutureUsage = usage,
-                        ),
-                    )
-                )
-            }
-        }
-        return scenarios
-    }
-
-    private fun formArgumentFromPaymentIntentTestInput(testInput: PaymentIntentTestInput) = BaseAddPaymentMethodFragment.getFormArguments(
-        hasCustomer = testInput.hasCustomer,
-        stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-            paymentMethodTypes = testInput.intentLpms
-        ),
-        supportedPaymentMethodName = SupportedPaymentMethod.fromCode(testInput.lpmTypeFormCode)!!.name,
-        merchantName = "Example, Inc",
-        injectorKey = DUMMY_INJECTOR_KEY
-    )
-
-    private fun formArgumentFromSetupIntentTestInput(testInput: SetupIntentTestInput) = BaseAddPaymentMethodFragment.getFormArguments(
-        hasCustomer = testInput.hasCustomer,
-        stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD.copy(
-            paymentMethodTypes = testInput.intentLpms
-        ),
-        supportedPaymentMethodName = SupportedPaymentMethod.fromCode(testInput.lpmTypeFormCode)!!.name,
-        merchantName = "Example, Inc",
-        injectorKey = DUMMY_INJECTOR_KEY
-    )
+//
+//    @Test
+//    fun `Verify correct list of pms requiring a mandate`() {
+//        SupportedPaymentMethod.values().filter {
+//            it.type.requiresMandate
+//        }.forEach {
+//            assertThat(expectedMandateRequiredLPMs).contains(it.type.code)
+//        }
+//        SupportedPaymentMethod.values().filter {
+//            !it.type.requiresMandate
+//        }.forEach {
+//            assertThat(expectedMandateRequiredLPMs).doesNotContain(it.type.code)
+//        }
+//    }
+//
+//    @Test
+//    fun `Verify correct list of pms support user confirm time save for future usage`() {
+//        SupportedPaymentMethod.values().filter {
+//            it.userRequestedConfirmSaveForFutureSupported
+//        }.forEach {
+//            assertThat(paymentMethodSupportsUserRequestedSaveForFutureUsage).contains(it.type.code)
+//        }
+//
+//        SupportedPaymentMethod.values().filter {
+//            !it.userRequestedConfirmSaveForFutureSupported
+//        }.forEach {
+//            assertThat(paymentMethodSupportsUserRequestedSaveForFutureUsage).doesNotContain(it.type.code)
+//        }
+//    }
+//
+//    /**
+//     * This "test" will generate test cases with test outputs hard coded
+//     * to false, these values will need to be manually set in the json output file.
+//     */
+//    @Test
+//    fun `Output baseline payment intent test inputs`() {
+//        val resource = File(javaClass.classLoader.getResource("FormSaveCheckboxPaymentIntent.json").file)
+//        val baseline = resource.readText().replace(" ", "").replace("\n", "")
+//        val newScenariosList = generatePaymentIntentScenarios()
+//            .map {
+//                PaymentIntentTestCase(
+//                    it,
+//                    TestOutput(
+//                        formArgumentFromPaymentIntentTestInput(it).displayUIRequiredForSaving,
+//                        formArgumentFromPaymentIntentTestInput(it).intentAndPmAllowUserInitiatedReuse
+//                    )
+//                )
+//            }
+//        val newScenarios = format.encodeToString(newScenariosList).replace(" ", "").replace("\n", "")
+//
+//        if (baseline != newScenarios) {
+//            println(formatPretty.encodeToString(newScenariosList))
+//        }
+//        assertThat(baseline).isEqualTo(newScenarios)
+//    }
+//
+//    /**
+//     * This "test" will generate test cases with test outputs hard coded
+//     * to false, these values will need to be manually set in the json output file.
+//     */
+//    @Test
+//    fun `Output baseline setup intent test inputs`() {
+//        println(
+//            format.encodeToString(
+//                generateSetupIntentScenarios().map {
+//                    SetupIntentTestCase(
+//                        it,
+//                        TestOutput(
+//                            formArgumentFromSetupIntentTestInput(it).displayUIRequiredForSaving,
+//                            formArgumentFromSetupIntentTestInput(it).intentAndPmAllowUserInitiatedReuse
+//                        )
+//                    )
+//                }
+//            )
+//        )
+//    }
+//
+//    private fun generateSetupIntentScenarios(): List<SetupIntentTestInput> {
+//        val scenarios = mutableListOf<SetupIntentTestInput>()
+//        val customerStates = listOf(true, false)
+//        val setupIntentLPM = listOf("card", "ideal", "sepa_debit", "bancontact", "sofort")
+//
+//        customerStates.forEach { customer ->
+//            setupIntentLPM.forEach { lpmCode ->
+//                scenarios.add(
+//                    SetupIntentTestInput(
+//                        hasCustomer = customer,
+//                        lpmTypeFormCode = lpmCode,
+//                        intentLpms = setupIntentLPM
+//                    )
+//                )
+//            }
+//        }
+//        return scenarios
+//    }
+//
+//    @Test
+//    fun `Verify form argument in setup intent`() {
+//        format.decodeFromString<List<SetupIntentTestCase>>(
+//            javaClass.classLoader!!.getResource("FormSaveCheckboxSetupIntent.json").readText(Charset.defaultCharset())
+//        ).forEach {
+//            assertThat(
+//                formArgumentFromSetupIntentTestInput(it.testInput)
+//            ).isEqualTo(
+//                FormFragmentArguments(
+//                    SupportedPaymentMethod.fromCode(it.testInput.lpmTypeFormCode)!!,
+//                    intentAndPmAllowUserInitiatedReuse = it.testOutput.expectedAllowUserInitiatedReuse,
+//                    displayUIRequiredForSaving = it.testOutput.expectedDisplayUIForSaving,
+//                    merchantName = "Example, Inc",
+//                    injectorKey = DUMMY_INJECTOR_KEY
+//                )
+//            )
+//        }
+//    }
+//
+//    @Test
+//    fun `Verify form argument in payment intent`() {
+//        format.decodeFromString<List<PaymentIntentTestCase>>(
+//            javaClass.classLoader!!.getResource("FormSaveCheckboxPaymentIntent.json").readText(Charset.defaultCharset())
+//        ).forEach {
+//            assertThat(
+//                formArgumentFromPaymentIntentTestInput(it.testInput)
+//            ).isEqualTo(
+//                FormFragmentArguments(
+//                    SupportedPaymentMethod.fromCode(it.testInput.lpmTypeFormCode)!!,
+//                    intentAndPmAllowUserInitiatedReuse = it.testOutput.expectedAllowUserInitiatedReuse,
+//                    displayUIRequiredForSaving = it.testOutput.expectedDisplayUIForSaving,
+//                    merchantName = "Example, Inc",
+//                    injectorKey = DUMMY_INJECTOR_KEY
+//                )
+//            )
+//        }
+//    }
+//
+//    private fun generatePaymentIntentScenarios(): List<PaymentIntentTestInput> {
+//        val scenarios = mutableListOf<PaymentIntentTestInput>()
+//        val customerStates = setOf(true, false)
+//        val setupFutureUsage = setOf(StripeIntent.Usage.OffSession, StripeIntent.Usage.OnSession, StripeIntent.Usage.OneTime)
+//
+//        customerStates.forEach { customer ->
+//            setupFutureUsage.forEach { usage ->
+//                scenarios.addAll(
+//                    listOf(
+//                        /**
+//                         * Save for future use is allowed when card is shown and only card is in the PI
+//                         */
+//                        PaymentIntentTestInput(
+//                            hasCustomer = customer,
+//                            lpmTypeFormCode = SupportedPaymentMethod.Card.type.code,
+//                            intentLpms = listOf(SupportedPaymentMethod.Card.type.code),
+//                            intentSetupFutureUsage = usage,
+//                        ),
+//                        /**
+//                         * Save for future use not allowed if the PI contains an LPM that does not support Save for future use on confirm
+//                         */
+//                        PaymentIntentTestInput(
+//                            hasCustomer = customer,
+//                            lpmTypeFormCode = SupportedPaymentMethod.Card.type.code,
+//                            intentLpms = listOf(SupportedPaymentMethod.Card.type.code, SupportedPaymentMethod.Eps.type.code),
+//                            intentSetupFutureUsage = usage,
+//                        ),
+//                        /**
+//                         * Save for future use not allowed if the form requested requires a mandate
+//                         */
+//                        PaymentIntentTestInput(
+//                            hasCustomer = customer,
+//                            lpmTypeFormCode = SupportedPaymentMethod.SepaDebit.type.code,
+//                            intentLpms = listOf(SupportedPaymentMethod.Card.type.code, SupportedPaymentMethod.SepaDebit.type.code),
+//                            intentSetupFutureUsage = usage,
+//                        ),
+//                    )
+//                )
+//            }
+//        }
+//        return scenarios
+//    }
+//
+//    private fun formArgumentFromPaymentIntentTestInput(testInput: PaymentIntentTestInput) = BaseAddPaymentMethodFragment.getFormArguments(
+//        stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+//            paymentMethodTypes = testInput.intentLpms,
+//            setupFutureUsage = testInput.intentSetupFutureUsage
+//        ),
+//        showPaymentMethod = SupportedPaymentMethod.fromCode(testInput.lpmTypeFormCode)!!,
+//        merchantName = "Example, Inc",
+//        injectorKey = DUMMY_INJECTOR_KEY
+//    )
+//
+//    private fun formArgumentFromSetupIntentTestInput(testInput: SetupIntentTestInput) = BaseAddPaymentMethodFragment.getFormArguments(
+//        stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD.copy(
+//            paymentMethodTypes = testInput.intentLpms
+//        ),
+//        showPaymentMethod = SupportedPaymentMethod.fromCode(testInput.lpmTypeFormCode)!!,
+//        merchantName = "Example, Inc",
+//        injectorKey = DUMMY_INJECTOR_KEY
+//    )
 
     @Serializable
     internal data class SetupIntentTestCase(
@@ -247,7 +252,7 @@ class FormSaveCheckboxTest {
 
     @Serializable
     internal data class TestOutput(
-        val expectedSaveCheckboxValue: Boolean,
-        val expectedSaveCheckboxVisible: Boolean
+        val expectedDisplayUIForSaving: Boolean,
+        val expectedAllowUserInitiatedReuse: Boolean
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormSaveCheckboxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormSaveCheckboxTest.kt
@@ -1,22 +1,11 @@
 package com.stripe.android.paymentsheet
 
-import com.google.common.truth.Truth.assertThat
-import com.stripe.android.model.PaymentIntentFixtures
-import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.payments.core.injection.DUMMY_INJECTOR_KEY
-import com.stripe.android.paymentsheet.model.SupportedPaymentMethod
-import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import java.io.File
-import java.nio.charset.Charset
 
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddPaymentMethodFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddPaymentMethodFragmentTest.kt
@@ -22,7 +22,6 @@ import com.stripe.android.paymentsheet.databinding.FragmentPaymentsheetAddPaymen
 import com.stripe.android.paymentsheet.databinding.PrimaryButtonBinding
 import com.stripe.android.paymentsheet.databinding.StripeGooglePayButtonBinding
 import com.stripe.android.paymentsheet.elements.IdentifierSpec
-import com.stripe.android.paymentsheet.elements.Requirement
 import com.stripe.android.paymentsheet.forms.FormFieldEntry
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.forms.getAllCapabilities
@@ -297,7 +296,7 @@ class PaymentSheetAddPaymentMethodFragmentTest {
         createFragment(
             stripeIntent = stripeIntent,
             args = args
-        ){ fragment, viewBinding ->
+        ) { fragment, viewBinding ->
             assertThat(
                 fragment.childFragmentManager.findFragmentById(
                     viewBinding.paymentMethodFragmentContainer.id

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -75,7 +75,7 @@ internal object PaymentSheetFixtures {
             SupportedPaymentMethod.Bancontact,
             capabilities = setOf(
                 Requirement.OneTimeUse,
-                Requirement.DelayedSettlementSupport,
+                Requirement.DelayedPaymentMethodSupport,
                 Requirement.ShippingInIntentAddressCountry,
                 Requirement.ShippingInIntentAddressLine1,
                 Requirement.ShippingInIntentName

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -2,15 +2,17 @@ package com.stripe.android.paymentsheet
 
 import androidx.core.graphics.toColorInt
 import com.stripe.android.payments.core.injection.DUMMY_INJECTOR_KEY
+import com.stripe.android.paymentsheet.elements.Requirement
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.SetupIntentClientSecret
 import com.stripe.android.paymentsheet.model.SupportedPaymentMethod
 import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
 
 internal object PaymentSheetFixtures {
-    internal val STATUS_BAR_COLOR = "#121212".toColorInt()
+    internal val STATUS_BAR_COLOR
+        get() = "#121212".toColorInt()
 
-    internal const val MERCHANT_DISPLAY_NAME = "Widget Store"
+    internal const val MERCHANT_DISPLAY_NAME = "Merchant, Inc."
     internal const val CLIENT_SECRET = "client_secret"
 
     internal val PAYMENT_INTENT_CLIENT_SECRET = PaymentIntentClientSecret(
@@ -29,57 +31,69 @@ internal object PaymentSheetFixtures {
         )
     )
 
-    internal val CONFIG_GOOGLEPAY = PaymentSheet.Configuration(
-        merchantDisplayName = MERCHANT_DISPLAY_NAME,
-        googlePay = ConfigFixtures.GOOGLE_PAY
-    )
+    internal val CONFIG_GOOGLEPAY
+        get() = PaymentSheet.Configuration(
+            merchantDisplayName = MERCHANT_DISPLAY_NAME,
+            googlePay = ConfigFixtures.GOOGLE_PAY
+        )
 
-    internal val CONFIG_CUSTOMER_WITH_GOOGLEPAY = CONFIG_CUSTOMER.copy(
-        googlePay = ConfigFixtures.GOOGLE_PAY
-    )
+    internal val CONFIG_CUSTOMER_WITH_GOOGLEPAY
+        get() = CONFIG_CUSTOMER.copy(
+            googlePay = ConfigFixtures.GOOGLE_PAY
+        )
 
-    internal val ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP = PaymentSheetContract.Args(
-        SetupIntentClientSecret(CLIENT_SECRET),
-        CONFIG_CUSTOMER_WITH_GOOGLEPAY,
-        STATUS_BAR_COLOR,
-    )
+    internal val ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP
+        get() = PaymentSheetContract.Args(
+            SetupIntentClientSecret(CLIENT_SECRET),
+            CONFIG_CUSTOMER_WITH_GOOGLEPAY,
+            STATUS_BAR_COLOR,
+        )
 
-    internal val ARGS_CUSTOMER_WITH_GOOGLEPAY = PaymentSheetContract.Args(
-        PAYMENT_INTENT_CLIENT_SECRET,
-        CONFIG_CUSTOMER_WITH_GOOGLEPAY,
-        STATUS_BAR_COLOR,
-    )
+    internal val ARGS_CUSTOMER_WITH_GOOGLEPAY
+        get() = PaymentSheetContract.Args(
+            PAYMENT_INTENT_CLIENT_SECRET,
+            CONFIG_CUSTOMER_WITH_GOOGLEPAY,
+            STATUS_BAR_COLOR,
+        )
 
-    internal val ARGS_CUSTOMER_WITHOUT_GOOGLEPAY = PaymentSheetContract.Args(
-        PAYMENT_INTENT_CLIENT_SECRET,
-        CONFIG_CUSTOMER,
-        STATUS_BAR_COLOR,
-    )
+    internal val ARGS_CUSTOMER_WITHOUT_GOOGLEPAY
+        get() = PaymentSheetContract.Args(
+            PAYMENT_INTENT_CLIENT_SECRET,
+            CONFIG_CUSTOMER,
+            STATUS_BAR_COLOR,
+        )
 
-    internal val ARGS_WITHOUT_CUSTOMER = PaymentSheetContract.Args(
-        PAYMENT_INTENT_CLIENT_SECRET,
-        config = null,
-        STATUS_BAR_COLOR,
-    )
+    internal val ARGS_WITHOUT_CUSTOMER
+        get() = PaymentSheetContract.Args(
+            PAYMENT_INTENT_CLIENT_SECRET,
+            config = null,
+            STATUS_BAR_COLOR,
+        )
 
-    internal val COMPOSE_FRAGMENT_ARGS = FormFragmentArguments(
-        SupportedPaymentMethod.Bancontact.name,
-        saveForFutureUseInitialVisibility = true,
-        saveForFutureUseInitialValue = true,
-        merchantName = "Merchant, Inc.",
-        billingDetails = PaymentSheet.BillingDetails(
-            address = PaymentSheet.Address(
-                line1 = "123 Main Street",
-                line2 = null,
-                city = "San Francisco",
-                state = "CA",
-                postalCode = "94111",
-                country = "DE",
+    internal val COMPOSE_FRAGMENT_ARGS
+        get() = FormFragmentArguments(
+            SupportedPaymentMethod.Bancontact,
+            capabilities = setOf(
+                Requirement.OneTimeUse,
+                Requirement.DelayedSettlementSupport,
+                Requirement.ShippingInIntentAddressCountry,
+                Requirement.ShippingInIntentAddressLine1,
+                Requirement.ShippingInIntentName
             ),
-            email = "email",
-            name = "Jenny Rosen",
-            phone = "+18008675309"
-        ),
-        injectorKey = DUMMY_INJECTOR_KEY
-    )
+            merchantName = "Merchant, Inc.",
+            billingDetails = PaymentSheet.BillingDetails(
+                address = PaymentSheet.Address(
+                    line1 = "123 Main Street",
+                    line2 = null,
+                    city = "San Francisco",
+                    state = "CA",
+                    postalCode = "94111",
+                    country = "DE",
+                ),
+                email = "email",
+                name = "Jenny Rosen",
+                phone = "+18008675309"
+            ),
+            injectorKey = DUMMY_INJECTOR_KEY
+        )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -887,17 +887,18 @@ internal class PaymentSheetViewModelTest {
         val viewModel = createViewModel()
 
         assertThat(
-            viewModel.getSupportedPaymentMethods(
-                PAYMENT_INTENT.copy(
-                    paymentMethodTypes = listOf(
-                        PaymentMethod.Type.Card.code,
-                        PaymentMethod.Type.Ideal.code,
-                        PaymentMethod.Type.SepaDebit.code,
-                        PaymentMethod.Type.Eps.code,
-                        PaymentMethod.Type.Sofort.code
-                    )
-                )
-            )
+            viewModel.supportedPaymentMethods
+//                (
+//                PAYMENT_INTENT.copy(
+//                    paymentMethodTypes = listOf(
+//                        PaymentMethod.Type.Card.code,
+//                        PaymentMethod.Type.Ideal.code,
+//                        PaymentMethod.Type.SepaDebit.code,
+//                        PaymentMethod.Type.Eps.code,
+//                        PaymentMethod.Type.Sofort.code
+//                    )
+//                )
+//            )
         ).containsExactly(
             SupportedPaymentMethod.Card,
             SupportedPaymentMethod.Ideal,
@@ -917,17 +918,16 @@ internal class PaymentSheetViewModelTest {
         )
 
         assertThat(
-            viewModel.getSupportedPaymentMethods(
-                PAYMENT_INTENT.copy(
-                    paymentMethodTypes = listOf(
-                        PaymentMethod.Type.Card.code,
-                        PaymentMethod.Type.Ideal.code,
-                        PaymentMethod.Type.SepaDebit.code,
-                        PaymentMethod.Type.Eps.code,
-                        PaymentMethod.Type.Sofort.code
-                    )
-                )
-            )
+            viewModel.supportedPaymentMethods
+//                PAYMENT_INTENT.copy(
+//                    paymentMethodTypes = listOf(
+//                        PaymentMethod.Type.Card.code,
+//                        PaymentMethod.Type.Ideal.code,
+//                        PaymentMethod.Type.SepaDebit.code,
+//                        PaymentMethod.Type.Eps.code,
+//                        PaymentMethod.Type.Sofort.code
+//                    )
+//                )
         ).containsExactly(
             SupportedPaymentMethod.Card,
             SupportedPaymentMethod.Ideal,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -271,7 +271,7 @@ internal class FormViewModelTest {
                 sofort.specs.first().layout,
                 COMPOSE_FRAGMENT_ARGS.copy(
                     billingDetails = null,
-                    capabilities = setOf(Requirement.MerchantSelectedSave)
+                    capabilities = setOf(Requirement.MerchantRequiresSave)
                 ),
                 resourceRepository = resourceRepository
             )
@@ -314,7 +314,7 @@ internal class FormViewModelTest {
             val formViewModel = FormViewModel(
                 sepaDebit.specs.first().layout,
                 COMPOSE_FRAGMENT_ARGS.copy(
-                    capabilities = setOf(Requirement.MerchantSelectedSave),
+                    capabilities = setOf(Requirement.MerchantRequiresSave),
                     billingDetails = null
                 ),
                 resourceRepository = resourceRepository

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/PaymentMethodSpecKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/PaymentMethodSpecKtxTest.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.paymentsheet.forms
+
+import org.junit.Test
+
+class PaymentMethodSpecKtxTest {
+
+    @Test
+    fun `GetAllCapabilities`() {
+        
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/PaymentMethodSpecKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/PaymentMethodSpecKtxTest.kt
@@ -6,6 +6,5 @@ class PaymentMethodSpecKtxTest {
 
     @Test
     fun `GetAllCapabilities`() {
-        
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformSpecToElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformSpecToElementTest.kt
@@ -4,28 +4,27 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.payments.core.injection.DUMMY_INJECTOR_KEY
+import com.stripe.android.paymentsheet.PaymentSheetFixtures.COMPOSE_FRAGMENT_ARGS
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.elements.BankDropdownSpec
-import com.stripe.android.paymentsheet.elements.CountryElement
-import com.stripe.android.paymentsheet.elements.CountryConfig
-import com.stripe.android.paymentsheet.elements.EmailElement
-import com.stripe.android.paymentsheet.elements.EmailConfig
-import com.stripe.android.paymentsheet.elements.MandateTextElement
-import com.stripe.android.paymentsheet.elements.NameConfig
-import com.stripe.android.paymentsheet.elements.SaveForFutureUseElement
-import com.stripe.android.paymentsheet.elements.SectionElement
-import com.stripe.android.paymentsheet.elements.SimpleDropdownElement
-import com.stripe.android.paymentsheet.elements.SimpleTextElement
-import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
 import com.stripe.android.paymentsheet.elements.BankRepository
+import com.stripe.android.paymentsheet.elements.CountryConfig
+import com.stripe.android.paymentsheet.elements.CountryElement
 import com.stripe.android.paymentsheet.elements.CountrySpec
+import com.stripe.android.paymentsheet.elements.EmailConfig
+import com.stripe.android.paymentsheet.elements.EmailElement
 import com.stripe.android.paymentsheet.elements.EmailSpec
 import com.stripe.android.paymentsheet.elements.IdentifierSpec
+import com.stripe.android.paymentsheet.elements.MandateTextElement
 import com.stripe.android.paymentsheet.elements.MandateTextSpec
+import com.stripe.android.paymentsheet.elements.NameConfig
 import com.stripe.android.paymentsheet.elements.ResourceRepository
+import com.stripe.android.paymentsheet.elements.SaveForFutureUseElement
 import com.stripe.android.paymentsheet.elements.SaveForFutureUseSpec
+import com.stripe.android.paymentsheet.elements.SectionElement
 import com.stripe.android.paymentsheet.elements.SectionSpec
+import com.stripe.android.paymentsheet.elements.SimpleDropdownElement
+import com.stripe.android.paymentsheet.elements.SimpleTextElement
 import com.stripe.android.paymentsheet.elements.SimpleTextSpec
 import com.stripe.android.paymentsheet.elements.SupportedBankType
 import kotlinx.coroutines.flow.first
@@ -62,13 +61,7 @@ internal class TransformSpecToElementTest {
                     bankRepository,
                     mock()
                 ),
-                FormFragmentArguments(
-                    supportedPaymentMethodName = "Card",
-                    saveForFutureUseInitialVisibility = true,
-                    saveForFutureUseInitialValue = true,
-                    merchantName = "Example, Inc.",
-                    injectorKey = DUMMY_INJECTOR_KEY
-                )
+                COMPOSE_FRAGMENT_ARGS
             )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/CardDataCollectionFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/CardDataCollectionFragmentTest.kt
@@ -15,8 +15,6 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.payments.core.injection.DUMMY_INJECTOR_KEY
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetActivity
 import com.stripe.android.paymentsheet.PaymentSheetContract
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
@@ -30,7 +28,6 @@ import com.stripe.android.paymentsheet.forms.getAllCapabilities
 import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.FragmentConfigFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.model.SupportedPaymentMethod
 import com.stripe.android.paymentsheet.ui.AddPaymentMethodsFragmentFactory
 import com.stripe.android.utils.TestUtils.idleLooper
 import org.junit.Before
@@ -179,7 +176,7 @@ class CardDataCollectionFragmentTest {
 
     @Test
     fun `launching with billing details populates the fields`() {
-        createFragment(fragmentArgs = PaymentSheetFixtures.COMPOSE_FRAGMENT_ARGS) { _, viewBinding ->
+        createFragment(fragmentArgs = COMPOSE_FRAGMENT_ARGS) { _, viewBinding ->
             assertThat(viewBinding.billingAddress.postalCodeView.text.toString())
                 .isEqualTo("94111")
             assertThat(viewBinding.billingAddress.address1View.text.toString())

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/CardDataCollectionFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/CardDataCollectionFragmentTest.kt
@@ -20,10 +20,13 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetActivity
 import com.stripe.android.paymentsheet.PaymentSheetContract
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
+import com.stripe.android.paymentsheet.PaymentSheetFixtures.COMPOSE_FRAGMENT_ARGS
 import com.stripe.android.paymentsheet.PaymentSheetViewModel
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.databinding.FragmentPaymentsheetAddCardBinding
 import com.stripe.android.paymentsheet.databinding.StripeBillingAddressLayoutBinding
+import com.stripe.android.paymentsheet.elements.Requirement
+import com.stripe.android.paymentsheet.forms.getAllCapabilities
 import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.FragmentConfigFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -155,26 +158,7 @@ class CardDataCollectionFragmentTest {
     @Test
     fun `launching with arguments populates the fields`() {
         createFragment(
-            fragmentArgs = FormFragmentArguments(
-                SupportedPaymentMethod.Bancontact.name,
-                saveForFutureUseInitialVisibility = false,
-                saveForFutureUseInitialValue = false,
-                merchantName = "Merchant, Inc.",
-                billingDetails = PaymentSheet.BillingDetails(
-                    address = PaymentSheet.Address(
-                        line1 = "123 Main Street",
-                        line2 = null,
-                        city = "San Francisco",
-                        state = "CA",
-                        postalCode = "94111",
-                        country = "DE",
-                    ),
-                    email = "email",
-                    name = "Jenny Rosen",
-                    phone = "+18008675309"
-                ),
-                injectorKey = DUMMY_INJECTOR_KEY
-            )
+            fragmentArgs = COMPOSE_FRAGMENT_ARGS
         ) { _, viewBinding ->
             assertThat(viewBinding.billingAddress.postalCodeView.text.toString())
                 .isEqualTo("94111")
@@ -189,7 +173,7 @@ class CardDataCollectionFragmentTest {
             assertThat(viewBinding.billingAddress.countryView.text.toString())
                 .isEqualTo("Germany")
             assertThat(viewBinding.saveCardCheckbox.isVisible).isFalse()
-            assertThat(viewBinding.saveCardCheckbox.isChecked).isFalse()
+            assertThat(viewBinding.saveCardCheckbox.isChecked).isTrue()
         }
     }
 
@@ -272,7 +256,7 @@ class CardDataCollectionFragmentTest {
     fun `checkbox text should reflect merchant display name`() {
         createFragment { _, viewBinding ->
             assertThat(viewBinding.saveCardCheckbox.text)
-                .isEqualTo("Save this card for future Widget Store payments")
+                .isEqualTo("Save this card for future Merchant, Inc. payments")
         }
     }
 
@@ -463,7 +447,9 @@ class CardDataCollectionFragmentTest {
         fragmentConfig: FragmentConfig? = FragmentConfigFixtures.DEFAULT,
         stripeIntent: StripeIntent? = PaymentIntentFixtures.PI_WITH_SHIPPING,
         newCard: PaymentSelection.New.Card? = null,
-        fragmentArgs: FormFragmentArguments? = PaymentSheetFixtures.COMPOSE_FRAGMENT_ARGS,
+        fragmentArgs: FormFragmentArguments? = COMPOSE_FRAGMENT_ARGS.copy(
+            capabilities = getAllCapabilities(stripeIntent, args.config).plus(Requirement.UserSelectableSave)
+        ),
         onReady: (CardDataCollectionFragment<PaymentSheetViewModel>, FragmentPaymentsheetAddCardBinding) -> Unit
     ) {
         val factory = AddPaymentMethodsFragmentFactory(

--- a/paymentsheet/src/test/resources/FormSaveCheckboxPaymentIntent.json
+++ b/paymentsheet/src/test/resources/FormSaveCheckboxPaymentIntent.json
@@ -9,8 +9,8 @@
       ]
     },
     "testOutput": {
-      "expectedSaveCheckboxValue": true,
-      "expectedSaveCheckboxVisible": true
+      "expectedDisplayUIForSaving": true,
+      "expectedAllowUserInitiatedReuse": false
     }
   },
   {
@@ -24,8 +24,8 @@
       ]
     },
     "testOutput": {
-      "expectedSaveCheckboxValue": false,
-      "expectedSaveCheckboxVisible": false
+      "expectedDisplayUIForSaving": true,
+      "expectedAllowUserInitiatedReuse": false
     }
   },
   {
@@ -39,8 +39,8 @@
       ]
     },
     "testOutput": {
-      "expectedSaveCheckboxValue": true,
-      "expectedSaveCheckboxVisible": true
+      "expectedDisplayUIForSaving": true,
+      "expectedAllowUserInitiatedReuse": false
     }
   },
   {
@@ -53,8 +53,8 @@
       ]
     },
     "testOutput": {
-      "expectedSaveCheckboxValue": true,
-      "expectedSaveCheckboxVisible": true
+      "expectedDisplayUIForSaving": true,
+      "expectedAllowUserInitiatedReuse": false
     }
   },
   {
@@ -68,8 +68,8 @@
       ]
     },
     "testOutput": {
-      "expectedSaveCheckboxValue": false,
-      "expectedSaveCheckboxVisible": false
+      "expectedDisplayUIForSaving": true,
+      "expectedAllowUserInitiatedReuse": false
     }
   },
   {
@@ -83,8 +83,52 @@
       ]
     },
     "testOutput": {
-      "expectedSaveCheckboxValue": true,
-      "expectedSaveCheckboxVisible": true
+      "expectedDisplayUIForSaving": true,
+      "expectedAllowUserInitiatedReuse": false
+    }
+  },
+  {
+    "testInput": {
+      "hasCustomer": true,
+      "lpmTypeFormCode": "card",
+      "intentSetupFutureUsage": "OneTime",
+      "intentLpms": [
+        "card"
+      ]
+    },
+    "testOutput": {
+      "expectedDisplayUIForSaving": true,
+      "expectedAllowUserInitiatedReuse": true
+    }
+  },
+  {
+    "testInput": {
+      "hasCustomer": true,
+      "lpmTypeFormCode": "card",
+      "intentSetupFutureUsage": "OneTime",
+      "intentLpms": [
+        "card",
+        "eps"
+      ]
+    },
+    "testOutput": {
+      "expectedDisplayUIForSaving": false,
+      "expectedAllowUserInitiatedReuse": false
+    }
+  },
+  {
+    "testInput": {
+      "hasCustomer": true,
+      "lpmTypeFormCode": "sepa_debit",
+      "intentSetupFutureUsage": "OneTime",
+      "intentLpms": [
+        "card",
+        "sepa_debit"
+      ]
+    },
+    "testOutput": {
+      "expectedDisplayUIForSaving": false,
+      "expectedAllowUserInitiatedReuse": false
     }
   },
   {
@@ -97,8 +141,8 @@
       ]
     },
     "testOutput": {
-      "expectedSaveCheckboxValue": false,
-      "expectedSaveCheckboxVisible": false
+      "expectedDisplayUIForSaving": true,
+      "expectedAllowUserInitiatedReuse": false
     }
   },
   {
@@ -112,8 +156,8 @@
       ]
     },
     "testOutput": {
-      "expectedSaveCheckboxValue": false,
-      "expectedSaveCheckboxVisible": false
+      "expectedDisplayUIForSaving": true,
+      "expectedAllowUserInitiatedReuse": false
     }
   },
   {
@@ -127,8 +171,8 @@
       ]
     },
     "testOutput": {
-      "expectedSaveCheckboxValue": false,
-      "expectedSaveCheckboxVisible": false
+      "expectedDisplayUIForSaving": true,
+      "expectedAllowUserInitiatedReuse": false
     }
   },
   {
@@ -141,8 +185,8 @@
       ]
     },
     "testOutput": {
-      "expectedSaveCheckboxValue": false,
-      "expectedSaveCheckboxVisible": false
+      "expectedDisplayUIForSaving": true,
+      "expectedAllowUserInitiatedReuse": false
     }
   },
   {
@@ -156,8 +200,8 @@
       ]
     },
     "testOutput": {
-      "expectedSaveCheckboxValue": false,
-      "expectedSaveCheckboxVisible": false
+      "expectedDisplayUIForSaving": true,
+      "expectedAllowUserInitiatedReuse": false
     }
   },
   {
@@ -171,8 +215,53 @@
       ]
     },
     "testOutput": {
-      "expectedSaveCheckboxValue": false,
-      "expectedSaveCheckboxVisible": false
+      "expectedDisplayUIForSaving": true,
+      "expectedAllowUserInitiatedReuse": false
+    }
+  },
+  {
+    "testInput": {
+      "hasCustomer": false,
+      "lpmTypeFormCode": "card",
+      "intentSetupFutureUsage": "OneTime",
+      "intentLpms": [
+        "card"
+      ]
+    },
+    "testOutput": {
+      "expectedDisplayUIForSaving": false,
+      "expectedAllowUserInitiatedReuse": false
+    }
+  },
+  {
+    "testInput": {
+      "hasCustomer": false,
+      "lpmTypeFormCode": "card",
+      "intentSetupFutureUsage": "OneTime",
+      "intentLpms": [
+        "card",
+        "eps"
+      ]
+    },
+    "testOutput": {
+      "expectedDisplayUIForSaving": false,
+      "expectedAllowUserInitiatedReuse": false
+    }
+  },
+  {
+    "testInput": {
+      "hasCustomer": false,
+      "lpmTypeFormCode": "sepa_debit",
+      "intentSetupFutureUsage": "OneTime",
+      "intentLpms": [
+        "card",
+        "sepa_debit"
+      ]
+    },
+    "testOutput": {
+      "expectedDisplayUIForSaving": false,
+      "expectedAllowUserInitiatedReuse": false
     }
   }
 ]
+

--- a/paymentsheet/src/test/resources/FormSaveCheckboxSetupIntent.json
+++ b/paymentsheet/src/test/resources/FormSaveCheckboxSetupIntent.json
@@ -12,8 +12,8 @@
       ]
     },
     "testOutput": {
-      "expectedSaveCheckboxValue": true,
-      "expectedSaveCheckboxVisible": false
+      "expectedDisplayUIForSaving": true,
+      "expectedAllowUserInitiatedReuse": false
     }
   },
   {
@@ -29,8 +29,8 @@
       ]
     },
     "testOutput": {
-      "expectedSaveCheckboxValue": true,
-      "expectedSaveCheckboxVisible": false
+      "expectedDisplayUIForSaving": true,
+      "expectedAllowUserInitiatedReuse": false
     }
   },
   {
@@ -46,8 +46,8 @@
       ]
     },
     "testOutput": {
-      "expectedSaveCheckboxValue": true,
-      "expectedSaveCheckboxVisible": false
+      "expectedDisplayUIForSaving": true,
+      "expectedAllowUserInitiatedReuse": false
     }
   },
   {
@@ -63,8 +63,8 @@
       ]
     },
     "testOutput": {
-      "expectedSaveCheckboxValue": true,
-      "expectedSaveCheckboxVisible": false
+      "expectedDisplayUIForSaving": true,
+      "expectedAllowUserInitiatedReuse": false
     }
   },
   {
@@ -80,8 +80,8 @@
       ]
     },
     "testOutput": {
-      "expectedSaveCheckboxValue": true,
-      "expectedSaveCheckboxVisible": false
+      "expectedDisplayUIForSaving": true,
+      "expectedAllowUserInitiatedReuse": false
     }
   },
   {
@@ -97,8 +97,8 @@
       ]
     },
     "testOutput": {
-      "expectedSaveCheckboxValue": true,
-      "expectedSaveCheckboxVisible": false
+      "expectedDisplayUIForSaving": true,
+      "expectedAllowUserInitiatedReuse": false
     }
   },
   {
@@ -114,8 +114,8 @@
       ]
     },
     "testOutput": {
-      "expectedSaveCheckboxValue": true,
-      "expectedSaveCheckboxVisible": false
+      "expectedDisplayUIForSaving": true,
+      "expectedAllowUserInitiatedReuse": false
     }
   },
   {
@@ -131,8 +131,8 @@
       ]
     },
     "testOutput": {
-      "expectedSaveCheckboxValue": true,
-      "expectedSaveCheckboxVisible": false
+      "expectedDisplayUIForSaving": true,
+      "expectedAllowUserInitiatedReuse": false
     }
   },
   {
@@ -148,8 +148,8 @@
       ]
     },
     "testOutput": {
-      "expectedSaveCheckboxValue": true,
-      "expectedSaveCheckboxVisible": false
+      "expectedDisplayUIForSaving": true,
+      "expectedAllowUserInitiatedReuse": false
     }
   },
   {
@@ -165,8 +165,8 @@
       ]
     },
     "testOutput": {
-      "expectedSaveCheckboxValue": true,
-      "expectedSaveCheckboxVisible": false
+      "expectedDisplayUIForSaving": true,
+      "expectedAllowUserInitiatedReuse": false
     }
   }
 ]


### PR DESCRIPTION
# Summary
SupportedPaymentMethod's spec contains a spec for each of the different PaymentMethods in each of the modes supported with a list of requirements
Capabilities are determined from the intent, code capabilities, and configuration
The supported modes: MerchantSaveRequired, UserSelectedSave, and OneTimeUse is determined by the Intent and the configuration
SupportedPaymentMethods is filtered based on requirements that are completely met by the capabilities
The FormSpec displayed for the payment method is selected based on the SupportedMode

# Motivation
Payment methods have different requirements based on if it is saved or not
Payment Method forms appear different based on if it is merchant saved, one time use, or user selected saved
Code has capabilities that it offers or not, for instance it is not able to provide the requirement mandate data on payment methods that are used from a saved state.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
