### PR TITLE
Close keyboard when changing payment methods

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
@@ -7,6 +7,8 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.view.ContextThemeWrapper
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
@@ -151,6 +153,10 @@ internal abstract class BaseAddPaymentMethodFragment(
 
     @VisibleForTesting
     internal fun onPaymentMethodSelected(paymentMethod: SupportedPaymentMethod) {
+        // hide the soft keyboard.
+        ViewCompat.getWindowInsetsController(requireView())
+            ?.hide(WindowInsetsCompat.Type.ime())
+
         replacePaymentMethodFragment(paymentMethod)
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Close the soft keyboard when users change payment methods.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
I've only seen this consistent behavior on emulators, but if I was a developer without a phone I would be concerned it would happen every time on a real device. The worst part is that the soft keyboard stays on screen but does not type anywhere. I have only gotten it to happen a few times out of several tries on a real device. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![keebstuck](https://user-images.githubusercontent.com/89166418/135686970-70c0edee-7c63-4fbb-83f0-4f86497906cc.gif)| ![keebunstuck](https://user-images.githubusercontent.com/89166418/135687667-402e6dc9-4006-4b3d-977f-c812a1dc3db4.gif)|
