### PR TITLE
Don't show generic iban errors until done typing

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/IbanConfig.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/IbanConfig.kt
@@ -88,7 +88,7 @@ internal class IbanConfig : TextFieldConfig {
                 TextFieldStateConstants.Valid.Limitless
             }
         } else {
-            TextFieldStateConstants.Error.Invalid(
+            TextFieldStateConstants.Error.Incomplete(
                 R.string.iban_invalid
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/elements/IbanConfigTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/elements/IbanConfigTest.kt
@@ -41,6 +41,9 @@ class IbanConfigTest {
 
         assertThat(ibanConfig.determineState("CA3ABC"))
             .isInstanceOf(TextFieldStateConstants.Error.Incomplete::class.java)
+
+        assertThat(ibanConfig.determineState("NL38RABO0300065264"))
+            .isInstanceOf(TextFieldStateConstants.Error.Incomplete::class.java)
     }
 
     @Test
@@ -54,10 +57,12 @@ class IbanConfigTest {
 
     @Test
     fun `invalid IBAN is in invalid state`() {
-        assertThat(ibanConfig.determineState("NL38RABO0300065264"))
+        // invalid country
+        assertThat(ibanConfig.determineState("ABCD61190430023457320"))
             .isInstanceOf(TextFieldStateConstants.Error.Invalid::class.java)
 
-        assertThat(ibanConfig.determineState("ABCD61190430023457320"))
+        // starts with digits
+        assertThat(ibanConfig.determineState("11CD61190430023457320"))
             .isInstanceOf(TextFieldStateConstants.Error.Invalid::class.java)
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Changes some IBAN state logic to label certain inputs incomplete rather than invalid.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
When a user is typing, they shouldn't see an error message until they're done or we know for sure the IBAN input is not valid. 

The only situations we know for sure are invalid: 
1. invalid country code. 
2. starting with a digit.

The return statement I changed from invalid to incomplete is the "correct country code and invalid IBAN but still typing" case. I also added a unit test for inputs that start with digits. 

[This official IBAN checker was helpful](https://www.iban.com/iban-checker) 
# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [X] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
|![ibanbefore](https://user-images.githubusercontent.com/89166418/135943044-43007cfd-4912-4360-9f36-e471ef61ccb8.gif)|![ibanafter](https://user-images.githubusercontent.com/89166418/135943121-bf70582a-0077-47f3-8554-6b749587ddd7.gif)|
