### PR TITLE
Add analytics event for failure creating 3ds2 params

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/networking/AnalyticsEvent.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/AnalyticsEvent.kt
@@ -61,6 +61,7 @@ internal enum class AnalyticsEvent(internal val code: String) {
     StripeUrlRetrieve("retrieve_stripe_url"),
 
     // 3DS2
+    Auth3ds2RequestParamsFailed("3ds2_authentication_request_params_failed"),
     Auth3ds2Fingerprint("3ds2_fingerprint"),
     Auth3ds2Start("3ds2_authenticate"),
     Auth3ds2Frictionless("3ds2_frictionless_flow"),

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel.kt
@@ -68,6 +68,10 @@ internal class Stripe3ds2TransactionViewModel @Inject constructor(
                 Stripe3ds2Fingerprint(args.nextActionData)
             )
         }.getOrElse {
+            analyticsRequestExecutor.executeAsync(
+                analyticsRequestFactory.createRequest(AnalyticsEvent.Auth3ds2RequestParamsFailed)
+            )
+
             NextStep.Complete(
                 PaymentFlowResult.Unvalidated(
                     exception = StripeException.create(it)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add analytics event for failure creating 3ds2 params.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Missing event for when we are unable to construct an request.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
Manually made the `Stripe3ds2Fingerprint` instantiation fail, verified the new event is logged.