### PR TITLE
Add jitpack.yml

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Jitpack tries to build with Java 8, Gradle plugin 7.0+ requires Java 11.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://github.com/jitpack/jitpack.io/issues/4691
