### PR TITLE
add extra height to CardMultilineWidget textboxes

### DIFF
--- a/payments-core/res/values/dimens.xml
+++ b/payments-core/res/values/dimens.xml
@@ -26,7 +26,7 @@
     <!-- Text size of CardInputWidget EditText views -->
     <dimen name="ciw_stripe_edit_text_size">18sp</dimen>
 
-    <dimen name="stripe_cmw_edit_text_minheight">48dp</dimen>
+    <dimen name="stripe_cmw_edit_text_minheight">50dp</dimen>
 
     <!-- Text size of BECS Debit Widget EditTexts -->
     <dimen name="stripe_becs_debit_widget_edit_text_size">14sp</dimen>


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
increase height of textboxes on CardMutlilineWidget from 48dp -> 50dp

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://github.com/stripe/stripe-android/issues/4294

The `PaymentMethodsActivityStarter` uses a different style to what is in `PaymentSheet`. By adding the extra 2dp we have a layout that is acceptable for both from a UX perspective. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

Tested on several different emulators to verify text was not cut off. 

# Screenshots
| Before  | After |
| ------------- | ------------- |
|![paymentSheetBefore](https://user-images.githubusercontent.com/89166418/137408851-a2040974-8395-4a6b-bbf2-34a3b2eba348.png)|![paymentSheetAfter](https://user-images.githubusercontent.com/89166418/137408683-9a969132-8cff-4068-a9e5-78bba713f7a1.png)|
|![exampleBefore](https://user-images.githubusercontent.com/89166418/137408701-3409a03a-7016-4450-a93e-722e098247b8.png)|![exampleAfter](https://user-images.githubusercontent.com/89166418/137408710-3d013010-f41c-4ed2-a0cb-a235b54b4185.png)|
