### PR TITLE
PaymentLauncher should use a transparent themed activity.

### DIFF
--- a/payments-core/res/values/themes.xml
+++ b/payments-core/res/values/themes.xml
@@ -38,5 +38,5 @@
 
     <style name="StripeGooglePayDefaultTheme" parent="StripePaymentSheetBaseTheme" />
 
-    <style name="PayLauncherDefaultTheme" parent="StripePaymentSheetBaseTheme" />
+    <style name="PayLauncherDefaultTheme" parent="StripeTransparentTheme" />
 </resources>


### PR DESCRIPTION
# Summary
If the PaymentLauncher doens't use the Transparent theme the background dims while processing is in progress.

# Motivation
See [internal doc](https://paper.dropbox.com/doc/Implementation-Review-Issue-Tracker-Mobile-Payment-Sheet-GA--BUiFuuCjf~vdwR2nJMYhpolCAg-1yJcfxQW1WjDBi7RD6kmU) "Screen occasionally covered with a grey overlay"

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
Before:
![image](https://user-images.githubusercontent.com/77996191/137764250-1ca76f1c-cd60-4c39-bdb2-15cb90f8eef5.png)

After:
https://user-images.githubusercontent.com/77996191/137764408-b23a362c-da62-44cb-986a-ea0363aad245.mov



