### PR TITLE
Create a dedicated no dim transparent theme for PaymentLauncher

### DIFF
--- a/payments-core/res/values/themes.xml
+++ b/payments-core/res/values/themes.xml
@@ -38,5 +38,15 @@
 
     <style name="StripeGooglePayDefaultTheme" parent="StripePaymentSheetBaseTheme" />
 
-    <style name="PayLauncherDefaultTheme" parent="StripeTransparentTheme" />
+    <style name="PayLauncherDefaultTheme" parent="@style/Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:backgroundDimEnabled">false</item>
+        <item name="windowNoTitle">true</item>
+        <item name="android:windowAnimationStyle">@null</item>
+        <item name="colorSurface">@color/stripe_paymentsheet_background</item>
+        <item name="actionMenuTextColor">@color/stripe_paymentsheet_toolbar_items_color</item>
+    </style>
 </resources>


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
remove the dim before `PaymentLauncher` starts confirmation, preserving status bar color

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
better UI for `PaymentLauncher` and `PaymentSheet`

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| withDim(before)  | noDimWrongColor(before) | noDimCorrectColor(after) |
| ------------- | ------------- | ------------- |
| ![withDim](https://user-images.githubusercontent.com/79880926/137797666-9a5db954-4740-40f5-ae12-59d0ff02b484.gif) | ![dimBefore](https://user-images.githubusercontent.com/79880926/137797771-4d729247-d55c-48dd-825e-732ab9d98408.gif) | ![dimAfter](https://user-images.githubusercontent.com/79880926/137797734-ede4b6f4-94b5-459f-92a5-1230e5406680.gif) |



