### PR TITLE
Set group id when building from JitPack

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -178,7 +178,7 @@ android {
 
 task ktlint(type: JavaExec, group: "verification") {
     description = "Check Kotlin code style."
-    main = "com.pinterest.ktlint.Main"
+    mainClass = "com.pinterest.ktlint.Main"
     classpath = configurations.ktlint
     args "src/**/*.kt"
     // to generate report in checkstyle format prepend following args:
@@ -189,7 +189,7 @@ check.dependsOn ktlint
 
 task ktlintFormat(type: JavaExec, group: "formatting") {
     description = "Fix Kotlin code style deviations."
-    main = "com.pinterest.ktlint.Main"
+    mainClass = "com.pinterest.ktlint.Main"
     classpath = configurations.ktlint
     args "-F", "src/**/*.kt"
 }

--- a/payments-core/build.gradle
+++ b/payments-core/build.gradle
@@ -15,6 +15,10 @@ configurations {
     ktlint
 }
 
+if (System.getenv("JITPACK")) {
+    group='com.github.stripe.stripe-android'
+}
+
 dependencies {
     implementation libraries.androidx.annotation
     implementation libraries.androidx.appcompat
@@ -63,7 +67,6 @@ dependencies {
     androidTestUtil "androidx.test:orchestrator:$androidTestVersion"
 
     ktlint "com.pinterest:ktlint:$ktlintVersion"
-
 }
 
 android {
@@ -139,7 +142,7 @@ android {
 
 task ktlint(type: JavaExec, group: "verification") {
     description = "Check Kotlin code style."
-    main = "com.pinterest.ktlint.Main"
+    mainClass = "com.pinterest.ktlint.Main"
     classpath = configurations.ktlint
     args "src/**/*.kt"
     // to generate report in checkstyle format prepend following args:
@@ -150,7 +153,7 @@ check.dependsOn ktlint
 
 task ktlintFormat(type: JavaExec, group: "formatting") {
     description = "Fix Kotlin code style deviations."
-    main = "com.pinterest.ktlint.Main"
+    mainClass = "com.pinterest.ktlint.Main"
     classpath = configurations.ktlint
     args "-F", "src/**/*.kt"
 }

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -7,72 +7,15 @@ plugins {
     id 'org.jetbrains.kotlin.plugin.serialization' version '1.5.31'
 }
 
-android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
-
-    defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion rootProject.ext.compileSdkVersion
-
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-
-        vectorDrawables.useSupportLibrary = true
-
-        // From https://developer.android.com/training/testing/junit-runner:
-        // > To remove all shared state from your device"s CPU and memory after each test,
-        // > use the clearPackageData flag.
-        testInstrumentationRunnerArguments clearPackageData: "true"
-    }
-
-    sourceSets {
-        main {
-            res.srcDirs = ['res']
-        }
-    }
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-
-    buildFeatures {
-        compose = true
-        viewBinding true
-    }
-
-    testOptions {
-        unitTests {
-            // Note: without this, all Robolectric tests using assets will fail.
-            includeAndroidResources = true
-            all {
-                maxHeapSize = "1024m"
-            }
-        }
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion "$composeVersion"
-    }
-
-    lintOptions {
-        disable "UnrememberedMutableState"
-    }
-
-    dokkaHtml {
-        outputDirectory = new File("${project.rootDir}/docs/$project.name")
-    }
-}
-
 assemble.dependsOn('lint')
 check.dependsOn('checkstyle')
 
 configurations {
     ktlint
+}
+
+if (System.getenv("JITPACK")) {
+    group='com.github.stripe.stripe-android'
 }
 
 dependencies {
@@ -135,9 +78,70 @@ dependencies {
     ktlint "com.pinterest:ktlint:$ktlintVersion"
 }
 
+android {
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
+
+    defaultConfig {
+        minSdkVersion 21
+        targetSdkVersion rootProject.ext.compileSdkVersion
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+
+        vectorDrawables.useSupportLibrary = true
+
+        // From https://developer.android.com/training/testing/junit-runner:
+        // > To remove all shared state from your device"s CPU and memory after each test,
+        // > use the clearPackageData flag.
+        testInstrumentationRunnerArguments clearPackageData: "true"
+    }
+
+    sourceSets {
+        main {
+            res.srcDirs = ['res']
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+
+    buildFeatures {
+        compose = true
+        viewBinding true
+    }
+
+    testOptions {
+        unitTests {
+            // Note: without this, all Robolectric tests using assets will fail.
+            includeAndroidResources = true
+            all {
+                maxHeapSize = "1024m"
+            }
+        }
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion "$composeVersion"
+    }
+
+    lintOptions {
+        disable "UnrememberedMutableState"
+    }
+
+    dokkaHtml {
+        outputDirectory = new File("${project.rootDir}/docs/$project.name")
+    }
+}
+
 task ktlint(type: JavaExec, group: "verification") {
     description = "Check Kotlin code style."
-    main = "com.pinterest.ktlint.Main"
+    mainClass = "com.pinterest.ktlint.Main"
     classpath = configurations.ktlint
     args "src/**/*.kt"
     // to generate report in checkstyle format prepend following args:
@@ -148,7 +152,7 @@ check.dependsOn ktlint
 
 task ktlintFormat(type: JavaExec, group: "formatting") {
     description = "Fix Kotlin code style deviations."
-    main = "com.pinterest.ktlint.Main"
+    mainClass = "com.pinterest.ktlint.Main"
     classpath = configurations.ktlint
     args "-F", "src/**/*.kt"
 }

--- a/stripe-test-e2e/build.gradle
+++ b/stripe-test-e2e/build.gradle
@@ -77,7 +77,7 @@ dependencies {
 
 task ktlint(type: JavaExec, group: "verification") {
     description = "Check Kotlin code style."
-    main = "com.pinterest.ktlint.Main"
+    mainClass = "com.pinterest.ktlint.Main"
     classpath = configurations.ktlint
     args "src/**/*.kt"
     // to generate report in checkstyle format prepend following args:
@@ -88,7 +88,7 @@ check.dependsOn ktlint
 
 task ktlintFormat(type: JavaExec, group: "formatting") {
     description = "Fix Kotlin code style deviations."
-    main = "com.pinterest.ktlint.Main"
+    mainClass = "com.pinterest.ktlint.Main"
     classpath = configurations.ktlint
     args "-F", "src/**/*.kt"
 }

--- a/wechatpay/build.gradle
+++ b/wechatpay/build.gradle
@@ -59,7 +59,7 @@ android {
 
 task ktlint(type: JavaExec, group: "verification") {
     description = "Check Kotlin code style."
-    main = "com.pinterest.ktlint.Main"
+    mainClass = "com.pinterest.ktlint.Main"
     classpath = configurations.ktlint
     args "src/**/*.kt"
     // to generate report in checkstyle format prepend following args:
@@ -70,7 +70,7 @@ check.dependsOn ktlint
 
 task ktlintFormat(type: JavaExec, group: "formatting") {
     description = "Fix Kotlin code style deviations."
-    main = "com.pinterest.ktlint.Main"
+    mainClass = "com.pinterest.ktlint.Main"
     classpath = configurations.ktlint
     args "-F", "src/**/*.kt"
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
When building from JitPack, set group id to `com.github.stripe.stripe-android`. That's what JitPack uses, and without setting it the library won't find its internal dependencies.
Updated [internal doc](https://confluence.corp.stripe.com/display/MOBILE/Branch+Release).
Also update deprecated `task.main`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix JitPack for the project.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified