### PR TITLE
Dynamic item width on saved payment method selector

### DIFF
--- a/paymentsheet/res/values/styles.xml
+++ b/paymentsheet/res/values/styles.xml
@@ -20,12 +20,12 @@
     </style>
 
     <style name="StripePaymentOptionItemCard">
-        <item name="android:layout_width">@dimen/stripe_paymentsheet_paymentmethod_icon_width</item>
+        <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">@dimen/stripe_paymentsheet_paymentmethod_icon_height
         </item>
-        <item name="android:layout_marginStart">7dp</item>
+        <item name="android:layout_marginStart">6dp</item>
         <item name="android:layout_marginTop">8dp</item>
-        <item name="android:layout_marginEnd">7dp</item>
+        <item name="android:layout_marginEnd">6dp</item>
         <item name="android:layout_marginBottom">4dp</item>
         <item name="android:padding">4dp</item>
         <item name="android:clickable">false</item>
@@ -59,7 +59,7 @@
         <item name="android:src">@drawable/stripe_ic_delete_symbol</item>
         <!-- modify the bottom and end layout to correctly position the icon -->
         <item name="android:paddingBottom">24dp</item>
-        <item name="android:paddingEnd">-24dp</item>
+        <item name="android:paddingEnd">-25dp</item>
         <item name="android:scaleType">center</item>
     </style>
 
@@ -86,8 +86,8 @@
         <item name="android:textSize">13sp</item>
         <item name="android:textStyle">bold</item>
         <item name="android:lineSpacingExtra">1sp</item>
-        <item name="android:layout_marginStart">4dp</item>
-        <item name="android:layout_marginEnd">4dp</item>
+        <item name="android:layout_marginStart">6dp</item>
+        <item name="android:layout_marginEnd">6dp</item>
     </style>
 
     <style name="StripePaymentSheetTitle">

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
@@ -8,6 +8,8 @@ import android.view.View.IMPORTANT_FOR_ACCESSIBILITY_YES
 import android.view.ViewGroup
 import androidx.annotation.VisibleForTesting
 import androidx.core.view.isVisible
+import androidx.core.view.marginEnd
+import androidx.core.view.marginStart
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.IMPORTANT_FOR_ACCESSIBILITY_NO
 import androidx.recyclerview.widget.RecyclerView.NO_POSITION
@@ -219,6 +221,16 @@ internal class PaymentOptionsAdapter(
                     onItemSelected(bindingAdapterPosition, isClick = true)
                 }
             }
+        }.apply {
+            val targetWidth = parent.measuredWidth - parent.paddingStart - parent.paddingEnd
+            // minimum width for each item, accounting for the CardView margin so that the CardView
+            // is at least 100dp wide
+            val minItemWidth = 100 * parent.context.resources.displayMetrics.density +
+                cardView.marginEnd + cardView.marginStart
+            // numVisibleItems is incremented in steps of 0.5 items (1, 1.5, 2, 2.5, 3, ...)
+            val numVisibleItems = (targetWidth * 2 / minItemWidth).toInt() / 2f
+            val viewWidth = targetWidth / numVisibleItems
+            itemView.layoutParams.width = viewWidth.toInt()
         }
     }
 
@@ -256,6 +268,9 @@ internal class PaymentOptionsAdapter(
             ),
             onRemoveListener
         )
+
+        override val cardView: View
+            get() = binding.card
 
         init {
             // ensure that the icons are above the card
@@ -313,6 +328,9 @@ internal class PaymentOptionsAdapter(
             )
         )
 
+        override val cardView: View
+            get() = binding.card
+
         override fun setEnabled(enabled: Boolean) {
             binding.card.isEnabled = enabled
             binding.root.isEnabled = enabled
@@ -331,6 +349,9 @@ internal class PaymentOptionsAdapter(
                 LayoutInflater.from(parent.context), parent, false
             )
         )
+
+        override val cardView: View
+            get() = binding.card
 
         init {
             // ensure that the check icon is above the card
@@ -354,6 +375,7 @@ internal class PaymentOptionsAdapter(
     internal abstract class PaymentOptionViewHolder(parent: ViewGroup) :
         RecyclerView.ViewHolder(parent) {
 
+        abstract val cardView: View
         abstract fun setEnabled(enabled: Boolean)
 
         fun cardStrokeWidth(selected: Boolean): Int {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
@@ -33,6 +33,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowAlertDialog
 
 @RunWith(RobolectricTestRunner::class)
@@ -107,6 +108,45 @@ class PaymentSheetListFragmentTest {
             val adapter = recyclerView(it).adapter as PaymentOptionsAdapter
             assertThat(adapter.itemCount)
                 .isEqualTo(4)
+        }
+    }
+
+    @Test
+    @Config(qualifiers = "w320dp")
+    fun `when screen is 320dp wide, adapter should show 2 and a half items with 114dp width`() {
+        createScenario(
+            initialState = Lifecycle.State.INITIALIZED
+        ).onFragment { fragment ->
+            fragment.sheetViewModel._paymentMethods.value = PAYMENT_METHODS
+        }.moveToState(Lifecycle.State.STARTED).onFragment {
+            val item = recyclerView(it).layoutManager!!.findViewByPosition(0)
+            assertThat(item!!.measuredWidth).isEqualTo(114)
+        }
+    }
+
+    @Test
+    @Config(qualifiers = "w481dp")
+    fun `when screen is 481dp wide, adapter should show 3 and a half items with 127dp width`() {
+        createScenario(
+            initialState = Lifecycle.State.INITIALIZED
+        ).onFragment { fragment ->
+            fragment.sheetViewModel._paymentMethods.value = PAYMENT_METHODS
+        }.moveToState(Lifecycle.State.STARTED).onFragment {
+            val item = recyclerView(it).layoutManager!!.findViewByPosition(0)
+            assertThat(item!!.measuredWidth).isEqualTo(127)
+        }
+    }
+
+    @Test
+    @Config(qualifiers = "w482dp")
+    fun `when screen is 482dp wide, adapter should show 4 items with 112dp width`() {
+        createScenario(
+            initialState = Lifecycle.State.INITIALIZED
+        ).onFragment { fragment ->
+            fragment.sheetViewModel._paymentMethods.value = PAYMENT_METHODS
+        }.moveToState(Lifecycle.State.STARTED).onFragment {
+            val item = recyclerView(it).layoutManager!!.findViewByPosition(0)
+            assertThat(item!!.measuredWidth).isEqualTo(112)
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Each CardView in the list of saved payment methods has a minimum width of 100dp, and the number of items visible within the padded area is always a multiple of 0.5.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Always hint that there are more saved payment method.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| w320dp |  |
| ------------- | ------------- |
| ![Screenshot_1635203931](https://user-images.githubusercontent.com/77990083/138785393-39dbeff1-aecb-498a-9ddc-e091d7ccf1b7.png) | ![Screenshot_1635203940](https://user-images.githubusercontent.com/77990083/138785399-d802de22-bc9e-4a4a-a533-28412d950906.png) |
| w480dp |
| ![Screenshot_1635203954](https://user-images.githubusercontent.com/77990083/138785398-03230d0c-8f77-4fd2-afde-a24ea63a60f1.png) | ![Screenshot_1635203958](https://user-images.githubusercontent.com/77990083/138785397-934756a9-0c8d-44cb-b7cc-f8d668c76cad.png) |
| w540dp |
| ![Screenshot_1635203974](https://user-images.githubusercontent.com/77990083/138785396-54f20c70-4906-4917-baf9-4a6cd7a0c5d4.png) | ![Screenshot_1635203980](https://user-images.githubusercontent.com/77990083/138785394-a1b51820-4b21-417a-9561-a53aa5ae98f4.png) |
