### PR TITLE
Bank value is allowed to be null in the case of "other"

### DIFF
--- a/paymentsheet/src/main/assets/epsBanks.json
+++ b/paymentsheet/src/main/assets/epsBanks.json
@@ -135,7 +135,7 @@
     "icon": "vr_bank_braunau"
   },
   {
-    "value": "",
+    "value": null,
     "text": "Other"
   }
 ]

--- a/paymentsheet/src/main/assets/idealBanks.json
+++ b/paymentsheet/src/main/assets/idealBanks.json
@@ -60,7 +60,7 @@
     "text": "Van Lanschot"
   },
   {
-    "value": "",
+    "value": null,
     "text": "Other"
   }
 ]

--- a/paymentsheet/src/main/assets/p24Banks.json
+++ b/paymentsheet/src/main/assets/p24Banks.json
@@ -125,7 +125,7 @@
     "text": "Volkswagen Bank"
   },
   {
-    "value": "",
+    "value": null,
     "text": "Other"
   }
 ]

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/DropdownItemSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/DropdownItemSpec.kt
@@ -4,6 +4,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 internal data class DropdownItemSpec(
-    val value: String,
+    val value: String?,
     val text: String
 )


### PR DESCRIPTION
# Summary
For the bank selector we always allow the user to enter Other and this is not associated with a bank.  The resource value associated with Other in the past was an empty string. This meant that we create a payment method create params with an empty string in the bank value.  In the past an empty string was removed when sent to the server, but there was a recent change that now allows this string to be sent.

For this review we change it so that Other is associated with a null string, which will not be sent to the server.

# Motivation
See screenshot below

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
![image](https://user-images.githubusercontent.com/77996191/139257007-342adb6b-dd59-4ae5-877e-f4b61681f172.png)

