### PR TITLE
Preserve the placeholder format when setting number pad.

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -6282,6 +6282,7 @@ public class com/stripe/android/view/StripeEditText : com/google/android/materia
 	public final fun setErrorMessage (Ljava/lang/String;)V
 	public final fun setErrorMessageListener (Lcom/stripe/android/view/StripeEditText$ErrorMessageListener;)V
 	protected final fun setLastKeyDelete (Z)V
+	public final fun setNumberOnlyInputType ()V
 	public final fun setOnFocusChangeListener (Landroid/view/View$OnFocusChangeListener;)V
 	public final fun setShouldShowError (Z)V
 	public fun setTextColor (I)V

--- a/payments-core/src/main/java/com/stripe/android/view/CardNumberEditText.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardNumberEditText.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import android.os.Build
 import android.text.Editable
 import android.text.InputFilter
-import android.text.InputType
-import android.text.method.HideReturnsTransformationMethod
 import android.util.AttributeSet
 import android.view.View
 import androidx.annotation.VisibleForTesting
@@ -143,8 +141,8 @@ class CardNumberEditText internal constructor(
     private var loadingJob: Job? = null
 
     init {
-        inputType = InputType.TYPE_NUMBER_VARIATION_PASSWORD or InputType.TYPE_CLASS_NUMBER
-        transformationMethod = HideReturnsTransformationMethod.getInstance()
+        setNumberOnlyInputType()
+
         setErrorMessage(resources.getString(R.string.invalid_card_number))
         addTextChangedListener(CardNumberTextWatcher())
 

--- a/payments-core/src/main/java/com/stripe/android/view/CvcEditText.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CvcEditText.kt
@@ -3,8 +3,6 @@ package com.stripe.android.view
 import android.content.Context
 import android.os.Build
 import android.text.InputFilter
-import android.text.InputType
-import android.text.method.HideReturnsTransformationMethod
 import android.util.AttributeSet
 import android.view.View
 import androidx.core.widget.doAfterTextChanged
@@ -44,8 +42,7 @@ class CvcEditText @JvmOverloads constructor(
         maxLines = 1
         filters = createFilters(CardBrand.Unknown)
 
-        inputType = InputType.TYPE_NUMBER_VARIATION_PASSWORD or InputType.TYPE_CLASS_NUMBER
-        transformationMethod = HideReturnsTransformationMethod.getInstance()
+        setNumberOnlyInputType()
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             setAutofillHints(View.AUTOFILL_HINT_CREDIT_CARD_SECURITY_CODE)

--- a/payments-core/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import android.os.Build
 import android.text.Editable
 import android.text.InputFilter
-import android.text.InputType
-import android.text.method.HideReturnsTransformationMethod
 import android.util.AttributeSet
 import android.view.View
 import android.widget.EditText
@@ -235,8 +233,7 @@ class ExpiryDateEditText @JvmOverloads constructor(
     }
 
     init {
-        inputType = InputType.TYPE_NUMBER_VARIATION_PASSWORD or InputType.TYPE_CLASS_NUMBER
-        transformationMethod = HideReturnsTransformationMethod.getInstance()
+        setNumberOnlyInputType()
 
         updateSeparatorUi()
 

--- a/payments-core/src/main/java/com/stripe/android/view/PostalCodeEditText.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PostalCodeEditText.kt
@@ -5,7 +5,6 @@ import android.os.Build
 import android.text.InputFilter
 import android.text.InputType
 import android.text.method.DigitsKeyListener
-import android.text.method.HideReturnsTransformationMethod
 import android.text.method.TextKeyListener
 import android.util.AttributeSet
 import android.view.View
@@ -67,8 +66,7 @@ class PostalCodeEditText @JvmOverloads constructor(
         updateHint(R.string.address_label_zip_code)
         filters = arrayOf(InputFilter.LengthFilter(MAX_LENGTH_US))
         keyListener = DigitsKeyListener.getInstance(false, true)
-        inputType = InputType.TYPE_NUMBER_VARIATION_PASSWORD or InputType.TYPE_CLASS_NUMBER
-        transformationMethod = HideReturnsTransformationMethod.getInstance()
+        setNumberOnlyInputType()
     }
 
     /**

--- a/payments-core/src/main/java/com/stripe/android/view/StripeEditText.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/StripeEditText.kt
@@ -3,7 +3,9 @@ package com.stripe.android.view
 import android.content.Context
 import android.content.res.ColorStateList
 import android.os.Parcelable
+import android.text.InputType
 import android.text.TextWatcher
+import android.text.method.HideReturnsTransformationMethod
 import android.util.AttributeSet
 import android.view.KeyEvent
 import android.view.accessibility.AccessibilityNodeInfo
@@ -298,6 +300,14 @@ open class StripeEditText @JvmOverloads constructor(
         textWatchers?.forEach {
             super.addTextChangedListener(it)
         }
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun setNumberOnlyInputType(){
+        val preTypeface = typeface
+        inputType = InputType.TYPE_NUMBER_VARIATION_PASSWORD or InputType.TYPE_CLASS_NUMBER
+        typeface = preTypeface
+        transformationMethod = HideReturnsTransformationMethod.getInstance()
     }
 
     @Parcelize

--- a/payments-core/src/main/java/com/stripe/android/view/StripeEditText.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/StripeEditText.kt
@@ -303,7 +303,7 @@ open class StripeEditText @JvmOverloads constructor(
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    fun setNumberOnlyInputType(){
+    fun setNumberOnlyInputType() {
         val preTypeface = typeface
         inputType = InputType.TYPE_NUMBER_VARIATION_PASSWORD or InputType.TYPE_CLASS_NUMBER
         typeface = preTypeface

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingAddressView.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingAddressView.kt
@@ -108,8 +108,14 @@ internal class BillingAddressView @JvmOverloads constructor(
     ) { _, _, config ->
         postalCodeView.filters = arrayOf(InputFilter.LengthFilter(config.maxLength))
         postalCodeView.keyListener = config.getKeyListener()
-        postalCodeView.inputType = config.inputType
-        postalCodeView.transformationMethod = HideReturnsTransformationMethod.getInstance()
+
+        if(config.inputType ==
+            (InputType.TYPE_NUMBER_VARIATION_PASSWORD or InputType.TYPE_CLASS_NUMBER)){
+            postalCodeView.setNumberOnlyInputType()
+        }
+        else {
+            postalCodeView.inputType = config.inputType
+        }
     }
 
     private val newCountryCodeCallback = { newCountryCode: CountryCode ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingAddressView.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingAddressView.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.text.InputFilter
 import android.text.InputType
 import android.text.method.DigitsKeyListener
-import android.text.method.HideReturnsTransformationMethod
 import android.text.method.KeyListener
 import android.text.method.TextKeyListener
 import android.util.AttributeSet
@@ -109,11 +108,11 @@ internal class BillingAddressView @JvmOverloads constructor(
         postalCodeView.filters = arrayOf(InputFilter.LengthFilter(config.maxLength))
         postalCodeView.keyListener = config.getKeyListener()
 
-        if(config.inputType ==
-            (InputType.TYPE_NUMBER_VARIATION_PASSWORD or InputType.TYPE_CLASS_NUMBER)){
+        if (config.inputType ==
+            (InputType.TYPE_NUMBER_VARIATION_PASSWORD or InputType.TYPE_CLASS_NUMBER)
+        ) {
             postalCodeView.setNumberOnlyInputType()
-        }
-        else {
+        } else {
             postalCodeView.inputType = config.inputType
         }
     }


### PR DESCRIPTION
# Summary
When an edit text is set to number password android updates the typeface.  In order to preserve the typeface we must reset it back.   The hide transformation will prevent the field from showing up as asterisks.  Moved this logic into StripeEditText so it can be shared by all fields needed a number pad. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
* Verified the font and number pad on the CardInputWidget, CardFormView, and PaymentSheet.

# Screenshots
| Before  | After |
| ------------- | ------------- |
See internal note.