### PR TITLE
Add merchant name to save payment method text. 

### DIFF
--- a/paymentsheet/res/values/totranslate.xml
+++ b/paymentsheet/res/values/totranslate.xml
@@ -3,4 +3,5 @@
     <!--
     Items here need to be entered in our translation tool
     -->
+    <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Save for future %s payments</string>
 </resources>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/SaveForFutureUseController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/SaveForFutureUseController.kt
@@ -11,7 +11,8 @@ internal class SaveForFutureUseController(
     identifiersRequiredForFutureUse: List<IdentifierSpec> = emptyList(),
     saveForFutureUseInitialValue: Boolean
 ) : InputController {
-    override val label: Int = R.string.stripe_paymentsheet_save_for_future_payments
+    override val label: Int =
+        R.string.stripe_paymentsheet_save_for_future_payments_with_merchant_name
     private val _saveForFutureUse = MutableStateFlow(saveForFutureUseInitialValue)
     val saveForFutureUse: Flow<Boolean> = _saveForFutureUse
     override val fieldValue: Flow<String> = saveForFutureUse.map { it.toString() }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/SaveForFutureUseElementUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/SaveForFutureUseElementUI.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.semantics
@@ -29,6 +30,7 @@ internal fun SaveForFutureUseElementUI(
 ) {
     val controller = element.controller
     val checked by controller.saveForFutureUse.asLiveData().observeAsState(true)
+    val resources = LocalContext.current.resources
 
     val description = stringResource(
         if (checked) {
@@ -62,7 +64,7 @@ internal fun SaveForFutureUseElementUI(
             enabled = enabled
         )
         Text(
-            stringResource(controller.label),
+            resources.getString(controller.label, element.merchantName),
             Modifier
                 .padding(start = 4.dp)
                 .align(Alignment.CenterVertically),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Adds the merchant name to the save payment method text. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This makes other payment methods fall in line with cards. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
|![newtext](https://user-images.githubusercontent.com/89166418/139956218-7c22ad48-aeb6-49f4-bd1c-33801f69f58d.png)|![newtextnew](https://user-images.githubusercontent.com/89166418/139956238-c6581131-6bf0-492d-965c-8d9be260d6d1.png)|
