### PR TITLE
Convert toast to snackbar in examples

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
@@ -1,10 +1,10 @@
 package com.stripe.android.paymentsheet.example.playground.activity
 
 import android.os.Bundle
-import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isInvisible
 import androidx.lifecycle.lifecycleScope
+import com.google.android.material.snackbar.Snackbar
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResult
 import com.stripe.android.paymentsheet.example.R
@@ -108,7 +108,11 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity() {
         }
 
         viewModel.status.observe(this) {
-            Toast.makeText(this, it, Toast.LENGTH_LONG).show()
+            Snackbar.make(
+                findViewById(android.R.id.content), it, Snackbar.LENGTH_SHORT)
+                .setBackgroundTint(resources.getColor(R.color.black))
+                .setTextColor(resources.getColor(R.color.white))
+                .show()
         }
 
         viewModel.inProgress.observe(this) {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/activity/BasePaymentSheetActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/activity/BasePaymentSheetActivity.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.google.android.material.snackbar.Snackbar
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResult
@@ -42,6 +43,11 @@ internal abstract class BasePaymentSheetActivity : AppCompatActivity() {
     protected val viewModel: PaymentSheetViewModel by lazy {
         PaymentSheetViewModel(application)
     }
+    
+    protected val snackbar = Snackbar.make(
+        findViewById(android.R.id.content),"", Snackbar.LENGTH_SHORT)
+        .setBackgroundTint(resources.getColor(R.color.black))
+        .setTextColor(resources.getColor(R.color.white))
 
     protected fun prepareCheckout(
         onSuccess: (PaymentSheet.CustomerConfiguration?, String) -> Unit

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/activity/LaunchPaymentSheetCompleteActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/activity/LaunchPaymentSheetCompleteActivity.kt
@@ -1,12 +1,10 @@
 package com.stripe.android.paymentsheet.example.samples.activity
 
 import android.os.Bundle
-import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.ui.platform.LocalContext
 import com.stripe.android.paymentsheet.PaymentSheet
 
 internal class LaunchPaymentSheetCompleteActivity : BasePaymentSheetActivity() {
@@ -21,7 +19,7 @@ internal class LaunchPaymentSheetCompleteActivity : BasePaymentSheetActivity() {
                 val status by viewModel.status.observeAsState("")
 
                 if (status.isNotBlank()) {
-                    Toast.makeText(LocalContext.current, status, Toast.LENGTH_SHORT).show()
+                    snackbar.setText(status).show()
                     viewModel.statusDisplayed()
                 }
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/activity/LaunchPaymentSheetCustomActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/activity/LaunchPaymentSheetCustomActivity.kt
@@ -1,12 +1,10 @@
 package com.stripe.android.paymentsheet.example.samples.activity
 
 import android.os.Bundle
-import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.map
@@ -47,7 +45,7 @@ internal class LaunchPaymentSheetCustomActivity : BasePaymentSheetActivity() {
                 val paymentMethodIcon by selectedPaymentMethodIcon.observeAsState()
 
                 if (status.isNotBlank()) {
-                    Toast.makeText(LocalContext.current, status, Toast.LENGTH_SHORT).show()
+                    snackbar.setText(status).show()
                     viewModel.statusDisplayed()
                 }
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/activity/LaunchPaymentSheetWithComposeActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/activity/LaunchPaymentSheetWithComposeActivity.kt
@@ -1,13 +1,11 @@
 package com.stripe.android.paymentsheet.example.samples.activity
 
 import android.os.Bundle
-import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.ui.platform.LocalContext
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetContract
 
@@ -28,7 +26,7 @@ internal class LaunchPaymentSheetWithComposeActivity :
                 val status by viewModel.status.observeAsState("")
 
                 if (status.isNotBlank()) {
-                    Toast.makeText(LocalContext.current, status, Toast.LENGTH_SHORT).show()
+                    snackbar.setText(status).show()
                     viewModel.statusDisplayed()
                 }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Changes out the toasts that popup with the result to snackbars.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Toasts work kind of inconsistently on emulators plus I think the snackbar is better.

See: https://jira.corp.stripe.com/browse/MOBILESDK-398

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
|![output](https://user-images.githubusercontent.com/89166418/140232532-58638833-328d-4d89-94a4-2d1753d8965e.gif)|![output](https://user-images.githubusercontent.com/89166418/140232792-84792f15-3032-49a7-99d7-1e68626a82d4.gif)|
