### PR TITLE
fix CardInputWidget separation

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidgetPlacement.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidgetPlacement.kt
@@ -41,7 +41,7 @@ internal data class CardInputWidgetPlacement(
     private val cardPeekPostalCodeStartMargin: Int
         @JvmSynthetic
         get() {
-            return cardPeekCvcStartMargin + postalCodeWidth + cvcPostalCodeSeparation
+            return cardPeekCvcStartMargin + cvcWidth + cvcPostalCodeSeparation
         }
 
     @JvmSynthetic
@@ -71,6 +71,10 @@ internal data class CardInputWidgetPlacement(
         }
     }
 
+    private fun toMinimalValueIfNegative(value: Int) = if (value >= 0) {
+        value
+    } else MIN_SEPARATION_IN_PX
+
     @JvmSynthetic
     internal fun updateSpacing(
         isShowingFullCard: Boolean,
@@ -80,16 +84,22 @@ internal data class CardInputWidgetPlacement(
     ) {
         when {
             isShowingFullCard -> {
-                cardDateSeparation = frameWidth - cardWidth - dateWidth
+                cardDateSeparation =
+                    toMinimalValueIfNegative(frameWidth - cardWidth - dateWidth)
                 cardTouchBufferLimit = frameStart + cardWidth + cardDateSeparation / 2
                 dateStartPosition = frameStart + cardWidth + cardDateSeparation
             }
             postalCodeEnabled -> {
-                this.cardDateSeparation = (frameWidth * 3 / 10) - peekCardWidth - dateWidth / 4
-                this.dateCvcSeparation = (frameWidth * 3 / 5) - peekCardWidth - cardDateSeparation -
-                    dateWidth - cvcWidth
-                this.cvcPostalCodeSeparation = (frameWidth * 4 / 5) - peekCardWidth - cardDateSeparation -
-                    dateWidth - cvcWidth - dateCvcSeparation - postalCodeWidth
+                this.cardDateSeparation = toMinimalValueIfNegative(
+                    (frameWidth * 3 / 10) - peekCardWidth - dateWidth / 4
+                )
+                this.dateCvcSeparation = toMinimalValueIfNegative(
+                    (frameWidth * 3 / 5) - peekCardWidth - cardDateSeparation - dateWidth - cvcWidth
+                )
+                this.cvcPostalCodeSeparation =
+                    toMinimalValueIfNegative(
+                        frameWidth - peekCardWidth - cardDateSeparation - dateWidth - cvcWidth - dateCvcSeparation - postalCodeWidth
+                    )
 
                 val dateStartPosition = frameStart + peekCardWidth + cardDateSeparation
                 this.cardTouchBufferLimit = dateStartPosition / 3
@@ -104,9 +114,12 @@ internal data class CardInputWidgetPlacement(
                 this.postalCodeStartPosition = postalCodeStartPosition
             }
             else -> {
-                this.cardDateSeparation = frameWidth / 2 - peekCardWidth - dateWidth / 2
-                this.dateCvcSeparation = frameWidth - peekCardWidth - cardDateSeparation -
-                    dateWidth - cvcWidth
+                this.cardDateSeparation = toMinimalValueIfNegative(
+                    frameWidth / 2 - peekCardWidth - dateWidth / 2
+                )
+                this.dateCvcSeparation = toMinimalValueIfNegative(
+                    frameWidth - peekCardWidth - cardDateSeparation - dateWidth - cvcWidth
+                )
 
                 this.cardTouchBufferLimit = frameStart + peekCardWidth + cardDateSeparation / 2
                 this.dateStartPosition = frameStart + peekCardWidth + cardDateSeparation
@@ -224,5 +237,9 @@ internal data class CardInputWidgetPlacement(
             """
 
         return elementSizeData + touchBufferData
+    }
+
+    private companion object {
+        const val MIN_SEPARATION_IN_PX = 10
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -808,14 +808,14 @@ internal class CardInputWidgetTest {
                     dateWidth = 50,
                     dateCvcSeparation = 82,
                     cvcWidth = 30,
-                    cvcPostalCodeSeparation = 0,
+                    cvcPostalCodeSeparation = 100,
                     postalCodeWidth = 100,
                     cvcStartPosition = 330,
                     dateEndTouchBufferLimit = 110,
                     cardTouchBufferLimit = 66,
                     dateStartPosition = 198,
-                    cvcEndTouchBufferLimit = 120,
-                    postalCodeStartPosition = 360
+                    cvcEndTouchBufferLimit = 153,
+                    postalCodeStartPosition = 460
                 )
             )
     }
@@ -854,7 +854,7 @@ internal class CardInputWidgetTest {
         cardInputWidget.postalCodeEnabled = true
 
         // Moving to the end with an actual Visa number does the same as moving when empty.
-        // |(peek==40)--(space==98)--(date==50)--(space==82)--(cvc==30)--(space==0)--(postal==100)|
+        // |(peek==40)--(space==98)--(date==50)--(space==82)--(cvc==30)--(space==100)--(postal==100)|
         updateCardNumberAndIdle(VISA_WITH_SPACES)
 
         assertThat(cardInputWidget.placement)
@@ -868,14 +868,14 @@ internal class CardInputWidgetTest {
                     dateWidth = 50,
                     dateCvcSeparation = 82,
                     cvcWidth = 30,
-                    cvcPostalCodeSeparation = 0,
+                    cvcPostalCodeSeparation = 100,
                     postalCodeWidth = 100,
                     cvcStartPosition = 330,
-                    cvcEndTouchBufferLimit = 120,
+                    cvcEndTouchBufferLimit = 153,
                     dateEndTouchBufferLimit = 110,
                     cardTouchBufferLimit = 66,
                     dateStartPosition = 198,
-                    postalCodeStartPosition = 360
+                    postalCodeStartPosition = 460
                 )
             )
     }
@@ -914,7 +914,7 @@ internal class CardInputWidgetTest {
         cardInputWidget.postalCodeEnabled = true
 
         // Moving to the end with an AmEx number has a larger peek and cvc size.
-        // |(peek==50)--(space==88)--(date==50)--(space==72)--(cvc==40)--(space==0)--(postal==100)|
+        // |(peek==50)--(space==88)--(date==50)--(space==72)--(cvc==40)--(space==100)--(postal==100)|
         updateCardNumberAndIdle(AMEX_WITH_SPACES)
 
         assertThat(cardInputWidget.placement)
@@ -928,14 +928,14 @@ internal class CardInputWidgetTest {
                     dateWidth = 50,
                     dateCvcSeparation = 72,
                     cvcWidth = 40,
-                    cvcPostalCodeSeparation = 0,
+                    cvcPostalCodeSeparation = 100,
                     postalCodeWidth = 100,
                     cvcStartPosition = 320,
-                    cvcEndTouchBufferLimit = 120,
+                    cvcEndTouchBufferLimit = 153,
                     dateEndTouchBufferLimit = 106,
                     cardTouchBufferLimit = 66,
                     dateStartPosition = 198,
-                    postalCodeStartPosition = 360
+                    postalCodeStartPosition = 460
                 )
             )
     }
@@ -974,7 +974,7 @@ internal class CardInputWidgetTest {
         cardInputWidget.postalCodeEnabled = true
 
         // When we move for a Diner's club card, the peek text is shorter, so we expect:
-        // |(peek==20)--(space==205)--(date==50)--(space==195)--(cvc==30)--(space==0)--(postal==100)|
+        // |(peek==20)--(space==205)--(date==50)--(space==195)--(cvc==30)--(space==100)--(postal==100)|
         updateCardNumberAndIdle(DINERS_CLUB_14_WITH_SPACES)
 
         assertThat(cardInputWidget.placement)
@@ -988,14 +988,14 @@ internal class CardInputWidgetTest {
                     dateWidth = 50,
                     dateCvcSeparation = 82,
                     cvcWidth = 30,
-                    cvcPostalCodeSeparation = 0,
+                    cvcPostalCodeSeparation = 100,
                     postalCodeWidth = 100,
                     cvcStartPosition = 330,
                     dateEndTouchBufferLimit = 110,
                     cardTouchBufferLimit = 66,
                     dateStartPosition = 198,
-                    cvcEndTouchBufferLimit = 120,
-                    postalCodeStartPosition = 360
+                    cvcEndTouchBufferLimit = 153,
+                    postalCodeStartPosition = 460
                 )
             )
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fix a bug in calculating postal code start margin and force the separators to be not negative values

This would still leave a field not fully visible in very large font, but they won't overlap with each other

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
See [this](https://jira.corp.stripe.com/browse/RUN_MOBILESDK-467) internal jira


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screens

| Before  | After |
| ------------- | ------------- |
| ![ciwBefore](https://user-images.githubusercontent.com/79880926/140443935-1d98840d-2347-4919-b7fb-83ed0b3b6d6c.gif) | ![cardInputWidgetAfter](https://user-images.githubusercontent.com/79880926/140443966-5e918014-c20c-4289-8006-df46eb940fdf.gif)|

