### PR TITLE
Set the Google Pay status bar color onCreate

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherActivity.kt
@@ -65,6 +65,11 @@ internal class GooglePayLauncherActivity : AppCompatActivity() {
             return
         }
 
+        val statusColor = intent.getIntExtra(GooglePayLauncherContract.EXTRA_STATUS_BAR_COLOR, -1)
+        if (statusColor != -1) {
+            window.statusBarColor = statusColor
+        }
+
         viewModel.googlePayResult.observe(this) { googlePayResult ->
             googlePayResult?.let(::finishWithResult)
         }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherActivity.kt
@@ -42,6 +42,12 @@ internal class GooglePayPaymentMethodLauncherActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val statusColor = intent.getIntExtra(GooglePayPaymentMethodLauncherContract.EXTRA_STATUS_BAR_COLOR, -1)
+        if (statusColor != -1) {
+            window.statusBarColor = statusColor
+        }
+
         if (Build.VERSION.SDK_INT != Build.VERSION_CODES.O) {
             // In Oreo, Activities where `android:windowIsTranslucent=true` can't request
             // orientation. See https://stackoverflow.com/a/50832408/11103900


### PR DESCRIPTION
# Summary
Set the status bar color of the launched activity

# Motivation
So that the status bar doesn't flash purple when the launching activity is created.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Related previous PRs:
https://github.com/stripe/stripe-android/pull/4305
https://github.com/stripe/stripe-android/pull/4303
Run: 523

# PaymentLauncher Screenshots
| Before  | After |
| ------------- | ------------- |
| [*before screenshot*](https://user-images.githubusercontent.com/77996191/141198854-7441e19d-a153-4db4-8875-5bf23241abb4.mov)  | [*after screenshot*](https://user-images.githubusercontent.com/77996191/141198862-c8d2890b-28d8-42b6-b70a-95dda1f48402.mov) |


# GooglePayLauncher Screenshots
# Screenshots
| Before  | After |
| ------------- | ------------- |
| [*before screenshot*](https://user-images.githubusercontent.com/77996191/141198252-7c89b399-b0c3-47f9-a632-6092c0522eae.mov)  | [*after screenshot*](https://user-images.githubusercontent.com/77996191/141198264-2a27beaf-433b-41dd-87ab-b7bbd3e68162.mov) |




