### PR TITLE
Convert entered country code to display name if needed

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/view/CountryTextInputLayout.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CountryTextInputLayout.kt
@@ -132,6 +132,8 @@ class CountryTextInputLayout @JvmOverloads internal constructor(
                 val countryEntered = countryAutocomplete.text.toString()
                 CountryUtils.getCountryCodeByName(countryEntered, getLocale())?.let {
                     updateUiForCountryEntered(it)
+                } ?: CountryUtils.getCountryByCode(CountryCode.create(countryEntered), getLocale())?.let {
+                    updateUiForCountryEntered(CountryCode.create(countryEntered))
                 }
             }
         }


### PR DESCRIPTION
# Summary
Update the country code entered when autocomplete to the country name.  The widget is able to accept text even country codes, but it is expected to be the display name of the country, not the country code.

# Motivation
JIRA run 66

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

https://user-images.githubusercontent.com/77996191/141822422-c9504bee-894f-4906-8120-0b13e65dd91f.mov



