### PR TITLE
Fix snackbar NPE

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/activity/BasePaymentSheetActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/activity/BasePaymentSheetActivity.kt
@@ -44,10 +44,11 @@ internal abstract class BasePaymentSheetActivity : AppCompatActivity() {
         PaymentSheetViewModel(application)
     }
     
-    protected val snackbar = Snackbar.make(
-        findViewById(android.R.id.content),"", Snackbar.LENGTH_SHORT)
+    protected val snackbar by lazy {
+        Snackbar.make(findViewById(android.R.id.content), "", Snackbar.LENGTH_SHORT)
         .setBackgroundTint(resources.getColor(R.color.black))
         .setTextColor(resources.getColor(R.color.white))
+    }
 
     protected fun prepareCheckout(
         onSuccess: (PaymentSheet.CustomerConfiguration?, String) -> Unit


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We were trying to initialize our snackbar in the example apps too soon. If we switch to lazy initialization, the snackbar is in a good state by the time we need it. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

```
2021-11-22 08:44:49.778 7861-7861/com.stripe.android.paymentsheet.example E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.stripe.android.paymentsheet.example, PID: 7861
    java.lang.RuntimeException: Unable to instantiate activity ComponentInfo{com.stripe.android.paymentsheet.example/com.stripe.android.paymentsheet.example.samples.activity.LaunchPaymentSheetCompleteActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'android.content.pm.ApplicationInfo android.content.Context.getApplicationInfo()' on a null object reference
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3365)
        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3601)
        at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:85)
        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2066)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loop(Looper.java:223)
        at android.app.ActivityThread.main(ActivityThread.java:7656)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
     Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'android.content.pm.ApplicationInfo android.content.Context.getApplicationInfo()' on a null object reference
        at android.content.ContextWrapper.getApplicationInfo(ContextWrapper.java:173)
        at android.view.ContextThemeWrapper.getTheme(ContextThemeWrapper.java:174)
        at android.content.Context.obtainStyledAttributes(Context.java:744)
        at androidx.appcompat.app.AppCompatDelegateImpl.createSubDecor(AppCompatDelegateImpl.java:842)
        at androidx.appcompat.app.AppCompatDelegateImpl.ensureSubDecor(AppCompatDelegateImpl.java:809)
        at androidx.appcompat.app.AppCompatDelegateImpl.findViewById(AppCompatDelegateImpl.java:633)
        at androidx.appcompat.app.AppCompatActivity.findViewById(AppCompatActivity.java:259)
        at com.stripe.android.paymentsheet.example.samples.activity.BasePaymentSheetActivity.<init>(BasePaymentSheetActivity.kt:48)
        at com.stripe.android.paymentsheet.example.samples.activity.LaunchPaymentSheetCompleteActivity.<init>(LaunchPaymentSheetCompleteActivity.kt:10)
        at java.lang.Class.newInstance(Native Method)
        at android.app.AppComponentFactory.instantiateActivity(AppComponentFactory.java:95)
        at androidx.core.app.CoreComponentFactory.instantiateActivity(CoreComponentFactory.java:45)
        at android.app.Instrumentation.newActivity(Instrumentation.java:1253)
```

https://github.com/stripe/stripe-android/issues/4390

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
