### PR TITLE
add new translations

### DIFF
--- a/paymentsheet/res/values-b+es+419/strings.xml
+++ b/paymentsheet/res/values-b+es+419/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (opcional)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">Banco iDEAL</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Compra ahora y paga después con Klarna.</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Paga después con Klarna.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">O pagar con</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">Elimina %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Guardar para futuros pagos</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Guardar para futuros pagos a %s</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Guardar esta tarjeta para futuros pagos de %s</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-ca-rES/strings.xml
+++ b/paymentsheet/res/values-ca-rES/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (opcional)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">Bank iDeal</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Compra ara o paga més endavant amb Klarna.</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Paga més endavant amb Klarna.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">O pagar fent servir</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">Eliminar %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Guardar per a futurs pagaments</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Desar per futurs pagaments de %s</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Desar aquesta tarjeta per futurs %s pagaments</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-cs-rCZ/strings.xml
+++ b/paymentsheet/res/values-cs-rCZ/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (volitelné)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">Banka iDEAL</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Kupte nyní nebo zaplaťte později pomocí Klarna</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Zaplaťte později pomocí Klarna.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Nebo zaplatit pomocí</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">Odebrat %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Uložit pro budoucí platby</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Uložit pro budoucí platby %s</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Uložit tuto kartu pro budoucí platby %s</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-da/strings.xml
+++ b/paymentsheet/res/values-da/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (valgfrit)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Køb nu, eller betal senere med Klarna.</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Betal senere med Klarna.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Eller betal med</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">Fjern %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Gem til fremtidige betalinger</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Gem til fremtidige %s-betalinger</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Gem dette kort til fremtidige %s betalinger</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-de/strings.xml
+++ b/paymentsheet/res/values-de/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (optional)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">iDEAL-Bank</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Jetzt kaufen oder später mit Klarna bezahlen.</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Später mit Klarna bezahlen.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Oder zahlen mit</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">%s entfernen</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Für zukünftige Zahlungen speichern</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Für zukünftige %s-Zahlungen speichern</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Karte für zukünftige Zahlungen von %s speichern</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-el-rGR/strings.xml
+++ b/paymentsheet/res/values-el-rGR/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (προαιρετικό)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Αγορά τώρα ή πληρωμή αργότερα με Klarna.</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Πληρωμή αργότερα με Klarna.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Ή πληρωμή χρησιμοποιώντας</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">Αφαίρεση %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Αποθήκευση για μελλοντικές πληρωμές</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Αποθήκευση για μελλοντικές πληρωμές %s</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Αποθηκεύστε αυτή την κάρτα για μελλοντικές %s πληρωμές</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-en-rGB/strings.xml
+++ b/paymentsheet/res/values-en-rGB/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (optional)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Buy now or pay later with Klarna.</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Pay later with Klarna.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Or pay using</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">Remove %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Save for future payments</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Save for future %s payments</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Save this card for future %s payments</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-es/strings.xml
+++ b/paymentsheet/res/values-es/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (opcional)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">Banco iDEAL</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Compra ahora y paga después con Klarna.</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Paga después con Klarna.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">O paga con</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">Elimina %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Guardar para futuros pagos</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Guardar para futuros %s pagos</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Guardar esta tarjeta para realizar compras futuras en %s</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-et-rEE/strings.xml
+++ b/paymentsheet/res/values-et-rEE/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (valikuline)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">iDEALi pank</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Ostke nüüd või makske hiljem Klarnaga.</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Makske hiljem Klarnaga.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Või kasuta makseviisi</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">Eemalda %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Salvestage tulevasteks makseteks</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Salvestage tulevasteks %s makseteks</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Salvestage see kaart tulevasteks makseteks teenuses %s</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-fi/strings.xml
+++ b/paymentsheet/res/values-fi/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (valinnainen)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">iDEAL-pankki</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Osta nyt tai maksa myöhemmin Klarnalla.</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Maksa myöhemmin Klarnalla.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Tai käytä maksutapaa</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">Poista %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Tallenna tulevia maksuja varten</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Tallenna tulevia maksuja (%s) varten</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Tallenna tämä kortti tulevia maksuja (%s) varten</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-fr-rCA/strings.xml
+++ b/paymentsheet/res/values-fr-rCA/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (facultatif)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">Banque iDEAL</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Payez maintenant ou plus tard avec Klarna.</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Payez plus tard avec Klarna.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Ou payer avec</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">Supprimer %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Enregistrer pour les prochains achats</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Enregistrer pour mes prochains paiements auprès de %s</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Enregistrer cette carte pour vos prochains achats chez %s</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-fr/strings.xml
+++ b/paymentsheet/res/values-fr/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (facultatif)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">Banque iDEAL</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Paiement différé avec Klarna.</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Payer plus tard avec Klarna.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Ou payer avec</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">Supprimer %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Enregistrer pour de futurs achats</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Enregistrer pour vos paiements futurs auprès de %s</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Enregistrer cette carte pour vos futurs achats auprès de %s</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-hu/strings.xml
+++ b/paymentsheet/res/values-hu/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (nem kötelező)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">iDEAL bank</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Megvásárlás most, vagy fizetés később Klarnával.</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Fizetés később Klarnával.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Vagy fizetés a következővel:</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">%s eltávolítása</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Mentés a későbbi fizetésekhez</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Mentés a jövőbeni %s fizetésekhez</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">A kártya mentése a(z) %s részére történő fizetésekhez</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-it/strings.xml
+++ b/paymentsheet/res/values-it/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (campo facoltativo)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">Banca iDEAL</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Acquista ora o paga dopo con Klarna.</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Paga dopo con Klarna.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">O paga con</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">Rimuovi %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Salva per i pagamenti futuri</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Salva per i pagamenti futuri con %s</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Salva la carta per i pagamenti futuri di %s</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-ja/strings.xml
+++ b/paymentsheet/res/values-ja/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (オプション)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">iDEAL銀行</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Klarna で後払いします。</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Klarna での後払いにします。</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">または別の方法で支払う</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">%s を削除</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">今後の支払いのために保存する</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">今後の %s の支払いのために保存する</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">今後の %s の支払いのためにこのカードを保存する</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-ko/strings.xml
+++ b/paymentsheet/res/values-ko/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s(선택 사항)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">iDEAL 은행</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">지금 구매하거나 Klarna로 나중에 결제</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Klarna로 나중에 결제</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">또는 다음 결제 방식 사용</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">%s 제거</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">향후 결제에 사용하도록 저장</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">향후 %s 결제에 사용하도록 저장</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">이 카드를 향후 %s 결제에 사용하도록 저장</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-lt-rLT/strings.xml
+++ b/paymentsheet/res/values-lt-rLT/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (pasirenkamas)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">iDEAL bankas</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Pirkite dabar arba mokėkite vėliau naudodami \"Klarna\".</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Mokėkite vėliau naudodami \"Klarna\".</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Arba mokėti naudojant</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">Pašalinti %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Išsaugokite vėlesniems mokėjimams</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Išsaugoti vėlesniems %s mokėjimams</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Išsaugoti kortelę vėlesniems %s mokėjimams</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-lv-rLV/strings.xml
+++ b/paymentsheet/res/values-lv-rLV/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (nav obligāti)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">iDEAL banka</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Pērciet tagad vai maksājiet vēlāk ar Klarna.</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Maksāt vēlāk ar Klarna.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Vai maksāt, izmantojot</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">Noņemt%s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Saglabāt nākotnes maksājumiem</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Saglabāt nākotnes %s maksājumiem</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Saglabāt šo karti %s maksājumiem nākotnē</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-mt/strings.xml
+++ b/paymentsheet/res/values-mt/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (mhux obbligatorja)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">Il-Bank iDEAL</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Ixtri issa jew ħallas iktar tard bil-Klarna.</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Ħlas aktar tard bil-Klarna.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Jew ħallas bil-</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">Neħħi %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Erfa\' għall-pagamenti fil-ġejjieni</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Issejvja għall-pagamenti futuri lil %s</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Erfa\' din il-kard għal pagamenti futuri %s</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-nb/strings.xml
+++ b/paymentsheet/res/values-nb/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (valgfritt)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Kjøp nå eller betal senere med Klarna.</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Betal senere med Klarna.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Eller betal med</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">Fjern %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Lagre til fremtidige betalinger</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Lagre til fremtidige betalinger til %s</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Lagre kortet til fremtidige betalinger hos %s</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-nl/strings.xml
+++ b/paymentsheet/res/values-nl/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (optioneel)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">iDEAL-bank</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Koop nu of betaal later met Klarna.</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Betaal later met Klarna.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Of betalen met</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">%s verwijderen</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Opslaan voor toekomstige betalingen</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Opslaan voor toekomstige %s-betalingen</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Deze kaart opslaan voor toekomstige aankopen bij %s</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-nn-rNO/strings.xml
+++ b/paymentsheet/res/values-nn-rNO/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (valfritt)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">***</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">***</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Eller betal ved å bruke</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">Fjern %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Lagre for framtidige betalingar</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">***</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Lagre dette kortet for framtidige %s betalingar</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-nn-rNO/strings.xml
+++ b/paymentsheet/res/values-nn-rNO/strings.xml
@@ -92,10 +92,6 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (valfritt)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
-  <!-- Klarna buy now or pay later copy -->
-  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">***</string>
-  <!-- Klarna pay later copy -->
-  <string name="stripe_paymentsheet_klarna_pay_later">***</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Eller betal ved å bruke</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -118,8 +114,6 @@
   <string name="stripe_paymentsheet_remove_pm">Fjern %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Lagre for framtidige betalingar</string>
-  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
-  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">***</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Lagre dette kortet for framtidige %s betalingar</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-pl-rPL/strings.xml
+++ b/paymentsheet/res/values-pl-rPL/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (opcjonalnie)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Kup teraz lub zapłać za pomocą Klarna później.</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Zapłać później za pomocą Klarna.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Lub zapłać, korzystając z</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">Usuń: %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Zapisz do przyszłych płatności</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Zapisz do przyszłych %s płatności</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Zapisz dane tej karty do przyszłych płatności %s</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-pt-rBR/strings.xml
+++ b/paymentsheet/res/values-pt-rBR/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (opcional)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">Banco iDEAL</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Compre agora ou pague depois com Klarna.</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Pagar depois com Klarna.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Ou pague com</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">Remover %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Salvar para pagamentos futuros</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Salvar para pagamentos futuros a %s</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Salvar este cartão para pagamentos futuros a %s</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-pt-rPT/strings.xml
+++ b/paymentsheet/res/values-pt-rPT/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (opcional)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">Banco iDEAL</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Comprar agora ou pagar mais tarde com Klarna.</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Pagar mais tarde com Klarna.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Ou pagar com</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">Remover %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Guardar para pagamentos futuros</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Guardar para pagamentos %s futuros</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Guardar este cartão para pagamentos futuros %s</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-ro-rRO/strings.xml
+++ b/paymentsheet/res/values-ro-rRO/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (opțional)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Cumpărați acum sau plătiți mai târziu folosind Klarna.</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Plătiți mai târziu folosind Klarna.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Sau folosiți ca metodă de plată</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">Eliminați %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Salvați pentru plăți viitoare</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Salvați pentru plăți viitoare %s</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Salvați acest card pentru plăți viitoare către %s</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-ru/strings.xml
+++ b/paymentsheet/res/values-ru/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (необязательно)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">Банк в системе iDEAL</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Купить немедленно или оплатить позже через систему Klarna.</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Оплатить позже через систему Klarna.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Или оплатить с помощью</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">Удалить %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Сохранить данные для будущих платежей</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Сохранить данные для будущих платежей поставщику %s</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Сохранить данные этой карты для будущих платежей %s</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-sk-rSK/strings.xml
+++ b/paymentsheet/res/values-sk-rSK/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (voliteľné)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">iDEAL banka</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Kúpte teraz alebo zaplaťte neskôr pomocou služby Klarna.</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Zaplatiť neskôr pomocou služby Klarna</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Alebo zaplaťte pomocou</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">Odstrániť %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Uložiť pre budúce platby</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Uložiť pre budúce platby spoločnosti %s</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Uložiť túto kartu pre budúce platby obchodníkovi %s</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-sl-rSI/strings.xml
+++ b/paymentsheet/res/values-sl-rSI/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (izbirno)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">Banka iDEAL</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Kupite zdaj ali pa plačajte pozneje s storitvijo Klarna.</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Plačajte pozneje s storitvijo Klarna.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Ali pa za plačilo uporabite</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">Odstrani %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Shrani za prihodnja plačila</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Shrani za prihodnja plačila trgovcu %s</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Shrani to kartico za prihodnja plačila trgovcu %s</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-sv/strings.xml
+++ b/paymentsheet/res/values-sv/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (valfritt)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Köp nu eller betala senare med Klarna.</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Betala senare med Klarna.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Eller betala genom att använda</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">Ta bort %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Spara för framtida betalningar</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Spara för framtida %s-betalningar</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Spara detta kort för framtiden %s betalningar</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-tr/strings.xml
+++ b/paymentsheet/res/values-tr/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (isteğe bağlı)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Şimdi satın alın veya daha sonra Klarna ile ödeyin.</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Daha sonra Klarna ile ödeyin.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Veya şununla ödeyin:</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">%s yöntemini kaldırın</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Gelecekteki ödemeler için kaydedilsin</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Gelecekteki %s ödemeleri için kaydedilsin</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Bu kartı gelecekteki %s ödemeleri için kaydedin</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-zh-rHK/strings.xml
+++ b/paymentsheet/res/values-zh-rHK/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s（可選）</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">iDEAL 銀行</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">用 Klarna 先買後付。</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">用 Klarna 延後支付。</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">或用以下方式支付</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">移除 %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">保存以用於未來的付款</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">保存以用於未來的%s付款</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">保存該卡，用於未來在 %s 付款</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-zh-rTW/strings.xml
+++ b/paymentsheet/res/values-zh-rTW/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s（可選）</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">iDEAL 銀行</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">用 Klarna 先買後付。</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">用 Klarna 延後支付。</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">或用以下方式支付</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">移除 %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">保存以用於未來的付款</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">保存以用於未來的%s付款</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">保存該卡，用於未來在 %s 付款。</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values-zh/strings.xml
+++ b/paymentsheet/res/values-zh/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s（可选）</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">iDEAL 银行</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">用 Klarna 先买后付。</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">用 Klarna 延后支付。</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">或用以下方式支付</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">移除 %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">保存以用于未来的付款</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">保存以用于未来的 %s 付款</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">保存该卡，用于未来在 %s 付款</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
   <!-- Used for accessibility to describe the button on the payment sheet list of options to add a new payment method. -->
   <string name="add_new_payment_method">Add a new payment method</string>
   <!-- Label for input requesting address line 2, used for international addresses -->
@@ -93,9 +93,9 @@
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
   <!-- Klarna buy now or pay later copy -->
-  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Buy now or pay later with Klarna.</string>
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later" tools:ignore="MissingTranslation">Buy now or pay later with Klarna.</string>
   <!-- Klarna pay later copy -->
-  <string name="stripe_paymentsheet_klarna_pay_later">Pay later with Klarna.</string>
+  <string name="stripe_paymentsheet_klarna_pay_later" tools:ignore="MissingTranslation">Pay later with Klarna.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Or pay using</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -119,7 +119,7 @@
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Save for future payments</string>
   <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
-  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Save for future %s payments</string>
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name" tools:ignore="MissingTranslation">Save for future %s payments</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Save this card for future %s payments</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -92,6 +92,10 @@
   <string name="stripe_paymentsheet_form_label_optional">%s (optional)</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="stripe_paymentsheet_ideal_bank">iDEAL Bank</string>
+  <!-- Klarna buy now or pay later copy -->
+  <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Buy now or pay later with Klarna.</string>
+  <!-- Klarna pay later copy -->
+  <string name="stripe_paymentsheet_klarna_pay_later">Pay later with Klarna.</string>
   <!-- Title of a section containing multiple payment methods that can selected and will collect the payment information from the user. -->
   <string name="stripe_paymentsheet_or_pay_using">Or pay using</string>
   <!-- Title of a section containing a card form that will collect the payment information from the user. -->
@@ -114,6 +118,8 @@
   <string name="stripe_paymentsheet_remove_pm">Remove %s</string>
   <!-- The label of a switch indicating whether to save the payment method for future payments. -->
   <string name="stripe_paymentsheet_save_for_future_payments">Save for future payments</string>
+  <!-- Next to the save payment method users will see the merchant name: "Save for future Example.inc Payments" -->
+  <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Save for future %s payments</string>
   <!-- The label of a switch indicating whether to save the user&apos;s card for future payments to this merchant -->
   <string name="stripe_paymentsheet_save_this_card_with_merchant_name">Save this card for future %s payments</string>
   <!-- Title shown above a carousel containing the customer&apos;s payment methods -->

--- a/paymentsheet/res/values/totranslate.xml
+++ b/paymentsheet/res/values/totranslate.xml
@@ -3,7 +3,4 @@
     <!--
     Items here need to be entered in our translation tool
     -->
-    <string name="stripe_paymentsheet_klarna_buy_now_pay_later">Buy now or pay later with Klarna.</string>
-    <string name="stripe_paymentsheet_klarna_pay_later">Pay later with Klarna.</string>
-    <string name="stripe_paymentsheet_save_for_future_payments_with_merchant_name">Save for future %s payments</string>
 </resources>


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Adds translations for the following strings and removes them from the untranslated list:
```
"stripe_paymentsheet_klarna_buy_now_pay_later"
"stripe_paymentsheet_klarna_pay_later"
"stripe_paymentsheet_save_for_future_payments_with_merchant_name"
```

supressing nn-NO while we wait for translation for that language, so the linter doesn't fail. 
# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
