### PR TITLE
Prevent rapidly swapping between card found and wrong card on difficult to read cards

### DIFF
--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/result/MainLoopState.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/result/MainLoopState.kt
@@ -53,9 +53,9 @@ internal sealed class MainLoopState(
     class OcrFound private constructor(
         private val panCounter: ItemCounter<String>,
         private var visibleCardCount: Int,
-        override val requiredCardIssuer: CardIssuer?,
-        override val requiredLastFour: String?,
-    ) : MainLoopState(runOcr = true, runCardDetect = true), RequiresMatchingCard {
+        private val requiredCardIssuer: CardIssuer?,
+        private val requiredLastFour: String?,
+    ) : MainLoopState(runOcr = true, runCardDetect = true) {
 
         internal constructor(
             pan: String,
@@ -99,15 +99,8 @@ internal sealed class MainLoopState(
             }
 
             val pan = mostLikelyPan
-            val cardMatch = compareToRequiredCard(pan)
 
             return when {
-                cardMatch is CardMatchResult.Mismatch ->
-                    WrongCard(
-                        pan = pan,
-                        requiredCardIssuer = requiredCardIssuer,
-                        requiredLastFour = requiredLastFour,
-                    )
                 isCardSatisfied() && isOcrSatisfied() ->
                     Finished(
                         pan = pan,
@@ -162,9 +155,9 @@ internal sealed class MainLoopState(
 
     class CardSatisfied(
         private val panCounter: ItemCounter<String>,
-        override val requiredCardIssuer: CardIssuer?,
-        override val requiredLastFour: String?,
-    ) : MainLoopState(runOcr = true, runCardDetect = false), RequiresMatchingCard {
+        private val requiredCardIssuer: CardIssuer?,
+        private val requiredLastFour: String?,
+    ) : MainLoopState(runOcr = true, runCardDetect = false) {
 
         private var lastCardVisible = Clock.markNow()
 
@@ -188,15 +181,8 @@ internal sealed class MainLoopState(
             }
 
             val pan = mostLikelyPan
-            val cardMatch = compareToRequiredCard(pan)
 
             return when {
-                cardMatch is CardMatchResult.Mismatch ->
-                    WrongCard(
-                        pan = pan,
-                        requiredCardIssuer = requiredCardIssuer,
-                        requiredLastFour = requiredLastFour,
-                    )
                 isOcrSatisfied() || isTimedOut() ->
                     Finished(
                         pan = pan,

--- a/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardimageverification/result/MainLoopStateMachineTest.kt
+++ b/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardimageverification/result/MainLoopStateMachineTest.kt
@@ -264,6 +264,25 @@ class MainLoopStateMachineTest {
     }
 
     @Test
+    @LargeTest
+    fun panFound_wrongCardIgnored() = runBlocking {
+        val state = MainLoopState.OcrFound(
+            pan = "4847186095118770",
+            isCardVisible = true,
+            requiredCardIssuer = CardIssuer.Visa,
+            requiredLastFour = "8770",
+        )
+
+        val prediction = MainLoopAnalyzer.Prediction(
+            ocr = SSDOcr.Prediction(pan = "5445435282861343"),
+            card = null,
+        )
+
+        val newState = state.consumeTransition(prediction)
+        assertTrue(newState is MainLoopState.OcrFound, "$newState is not OcrFound")
+    }
+
+    @Test
     fun panSatisfied_runsCardDetectOnly() {
         val state = MainLoopState.OcrSatisfied(
             pan = "4847186095118770",
@@ -418,6 +437,24 @@ class MainLoopStateMachineTest {
 
         val newState = state.consumeTransition(prediction)
         assertTrue(newState is MainLoopState.Finished)
+    }
+
+    @Test
+    @LargeTest
+    fun cardSatisfied_wrongCardIgnored() = runBlocking {
+        val state = MainLoopState.CardSatisfied(
+            panCounter = ItemCounter("4847186095118770"),
+            requiredCardIssuer = CardIssuer.Visa,
+            requiredLastFour = "8770",
+        )
+
+        val prediction = MainLoopAnalyzer.Prediction(
+            ocr = SSDOcr.Prediction(pan = "5445435282861343"),
+            card = null,
+        )
+
+        val newState = state.consumeTransition(prediction)
+        assertTrue(newState is MainLoopState.CardSatisfied, "$newState is not CardSatisfied")
     }
 
     @Test


### PR DESCRIPTION
# Summary
For cards that are difficult for OCR to read, it's possible that OCR will flip back and forth between two valid PANs. In this case, if one of the PANs matches the required card, it's likely the correct pan.

Once we've read a correct PAN, do not swap back to an incorrect state.

# Motivation
This is to improve the good user experience when the card is difficult for OCR to read.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified
