### PR TITLE
revert static height on cmw text boxes

### DIFF
--- a/payments-core/res/layout/card_multiline_widget.xml
+++ b/payments-core/res/layout/card_multiline_widget.xml
@@ -8,7 +8,7 @@
         android:id="@+id/tl_card_number"
         style="@style/Stripe.CardMultilineWidget.TextInputLayout"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/stripe_cmw_edit_text_minheight"
+        android:layout_height="wrap_content"
         android:hint="@string/acc_label_card_number"
         android:layout_marginTop="@dimen/stripe_add_card_element_vertical_margin">
 
@@ -34,7 +34,7 @@
             android:id="@+id/tl_expiry"
             style="@style/Stripe.CardMultilineWidget.TextInputLayout"
             android:layout_width="0dp"
-            android:layout_height="@dimen/stripe_cmw_edit_text_minheight"
+            android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/stripe_add_card_element_vertical_margin"
             android:layout_marginEnd="@dimen/stripe_add_card_expiry_middle_margin"
             android:layout_weight="1"
@@ -48,7 +48,8 @@
                 android:imeOptions="actionNext"
                 android:digits="@string/stripe_expiration_date_allowlist"
                 android:nextFocusDown="@+id/et_cvc"
-                android:nextFocusForward="@+id/et_cvc"/>
+                android:nextFocusForward="@+id/et_cvc"
+                android:minHeight="@dimen/stripe_cmw_edit_text_minheight" />
 
         </com.google.android.material.textfield.TextInputLayout>
 
@@ -56,7 +57,7 @@
             android:id="@+id/tl_cvc"
             style="@style/Stripe.CardMultilineWidget.TextInputLayout"
             android:layout_width="0dp"
-            android:layout_height="@dimen/stripe_cmw_edit_text_minheight"
+            android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/stripe_add_card_element_vertical_margin"
             android:layout_marginEnd="@dimen/stripe_add_card_expiry_middle_margin"
             android:layout_weight="1"
@@ -68,7 +69,8 @@
                 android:layout_height="wrap_content"
                 android:imeOptions="actionNext"
                 android:nextFocusDown="@+id/et_postal_code"
-                android:nextFocusForward="@+id/et_postal_code"/>
+                android:nextFocusForward="@+id/et_postal_code"
+                android:minHeight="@dimen/stripe_cmw_edit_text_minheight" />
 
         </com.google.android.material.textfield.TextInputLayout>
 
@@ -76,7 +78,7 @@
             android:id="@+id/tl_postal_code"
             style="@style/Stripe.CardMultilineWidget.TextInputLayout"
             android:layout_width="0dp"
-            android:layout_height="@dimen/stripe_cmw_edit_text_minheight"
+            android:layout_height="wrap_content"
             android:layout_weight="1"
             android:layout_marginTop="@dimen/stripe_add_card_element_vertical_margin"
             app:placeholderText="@string/stripe_postalcode_placeholder">
@@ -85,7 +87,8 @@
                 android:id="@+id/et_postal_code"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:imeOptions="actionDone"/>
+                android:imeOptions="actionDone"
+                android:minHeight="@dimen/stripe_cmw_edit_text_minheight" />
 
         </com.google.android.material.textfield.TextInputLayout>
     </LinearLayout>

--- a/payments-core/res/values/dimens.xml
+++ b/payments-core/res/values/dimens.xml
@@ -26,7 +26,7 @@
     <!-- Text size of CardInputWidget EditText views -->
     <dimen name="ciw_stripe_edit_text_size">18sp</dimen>
 
-    <dimen name="stripe_cmw_edit_text_minheight">50dp</dimen>
+    <dimen name="stripe_cmw_edit_text_minheight">48dp</dimen>
 
     <!-- Text size of BECS Debit Widget EditTexts -->
     <dimen name="stripe_becs_debit_widget_edit_text_size">14sp</dimen>


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This reverts my change here: https://github.com/stripe/stripe-android/pull/4266

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
We've been getting some user issues: https://github.com/stripe/stripe-android/issues/4389

Making the text boxes `wrap_content` for CardMultilineWidget is okay now that we'll have a compose version of the card payment form for payment sheet.  Then we won't need the height of CardMultilineWidget static for payment sheet. We'll be able to set text box heights independently of other UIs and keep it uniform across all payment sheet PM forms. For now with this change, the text boxes will be slightly taller but CardMultilineWidget users will not see cutoff text. (until this pr https://github.com/stripe/stripe-android/pull/4358 then the issue will go away completely) 

This also fixes a spacing issue where the new card icons were sitting on the divider lines with no spacing.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After|
| ------------- | ------------- |
|![psbefore](https://user-images.githubusercontent.com/89166418/143178252-cc640de7-324d-4095-bef1-f2a109580ea5.png)|  ![psafter](https://user-images.githubusercontent.com/89166418/143178287-4b24d93e-d8c9-4100-84eb-4cf650b9115b.png)|
|![examplebefore](https://user-images.githubusercontent.com/89166418/143178305-975bb13d-aa20-4a3e-a039-6fe914d70aca.png)|![exampleafter](https://user-images.githubusercontent.com/89166418/143178314-ad5de387-3b12-4f43-984b-76397341e72b.png)|


