### PR TITLE
Match klarna text to or pay using text

### DIFF
--- a/paymentsheet/res/values/colors.xml
+++ b/paymentsheet/res/values/colors.xml
@@ -35,6 +35,7 @@
     <color name="stripe_paymentsheet_add_payment_method_form_stroke">#33787880</color>
     <color name="stripe_paymentsheet_add_pm_card_unselected_stroke">#E7E7E7</color>
     <color name="stripe_paymentsheet_add_pm_card_selected_stroke">#343434</color>
+    <color name="stripe_paymentsheet_mandate_text_color">#FF888888</color>
 
     <color name="stripe_paymentsheet_error_text">#DC2727</color>
     <color name="stripe_paymentsheet_form_error">#CF6679</color>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/StaticTextElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/StaticTextElement.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet.elements
 
-import androidx.compose.ui.graphics.Color
 import com.stripe.android.paymentsheet.forms.FormFieldEntry
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -13,7 +12,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 internal data class StaticTextElement(
     override val identifier: IdentifierSpec,
     val stringResId: Int,
-    val color: Color?,
+    val color: Int?,
     val merchantName: String?,
     val fontSizeSp: Int = 10,
     val letterSpacingSp: Double = .7,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/StaticTextElementUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/StaticTextElementUI.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
@@ -22,10 +23,16 @@ internal fun StaticElementUI(
         modifier = Modifier
             .padding(vertical = 8.dp)
             .semantics(mergeDescendants = true) {}, // makes it a separate accessibile item
-        color = element.color ?: if (isSystemInDarkTheme()) {
-            Color.LightGray
-        } else {
-            Color.Black
+        color = when {
+            element.color != null -> {
+                colorResource(element.color)
+            }
+            isSystemInDarkTheme() -> {
+                Color.LightGray
+            }
+            else -> {
+                Color.Black
+            }
         }
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/StaticTextSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/StaticTextSpec.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.paymentsheet.elements
 
+import androidx.annotation.ColorRes
 import androidx.annotation.StringRes
-import androidx.compose.ui.graphics.Color
 
 /**
  * This is for elements that do not receive user input
@@ -9,7 +9,7 @@ import androidx.compose.ui.graphics.Color
 internal data class StaticTextSpec(
     override val identifier: IdentifierSpec,
     @StringRes val stringResId: Int,
-    val color: Color? = null,
+    @ColorRes val color: Int? = null,
     val fontSizeSp: Int = 10,
     val letterSpacingSp: Double = .7
 ) : FormItemSpec(), RequiredItemSpec

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/BancontactSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/BancontactSpec.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet.forms
 
-import androidx.compose.ui.graphics.Color
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.elements.EmailSpec
 import com.stripe.android.paymentsheet.elements.IdentifierSpec
@@ -53,7 +52,7 @@ internal val bancontactEmailSection =
 internal val bancontactMandate = StaticTextSpec(
     IdentifierSpec.Generic("mandate"),
     R.string.stripe_paymentsheet_sepa_mandate,
-    Color.Gray
+    R.color.stripe_paymentsheet_mandate_text_color
 )
 
 internal val BancontactForm = LayoutSpec.create(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/IdealSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/IdealSpec.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet.forms
 
-import androidx.compose.ui.graphics.Color
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.elements.BankDropdownSpec
 import com.stripe.android.paymentsheet.elements.EmailSpec
@@ -67,7 +66,7 @@ internal val idealBankSection = SectionSpec(
 internal val idealMandate = StaticTextSpec(
     IdentifierSpec.Generic("mandate"),
     R.string.stripe_paymentsheet_sepa_mandate,
-    Color.Gray
+    R.color.stripe_paymentsheet_mandate_text_color
 )
 
 internal val IdealForm = LayoutSpec.create(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/KlarnaSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/KlarnaSpec.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.forms
 
+import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.elements.EmailSpec
 import com.stripe.android.paymentsheet.elements.IdentifierSpec
 import com.stripe.android.paymentsheet.elements.KlarnaCountrySpec
@@ -27,7 +28,8 @@ internal val klarnaHeader = StaticTextSpec(
     identifier = IdentifierSpec.Generic("klarna_header"),
     stringResId = KlarnaHelper.getKlarnaHeader(),
     fontSizeSp = 13,
-    letterSpacingSp = -.15
+    letterSpacingSp = -.15,
+    color = R.color.stripe_paymentsheet_googlepay_divider_text
 )
 
 internal val klarnaEmailSection =

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/SepaDebitSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/SepaDebitSpec.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet.forms
 
-import androidx.compose.ui.graphics.Color
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.elements.AddressSpec
@@ -85,7 +84,7 @@ internal val sepaDebitIbanSection = SectionSpec(
 internal val sepaDebitMandate = StaticTextSpec(
     IdentifierSpec.Generic("mandate"),
     R.string.stripe_paymentsheet_sepa_mandate,
-    Color.Gray
+    R.color.stripe_paymentsheet_mandate_text_color
 )
 internal val sepaBillingSection = SectionSpec(
     IdentifierSpec.Generic("billing_section"),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/SofortSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/SofortSpec.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet.forms
 
-import androidx.compose.ui.graphics.Color
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.elements.CountrySpec
 import com.stripe.android.paymentsheet.elements.EmailSpec
@@ -63,7 +62,7 @@ internal val sofortCountrySection =
 internal val sofortMandate = StaticTextSpec(
     IdentifierSpec.Generic("mandate"),
     R.string.stripe_paymentsheet_sepa_mandate,
-    Color.Gray
+    R.color.stripe_paymentsheet_mandate_text_color
 )
 
 internal val SofortForm = LayoutSpec.create(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformSpecToElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/TransformSpecToElementTest.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet.forms
 
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import com.google.common.truth.Truth.assertThat
@@ -192,7 +191,7 @@ internal class TransformSpecToElementTest {
         val staticText = StaticTextSpec(
             IdentifierSpec.Generic("mandate"),
             stringResId = R.string.stripe_paymentsheet_sepa_mandate,
-            color = Color.Gray,
+            color = R.color.stripe_paymentsheet_mandate_text_color,
             fontSizeSp = 120,
             letterSpacingSp = 120.0
         )
@@ -216,7 +215,7 @@ internal class TransformSpecToElementTest {
             val mandate = StaticTextSpec(
                 IdentifierSpec.Generic("mandate"),
                 R.string.stripe_paymentsheet_sepa_mandate,
-                Color.Gray
+                color = R.color.stripe_paymentsheet_mandate_text_color,
             )
             val hiddenIdentifiers = listOf(nameSection, mandate)
             val saveForFutureUseSpec = SaveForFutureUseSpec(hiddenIdentifiers)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* matches Klarna's "buy now or pay later" text to to "or pay using" text.
* converts the StaticTextSpec from using compose's color class as an input to using color resource IDs. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
* https://paper.dropbox.com/doc/Klarna-UI-polish-items--BW2_srb9vbiB_KCm6ofBt7CEAg-Ox7FXrEh90mKen5IeploR
* I think the api is better with a color resource rather than the limited colors compose provides by default.
* Note that the mandate text color is the same as compose's `Color.gray`

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
|![paylaterdarkold](https://user-images.githubusercontent.com/89166418/143291838-e3c558d8-58fe-48d4-b718-ceede27192f8.png)|![paylaterdarknew](https://user-images.githubusercontent.com/89166418/143291872-8c8d6cc4-8daf-43b0-807b-38ec9b8e18f6.png)|
|![paylaterlightold](https://user-images.githubusercontent.com/89166418/143291912-8abfa860-7f32-490d-9d00-3d31015dbe2c.png)|![paylaterlightnew](https://user-images.githubusercontent.com/89166418/143291942-652bdd63-fb1c-49f7-8923-9bddc42c2fd5.png)|
