### PR TITLE
Remove proguard section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Table of contents
    * [Installation](#installation)
       * [Requirements](#requirements)
       * [Configuration](#configuration)
-      * [Proguard](#proguard)
    * [Getting Started](#getting-started)
    * [Examples](#examples)
 <!--te-->
@@ -68,10 +67,6 @@ dependencies {
     implementation 'com.stripe:stripe-android:18.2.0'
 }
 ```
-
-### Proguard
-
-The Stripe Android SDK will configure your app's Proguard rules using [proguard-rules.txt](stripe/proguard-rules.txt).
 
 ## Getting Started
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Remove proguard section from README.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Reference was broken after we modularized the SDK, but it's not really needed since there's no action needed from developers (#1597) and can cause confusion (#4401).
