### PR TITLE
callback for postal code complete

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -5671,6 +5671,7 @@ public abstract interface class com/stripe/android/view/CardInputListener {
 	public abstract fun onCvcComplete ()V
 	public abstract fun onExpirationComplete ()V
 	public abstract fun onFocusChange (Lcom/stripe/android/view/CardInputListener$FocusField;)V
+	public abstract fun onUsZipCodeComplete ()V
 }
 
 public final class com/stripe/android/view/CardInputListener$FocusField : java/lang/Enum {

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -5671,7 +5671,7 @@ public abstract interface class com/stripe/android/view/CardInputListener {
 	public abstract fun onCvcComplete ()V
 	public abstract fun onExpirationComplete ()V
 	public abstract fun onFocusChange (Lcom/stripe/android/view/CardInputListener$FocusField;)V
-	public abstract fun onUsZipCodeComplete ()V
+	public abstract fun onPostalCodeComplete ()V
 }
 
 public final class com/stripe/android/view/CardInputListener$FocusField : java/lang/Enum {

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputListener.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputListener.kt
@@ -41,9 +41,9 @@ interface CardInputListener {
     fun onCvcComplete()
 
     /**
-     * Called when a valid US zip code has been entered.
+     * Called when a valid postal code has been entered.
      * May be called multiple times, if the user edits the field.
-     * Only works if the [CardWidget] it's used in requires zip code and only collects US cards.
+     * If the [CardWidget] is not collecting US card, any non-empty postal is considered valid.
      */
-    fun onUsZipCodeComplete()
+    fun onPostalCodeComplete()
 }

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputListener.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputListener.kt
@@ -43,7 +43,7 @@ interface CardInputListener {
     /**
      * Called when a valid US zip code has been entered.
      * May be called multiple times, if the user edits the field.
-     * Only works if the [CardWidget] it's used in collects US cards.
+     * Only works if the [CardWidget] it's used in requires zip code and only collects US cards.
      */
     fun onUsZipCodeComplete()
 }

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputListener.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputListener.kt
@@ -39,4 +39,11 @@ interface CardInputListener {
      * the user edits the CVC.
      */
     fun onCvcComplete()
+
+    /**
+     * Called when a valid US zip code has been entered.
+     * May be called multiple times, if the user edits the field.
+     * Only works if the [CardWidget] it's used in collects US cards.
+     */
+    fun onUsZipCodeComplete()
 }

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -747,6 +747,12 @@ class CardInputWidget @JvmOverloads constructor(
             }
         }
 
+        postalCodeEditText.setAfterTextChangedListener {
+            if (postalCodeEditText.hasValidUsZip()) {
+                cardInputListener?.onUsZipCodeComplete()
+            }
+        }
+
         cardNumberEditText.completionCallback = {
             scrollEnd()
             cardInputListener?.onCardComplete()

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -748,8 +748,8 @@ class CardInputWidget @JvmOverloads constructor(
         }
 
         postalCodeEditText.setAfterTextChangedListener {
-            if (postalCodeEditText.hasValidUsZip()) {
-                cardInputListener?.onUsZipCodeComplete()
+            if (isPostalRequired() && postalCodeEditText.hasValidPostal()) {
+                cardInputListener?.onPostalCodeComplete()
             }
         }
 

--- a/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -367,6 +367,12 @@ class CardMultilineWidget @JvmOverloads constructor(
             cvcEditText.shouldShowError = false
         }
 
+        postalCodeEditText.setAfterTextChangedListener {
+            if (postalCodeEditText.hasValidUsZip()) {
+                cardInputListener?.onUsZipCodeComplete()
+            }
+        }
+
         adjustViewForPostalCodeAttribute(shouldShowPostalCode)
 
         cardNumberEditText.updateLengthFilter()

--- a/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -146,6 +146,9 @@ class CardMultilineWidget @JvmOverloads constructor(
         }
     }
 
+    private fun isPostalRequired() =
+        (postalCodeRequired || usZipCodeRequired) && shouldShowPostalCode
+
     /**
      * A [PaymentMethodCreateParams.Card] representing the card details if all fields are valid;
      * otherwise `null`
@@ -368,8 +371,8 @@ class CardMultilineWidget @JvmOverloads constructor(
         }
 
         postalCodeEditText.setAfterTextChangedListener {
-            if (postalCodeEditText.hasValidUsZip()) {
-                cardInputListener?.onUsZipCodeComplete()
+            if (isPostalRequired() && postalCodeEditText.hasValidPostal()) {
+                cardInputListener?.onPostalCodeComplete()
             }
         }
 

--- a/payments-core/src/main/java/com/stripe/android/view/PostalCodeEditText.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PostalCodeEditText.kt
@@ -112,8 +112,12 @@ class PostalCodeEditText @JvmOverloads constructor(
         US
     }
 
-    internal fun hasValidUsZip() =
-        config == Config.US && ZIP_CODE_PATTERN.matcher(fieldText).matches()
+    /**
+     * Returns if the postal is valid. If config is not US, any non-empty postal is valid.
+     */
+    internal fun hasValidPostal() =
+        config == Config.US && ZIP_CODE_PATTERN.matcher(fieldText)
+            .matches() || config == Config.Global && fieldText.isNotEmpty()
 
     private companion object {
         private const val MAX_LENGTH_US = 5

--- a/payments-core/src/main/java/com/stripe/android/view/PostalCodeEditText.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PostalCodeEditText.kt
@@ -112,6 +112,9 @@ class PostalCodeEditText @JvmOverloads constructor(
         US
     }
 
+    internal fun hasValidUsZip() =
+        config == Config.US && ZIP_CODE_PATTERN.matcher(fieldText).matches()
+
     private companion object {
         private const val MAX_LENGTH_US = 5
 

--- a/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -1526,24 +1526,45 @@ internal class CardInputWidgetTest {
     }
 
     @Test
-    fun usZipCodeRequired_whenFalse_shouldNotCallonUsZipCodeComplete() {
+    fun usZipCodeRequired_whenFalse_shouldNotCallOnPostalCodeComplete() {
         cardInputWidget.usZipCodeRequired = false
         postalCodeEditText.setText(POSTAL_CODE_VALUE)
-        assertThat(cardInputListener.usZipCodeCompleteCalls).isEqualTo(0)
+        assertThat(cardInputListener.onPostalCodeCompleteCalls).isEqualTo(0)
     }
 
     @Test
-    fun usZipCodeRequired_whenTrue_withValidZip_shouldCallonUsZipCodeComplete() {
+    fun usZipCodeRequired_whenTrue_withValidZip_shouldCallOnPostalCodeComplete() {
         cardInputWidget.usZipCodeRequired = true
         postalCodeEditText.setText(POSTAL_CODE_VALUE)
-        assertThat(cardInputListener.usZipCodeCompleteCalls).isEqualTo(1)
+        assertThat(cardInputListener.onPostalCodeCompleteCalls).isEqualTo(1)
     }
 
     @Test
-    fun usZipCodeRequired_whenTrue_withInvalidZip_shouldNotCallonUsZipCodeComplete() {
+    fun postalCodeEnabled_whenFalse_shouldNotCallOnPostalCodeComplete() {
+        cardInputWidget.postalCodeEnabled = false
+        postalCodeEditText.setText("123")
+        assertThat(cardInputListener.onPostalCodeCompleteCalls).isEqualTo(0)
+    }
+
+    @Test
+    fun usZipCodeRequired_whenTrue_withInvalidZip_shouldNotCallOnPostalCodeComplete() {
         cardInputWidget.usZipCodeRequired = true
         postalCodeEditText.setText("1234")
-        assertThat(cardInputListener.usZipCodeCompleteCalls).isEqualTo(0)
+        assertThat(cardInputListener.onPostalCodeCompleteCalls).isEqualTo(0)
+    }
+
+    @Test
+    fun postalCode_whenTrue_withNonEmptyZip_shouldCallOnPostalCodeComplete() {
+        cardInputWidget.postalCodeRequired = true
+        postalCodeEditText.setText("1234")
+        assertThat(cardInputListener.onPostalCodeCompleteCalls).isEqualTo(1)
+    }
+
+    @Test
+    fun postalCode_whenTrue_withEmptyZip_shouldNotCallOnPostalCodeComplete() {
+        cardInputWidget.postalCodeRequired = true
+        postalCodeEditText.setText("")
+        assertThat(cardInputListener.onPostalCodeCompleteCalls).isEqualTo(0)
     }
 
     @Test
@@ -1599,7 +1620,7 @@ internal class CardInputWidgetTest {
         var cardCompleteCalls = 0
         var expirationCompleteCalls = 0
         var cvcCompleteCalls = 0
-        var usZipCodeCompleteCalls = 0
+        var onPostalCodeCompleteCalls = 0
 
         override fun onFocusChange(focusField: CardInputListener.FocusField) {
             focusedFields.add(focusField)
@@ -1617,8 +1638,8 @@ internal class CardInputWidgetTest {
             cvcCompleteCalls++
         }
 
-        override fun onUsZipCodeComplete() {
-            usZipCodeCompleteCalls++
+        override fun onPostalCodeComplete() {
+            onPostalCodeCompleteCalls++
         }
     }
 

--- a/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -1526,6 +1526,27 @@ internal class CardInputWidgetTest {
     }
 
     @Test
+    fun usZipCodeRequired_whenFalse_shouldNotCallonUsZipCodeComplete() {
+        cardInputWidget.usZipCodeRequired = false
+        postalCodeEditText.setText(POSTAL_CODE_VALUE)
+        assertThat(cardInputListener.usZipCodeCompleteCalls).isEqualTo(0)
+    }
+
+    @Test
+    fun usZipCodeRequired_whenTrue_withValidZip_shouldCallonUsZipCodeComplete() {
+        cardInputWidget.usZipCodeRequired = true
+        postalCodeEditText.setText(POSTAL_CODE_VALUE)
+        assertThat(cardInputListener.usZipCodeCompleteCalls).isEqualTo(1)
+    }
+
+    @Test
+    fun usZipCodeRequired_whenTrue_withInvalidZip_shouldNotCallonUsZipCodeComplete() {
+        cardInputWidget.usZipCodeRequired = true
+        postalCodeEditText.setText("1234")
+        assertThat(cardInputListener.usZipCodeCompleteCalls).isEqualTo(0)
+    }
+
+    @Test
     fun `setCvcLabel is not reset when card number entered`() {
         cardInputWidget.setCvcLabel("123")
         assertThat(cardInputWidget.cvcEditText.hint)
@@ -1578,6 +1599,7 @@ internal class CardInputWidgetTest {
         var cardCompleteCalls = 0
         var expirationCompleteCalls = 0
         var cvcCompleteCalls = 0
+        var usZipCodeCompleteCalls = 0
 
         override fun onFocusChange(focusField: CardInputListener.FocusField) {
             focusedFields.add(focusField)
@@ -1593,6 +1615,10 @@ internal class CardInputWidgetTest {
 
         override fun onCvcComplete() {
             cvcCompleteCalls++
+        }
+
+        override fun onUsZipCodeComplete() {
+            usZipCodeCompleteCalls++
         }
     }
 

--- a/payments-core/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
@@ -330,35 +330,42 @@ internal class CardMultilineWidgetTest {
     @Test
     fun paymentMethodCreateParams_whenPostalCodeIsRequiredAndValueIsBlank_returnsNull() {
         cardMultilineWidget.setShouldShowPostalCode(true)
+        cardMultilineWidget.setCardInputListener(fullCardListener)
         cardMultilineWidget.postalCodeRequired = true
 
         fullGroup.cardNumberEditText.setText(VISA_WITH_SPACES)
         fullGroup.expiryDateEditText.append("12")
         fullGroup.expiryDateEditText.append("50")
         fullGroup.cvcEditText.append(CVC_VALUE_COMMON)
+        fullGroup.postalCodeEditText.setText("")
 
         assertThat(cardMultilineWidget.paymentMethodCreateParams)
             .isNull()
+        verify(fullCardListener, never()).onPostalCodeComplete()
     }
 
     @Test
     fun paymentMethodCreateParams_whenPostalCodeIsRequiredAndValueIsNotBlank_returnsNotNull() {
         cardMultilineWidget.setShouldShowPostalCode(true)
-        cardMultilineWidget.postalCodeRequired = false
+        cardMultilineWidget.setCardInputListener(fullCardListener)
+        cardMultilineWidget.postalCodeRequired = true
 
         fullGroup.cardNumberEditText.setText(VISA_WITH_SPACES)
         fullGroup.expiryDateEditText.append("12")
         fullGroup.expiryDateEditText.append("50")
         fullGroup.cvcEditText.append(CVC_VALUE_COMMON)
+        fullGroup.postalCodeEditText.setText("1234")
 
         assertThat(cardMultilineWidget.paymentMethodCreateParams)
             .isNotNull()
+        verify(fullCardListener).onPostalCodeComplete()
     }
 
     @Test
     fun paymentMethodCreateParams_whenPostalCodeIsNotRequiredAndValueIsBlank_returnsNotNull() {
         cardMultilineWidget.setShouldShowPostalCode(true)
         cardMultilineWidget.postalCodeRequired = false
+        cardMultilineWidget.setCardInputListener(fullCardListener)
 
         fullGroup.cardNumberEditText.setText(VISA_WITH_SPACES)
         fullGroup.expiryDateEditText.append("12")
@@ -367,6 +374,7 @@ internal class CardMultilineWidgetTest {
 
         assertThat(cardMultilineWidget.paymentMethodCreateParams)
             .isNotNull()
+        verify(fullCardListener, never()).onPostalCodeComplete()
     }
 
     @Test
@@ -587,8 +595,8 @@ internal class CardMultilineWidgetTest {
         assertThat(noZipGroup.expiryDateEditText.hasFocus())
             .isTrue()
 
-        verify(fullCardListener, never()).onUsZipCodeComplete()
-        verify(noZipCardListener, never()).onUsZipCodeComplete()
+        verify(fullCardListener, never()).onPostalCodeComplete()
+        verify(noZipCardListener, never()).onPostalCodeComplete()
     }
 
     @Test
@@ -610,8 +618,8 @@ internal class CardMultilineWidgetTest {
         assertThat(noZipGroup.cvcEditText.hasFocus())
             .isTrue()
 
-        verify(fullCardListener, never()).onUsZipCodeComplete()
-        verify(noZipCardListener, never()).onUsZipCodeComplete()
+        verify(fullCardListener, never()).onPostalCodeComplete()
+        verify(noZipCardListener, never()).onPostalCodeComplete()
     }
 
     @Test
@@ -637,8 +645,8 @@ internal class CardMultilineWidgetTest {
         assertThat(noZipGroup.cvcEditText.hasFocus())
             .isTrue()
 
-        verify(fullCardListener, never()).onUsZipCodeComplete()
-        verify(noZipCardListener, never()).onUsZipCodeComplete()
+        verify(fullCardListener, never()).onPostalCodeComplete()
+        verify(noZipCardListener, never()).onPostalCodeComplete()
     }
 
     @Test
@@ -656,9 +664,9 @@ internal class CardMultilineWidgetTest {
         assertThat(fullGroup.cardNumberEditText.text?.toString())
             .isEqualTo(VISA_WITH_SPACES.take(VISA_WITH_SPACES.length - 1))
 
-        verify(fullCardListener, never()).onUsZipCodeComplete()
+        verify(fullCardListener, never()).onPostalCodeComplete()
 
-        verify(fullCardListener, never()).onUsZipCodeComplete()
+        verify(fullCardListener, never()).onPostalCodeComplete()
     }
 
     @Test
@@ -676,7 +684,7 @@ internal class CardMultilineWidgetTest {
         assertThat(noZipGroup.cardNumberEditText.text?.toString())
             .isEqualTo(VISA_WITH_SPACES.take(VISA_WITH_SPACES.length - 1))
 
-        verify(noZipCardListener, never()).onUsZipCodeComplete()
+        verify(noZipCardListener, never()).onPostalCodeComplete()
     }
 
     @Test
@@ -710,8 +718,8 @@ internal class CardMultilineWidgetTest {
         assertThat(noZipGroup.expiryDateEditText.fieldText)
             .isEqualTo("12/5")
 
-        verify(fullCardListener, never()).onUsZipCodeComplete()
-        verify(noZipCardListener, never()).onUsZipCodeComplete()
+        verify(fullCardListener, never()).onPostalCodeComplete()
+        verify(noZipCardListener, never()).onPostalCodeComplete()
     }
 
     @Test
@@ -846,7 +854,7 @@ internal class CardMultilineWidgetTest {
                 )
             )
 
-        verify(fullCardListener, never()).onUsZipCodeComplete()
+        verify(fullCardListener, never()).onPostalCodeComplete()
     }
 
     @Test
@@ -866,7 +874,7 @@ internal class CardMultilineWidgetTest {
         assertThat(cardMultilineWidget.cardParams)
             .isNull()
 
-        verify(fullCardListener, never()).onUsZipCodeComplete()
+        verify(fullCardListener, never()).onPostalCodeComplete()
     }
 
     @Test
@@ -898,7 +906,7 @@ internal class CardMultilineWidgetTest {
                 )
             )
 
-        verify(fullCardListener).onUsZipCodeComplete()
+        verify(fullCardListener).onPostalCodeComplete()
     }
 
     @Test

--- a/payments-core/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
@@ -586,6 +586,9 @@ internal class CardMultilineWidgetTest {
         verify(noZipCardListener).onFocusChange(CardInputListener.FocusField.ExpiryDate)
         assertThat(noZipGroup.expiryDateEditText.hasFocus())
             .isTrue()
+
+        verify(fullCardListener, never()).onUsZipCodeComplete()
+        verify(noZipCardListener, never()).onUsZipCodeComplete()
     }
 
     @Test
@@ -606,6 +609,9 @@ internal class CardMultilineWidgetTest {
         verify(noZipCardListener).onFocusChange(CardInputListener.FocusField.Cvc)
         assertThat(noZipGroup.cvcEditText.hasFocus())
             .isTrue()
+
+        verify(fullCardListener, never()).onUsZipCodeComplete()
+        verify(noZipCardListener, never()).onUsZipCodeComplete()
     }
 
     @Test
@@ -630,6 +636,9 @@ internal class CardMultilineWidgetTest {
         verify(noZipCardListener, never()).onFocusChange(CardInputListener.FocusField.PostalCode)
         assertThat(noZipGroup.cvcEditText.hasFocus())
             .isTrue()
+
+        verify(fullCardListener, never()).onUsZipCodeComplete()
+        verify(noZipCardListener, never()).onUsZipCodeComplete()
     }
 
     @Test
@@ -646,6 +655,10 @@ internal class CardMultilineWidgetTest {
             .isTrue()
         assertThat(fullGroup.cardNumberEditText.text?.toString())
             .isEqualTo(VISA_WITH_SPACES.take(VISA_WITH_SPACES.length - 1))
+
+        verify(fullCardListener, never()).onUsZipCodeComplete()
+
+        verify(fullCardListener, never()).onUsZipCodeComplete()
     }
 
     @Test
@@ -662,6 +675,8 @@ internal class CardMultilineWidgetTest {
             .isTrue()
         assertThat(noZipGroup.cardNumberEditText.text?.toString())
             .isEqualTo(VISA_WITH_SPACES.take(VISA_WITH_SPACES.length - 1))
+
+        verify(noZipCardListener, never()).onUsZipCodeComplete()
     }
 
     @Test
@@ -694,6 +709,9 @@ internal class CardMultilineWidgetTest {
             .isTrue()
         assertThat(noZipGroup.expiryDateEditText.fieldText)
             .isEqualTo("12/5")
+
+        verify(fullCardListener, never()).onUsZipCodeComplete()
+        verify(noZipCardListener, never()).onUsZipCodeComplete()
     }
 
     @Test
@@ -805,6 +823,7 @@ internal class CardMultilineWidgetTest {
     @Test
     fun usZipCodeRequired_whenFalse_shouldSetPostalCodeHint() {
         cardMultilineWidget.usZipCodeRequired = false
+        cardMultilineWidget.setCardInputListener(fullCardListener)
         assertThat(cardMultilineWidget.postalInputLayout.hint)
             .isEqualTo("Postal code")
 
@@ -826,11 +845,14 @@ internal class CardMultilineWidgetTest {
                         .build()
                 )
             )
+
+        verify(fullCardListener, never()).onUsZipCodeComplete()
     }
 
     @Test
     fun usZipCodeRequired_whenTrue_withInvalidZipCode_shouldReturnNullCard() {
         cardMultilineWidget.usZipCodeRequired = true
+        cardMultilineWidget.setCardInputListener(fullCardListener)
         assertThat(cardMultilineWidget.postalInputLayout.hint)
             .isEqualTo("ZIP Code")
 
@@ -843,11 +865,14 @@ internal class CardMultilineWidgetTest {
         fullGroup.postalCodeEditText.setText("1234")
         assertThat(cardMultilineWidget.cardParams)
             .isNull()
+
+        verify(fullCardListener, never()).onUsZipCodeComplete()
     }
 
     @Test
     fun usZipCodeRequired_whenTrue_withValidZipCode_shouldReturnNotNullCard() {
         cardMultilineWidget.usZipCodeRequired = true
+        cardMultilineWidget.setCardInputListener(fullCardListener)
         assertThat(cardMultilineWidget.postalInputLayout.hint)
             .isEqualTo("ZIP Code")
 
@@ -872,6 +897,8 @@ internal class CardMultilineWidgetTest {
                         .build()
                 )
             )
+
+        verify(fullCardListener).onUsZipCodeComplete()
     }
 
     @Test

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/CardDataCollectionFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/CardDataCollectionFragment.kt
@@ -126,6 +126,8 @@ internal class CardDataCollectionFragment<ViewModelType : BaseSheetViewModel<*>>
                 // move to first field when CVC is complete
                 billingAddressView.focusFirstField()
             }
+
+            override fun onUsZipCodeComplete() {}
         })
 
         sheetViewModel.processing.observe(viewLifecycleOwner) { isProcessing ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/CardDataCollectionFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/CardDataCollectionFragment.kt
@@ -127,7 +127,7 @@ internal class CardDataCollectionFragment<ViewModelType : BaseSheetViewModel<*>>
                 billingAddressView.focusFirstField()
             }
 
-            override fun onUsZipCodeComplete() {}
+            override fun onPostalCodeComplete() {}
         })
 
         sheetViewModel.processing.observe(viewLifecycleOwner) { isProcessing ->


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Introduce `CardInputListener#onPostalCodeComplete`
Note: Since there is no matching standard for Global, any non empty global postal is considered valid.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-549

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
