### PR TITLE
don't override returnUrl for instant app

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -5103,11 +5103,11 @@ public final class com/stripe/android/payments/core/authentication/PaymentAuthen
 }
 
 public final class com/stripe/android/payments/core/authentication/SourceAuthenticator_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/SourceAuthenticator_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/SourceAuthenticator_Factory;
 	public fun get ()Lcom/stripe/android/payments/core/authentication/SourceAuthenticator;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lcom/stripe/android/core/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/PaymentAnalyticsRequestFactory;ZLkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function0;)Lcom/stripe/android/payments/core/authentication/SourceAuthenticator;
+	public static fun newInstance (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lcom/stripe/android/core/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/PaymentAnalyticsRequestFactory;ZLkotlin/coroutines/CoroutineContext;Lkotlin/jvm/functions/Function0;Z)Lcom/stripe/android/payments/core/authentication/SourceAuthenticator;
 }
 
 public final class com/stripe/android/payments/core/authentication/UnsupportedAuthenticator_Factory : dagger/internal/Factory {
@@ -5119,11 +5119,11 @@ public final class com/stripe/android/payments/core/authentication/UnsupportedAu
 }
 
 public final class com/stripe/android/payments/core/authentication/WebIntentAuthenticator_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator_Factory;
 	public fun get ()Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lkotlin/jvm/functions/Function1;Lcom/stripe/android/core/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/PaymentAnalyticsRequestFactory;ZLkotlin/coroutines/CoroutineContext;Ljava/util/Map;Lkotlin/jvm/functions/Function0;)Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;
+	public static fun newInstance (Lkotlin/jvm/functions/Function1;Lcom/stripe/android/core/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/PaymentAnalyticsRequestFactory;ZLkotlin/coroutines/CoroutineContext;Ljava/util/Map;Lkotlin/jvm/functions/Function0;Z)Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;
 }
 
 public final class com/stripe/android/payments/core/authentication/threeds2/DefaultStripe3ds2ChallengeResultProcessor_Factory : dagger/internal/Factory {
@@ -5151,11 +5151,11 @@ public final class com/stripe/android/payments/core/authentication/threeds2/Stri
 }
 
 public final class com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel_Factory;
 	public fun get ()Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionContract$Args;Lcom/stripe/android/networking/StripeRepository;Lcom/stripe/android/core/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/PaymentAnalyticsRequestFactory;Lcom/stripe/android/stripe3ds2/service/StripeThreeDs2Service;Lcom/stripe/android/stripe3ds2/transaction/MessageVersionRegistry;Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2ChallengeResultProcessor;Lcom/stripe/android/stripe3ds2/transaction/InitChallengeRepository;Lkotlin/coroutines/CoroutineContext;Landroidx/lifecycle/SavedStateHandle;)Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel;
+	public static fun newInstance (Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionContract$Args;Lcom/stripe/android/networking/StripeRepository;Lcom/stripe/android/core/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/PaymentAnalyticsRequestFactory;Lcom/stripe/android/stripe3ds2/service/StripeThreeDs2Service;Lcom/stripe/android/stripe3ds2/transaction/MessageVersionRegistry;Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2ChallengeResultProcessor;Lcom/stripe/android/stripe3ds2/transaction/InitChallengeRepository;Lkotlin/coroutines/CoroutineContext;Landroidx/lifecycle/SavedStateHandle;Z)Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel;
 }
 
 public final class com/stripe/android/payments/core/injection/AuthenticationModule_Companion_ProvideDefaultReturnUrlFactory : dagger/internal/Factory {
@@ -5211,6 +5211,7 @@ public abstract interface annotation class com/stripe/android/payments/core/inje
 }
 
 public final class com/stripe/android/payments/core/injection/NamedConstantsKt {
+	public static final field IS_INSTANT_APP Ljava/lang/String;
 	public static final field IS_PAYMENT_INTENT Ljava/lang/String;
 	public static final field PRODUCT_USAGE Ljava/lang/String;
 	public static final field PUBLISHABLE_KEY Ljava/lang/String;
@@ -5225,12 +5226,20 @@ public final class com/stripe/android/payments/core/injection/PaymentLauncherMod
 	public static fun provideDefaultReturnUrl (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Landroid/content/Context;)Lcom/stripe/android/payments/DefaultReturnUrl;
 }
 
+public final class com/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideIsInstantAppFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideIsInstantAppFactory;
+	public fun get ()Ljava/lang/Boolean;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideIsInstantApp (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Landroid/content/Context;)Z
+}
+
 public final class com/stripe/android/payments/core/injection/PaymentLauncherModule_ProvidePaymentAuthenticatorRegistryFactory : dagger/internal/Factory {
-	public fun <init> (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/PaymentLauncherModule_ProvidePaymentAuthenticatorRegistryFactory;
+	public fun <init> (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/PaymentLauncherModule_ProvidePaymentAuthenticatorRegistryFactory;
 	public fun get ()Lcom/stripe/android/payments/core/authentication/PaymentAuthenticatorRegistry;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun providePaymentAuthenticatorRegistry (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Landroid/content/Context;Lcom/stripe/android/networking/StripeRepository;ZLkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Ljava/util/Map;Lcom/stripe/android/core/networking/DefaultAnalyticsRequestExecutor;Lcom/stripe/android/networking/PaymentAnalyticsRequestFactory;Lkotlin/jvm/functions/Function0;Ljava/util/Set;)Lcom/stripe/android/payments/core/authentication/PaymentAuthenticatorRegistry;
+	public static fun providePaymentAuthenticatorRegistry (Lcom/stripe/android/payments/core/injection/PaymentLauncherModule;Landroid/content/Context;Lcom/stripe/android/networking/StripeRepository;ZLkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Ljava/util/Map;Lcom/stripe/android/core/networking/DefaultAnalyticsRequestExecutor;Lcom/stripe/android/networking/PaymentAnalyticsRequestFactory;Lkotlin/jvm/functions/Function0;Ljava/util/Set;Z)Lcom/stripe/android/payments/core/authentication/PaymentAuthenticatorRegistry;
 }
 
 public final class com/stripe/android/payments/core/injection/PaymentLauncherModule_ProvideThreeDs1IntentReturnUrlMapFactory : dagger/internal/Factory {
@@ -5411,11 +5420,11 @@ public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherFa
 }
 
 public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel_Factory;
 	public fun get ()Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (ZLcom/stripe/android/networking/StripeRepository;Lcom/stripe/android/payments/core/authentication/PaymentAuthenticatorRegistry;Lcom/stripe/android/payments/DefaultReturnUrl;Ljavax/inject/Provider;Ljava/util/Map;Ldagger/Lazy;Ldagger/Lazy;Lcom/stripe/android/core/networking/DefaultAnalyticsRequestExecutor;Lcom/stripe/android/networking/PaymentAnalyticsRequestFactory;Lkotlin/coroutines/CoroutineContext;Lcom/stripe/android/view/AuthActivityStarterHost;Landroidx/activity/result/ActivityResultCaller;Landroidx/lifecycle/SavedStateHandle;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel;
+	public static fun newInstance (ZLcom/stripe/android/networking/StripeRepository;Lcom/stripe/android/payments/core/authentication/PaymentAuthenticatorRegistry;Lcom/stripe/android/payments/DefaultReturnUrl;Ljavax/inject/Provider;Ljava/util/Map;Ldagger/Lazy;Ldagger/Lazy;Lcom/stripe/android/core/networking/DefaultAnalyticsRequestExecutor;Lcom/stripe/android/networking/PaymentAnalyticsRequestFactory;Lkotlin/coroutines/CoroutineContext;Lcom/stripe/android/view/AuthActivityStarterHost;Landroidx/activity/result/ActivityResultCaller;Landroidx/lifecycle/SavedStateHandle;Z)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel;
 }
 
 public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel_Factory_MembersInjector : dagger/MembersInjector {

--- a/payments-core/build.gradle
+++ b/payments-core/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     kapt "com.google.dagger:dagger-compiler:$daggerVersion"
 
     implementation "androidx.activity:activity-compose:$composeActivityVersion"
+    implementation 'com.google.android.instantapps:instantapps:1.1.0'
 
     // For instructions on replacing the BouncyCastle dependency used by the 3DS2 SDK, see
     // https://github.com/stripe/stripe-android/issues/3173#issuecomment-785176608

--- a/payments-core/src/main/java/com/stripe/android/PaymentBrowserAuthStarter.kt
+++ b/payments-core/src/main/java/com/stripe/android/PaymentBrowserAuthStarter.kt
@@ -24,7 +24,7 @@ internal interface PaymentBrowserAuthStarter :
                 .toBundle()
 
             host.startActivityForResult(
-                when (args.hasDefaultReturnUrl(defaultReturnUrl)) {
+                when (args.hasDefaultReturnUrl(defaultReturnUrl) || args.isInstantApp) {
                     true -> StripeBrowserLauncherActivity::class.java
                     false -> PaymentAuthWebViewActivity::class.java
                 },

--- a/payments-core/src/main/java/com/stripe/android/auth/PaymentBrowserAuthContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/auth/PaymentBrowserAuthContract.kt
@@ -25,7 +25,8 @@ internal class PaymentBrowserAuthContract :
         input: Args
     ): Intent {
         val defaultReturnUrl = DefaultReturnUrl.create(context)
-        val shouldUseBrowser = input.hasDefaultReturnUrl(defaultReturnUrl)
+        val shouldUseBrowser =
+            input.hasDefaultReturnUrl(defaultReturnUrl) || input.isInstantApp
 
         val statusBarColor = when (context) {
             is Activity -> context.window?.statusBarColor
@@ -82,7 +83,8 @@ internal class PaymentBrowserAuthContract :
         val shouldCancelIntentOnUserNavigation: Boolean = true,
 
         val statusBarColor: Int? = null,
-        val publishableKey: String
+        val publishableKey: String,
+        val isInstantApp: Boolean
     ) : Parcelable {
         /**
          * Pre-requisite for using [StripeBrowserLauncherActivity].

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultPaymentAuthenticatorRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultPaymentAuthenticatorRegistry.kt
@@ -138,7 +138,8 @@ internal class DefaultPaymentAuthenticatorRegistry @Inject internal constructor(
             uiContext: CoroutineContext,
             threeDs1IntentReturnUrlMap: MutableMap<String, String>,
             publishableKeyProvider: () -> String,
-            productUsage: Set<String>
+            productUsage: Set<String>,
+            isInstantApp: Boolean
         ): PaymentAuthenticatorRegistry {
             val injectorKey =
                 WeakMapInjectorRegistry.nextKey(requireNotNull(PaymentAuthenticatorRegistry::class.simpleName))
@@ -154,6 +155,7 @@ internal class DefaultPaymentAuthenticatorRegistry @Inject internal constructor(
                 .injectorKey(injectorKey)
                 .publishableKeyProvider(publishableKeyProvider)
                 .productUsage(productUsage)
+                .isInstantApp(isInstantApp)
                 .build()
             val registry = component.registry
             registry.authenticationComponent = component

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/SourceAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/SourceAuthenticator.kt
@@ -11,6 +11,7 @@ import com.stripe.android.model.Source
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.networking.PaymentAnalyticsEvent
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
+import com.stripe.android.payments.core.injection.IS_INSTANT_APP
 import com.stripe.android.payments.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.view.AuthActivityStarterHost
 import kotlinx.coroutines.withContext
@@ -31,7 +32,8 @@ internal class SourceAuthenticator @Inject constructor(
     private val paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory,
     @Named(ENABLE_LOGGING) private val enableLogging: Boolean,
     @UIContext private val uiContext: CoroutineContext,
-    @Named(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String
+    @Named(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String,
+    @Named(IS_INSTANT_APP) private val isInstantApp: Boolean
 ) : PaymentAuthenticator<Source> {
 
     override suspend fun authenticate(
@@ -68,7 +70,8 @@ internal class SourceAuthenticator @Inject constructor(
                 returnUrl = source.redirect?.returnUrl,
                 enableLogging = enableLogging,
                 stripeAccountId = requestOptions.stripeAccount,
-                publishableKey = publishableKeyProvider()
+                publishableKey = publishableKeyProvider(),
+                isInstantApp = isInstantApp
             )
         )
     }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticator.kt
@@ -10,6 +10,7 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.ApiRequest
 import com.stripe.android.networking.PaymentAnalyticsEvent
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
+import com.stripe.android.payments.core.injection.IS_INSTANT_APP
 import com.stripe.android.payments.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.view.AuthActivityStarterHost
 import kotlinx.coroutines.withContext
@@ -30,7 +31,8 @@ internal class WebIntentAuthenticator @Inject constructor(
     @Named(ENABLE_LOGGING) private val enableLogging: Boolean,
     @UIContext private val uiContext: CoroutineContext,
     private val threeDs1IntentReturnUrlMap: MutableMap<String, String>,
-    @Named(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String
+    @Named(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String,
+    @Named(IS_INSTANT_APP) private val isInstantApp: Boolean
 ) : PaymentAuthenticator<StripeIntent> {
 
     override suspend fun authenticate(
@@ -120,7 +122,8 @@ internal class WebIntentAuthenticator @Inject constructor(
                 stripeAccountId = stripeAccount,
                 shouldCancelSource = shouldCancelSource,
                 shouldCancelIntentOnUserNavigation = shouldCancelIntentOnUserNavigation,
-                publishableKey = publishableKeyProvider()
+                publishableKey = publishableKeyProvider(),
+                isInstantApp = isInstantApp
             )
         )
     }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.AbstractSavedStateViewModelFactory
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.savedstate.SavedStateRegistryOwner
+import com.google.android.instantapps.InstantApps
 import com.stripe.android.StripePaymentController
 import com.stripe.android.auth.PaymentBrowserAuthContract
 import com.stripe.android.core.exception.StripeException
@@ -23,6 +24,7 @@ import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.payments.core.injection.DaggerStripe3ds2TransactionViewModelFactoryComponent
+import com.stripe.android.payments.core.injection.IS_INSTANT_APP
 import com.stripe.android.payments.core.injection.Stripe3ds2TransactionViewModelSubcomponent
 import com.stripe.android.stripe3ds2.service.StripeThreeDs2Service
 import com.stripe.android.stripe3ds2.transaction.ChallengeParameters
@@ -35,6 +37,7 @@ import com.stripe.android.stripe3ds2.transaction.Transaction
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
+import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
 
 internal class Stripe3ds2TransactionViewModel @Inject constructor(
@@ -47,7 +50,8 @@ internal class Stripe3ds2TransactionViewModel @Inject constructor(
     private val challengeResultProcessor: Stripe3ds2ChallengeResultProcessor,
     private val initChallengeRepository: InitChallengeRepository,
     @IOContext private val workContext: CoroutineContext,
-    private val savedStateHandle: SavedStateHandle
+    private val savedStateHandle: SavedStateHandle,
+    @Named(IS_INSTANT_APP) private val isInstantApp: Boolean
 ) : ViewModel() {
 
     var hasCompleted: Boolean = savedStateHandle.contains(KEY_HAS_COMPLETED)
@@ -222,7 +226,8 @@ internal class Stripe3ds2TransactionViewModel @Inject constructor(
                 stripeAccountId = args.requestOptions.stripeAccount,
                 // 3D-Secure requires cancelling the source when the user cancels auth (AUTHN-47)
                 shouldCancelSource = true,
-                publishableKey = args.publishableKey
+                publishableKey = args.publishableKey,
+                isInstantApp = isInstantApp
             )
         )
     }
@@ -319,6 +324,7 @@ internal class Stripe3ds2TransactionViewModelFactory(
             .enableLogging(arg.enableLogging)
             .publishableKeyProvider { arg.publishableKey }
             .productUsage(arg.productUsage)
+            .isInstantApp(InstantApps.isInstantApp(arg.application))
             .build()
             .inject(this)
     }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/AuthenticationComponent.kt
@@ -77,6 +77,9 @@ internal interface AuthenticationComponent {
         @BindsInstance
         fun productUsage(@Named(PRODUCT_USAGE) productUsage: Set<String>): Builder
 
+        @BindsInstance
+        fun isInstantApp(@Named(IS_INSTANT_APP) isInstantApp: Boolean): Builder
+
         fun build(): AuthenticationComponent
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/NamedConstants.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/NamedConstants.kt
@@ -23,3 +23,8 @@ const val STRIPE_ACCOUNT_ID = "stripeAccountId"
  * Name to indicate whether the current [StripeIntent] is a [PaymentIntent] or [SetupIntent].
  */
 const val IS_PAYMENT_INTENT = "isPaymentIntent"
+
+/**
+ * Name to indicate whether the current app is an instant app.
+ */
+const val IS_INSTANT_APP = "isInstantApp"

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherModule.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.payments.core.injection
 
 import android.content.Context
+import com.google.android.instantapps.InstantApps
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.UIContext
@@ -40,7 +41,8 @@ internal class PaymentLauncherModule {
         defaultAnalyticsRequestExecutor: DefaultAnalyticsRequestExecutor,
         paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory,
         @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
-        @Named(PRODUCT_USAGE) productUsage: Set<String>
+        @Named(PRODUCT_USAGE) productUsage: Set<String>,
+        @Named(IS_INSTANT_APP) isInstantApp: Boolean
     ): PaymentAuthenticatorRegistry = DefaultPaymentAuthenticatorRegistry.createInstance(
         context,
         stripeRepository,
@@ -51,6 +53,13 @@ internal class PaymentLauncherModule {
         uiContext,
         threeDs1IntentReturnUrlMap,
         publishableKeyProvider,
-        productUsage
+        productUsage,
+        isInstantApp
     )
+
+    @Provides
+    @Named(IS_INSTANT_APP)
+    fun provideIsInstantApp(context: Context): Boolean {
+        return InstantApps.isInstantApp(context)
+    }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelFactoryComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/Stripe3ds2TransactionViewModelFactoryComponent.kt
@@ -42,6 +42,9 @@ internal interface Stripe3ds2TransactionViewModelFactoryComponent {
         @BindsInstance
         fun productUsage(@Named(PRODUCT_USAGE) productUsage: Set<String>): Builder
 
+        @BindsInstance
+        fun isInstantApp(@Named(IS_INSTANT_APP) isInstantApp: Boolean): Builder
+
         fun build(): Stripe3ds2TransactionViewModelFactoryComponent
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/PaymentBrowserAuthStarterTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentBrowserAuthStarterTest.kt
@@ -6,8 +6,10 @@ import androidx.activity.ComponentActivity
 import androidx.test.core.app.ApplicationProvider
 import com.stripe.android.auth.PaymentBrowserAuthContract
 import com.stripe.android.payments.DefaultReturnUrl
+import com.stripe.android.payments.StripeBrowserLauncherActivity
 import com.stripe.android.stripe3ds2.init.ui.StripeToolbarCustomization
 import com.stripe.android.view.AuthActivityStarterHost
+import com.stripe.android.view.PaymentAuthWebViewActivity
 import org.junit.runner.RunWith
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
@@ -72,6 +74,50 @@ class PaymentBrowserAuthStarterTest {
     }
 
     @Test
+    fun `start with isInstantApp false and defaultReturnUrl will start PaymentAuthWebViewActivity`() {
+        val legacyStarter = PaymentBrowserAuthStarter.Legacy(
+            AuthActivityStarterHost.ActivityHost(
+                activity,
+                statusBarColor = Color.RED
+            ),
+            defaultReturnUrl
+        )
+        legacyStarter.start(
+            DATA.copy(
+                isInstantApp = false
+            )
+        )
+        verify(activity).startActivityForResult(
+            argWhere { intent ->
+                intent.component?.className == PaymentAuthWebViewActivity::class.java.name
+            },
+            any()
+        )
+    }
+
+    @Test
+    fun `start with isInstantApp true and defaultReturnUrl will start StripeBrowserLauncherActivity`() {
+        val legacyStarter = PaymentBrowserAuthStarter.Legacy(
+            AuthActivityStarterHost.ActivityHost(
+                activity,
+                statusBarColor = Color.RED
+            ),
+            defaultReturnUrl
+        )
+        legacyStarter.start(
+            DATA.copy(
+                isInstantApp = true
+            )
+        )
+        verify(activity).startActivityForResult(
+            argWhere { intent ->
+                intent.component?.className == StripeBrowserLauncherActivity::class.java.name
+            },
+            any()
+        )
+    }
+
+    @Test
     fun `intent extras should include statusBarColor when available`() {
         val legacyStarter = PaymentBrowserAuthStarter.Legacy(
             AuthActivityStarterHost.ActivityHost(
@@ -99,7 +145,8 @@ class PaymentBrowserAuthStarterTest {
             clientSecret = "pi_1EceMnCRMbs6FrXfCXdF8dnx_secret_vew0L3IGaO0x9o0eyRMGzKr0k",
             url = "https://hooks.stripe.com/",
             returnUrl = "stripe://payment-auth",
-            publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+            publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+            isInstantApp = false
         )
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/auth/PaymentBrowserAuthContractTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/auth/PaymentBrowserAuthContractTest.kt
@@ -77,6 +77,19 @@ class PaymentBrowserAuthContractTest {
     }
 
     @Test
+    fun `createIntent() when isInstantApp should use StripeBrowserLauncherActivity`() {
+        val intent = PaymentBrowserAuthContract().createIntent(
+            activity,
+            ARGS.copy(
+                isInstantApp = true
+            )
+        )
+
+        assertThat(intent.component?.className)
+            .isEqualTo(StripeBrowserLauncherActivity::class.java.name)
+    }
+
+    @Test
     fun `createIntent() should set statusBarColor from activity`() {
         val intent = PaymentBrowserAuthContract().createIntent(
             activity,
@@ -99,7 +112,8 @@ class PaymentBrowserAuthContractTest {
             requestCode = 5000,
             url = "https://mybank.com/auth",
             returnUrl = "myapp://custom",
-            publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+            publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+            isInstantApp = false
         )
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/payments/StripeBrowserLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/StripeBrowserLauncherViewModelTest.kt
@@ -112,7 +112,8 @@ class StripeBrowserLauncherViewModelTest {
             requestCode = 50000,
             clientSecret = "pi_1F7J1aCRMbs6FrXfaJcvbxF6_secret_mIuDLsSfoo1m6s",
             url = "https://bank.com",
-            publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+            publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+            isInstantApp = false
         )
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/SourceAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/SourceAuthenticatorTest.kt
@@ -50,7 +50,8 @@ class SourceAuthenticatorTest {
         analyticsRequestFactory,
         false,
         testDispatcher,
-        { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY }
+        { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
+        false
     )
 
     @Test

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticatorTest.kt
@@ -61,7 +61,8 @@ class WebIntentAuthenticatorTest {
         enableLogging = false,
         testDispatcher,
         threeDs1IntentReturnUrlMap,
-        { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY }
+        { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
+        false
     )
 
     @Before

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelFactoryTest.kt
@@ -58,7 +58,7 @@ class Stripe3ds2TransactionViewModelFactoryTest {
             // ViewModel.mBagOfTags that's initialized in base class.
             // Mocking it would leave this field null, causing an NPE.
             val viewModel = Stripe3ds2TransactionViewModel(
-                mock(), mock(), mock(), mock(), mock(), mock(), mock(), mock(), mock(), mock()
+                mock(), mock(), mock(), mock(), mock(), mock(), mock(), mock(), mock(), mock(), false
             )
             val mockBuilder = mock<Stripe3ds2TransactionViewModelSubcomponent.Builder>()
             val mockSubcomponent = mock<Stripe3ds2TransactionViewModelSubcomponent>()

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModelTest.kt
@@ -105,7 +105,7 @@ class PaymentLauncherViewModelTest {
     private val succeededSetupResult =
         SetupIntentResult(setupIntent, StripeIntentResult.Outcome.SUCCEEDED)
 
-    private fun createViewModel(isPaymentIntent: Boolean = true) =
+    private fun createViewModel(isPaymentIntent: Boolean = true, isInstantApp: Boolean = false) =
         PaymentLauncherViewModel(
             isPaymentIntent,
             stripeApiRepository,
@@ -120,7 +120,8 @@ class PaymentLauncherViewModelTest {
             uiContext,
             authHost,
             activityResultCaller,
-            savedStateHandle
+            savedStateHandle,
+            isInstantApp
         )
 
     @Before
@@ -260,6 +261,23 @@ class PaymentLauncherViewModelTest {
                 eq(authHost),
                 eq(setupIntent),
                 eq(apiRequestOptions)
+            )
+        }
+
+    @Test
+    fun `verify instantApp confirm PaymentIntent without returnUrl gets null returnUrl`() =
+        runBlockingTest {
+            createViewModel(isInstantApp = true).confirmStripeIntent(confirmPaymentIntentParams)
+
+            verify(analyticsRequestFactory).createRequest(
+                PaymentAnalyticsEvent.ConfirmReturnUrlNull
+            )
+            verify(stripeApiRepository).confirmPaymentIntent(
+                argWhere {
+                    it.returnUrl == null
+                },
+                any(),
+                any()
             )
         }
 

--- a/payments-core/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityTest.kt
@@ -96,7 +96,8 @@ internal class PaymentAuthWebViewActivityTest {
             requestCode = REQUEST_CODE,
             clientSecret = CLIENT_SECRET,
             url = "https://example.com",
-            publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+            publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+            isInstantApp = false
         )
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModelTest.kt
@@ -151,7 +151,8 @@ class PaymentAuthWebViewActivityViewModelTest {
             requestCode = 100,
             clientSecret = "client_secret",
             url = "https://example.com",
-            publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+            publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+            isInstantApp = false
         )
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
When the sdk is used in an instant app, don't override defaultReturnUrl to `stripesdk://` as instant app is not able to capture the deep link because it's not really installed locally.

with offline discussion with @mshafrir-stripe, instead we leave the returnUrl empty and use `StripeBrowserLauncherActivity` when it's instant app, the client will need to dismiss the page at the end of confirmation flow.


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
#4419 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Recording
imitate the flow on instant app:
![instantApp](https://user-images.githubusercontent.com/79880926/144176842-108f2efa-9ee2-4404-80fe-829ab73f8151.gif)
