### PR TITLE
Span PMs across the PaymentSheet when there are only two of them. 

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/AddPaymentMethodsAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/AddPaymentMethodsAdapter.kt
@@ -30,21 +30,21 @@ internal class AddPaymentMethodsAdapter(
         return AddPaymentMethodViewHolder(parent)
             .apply {
                 val targetWidth = parent.measuredWidth - parent.paddingStart - parent.paddingEnd
+                val minItemWidth = 100 * parent.context.resources.displayMetrics.density +
+                    itemView.marginEnd + itemView.marginStart
 
-                // if there are two items span them across the sheet.
-                // Otherwise the number of items visible should be a multiple of .5
+                // if all items fit at min width, then span them across the sheet evenly filling it.
+                // otherwise the number of items visible should be a multiple of .5
                 val viewWidth =
-                    if (paymentMethods.size == 2) {
-                        targetWidth / 2
+                    if (minItemWidth * paymentMethods.size < targetWidth) {
+                        targetWidth / paymentMethods.size
                     } else {
-                        val minItemWidth = 100 * parent.context.resources.displayMetrics.density +
-                            itemView.marginEnd + itemView.marginStart
                         // numVisibleItems is incremented in steps of 0.5 items
                         // (1, 1.5, 2, 2.5, 3, ...)
                         val numVisibleItems = (targetWidth * 2 / minItemWidth).toInt() / 2f
-
                         targetWidth / numVisibleItems
                     }
+
                 itemView.layoutParams.width =
                     viewWidth.toInt() - itemView.marginEnd - itemView.marginStart
                 itemView.setOnClickListener {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/AddPaymentMethodsAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/AddPaymentMethodsAdapter.kt
@@ -30,13 +30,23 @@ internal class AddPaymentMethodsAdapter(
         return AddPaymentMethodViewHolder(parent)
             .apply {
                 val targetWidth = parent.measuredWidth - parent.paddingStart - parent.paddingEnd
-                val minItemWidth = 100 * parent.context.resources.displayMetrics.density +
-                    itemView.marginEnd + itemView.marginStart
-                // numVisibleItems is incremented in steps of 0.5 items (1, 1.5, 2, 2.5, 3, ...)
-                val numVisibleItems = (targetWidth * 2 / minItemWidth).toInt() / 2f
+
+                // if there are two items span them across the sheet.
+                // Otherwise the number of items visible should be a multiple of .5
                 val viewWidth =
-                    targetWidth / numVisibleItems - itemView.marginEnd - itemView.marginStart
-                itemView.layoutParams.width = viewWidth.toInt()
+                    if (paymentMethods.size == 2) {
+                        targetWidth / 2
+                    } else {
+                        val minItemWidth = 100 * parent.context.resources.displayMetrics.density +
+                            itemView.marginEnd + itemView.marginStart
+                        // numVisibleItems is incremented in steps of 0.5 items
+                        // (1, 1.5, 2, 2.5, 3, ...)
+                        val numVisibleItems = (targetWidth * 2 / minItemWidth).toInt() / 2f
+
+                        targetWidth / numVisibleItems
+                    }
+                itemView.layoutParams.width =
+                    viewWidth.toInt() - itemView.marginEnd - itemView.marginStart
                 itemView.setOnClickListener {
                     onItemSelected(bindingAdapterPosition)
                 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This makes it so when there are only two payment methods we span them across the sheet each taking 50% of the width. This matches iOS behavior: https://github.com/stripe-ios/stripe-ios/pull/538

Edit: We now span the payment methods evenly across the sheet if they all fit. See wide device screenshots for example.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

https://paper.dropbox.com/doc/Klarna-UI-polish-items--BWwhjD7FRVxPRMr5_HnXwep0AQ-Ox7FXrEh90mKen5IeploR

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before 2 methods  | After 2 methods |
| ------------- | ------------- |
|![twobefore](https://user-images.githubusercontent.com/89166418/144519899-321a36df-3e6f-448d-b15b-2bbcd8f48e9f.png)| ![twoafter](https://user-images.githubusercontent.com/89166418/144519906-bef60f86-8584-441a-82dc-bf05c3bf3d3b.png)|

| Before 2+ methods  | After 2+ methods |
| ------------- | ------------- |
| ![severalbefore](https://user-images.githubusercontent.com/89166418/144519922-ea798f6d-c15c-4b71-8a79-112aa5fbb045.png)|![severalafter](https://user-images.githubusercontent.com/89166418/144519936-ae5b36a5-a289-4449-9966-4f2535665421.png)|

| before extra wide 2+ methods  | after  extra wide  2+ methods |
| ------------- | ------------- |
|![widebefore](https://user-images.githubusercontent.com/89166418/144679953-7ccb1022-039c-4431-b349-d54a8cd797de.png)|![wideafter](https://user-images.githubusercontent.com/89166418/144679967-2ef4e99e-05f1-4716-8586-6217ca8c7ffe.png)|