### PR TITLE
external link for support requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🤔 SDK Integration Support
+    url: https://support.stripe.com/ 
+    about: If you're having general trouble with your Stripe integration, please reach out to support

--- a/.github/ISSUE_TEMPLATE/sdk-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/sdk-bug-report.md
@@ -1,19 +1,11 @@
 ---
-name: "\U0001F41B SDK Bug report"
+name: "🐛 SDK Bug Report"
 about: Create a report to help us improve
 title: "[BUG] "
-labels: ''
+labels: 'bug'
 assignees: ''
 
 ---
-
-<!--
-Please only file issues here that you believe represent actual bugs for the Stripe Android SDK.
-
-If you're having general trouble with your Stripe integration, please reach out to support using the form at https://support.stripe.com/ (preferred) or via email to support@stripe.com.
-
-Otherwise, to make it easier to diagnose your issue, please fill out the following:
--->
 
 ## Summary
 <!-- A simple summary of the problems you're having. -->

--- a/.github/ISSUE_TEMPLATE/sdk-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/sdk-feature-request.md
@@ -1,28 +1,20 @@
 ---
-name: "\U0001F4A1 SDK Feature Request"
+name: "💡 SDK Feature Request"
 about: Suggest an idea for this project
 title: "[Feature]"
-labels: ''
+labels: 'feature'
 assignees: ''
 
 ---
 
-<!--
-Please only file issues here that you believe represent new features for the Stripe Android SDK.
-
-If you're having general trouble with your Stripe integration, please reach out to support using the form at https://support.stripe.com/ (preferred) or via email to support@stripe.com.
-
-Otherwise, please fill out the following:
--->
-
-**Is your feature request related to a problem? Please describe.**
+## Is your feature request related to a problem? Please describe.
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+## Describe the solution you'd like
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+## Describe alternatives you've considered
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+## Additional context
 Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
# Summary
Similar change to that from the [iOS repo](https://github.com/stripe-ios/stripe-ios/pull/577) to add a support link which leads to support.stripe.com

<img width="870" alt="144874064-91b99ea9-526b-4aeb-977f-588362e16130" src="https://user-images.githubusercontent.com/89988962/145068585-a9e65c3d-4247-44d5-aef7-3c675dac5124.png">


# Motivation
Attempt to provide better routing at the time of issue creation to improve the probability that the issue is created in the right place

# Testing
Open an issue, attempt each type.

