### PR TITLE
Add parcelization to the FormSpec

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/AddressSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/AddressSpec.kt
@@ -1,5 +1,8 @@
 package com.stripe.android.paymentsheet.elements
 
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 internal data class AddressSpec(
     override val identifier: IdentifierSpec,
 ) : SectionFieldSpec(identifier)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/AfterpayClearpayTextSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/AfterpayClearpayTextSpec.kt
@@ -1,8 +1,12 @@
 package com.stripe.android.paymentsheet.elements
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
 /**
  * Header that displays information about installments for Afterpay
  */
+@Parcelize
 internal data class AfterpayClearpayTextSpec(
     override val identifier: IdentifierSpec
-) : FormItemSpec(), RequiredItemSpec
+) : FormItemSpec(), RequiredItemSpec, Parcelable

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/BankDropdownSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/BankDropdownSpec.kt
@@ -1,7 +1,9 @@
 package com.stripe.android.paymentsheet.elements
 
 import androidx.annotation.StringRes
+import kotlinx.parcelize.Parcelize
 
+@Parcelize
 internal data class BankDropdownSpec(
     override val identifier: IdentifierSpec,
     @StringRes val label: Int,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/CountrySpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/CountrySpec.kt
@@ -1,9 +1,12 @@
 package com.stripe.android.paymentsheet.elements
 
+import kotlinx.parcelize.Parcelize
+
 /**
  * This is the specification for a country field.
  * @property onlyShowCountryCodes: a list of country code that should be shown.  If empty all
  * countries will be shown.
  */
+@Parcelize
 internal data class CountrySpec(val onlyShowCountryCodes: Set<String> = emptySet()) :
     SectionFieldSpec(IdentifierSpec.Country)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/EmailSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/EmailSpec.kt
@@ -1,3 +1,6 @@
 package com.stripe.android.paymentsheet.elements
 
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 internal object EmailSpec : SectionFieldSpec(IdentifierSpec.Email)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/EmptyFormSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/EmptyFormSpec.kt
@@ -1,9 +1,13 @@
 package com.stripe.android.paymentsheet.elements
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
 /**
  * This defines an empty form spec. It is not intended to be used when building forms for
  * PaymentSheet. This form solves an issue where {@link CompleteFormFieldValueFilter#filterFlow()}
  * returns null when filtering no elements. If given this EmptyFormSpec, the filtering will view
  * the form as complete. {@link LayoutSpec#create()} is the way to build a form with no elements.
  */
-internal object EmptyFormSpec : FormItemSpec()
+@Parcelize
+internal object EmptyFormSpec : FormItemSpec(), Parcelable

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/FormItemSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/FormItemSpec.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.paymentsheet.elements
 
+import android.os.Parcelable
+
 /**
  * This is used to define each section in the visual form layout specification
  */
-internal sealed class FormItemSpec
+internal sealed class FormItemSpec : Parcelable

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/IbanSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/IbanSpec.kt
@@ -1,3 +1,6 @@
 package com.stripe.android.paymentsheet.elements
 
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
 internal object IbanSpec : SectionFieldSpec(IdentifierSpec.Generic("iban"))

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/IdentifierSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/IdentifierSpec.kt
@@ -1,23 +1,37 @@
 package com.stripe.android.paymentsheet.elements
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
 /**
  * This uniquely identifies a element in the form.  The objects here are for identifier
  * specs that need to be found when pre-populating fields, or when extracting data.
  */
-internal sealed class IdentifierSpec(val value: String) {
-    data class Generic(private val _value: String) : IdentifierSpec(_value)
+internal sealed class IdentifierSpec(val value: String) : Parcelable {
+    @Parcelize
+    data class Generic(@Transient private val _value: String) : IdentifierSpec(_value)
 
     // Needed to pre-populate forms
+    @Parcelize
     object Name : IdentifierSpec("name")
+    @Parcelize
     object Email : IdentifierSpec("email")
+    @Parcelize
     object Phone : IdentifierSpec("phone")
+    @Parcelize
     object Line1 : IdentifierSpec("line1")
+    @Parcelize
     object Line2 : IdentifierSpec("line2")
+    @Parcelize
     object City : IdentifierSpec("city")
+    @Parcelize
     object PostalCode : IdentifierSpec("postal_code")
+    @Parcelize
     object State : IdentifierSpec("state")
+    @Parcelize
     object Country : IdentifierSpec("country")
 
     // Unique extracting functionality
+    @Parcelize
     object SaveForFutureUse : IdentifierSpec("save_for_future_use")
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/KlarnaCountrySpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/KlarnaCountrySpec.kt
@@ -1,6 +1,9 @@
 package com.stripe.android.paymentsheet.elements
 
+import kotlinx.parcelize.Parcelize
+
 /**
  * This is the specification for a klarna country field
  */
+@Parcelize
 internal class KlarnaCountrySpec : SectionFieldSpec(IdentifierSpec.Country)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/LayoutSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/LayoutSpec.kt
@@ -1,10 +1,14 @@
 package com.stripe.android.paymentsheet.elements
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
 /**
  * This is a data representation of the layout of UI fields on the screen.
  */
 @Suppress("DataClassPrivateConstructor")
-internal data class LayoutSpec private constructor(val items: List<FormItemSpec>) {
+@Parcelize
+internal data class LayoutSpec private constructor(val items: List<FormItemSpec>) : Parcelable {
     companion object {
         fun create(vararg item: FormItemSpec) = LayoutSpec(item.toList())
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/RequiredItemSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/RequiredItemSpec.kt
@@ -1,8 +1,10 @@
 package com.stripe.android.paymentsheet.elements
 
+import android.os.Parcelable
+
 /**
  * Identifies a field that can be made hidden.
  */
-internal interface RequiredItemSpec {
+internal interface RequiredItemSpec : Parcelable {
     val identifier: IdentifierSpec
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/SaveForFutureUseSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/SaveForFutureUseSpec.kt
@@ -1,11 +1,15 @@
 package com.stripe.android.paymentsheet.elements
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
 /**
  * This is an element that will make elements (as specified by identifier) hidden
  * when save for future use is unchecked
  */
+@Parcelize
 internal data class SaveForFutureUseSpec(
     val identifierRequiredForFutureUse: List<RequiredItemSpec>
-) : FormItemSpec(), RequiredItemSpec {
+) : FormItemSpec(), RequiredItemSpec, Parcelable {
     override val identifier = IdentifierSpec.SaveForFutureUse
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/SectionFieldSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/SectionFieldSpec.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.paymentsheet.elements
 
+import android.os.Parcelable
+
 /**
  * This represents a field in a section.
  */
-internal sealed class SectionFieldSpec(open val identifier: IdentifierSpec)
+internal sealed class SectionFieldSpec(open val identifier: IdentifierSpec) : Parcelable

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/SectionSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/SectionSpec.kt
@@ -1,15 +1,18 @@
 package com.stripe.android.paymentsheet.elements
 
+import android.os.Parcelable
 import androidx.annotation.StringRes
+import kotlinx.parcelize.Parcelize
 
 /**
  * This represents a section in a form that contains other elements
  */
+@Parcelize
 internal data class SectionSpec(
     override val identifier: IdentifierSpec,
     val fields: List<SectionFieldSpec>,
     @StringRes val title: Int? = null,
-) : FormItemSpec(), RequiredItemSpec {
+) : FormItemSpec(), RequiredItemSpec, Parcelable {
     constructor(
         identifier: IdentifierSpec,
         field: SectionFieldSpec,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/SimpleTextSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/SimpleTextSpec.kt
@@ -4,7 +4,9 @@ import androidx.annotation.StringRes
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import com.stripe.android.paymentsheet.R
+import kotlinx.parcelize.Parcelize
 
+@Parcelize
 internal data class SimpleTextSpec(
     override val identifier: IdentifierSpec,
     @StringRes val label: Int,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/StaticTextSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/elements/StaticTextSpec.kt
@@ -1,15 +1,18 @@
 package com.stripe.android.paymentsheet.elements
 
+import android.os.Parcelable
 import androidx.annotation.ColorRes
 import androidx.annotation.StringRes
+import kotlinx.parcelize.Parcelize
 
 /**
  * This is for elements that do not receive user input
  */
+@Parcelize
 internal data class StaticTextSpec(
     override val identifier: IdentifierSpec,
     @StringRes val stringResId: Int,
     @ColorRes val color: Int? = null,
     val fontSizeSp: Int = 10,
     val letterSpacingSp: Double = .7
-) : FormItemSpec(), RequiredItemSpec
+) : FormItemSpec(), RequiredItemSpec, Parcelable

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/PaymentMethodRequirements.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/PaymentMethodRequirements.kt
@@ -1,14 +1,19 @@
 package com.stripe.android.paymentsheet.forms
 
-internal sealed interface Requirement
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+internal sealed interface Requirement : Parcelable
 internal sealed interface PIRequirement : Requirement
 internal sealed interface SIRequirement : Requirement
 
 /**
  * This requirement is dependent on the configuration passed by the app to the SDK.
  */
+@Parcelize
 internal object Delayed : PIRequirement, SIRequirement
 
+@Parcelize
 internal data class PaymentMethodRequirements(
 
     /**
@@ -43,4 +48,4 @@ internal data class PaymentMethodRequirements(
      *  - true means that a PM of this type attached to a customer can be confirmed
      */
     val confirmPMFromCustomer: Boolean?,
-)
+) : Parcelable

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/SepaDebitSpec.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/SepaDebitSpec.kt
@@ -70,7 +70,7 @@ internal val SepaDebitParamKey: MutableMap<String, Any?> = mutableMapOf(
 )
 
 internal val sepaDebitNameSection = SectionSpec(
-    IdentifierSpec.Generic("name _ection"),
+    IdentifierSpec.Generic("name_section"),
     SimpleTextSpec.NAME
 )
 internal val sepaDebitEmailSection = SectionSpec(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethod.kt
@@ -12,12 +12,14 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.elements.LayoutFormDescriptor
 import com.stripe.android.paymentsheet.elements.LayoutSpec
+import com.stripe.android.paymentsheet.elements.SaveForFutureUseSpec
 import com.stripe.android.paymentsheet.forms.AfterpayClearpayForm
 import com.stripe.android.paymentsheet.forms.AfterpayClearpayParamKey
 import com.stripe.android.paymentsheet.forms.AfterpayClearpayRequirement
 import com.stripe.android.paymentsheet.forms.BancontactForm
 import com.stripe.android.paymentsheet.forms.BancontactParamKey
 import com.stripe.android.paymentsheet.forms.BancontactRequirement
+import com.stripe.android.paymentsheet.forms.CardRequirement
 import com.stripe.android.paymentsheet.forms.Delayed
 import com.stripe.android.paymentsheet.forms.EpsForm
 import com.stripe.android.paymentsheet.forms.EpsParamKey
@@ -67,9 +69,11 @@ internal sealed class SupportedPaymentMethod(
         PaymentMethod.Type.Card,
         R.string.stripe_paymentsheet_payment_method_card,
         R.drawable.stripe_ic_paymentsheet_pm_card,
-        BancontactRequirement,
-        BancontactParamKey,
-        BancontactForm
+        CardRequirement,
+        mutableMapOf(),
+        LayoutSpec.create(
+            SaveForFutureUseSpec(emptyList())
+        )
     )
 
     @Parcelize

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethod.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.model
 
+import android.os.Parcelable
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
@@ -11,14 +12,12 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.elements.LayoutFormDescriptor
 import com.stripe.android.paymentsheet.elements.LayoutSpec
-import com.stripe.android.paymentsheet.elements.SaveForFutureUseSpec
 import com.stripe.android.paymentsheet.forms.AfterpayClearpayForm
 import com.stripe.android.paymentsheet.forms.AfterpayClearpayParamKey
 import com.stripe.android.paymentsheet.forms.AfterpayClearpayRequirement
 import com.stripe.android.paymentsheet.forms.BancontactForm
 import com.stripe.android.paymentsheet.forms.BancontactParamKey
 import com.stripe.android.paymentsheet.forms.BancontactRequirement
-import com.stripe.android.paymentsheet.forms.CardRequirement
 import com.stripe.android.paymentsheet.forms.Delayed
 import com.stripe.android.paymentsheet.forms.EpsForm
 import com.stripe.android.paymentsheet.forms.EpsParamKey
@@ -46,6 +45,7 @@ import com.stripe.android.paymentsheet.forms.SepaDebitRequirement
 import com.stripe.android.paymentsheet.forms.SofortForm
 import com.stripe.android.paymentsheet.forms.SofortParamKey
 import com.stripe.android.paymentsheet.forms.SofortRequirement
+import kotlinx.parcelize.Parcelize
 
 /**
  * Enum defining all payment method types for which Payment Sheet can collect
@@ -54,111 +54,123 @@ import com.stripe.android.paymentsheet.forms.SofortRequirement
  * FormSpec is optionally null only because Card is not converted to the
  * compose model.
  */
-internal enum class SupportedPaymentMethod(
+internal sealed class SupportedPaymentMethod(
     val type: PaymentMethod.Type,
     @StringRes val displayNameResource: Int,
     @DrawableRes val iconResource: Int,
     private val requirement: PaymentMethodRequirements,
     val paramKey: MutableMap<String, Any?>,
     val formSpec: LayoutSpec?,
-) {
-    Card(
+) : Parcelable {
+    @Parcelize
+    object Card : SupportedPaymentMethod(
         PaymentMethod.Type.Card,
         R.string.stripe_paymentsheet_payment_method_card,
         R.drawable.stripe_ic_paymentsheet_pm_card,
-        CardRequirement,
-        mutableMapOf(),
-        LayoutSpec.create(
-            SaveForFutureUseSpec(emptyList())
-        )
-    ),
+        BancontactRequirement,
+        BancontactParamKey,
+        BancontactForm
+    )
 
-    Bancontact(
+    @Parcelize
+    object Bancontact : SupportedPaymentMethod(
         PaymentMethod.Type.Bancontact,
         R.string.stripe_paymentsheet_payment_method_bancontact,
         R.drawable.stripe_ic_paymentsheet_pm_bancontact,
         BancontactRequirement,
         BancontactParamKey,
         BancontactForm
-    ),
+    )
 
-    Sofort(
+    @Parcelize
+    object Sofort : SupportedPaymentMethod(
         PaymentMethod.Type.Sofort,
         R.string.stripe_paymentsheet_payment_method_sofort,
         R.drawable.stripe_ic_paymentsheet_pm_klarna,
         SofortRequirement,
         SofortParamKey,
         SofortForm
-    ),
+    )
 
-    Ideal(
+    @Parcelize
+    object Ideal : SupportedPaymentMethod(
         PaymentMethod.Type.Ideal,
         R.string.stripe_paymentsheet_payment_method_ideal,
         R.drawable.stripe_ic_paymentsheet_pm_ideal,
         IdealRequirement,
         IdealParamKey,
         IdealForm
-    ),
+    )
 
-    SepaDebit(
+    @Parcelize
+    object SepaDebit : SupportedPaymentMethod(
         PaymentMethod.Type.SepaDebit,
         R.string.stripe_paymentsheet_payment_method_sepa_debit,
         R.drawable.stripe_ic_paymentsheet_pm_sepa_debit,
         SepaDebitRequirement,
         SepaDebitParamKey,
         SepaDebitForm
-    ),
+    )
 
-    Eps(
+    @Parcelize
+    object Eps : SupportedPaymentMethod(
         PaymentMethod.Type.Eps,
         R.string.stripe_paymentsheet_payment_method_eps,
         R.drawable.stripe_ic_paymentsheet_pm_eps,
         EpsRequirement,
         EpsParamKey,
         EpsForm
-    ),
+    )
 
-    P24(
+    @Parcelize
+    object P24 : SupportedPaymentMethod(
         PaymentMethod.Type.P24,
         R.string.stripe_paymentsheet_payment_method_p24,
         R.drawable.stripe_ic_paymentsheet_pm_p24,
         P24Requirement,
         P24ParamKey,
         P24Form
-    ),
+    )
 
-    Giropay(
+    @Parcelize
+    object Giropay : SupportedPaymentMethod(
         PaymentMethod.Type.Giropay,
         R.string.stripe_paymentsheet_payment_method_giropay,
         R.drawable.stripe_ic_paymentsheet_pm_giropay,
         GiropayRequirement,
         GiropayParamKey,
         GiropayForm
-    ),
-    AfterpayClearpay(
+    )
+
+    @Parcelize
+    object AfterpayClearpay : SupportedPaymentMethod(
         PaymentMethod.Type.AfterpayClearpay,
         R.string.stripe_paymentsheet_payment_method_afterpay_clearpay,
         R.drawable.stripe_ic_paymentsheet_pm_afterpay_clearpay,
         AfterpayClearpayRequirement,
         AfterpayClearpayParamKey,
         AfterpayClearpayForm
-    ),
-    Klarna(
+    )
+
+    @Parcelize
+    object Klarna : SupportedPaymentMethod(
         PaymentMethod.Type.Klarna,
         R.string.stripe_paymentsheet_payment_method_klarna,
         R.drawable.stripe_ic_paymentsheet_pm_klarna,
         KlarnaRequirement,
         KlarnaParamKey,
         KlarnaForm
-    ),
-    PayPal(
+    )
+
+    @Parcelize
+    object PayPal : SupportedPaymentMethod(
         PaymentMethod.Type.PayPal,
         R.string.stripe_paymentsheet_payment_method_paypal,
         R.drawable.stripe_ic_paymentsheet_pm_paypal,
         PaypalRequirement,
         PaypalParamKey,
         PaypalForm
-    );
+    )
 
     /**
      * This will get the form layout for the supported method that matches the top pick for the
@@ -336,6 +348,9 @@ internal enum class SupportedPaymentMethod(
     }
 
     companion object {
+
+        fun values() = exposedPaymentMethods
+
         /**
          * This is a list of the payment methods that we are allowing in the release
          */

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/AddPaymentMethodsAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/AddPaymentMethodsAdapterTest.kt
@@ -32,6 +32,6 @@ class AddPaymentMethodsAdapterTest {
     }
 
     private fun createAdapter() = AddPaymentMethodsAdapter(
-        listOf(*SupportedPaymentMethod.values()), 0
+        SupportedPaymentMethod.values(), 0
     ) { }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/CompleteFormFieldValueFilterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/CompleteFormFieldValueFilterTest.kt
@@ -1,12 +1,12 @@
 package com.stripe.android.paymentsheet.forms
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.paymentsheet.elements.EmailElement
 import com.stripe.android.paymentsheet.elements.EmailConfig
+import com.stripe.android.paymentsheet.elements.EmailElement
+import com.stripe.android.paymentsheet.elements.IdentifierSpec
 import com.stripe.android.paymentsheet.elements.SectionController
 import com.stripe.android.paymentsheet.elements.SectionElement
 import com.stripe.android.paymentsheet.elements.TextFieldController
-import com.stripe.android.paymentsheet.elements.IdentifierSpec
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethodTest.kt
@@ -45,9 +45,9 @@ class SupportedPaymentMethodTest {
                         )
                         csvOutput.append(
                             "${lpm.type.code}, ${
-                            testInput.copy(
-                                intentPMs = testInput.intentPMs.plus(lpm.type.code)
-                            ).toCsv()
+                                testInput.copy(
+                                    intentPMs = testInput.intentPMs.plus(lpm.type.code)
+                                ).toCsv()
                             }, ${testOutput.toCsv()}\n"
                         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethodTest.kt
@@ -45,9 +45,9 @@ class SupportedPaymentMethodTest {
                         )
                         csvOutput.append(
                             "${lpm.type.code}, ${
-                                testInput.copy(
-                                    intentPMs = testInput.intentPMs.plus(lpm.type.code)
-                                ).toCsv()
+                            testInput.copy(
+                                intentPMs = testInput.intentPMs.plus(lpm.type.code)
+                            ).toCsv()
                             }, ${testOutput.toCsv()}\n"
                         )
 


### PR DESCRIPTION
# Summary
Add parcelization to the FormSpec, and change SupportedPaymentMethods to a sealed class.

# Motivation
Parcelization was added so that we can send the FormSpec as desired to the FormUI rather than the Spec and the save for future use checkbox state and visibility state.
Changed the SupportedPaymentMethods to a sealed class so that the full PaymentMethod specification can be defined in a single file.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
