### PR TITLE
Move Country classes into `stripe-core`

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -1623,7 +1623,7 @@ public final class com/stripe/android/model/Address : com/stripe/android/core/mo
 	public static final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/Address;
 	public final fun getCity ()Ljava/lang/String;
 	public final fun getCountry ()Ljava/lang/String;
-	public final fun getCountryCode ()Lcom/stripe/android/model/CountryCode;
+	public final fun getCountryCode ()Lcom/stripe/android/core/model/CountryCode;
 	public final fun getLine1 ()Ljava/lang/String;
 	public final fun getLine2 ()Ljava/lang/String;
 	public final fun getPostalCode ()Ljava/lang/String;
@@ -1641,7 +1641,7 @@ public final class com/stripe/android/model/Address$Builder : com/stripe/android
 	public synthetic fun build ()Ljava/lang/Object;
 	public final fun setCity (Ljava/lang/String;)Lcom/stripe/android/model/Address$Builder;
 	public final fun setCountry (Ljava/lang/String;)Lcom/stripe/android/model/Address$Builder;
-	public final fun setCountryCode (Lcom/stripe/android/model/CountryCode;)Lcom/stripe/android/model/Address$Builder;
+	public final fun setCountryCode (Lcom/stripe/android/core/model/CountryCode;)Lcom/stripe/android/model/Address$Builder;
 	public final fun setLine1 (Ljava/lang/String;)Lcom/stripe/android/model/Address$Builder;
 	public final fun setLine2 (Ljava/lang/String;)Lcom/stripe/android/model/Address$Builder;
 	public final fun setPostalCode (Ljava/lang/String;)Lcom/stripe/android/model/Address$Builder;
@@ -2094,32 +2094,6 @@ public abstract interface class com/stripe/android/model/ConfirmStripeIntentPara
 }
 
 public final class com/stripe/android/model/ConfirmStripeIntentParams$Companion {
-}
-
-public final class com/stripe/android/model/CountryCode : android/os/Parcelable {
-	public static final field $stable I
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public static final field Companion Lcom/stripe/android/model/CountryCode$Companion;
-	public fun <init> (Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/model/CountryCode;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/CountryCode;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/CountryCode;
-	public fun describeContents ()I
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getValue ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
-public final class com/stripe/android/model/CountryCode$Companion {
-	public final fun create (Ljava/lang/String;)Lcom/stripe/android/model/CountryCode;
-	public final fun getCA ()Lcom/stripe/android/model/CountryCode;
-	public final fun getGB ()Lcom/stripe/android/model/CountryCode;
-	public final fun getUS ()Lcom/stripe/android/model/CountryCode;
-	public final fun isCA (Lcom/stripe/android/model/CountryCode;)Z
-	public final fun isGB (Lcom/stripe/android/model/CountryCode;)Z
-	public final fun isUS (Lcom/stripe/android/model/CountryCode;)Z
 }
 
 public final class com/stripe/android/model/Customer : com/stripe/android/core/model/StripeModel {
@@ -5795,21 +5769,6 @@ public final class com/stripe/android/view/CardValidCallback$Fields : java/lang/
 	public static fun values ()[Lcom/stripe/android/view/CardValidCallback$Fields;
 }
 
-public final class com/stripe/android/view/Country {
-	public static final field $stable I
-	public fun <init> (Lcom/stripe/android/model/CountryCode;Ljava/lang/String;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
-	public final fun component1 ()Lcom/stripe/android/model/CountryCode;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Lcom/stripe/android/model/CountryCode;Ljava/lang/String;)Lcom/stripe/android/view/Country;
-	public static synthetic fun copy$default (Lcom/stripe/android/view/Country;Lcom/stripe/android/model/CountryCode;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/view/Country;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getCode ()Lcom/stripe/android/model/CountryCode;
-	public final fun getName ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
 public final class com/stripe/android/view/CountryTextInputLayout : com/google/android/material/textfield/TextInputLayout {
 	public static final field $stable I
 	public static final field INVALID_COUNTRY_AUTO_COMPLETE_STYLE I
@@ -5817,22 +5776,12 @@ public final class com/stripe/android/view/CountryTextInputLayout : com/google/a
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public final fun getCountryAutocomplete ()Landroid/widget/AutoCompleteTextView;
 	public final fun getCountryCodeChangeCallback ()Lkotlin/jvm/functions/Function1;
-	public final fun getSelectedCountryCode ()Lcom/stripe/android/model/CountryCode;
+	public final fun getSelectedCountryCode ()Lcom/stripe/android/core/model/CountryCode;
 	public fun onSaveInstanceState ()Landroid/os/Parcelable;
 	public final fun setCountryCodeChangeCallback (Lkotlin/jvm/functions/Function1;)V
 	public fun setEnabled (Z)V
-	public final fun setSelectedCountryCode (Lcom/stripe/android/model/CountryCode;)V
-	public final fun updateUiForCountryEntered (Lcom/stripe/android/model/CountryCode;)V
-}
-
-public final class com/stripe/android/view/CountryUtils {
-	public static final field $stable I
-	public static final field INSTANCE Lcom/stripe/android/view/CountryUtils;
-	public final synthetic fun doesCountryUsePostalCode (Lcom/stripe/android/model/CountryCode;)Z
-	public final synthetic fun getCountryByCode (Lcom/stripe/android/model/CountryCode;Ljava/util/Locale;)Lcom/stripe/android/view/Country;
-	public final synthetic fun getCountryCodeByName (Ljava/lang/String;Ljava/util/Locale;)Lcom/stripe/android/model/CountryCode;
-	public final synthetic fun getDisplayCountry (Lcom/stripe/android/model/CountryCode;Ljava/util/Locale;)Ljava/lang/String;
-	public final synthetic fun getOrderedCountries (Ljava/util/Locale;)Ljava/util/List;
+	public final fun setSelectedCountryCode (Lcom/stripe/android/core/model/CountryCode;)V
+	public final fun updateUiForCountryEntered (Lcom/stripe/android/core/model/CountryCode;)V
 }
 
 public final class com/stripe/android/view/CvcEditText : com/stripe/android/view/StripeEditText {

--- a/payments-core/src/main/java/com/stripe/android/model/Address.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/Address.kt
@@ -3,6 +3,7 @@ package com.stripe.android.model
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.ObjectBuilder
+import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.model.StripeModel
 import com.stripe.android.model.parsers.AddressJsonParser
 import kotlinx.parcelize.Parcelize

--- a/payments-core/src/main/java/com/stripe/android/view/CardFormView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardFormView.kt
@@ -18,12 +18,13 @@ import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.core.widget.doAfterTextChanged
 import com.stripe.android.R
+import com.stripe.android.core.model.CountryCode
+import com.stripe.android.core.model.CountryUtils
 import com.stripe.android.databinding.StripeCardFormViewBinding
 import com.stripe.android.databinding.StripeHorizontalDividerBinding
 import com.stripe.android.databinding.StripeVerticalDividerBinding
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardParams
-import com.stripe.android.model.CountryCode
 import com.stripe.android.view.CardFormView.Style
 import com.stripe.android.view.CardValidCallback.Fields
 

--- a/payments-core/src/main/java/com/stripe/android/view/CountryAdapter.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CountryAdapter.kt
@@ -9,6 +9,7 @@ import android.widget.ArrayAdapter
 import android.widget.Filter
 import android.widget.TextView
 import com.stripe.android.R
+import com.stripe.android.core.model.Country
 import java.lang.ref.WeakReference
 
 /**

--- a/payments-core/src/main/java/com/stripe/android/view/CountryAutoCompleteTextViewValidator.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CountryAutoCompleteTextViewValidator.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.view
 
 import android.widget.AutoCompleteTextView
+import com.stripe.android.core.model.Country
 
 internal class CountryAutoCompleteTextViewValidator(
     private val countryAdapter: CountryAdapter,

--- a/payments-core/src/main/java/com/stripe/android/view/CountryTextInputLayout.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CountryTextInputLayout.kt
@@ -17,7 +17,9 @@ import androidx.core.os.ConfigurationCompat
 import androidx.core.view.doOnNextLayout
 import com.google.android.material.textfield.TextInputLayout
 import com.stripe.android.R
-import com.stripe.android.model.CountryCode
+import com.stripe.android.core.model.Country
+import com.stripe.android.core.model.CountryCode
+import com.stripe.android.core.model.CountryUtils
 import kotlinx.parcelize.Parcelize
 import java.util.Locale
 import kotlin.properties.Delegates

--- a/payments-core/src/main/java/com/stripe/android/view/PostalCodeValidator.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PostalCodeValidator.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.view
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.model.CountryUtils
 import java.util.Locale
 import java.util.regex.Pattern
 

--- a/payments-core/src/main/java/com/stripe/android/view/ShippingInfoWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/ShippingInfoWidget.kt
@@ -10,6 +10,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.widget.LinearLayout
 import com.stripe.android.R
+import com.stripe.android.core.model.Country
+import com.stripe.android.core.model.CountryUtils
 import com.stripe.android.databinding.AddressWidgetBinding
 import com.stripe.android.model.Address
 import com.stripe.android.model.ShippingInformation

--- a/payments-core/src/test/java/com/stripe/android/view/CardFormViewTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardFormViewTest.kt
@@ -16,7 +16,7 @@ import com.stripe.android.databinding.StripeCardFormViewBinding
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CardParams
-import com.stripe.android.model.CountryCode
+ import com.stripe.android.core.model.CountryCode
 import com.stripe.android.utils.TestUtils.idleLooper
 import org.junit.After
 import org.junit.Before

--- a/payments-core/src/test/java/com/stripe/android/view/CardFormViewTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardFormViewTest.kt
@@ -12,11 +12,11 @@ import com.stripe.android.CardNumberFixtures
 import com.stripe.android.CardNumberFixtures.VISA_WITH_SPACES
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
+import com.stripe.android.core.model.CountryCode
 import com.stripe.android.databinding.StripeCardFormViewBinding
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.CardParams
- import com.stripe.android.core.model.CountryCode
 import com.stripe.android.utils.TestUtils.idleLooper
 import org.junit.After
 import org.junit.Before

--- a/payments-core/src/test/java/com/stripe/android/view/CountryAdapterTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CountryAdapterTest.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import android.widget.TextView
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.model.CountryCode
+import com.stripe.android.core.model.Country
+import com.stripe.android.core.model.CountryUtils
+import com.stripe.android.core.model.CountryCode
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.util.Locale

--- a/payments-core/src/test/java/com/stripe/android/view/CountryAdapterTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CountryAdapterTest.kt
@@ -5,8 +5,8 @@ import android.widget.TextView
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.model.Country
-import com.stripe.android.core.model.CountryUtils
 import com.stripe.android.core.model.CountryCode
+import com.stripe.android.core.model.CountryUtils
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.util.Locale

--- a/payments-core/src/test/java/com/stripe/android/view/CountryAutoCompleteTextViewValidatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CountryAutoCompleteTextViewValidatorTest.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.widget.TextView
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.model.Country
+import com.stripe.android.core.model.CountryUtils
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.util.Locale

--- a/payments-core/src/test/java/com/stripe/android/view/CountryTextInputLayoutTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CountryTextInputLayoutTest.kt
@@ -10,8 +10,9 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.PaymentSessionData
 import com.stripe.android.PaymentSessionFixtures
 import com.stripe.android.R
-import com.stripe.android.model.CountryCode
-import com.stripe.android.model.getCountryCode
+import com.stripe.android.core.model.CountryCode
+import com.stripe.android.core.model.CountryUtils
+import com.stripe.android.core.model.getCountryCode
 import com.stripe.android.utils.TestUtils.idleLooper
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock

--- a/payments-core/src/test/java/com/stripe/android/view/ShippingInfoWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/ShippingInfoWidgetTest.kt
@@ -14,7 +14,7 @@ import com.stripe.android.PaymentSessionFixtures
 import com.stripe.android.R
 import com.stripe.android.model.Address
 import com.stripe.android.model.ShippingInformation
-import com.stripe.android.model.getCountryCode
+import com.stripe.android.core.model.getCountryCode
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner

--- a/payments-core/src/test/java/com/stripe/android/view/ShippingInfoWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/ShippingInfoWidgetTest.kt
@@ -12,9 +12,9 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.PaymentSessionData
 import com.stripe.android.PaymentSessionFixtures
 import com.stripe.android.R
+import com.stripe.android.core.model.getCountryCode
 import com.stripe.android.model.Address
 import com.stripe.android.model.ShippingInformation
-import com.stripe.android.core.model.getCountryCode
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
@@ -68,8 +68,10 @@ class ShippingInfoWidgetTest {
         ).use { activityScenario ->
             activityScenario.onActivity {
                 shippingInfoWidget = it.findViewById(R.id.shipping_info_widget)
-                addressLine1TextInputLayout = shippingInfoWidget.findViewById(R.id.tl_address_line1_aaw)
-                addressLine2TextInputLayout = shippingInfoWidget.findViewById(R.id.tl_address_line2_aaw)
+                addressLine1TextInputLayout =
+                    shippingInfoWidget.findViewById(R.id.tl_address_line1_aaw)
+                addressLine2TextInputLayout =
+                    shippingInfoWidget.findViewById(R.id.tl_address_line2_aaw)
                 cityTextInputLayout = shippingInfoWidget.findViewById(R.id.tl_city_aaw)
                 nameTextInputLayout = shippingInfoWidget.findViewById(R.id.tl_name_aaw)
                 postalCodeTextInputLayout = shippingInfoWidget.findViewById(R.id.tl_postal_code_aaw)
@@ -81,7 +83,8 @@ class ShippingInfoWidgetTest {
                 postalEditText = shippingInfoWidget.findViewById(R.id.et_postal_code_aaw)
                 stateEditText = shippingInfoWidget.findViewById(R.id.et_state_aaw)
                 phoneEditText = shippingInfoWidget.findViewById(R.id.et_phone_number_aaw)
-                countryTextInputLayout = shippingInfoWidget.findViewById(R.id.country_autocomplete_aaw)
+                countryTextInputLayout =
+                    shippingInfoWidget.findViewById(R.id.country_autocomplete_aaw)
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/CardDataCollectionFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/CardDataCollectionFragment.kt
@@ -19,7 +19,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.model.Address
-import com.stripe.android.model.CountryCode
+import com.stripe.android.core.model.CountryCode
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.databinding.FragmentPaymentsheetAddCardBinding
@@ -30,7 +30,7 @@ import com.stripe.android.paymentsheet.ui.BillingAddressView
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.view.CardInputListener
 import com.stripe.android.view.CardMultilineWidget
-import com.stripe.android.view.Country
+import com.stripe.android.core.model.Country
 
 /**
  * A [Fragment] for collecting data for a new card payment method.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingAddressView.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingAddressView.kt
@@ -18,12 +18,12 @@ import androidx.core.widget.doAfterTextChanged
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.stripe.android.model.Address
-import com.stripe.android.model.CountryCode
-import com.stripe.android.model.CountryCode.Companion.isUS
+import com.stripe.android.core.model.CountryCode
+import com.stripe.android.core.model.CountryCode.Companion.isUS
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.databinding.StripeBillingAddressLayoutBinding
-import com.stripe.android.view.Country
-import com.stripe.android.view.CountryUtils
+import com.stripe.android.core.model.Country
+import com.stripe.android.core.model.CountryUtils
 import com.stripe.android.view.PostalCodeValidator
 import java.util.Locale
 import kotlin.properties.Delegates

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/CardDataCollectionFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/CardDataCollectionFragmentTest.kt
@@ -10,7 +10,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.model.CardBrand
-import com.stripe.android.model.CountryCode
+import com.stripe.android.core.model.CountryCode
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/BillingAddressViewTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/BillingAddressViewTest.kt
@@ -8,10 +8,10 @@ import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.model.Address
 import com.stripe.android.model.AddressFixtures
-import com.stripe.android.model.CountryCode
+import com.stripe.android.core.model.CountryCode
 import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.view.ActivityScenarioFactory
-import com.stripe.android.view.Country
+import com.stripe.android.core.model.Country
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify

--- a/stripe-core/api/stripe-core.api
+++ b/stripe-core/api/stripe-core.api
@@ -181,6 +181,62 @@ public final class com/stripe/android/core/injection/WeakMapInjectorRegistry : c
 	public fun retrieve (Ljava/lang/String;)Lcom/stripe/android/core/injection/Injector;
 }
 
+public final class com/stripe/android/core/model/Country {
+	public static final field $stable I
+	public fun <init> (Lcom/stripe/android/core/model/CountryCode;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Lcom/stripe/android/core/model/CountryCode;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Lcom/stripe/android/core/model/CountryCode;Ljava/lang/String;)Lcom/stripe/android/core/model/Country;
+	public static synthetic fun copy$default (Lcom/stripe/android/core/model/Country;Lcom/stripe/android/core/model/CountryCode;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/core/model/Country;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCode ()Lcom/stripe/android/core/model/CountryCode;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/core/model/CountryCode : android/os/Parcelable {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/core/model/CountryCode$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/core/model/CountryCode;
+	public static synthetic fun copy$default (Lcom/stripe/android/core/model/CountryCode;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/core/model/CountryCode;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/core/model/CountryCode$Companion {
+	public final fun create (Ljava/lang/String;)Lcom/stripe/android/core/model/CountryCode;
+	public final fun getCA ()Lcom/stripe/android/core/model/CountryCode;
+	public final fun getGB ()Lcom/stripe/android/core/model/CountryCode;
+	public final fun getUS ()Lcom/stripe/android/core/model/CountryCode;
+	public final fun isCA (Lcom/stripe/android/core/model/CountryCode;)Z
+	public final fun isGB (Lcom/stripe/android/core/model/CountryCode;)Z
+	public final fun isUS (Lcom/stripe/android/core/model/CountryCode;)Z
+}
+
+public final class com/stripe/android/core/model/CountryCodeKt {
+	public static final fun getCountryCode (Ljava/util/Locale;)Lcom/stripe/android/core/model/CountryCode;
+}
+
+public final class com/stripe/android/core/model/CountryUtils {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/stripe/android/core/model/CountryUtils;
+	public final synthetic fun doesCountryUsePostalCode (Lcom/stripe/android/core/model/CountryCode;)Z
+	public final synthetic fun doesCountryUsePostalCode (Ljava/lang/String;)Z
+	public final synthetic fun getCountryByCode (Lcom/stripe/android/core/model/CountryCode;Ljava/util/Locale;)Lcom/stripe/android/core/model/Country;
+	public final synthetic fun getCountryCodeByName (Ljava/lang/String;Ljava/util/Locale;)Lcom/stripe/android/core/model/CountryCode;
+	public final synthetic fun getDisplayCountry (Lcom/stripe/android/core/model/CountryCode;Ljava/util/Locale;)Ljava/lang/String;
+	public final synthetic fun getOrderedCountries (Ljava/util/Locale;)Ljava/util/List;
+}
+
 public abstract interface class com/stripe/android/core/model/StripeModel : android/os/Parcelable {
 	public abstract fun equals (Ljava/lang/Object;)Z
 	public abstract fun hashCode ()I

--- a/stripe-core/src/main/java/com/stripe/android/core/model/Country.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/model/Country.kt
@@ -1,9 +1,8 @@
-package com.stripe.android.view
+package com.stripe.android.core.model
 
 import androidx.annotation.RestrictTo
-import com.stripe.android.model.CountryCode
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) // For paymentsheet
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class Country(
     val code: CountryCode,
     val name: String

--- a/stripe-core/src/main/java/com/stripe/android/core/model/CountryCode.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/model/CountryCode.kt
@@ -1,18 +1,19 @@
-package com.stripe.android.model
+package com.stripe.android.core.model
 
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import kotlinx.parcelize.Parcelize
 import java.util.Locale
 
-internal fun Locale.getCountryCode(): CountryCode = CountryCode.create(this.country)
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun Locale.getCountryCode(): CountryCode = CountryCode.create(this.country)
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) // For paymentsheet
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Parcelize
 data class CountryCode(
     val value: String,
 ) : Parcelable {
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) // For paymentsheet
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
         val US = CountryCode("US")
         val CA = CountryCode("CA")

--- a/stripe-core/src/main/java/com/stripe/android/core/model/CountryUtils.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/model/CountryUtils.kt
@@ -1,9 +1,7 @@
-package com.stripe.android.view
+package com.stripe.android.core.model
 
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
-import com.stripe.android.model.CountryCode
-import com.stripe.android.model.getCountryCode
 import java.text.Normalizer
 import java.util.Locale
 
@@ -81,7 +79,7 @@ object CountryUtils {
         )
     )
     @JvmSynthetic
-    internal fun doesCountryUsePostalCode(countryCode: String): Boolean {
+    fun doesCountryUsePostalCode(countryCode: String): Boolean {
         return CARD_POSTAL_CODE_COUNTRIES.contains(countryCode.uppercase())
     }
 

--- a/stripe-core/src/test/java/com/stripe/android/core/model/CountryCodeTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/model/CountryCodeTest.kt
@@ -1,6 +1,6 @@
-package com.stripe.android.model
+package com.stripe.android.core.model
 
-import com.stripe.android.utils.ParcelUtils
+import com.stripe.android.core.utils.ParcelUtils
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test

--- a/stripe-core/src/test/java/com/stripe/android/core/model/CountryUtilsTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/model/CountryUtilsTest.kt
@@ -1,9 +1,7 @@
-package com.stripe.android.view
+package com.stripe.android.core.model
 
 import android.os.Build
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.model.CountryCode
-import com.stripe.android.model.getCountryCode
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config

--- a/stripe-core/src/test/java/com/stripe/android/core/utils/ParcelUtils.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/utils/ParcelUtils.kt
@@ -1,0 +1,57 @@
+package com.stripe.android.core.utils
+
+import android.os.Bundle
+import android.os.Parcel
+import android.os.Parcelable
+import androidx.core.os.bundleOf
+import com.google.common.truth.Truth.assertThat
+
+internal object ParcelUtils {
+    /**
+     * @param source the source from which to parcel and unparcel a new object
+     *
+     * @return a new [Source] instance based on the original source
+     */
+    internal fun <Source : Parcelable> create(
+        source: Source
+    ): Source {
+        val bundle = bundleOf(KEY to source)
+        return requireNotNull(bundle.getParcelable(KEY))
+    }
+
+    /**
+     * @param source the source from which to parcel and unparcel a new object
+     * @param creator the [Parcelable.Creator]
+     *
+     * @return a new [SOURCE] instance based on the original source
+     */
+    @JvmStatic
+    fun <SOURCE : Parcelable> copy(
+        source: SOURCE,
+        creator: Parcelable.Creator<SOURCE>
+    ): SOURCE {
+        val parcel = Parcel.obtain()
+        source.writeToParcel(parcel, source.describeContents())
+        parcel.setDataPosition(0)
+        return creator.createFromParcel(parcel)
+    }
+
+    internal fun verifyParcelRoundtrip(expected: Parcelable) {
+        val actual: Parcelable = createParcelRoundtrip(expected)
+
+        assertThat(actual)
+            .isEqualTo(expected)
+    }
+
+    private inline fun <reified T : Parcelable> createParcelRoundtrip(
+        source: Parcelable
+    ): T {
+        val bundle = bundleOf(KEY to source)
+
+        return requireNotNull(
+            copy(bundle, Bundle.CREATOR).getParcelable(KEY)
+        )
+    }
+
+    private const val KEY = "parcelable"
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/ui/core/elements/CountryConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/ui/core/elements/CountryConfig.kt
@@ -2,9 +2,9 @@ package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
 import androidx.annotation.StringRes
-import com.stripe.android.model.CountryCode
+import com.stripe.android.core.model.CountryCode
+import com.stripe.android.core.model.CountryUtils
 import com.stripe.android.ui.core.R
-import com.stripe.android.view.CountryUtils
 import java.util.Locale
 
 /**

--- a/stripe-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/AsyncResourceRepository.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/AsyncResourceRepository.kt
@@ -3,9 +3,9 @@ package com.stripe.android.ui.core.forms.resources
 import android.content.res.Resources
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.injection.IOContext
+import com.stripe.android.core.model.CountryUtils
 import com.stripe.android.ui.core.address.AddressFieldElementRepository
 import com.stripe.android.ui.core.elements.BankRepository
-import com.stripe.android.view.CountryUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.joinAll


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Move Country classes into `stripe-core`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Classes are not payment-specific and used by `stripe-ui-core`.
[MOBILESDK-477](https://jira.corp.stripe.com/browse/MOBILESDK-477)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified