### PR TITLE
Rename some classes to match the associated files

### DIFF
--- a/stripecardscan/api/stripecardscan.api
+++ b/stripecardscan/api/stripecardscan.api
@@ -19,6 +19,35 @@ public final class com/stripe/android/stripecardscan/camera/CameraPreviewImage {
 	public fun toString ()Ljava/lang/String;
 }
 
+public class com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationActivity : com/stripe/android/stripecardscan/scanui/SimpleScanActivity {
+	public static final field $stable I
+	public fun <init> ()V
+	protected fun addUiComponents ()V
+	protected fun closeScanner ()V
+	protected fun displayState (Lcom/stripe/android/stripecardscan/scanui/SimpleScanActivity$ScanState;Lcom/stripe/android/stripecardscan/scanui/SimpleScanActivity$ScanState;)V
+	protected fun getCannotScanTextView ()Landroid/widget/TextView;
+	protected fun getCardDescriptionTextView ()Landroid/widget/TextView;
+	protected fun getMinimumAnalysisResolution ()Landroid/util/Size;
+	protected fun getProcessingOverlayView ()Landroid/view/View;
+	protected fun getProcessingSpinnerView ()Landroid/widget/ProgressBar;
+	protected fun getProcessingTextView ()Landroid/widget/TextView;
+	public synthetic fun getResultListener$stripecardscan_release ()Lcom/stripe/android/stripecardscan/scanui/ScanResultListener;
+	public synthetic fun getScanFlow$stripecardscan_release ()Lcom/stripe/android/stripecardscan/scanui/ScanFlow;
+	protected fun onCreate (Landroid/os/Bundle;)V
+	protected fun setupCannotScanTextViewConstraints ()V
+	protected fun setupCannotScanUi ()V
+	protected fun setupCardDescriptionTextViewConstraints ()V
+	protected fun setupCardDescriptionUi ()V
+	protected fun setupInstructionsViewConstraints ()V
+	protected fun setupProcessingOverlayViewConstraints ()V
+	protected fun setupProcessingOverlayViewUi ()V
+	protected fun setupProcessingSpinnerViewConstraints ()V
+	protected fun setupProcessingTextViewConstraints ()V
+	protected fun setupProcessingTextViewUi ()V
+	protected fun setupUiComponents ()V
+	protected fun setupUiConstraints ()V
+}
+
 public final class com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationConfig {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationConfig;
@@ -100,35 +129,6 @@ public final class com/stripe/android/stripecardscan/cardimageverification/CardI
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
-public class com/stripe/android/stripecardscan/cardimageverification/CardVerifyActivity : com/stripe/android/stripecardscan/scanui/SimpleScanActivity {
-	public static final field $stable I
-	public fun <init> ()V
-	protected fun addUiComponents ()V
-	protected fun closeScanner ()V
-	protected fun displayState (Lcom/stripe/android/stripecardscan/scanui/SimpleScanActivity$ScanState;Lcom/stripe/android/stripecardscan/scanui/SimpleScanActivity$ScanState;)V
-	protected fun getCannotScanTextView ()Landroid/widget/TextView;
-	protected fun getCardDescriptionTextView ()Landroid/widget/TextView;
-	protected fun getMinimumAnalysisResolution ()Landroid/util/Size;
-	protected fun getProcessingOverlayView ()Landroid/view/View;
-	protected fun getProcessingSpinnerView ()Landroid/widget/ProgressBar;
-	protected fun getProcessingTextView ()Landroid/widget/TextView;
-	public synthetic fun getResultListener$stripecardscan_release ()Lcom/stripe/android/stripecardscan/scanui/ScanResultListener;
-	public synthetic fun getScanFlow$stripecardscan_release ()Lcom/stripe/android/stripecardscan/scanui/ScanFlow;
-	protected fun onCreate (Landroid/os/Bundle;)V
-	protected fun setupCannotScanTextViewConstraints ()V
-	protected fun setupCannotScanUi ()V
-	protected fun setupCardDescriptionTextViewConstraints ()V
-	protected fun setupCardDescriptionUi ()V
-	protected fun setupInstructionsViewConstraints ()V
-	protected fun setupProcessingOverlayViewConstraints ()V
-	protected fun setupProcessingOverlayViewUi ()V
-	protected fun setupProcessingSpinnerViewConstraints ()V
-	protected fun setupProcessingTextViewConstraints ()V
-	protected fun setupProcessingTextViewUi ()V
-	protected fun setupUiComponents ()V
-	protected fun setupUiConstraints ()V
 }
 
 public final class com/stripe/android/stripecardscan/cardimageverification/RequiredCardDetails {

--- a/stripecardscan/src/main/AndroidManifest.xml
+++ b/stripecardscan/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
 
     <application>
         <activity
-            android:name=".cardimageverification.CardVerifyActivity"
+            android:name=".cardimageverification.CardImageVerificationActivity"
             android:screenOrientation="nosensor"
             android:theme="@style/stripeDefaultTheme" />
     </application>

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationActivity.kt
@@ -54,18 +54,17 @@ import java.util.concurrent.atomic.AtomicBoolean
 internal const val INTENT_PARAM_REQUEST = "request"
 internal const val INTENT_PARAM_RESULT = "result"
 
-@Keep
-internal interface CardVerifyResultListener : ScanResultListener {
+internal interface CardImageVerificationResultListener : ScanResultListener {
 
     /**
      * A payment card was successfully scanned.
      */
-    fun cardVerificationComplete(pan: String)
+    fun cardImageVerificationComplete(pan: String)
 
     /**
      * A card was scanned and is ready to be verified.
      */
-    fun cardScanned(pan: String, frames: Collection<SavedFrame>)
+    fun cardReadyForVerification(pan: String, frames: Collection<SavedFrame>)
 }
 
 data class RequiredCardDetails(
@@ -76,7 +75,7 @@ data class RequiredCardDetails(
 private val MINIMUM_RESOLUTION = Size(1067, 600) // minimum size of OCR
 
 @Keep
-open class CardVerifyActivity : SimpleScanActivity<RequiredCardDetails?>() {
+open class CardImageVerificationActivity : SimpleScanActivity<RequiredCardDetails?>() {
 
     /**
      * The text view that lets a user indicate they do not have possession of the required card.
@@ -121,40 +120,41 @@ open class CardVerifyActivity : SimpleScanActivity<RequiredCardDetails?>() {
     /**
      * The listener which handles results from the scan.
      */
-    override val resultListener: CardVerifyResultListener = object : CardVerifyResultListener {
-        override fun cardVerificationComplete(pan: String) {
-            val intent = Intent()
-                .putExtra(
-                    INTENT_PARAM_RESULT,
-                    CardImageVerificationSheetResult.Completed(
-                        ScannedCard(
-                            pan = pan
+    override val resultListener: CardImageVerificationResultListener =
+        object : CardImageVerificationResultListener {
+            override fun cardImageVerificationComplete(pan: String) {
+                val intent = Intent()
+                    .putExtra(
+                        INTENT_PARAM_RESULT,
+                        CardImageVerificationSheetResult.Completed(
+                            ScannedCard(
+                                pan = pan
+                            )
                         )
                     )
-                )
-            setResult(Activity.RESULT_OK, intent)
-            closeScanner()
-        }
+                setResult(Activity.RESULT_OK, intent)
+                closeScanner()
+            }
 
-        override fun cardScanned(pan: String, frames: Collection<SavedFrame>) {
-            launch {
-                when (
-                    val result = uploadSavedFrames(
-                        stripePublishableKey = params.stripePublishableKey,
-                        civId = params.cardImageVerificationIntentId,
-                        civSecret = params.cardImageVerificationIntentSecret,
-                        savedFrames = frames,
-                    )
-                ) {
-                    is NetworkResult.Success ->
-                        cardVerificationComplete(pan)
-                    is NetworkResult.Error ->
-                        scanFailure(StripeNetworkException(result.error.error.message))
-                    is NetworkResult.Exception ->
-                        scanFailure(result.exception)
+            override fun cardReadyForVerification(pan: String, frames: Collection<SavedFrame>) {
+                launch {
+                    when (
+                        val result = uploadSavedFrames(
+                            stripePublishableKey = params.stripePublishableKey,
+                            civId = params.cardImageVerificationIntentId,
+                            civSecret = params.cardImageVerificationIntentSecret,
+                            savedFrames = frames,
+                        )
+                    ) {
+                        is NetworkResult.Success ->
+                            cardImageVerificationComplete(pan)
+                        is NetworkResult.Error ->
+                            scanFailure(StripeNetworkException(result.error.error.message))
+                        is NetworkResult.Exception ->
+                            scanFailure(result.exception)
+                    }
                 }
             }
-        }
 
         override fun userCanceled(reason: CancellationReason) {
             val intent = Intent()
@@ -175,8 +175,8 @@ open class CardVerifyActivity : SimpleScanActivity<RequiredCardDetails?>() {
     /**
      * The flow used to scan an item.
      */
-    override val scanFlow: CardVerifyFlow by lazy {
-        object : CardVerifyFlow(scanErrorListener) {
+    override val scanFlow: CardImageVerificationFlow by lazy {
+        object : CardImageVerificationFlow(scanErrorListener) {
             /**
              * A final result was received from the aggregator. Set the result from this activity.
              */
@@ -187,8 +187,8 @@ open class CardVerifyActivity : SimpleScanActivity<RequiredCardDetails?>() {
 
                 launch(Dispatchers.Main) {
                     changeScanState(ScanState.Correct)
-                    cameraAdapter.unbindFromLifecycle(this@CardVerifyActivity)
-                    resultListener.cardScanned(
+                    cameraAdapter.unbindFromLifecycle(this@CardImageVerificationActivity)
+                    resultListener.cardReadyForVerification(
                         pan = result.pan,
                         frames = scanFlow.selectCompletionLoopFrames(result.savedFrames),
                     )

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationActivity.kt
@@ -156,21 +156,24 @@ open class CardImageVerificationActivity : SimpleScanActivity<RequiredCardDetail
                 }
             }
 
-        override fun userCanceled(reason: CancellationReason) {
-            val intent = Intent()
-                .putExtra(INTENT_PARAM_RESULT, CardImageVerificationSheetResult.Canceled(reason))
-            setResult(Activity.RESULT_CANCELED, intent)
-        }
+            override fun userCanceled(reason: CancellationReason) {
+                val intent = Intent()
+                    .putExtra(
+                        INTENT_PARAM_RESULT,
+                        CardImageVerificationSheetResult.Canceled(reason),
+                    )
+                setResult(Activity.RESULT_CANCELED, intent)
+            }
 
-        override fun failed(cause: Throwable?) {
-            val intent = Intent()
-                .putExtra(
-                    INTENT_PARAM_RESULT,
-                    CardImageVerificationSheetResult.Failed(cause ?: UnknownScanException()),
-                )
-            setResult(Activity.RESULT_CANCELED, intent)
+            override fun failed(cause: Throwable?) {
+                val intent = Intent()
+                    .putExtra(
+                        INTENT_PARAM_RESULT,
+                        CardImageVerificationSheetResult.Failed(cause ?: UnknownScanException()),
+                    )
+                setResult(Activity.RESULT_CANCELED, intent)
+            }
         }
-    }
 
     /**
      * The flow used to scan an item.

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationFlow.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationFlow.kt
@@ -3,7 +3,6 @@ package com.stripe.android.stripecardscan.cardimageverification
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Rect
-import androidx.annotation.Keep
 import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.stripecardscan.camera.CameraPreviewImage
 import com.stripe.android.stripecardscan.cardimageverification.analyzer.MainLoopAnalyzer

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationFlow.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationFlow.kt
@@ -25,20 +25,17 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
-@Keep
 internal data class SavedFrame(
     val hasOcr: Boolean,
     val frame: MainLoopAnalyzer.Input,
 )
 
-@Keep
 internal data class SavedFrameType(
     val hasCard: Boolean,
     val hasOcr: Boolean,
 )
 
-@Keep
-internal abstract class CardVerifyFlow(
+internal abstract class CardImageVerificationFlow(
     private val scanErrorListener: AnalyzerLoopErrorListener,
 ) : ScanFlow<RequiredCardDetails?>,
     AggregateResultListener<MainLoopAggregator.InterimResult, MainLoopAggregator.FinalResult> {
@@ -73,7 +70,7 @@ internal abstract class CardVerifyFlow(
         }
 
         mainLoopAggregator = MainLoopAggregator(
-            listener = this@CardVerifyFlow,
+            listener = this@CardImageVerificationFlow,
             requiredCardIssuer = parameters?.cardIssuer,
             requiredLastFour = parameters?.lastFour,
         ).also { mainLoopOcrAggregator ->

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet.kt
@@ -73,7 +73,7 @@ class CardImageVerificationSheet private constructor(private val stripePublishab
             }
 
         private fun createIntent(context: Context, input: CardImageVerificationSheetParams) =
-            Intent(context, CardVerifyActivity::class.java).putExtra(INTENT_PARAM_REQUEST, input)
+            Intent(context, CardImageVerificationActivity::class.java).putExtra(INTENT_PARAM_REQUEST, input)
 
         private fun parseResult(intent: Intent): CardImageVerificationSheetResult =
             intent.getParcelableExtra(INTENT_PARAM_RESULT)

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet.kt
@@ -73,7 +73,8 @@ class CardImageVerificationSheet private constructor(private val stripePublishab
             }
 
         private fun createIntent(context: Context, input: CardImageVerificationSheetParams) =
-            Intent(context, CardImageVerificationActivity::class.java).putExtra(INTENT_PARAM_REQUEST, input)
+            Intent(context, CardImageVerificationActivity::class.java)
+                .putExtra(INTENT_PARAM_REQUEST, input)
 
         private fun parseResult(intent: Intent): CardImageVerificationSheetResult =
             intent.getParcelableExtra(INTENT_PARAM_RESULT)

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/result/MainLoopAggregator.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/result/MainLoopAggregator.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.stripecardscan.cardimageverification.result
 
-import androidx.annotation.Keep
 import com.stripe.android.stripecardscan.cardimageverification.SavedFrame
 import com.stripe.android.stripecardscan.cardimageverification.SavedFrameType
 import com.stripe.android.stripecardscan.cardimageverification.CardImageVerificationConfig

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/result/MainLoopAggregator.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/result/MainLoopAggregator.kt
@@ -43,14 +43,12 @@ internal class MainLoopAggregator(
         statsName = null, // TODO: when we want to collect this in scan stats, give this a name
     ) {
 
-    @Keep
     internal data class FinalResult(
         val pan: String,
         val savedFrames: Map<SavedFrameType, List<SavedFrame>>,
     )
 
-    @Keep
-    data class InterimResult(
+    internal data class InterimResult(
         val analyzerResult: MainLoopAnalyzer.Prediction,
         val frame: MainLoopAnalyzer.Input,
         val state: MainLoopState,

--- a/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationFlowTest.kt
+++ b/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationFlowTest.kt
@@ -6,13 +6,13 @@ import com.stripe.android.stripecardscan.framework.AnalyzerLoopErrorListener
 import org.junit.Test
 import kotlin.test.assertEquals
 
-class CardVerifyFlowTest {
+class CardImageVerificationFlowTest {
 
     @Test
     @SmallTest
     fun selectCompletionLoopFrames() {
 
-        val flow = object : CardVerifyFlow(
+        val flow = object : CardImageVerificationFlow(
             scanErrorListener = object : AnalyzerLoopErrorListener {
                 override fun onAnalyzerFailure(t: Throwable): Boolean = false
                 override fun onResultFailure(t: Throwable): Boolean = false


### PR DESCRIPTION
# Summary
When renaming files, I missed some classes that should have been renamed to match. This addresses that.

# Motivation
Consistency in naming.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified
