### PR TITLE
update timeout

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ buildscript {
 
 plugins {
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
+    id 'io.codearte.nexus-staging' version '0.30.0'
 }
 
 allprojects {

--- a/deploy/deploy.gradle
+++ b/deploy/deploy.gradle
@@ -1,6 +1,12 @@
 apply plugin: "signing"
 apply plugin: "maven-publish"
 
+nexusStaging {
+    packageGroup = GROUP
+    numberOfRetries = 40
+    delayBetweenRetriesInMillis = 4000
+}
+
 def getReleaseRepositoryUrl() {
     return findProperty('RELEASE_REPOSITORY_URL') ?:
             "https://oss.sonatype.org/service/local/staging/deploy/maven2/"


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update the timeout when communicating to sonatype

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
When releasing, `gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository` sometimes takes a long time and the script ended up failing with the following error, update the time out and retry times to wait longer.
```
Execution failed for task ':closeSonatypeStagingRepository'.
> Staging repository is still transitioning after defined time. Consider its increment. StagingRepository(id=comstripe-2512, state=open, transitioning=true)
```

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
