### PR TITLE
Add CIV beta opt-in instructions

### DIFF
--- a/stripecardscan-example/README.md
+++ b/stripecardscan-example/README.md
@@ -9,6 +9,15 @@
 
 <img width="215" height="108" src="https://raw.githubusercontent.com/stripe/stripe-android/master/stripecardscan-example/images/run_project.png" />
 
+### Set up permissions to use the flow
+The stripecardscan module is currently in private beta, and merchants must be manually included in the beta for this demo to work.
+
+If you're from outside Stripe, contact Stripe support to request to be added to the card image verification beta.
+
+If you're internal to Stripe:
+1. Add your merchant to the [feature flag](https://amp.corp.stripe.com/feature-flags/flag/gopiori.frontend.enable_card_verification).
+2. Add your merchant to the [gate](https://admin.corp.stripe.com/gates/card_verification_intent_web_beta).
+
 ### Set up your own backend with Glitch
 1. [Create a Glitch account](https://glitch.com/signup/) if you don't have one.
 2. Create your own copy of the [example mobile backend application](https://stripe-card-scan-civ-example-app.glitch.me/)

--- a/stripecardscan-example/README.md
+++ b/stripecardscan-example/README.md
@@ -14,9 +14,7 @@ The stripecardscan module is currently in private beta, and merchants must be ma
 
 If you're from outside Stripe, contact Stripe support to request to be added to the card image verification beta.
 
-If you're internal to Stripe:
-1. Add your merchant to the [feature flag](https://amp.corp.stripe.com/feature-flags/flag/gopiori.frontend.enable_card_verification).
-2. Add your merchant to the [gate](https://admin.corp.stripe.com/gates/card_verification_intent_web_beta).
+If you're internal to Stripe, contact the Bouncer team for help.
 
 ### Set up your own backend with Glitch
 1. [Create a Glitch account](https://glitch.com/signup/) if you don't have one.


### PR DESCRIPTION
# Summary
Add instructions to add a merchant to the CIV beta

# Motivation
Users who find the stripecardscan-example readme will not know that they must be manually gated into the experiment or the example won't work.
