### PR TITLE
Enable Eps, Giropay, p24, klarna and paypal in payment sheet

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethod.kt
@@ -348,7 +348,9 @@ internal sealed class SupportedPaymentMethod(
          * This is a list of the payment methods that we are allowing in the release
          */
         @VisibleForTesting
-        internal val exposedPaymentMethods = listOf(Card, Bancontact, Sofort, Ideal, SepaDebit)
+        internal val exposedPaymentMethods = listOf(
+            Card, Bancontact, Sofort, Ideal, SepaDebit, Eps, Giropay, P24, Klarna, PayPal
+        )
 
         /**
          * This will use only those payment methods that are allowed in the release

--- a/paymentsheet/src/test/resources/klarna-support.csv
+++ b/paymentsheet/src/test/resources/klarna-support.csv
@@ -7,10 +7,10 @@ klarna, true, true, on_session, false, card/klarna, false, false, not available,
 klarna, true, true, on_session, false, card/eps/klarna, false, false, not available, false
 klarna, true, false, on_session, false, card/klarna, false, false, not available, false
 klarna, true, false, on_session, false, card/eps/klarna, false, false, not available, false
-klarna, true, true, null, false, card/klarna, false, true, oneTime, false
-klarna, true, true, null, false, card/eps/klarna, false, true, oneTime, false
-klarna, true, false, null, false, card/klarna, false, true, oneTime, false
-klarna, true, false, null, false, card/eps/klarna, false, true, oneTime, false
+klarna, true, true, null, false, card/klarna, false, true, oneTime, true
+klarna, true, true, null, false, card/eps/klarna, false, true, oneTime, true
+klarna, true, false, null, false, card/klarna, false, true, oneTime, true
+klarna, true, false, null, false, card/eps/klarna, false, true, oneTime, true
 klarna, false, true, off_session, false, card/klarna, false, false, not available, false
 klarna, false, true, off_session, false, card/eps/klarna, false, false, not available, false
 klarna, false, false, off_session, false, card/klarna, false, false, not available, false
@@ -19,7 +19,7 @@ klarna, false, true, on_session, false, card/klarna, false, false, not available
 klarna, false, true, on_session, false, card/eps/klarna, false, false, not available, false
 klarna, false, false, on_session, false, card/klarna, false, false, not available, false
 klarna, false, false, on_session, false, card/eps/klarna, false, false, not available, false
-klarna, false, true, null, false, card/klarna, false, true, oneTime, false
-klarna, false, true, null, false, card/eps/klarna, false, true, oneTime, false
-klarna, false, false, null, false, card/klarna, false, true, oneTime, false
-klarna, false, false, null, false, card/eps/klarna, false, true, oneTime, false
+klarna, false, true, null, false, card/klarna, false, true, oneTime, true
+klarna, false, true, null, false, card/eps/klarna, false, true, oneTime, true
+klarna, false, false, null, false, card/klarna, false, true, oneTime, true
+klarna, false, false, null, false, card/eps/klarna, false, true, oneTime, true

--- a/paymentsheet/src/test/resources/paypal-support.csv
+++ b/paymentsheet/src/test/resources/paypal-support.csv
@@ -7,10 +7,10 @@ paypal, true, true, on_session, false, card/paypal, false, false, not available,
 paypal, true, true, on_session, false, card/eps/paypal, false, false, not available, false
 paypal, true, false, on_session, false, card/paypal, false, false, not available, false
 paypal, true, false, on_session, false, card/eps/paypal, false, false, not available, false
-paypal, true, true, null, false, card/paypal, false, true, oneTime, false
-paypal, true, true, null, false, card/eps/paypal, false, true, oneTime, false
-paypal, true, false, null, false, card/paypal, false, true, oneTime, false
-paypal, true, false, null, false, card/eps/paypal, false, true, oneTime, false
+paypal, true, true, null, false, card/paypal, false, true, oneTime, true
+paypal, true, true, null, false, card/eps/paypal, false, true, oneTime, true
+paypal, true, false, null, false, card/paypal, false, true, oneTime, true
+paypal, true, false, null, false, card/eps/paypal, false, true, oneTime, true
 paypal, false, true, off_session, false, card/paypal, false, false, not available, false
 paypal, false, true, off_session, false, card/eps/paypal, false, false, not available, false
 paypal, false, false, off_session, false, card/paypal, false, false, not available, false
@@ -19,7 +19,7 @@ paypal, false, true, on_session, false, card/paypal, false, false, not available
 paypal, false, true, on_session, false, card/eps/paypal, false, false, not available, false
 paypal, false, false, on_session, false, card/paypal, false, false, not available, false
 paypal, false, false, on_session, false, card/eps/paypal, false, false, not available, false
-paypal, false, true, null, false, card/paypal, false, true, oneTime, false
-paypal, false, true, null, false, card/eps/paypal, false, true, oneTime, false
-paypal, false, false, null, false, card/paypal, false, true, oneTime, false
-paypal, false, false, null, false, card/eps/paypal, false, true, oneTime, false
+paypal, false, true, null, false, card/paypal, false, true, oneTime, true
+paypal, false, true, null, false, card/eps/paypal, false, true, oneTime, true
+paypal, false, false, null, false, card/paypal, false, true, oneTime, true
+paypal, false, false, null, false, card/eps/paypal, false, true, oneTime, true


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Enables Klarna, Paypal, EPS, Giropay, P24, and Afterpay for PaymentSheet

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Match with iOS: https://github.com/stripe-ios/stripe-ios/pull/565

https://paper.dropbox.com/doc/PaymentSheet-December-release--BXXdYEs7PwD4GBjX9n5pvycjAg-0lBp7fRvXHaLBjSmPyZxE

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
