### PR TITLE
[CardInputWidget] Fix CardValidCallback not firing on postal code changes

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -333,8 +333,14 @@ class CardInputWidget @JvmOverloads constructor(
     private fun updatePostalRequired() {
         if (isPostalRequired()) {
             requiredFields.add(postalCodeEditText)
+            cardValidCallback?.let {
+                postalCodeEditText.addTextChangedListener(cardValidTextWatcher)
+            }
         } else {
             requiredFields.remove(postalCodeEditText)
+            cardValidCallback?.let {
+                postalCodeEditText.removeTextChangedListener(cardValidTextWatcher)
+            }
         }
     }
 

--- a/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -32,6 +32,10 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 import java.util.Calendar
 import kotlin.test.AfterTest
@@ -1607,6 +1611,29 @@ internal class CardInputWidgetTest {
 
         assertThat(cardInputListener.focusedFields)
             .contains(CardInputListener.FocusField.CardNumber)
+    }
+
+    @Test
+    fun `Requiring postal code after setting CardValidCallback should still notify of change`() {
+        val callback = mock<CardValidCallback>()
+        cardInputWidget.setCardValidCallback(callback)
+
+        cardInputWidget.postalCodeRequired = true
+        postalCodeEditText.setText("54321")
+
+        verify(callback, times(2)).onInputChanged(any(), any())
+    }
+
+    @Test
+    fun `Removing postal code requirement removes CardValidCallback notifications for the field`() {
+        val callback = mock<CardValidCallback>()
+        cardInputWidget.postalCodeRequired = true
+        cardInputWidget.setCardValidCallback(callback)
+        cardInputWidget.postalCodeRequired = false
+
+        postalCodeEditText.setText("54321")
+
+        verify(callback, times(1)).onInputChanged(any(), any())
     }
 
     private fun updateCardNumberAndIdle(cardNumber: String) {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This fixes a bug where we had a user adding a postal code requirement **after** setting their `CardValidCallback`. It resulted in changes to the postal code not triggering the callback. This should make it so you can set (or remove) the postal code requirement anytime and your custom callback will be triggered upon changes to the text field. Previously it was required that you set the postal code requirement before setting your callback. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-653

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

