### PR TITLE
Add config to opt out of default save PM checkbox behavior

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
@@ -254,6 +254,8 @@ internal abstract class BaseAddPaymentMethodFragment(
                 merchantName = merchantName,
                 amount = amount,
                 billingDetails = config?.defaultBillingDetails,
+                requiresUserOptInToSavePaymentMethod
+                    = config?.requiresUserOptInToSavePaymentMethod ?: false,
                 injectorKey = injectorKey
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -122,7 +122,15 @@ class PaymentSheet internal constructor(
          *
          * See [payment-notification](https://stripe.com/docs/payments/payment-methods#payment-notification).
          */
-        val allowsDelayedPaymentMethods: Boolean = false
+        val allowsDelayedPaymentMethods: Boolean = false,
+
+        /**
+         * PaymentSheet offers users an option to save some payment methods for later use.
+         * By default, this option is enabled, and the user can opt-out.
+         * Setting this to `true` will require that the user explicitly opt-in
+         * (e.g. by checking a box) to save their payment method.
+         */
+        val requiresUserOptInToSavePaymentMethod: Boolean = false
     ) : Parcelable {
         /**
          * [Configuration] builder for cleaner object creation from Java.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/CardDataCollectionFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/CardDataCollectionFragment.kt
@@ -324,7 +324,7 @@ internal class CardDataCollectionFragment<ViewModelType : BaseSheetViewModel<*>>
         requireArguments().getParcelable<FormFragmentArguments>(
             ComposeFormDataCollectionFragment.EXTRA_CONFIG
         )?.let { args ->
-            saveCardCheckbox.isChecked = true
+            saveCardCheckbox.isChecked = !args.requiresUserOptInToSavePaymentMethod
             saveCardCheckbox.isVisible = args.showCheckbox
         }
         sheetViewModel.newCard?.customerRequestedSave?.also {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormFragmentArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormFragmentArguments.kt
@@ -16,6 +16,7 @@ internal data class FormFragmentArguments(
     val merchantName: String,
     val amount: Amount? = null,
     val billingDetails: PaymentSheet.BillingDetails? = null,
+    val requiresUserOptInToSavePaymentMethod: Boolean = false,
     @InjectorKey val injectorKey: String,
 ) : Parcelable
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/CardDataCollectionFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/CardDataCollectionFragmentTest.kt
@@ -28,6 +28,8 @@ import com.stripe.android.paymentsheet.model.FragmentConfigFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.AddPaymentMethodsFragmentFactory
 import com.stripe.android.utils.TestUtils.idleLooper
+import junit.framework.Assert.assertFalse
+import junit.framework.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -437,6 +439,24 @@ class CardDataCollectionFragmentTest {
                         PaymentSheetFixtures.MERCHANT_DISPLAY_NAME
                     )
                 )
+        }
+    }
+
+    @Test
+    fun `checkbox is checked by default`() {
+        createFragment { _, viewBinding ->
+            assertTrue(viewBinding.saveCardCheckbox.isChecked)
+        }
+    }
+
+    @Test
+    fun `checkbox can be configured to default to unchecked`() {
+        createFragment(
+            fragmentArgs = COMPOSE_FRAGMENT_ARGS.copy(
+                requiresUserOptInToSavePaymentMethod = true
+            )
+        ) { _, viewBinding ->
+            assertFalse(viewBinding.saveCardCheckbox.isChecked)
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This lets merchants opt out of having the save card checkbox enabled by default. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
I copied ios with my naming: https://github.com/stripe-ios/stripe-ios/pull/654

https://jira.corp.stripe.com/browse/RUN_MOBILESDK-662?focusedCommentId=5833611&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-5833611

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
