### PR TITLE
Relay error message on PaymentResult.Failed

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -450,9 +450,7 @@ internal class DefaultFlowController @Inject internal constructor(
         }
         is PaymentResult.Failed -> {
             PaymentSheetResult.Failed(
-                IllegalArgumentException(
-                    "Failed to confirm intent: ${paymentResult.throwable.message}"
-                )
+                paymentResult.throwable
             )
         }
         else -> {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -704,8 +704,8 @@ internal class DefaultFlowControllerTest {
 
             verify(paymentResultCallback).onPaymentSheetResult(
                 argWhere { paymentResult ->
-                    paymentResult is PaymentSheetResult.Failed
-                        && errorMessage.equals(paymentResult.error.localizedMessage)
+                    paymentResult is PaymentSheetResult.Failed &&
+                        errorMessage == paymentResult.error.localizedMessage
                 }
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -697,13 +697,15 @@ internal class DefaultFlowControllerTest {
         }
 
     @Test
-    fun `onPaymentResult when error should invoke callback with Failed`() =
+    fun `onPaymentResult when error should invoke callback with Failed and relay error message`() =
         runTest {
-            flowController.onPaymentResult(PaymentResult.Failed(Throwable("error")))
+            val errorMessage = "Localized error message"
+            flowController.onPaymentResult(PaymentResult.Failed(Throwable(errorMessage)))
 
             verify(paymentResultCallback).onPaymentSheetResult(
                 argWhere { paymentResult ->
                     paymentResult is PaymentSheetResult.Failed
+                        && errorMessage.equals(paymentResult.error.localizedMessage)
                 }
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -699,7 +699,7 @@ internal class DefaultFlowControllerTest {
     @Test
     fun `onPaymentResult when error should invoke callback with Failed and relay error message`() =
         runTest {
-            val errorMessage = "Localized error message"
+            val errorMessage = "Original error message"
             flowController.onPaymentResult(PaymentResult.Failed(Throwable(errorMessage)))
 
             verify(paymentResultCallback).onPaymentSheetResult(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Instead of wrapping the errors with an `IllegalArgumentException`, relay the original `Throwable`. That way we preserve the localized message (although it's not guaranteed that it'll be localized).
Besides, "Failed to confirm intent" doesn't add any helpful information.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
RUN_MOBILESDK-678

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified