### PR TITLE
Disable card saving by default in PaymentSheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## X.X.X - 2022-XX-XX
 
 ### PaymentSheet
+* [CHANGED] [4515](https://github.com/stripe/stripe-android/pull/4515) Disable card saving by default in PaymentSheet
 ### Identity
 ### Card scanning
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/CardDataCollectionFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/CardDataCollectionFragment.kt
@@ -324,7 +324,7 @@ internal class CardDataCollectionFragment<ViewModelType : BaseSheetViewModel<*>>
         requireArguments().getParcelable<FormFragmentArguments>(
             ComposeFormDataCollectionFragment.EXTRA_CONFIG
         )?.let { args ->
-            saveCardCheckbox.isChecked = true
+            saveCardCheckbox.isChecked = false
             saveCardCheckbox.isVisible = args.showCheckbox
         }
         sheetViewModel.newCard?.customerRequestedSave?.also {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/CardDataCollectionFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/CardDataCollectionFragmentTest.kt
@@ -171,7 +171,7 @@ class CardDataCollectionFragmentTest {
             assertThat(viewBinding.billingAddress.countryView.text.toString())
                 .isEqualTo("Germany")
             assertThat(viewBinding.saveCardCheckbox.isVisible).isTrue()
-            assertThat(viewBinding.saveCardCheckbox.isChecked).isTrue()
+            assertThat(viewBinding.saveCardCheckbox.isChecked).isFalse()
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This unchecks the save card for future payments by default. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Matching iOS behavior here: https://github.com/stripe-ios/stripe-ios/pull/661

In the future we can explore making this a configuration once we have a response from legal.  

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
This should be noted. 
