### PR TITLE
Save playground toggle state in paymentsheet-example

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
@@ -16,10 +16,7 @@ import com.stripe.android.paymentsheet.example.playground.model.CheckoutMode
 import com.stripe.android.paymentsheet.example.playground.viewmodel.PaymentSheetPlaygroundViewModel
 import com.stripe.android.paymentsheet.model.PaymentOption
 import kotlinx.coroutines.launch
-import android.content.SharedPreferences
-
-
-
+import com.stripe.android.paymentsheet.example.playground.model.Toggle
 
 internal class PaymentSheetPlaygroundActivity : AppCompatActivity() {
     private val viewBinding by lazy {
@@ -88,7 +85,14 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity() {
         val backendUrl = Settings(this).playgroundBackendUrl
 
         viewBinding.resetDefaultsButton.setOnClickListener {
-            setToggles(CheckoutCustomer.Guest.value, true, CheckoutCurrency.USD.value, CheckoutMode.Payment.value, true, true)
+            setToggles(
+                Toggle.Customer.default.toString(),
+                Toggle.GooglePay.default as Boolean,
+                Toggle.Currency.default.toString(),
+                Toggle.Mode.default.toString(),
+                Toggle.SetShippingAddress.default as Boolean,
+                Toggle.SetAutomaticPaymentMethods.default as Boolean
+            )
         }
 
         viewBinding.reloadButton.setOnClickListener {
@@ -142,31 +146,13 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
-        val sharedPreferences = getSharedPreferences(sharedPreferencesName, MODE_PRIVATE)
-
-        val customer = sharedPreferences.getString("customer", CheckoutCustomer.Guest.value)
-        val googlePay = sharedPreferences.getBoolean("googlePayConfig", true)
-        val currency = sharedPreferences.getString("currency", CheckoutCurrency.USD.value)
-        val mode = sharedPreferences.getString("mode", CheckoutMode.Payment.value)
-        val setShippingAddress = sharedPreferences.getBoolean("setShippingAddress", true)
-        val setAutomaticPaymentMethods = sharedPreferences.getBoolean("setAutomaticPaymentMethods", true)
-
+        val (customer, googlePay, currency, mode, setShippingAddress, setAutomaticPaymentMethods) = viewModel.getSharedPreferences()
         setToggles(customer, googlePay, currency, mode, setShippingAddress, setAutomaticPaymentMethods)
     }
 
     override fun onPause() {
         super.onPause()
-
-        val sharedPreferences = getSharedPreferences(sharedPreferencesName, MODE_PRIVATE)
-        val editor = sharedPreferences.edit()
-
-        editor.putString("customer", customer.value)
-        editor.putBoolean("googlePayConfig", googlePayConfig != null)
-        editor.putString("currency", currency.value)
-        editor.putString("mode", mode.value)
-        editor.putBoolean("setShippingAddress", setShippingAddress)
-        editor.putBoolean("setAutomaticPaymentMethods", setAutomaticPaymentMethods)
-        editor.apply()
+        viewModel.setSharedPreferences(customer.value, googlePayConfig != null, currency.value, mode.value, setShippingAddress, setAutomaticPaymentMethods)
     }
 
     private fun setToggles(customer: String?, googlePay: Boolean, currency: String?, mode: String?, setShippingAddress: Boolean, setAutomaticPaymentMethods: Boolean) {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
@@ -146,13 +146,13 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
-        val (customer, googlePay, currency, mode, setShippingAddress, setAutomaticPaymentMethods) = viewModel.getSharedPreferences()
+        val (customer, googlePay, currency, mode, setShippingAddress, setAutomaticPaymentMethods) = viewModel.getSavedToggleState()
         setToggles(customer, googlePay, currency, mode, setShippingAddress, setAutomaticPaymentMethods)
     }
 
     override fun onPause() {
         super.onPause()
-        viewModel.setSharedPreferences(customer.value, googlePayConfig != null, currency.value, mode.value, setShippingAddress, setAutomaticPaymentMethods)
+        viewModel.storeToggleState(customer.value, googlePayConfig != null, currency.value, mode.value, setShippingAddress, setAutomaticPaymentMethods)
     }
 
     private fun setToggles(customer: String?, googlePay: Boolean, currency: String?, mode: String?, setShippingAddress: Boolean, setAutomaticPaymentMethods: Boolean) {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
@@ -16,6 +16,10 @@ import com.stripe.android.paymentsheet.example.playground.model.CheckoutMode
 import com.stripe.android.paymentsheet.example.playground.viewmodel.PaymentSheetPlaygroundViewModel
 import com.stripe.android.paymentsheet.model.PaymentOption
 import kotlinx.coroutines.launch
+import android.content.SharedPreferences
+
+
+
 
 internal class PaymentSheetPlaygroundActivity : AppCompatActivity() {
     private val viewBinding by lazy {
@@ -82,6 +86,11 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity() {
             ::onPaymentSheetResult
         )
         val backendUrl = Settings(this).playgroundBackendUrl
+
+        viewBinding.resetDefaultsButton.setOnClickListener {
+            setToggles(CheckoutCustomer.Guest.value, true, CheckoutCurrency.USD.value, CheckoutMode.Payment.value, true, true)
+        }
+
         viewBinding.reloadButton.setOnClickListener {
             lifecycleScope.launch {
                 viewModel.prepareCheckout(
@@ -129,6 +138,69 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity() {
         }
 
         disableViews()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        val sharedPreferences = getSharedPreferences(sharedPreferencesName, MODE_PRIVATE)
+
+        val customer = sharedPreferences.getString("customer", CheckoutCustomer.Guest.value)
+        val googlePay = sharedPreferences.getBoolean("googlePayConfig", true)
+        val currency = sharedPreferences.getString("currency", CheckoutCurrency.USD.value)
+        val mode = sharedPreferences.getString("mode", CheckoutMode.Payment.value)
+        val setShippingAddress = sharedPreferences.getBoolean("setShippingAddress", true)
+        val setAutomaticPaymentMethods = sharedPreferences.getBoolean("setAutomaticPaymentMethods", true)
+
+        setToggles(customer, googlePay, currency, mode, setShippingAddress, setAutomaticPaymentMethods)
+    }
+
+    override fun onPause() {
+        super.onPause()
+
+        val sharedPreferences = getSharedPreferences(sharedPreferencesName, MODE_PRIVATE)
+        val editor = sharedPreferences.edit()
+
+        editor.putString("customer", customer.value)
+        editor.putBoolean("googlePayConfig", googlePayConfig != null)
+        editor.putString("currency", currency.value)
+        editor.putString("mode", mode.value)
+        editor.putBoolean("setShippingAddress", setShippingAddress)
+        editor.putBoolean("setAutomaticPaymentMethods", setAutomaticPaymentMethods)
+        editor.apply()
+    }
+
+    private fun setToggles(customer: String?, googlePay: Boolean, currency: String?, mode: String?, setShippingAddress: Boolean, setAutomaticPaymentMethods: Boolean) {
+        when (customer) {
+            CheckoutCustomer.Guest.value -> viewBinding.customerRadioGroup.check(R.id.guest_customer_button)
+            CheckoutCustomer.New.value -> viewBinding.customerRadioGroup.check(R.id.new_customer_button)
+            else -> viewBinding.customerRadioGroup.check(R.id.returning_customer_button)
+        }
+
+        when (googlePay) {
+            true -> viewBinding.googlePayRadioGroup.check(R.id.google_pay_on_button)
+            false -> viewBinding.googlePayRadioGroup.check(R.id.google_pay_off_button)
+        }
+
+        when (currency) {
+            CheckoutCurrency.USD.value -> viewBinding.currencyRadioGroup.check(R.id.currency_usd_button)
+            else -> viewBinding.currencyRadioGroup.check(R.id.currency_eur_button)
+        }
+
+        when (mode) {
+            CheckoutMode.Payment.value -> viewBinding.modeRadioGroup.check(R.id.mode_payment_button)
+            CheckoutMode.PaymentWithSetup.value -> viewBinding.modeRadioGroup.check(R.id.mode_payment_with_setup_button)
+            else -> viewBinding.modeRadioGroup.check(R.id.mode_setup_button)
+        }
+
+        when (setShippingAddress) {
+            true -> viewBinding.shippingRadioGroup.check(R.id.shipping_on_button)
+            false -> viewBinding.shippingRadioGroup.check(R.id.shipping_off_button)
+        }
+
+        when (setAutomaticPaymentMethods) {
+            true -> viewBinding.automaticPmGroup.check(R.id.automatic_pm_on_button)
+            false -> viewBinding.automaticPmGroup.check(R.id.automatic_pm_off_button)
+        }
     }
 
     private fun disableViews() {
@@ -232,5 +304,6 @@ internal class PaymentSheetPlaygroundActivity : AppCompatActivity() {
 
     companion object {
         private const val merchantName = "Example, Inc."
+        private const val sharedPreferencesName = "playgroundToggles"
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
@@ -14,6 +14,17 @@ enum class CheckoutCurrency(val value: String) {
     EUR("eur")
 }
 
+data class SavedToggles(val customer: String, val googlePay: Boolean, val currency: String, val mode: String, val setShippingAddress: Boolean, val setAutomaticPaymentMethods: Boolean)
+
+enum class Toggle(val key: String, val default: Any) {
+    Customer("customer", CheckoutCustomer.Guest.value),
+    GooglePay("googlePayConfig", true),
+    Currency("currency", CheckoutCurrency.USD.value),
+    Mode("mode", CheckoutMode.Payment.value),
+    SetShippingAddress("setShippingAddress", true),
+    SetAutomaticPaymentMethods("setAutomaticPaymentMethods", true)
+}
+
 sealed class CheckoutCustomer(val value: String) {
     object Guest : CheckoutCustomer("guest")
     object New : CheckoutCustomer("new")

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/viewmodel/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/viewmodel/PaymentSheetPlaygroundViewModel.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.example.playground.viewmodel
 
 import android.app.Application
+import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -16,6 +17,8 @@ import com.stripe.android.paymentsheet.example.playground.model.CheckoutCustomer
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutMode
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutResponse
+import com.stripe.android.paymentsheet.example.playground.model.SavedToggles
+import com.stripe.android.paymentsheet.example.playground.model.Toggle
 
 internal class PaymentSheetPlaygroundViewModel(
     application: Application
@@ -32,6 +35,34 @@ internal class PaymentSheetPlaygroundViewModel(
 
     var checkoutMode: CheckoutMode? = null
     var temporaryCustomerId: String? = null
+
+    private val sharedPreferencesName = "playgroundToggles"
+
+    fun setSharedPreferences(customer: String, googlePay: Boolean, currency: String, mode: String, setShippingAddress: Boolean, setAutomaticPaymentMethods: Boolean) {
+        val sharedPreferences = getApplication<Application>().getSharedPreferences(sharedPreferencesName, AppCompatActivity.MODE_PRIVATE)
+        val editor = sharedPreferences.edit()
+
+        editor.putString(Toggle.Customer.key, customer)
+        editor.putBoolean(Toggle.GooglePay.key, googlePay)
+        editor.putString(Toggle.Currency.key, currency)
+        editor.putString(Toggle.Mode.key, mode)
+        editor.putBoolean(Toggle.SetShippingAddress.key, setShippingAddress)
+        editor.putBoolean(Toggle.SetAutomaticPaymentMethods.key, setAutomaticPaymentMethods)
+        editor.apply()
+    }
+
+    fun getSharedPreferences(): SavedToggles {
+        val sharedPreferences = getApplication<Application>().getSharedPreferences(sharedPreferencesName, AppCompatActivity.MODE_PRIVATE)
+
+        val customer = sharedPreferences.getString(Toggle.Customer.key, Toggle.Customer.default.toString())
+        val googlePay = sharedPreferences.getBoolean(Toggle.GooglePay.key, Toggle.GooglePay.default as Boolean)
+        val currency = sharedPreferences.getString(Toggle.Currency.key, Toggle.Currency.default.toString())
+        val mode = sharedPreferences.getString(Toggle.Mode.key, Toggle.Mode.default.toString())
+        val setShippingAddress = sharedPreferences.getBoolean(Toggle.SetShippingAddress.key, Toggle.SetShippingAddress.default as Boolean)
+        val setAutomaticPaymentMethods = sharedPreferences.getBoolean(Toggle.SetAutomaticPaymentMethods.key, Toggle.SetAutomaticPaymentMethods.default as Boolean)
+
+        return SavedToggles(customer.toString(), googlePay, currency.toString(), mode.toString(), setShippingAddress, setAutomaticPaymentMethods)
+    }
 
     /**
      * Calls the backend to prepare for checkout. The server creates a new Payment or Setup Intent

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/viewmodel/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/viewmodel/PaymentSheetPlaygroundViewModel.kt
@@ -38,7 +38,7 @@ internal class PaymentSheetPlaygroundViewModel(
 
     private val sharedPreferencesName = "playgroundToggles"
 
-    fun setSharedPreferences(customer: String, googlePay: Boolean, currency: String, mode: String, setShippingAddress: Boolean, setAutomaticPaymentMethods: Boolean) {
+    fun storeToggleState(customer: String, googlePay: Boolean, currency: String, mode: String, setShippingAddress: Boolean, setAutomaticPaymentMethods: Boolean) {
         val sharedPreferences = getApplication<Application>().getSharedPreferences(sharedPreferencesName, AppCompatActivity.MODE_PRIVATE)
         val editor = sharedPreferences.edit()
 
@@ -51,7 +51,7 @@ internal class PaymentSheetPlaygroundViewModel(
         editor.apply()
     }
 
-    fun getSharedPreferences(): SavedToggles {
+    fun getSavedToggleState(): SavedToggles {
         val sharedPreferences = getApplication<Application>().getSharedPreferences(sharedPreferencesName, AppCompatActivity.MODE_PRIVATE)
 
         val customer = sharedPreferences.getString(Toggle.Customer.key, Toggle.Customer.default.toString())

--- a/paymentsheet-example/src/main/res/layout/activity_payment_sheet_playground.xml
+++ b/paymentsheet-example/src/main/res/layout/activity_payment_sheet_playground.xml
@@ -305,14 +305,23 @@
         </RadioGroup>
 
         <Button
-            android:id="@+id/reload_button"
-            android:text="@string/reload_paymentsheet"
+            android:id="@+id/reset_defaults_button"
+            android:text="@string/reset_defaults"
             android:layout_width="wrap_content"
             android:layout_height="48dp"
             android:layout_marginTop="8dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/allowsDelayedPaymentMethods_radio_group" />
+
+        <Button
+            android:id="@+id/reload_button"
+            android:text="@string/reload_paymentsheet"
+            android:layout_width="wrap_content"
+            android:layout_height="48dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/reset_defaults_button" />
 
         <View
             android:id="@+id/divider"

--- a/paymentsheet-example/src/main/res/values/strings.xml
+++ b/paymentsheet-example/src/main/res/values/strings.xml
@@ -34,4 +34,5 @@
     <string name="shipping_address">Shipping Address</string>
     <string name="allowsDelayedPaymentMethods">Delayed PMs</string>
     <string name="automatic_pm">Automatic PMs</string>
+    <string name="reset_defaults">Reset Defaults</string>
 </resources>


### PR DESCRIPTION
# Summary
This saves the state of the playground toggles in the paymentsheet-example app.

# Motivation
Storing the state of the toggles would make it more convenient for developers to test the PaymentSheet through the example app.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
