### PR TITLE
fix bitmap related instrumentation test

### DIFF
--- a/stripecardscan/src/androidTest/java/com/stripe/android/stripecardscan/framework/image/BitmapExtensionsTest.kt
+++ b/stripecardscan/src/androidTest/java/com/stripe/android/stripecardscan/framework/image/BitmapExtensionsTest.kt
@@ -8,6 +8,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.stripe.android.stripecardscan.test.R
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -22,11 +23,9 @@ class BitmapExtensionsTest {
         val bitmap = testResources.getDrawable(R.drawable.ocr_card_numbers, null)
             .toBitmap()
         assertNotNull(bitmap)
-        // we use modulus division because some android devices scale up the bitmap size for display
-        // purposes. This does not affect camera image processing, only reading images from
-        // resources.
-        assertEquals(0, bitmap.width % 600, "Bitmap width is not expected")
-        assertEquals(0, bitmap.height % 375, "Bitmap height is not expected")
+        // Make sure a non-empty image is read.
+        assertNotEquals(0, bitmap.width , "Bitmap width is 0")
+        assertNotEquals(0, bitmap.height , "Bitmap height is 0")
 
         // scale the bitmap
         val scaledBitmap = bitmap.scale(0.2F)
@@ -56,11 +55,9 @@ class BitmapExtensionsTest {
         val bitmap = testResources.getDrawable(R.drawable.ocr_card_numbers, null)
             .toBitmap()
         assertNotNull(bitmap)
-        // we use modulus division because some android devices scale up the bitmap size for display
-        // purposes. This does not affect camera image processing, only reading images from
-        // resources.
-        assertEquals(0, bitmap.width % 600, "Bitmap width is not expected")
-        assertEquals(0, bitmap.height % 375, "Bitmap height is not expected")
+        // Make sure a non-empty image is read.
+        assertNotEquals(0, bitmap.width , "Bitmap width is 0")
+        assertNotEquals(0, bitmap.height , "Bitmap height is 0")
 
         // crop the bitmap
         val croppedBitmap = bitmap.crop(

--- a/stripecardscan/src/androidTest/java/com/stripe/android/stripecardscan/framework/image/BitmapExtensionsTest.kt
+++ b/stripecardscan/src/androidTest/java/com/stripe/android/stripecardscan/framework/image/BitmapExtensionsTest.kt
@@ -24,8 +24,8 @@ class BitmapExtensionsTest {
             .toBitmap()
         assertNotNull(bitmap)
         // Make sure a non-empty image is read.
-        assertNotEquals(0, bitmap.width , "Bitmap width is 0")
-        assertNotEquals(0, bitmap.height , "Bitmap height is 0")
+        assertNotEquals(0, bitmap.width, "Bitmap width is 0")
+        assertNotEquals(0, bitmap.height, "Bitmap height is 0")
 
         // scale the bitmap
         val scaledBitmap = bitmap.scale(0.2F)
@@ -56,8 +56,8 @@ class BitmapExtensionsTest {
             .toBitmap()
         assertNotNull(bitmap)
         // Make sure a non-empty image is read.
-        assertNotEquals(0, bitmap.width , "Bitmap width is 0")
-        assertNotEquals(0, bitmap.height , "Bitmap height is 0")
+        assertNotEquals(0, bitmap.width, "Bitmap width is 0")
+        assertNotEquals(0, bitmap.height, "Bitmap height is 0")
 
         // crop the bitmap
         val croppedBitmap = bitmap.crop(

--- a/stripecardscan/src/androidTest/java/com/stripe/android/stripecardscan/payment/ImageTest.kt
+++ b/stripecardscan/src/androidTest/java/com/stripe/android/stripecardscan/payment/ImageTest.kt
@@ -74,8 +74,8 @@ class ImageTest {
         val bitmap = testResources.getDrawable(R.drawable.ocr_card_numbers, null).toBitmap()
         assertNotNull(bitmap)
         // Make sure a non-empty image is read.
-        assertNotEquals(0, bitmap.width , "Bitmap width is 0")
-        assertNotEquals(0, bitmap.height , "Bitmap height is 0")
+        assertNotEquals(0, bitmap.width, "Bitmap width is 0")
+        assertNotEquals(0, bitmap.height, "Bitmap height is 0")
 
         // scale the bitmap
         val scaledBitmap = bitmap.scale(Size(bitmap.width / 5, bitmap.height / 5))
@@ -105,8 +105,8 @@ class ImageTest {
         val bitmap = testResources.getDrawable(R.drawable.ocr_card_numbers, null).toBitmap()
         assertNotNull(bitmap)
         // Make sure a non-empty image is read.
-        assertNotEquals(0, bitmap.width , "Bitmap width is 0")
-        assertNotEquals(0, bitmap.height , "Bitmap height is 0")
+        assertNotEquals(0, bitmap.width, "Bitmap width is 0")
+        assertNotEquals(0, bitmap.height, "Bitmap height is 0")
 
         // crop the bitmap
         val croppedBitmap = bitmap.crop(
@@ -149,8 +149,8 @@ class ImageTest {
         val bitmap = testResources.getDrawable(R.drawable.ocr_card_numbers, null).toBitmap()
         assertNotNull(bitmap)
         // Make sure a non-empty image is read.
-        assertNotEquals(0, bitmap.width , "Bitmap width is 0")
-        assertNotEquals(0, bitmap.height , "Bitmap height is 0")
+        assertNotEquals(0, bitmap.width, "Bitmap width is 0")
+        assertNotEquals(0, bitmap.height, "Bitmap height is 0")
 
         val cropRegion = Rect(
             -100,
@@ -208,8 +208,8 @@ class ImageTest {
         val bitmap = testResources.getDrawable(R.drawable.ocr_card_numbers, null).toBitmap()
         assertNotNull(bitmap)
         // Make sure a non-empty image is read.
-        assertNotEquals(0, bitmap.width , "Bitmap width is 0")
-        assertNotEquals(0, bitmap.height , "Bitmap height is 0")
+        assertNotEquals(0, bitmap.width, "Bitmap width is 0")
+        assertNotEquals(0, bitmap.height, "Bitmap height is 0")
 
         // zoom the bitmap
         val zoomedBitmap = bitmap.zoom(

--- a/stripecardscan/src/androidTest/java/com/stripe/android/stripecardscan/payment/ImageTest.kt
+++ b/stripecardscan/src/androidTest/java/com/stripe/android/stripecardscan/payment/ImageTest.kt
@@ -22,6 +22,7 @@ import com.stripe.android.stripecardscan.test.R
 import org.junit.Test
 import java.nio.ByteBuffer
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -72,11 +73,9 @@ class ImageTest {
         // read in a sample bitmap file
         val bitmap = testResources.getDrawable(R.drawable.ocr_card_numbers, null).toBitmap()
         assertNotNull(bitmap)
-        // we use modulus division because some android devices scale up the bitmap size for display
-        // purposes. This does not affect camera image processing, only reading images from
-        // resources.
-        assertEquals(0, bitmap.width % 600, "Bitmap width is not expected")
-        assertEquals(0, bitmap.height % 375, "Bitmap height is not expected")
+        // Make sure a non-empty image is read.
+        assertNotEquals(0, bitmap.width , "Bitmap width is 0")
+        assertNotEquals(0, bitmap.height , "Bitmap height is 0")
 
         // scale the bitmap
         val scaledBitmap = bitmap.scale(Size(bitmap.width / 5, bitmap.height / 5))
@@ -105,11 +104,9 @@ class ImageTest {
     fun bitmap_crop_isCorrect() {
         val bitmap = testResources.getDrawable(R.drawable.ocr_card_numbers, null).toBitmap()
         assertNotNull(bitmap)
-        // we use modulus division because some android devices scale up the bitmap size for display
-        // purposes. This does not affect camera image processing, only reading images from
-        // resources.
-        assertEquals(0, bitmap.width % 600, "Bitmap width is not expected")
-        assertEquals(0, bitmap.height % 375, "Bitmap height is not expected")
+        // Make sure a non-empty image is read.
+        assertNotEquals(0, bitmap.width , "Bitmap width is 0")
+        assertNotEquals(0, bitmap.height , "Bitmap height is 0")
 
         // crop the bitmap
         val croppedBitmap = bitmap.crop(
@@ -151,11 +148,9 @@ class ImageTest {
     fun bitmap_cropWithFill_isCorrect() {
         val bitmap = testResources.getDrawable(R.drawable.ocr_card_numbers, null).toBitmap()
         assertNotNull(bitmap)
-        // we use modulus division because some android devices scale up the bitmap size for display
-        // purposes. This does not affect camera image processing, only reading images from
-        // resources.
-        assertEquals(0, bitmap.width % 600, "Bitmap width is not expected")
-        assertEquals(0, bitmap.height % 375, "Bitmap height is not expected")
+        // Make sure a non-empty image is read.
+        assertNotEquals(0, bitmap.width , "Bitmap width is 0")
+        assertNotEquals(0, bitmap.height , "Bitmap height is 0")
 
         val cropRegion = Rect(
             -100,
@@ -212,11 +207,9 @@ class ImageTest {
     fun zoom_isCorrect() {
         val bitmap = testResources.getDrawable(R.drawable.ocr_card_numbers, null).toBitmap()
         assertNotNull(bitmap)
-        // we use modulus division because some android devices scale up the bitmap size for display
-        // purposes. This does not affect camera image processing, only reading images from
-        // resources.
-        assertEquals(0, bitmap.width % 600, "Bitmap width is not expected")
-        assertEquals(0, bitmap.height % 375, "Bitmap height is not expected")
+        // Make sure a non-empty image is read.
+        assertNotEquals(0, bitmap.width , "Bitmap width is 0")
+        assertNotEquals(0, bitmap.height , "Bitmap height is 0")
 
         // zoom the bitmap
         val zoomedBitmap = bitmap.zoom(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Some devices don't return a bitmap of size that's multiple of (600, 375), just check the bitmap is not (0, 0)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
