### PR TITLE
simplify `CameraPermissionCheckingActivity`

### DIFF
--- a/camera-core/api/camera-core.api
+++ b/camera-core/api/camera-core.api
@@ -55,12 +55,11 @@ public abstract interface class com/stripe/android/camera/CameraErrorListener {
 
 public abstract class com/stripe/android/camera/CameraPermissionCheckingActivity : androidx/appcompat/app/AppCompatActivity {
 	public fun <init> ()V
-	protected final fun ensureCameraPermission ()V
+	protected final fun ensureCameraPermission ()Ljava/lang/Object;
 	protected abstract fun onCameraReady ()V
 	public fun onRequestPermissionsResult (I[Ljava/lang/String;[I)V
 	protected abstract fun onUserDeniedCameraPermission ()V
 	protected fun openAppSettings (Landroid/app/Activity;)V
-	protected abstract fun prepareCamera (Lkotlin/jvm/functions/Function0;)V
 	protected fun requestCameraPermission ()V
 	protected fun showPermissionDeniedDialog ()V
 	protected fun showPermissionRationaleDialog ()V

--- a/camera-core/src/main/java/com/stripe/android/camera/CameraPermissionCheckingActivity.kt
+++ b/camera-core/src/main/java/com/stripe/android/camera/CameraPermissionCheckingActivity.kt
@@ -19,19 +19,14 @@ import kotlinx.coroutines.launch
 
 /**
  * A [AppCompatActivity] class to handle camera permission.
- * Subclass should override [prepareCamera], [onCameraReady] and [onUserDeniedCameraPermission].
+ * Subclass should override [onCameraReady] and [onUserDeniedCameraPermission].
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 abstract class CameraPermissionCheckingActivity : AppCompatActivity() {
 
     /**
-     * Prepare to start the camera. Once the camera is ready, [onCameraReady] must be called.
-     */
-    protected abstract fun prepareCamera(onCameraReady: () -> Unit)
-
-    /**
-     * Callback when camera permission is granted, [prepareCamera] is called and camera is
-     * ready to use.
+     * The camera permission was granted and camera is ready to use.
+     * Note this callback will be invoked on the main thread.
      */
     protected abstract fun onCameraReady()
 
@@ -58,7 +53,9 @@ abstract class CameraPermissionCheckingActivity : AppCompatActivity() {
             Manifest.permission.CAMERA,
         ) == PackageManager.PERMISSION_GRANTED -> {
             mainScope.launch { permissionStat.trackResult("success") }
-            prepareCamera { onCameraReady() }
+            mainScope.launch {
+                onCameraReady()
+            }
         }
         ActivityCompat.shouldShowRequestPermissionRationale(
             this,
@@ -86,7 +83,9 @@ abstract class CameraPermissionCheckingActivity : AppCompatActivity() {
             when (grantResults[0]) {
                 PackageManager.PERMISSION_GRANTED -> {
                     mainScope.launch { permissionStat.trackResult("success") }
-                    prepareCamera { onCameraReady() }
+                    mainScope.launch {
+                        onCameraReady()
+                    }
                 }
                 else -> {
                     mainScope.launch { permissionStat.trackResult("failure") }

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanActivity.kt
@@ -256,15 +256,10 @@ internal class CardScanActivity : ScanActivity(), SimpleScanStateful<CardScanSta
         viewBinding.swapCameraButton.setVisible(supported)
     }
 
-    /**
-     * Prepare to start the camera. Once the camera is ready, [onCameraReady] must be called.
-     */
-    override fun prepareCamera(onCameraReady: () -> Unit) {
-        viewBinding.previewFrame.post {
-            viewBinding.viewFinderBackground
-                .setViewFinderRect(viewBinding.viewFinderWindow.asRect())
-            onCameraReady()
-        }
+    override fun onCameraReady() {
+        viewBinding.viewFinderBackground
+            .setViewFinderRect(viewBinding.viewFinderWindow.asRect())
+        startCameraAdapter()
     }
 
     /**

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/scanui/ScanActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/scanui/ScanActivity.kt
@@ -262,7 +262,7 @@ internal abstract class ScanActivity : CameraPermissionCheckingActivity(), Corou
         finish()
     }
 
-    override fun onCameraReady() {
+    protected fun startCameraAdapter() {
         cameraAdapter.bindToLifecycle(this)
 
         val torchStat = Stats.trackTask("torch_supported")

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/scanui/SimpleScanActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/scanui/SimpleScanActivity.kt
@@ -597,11 +597,9 @@ internal abstract class SimpleScanActivity<ScanFlowParameters> : ScanActivity() 
         setupUiComponents()
     }
 
-    override fun prepareCamera(onCameraReady: () -> Unit) {
-        previewFrame.post {
-            viewFinderBackgroundView.setViewFinderRect(viewFinderWindowView.asRect())
-            onCameraReady()
-        }
+    override fun onCameraReady() {
+        viewFinderBackgroundView.setViewFinderRect(viewFinderWindowView.asRect())
+        startCameraAdapter()
     }
 
     override fun onFlashSupported(supported: Boolean) {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Combine the `prepareCamera` and `onCameraReady` call into one.
* Created a more descriptive `ScanActivity::startCameraAdapter` method to start the adapter, call them in `onCameraReady` callbacks
* Always invoke `onCameraReady` on main dispatcher so we don't need to use `post` - please lmk if this is needed, happy to revert otherwise :)


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Simplify `CameraPermissionCheckingActivity` implementations

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
