### PR TITLE
Track the main loop for cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### PaymentSheet
 ### Identity
 ### Card scanning
+* [FIXED] [4548](https://github.com/stripe/stripe-android/pull/4548) Potential work leak when canceling a card scan in StripeCardScan
 
 ## 19.1.1 - 2022-01-31
 ### PaymentSheet

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationFlow.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationFlow.kt
@@ -103,7 +103,7 @@ internal abstract class CardImageVerificationFlow(
                 resultHandler = mainLoopOcrAggregator,
                 analyzerLoopErrorListener = scanErrorListener
             ).apply {
-                subscribeTo(
+                mainLoopJob = subscribeTo(
                     imageStream.map {
                         MainLoopAnalyzer.Input(
                             cameraPreviewImage = it,

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanFlow.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanFlow.kt
@@ -78,7 +78,7 @@ internal abstract class CardScanFlow(
                 resultHandler = it,
                 analyzerLoopErrorListener = scanErrorListener
             ).apply {
-                subscribeTo(
+                mainLoopJob = subscribeTo(
                     imageStream.map {
                         SSDOcr.cameraPreviewToInput(it.image, it.viewBounds, viewFinder)
                     },


### PR DESCRIPTION
# Summary
Track the main loop job for cleanup on cancel

# Motivation
Make sure the main loop job is canceled when the scan is canceled.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
