### PR TITLE
don't generate api check for @RestrictTo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,4 +111,5 @@ tasks.dokkaHtmlMultiModule.configure {
 apiValidation {
     ignoredPackages += ["com.stripe.android.databinding"]
     ignoredProjects += ["example", "paymentsheet-example", "stripecardscan-example", "identity-example"]
+    nonPublicMarkers.add("androidx.annotation.RestrictTo")
 }

--- a/camera-core/api/camera-core.api
+++ b/camera-core/api/camera-core.api
@@ -5,128 +5,10 @@ public final class com/stripe/android/camera/BuildConfig {
 	public fun <init> ()V
 }
 
-public final class com/stripe/android/camera/Camera1Adapter : com/stripe/android/camera/CameraAdapter, android/hardware/Camera$PreviewCallback {
-	public fun <init> (Landroid/app/Activity;Landroid/view/ViewGroup;Landroid/util/Size;Lcom/stripe/android/camera/CameraErrorListener;)V
-	public fun changeCamera ()V
-	public fun getCurrentCamera ()I
-	public fun getImplementationName ()Ljava/lang/String;
-	public fun isTorchOn ()Z
-	public fun onPause ()V
-	public fun onPreviewFrame ([BLandroid/hardware/Camera;)V
-	public final fun onResume ()V
-	public fun setFocus (Landroid/graphics/PointF;)V
-	public fun setTorchState (Z)V
-	public fun withFlashSupport (Lkotlin/jvm/functions/Function1;)V
-	public fun withSupportsMultipleCameras (Lkotlin/jvm/functions/Function1;)V
-}
-
-public abstract class com/stripe/android/camera/CameraAdapter : androidx/lifecycle/LifecycleObserver {
-	public static final field Companion Lcom/stripe/android/camera/CameraAdapter$Companion;
-	public fun <init> ()V
-	public fun bindToLifecycle (Landroidx/lifecycle/LifecycleOwner;)V
-	public abstract fun changeCamera ()V
-	public abstract fun getCurrentCamera ()I
-	public final fun getImageStream ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getImplementationName ()Ljava/lang/String;
-	public fun isBoundToLifecycle ()Z
-	public static final fun isCameraSupported (Landroid/content/Context;)Z
-	public abstract fun isTorchOn ()Z
-	public final fun onDestroyed ()V
-	public fun onPause ()V
-	protected final fun sendImageToStream (Ljava/lang/Object;)Ljava/lang/Object;
-	public abstract fun setFocus (Landroid/graphics/PointF;)V
-	public abstract fun setTorchState (Z)V
-	public fun unbindFromLifecycle (Landroidx/lifecycle/LifecycleOwner;)V
-	public abstract fun withFlashSupport (Lkotlin/jvm/functions/Function1;)V
-	public abstract fun withSupportsMultipleCameras (Lkotlin/jvm/functions/Function1;)V
-}
-
 public final class com/stripe/android/camera/CameraAdapter$Companion {
 	public final fun getLogTag ()Ljava/lang/String;
 	public final fun isCameraSupported (Landroid/content/Context;)Z
 	public final fun rotationToDegrees (I)I
-}
-
-public abstract interface class com/stripe/android/camera/CameraErrorListener {
-	public abstract fun onCameraAccessError (Ljava/lang/Throwable;)V
-	public abstract fun onCameraOpenError (Ljava/lang/Throwable;)V
-	public abstract fun onCameraUnsupportedError (Ljava/lang/Throwable;)V
-}
-
-public abstract class com/stripe/android/camera/CameraPermissionCheckingActivity : androidx/appcompat/app/AppCompatActivity {
-	public fun <init> ()V
-	protected final fun ensureCameraPermission ()V
-	protected abstract fun onCameraReady ()V
-	public fun onRequestPermissionsResult (I[Ljava/lang/String;[I)V
-	protected abstract fun onUserDeniedCameraPermission ()V
-	protected fun openAppSettings (Landroid/app/Activity;)V
-	protected fun requestCameraPermission ()V
-	protected fun showPermissionDeniedDialog ()V
-	protected fun showPermissionRationaleDialog ()V
-}
-
-public final class com/stripe/android/camera/CameraPreviewImage {
-	public fun <init> (Ljava/lang/Object;Landroid/graphics/Rect;)V
-	public final fun component1 ()Ljava/lang/Object;
-	public final fun component2 ()Landroid/graphics/Rect;
-	public final fun copy (Ljava/lang/Object;Landroid/graphics/Rect;)Lcom/stripe/android/camera/CameraPreviewImage;
-	public static synthetic fun copy$default (Lcom/stripe/android/camera/CameraPreviewImage;Ljava/lang/Object;Landroid/graphics/Rect;ILjava/lang/Object;)Lcom/stripe/android/camera/CameraPreviewImage;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getImage ()Ljava/lang/Object;
-	public final fun getViewBounds ()Landroid/graphics/Rect;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/stripe/android/camera/DefaultCameraErrorListener : com/stripe/android/camera/CameraErrorListener {
-	public fun <init> (Landroid/content/Context;Lkotlin/jvm/functions/Function1;)V
-	public fun onCameraAccessError (Ljava/lang/Throwable;)V
-	public fun onCameraOpenError (Ljava/lang/Throwable;)V
-	public fun onCameraUnsupportedError (Ljava/lang/Throwable;)V
-}
-
-public abstract interface class com/stripe/android/camera/framework/AggregateResultListener {
-	public abstract fun onInterimResult (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onReset (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onResult (Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public abstract interface class com/stripe/android/camera/framework/Analyzer {
-	public abstract fun analyze (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getStatsName ()Ljava/lang/String;
-}
-
-public abstract interface class com/stripe/android/camera/framework/AnalyzerFactory {
-	public abstract fun newInstance (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public abstract class com/stripe/android/camera/framework/AnalyzerLoop : com/stripe/android/camera/framework/ResultHandler {
-	public synthetic fun <init> (Lcom/stripe/android/camera/framework/AnalyzerPool;Lcom/stripe/android/camera/framework/AnalyzerLoopErrorListener;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	protected final fun getStartedAt ()Lcom/stripe/android/camera/framework/time/ClockMark;
-	public abstract fun getState ()Ljava/lang/Object;
-	protected final fun setStartedAt (Lcom/stripe/android/camera/framework/time/ClockMark;)V
-	protected final fun subscribeToFlow (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/CoroutineScope;)Lkotlinx/coroutines/Job;
-	protected final fun unsubscribeFromFlow (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public abstract interface class com/stripe/android/camera/framework/AnalyzerLoopErrorListener {
-	public abstract fun onAnalyzerFailure (Ljava/lang/Throwable;)Z
-	public abstract fun onResultFailure (Ljava/lang/Throwable;)Z
-}
-
-public final class com/stripe/android/camera/framework/AnalyzerPool {
-	public static final field Companion Lcom/stripe/android/camera/framework/AnalyzerPool$Companion;
-	public fun <init> (ILjava/util/List;)V
-	public final fun closeAllAnalyzers ()V
-	public final fun component1 ()I
-	public final fun component2 ()Ljava/util/List;
-	public final fun copy (ILjava/util/List;)Lcom/stripe/android/camera/framework/AnalyzerPool;
-	public static synthetic fun copy$default (Lcom/stripe/android/camera/framework/AnalyzerPool;ILjava/util/List;ILjava/lang/Object;)Lcom/stripe/android/camera/framework/AnalyzerPool;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAnalyzers ()Ljava/util/List;
-	public final fun getDesiredAnalyzerCount ()I
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/stripe/android/camera/framework/AnalyzerPool$Companion {
@@ -134,203 +16,23 @@ public final class com/stripe/android/camera/framework/AnalyzerPool$Companion {
 	public static synthetic fun of$default (Lcom/stripe/android/camera/framework/AnalyzerPool$Companion;Lcom/stripe/android/camera/framework/AnalyzerFactory;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
-public final class com/stripe/android/camera/framework/FiniteAnalyzerLoop : com/stripe/android/camera/framework/AnalyzerLoop {
-	public fun <init> (Lcom/stripe/android/camera/framework/AnalyzerPool;Lcom/stripe/android/camera/framework/TerminatingResultHandler;Lcom/stripe/android/camera/framework/AnalyzerLoopErrorListener;Lcom/stripe/android/camera/framework/time/Duration;)V
-	public synthetic fun <init> (Lcom/stripe/android/camera/framework/AnalyzerPool;Lcom/stripe/android/camera/framework/TerminatingResultHandler;Lcom/stripe/android/camera/framework/AnalyzerLoopErrorListener;Lcom/stripe/android/camera/framework/time/Duration;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun cancel ()V
-	public fun getState ()Ljava/lang/Object;
-	public fun onResult (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun process (Ljava/util/Collection;Lkotlinx/coroutines/CoroutineScope;)Lkotlinx/coroutines/Job;
-}
-
-public final class com/stripe/android/camera/framework/ProcessBoundAnalyzerLoop : com/stripe/android/camera/framework/AnalyzerLoop {
-	public fun <init> (Lcom/stripe/android/camera/framework/AnalyzerPool;Lcom/stripe/android/camera/framework/StatefulResultHandler;Lcom/stripe/android/camera/framework/AnalyzerLoopErrorListener;)V
-	public fun getState ()Ljava/lang/Object;
-	public fun onResult (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun subscribeTo (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/CoroutineScope;)Lkotlinx/coroutines/Job;
-	public final fun unsubscribe ()V
-}
-
-public final class com/stripe/android/camera/framework/RepeatingTaskStats {
-	public fun <init> (ILcom/stripe/android/camera/framework/time/ClockMark;Lcom/stripe/android/camera/framework/time/Duration;Lcom/stripe/android/camera/framework/time/Duration;Lcom/stripe/android/camera/framework/time/Duration;Lcom/stripe/android/camera/framework/time/Duration;)V
-	public final fun averageDuration ()Lcom/stripe/android/camera/framework/time/Duration;
-	public final fun component1 ()I
-	public final fun component2 ()Lcom/stripe/android/camera/framework/time/ClockMark;
-	public final fun component3 ()Lcom/stripe/android/camera/framework/time/Duration;
-	public final fun component4 ()Lcom/stripe/android/camera/framework/time/Duration;
-	public final fun component5 ()Lcom/stripe/android/camera/framework/time/Duration;
-	public final fun component6 ()Lcom/stripe/android/camera/framework/time/Duration;
-	public final fun copy (ILcom/stripe/android/camera/framework/time/ClockMark;Lcom/stripe/android/camera/framework/time/Duration;Lcom/stripe/android/camera/framework/time/Duration;Lcom/stripe/android/camera/framework/time/Duration;Lcom/stripe/android/camera/framework/time/Duration;)Lcom/stripe/android/camera/framework/RepeatingTaskStats;
-	public static synthetic fun copy$default (Lcom/stripe/android/camera/framework/RepeatingTaskStats;ILcom/stripe/android/camera/framework/time/ClockMark;Lcom/stripe/android/camera/framework/time/Duration;Lcom/stripe/android/camera/framework/time/Duration;Lcom/stripe/android/camera/framework/time/Duration;Lcom/stripe/android/camera/framework/time/Duration;ILjava/lang/Object;)Lcom/stripe/android/camera/framework/RepeatingTaskStats;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getExecutions ()I
-	public final fun getMaximumDuration ()Lcom/stripe/android/camera/framework/time/Duration;
-	public final fun getMinimumDuration ()Lcom/stripe/android/camera/framework/time/Duration;
-	public final fun getStartedAt ()Lcom/stripe/android/camera/framework/time/ClockMark;
-	public final fun getTotalCpuDuration ()Lcom/stripe/android/camera/framework/time/Duration;
-	public final fun getTotalDuration ()Lcom/stripe/android/camera/framework/time/Duration;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public abstract class com/stripe/android/camera/framework/ResultAggregator : com/stripe/android/camera/framework/StatefulResultHandler, androidx/lifecycle/LifecycleObserver {
-	public fun <init> (Lcom/stripe/android/camera/framework/AggregateResultListener;Ljava/lang/Object;Ljava/lang/String;)V
-	public abstract fun aggregateResult (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun bindToLifecycle (Landroidx/lifecycle/LifecycleOwner;)V
-	public final fun cancel ()V
-	public fun onResult (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	protected fun reset ()V
-}
-
-public abstract interface class com/stripe/android/camera/framework/StatTracker {
-	public abstract fun getStartedAt ()Lcom/stripe/android/camera/framework/time/ClockMark;
-	public abstract fun trackResult (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
 public final class com/stripe/android/camera/framework/StatTracker$DefaultImpls {
 	public static synthetic fun trackResult$default (Lcom/stripe/android/camera/framework/StatTracker;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-}
-
-public final class com/stripe/android/camera/framework/StatTrackerImpl : com/stripe/android/camera/framework/StatTracker {
-	public fun <init> (Lkotlin/jvm/functions/Function3;)V
-	public fun getStartedAt ()Lcom/stripe/android/camera/framework/time/ClockMark;
-	public fun trackResult (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public abstract class com/stripe/android/camera/framework/StatefulResultHandler : com/stripe/android/camera/framework/ResultHandler {
-	public fun <init> (Ljava/lang/Object;)V
-	public final fun getState ()Ljava/lang/Object;
-	protected fun reset ()V
-	protected final fun setState (Ljava/lang/Object;)V
-}
-
-public final class com/stripe/android/camera/framework/Stats {
-	public static final field INSTANCE Lcom/stripe/android/camera/framework/Stats;
-	public final fun getInstanceId ()Ljava/lang/String;
-	public final fun getLogTag ()Ljava/lang/String;
-	public static final fun getRepeatingTasks ()Ljava/util/Map;
-	public final fun getScanId ()Ljava/lang/String;
-	public static final fun getTasks ()Ljava/util/Map;
-	public final fun startScan ()V
-	public final fun trackPersistentRepeatingTask (Ljava/lang/String;)Lcom/stripe/android/camera/framework/StatTracker;
-	public final fun trackRepeatingTask (Ljava/lang/String;)Lcom/stripe/android/camera/framework/StatTracker;
-	public final fun trackTask (Ljava/lang/String;)Lcom/stripe/android/camera/framework/StatTracker;
-}
-
-public final class com/stripe/android/camera/framework/TaskStats {
-	public fun <init> (Lcom/stripe/android/camera/framework/time/ClockMark;Lcom/stripe/android/camera/framework/time/Duration;Ljava/lang/String;)V
-	public final fun component1 ()Lcom/stripe/android/camera/framework/time/ClockMark;
-	public final fun component2 ()Lcom/stripe/android/camera/framework/time/Duration;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Lcom/stripe/android/camera/framework/time/ClockMark;Lcom/stripe/android/camera/framework/time/Duration;Ljava/lang/String;)Lcom/stripe/android/camera/framework/TaskStats;
-	public static synthetic fun copy$default (Lcom/stripe/android/camera/framework/TaskStats;Lcom/stripe/android/camera/framework/time/ClockMark;Lcom/stripe/android/camera/framework/time/Duration;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/camera/framework/TaskStats;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getDuration ()Lcom/stripe/android/camera/framework/time/Duration;
-	public final fun getResult ()Ljava/lang/String;
-	public final fun getStarted ()Lcom/stripe/android/camera/framework/time/ClockMark;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public abstract class com/stripe/android/camera/framework/TerminatingResultHandler : com/stripe/android/camera/framework/StatefulResultHandler {
-	public fun <init> (Ljava/lang/Object;)V
-	public abstract fun onAllDataProcessed (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onTerminatedEarly (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class com/stripe/android/camera/framework/exception/ImageTypeNotSupportedException : java/lang/Exception {
-	public fun <init> (I)V
-	public final fun getImageType ()I
 }
 
 public final class com/stripe/android/camera/framework/image/BitmapExtensionsKt {
 	public static final fun constrainToSize (Landroid/graphics/Bitmap;Landroid/util/Size;Z)Landroid/graphics/Bitmap;
 	public static synthetic fun constrainToSize$default (Landroid/graphics/Bitmap;Landroid/util/Size;ZILjava/lang/Object;)Landroid/graphics/Bitmap;
-	public static final fun crop (Landroid/graphics/Bitmap;Landroid/graphics/Rect;)Landroid/graphics/Bitmap;
-	public static final fun cropCenter (Landroid/graphics/Bitmap;Landroid/util/Size;)Landroid/graphics/Bitmap;
-	public static final fun cropWithFill (Landroid/graphics/Bitmap;Landroid/graphics/Rect;)Landroid/graphics/Bitmap;
-	public static final fun rearrangeBySegments (Landroid/graphics/Bitmap;Ljava/util/Map;)Landroid/graphics/Bitmap;
-	public static final fun scale (Landroid/graphics/Bitmap;FZ)Landroid/graphics/Bitmap;
 	public static final fun scale (Landroid/graphics/Bitmap;Landroid/util/Size;Z)Landroid/graphics/Bitmap;
 	public static synthetic fun scale$default (Landroid/graphics/Bitmap;FZILjava/lang/Object;)Landroid/graphics/Bitmap;
 	public static synthetic fun scale$default (Landroid/graphics/Bitmap;Landroid/util/Size;ZILjava/lang/Object;)Landroid/graphics/Bitmap;
-	public static final fun scaleAndCrop (Landroid/graphics/Bitmap;Landroid/util/Size;Z)Landroid/graphics/Bitmap;
 	public static synthetic fun scaleAndCrop$default (Landroid/graphics/Bitmap;Landroid/util/Size;ZILjava/lang/Object;)Landroid/graphics/Bitmap;
-	public static final fun size (Landroid/graphics/Bitmap;)Landroid/util/Size;
-	public static final fun toJpeg (Landroid/graphics/Bitmap;)[B
-	public static final fun toWebP (Landroid/graphics/Bitmap;)[B
-	public static final fun zoom (Landroid/graphics/Bitmap;Landroid/graphics/Rect;Landroid/graphics/Rect;Landroid/util/Size;)Landroid/graphics/Bitmap;
 }
 
 public final class com/stripe/android/camera/framework/image/ImageKt {
-	public static final fun cropCameraPreviewToSquare (Landroid/graphics/Bitmap;Landroid/graphics/Rect;Landroid/graphics/Rect;)Landroid/graphics/Bitmap;
-	public static final fun cropCameraPreviewToViewFinder (Landroid/graphics/Bitmap;Landroid/graphics/Rect;Landroid/graphics/Rect;)Landroid/graphics/Bitmap;
-	public static final fun determineViewFinderCrop (Landroid/util/Size;Landroid/graphics/Rect;Landroid/graphics/Rect;)Landroid/graphics/Rect;
-	public static final fun hasOpenGl31 (Landroid/content/Context;)Z
-}
-
-public final class com/stripe/android/camera/framework/image/NV21Image {
-	public fun <init> (II[B)V
-	public fun <init> (Landroid/graphics/YuvImage;)V
-	public fun <init> (Landroid/media/Image;)V
-	public final fun crop (IIII)Lcom/stripe/android/camera/framework/image/NV21Image;
-	public final fun crop (Landroid/graphics/Rect;)Lcom/stripe/android/camera/framework/image/NV21Image;
-	public final fun getHeight ()I
-	public final fun getNv21Data ()[B
-	public final fun getSize ()Landroid/util/Size;
-	public final fun getWidth ()I
-	public final fun rotate (I)Lcom/stripe/android/camera/framework/image/NV21Image;
-	public final fun toBitmap (Landroid/renderscript/RenderScript;)Landroid/graphics/Bitmap;
-	public final fun toYuvImage ()Landroid/graphics/YuvImage;
-}
-
-public final class com/stripe/android/camera/framework/time/Clock {
-	public static final field INSTANCE Lcom/stripe/android/camera/framework/time/Clock;
-	public static final fun markNow ()Lcom/stripe/android/camera/framework/time/ClockMark;
 }
 
 public final class com/stripe/android/camera/framework/time/ClockKt {
-	public static final fun measureTime (Lkotlin/jvm/functions/Function0;)Lkotlin/Pair;
-}
-
-public abstract class com/stripe/android/camera/framework/time/ClockMark {
-	public abstract fun compareTo (Lcom/stripe/android/camera/framework/time/ClockMark;)I
-	public abstract fun elapsedSince ()Lcom/stripe/android/camera/framework/time/Duration;
-	public abstract fun hasPassed ()Z
-	public abstract fun isInFuture ()Z
-	public abstract fun minus (Lcom/stripe/android/camera/framework/time/Duration;)Lcom/stripe/android/camera/framework/time/ClockMark;
-	public abstract fun plus (Lcom/stripe/android/camera/framework/time/Duration;)Lcom/stripe/android/camera/framework/time/ClockMark;
-	public abstract fun toMillisecondsSinceEpoch ()J
-}
-
-public abstract class com/stripe/android/camera/framework/time/Duration : java/lang/Comparable {
-	public static final field Companion Lcom/stripe/android/camera/framework/time/Duration$Companion;
-	public fun compareTo (Lcom/stripe/android/camera/framework/time/Duration;)I
-	public synthetic fun compareTo (Ljava/lang/Object;)I
-	public fun div (D)Lcom/stripe/android/camera/framework/time/Duration;
-	public fun div (F)Lcom/stripe/android/camera/framework/time/Duration;
-	public fun div (I)Lcom/stripe/android/camera/framework/time/Duration;
-	public fun div (J)Lcom/stripe/android/camera/framework/time/Duration;
-	public fun equals (Ljava/lang/Object;)Z
-	public abstract fun getInDays ()D
-	public abstract fun getInHours ()D
-	public abstract fun getInMicroseconds ()D
-	public abstract fun getInMilliseconds ()D
-	public abstract fun getInMinutes ()D
-	public abstract fun getInMonths ()D
-	public abstract fun getInNanoseconds ()J
-	public abstract fun getInSeconds ()D
-	public abstract fun getInWeeks ()D
-	public abstract fun getInYears ()D
-	public fun hashCode ()I
-	public fun minus (Lcom/stripe/android/camera/framework/time/Duration;)Lcom/stripe/android/camera/framework/time/Duration;
-	public fun plus (Lcom/stripe/android/camera/framework/time/Duration;)Lcom/stripe/android/camera/framework/time/Duration;
-	public fun times (D)Lcom/stripe/android/camera/framework/time/Duration;
-	public fun times (F)Lcom/stripe/android/camera/framework/time/Duration;
-	public fun times (I)Lcom/stripe/android/camera/framework/time/Duration;
-	public fun times (J)Lcom/stripe/android/camera/framework/time/Duration;
-	public fun toString ()Ljava/lang/String;
-	public fun unaryMinus ()Lcom/stripe/android/camera/framework/time/Duration;
 }
 
 public final class com/stripe/android/camera/framework/time/Duration$Companion {
@@ -380,48 +82,9 @@ public final class com/stripe/android/camera/framework/time/DurationKt {
 	public static final fun getYears (F)Lcom/stripe/android/camera/framework/time/Duration;
 	public static final fun getYears (I)Lcom/stripe/android/camera/framework/time/Duration;
 	public static final fun getYears (J)Lcom/stripe/android/camera/framework/time/Duration;
-	public static final fun max (Lcom/stripe/android/camera/framework/time/Duration;Lcom/stripe/android/camera/framework/time/Duration;)Lcom/stripe/android/camera/framework/time/Duration;
-	public static final fun min (Lcom/stripe/android/camera/framework/time/Duration;Lcom/stripe/android/camera/framework/time/Duration;)Lcom/stripe/android/camera/framework/time/Duration;
 }
 
 public final class com/stripe/android/camera/framework/util/LayoutKt {
-	public static final fun adjustSizeToAspectRatio (Landroid/util/Size;F)Landroid/util/Size;
-	public static final fun aspectRatio (Landroid/util/Size;)F
-	public static final fun aspectRatio (Landroid/util/SizeF;)F
-	public static final fun centerOn (Landroid/util/Size;Landroid/graphics/Rect;)Landroid/graphics/Rect;
-	public static final fun centerScaled (Landroid/graphics/Rect;FF)Landroid/graphics/Rect;
-	public static final fun centerScaled (Landroid/graphics/RectF;FF)Landroid/graphics/RectF;
-	public static final fun intersectionWith (Landroid/graphics/Rect;Landroid/graphics/Rect;)Landroid/graphics/Rect;
-	public static final fun maxAspectRatioInSize (Landroid/util/Size;F)Landroid/util/Size;
-	public static final fun minAspectRatioSurroundingSize (Landroid/util/Size;F)Landroid/util/Size;
-	public static final fun move (Landroid/graphics/Rect;II)Landroid/graphics/Rect;
-	public static final fun move (Landroid/graphics/RectF;FF)Landroid/graphics/RectF;
-	public static final fun projectRegionOfInterest (Landroid/graphics/Rect;Landroid/graphics/Rect;Landroid/graphics/Rect;)Landroid/graphics/Rect;
-	public static final fun projectRegionOfInterest (Landroid/graphics/Rect;Landroid/util/Size;Landroid/graphics/Rect;)Landroid/graphics/Rect;
-	public static final fun projectRegionOfInterest (Landroid/graphics/RectF;Landroid/graphics/RectF;Landroid/graphics/RectF;)Landroid/graphics/RectF;
-	public static final fun projectRegionOfInterest (Landroid/graphics/RectF;Landroid/util/SizeF;Landroid/graphics/RectF;)Landroid/graphics/RectF;
-	public static final fun projectRegionOfInterest (Landroid/util/Size;Landroid/util/Size;Landroid/graphics/Rect;)Landroid/graphics/Rect;
-	public static final fun projectRegionOfInterest (Landroid/util/SizeF;Landroid/util/SizeF;Landroid/graphics/RectF;)Landroid/graphics/RectF;
-	public static final fun resizeRegion (Landroid/util/Size;Landroid/graphics/Rect;Landroid/graphics/Rect;Landroid/util/Size;)Ljava/util/Map;
-	public static final fun scale (Landroid/util/Size;F)Landroid/util/Size;
-	public static final fun scale (Landroid/util/Size;FF)Landroid/util/Size;
-	public static final fun scale (Landroid/util/SizeF;F)Landroid/util/SizeF;
-	public static final fun scale (Landroid/util/SizeF;FF)Landroid/util/SizeF;
-	public static final fun scaleAndCenterSurrounding (Landroid/util/Size;Landroid/util/Size;)Landroid/graphics/Rect;
-	public static final fun scaleAndCenterWithin (Landroid/util/Size;Landroid/graphics/Rect;)Landroid/graphics/Rect;
-	public static final fun scaleAndCenterWithin (Landroid/util/Size;Landroid/util/Size;)Landroid/graphics/Rect;
-	public static final fun scaleCentered (Landroid/util/Size;FF)Landroid/graphics/Rect;
-	public static final fun scaled (Landroid/graphics/RectF;Landroid/util/Size;)Landroid/graphics/RectF;
-	public static final fun size (Landroid/graphics/Rect;)Landroid/util/Size;
-	public static final fun size (Landroid/graphics/RectF;)Landroid/util/SizeF;
-	public static final fun size (Landroid/view/View;)Landroid/util/Size;
-	public static final fun toRect (Landroid/graphics/RectF;)Landroid/graphics/Rect;
-	public static final fun toRect (Landroid/util/Size;)Landroid/graphics/Rect;
-	public static final fun toRectF (Landroid/graphics/Rect;)Landroid/graphics/RectF;
-	public static final fun toRectF (Landroid/util/Size;)Landroid/graphics/RectF;
-	public static final fun toSize (Landroid/util/SizeF;)Landroid/util/Size;
-	public static final fun toSizeF (Landroid/util/Size;)Landroid/util/SizeF;
-	public static final fun transpose (Landroid/util/Size;)Landroid/util/Size;
 }
 
 public final class com/stripe/android/camera/framework/util/MemoizeKt {
@@ -475,31 +138,6 @@ public final class com/stripe/android/camera/framework/util/MemoizeKt {
 	public static final fun memoizedSuspend (Lkotlin/jvm/functions/Function4;Lcom/stripe/android/camera/framework/time/Duration;)Lkotlin/jvm/functions/Function4;
 }
 
-public final class com/stripe/android/camera/framework/util/UnexpectedRetryException : java/lang/Exception {
-	public fun <init> ()V
-}
-
-public final class com/stripe/android/camera/scanui/CameraView : androidx/constraintlayout/widget/ConstraintLayout {
-	public static final field CREDIT_CARD_ASPECT_RATIO Ljava/lang/String;
-	public static final field FILL_ASPECT_RATIO Ljava/lang/String;
-	public static final field ID_ASPECT_RATIO Ljava/lang/String;
-	public static final field NO_BORDER I
-	public static final field PASSPORT_ASPECT_RATIO Ljava/lang/String;
-	public fun <init> (Landroid/content/Context;)V
-	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
-	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
-	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getPreviewFrame ()Landroid/widget/FrameLayout;
-	public final fun getViewFinderBackgroundView ()Lcom/stripe/android/camera/scanui/ViewFinderBackground;
-	public final fun getViewFinderBorderView ()Landroid/widget/ImageView;
-	public final fun getViewFinderWindowView ()Landroid/view/View;
-}
-
-public abstract interface class com/stripe/android/camera/scanui/ScanFlow {
-	public abstract fun cancelFlow ()V
-	public abstract fun startFlow (Landroid/content/Context;Lkotlinx/coroutines/flow/Flow;Landroid/graphics/Rect;Landroidx/lifecycle/LifecycleOwner;Lkotlinx/coroutines/CoroutineScope;Ljava/lang/Object;)V
-}
-
 public final class com/stripe/android/camera/scanui/ViewFinderBackground : android/view/View {
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -512,7 +150,6 @@ public final class com/stripe/android/camera/scanui/ViewFinderBackground : andro
 }
 
 public final class com/stripe/android/camera/scanui/util/ViewExtensionsKt {
-	public static final fun asRect (Landroid/view/View;)Landroid/graphics/Rect;
 }
 
 public final class com/stripe/android/camera/scanui/util/ViewUtilsKt {

--- a/link/api/link.api
+++ b/link/api/link.api
@@ -12,17 +12,6 @@ public final class com/stripe/android/link/ComposableSingletons$LinkActivityKt {
 	public final fun getLambda-1$link_release ()Lkotlin/jvm/functions/Function3;
 }
 
-public final class com/stripe/android/link/LinkActivityContract : androidx/activity/result/contract/ActivityResultContract {
-	public static final field $stable I
-	public static final field Companion Lcom/stripe/android/link/LinkActivityContract$Companion;
-	public static final field EXTRA_ARGS Ljava/lang/String;
-	public fun <init> ()V
-	public fun createIntent (Landroid/content/Context;Lcom/stripe/android/link/LinkActivityContract$Args;)Landroid/content/Intent;
-	public synthetic fun createIntent (Landroid/content/Context;Ljava/lang/Object;)Landroid/content/Intent;
-	public fun parseResult (ILandroid/content/Intent;)Lcom/stripe/android/link/LinkActivityResult$Success;
-	public synthetic fun parseResult (ILandroid/content/Intent;)Ljava/lang/Object;
-}
-
 public final class com/stripe/android/link/LinkActivityContract$Args : com/stripe/android/view/ActivityStarter$Args {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
@@ -54,13 +43,6 @@ public final class com/stripe/android/link/LinkActivityResult$Success : com/stri
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public final class com/stripe/android/link/LinkPaymentLauncher {
-	public static final field $stable I
-	public fun <init> (Landroidx/activity/result/ActivityResultLauncher;Landroid/content/Context;Ljava/util/Set;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ZLkotlin/coroutines/CoroutineContext;Lcom/stripe/android/networking/PaymentAnalyticsRequestFactory;Lcom/stripe/android/core/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/StripeRepository;)V
-	public final fun present (Ljava/lang/String;Ljava/lang/String;)V
-	public static synthetic fun present$default (Lcom/stripe/android/link/LinkPaymentLauncher;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)V
-}
-
 public final class com/stripe/android/link/LinkPaymentLauncher_Factory {
 	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/link/LinkPaymentLauncher_Factory;
@@ -76,10 +58,6 @@ public final class com/stripe/android/link/injection/DaggerLinkPaymentLauncherCo
 public final class com/stripe/android/link/injection/DaggerSignUpViewModelFactoryComponent : com/stripe/android/link/injection/SignUpViewModelFactoryComponent {
 	public static fun builder ()Lcom/stripe/android/link/injection/SignUpViewModelFactoryComponent$Builder;
 	public fun inject (Lcom/stripe/android/link/ui/signup/SignUpViewModel$Factory;)V
-}
-
-public abstract interface class com/stripe/android/link/injection/LinkPaymentLauncherFactory {
-	public abstract fun create (Landroidx/activity/result/ActivityResultLauncher;)Lcom/stripe/android/link/LinkPaymentLauncher;
 }
 
 public final class com/stripe/android/link/injection/LinkPaymentLauncherFactory_Impl : com/stripe/android/link/injection/LinkPaymentLauncherFactory {
@@ -100,17 +78,6 @@ public final class com/stripe/android/link/ui/ComposableSingletons$LinkButtonKt 
 	public static field lambda-1 Lkotlin/jvm/functions/Function3;
 	public fun <init> ()V
 	public final fun getLambda-1$link_release ()Lkotlin/jvm/functions/Function3;
-}
-
-public final class com/stripe/android/link/ui/LinkViewButton : androidx/compose/ui/platform/AbstractComposeView {
-	public static final field $stable I
-	public fun <init> (Landroid/content/Context;)V
-	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
-	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
-	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun Content (Landroidx/compose/runtime/Composer;I)V
-	public final fun getOnClick ()Lkotlin/jvm/functions/Function0;
-	public final fun setOnClick (Lkotlin/jvm/functions/Function0;)V
 }
 
 public final class com/stripe/android/link/ui/signup/ComposableSingletons$SignUpScreenKt {

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -470,7 +470,6 @@ public final class com/stripe/android/PaymentConfiguration : android/os/Parcelab
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/PaymentConfiguration$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
@@ -489,7 +488,6 @@ public final class com/stripe/android/PaymentConfiguration : android/os/Parcelab
 }
 
 public final class com/stripe/android/PaymentConfiguration$Companion {
-	public final synthetic fun clearInstance ()V
 	public final fun getInstance (Landroid/content/Context;)Lcom/stripe/android/PaymentConfiguration;
 	public final fun init (Landroid/content/Context;Ljava/lang/String;)V
 	public final fun init (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;)V
@@ -499,7 +497,6 @@ public final class com/stripe/android/PaymentConfiguration$Companion {
 public final class com/stripe/android/PaymentIntentResult : com/stripe/android/StripeIntentResult {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (Lcom/stripe/android/model/PaymentIntent;ILjava/lang/String;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/PaymentIntent;ILjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/stripe/android/model/PaymentIntent;
 	public final fun component3 ()Ljava/lang/String;
@@ -1278,22 +1275,12 @@ public final class com/stripe/android/googlepaylauncher/injection/DaggerGooglePa
 	public fun inject (Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel$Factory;)V
 }
 
-public final class com/stripe/android/googlepaylauncher/injection/GooglePayLauncherModule {
-	public static final field $stable I
-	public fun <init> ()V
-	public final fun provideGooglePayRepositoryFactory (Landroid/content/Context;Lcom/stripe/android/core/Logger;)Lkotlin/jvm/functions/Function1;
-}
-
 public final class com/stripe/android/googlepaylauncher/injection/GooglePayLauncherModule_ProvideGooglePayRepositoryFactoryFactory : dagger/internal/Factory {
 	public fun <init> (Lcom/stripe/android/googlepaylauncher/injection/GooglePayLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
 	public static fun create (Lcom/stripe/android/googlepaylauncher/injection/GooglePayLauncherModule;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/googlepaylauncher/injection/GooglePayLauncherModule_ProvideGooglePayRepositoryFactoryFactory;
 	public synthetic fun get ()Ljava/lang/Object;
 	public fun get ()Lkotlin/jvm/functions/Function1;
 	public static fun provideGooglePayRepositoryFactory (Lcom/stripe/android/googlepaylauncher/injection/GooglePayLauncherModule;Landroid/content/Context;Lcom/stripe/android/core/Logger;)Lkotlin/jvm/functions/Function1;
-}
-
-public abstract interface class com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherFactory {
-	public abstract fun create (Lkotlinx/coroutines/CoroutineScope;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Config;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$ReadyCallback;Landroidx/activity/result/ActivityResultLauncher;Z)Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher;
 }
 
 public final class com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherFactory$DefaultImpls {
@@ -1623,7 +1610,6 @@ public final class com/stripe/android/model/Address : com/stripe/android/core/mo
 	public static final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/Address;
 	public final fun getCity ()Ljava/lang/String;
 	public final fun getCountry ()Ljava/lang/String;
-	public final fun getCountryCode ()Lcom/stripe/android/core/model/CountryCode;
 	public final fun getLine1 ()Ljava/lang/String;
 	public final fun getLine2 ()Ljava/lang/String;
 	public final fun getPostalCode ()Ljava/lang/String;
@@ -1641,7 +1627,6 @@ public final class com/stripe/android/model/Address$Builder : com/stripe/android
 	public synthetic fun build ()Ljava/lang/Object;
 	public final fun setCity (Ljava/lang/String;)Lcom/stripe/android/model/Address$Builder;
 	public final fun setCountry (Ljava/lang/String;)Lcom/stripe/android/model/Address$Builder;
-	public final fun setCountryCode (Lcom/stripe/android/core/model/CountryCode;)Lcom/stripe/android/model/Address$Builder;
 	public final fun setLine1 (Ljava/lang/String;)Lcom/stripe/android/model/Address$Builder;
 	public final fun setLine2 (Ljava/lang/String;)Lcom/stripe/android/model/Address$Builder;
 	public final fun setPostalCode (Ljava/lang/String;)Lcom/stripe/android/model/Address$Builder;
@@ -2098,24 +2083,6 @@ public abstract interface class com/stripe/android/model/ConfirmStripeIntentPara
 public final class com/stripe/android/model/ConfirmStripeIntentParams$Companion {
 }
 
-public final class com/stripe/android/model/ConsumerSessionLookup : com/stripe/android/core/model/StripeModel {
-	public static final field $stable I
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public final fun component1 ()Z
-	public final fun component2 ()Lcom/stripe/android/model/ConsumerSessionLookup$ConsumerSession;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (ZLcom/stripe/android/model/ConsumerSessionLookup$ConsumerSession;Ljava/lang/String;)Lcom/stripe/android/model/ConsumerSessionLookup;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/ConsumerSessionLookup;ZLcom/stripe/android/model/ConsumerSessionLookup$ConsumerSession;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/ConsumerSessionLookup;
-	public fun describeContents ()I
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getConsumerSession ()Lcom/stripe/android/model/ConsumerSessionLookup$ConsumerSession;
-	public final fun getErrorMessage ()Ljava/lang/String;
-	public final fun getExists ()Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
 public final class com/stripe/android/model/ConsumerSessionLookup$ConsumerSession : com/stripe/android/core/model/StripeModel {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
@@ -2486,21 +2453,6 @@ public final class com/stripe/android/model/KlarnaSourceParams$PaymentPageOption
 	public static fun values ()[Lcom/stripe/android/model/KlarnaSourceParams$PaymentPageOptions$PurchaseType;
 }
 
-public final class com/stripe/android/model/ListPaymentMethodsParams : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
-	public static final field $stable I
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Type;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Type;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy (Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Type;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ListPaymentMethodsParams;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/ListPaymentMethodsParams;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Type;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/ListPaymentMethodsParams;
-	public fun describeContents ()I
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun toParamMap ()Ljava/util/Map;
-	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
 public final class com/stripe/android/model/MandateDataParams : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
@@ -2534,10 +2486,6 @@ public final class com/stripe/android/model/MandateDataParams$Type$Online : com/
 	public fun toParamMap ()Ljava/util/Map;
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
-public final class com/stripe/android/model/MandateDataParams$Type$Online$Companion {
-	public final fun getDEFAULT ()Lcom/stripe/android/model/MandateDataParams$Type$Online;
 }
 
 public final class com/stripe/android/model/PaymentIntent : com/stripe/android/model/StripeIntent {
@@ -2595,7 +2543,6 @@ public final class com/stripe/android/model/PaymentIntent : com/stripe/android/m
 	public fun hashCode ()I
 	public fun isConfirmed ()Z
 	public fun isLiveMode ()Z
-	public final fun isSetupFutureUsageSet ()Z
 	public fun requiresAction ()Z
 	public fun requiresConfirmation ()Z
 	public fun toString ()Ljava/lang/String;
@@ -2717,7 +2664,6 @@ public final class com/stripe/android/model/PaymentMethod : com/stripe/android/c
 	public final field sofort Lcom/stripe/android/model/PaymentMethod$Sofort;
 	public final field type Lcom/stripe/android/model/PaymentMethod$Type;
 	public final field upi Lcom/stripe/android/model/PaymentMethod$Upi;
-	public fun <init> (Ljava/lang/String;Ljava/lang/Long;ZLcom/stripe/android/model/PaymentMethod$Type;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Card;Lcom/stripe/android/model/PaymentMethod$CardPresent;Lcom/stripe/android/model/PaymentMethod$Fpx;Lcom/stripe/android/model/PaymentMethod$Ideal;Lcom/stripe/android/model/PaymentMethod$SepaDebit;Lcom/stripe/android/model/PaymentMethod$AuBecsDebit;Lcom/stripe/android/model/PaymentMethod$BacsDebit;Lcom/stripe/android/model/PaymentMethod$Sofort;Lcom/stripe/android/model/PaymentMethod$Upi;Lcom/stripe/android/model/PaymentMethod$Netbanking;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Long;ZLcom/stripe/android/model/PaymentMethod$Type;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Card;Lcom/stripe/android/model/PaymentMethod$CardPresent;Lcom/stripe/android/model/PaymentMethod$Fpx;Lcom/stripe/android/model/PaymentMethod$Ideal;Lcom/stripe/android/model/PaymentMethod$SepaDebit;Lcom/stripe/android/model/PaymentMethod$AuBecsDebit;Lcom/stripe/android/model/PaymentMethod$BacsDebit;Lcom/stripe/android/model/PaymentMethod$Sofort;Lcom/stripe/android/model/PaymentMethod$Upi;Lcom/stripe/android/model/PaymentMethod$Netbanking;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Lcom/stripe/android/model/PaymentMethod$Ideal;
@@ -2740,7 +2686,6 @@ public final class com/stripe/android/model/PaymentMethod : com/stripe/android/c
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/PaymentMethod;
-	public final fun hasExpectedDetails ()Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
@@ -2752,7 +2697,6 @@ public final class com/stripe/android/model/PaymentMethod$AuBecsDebit : com/stri
 	public final field bsbNumber Ljava/lang/String;
 	public final field fingerprint Ljava/lang/String;
 	public final field last4 Ljava/lang/String;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
@@ -2861,8 +2805,6 @@ public final class com/stripe/android/model/PaymentMethod$Card : com/stripe/andr
 	public final field last4 Ljava/lang/String;
 	public final field threeDSecureUsage Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;
 	public final field wallet Lcom/stripe/android/model/wallets/Wallet;
-	public fun <init> ()V
-	public fun <init> (Lcom/stripe/android/model/CardBrand;Lcom/stripe/android/model/PaymentMethod$Card$Checks;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;Lcom/stripe/android/model/wallets/Wallet;Lcom/stripe/android/model/PaymentMethod$Card$Networks;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/CardBrand;Lcom/stripe/android/model/PaymentMethod$Card$Checks;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;Lcom/stripe/android/model/wallets/Wallet;Lcom/stripe/android/model/PaymentMethod$Card$Networks;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/stripe/android/model/CardBrand;
 	public final fun component10 ()Lcom/stripe/android/model/wallets/Wallet;
@@ -2890,7 +2832,6 @@ public final class com/stripe/android/model/PaymentMethod$Card$Checks : com/stri
 	public final field addressLine1Check Ljava/lang/String;
 	public final field addressPostalCodeCheck Ljava/lang/String;
 	public final field cvcCheck Ljava/lang/String;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
@@ -2928,7 +2869,6 @@ public final class com/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public final field isSupported Z
-	public fun <init> (Z)V
 	public final fun component1 ()Z
 	public final fun copy (Z)Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;
 	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;ZILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;
@@ -3074,7 +3014,6 @@ public final class com/stripe/android/model/PaymentMethod$Type : java/lang/Enum,
 	public final field isVoucher Z
 	public final field requiresMandate Z
 	public fun describeContents ()I
-	public final fun hasDelayedSettlement ()Z
 	public fun toString ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$Type;
 	public static fun values ()[Lcom/stripe/android/model/PaymentMethod$Type;
@@ -3082,7 +3021,6 @@ public final class com/stripe/android/model/PaymentMethod$Type : java/lang/Enum,
 }
 
 public final class com/stripe/android/model/PaymentMethod$Type$Companion {
-	public final synthetic fun fromCode (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$Type;
 }
 
 public abstract class com/stripe/android/model/PaymentMethod$TypeData : com/stripe/android/core/model/StripeModel {
@@ -3232,15 +3170,12 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Card : and
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/PaymentMethodCreateParams$Card$Companion;
-	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
 	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Card;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
 	public static final fun create (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethodCreateParams$Card;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getLast4 ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toParamMap ()Ljava/util/Map;
 	public fun toString ()Ljava/lang/String;
@@ -3339,7 +3274,6 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Companion 
 	public final fun createWeChatPay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun createWeChatPay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static synthetic fun createWeChatPay$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
-	public final fun createWithOverride (Lcom/stripe/android/model/PaymentMethod$Type;Ljava/util/Map;Ljava/util/Set;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 }
 
 public final class com/stripe/android/model/PaymentMethodCreateParams$Fpx : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
@@ -4668,21 +4602,6 @@ public final class com/stripe/android/model/StripeIntent$NextActionData$SdkData$
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public final class com/stripe/android/model/StripeIntent$NextActionData$WeChatPayRedirect : com/stripe/android/model/StripeIntent$NextActionData {
-	public static final field $stable I
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (Lcom/stripe/android/model/WeChat;)V
-	public final fun component1 ()Lcom/stripe/android/model/WeChat;
-	public final fun copy (Lcom/stripe/android/model/WeChat;)Lcom/stripe/android/model/StripeIntent$NextActionData$WeChatPayRedirect;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/StripeIntent$NextActionData$WeChatPayRedirect;Lcom/stripe/android/model/WeChat;ILjava/lang/Object;)Lcom/stripe/android/model/StripeIntent$NextActionData$WeChatPayRedirect;
-	public fun describeContents ()I
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getWeChat ()Lcom/stripe/android/model/WeChat;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
 public final class com/stripe/android/model/StripeIntent$NextActionType : java/lang/Enum {
 	public static final field AlipayRedirect Lcom/stripe/android/model/StripeIntent$NextActionType;
 	public static final field BlikAuthorize Lcom/stripe/android/model/StripeIntent$NextActionType;
@@ -4840,34 +4759,6 @@ public final class com/stripe/android/model/WeChatPayNextAction : com/stripe/and
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public final class com/stripe/android/model/parsers/AddressJsonParser : com/stripe/android/model/parsers/ModelJsonParser {
-	public static final field $stable I
-	public fun <init> ()V
-	public synthetic fun parse (Lorg/json/JSONObject;)Lcom/stripe/android/core/model/StripeModel;
-	public fun parse (Lorg/json/JSONObject;)Lcom/stripe/android/model/Address;
-}
-
-public final class com/stripe/android/model/parsers/PaymentIntentJsonParser : com/stripe/android/model/parsers/ModelJsonParser {
-	public static final field $stable I
-	public fun <init> ()V
-	public synthetic fun parse (Lorg/json/JSONObject;)Lcom/stripe/android/core/model/StripeModel;
-	public fun parse (Lorg/json/JSONObject;)Lcom/stripe/android/model/PaymentIntent;
-}
-
-public final class com/stripe/android/model/parsers/PaymentMethodJsonParser : com/stripe/android/model/parsers/ModelJsonParser {
-	public static final field $stable I
-	public fun <init> ()V
-	public synthetic fun parse (Lorg/json/JSONObject;)Lcom/stripe/android/core/model/StripeModel;
-	public fun parse (Lorg/json/JSONObject;)Lcom/stripe/android/model/PaymentMethod;
-}
-
-public final class com/stripe/android/model/parsers/SetupIntentJsonParser : com/stripe/android/model/parsers/ModelJsonParser {
-	public static final field $stable I
-	public fun <init> ()V
-	public synthetic fun parse (Lorg/json/JSONObject;)Lcom/stripe/android/core/model/StripeModel;
-	public fun parse (Lorg/json/JSONObject;)Lcom/stripe/android/model/SetupIntent;
-}
-
 public abstract class com/stripe/android/model/wallets/Wallet : com/stripe/android/core/model/StripeModel {
 	public static final field $stable I
 	public synthetic fun <init> (Lcom/stripe/android/model/wallets/Wallet$Type;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -4971,24 +4862,6 @@ public final class com/stripe/android/model/wallets/Wallet$VisaCheckoutWallet : 
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public final class com/stripe/android/networking/ApiRequest : com/stripe/android/core/networking/StripeRequest {
-	public static final field $stable I
-	public final fun component1 ()Lcom/stripe/android/core/networking/StripeRequest$Method;
-	public final fun copy (Lcom/stripe/android/core/networking/StripeRequest$Method;Ljava/lang/String;Ljava/util/Map;Lcom/stripe/android/networking/ApiRequest$Options;Lcom/stripe/android/AppInfo;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/networking/ApiRequest;
-	public static synthetic fun copy$default (Lcom/stripe/android/networking/ApiRequest;Lcom/stripe/android/core/networking/StripeRequest$Method;Ljava/lang/String;Ljava/util/Map;Lcom/stripe/android/networking/ApiRequest$Options;Lcom/stripe/android/AppInfo;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/networking/ApiRequest;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun getHeaders ()Ljava/util/Map;
-	public fun getMethod ()Lcom/stripe/android/core/networking/StripeRequest$Method;
-	public fun getMimeType ()Lcom/stripe/android/core/networking/StripeRequest$MimeType;
-	public fun getPostHeaders ()Ljava/util/Map;
-	public fun getRetryResponseCodes ()Ljava/lang/Iterable;
-	public fun getUrl ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun setPostHeaders (Ljava/util/Map;)V
-	public fun toString ()Ljava/lang/String;
-	public fun writePostBody (Ljava/io/OutputStream;)V
-}
-
 public final class com/stripe/android/networking/ApiRequest$Factory {
 	public static final field $stable I
 	public fun <init> ()V
@@ -5029,13 +4902,6 @@ public final class com/stripe/android/networking/ApiRequest_Options_Factory : da
 	public static fun newInstance (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)Lcom/stripe/android/networking/ApiRequest$Options;
 }
 
-public final class com/stripe/android/networking/PaymentAnalyticsRequestFactory {
-	public static final field $stable I
-	public fun <init> (Landroid/content/Context;Ljava/lang/String;Ljava/util/Set;)V
-	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/String;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final synthetic fun createRequest (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/core/networking/AnalyticsRequest;
-}
-
 public final class com/stripe/android/networking/PaymentAnalyticsRequestFactory_Factory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/networking/PaymentAnalyticsRequestFactory_Factory;
@@ -5050,26 +4916,6 @@ public final class com/stripe/android/networking/StripeApiRepository_Factory : d
 	public fun get ()Lcom/stripe/android/networking/StripeApiRepository;
 	public synthetic fun get ()Ljava/lang/Object;
 	public static fun newInstance (Landroid/content/Context;Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/CoroutineContext;Ljava/util/Set;Lcom/stripe/android/networking/PaymentAnalyticsRequestFactory;Lcom/stripe/android/core/networking/AnalyticsRequestExecutor;Lcom/stripe/android/core/Logger;)Lcom/stripe/android/networking/StripeApiRepository;
-}
-
-public abstract class com/stripe/android/networking/StripeRepository {
-	public static final field $stable I
-	public fun <init> ()V
-	public abstract fun attachPaymentMethod (Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/lang/String;Lcom/stripe/android/networking/ApiRequest$Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun createPaymentMethod (Lcom/stripe/android/model/PaymentMethodCreateParams;Lcom/stripe/android/networking/ApiRequest$Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun detachPaymentMethod (Ljava/lang/String;Ljava/util/Set;Ljava/lang/String;Lcom/stripe/android/networking/ApiRequest$Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun getPaymentMethods (Lcom/stripe/android/model/ListPaymentMethodsParams;Ljava/lang/String;Ljava/util/Set;Lcom/stripe/android/networking/ApiRequest$Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun lookupConsumerSession (Ljava/lang/String;Lcom/stripe/android/networking/ApiRequest$Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun retrievePaymentIntent (Ljava/lang/String;Lcom/stripe/android/networking/ApiRequest$Options;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun retrievePaymentIntent$default (Lcom/stripe/android/networking/StripeRepository;Ljava/lang/String;Lcom/stripe/android/networking/ApiRequest$Options;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public abstract fun retrievePaymentIntentWithOrderedPaymentMethods (Ljava/lang/String;Lcom/stripe/android/networking/ApiRequest$Options;Ljava/util/Locale;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun retrieveSetupIntent (Ljava/lang/String;Lcom/stripe/android/networking/ApiRequest$Options;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun retrieveSetupIntent$default (Lcom/stripe/android/networking/StripeRepository;Ljava/lang/String;Lcom/stripe/android/networking/ApiRequest$Options;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public abstract fun retrieveSetupIntentWithOrderedPaymentMethods (Ljava/lang/String;Lcom/stripe/android/networking/ApiRequest$Options;Ljava/util/Locale;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public abstract class com/stripe/android/payments/PaymentFlowResult {
-	public static final field $stable I
 }
 
 public final class com/stripe/android/payments/PaymentFlowResult$Unvalidated : android/os/Parcelable {
@@ -5095,16 +4941,6 @@ public final class com/stripe/android/payments/PaymentFlowResult$Unvalidated : a
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public final class com/stripe/android/payments/PaymentFlowResult$Unvalidated$Companion : kotlinx/parcelize/Parceler {
-	public fun create (Landroid/os/Parcel;)Lcom/stripe/android/payments/PaymentFlowResult$Unvalidated;
-	public synthetic fun create (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final synthetic fun fromIntent (Landroid/content/Intent;)Lcom/stripe/android/payments/PaymentFlowResult$Unvalidated;
-	public fun newArray (I)[Lcom/stripe/android/payments/PaymentFlowResult$Unvalidated;
-	public synthetic fun newArray (I)[Ljava/lang/Object;
-	public fun write (Lcom/stripe/android/payments/PaymentFlowResult$Unvalidated;Landroid/os/Parcel;I)V
-	public synthetic fun write (Ljava/lang/Object;Landroid/os/Parcel;I)V
-}
-
 public final class com/stripe/android/payments/PaymentIntentFlowResultProcessor_Factory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/PaymentIntentFlowResultProcessor_Factory;
@@ -5119,11 +4955,6 @@ public final class com/stripe/android/payments/SetupIntentFlowResultProcessor_Fa
 	public fun get ()Lcom/stripe/android/payments/SetupIntentFlowResultProcessor;
 	public synthetic fun get ()Ljava/lang/Object;
 	public static fun newInstance (Landroid/content/Context;Lkotlin/jvm/functions/Function0;Lcom/stripe/android/networking/StripeRepository;Lcom/stripe/android/core/Logger;Lkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/payments/SetupIntentFlowResultProcessor;
-}
-
-public abstract interface class com/stripe/android/payments/core/ActivityResultLauncherHost {
-	public abstract fun onLauncherInvalidated ()V
-	public abstract fun onNewActivityResultCaller (Landroidx/activity/result/ActivityResultCaller;Landroidx/activity/result/ActivityResultCallback;)V
 }
 
 public final class com/stripe/android/payments/core/ActivityResultLauncherHost$DefaultImpls {
@@ -5153,10 +4984,6 @@ public final class com/stripe/android/payments/core/authentication/OxxoAuthentic
 	public fun get ()Lcom/stripe/android/payments/core/authentication/OxxoAuthenticator;
 	public synthetic fun get ()Ljava/lang/Object;
 	public static fun newInstance (Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;Lcom/stripe/android/payments/core/authentication/NoOpIntentAuthenticator;)Lcom/stripe/android/payments/core/authentication/OxxoAuthenticator;
-}
-
-public abstract interface class com/stripe/android/payments/core/authentication/PaymentAuthenticator : com/stripe/android/payments/core/ActivityResultLauncherHost {
-	public abstract fun authenticate (Lcom/stripe/android/view/AuthActivityStarterHost;Ljava/lang/Object;Lcom/stripe/android/networking/ApiRequest$Options;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class com/stripe/android/payments/core/authentication/PaymentAuthenticator$DefaultImpls {
@@ -5344,11 +5171,6 @@ public final class com/stripe/android/payments/core/injection/Stripe3dsTransacti
 	public static fun providesInitChallengeRepository (Lcom/stripe/android/payments/core/injection/Stripe3dsTransactionViewModelModule;Landroid/app/Application;Lcom/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionContract$Args;Lkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/stripe3ds2/transaction/InitChallengeRepository;
 }
 
-public abstract class com/stripe/android/payments/core/injection/StripeRepositoryModule {
-	public static final field $stable I
-	public fun <init> ()V
-}
-
 public final class com/stripe/android/payments/core/injection/WeChatPayAuthenticatorModule_ProvideWeChatAuthenticator$payments_core_releaseFactory : dagger/internal/Factory {
 	public fun <init> (Lcom/stripe/android/payments/core/injection/WeChatPayAuthenticatorModule;Ljavax/inject/Provider;)V
 	public static fun create (Lcom/stripe/android/payments/core/injection/WeChatPayAuthenticatorModule;Ljavax/inject/Provider;)Lcom/stripe/android/payments/core/injection/WeChatPayAuthenticatorModule_ProvideWeChatAuthenticator$payments_core_releaseFactory;
@@ -5375,15 +5197,6 @@ public final class com/stripe/android/payments/paymentlauncher/PaymentLauncher$C
 
 public abstract interface class com/stripe/android/payments/paymentlauncher/PaymentLauncher$PaymentResultCallback {
 	public abstract fun onPaymentResult (Lcom/stripe/android/payments/paymentlauncher/PaymentResult;)V
-}
-
-public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherContract : androidx/activity/result/contract/ActivityResultContract {
-	public static final field $stable I
-	public fun <init> ()V
-	public fun createIntent (Landroid/content/Context;Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args;)Landroid/content/Intent;
-	public synthetic fun createIntent (Landroid/content/Context;Ljava/lang/Object;)Landroid/content/Intent;
-	public fun parseResult (ILandroid/content/Intent;)Lcom/stripe/android/payments/paymentlauncher/PaymentResult;
-	public synthetic fun parseResult (ILandroid/content/Intent;)Ljava/lang/Object;
 }
 
 public abstract class com/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args : android/os/Parcelable {
@@ -5472,15 +5285,6 @@ public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherCo
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherFactory {
-	public static final field $stable I
-	public fun <init> (Landroid/content/Context;Landroidx/activity/result/ActivityResultLauncher;)V
-	public fun <init> (Landroidx/activity/ComponentActivity;Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$PaymentResultCallback;)V
-	public fun <init> (Landroidx/fragment/app/Fragment;Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$PaymentResultCallback;)V
-	public final fun create (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher;
-	public static synthetic fun create$default (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherFactory;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher;
-}
-
 public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel_Factory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel_Factory;
@@ -5527,19 +5331,6 @@ public final class com/stripe/android/payments/paymentlauncher/PaymentResult$Fai
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public final class com/stripe/android/payments/paymentlauncher/StripePaymentLauncher : com/stripe/android/core/injection/Injector, com/stripe/android/payments/paymentlauncher/PaymentLauncher {
-	public static final field $stable I
-	public fun confirm (Lcom/stripe/android/model/ConfirmPaymentIntentParams;)V
-	public fun confirm (Lcom/stripe/android/model/ConfirmSetupIntentParams;)V
-	public fun handleNextActionForPaymentIntent (Ljava/lang/String;)V
-	public fun handleNextActionForSetupIntent (Ljava/lang/String;)V
-	public fun inject (Lcom/stripe/android/core/injection/Injectable;)V
-}
-
-public abstract interface class com/stripe/android/payments/paymentlauncher/StripePaymentLauncherAssistedFactory {
-	public abstract fun create (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Landroidx/activity/result/ActivityResultLauncher;)Lcom/stripe/android/payments/paymentlauncher/StripePaymentLauncher;
-}
-
 public final class com/stripe/android/payments/paymentlauncher/StripePaymentLauncherAssistedFactory_Impl : com/stripe/android/payments/paymentlauncher/StripePaymentLauncherAssistedFactory {
 	public static fun create (Lcom/stripe/android/payments/paymentlauncher/StripePaymentLauncher_Factory;)Ljavax/inject/Provider;
 	public fun create (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Landroidx/activity/result/ActivityResultLauncher;)Lcom/stripe/android/payments/paymentlauncher/StripePaymentLauncher;
@@ -5554,28 +5345,21 @@ public final class com/stripe/android/payments/paymentlauncher/StripePaymentLaun
 
 public abstract class com/stripe/android/view/ActivityStarter {
 	public static final field $stable I
-	public fun <init> (Landroid/app/Activity;Ljava/lang/Class;ILjava/lang/Integer;)V
 	public synthetic fun <init> (Landroid/app/Activity;Ljava/lang/Class;ILjava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun startForResult (Lcom/stripe/android/view/ActivityStarter$Args;)V
 }
 
 public abstract interface class com/stripe/android/view/ActivityStarter$Args : android/os/Parcelable {
 	public static final field Companion Lcom/stripe/android/view/ActivityStarter$Args$Companion;
-	public static final field EXTRA Ljava/lang/String;
 }
 
 public final class com/stripe/android/view/ActivityStarter$Args$Companion {
-	public static final field EXTRA Ljava/lang/String;
 }
 
 public abstract interface class com/stripe/android/view/ActivityStarter$Result : android/os/Parcelable {
 	public static final field Companion Lcom/stripe/android/view/ActivityStarter$Result$Companion;
 	public static final field EXTRA Ljava/lang/String;
 	public abstract fun toBundle ()Landroid/os/Bundle;
-}
-
-public final class com/stripe/android/view/ActivityStarter$Result$Companion {
-	public static final field EXTRA Ljava/lang/String;
 }
 
 public final class com/stripe/android/view/AddPaymentMethodActivity : com/stripe/android/view/StripeActivity {
@@ -5611,7 +5395,6 @@ public final class com/stripe/android/view/AddPaymentMethodActivityStarter$Args$
 	public synthetic fun build ()Ljava/lang/Object;
 	public final fun setAddPaymentMethodFooter (I)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Args$Builder;
 	public final fun setBillingAddressFields (Lcom/stripe/android/view/BillingAddressFields;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Args$Builder;
-	public final synthetic fun setPaymentConfiguration (Lcom/stripe/android/PaymentConfiguration;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Args$Builder;
 	public final fun setPaymentMethodType (Lcom/stripe/android/model/PaymentMethod$Type;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Args$Builder;
 	public final fun setShouldAttachToCustomer (Z)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Args$Builder;
 	public final fun setWindowFlags (Ljava/lang/Integer;)Lcom/stripe/android/view/AddPaymentMethodActivityStarter$Args$Builder;
@@ -5665,15 +5448,6 @@ public final class com/stripe/android/view/AddPaymentMethodActivityStarter$Resul
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
-public abstract interface class com/stripe/android/view/AuthActivityStarter {
-	public abstract fun start (Ljava/lang/Object;)V
-}
-
-public abstract class com/stripe/android/view/AuthActivityStarterHost {
-	public static final field $stable I
-	public abstract fun startActivityForResult (Ljava/lang/Class;Landroid/os/Bundle;I)V
 }
 
 public final class com/stripe/android/view/BecsDebitMandateAcceptanceTextFactory {
@@ -5785,7 +5559,6 @@ public final class com/stripe/android/view/CardMultilineWidget : android/widget/
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IZ)V
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun clear ()V
-	public final fun getBrand ()Lcom/stripe/android/model/CardBrand;
 	public final fun getCardNumberEditText ()Lcom/stripe/android/view/CardNumberEditText;
 	public final fun getCardNumberTextInputLayout ()Lcom/stripe/android/view/CardNumberTextInputLayout;
 	public fun getCardParams ()Lcom/stripe/android/model/CardParams;
@@ -5802,25 +5575,17 @@ public final class com/stripe/android/view/CardMultilineWidget : android/widget/
 	public final fun getUsZipCodeRequired ()Z
 	public fun isEnabled ()Z
 	public fun onWindowFocusChanged (Z)V
-	public final fun populate (Lcom/stripe/android/model/PaymentMethodCreateParams$Card;)V
 	public fun setCardHint (Ljava/lang/String;)V
 	public fun setCardInputListener (Lcom/stripe/android/view/CardInputListener;)V
 	public fun setCardNumber (Ljava/lang/String;)V
-	public final fun setCardNumberErrorListener (Lcom/stripe/android/view/StripeEditText$ErrorMessageListener;)V
 	public fun setCardNumberTextWatcher (Landroid/text/TextWatcher;)V
 	public fun setCardValidCallback (Lcom/stripe/android/view/CardValidCallback;)V
 	public fun setCvcCode (Ljava/lang/String;)V
-	public final fun setCvcErrorListener (Lcom/stripe/android/view/StripeEditText$ErrorMessageListener;)V
-	public final synthetic fun setCvcIcon (Ljava/lang/Integer;)V
 	public final fun setCvcLabel (Ljava/lang/String;)V
 	public fun setCvcNumberTextWatcher (Landroid/text/TextWatcher;)V
-	public final fun setCvcPlaceholderText (Ljava/lang/String;)V
 	public fun setEnabled (Z)V
-	public final fun setExpirationDateErrorListener (Lcom/stripe/android/view/StripeEditText$ErrorMessageListener;)V
-	public final fun setExpirationDatePlaceholderRes (Ljava/lang/Integer;)V
 	public fun setExpiryDate (II)V
 	public fun setExpiryDateTextWatcher (Landroid/text/TextWatcher;)V
-	public final fun setPostalCodeErrorListener (Lcom/stripe/android/view/StripeEditText$ErrorMessageListener;)V
 	public final fun setPostalCodeRequired (Z)V
 	public fun setPostalCodeTextWatcher (Landroid/text/TextWatcher;)V
 	public final fun setShouldShowPostalCode (Z)V
@@ -5839,12 +5604,6 @@ public final class com/stripe/android/view/CardNumberEditText : com/stripe/andro
 	public final fun isCardNumberValid ()Z
 }
 
-public final class com/stripe/android/view/CardNumberTextInputLayout : com/google/android/material/textfield/TextInputLayout {
-	public static final field $stable I
-	public fun <init> (Landroid/content/Context;)V
-	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
-}
-
 public abstract interface class com/stripe/android/view/CardValidCallback {
 	public abstract fun onInputChanged (ZLjava/util/Set;)V
 }
@@ -5856,21 +5615,6 @@ public final class com/stripe/android/view/CardValidCallback$Fields : java/lang/
 	public static final field Postal Lcom/stripe/android/view/CardValidCallback$Fields;
 	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/view/CardValidCallback$Fields;
 	public static fun values ()[Lcom/stripe/android/view/CardValidCallback$Fields;
-}
-
-public final class com/stripe/android/view/CountryTextInputLayout : com/google/android/material/textfield/TextInputLayout {
-	public static final field $stable I
-	public static final field INVALID_COUNTRY_AUTO_COMPLETE_STYLE I
-	public fun <init> (Landroid/content/Context;)V
-	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
-	public final fun getCountryAutocomplete ()Landroid/widget/AutoCompleteTextView;
-	public final fun getCountryCodeChangeCallback ()Lkotlin/jvm/functions/Function1;
-	public final fun getSelectedCountryCode ()Lcom/stripe/android/core/model/CountryCode;
-	public fun onSaveInstanceState ()Landroid/os/Parcelable;
-	public final fun setCountryCodeChangeCallback (Lkotlin/jvm/functions/Function1;)V
-	public fun setEnabled (Z)V
-	public final fun setSelectedCountryCode (Lcom/stripe/android/core/model/CountryCode;)V
-	public final fun updateUiForCountryEntered (Lcom/stripe/android/core/model/CountryCode;)V
 }
 
 public final class com/stripe/android/view/CvcEditText : com/stripe/android/view/StripeEditText {
@@ -5889,13 +5633,6 @@ public final class com/stripe/android/view/ExpiryDateEditText : com/stripe/andro
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getValidatedDate ()Lcom/stripe/android/model/ExpirationDate$Validated;
 	public final fun isDateValid ()Z
-	public final fun setIncludeSeparatorGaps (Z)V
-}
-
-public final class com/stripe/android/view/KeyboardController {
-	public static final field $stable I
-	public fun <init> (Landroid/app/Activity;)V
-	public final synthetic fun hide ()V
 }
 
 public final class com/stripe/android/view/PaymentAuthWebViewActivity : androidx/appcompat/app/AppCompatActivity {
@@ -6052,12 +5789,6 @@ public final class com/stripe/android/view/PostalCodeEditText : com/stripe/andro
 	public synthetic fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
-public final class com/stripe/android/view/PostalCodeValidator {
-	public static final field $stable I
-	public fun <init> ()V
-	public final fun isValid (Ljava/lang/String;Ljava/lang/String;)Z
-}
-
 public final class com/stripe/android/view/ShippingInfoWidget : android/widget/LinearLayout {
 	public static final field $stable I
 	public fun <init> (Landroid/content/Context;)V
@@ -6110,7 +5841,6 @@ public class com/stripe/android/view/StripeEditText : com/google/android/materia
 	public final fun getDefaultErrorColorInt ()I
 	public final fun getInternalFocusChangeListeners ()Ljava/util/List;
 	public fun getOnFocusChangeListener ()Landroid/view/View$OnFocusChangeListener;
-	public final fun getParentOnFocusChangeListener ()Landroid/view/View$OnFocusChangeListener;
 	public final fun getShouldShowError ()Z
 	protected final fun isLastKeyDelete ()Z
 	public fun onCreateInputConnection (Landroid/view/inputmethod/EditorInfo;)Landroid/view/inputmethod/InputConnection;
@@ -6124,7 +5854,6 @@ public class com/stripe/android/view/StripeEditText : com/google/android/materia
 	public final fun setErrorMessage (Ljava/lang/String;)V
 	public final fun setErrorMessageListener (Lcom/stripe/android/view/StripeEditText$ErrorMessageListener;)V
 	protected final fun setLastKeyDelete (Z)V
-	public final fun setNumberOnlyInputType ()V
 	public final fun setOnFocusChangeListener (Landroid/view/View$OnFocusChangeListener;)V
 	public final fun setShouldShowError (Z)V
 	public fun setTextColor (I)V

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -1,20 +1,3 @@
-public final class com/stripe/android/ui/core/Amount : android/os/Parcelable {
-	public static final field $stable I
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (JLjava/lang/String;)V
-	public final fun component1 ()J
-	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (JLjava/lang/String;)Lcom/stripe/android/ui/core/Amount;
-	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/Amount;JLjava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/ui/core/Amount;
-	public fun describeContents ()I
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getCurrencyCode ()Ljava/lang/String;
-	public final fun getValue ()J
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
 public final class com/stripe/android/ui/core/BuildConfig {
 	public static final field BUILD_TYPE Ljava/lang/String;
 	public static final field DEBUG Z
@@ -22,25 +5,7 @@ public final class com/stripe/android/ui/core/BuildConfig {
 	public fun <init> ()V
 }
 
-public final class com/stripe/android/ui/core/CurrencyFormatter {
-	public static final field $stable I
-	public fun <init> ()V
-	public final fun format (JLjava/lang/String;Ljava/util/Locale;)Ljava/lang/String;
-	public final fun format (JLjava/util/Currency;Ljava/util/Locale;)Ljava/lang/String;
-	public static synthetic fun format$default (Lcom/stripe/android/ui/core/CurrencyFormatter;JLjava/lang/String;Ljava/util/Locale;ILjava/lang/Object;)Ljava/lang/String;
-	public static synthetic fun format$default (Lcom/stripe/android/ui/core/CurrencyFormatter;JLjava/util/Currency;Ljava/util/Locale;ILjava/lang/Object;)Ljava/lang/String;
-}
-
 public final class com/stripe/android/ui/core/StripeThemeKt {
-	public static final fun StripeTheme (ZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
-}
-
-public final class com/stripe/android/ui/core/address/AddressFieldElementRepository {
-	public static final field $stable I
-	public static final field Companion Lcom/stripe/android/ui/core/address/AddressFieldElementRepository$Companion;
-	public fun <init> (Landroid/content/res/Resources;)V
-	public final fun getResources ()Landroid/content/res/Resources;
-	public final fun initialize (Ljava/lang/String;Ljava/io/ByteArrayInputStream;)V
 }
 
 public final class com/stripe/android/ui/core/address/AddressFieldElementRepository$Companion {
@@ -54,65 +19,10 @@ public final class com/stripe/android/ui/core/address/AddressFieldElementReposit
 	public static fun newInstance (Landroid/content/res/Resources;)Lcom/stripe/android/ui/core/address/AddressFieldElementRepository;
 }
 
-public final class com/stripe/android/ui/core/elements/AddressController : com/stripe/android/ui/core/elements/SectionFieldErrorController {
-	public static final field $stable I
-	public fun <init> (Lkotlinx/coroutines/flow/Flow;)V
-	public fun getError ()Lkotlinx/coroutines/flow/Flow;
-	public final fun getFieldsFlowable ()Lkotlinx/coroutines/flow/Flow;
-	public final fun getLabel ()Ljava/lang/Integer;
-}
-
-public final class com/stripe/android/ui/core/elements/AddressElement : com/stripe/android/ui/core/elements/SectionMultiFieldElement {
-	public static final field $stable I
-	public fun <init> (Lcom/stripe/android/ui/core/elements/IdentifierSpec;Lcom/stripe/android/ui/core/address/AddressFieldElementRepository;Ljava/util/Map;Ljava/util/Set;Lcom/stripe/android/ui/core/elements/DropdownFieldController;)V
-	public synthetic fun <init> (Lcom/stripe/android/ui/core/elements/IdentifierSpec;Lcom/stripe/android/ui/core/address/AddressFieldElementRepository;Ljava/util/Map;Ljava/util/Set;Lcom/stripe/android/ui/core/elements/DropdownFieldController;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getController ()Lcom/stripe/android/ui/core/elements/AddressController;
-	public final fun getCountryElement ()Lcom/stripe/android/ui/core/elements/CountryElement;
-	public final fun getFields ()Lkotlinx/coroutines/flow/Flow;
-	public fun getFormFieldValueFlow ()Lkotlinx/coroutines/flow/Flow;
-	public fun sectionFieldErrorController ()Lcom/stripe/android/ui/core/elements/SectionFieldErrorController;
-	public fun setRawValue (Ljava/util/Map;)V
-}
-
 public final class com/stripe/android/ui/core/elements/AfterpayClearpayElementUIKt {
-	public static final fun AfterpayClearpayElementUI (ZLcom/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement;Landroidx/compose/runtime/Composer;I)V
-}
-
-public final class com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement : com/stripe/android/ui/core/elements/FormElement {
-	public static final field $stable I
-	public static final field Companion Lcom/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement$Companion;
-	public static final field url Ljava/lang/String;
-	public fun <init> (Lcom/stripe/android/ui/core/elements/IdentifierSpec;Lcom/stripe/android/ui/core/Amount;Lcom/stripe/android/ui/core/elements/Controller;)V
-	public synthetic fun <init> (Lcom/stripe/android/ui/core/elements/IdentifierSpec;Lcom/stripe/android/ui/core/Amount;Lcom/stripe/android/ui/core/elements/Controller;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
-	public final fun component3 ()Lcom/stripe/android/ui/core/elements/Controller;
-	public final fun copy (Lcom/stripe/android/ui/core/elements/IdentifierSpec;Lcom/stripe/android/ui/core/Amount;Lcom/stripe/android/ui/core/elements/Controller;)Lcom/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement;
-	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement;Lcom/stripe/android/ui/core/elements/IdentifierSpec;Lcom/stripe/android/ui/core/Amount;Lcom/stripe/android/ui/core/elements/Controller;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun getController ()Lcom/stripe/android/ui/core/elements/Controller;
-	public fun getFormFieldValueFlow ()Lkotlinx/coroutines/flow/Flow;
-	public fun getIdentifier ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
-	public final fun getInfoUrl ()Ljava/lang/String;
-	public final fun getLabel (Landroid/content/res/Resources;)Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement$Companion {
-}
-
-public final class com/stripe/android/ui/core/elements/BankRepository {
-	public static final field $stable I
-	public fun <init> (Landroid/content/res/Resources;)V
-	public final fun component1 ()Landroid/content/res/Resources;
-	public final fun copy (Landroid/content/res/Resources;)Lcom/stripe/android/ui/core/elements/BankRepository;
-	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/BankRepository;Landroid/content/res/Resources;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/BankRepository;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun get (Lcom/stripe/android/ui/core/elements/SupportedBankType;)Ljava/util/List;
-	public final fun getResources ()Landroid/content/res/Resources;
-	public fun hashCode ()I
-	public final fun initialize (Ljava/util/Map;)V
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/stripe/android/ui/core/elements/BankRepository_Factory : dagger/internal/Factory {
@@ -128,98 +38,6 @@ public final class com/stripe/android/ui/core/elements/ComposableSingletons$Afte
 	public static field lambda-1 Lkotlin/jvm/functions/Function3;
 	public fun <init> ()V
 	public final fun getLambda-1$payments_ui_core_release ()Lkotlin/jvm/functions/Function3;
-}
-
-public abstract interface class com/stripe/android/ui/core/elements/Controller {
-}
-
-public final class com/stripe/android/ui/core/elements/CountryConfig : com/stripe/android/ui/core/elements/DropdownConfig {
-	public static final field $stable I
-	public fun <init> ()V
-	public fun <init> (Ljava/util/Set;Ljava/util/Locale;)V
-	public synthetic fun <init> (Ljava/util/Set;Ljava/util/Locale;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun convertFromRaw (Ljava/lang/String;)Ljava/lang/String;
-	public fun convertToRaw (Ljava/lang/String;)Ljava/lang/String;
-	public fun getDebugLabel ()Ljava/lang/String;
-	public fun getDisplayItems ()Ljava/util/List;
-	public fun getLabel ()I
-	public final fun getLocale ()Ljava/util/Locale;
-	public final fun getOnlyShowCountryCodes ()Ljava/util/Set;
-}
-
-public final class com/stripe/android/ui/core/elements/CountryElement : com/stripe/android/ui/core/elements/SectionSingleFieldElement {
-	public static final field $stable I
-	public fun <init> (Lcom/stripe/android/ui/core/elements/IdentifierSpec;Lcom/stripe/android/ui/core/elements/DropdownFieldController;)V
-	public final fun component1 ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
-	public final fun component2 ()Lcom/stripe/android/ui/core/elements/DropdownFieldController;
-	public final fun copy (Lcom/stripe/android/ui/core/elements/IdentifierSpec;Lcom/stripe/android/ui/core/elements/DropdownFieldController;)Lcom/stripe/android/ui/core/elements/CountryElement;
-	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/CountryElement;Lcom/stripe/android/ui/core/elements/IdentifierSpec;Lcom/stripe/android/ui/core/elements/DropdownFieldController;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/CountryElement;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun getController ()Lcom/stripe/android/ui/core/elements/DropdownFieldController;
-	public synthetic fun getController ()Lcom/stripe/android/ui/core/elements/InputController;
-	public fun getIdentifier ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/stripe/android/ui/core/elements/CountrySpec : com/stripe/android/ui/core/elements/SectionFieldSpec {
-	public static final field $stable I
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> ()V
-	public fun <init> (Ljava/util/Set;)V
-	public synthetic fun <init> (Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/util/Set;
-	public final fun copy (Ljava/util/Set;)Lcom/stripe/android/ui/core/elements/CountrySpec;
-	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/CountrySpec;Ljava/util/Set;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/CountrySpec;
-	public fun describeContents ()I
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getOnlyShowCountryCodes ()Ljava/util/Set;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-	public final fun transform (Ljava/lang/String;)Lcom/stripe/android/ui/core/elements/SectionFieldElement;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
-public abstract interface class com/stripe/android/ui/core/elements/DropdownConfig {
-	public abstract fun convertFromRaw (Ljava/lang/String;)Ljava/lang/String;
-	public abstract fun convertToRaw (Ljava/lang/String;)Ljava/lang/String;
-	public abstract fun getDebugLabel ()Ljava/lang/String;
-	public abstract fun getDisplayItems ()Ljava/util/List;
-	public abstract fun getLabel ()I
-}
-
-public final class com/stripe/android/ui/core/elements/DropdownFieldController : com/stripe/android/ui/core/elements/InputController, com/stripe/android/ui/core/elements/SectionFieldErrorController {
-	public static final field $stable I
-	public fun <init> (Lcom/stripe/android/ui/core/elements/DropdownConfig;Ljava/lang/String;)V
-	public synthetic fun <init> (Lcom/stripe/android/ui/core/elements/DropdownConfig;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getDisplayItems ()Ljava/util/List;
-	public fun getError ()Lkotlinx/coroutines/flow/Flow;
-	public fun getFieldValue ()Lkotlinx/coroutines/flow/Flow;
-	public fun getFormFieldValue ()Lkotlinx/coroutines/flow/Flow;
-	public fun getLabel ()I
-	public fun getRawFieldValue ()Lkotlinx/coroutines/flow/Flow;
-	public final fun getSelectedIndex ()Lkotlinx/coroutines/flow/Flow;
-	public fun getShowOptionalLabel ()Z
-	public fun isComplete ()Lkotlinx/coroutines/flow/Flow;
-	public fun onRawValueChange (Ljava/lang/String;)V
-	public final fun onValueChange (I)V
-}
-
-public final class com/stripe/android/ui/core/elements/DropdownItemSpec {
-	public static final field $stable I
-	public static final field Companion Lcom/stripe/android/ui/core/elements/DropdownItemSpec$Companion;
-	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/ui/core/elements/DropdownItemSpec;
-	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/DropdownItemSpec;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/DropdownItemSpec;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getText ()Ljava/lang/String;
-	public final fun getValue ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lcom/stripe/android/ui/core/elements/DropdownItemSpec;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
 }
 
 public final class com/stripe/android/ui/core/elements/DropdownItemSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
@@ -239,88 +57,8 @@ public final class com/stripe/android/ui/core/elements/DropdownItemSpec$Companio
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/stripe/android/ui/core/elements/EmailConfig : com/stripe/android/ui/core/elements/TextFieldConfig {
-	public static final field $stable I
-	public static final field Companion Lcom/stripe/android/ui/core/elements/EmailConfig$Companion;
-	public fun <init> ()V
-	public fun convertFromRaw (Ljava/lang/String;)Ljava/lang/String;
-	public fun convertToRaw (Ljava/lang/String;)Ljava/lang/String;
-	public fun determineState (Ljava/lang/String;)Lcom/stripe/android/ui/core/elements/TextFieldState;
-	public fun filter (Ljava/lang/String;)Ljava/lang/String;
-	public fun getCapitalization-IUNYP9k ()I
-	public fun getDebugLabel ()Ljava/lang/String;
-	public fun getKeyboard-PjHm6EE ()I
-	public fun getLabel ()I
-	public fun getVisualTransformation ()Landroidx/compose/ui/text/input/VisualTransformation;
-}
-
 public final class com/stripe/android/ui/core/elements/EmailConfig$Companion {
 	public final fun getPATTERN ()Ljava/util/regex/Pattern;
-}
-
-public final class com/stripe/android/ui/core/elements/EmailElement : com/stripe/android/ui/core/elements/SectionSingleFieldElement {
-	public static final field $stable I
-	public fun <init> (Lcom/stripe/android/ui/core/elements/IdentifierSpec;Lcom/stripe/android/ui/core/elements/TextFieldController;)V
-	public final fun component1 ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
-	public final fun component2 ()Lcom/stripe/android/ui/core/elements/TextFieldController;
-	public final fun copy (Lcom/stripe/android/ui/core/elements/IdentifierSpec;Lcom/stripe/android/ui/core/elements/TextFieldController;)Lcom/stripe/android/ui/core/elements/EmailElement;
-	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/EmailElement;Lcom/stripe/android/ui/core/elements/IdentifierSpec;Lcom/stripe/android/ui/core/elements/TextFieldController;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/EmailElement;
-	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun getController ()Lcom/stripe/android/ui/core/elements/InputController;
-	public fun getController ()Lcom/stripe/android/ui/core/elements/TextFieldController;
-	public fun getIdentifier ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/stripe/android/ui/core/elements/EmailSpec : com/stripe/android/ui/core/elements/SectionFieldSpec {
-	public static final field $stable I
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/EmailSpec;
-	public fun describeContents ()I
-	public final fun transform (Ljava/lang/String;)Lcom/stripe/android/ui/core/elements/SectionFieldElement;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
-public final class com/stripe/android/ui/core/elements/FieldError {
-	public static final field $stable I
-	public fun <init> (I[Ljava/lang/Object;)V
-	public synthetic fun <init> (I[Ljava/lang/Object;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getErrorMessage ()I
-	public final fun getFormatArgs ()[Ljava/lang/Object;
-}
-
-public abstract class com/stripe/android/ui/core/elements/FormElement {
-	public static final field $stable I
-	public abstract fun getController ()Lcom/stripe/android/ui/core/elements/Controller;
-	public abstract fun getFormFieldValueFlow ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getIdentifier ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
-}
-
-public abstract class com/stripe/android/ui/core/elements/FormItemSpec : android/os/Parcelable {
-	public static final field $stable I
-}
-
-public final class com/stripe/android/ui/core/elements/IbanConfig : com/stripe/android/ui/core/elements/TextFieldConfig {
-	public static final field $stable I
-	public static final field MAX_LENGTH I
-	public static final field MIN_LENGTH I
-	public fun <init> ()V
-	public fun convertFromRaw (Ljava/lang/String;)Ljava/lang/String;
-	public fun convertToRaw (Ljava/lang/String;)Ljava/lang/String;
-	public fun determineState (Ljava/lang/String;)Lcom/stripe/android/ui/core/elements/TextFieldState;
-	public fun filter (Ljava/lang/String;)Ljava/lang/String;
-	public fun getCapitalization-IUNYP9k ()I
-	public fun getDebugLabel ()Ljava/lang/String;
-	public fun getKeyboard-PjHm6EE ()I
-	public fun getLabel ()I
-	public fun getVisualTransformation ()Landroidx/compose/ui/text/input/VisualTransformation;
-}
-
-public abstract class com/stripe/android/ui/core/elements/IdentifierSpec : android/os/Parcelable {
-	public static final field $stable I
-	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getValue ()Ljava/lang/String;
 }
 
 public final class com/stripe/android/ui/core/elements/IdentifierSpec$City : com/stripe/android/ui/core/elements/IdentifierSpec {
@@ -416,410 +154,25 @@ public final class com/stripe/android/ui/core/elements/IdentifierSpec$State : co
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public abstract interface class com/stripe/android/ui/core/elements/InputController : com/stripe/android/ui/core/elements/SectionFieldErrorController {
-	public abstract fun getFieldValue ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getFormFieldValue ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getLabel ()I
-	public abstract fun getRawFieldValue ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getShowOptionalLabel ()Z
-	public abstract fun isComplete ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun onRawValueChange (Ljava/lang/String;)V
-}
-
-public final class com/stripe/android/ui/core/elements/KlarnaHelper {
-	public static final field $stable I
-	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/KlarnaHelper;
-	public final fun getAllowedCountriesForCurrency (Ljava/lang/String;)Ljava/util/Set;
-	public final fun getKlarnaHeader (Ljava/util/Locale;)I
-	public static synthetic fun getKlarnaHeader$default (Lcom/stripe/android/ui/core/elements/KlarnaHelper;Ljava/util/Locale;ILjava/lang/Object;)I
-}
-
-public final class com/stripe/android/ui/core/elements/LayoutFormDescriptor {
-	public static final field $stable I
-	public fun <init> (Lcom/stripe/android/ui/core/elements/LayoutSpec;ZZ)V
-	public final fun component1 ()Lcom/stripe/android/ui/core/elements/LayoutSpec;
-	public final fun component2 ()Z
-	public final fun component3 ()Z
-	public final fun copy (Lcom/stripe/android/ui/core/elements/LayoutSpec;ZZ)Lcom/stripe/android/ui/core/elements/LayoutFormDescriptor;
-	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/LayoutFormDescriptor;Lcom/stripe/android/ui/core/elements/LayoutSpec;ZZILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/LayoutFormDescriptor;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getLayoutSpec ()Lcom/stripe/android/ui/core/elements/LayoutSpec;
-	public final fun getShowCheckbox ()Z
-	public final fun getShowCheckboxControlledFields ()Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/stripe/android/ui/core/elements/LayoutSpec : android/os/Parcelable {
-	public static final field $stable I
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public static final field Companion Lcom/stripe/android/ui/core/elements/LayoutSpec$Companion;
-	public synthetic fun <init> (Ljava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/util/List;
-	public final fun copy (Ljava/util/List;)Lcom/stripe/android/ui/core/elements/LayoutSpec;
-	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/LayoutSpec;Ljava/util/List;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/LayoutSpec;
-	public fun describeContents ()I
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getItems ()Ljava/util/List;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
 public final class com/stripe/android/ui/core/elements/LayoutSpec$Companion {
 	public final fun create ()Lcom/stripe/android/ui/core/elements/LayoutSpec;
 	public final fun create ([Lcom/stripe/android/ui/core/elements/FormItemSpec;)Lcom/stripe/android/ui/core/elements/LayoutSpec;
 }
 
-public final class com/stripe/android/ui/core/elements/NameConfig : com/stripe/android/ui/core/elements/TextFieldConfig {
-	public static final field $stable I
-	public fun <init> ()V
-	public fun convertFromRaw (Ljava/lang/String;)Ljava/lang/String;
-	public fun convertToRaw (Ljava/lang/String;)Ljava/lang/String;
-	public fun determineState (Ljava/lang/String;)Lcom/stripe/android/ui/core/elements/TextFieldState;
-	public fun filter (Ljava/lang/String;)Ljava/lang/String;
-	public fun getCapitalization-IUNYP9k ()I
-	public fun getDebugLabel ()Ljava/lang/String;
-	public fun getKeyboard-PjHm6EE ()I
-	public fun getLabel ()I
-	public fun getVisualTransformation ()Landroidx/compose/ui/text/input/VisualTransformation;
-}
-
-public abstract interface class com/stripe/android/ui/core/elements/RequiredItemSpec : android/os/Parcelable {
-	public abstract fun getIdentifier ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
-}
-
-public final class com/stripe/android/ui/core/elements/RowController : com/stripe/android/ui/core/elements/SectionFieldErrorController {
-	public static final field $stable I
-	public fun <init> (Ljava/util/List;)V
-	public fun getError ()Lkotlinx/coroutines/flow/Flow;
-	public final fun getFields ()Ljava/util/List;
-}
-
-public final class com/stripe/android/ui/core/elements/RowElement : com/stripe/android/ui/core/elements/SectionMultiFieldElement {
-	public static final field $stable I
-	public fun <init> (Lcom/stripe/android/ui/core/elements/IdentifierSpec;Ljava/util/List;Lcom/stripe/android/ui/core/elements/RowController;)V
-	public final fun getController ()Lcom/stripe/android/ui/core/elements/RowController;
-	public final fun getFields ()Ljava/util/List;
-	public fun getFormFieldValueFlow ()Lkotlinx/coroutines/flow/Flow;
-	public fun sectionFieldErrorController ()Lcom/stripe/android/ui/core/elements/RowController;
-	public synthetic fun sectionFieldErrorController ()Lcom/stripe/android/ui/core/elements/SectionFieldErrorController;
-	public fun setRawValue (Ljava/util/Map;)V
-}
-
-public final class com/stripe/android/ui/core/elements/SaveForFutureUseController : com/stripe/android/ui/core/elements/InputController {
-	public static final field $stable I
-	public fun <init> (Ljava/util/List;Z)V
-	public synthetic fun <init> (Ljava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getError ()Lkotlinx/coroutines/flow/Flow;
-	public fun getFieldValue ()Lkotlinx/coroutines/flow/Flow;
-	public fun getFormFieldValue ()Lkotlinx/coroutines/flow/Flow;
-	public final fun getHiddenIdentifiers ()Lkotlinx/coroutines/flow/Flow;
-	public fun getLabel ()I
-	public fun getRawFieldValue ()Lkotlinx/coroutines/flow/Flow;
-	public final fun getSaveForFutureUse ()Lkotlinx/coroutines/flow/Flow;
-	public fun getShowOptionalLabel ()Z
-	public fun isComplete ()Lkotlinx/coroutines/flow/Flow;
-	public fun onRawValueChange (Ljava/lang/String;)V
-	public final fun onValueChange (Z)V
-}
-
-public final class com/stripe/android/ui/core/elements/SaveForFutureUseElement : com/stripe/android/ui/core/elements/FormElement {
-	public static final field $stable I
-	public fun <init> (Lcom/stripe/android/ui/core/elements/IdentifierSpec;Lcom/stripe/android/ui/core/elements/SaveForFutureUseController;Ljava/lang/String;)V
-	public final fun component1 ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
-	public final fun component2 ()Lcom/stripe/android/ui/core/elements/SaveForFutureUseController;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Lcom/stripe/android/ui/core/elements/IdentifierSpec;Lcom/stripe/android/ui/core/elements/SaveForFutureUseController;Ljava/lang/String;)Lcom/stripe/android/ui/core/elements/SaveForFutureUseElement;
-	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/SaveForFutureUseElement;Lcom/stripe/android/ui/core/elements/IdentifierSpec;Lcom/stripe/android/ui/core/elements/SaveForFutureUseController;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/SaveForFutureUseElement;
-	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun getController ()Lcom/stripe/android/ui/core/elements/Controller;
-	public fun getController ()Lcom/stripe/android/ui/core/elements/SaveForFutureUseController;
-	public fun getFormFieldValueFlow ()Lkotlinx/coroutines/flow/Flow;
-	public fun getIdentifier ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
-	public final fun getMerchantName ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
 public final class com/stripe/android/ui/core/elements/SaveForFutureUseElementUIKt {
-	public static final fun SaveForFutureUseElementUI (ZLcom/stripe/android/ui/core/elements/SaveForFutureUseElement;Landroidx/compose/runtime/Composer;I)V
-}
-
-public final class com/stripe/android/ui/core/elements/SaveForFutureUseSpec : com/stripe/android/ui/core/elements/FormItemSpec, com/stripe/android/ui/core/elements/RequiredItemSpec {
-	public static final field $stable I
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (Ljava/util/List;)V
-	public final fun component1 ()Ljava/util/List;
-	public final fun copy (Ljava/util/List;)Lcom/stripe/android/ui/core/elements/SaveForFutureUseSpec;
-	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/SaveForFutureUseSpec;Ljava/util/List;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/SaveForFutureUseSpec;
-	public fun describeContents ()I
-	public fun equals (Ljava/lang/Object;)Z
-	public fun getIdentifier ()Lcom/stripe/android/ui/core/elements/IdentifierSpec$SaveForFutureUse;
-	public synthetic fun getIdentifier ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
-	public final fun getIdentifierRequiredForFutureUse ()Ljava/util/List;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-	public final fun transform (ZLjava/lang/String;)Lcom/stripe/android/ui/core/elements/FormElement;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
-public final class com/stripe/android/ui/core/elements/SectionController : com/stripe/android/ui/core/elements/Controller {
-	public static final field $stable I
-	public fun <init> (Ljava/lang/Integer;Ljava/util/List;)V
-	public final fun getError ()Lkotlinx/coroutines/flow/Flow;
-	public final fun getLabel ()Ljava/lang/Integer;
-	public final fun getSectionFieldErrorControllers ()Ljava/util/List;
-}
-
-public final class com/stripe/android/ui/core/elements/SectionElement : com/stripe/android/ui/core/elements/FormElement {
-	public static final field $stable I
-	public fun <init> (Lcom/stripe/android/ui/core/elements/IdentifierSpec;Lcom/stripe/android/ui/core/elements/SectionFieldElement;Lcom/stripe/android/ui/core/elements/SectionController;)V
-	public fun <init> (Lcom/stripe/android/ui/core/elements/IdentifierSpec;Ljava/util/List;Lcom/stripe/android/ui/core/elements/SectionController;)V
-	public final fun component1 ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
-	public final fun component2 ()Ljava/util/List;
-	public final fun component3 ()Lcom/stripe/android/ui/core/elements/SectionController;
-	public final fun copy (Lcom/stripe/android/ui/core/elements/IdentifierSpec;Ljava/util/List;Lcom/stripe/android/ui/core/elements/SectionController;)Lcom/stripe/android/ui/core/elements/SectionElement;
-	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/SectionElement;Lcom/stripe/android/ui/core/elements/IdentifierSpec;Ljava/util/List;Lcom/stripe/android/ui/core/elements/SectionController;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/SectionElement;
-	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun getController ()Lcom/stripe/android/ui/core/elements/Controller;
-	public fun getController ()Lcom/stripe/android/ui/core/elements/SectionController;
-	public final fun getFields ()Ljava/util/List;
-	public fun getFormFieldValueFlow ()Lkotlinx/coroutines/flow/Flow;
-	public fun getIdentifier ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/stripe/android/ui/core/elements/SectionElementUIKt {
-	public static final fun SectionElementUI (ZLcom/stripe/android/ui/core/elements/SectionElement;Ljava/util/List;Landroidx/compose/runtime/Composer;I)V
-}
-
-public abstract interface class com/stripe/android/ui/core/elements/SectionFieldElement {
-	public abstract fun getFormFieldValueFlow ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getIdentifier ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
-	public abstract fun sectionFieldErrorController ()Lcom/stripe/android/ui/core/elements/SectionFieldErrorController;
-	public abstract fun setRawValue (Ljava/util/Map;)V
-}
-
-public abstract interface class com/stripe/android/ui/core/elements/SectionFieldErrorController : com/stripe/android/ui/core/elements/Controller {
-	public abstract fun getError ()Lkotlinx/coroutines/flow/Flow;
-}
-
-public abstract class com/stripe/android/ui/core/elements/SectionFieldSpec : android/os/Parcelable {
-	public static final field $stable I
-	public synthetic fun <init> (Lcom/stripe/android/ui/core/elements/IdentifierSpec;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getIdentifier ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
-}
-
-public abstract class com/stripe/android/ui/core/elements/SectionMultiFieldElement : com/stripe/android/ui/core/elements/SectionFieldElement {
-	public static final field $stable I
-	public synthetic fun <init> (Lcom/stripe/android/ui/core/elements/IdentifierSpec;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getIdentifier ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
-}
-
-public abstract class com/stripe/android/ui/core/elements/SectionSingleFieldElement : com/stripe/android/ui/core/elements/SectionFieldElement {
-	public static final field $stable I
-	public synthetic fun <init> (Lcom/stripe/android/ui/core/elements/IdentifierSpec;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public abstract fun getController ()Lcom/stripe/android/ui/core/elements/InputController;
-	public fun getFormFieldValueFlow ()Lkotlinx/coroutines/flow/Flow;
-	public fun getIdentifier ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
-	public fun sectionFieldErrorController ()Lcom/stripe/android/ui/core/elements/SectionFieldErrorController;
-	public fun setRawValue (Ljava/util/Map;)V
-}
-
-public final class com/stripe/android/ui/core/elements/SectionSpec : com/stripe/android/ui/core/elements/FormItemSpec, android/os/Parcelable, com/stripe/android/ui/core/elements/RequiredItemSpec {
-	public static final field $stable I
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (Lcom/stripe/android/ui/core/elements/IdentifierSpec;Lcom/stripe/android/ui/core/elements/SectionFieldSpec;Ljava/lang/Integer;)V
-	public synthetic fun <init> (Lcom/stripe/android/ui/core/elements/IdentifierSpec;Lcom/stripe/android/ui/core/elements/SectionFieldSpec;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Lcom/stripe/android/ui/core/elements/IdentifierSpec;Ljava/util/List;Ljava/lang/Integer;)V
-	public synthetic fun <init> (Lcom/stripe/android/ui/core/elements/IdentifierSpec;Ljava/util/List;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
-	public final fun component2 ()Ljava/util/List;
-	public final fun component3 ()Ljava/lang/Integer;
-	public final fun copy (Lcom/stripe/android/ui/core/elements/IdentifierSpec;Ljava/util/List;Ljava/lang/Integer;)Lcom/stripe/android/ui/core/elements/SectionSpec;
-	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/SectionSpec;Lcom/stripe/android/ui/core/elements/IdentifierSpec;Ljava/util/List;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/SectionSpec;
-	public fun describeContents ()I
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getFields ()Ljava/util/List;
-	public fun getIdentifier ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
-	public final fun getTitle ()Ljava/lang/Integer;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
 public final class com/stripe/android/ui/core/elements/SectionUIKt {
-	public static final fun SectionCard (Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
-}
-
-public final class com/stripe/android/ui/core/elements/SimpleDropdownConfig : com/stripe/android/ui/core/elements/DropdownConfig {
-	public static final field $stable I
-	public fun <init> (ILjava/util/List;)V
-	public fun convertFromRaw (Ljava/lang/String;)Ljava/lang/String;
-	public fun convertToRaw (Ljava/lang/String;)Ljava/lang/String;
-	public fun getDebugLabel ()Ljava/lang/String;
-	public fun getDisplayItems ()Ljava/util/List;
-	public fun getLabel ()I
-}
-
-public final class com/stripe/android/ui/core/elements/SimpleDropdownElement : com/stripe/android/ui/core/elements/SectionSingleFieldElement {
-	public static final field $stable I
-	public fun <init> (Lcom/stripe/android/ui/core/elements/IdentifierSpec;Lcom/stripe/android/ui/core/elements/DropdownFieldController;)V
-	public final fun component1 ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
-	public final fun component2 ()Lcom/stripe/android/ui/core/elements/DropdownFieldController;
-	public final fun copy (Lcom/stripe/android/ui/core/elements/IdentifierSpec;Lcom/stripe/android/ui/core/elements/DropdownFieldController;)Lcom/stripe/android/ui/core/elements/SimpleDropdownElement;
-	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/SimpleDropdownElement;Lcom/stripe/android/ui/core/elements/IdentifierSpec;Lcom/stripe/android/ui/core/elements/DropdownFieldController;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/SimpleDropdownElement;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun getController ()Lcom/stripe/android/ui/core/elements/DropdownFieldController;
-	public synthetic fun getController ()Lcom/stripe/android/ui/core/elements/InputController;
-	public fun getIdentifier ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/stripe/android/ui/core/elements/SimpleTextElement : com/stripe/android/ui/core/elements/SectionSingleFieldElement {
-	public static final field $stable I
-	public fun <init> (Lcom/stripe/android/ui/core/elements/IdentifierSpec;Lcom/stripe/android/ui/core/elements/TextFieldController;)V
-	public final fun component1 ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
-	public final fun component2 ()Lcom/stripe/android/ui/core/elements/TextFieldController;
-	public final fun copy (Lcom/stripe/android/ui/core/elements/IdentifierSpec;Lcom/stripe/android/ui/core/elements/TextFieldController;)Lcom/stripe/android/ui/core/elements/SimpleTextElement;
-	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/SimpleTextElement;Lcom/stripe/android/ui/core/elements/IdentifierSpec;Lcom/stripe/android/ui/core/elements/TextFieldController;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/SimpleTextElement;
-	public fun equals (Ljava/lang/Object;)Z
-	public synthetic fun getController ()Lcom/stripe/android/ui/core/elements/InputController;
-	public fun getController ()Lcom/stripe/android/ui/core/elements/TextFieldController;
-	public fun getIdentifier ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/stripe/android/ui/core/elements/SimpleTextFieldConfig : com/stripe/android/ui/core/elements/TextFieldConfig {
-	public static final field $stable I
-	public synthetic fun <init> (IIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun convertFromRaw (Ljava/lang/String;)Ljava/lang/String;
-	public fun convertToRaw (Ljava/lang/String;)Ljava/lang/String;
-	public fun determineState (Ljava/lang/String;)Lcom/stripe/android/ui/core/elements/TextFieldState;
-	public fun filter (Ljava/lang/String;)Ljava/lang/String;
-	public fun getCapitalization-IUNYP9k ()I
-	public fun getDebugLabel ()Ljava/lang/String;
-	public fun getKeyboard-PjHm6EE ()I
-	public fun getLabel ()I
-	public fun getVisualTransformation ()Landroidx/compose/ui/text/input/VisualTransformation;
-}
-
-public final class com/stripe/android/ui/core/elements/SimpleTextSpec : com/stripe/android/ui/core/elements/SectionFieldSpec {
-	public static final field $stable I
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public static final field Companion Lcom/stripe/android/ui/core/elements/SimpleTextSpec$Companion;
-	public synthetic fun <init> (Lcom/stripe/android/ui/core/elements/IdentifierSpec;IIIZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Lcom/stripe/android/ui/core/elements/IdentifierSpec;IIIZLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
-	public final fun component2 ()I
-	public final fun component3-IUNYP9k ()I
-	public final fun component4-PjHm6EE ()I
-	public final fun component5 ()Z
-	public final fun copy-25FCGzQ (Lcom/stripe/android/ui/core/elements/IdentifierSpec;IIIZ)Lcom/stripe/android/ui/core/elements/SimpleTextSpec;
-	public static synthetic fun copy-25FCGzQ$default (Lcom/stripe/android/ui/core/elements/SimpleTextSpec;Lcom/stripe/android/ui/core/elements/IdentifierSpec;IIIZILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/SimpleTextSpec;
-	public fun describeContents ()I
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getCapitalization-IUNYP9k ()I
-	public fun getIdentifier ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
-	public final fun getKeyboardType-PjHm6EE ()I
-	public final fun getLabel ()I
-	public final fun getShowOptionalLabel ()Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-	public final fun transform (Ljava/util/Map;)Lcom/stripe/android/ui/core/elements/SectionSingleFieldElement;
-	public static synthetic fun transform$default (Lcom/stripe/android/ui/core/elements/SimpleTextSpec;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/SectionSingleFieldElement;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
 public final class com/stripe/android/ui/core/elements/SimpleTextSpec$Companion {
 	public final fun getNAME ()Lcom/stripe/android/ui/core/elements/SimpleTextSpec;
 }
 
-public final class com/stripe/android/ui/core/elements/StaticTextElement : com/stripe/android/ui/core/elements/FormElement {
-	public static final field $stable I
-	public fun <init> (Lcom/stripe/android/ui/core/elements/IdentifierSpec;ILjava/lang/Integer;Ljava/lang/String;IDLcom/stripe/android/ui/core/elements/InputController;)V
-	public synthetic fun <init> (Lcom/stripe/android/ui/core/elements/IdentifierSpec;ILjava/lang/Integer;Ljava/lang/String;IDLcom/stripe/android/ui/core/elements/InputController;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
-	public final fun component2 ()I
-	public final fun component3 ()Ljava/lang/Integer;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()I
-	public final fun component6 ()D
-	public final fun component7 ()Lcom/stripe/android/ui/core/elements/InputController;
-	public final fun copy (Lcom/stripe/android/ui/core/elements/IdentifierSpec;ILjava/lang/Integer;Ljava/lang/String;IDLcom/stripe/android/ui/core/elements/InputController;)Lcom/stripe/android/ui/core/elements/StaticTextElement;
-	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/StaticTextElement;Lcom/stripe/android/ui/core/elements/IdentifierSpec;ILjava/lang/Integer;Ljava/lang/String;IDLcom/stripe/android/ui/core/elements/InputController;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/StaticTextElement;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getColor ()Ljava/lang/Integer;
-	public synthetic fun getController ()Lcom/stripe/android/ui/core/elements/Controller;
-	public fun getController ()Lcom/stripe/android/ui/core/elements/InputController;
-	public final fun getFontSizeSp ()I
-	public fun getFormFieldValueFlow ()Lkotlinx/coroutines/flow/Flow;
-	public fun getIdentifier ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
-	public final fun getLetterSpacingSp ()D
-	public final fun getMerchantName ()Ljava/lang/String;
-	public final fun getStringResId ()I
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
 public final class com/stripe/android/ui/core/elements/StaticTextElementUIKt {
-	public static final fun StaticElementUI (Lcom/stripe/android/ui/core/elements/StaticTextElement;Landroidx/compose/runtime/Composer;I)V
-}
-
-public final class com/stripe/android/ui/core/elements/SupportedBankType : java/lang/Enum {
-	public static final field Eps Lcom/stripe/android/ui/core/elements/SupportedBankType;
-	public static final field Ideal Lcom/stripe/android/ui/core/elements/SupportedBankType;
-	public static final field P24 Lcom/stripe/android/ui/core/elements/SupportedBankType;
-	public final fun getAssetFileName ()Ljava/lang/String;
-	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/ui/core/elements/SupportedBankType;
-	public static fun values ()[Lcom/stripe/android/ui/core/elements/SupportedBankType;
-}
-
-public abstract interface class com/stripe/android/ui/core/elements/TextFieldConfig {
-	public abstract fun convertFromRaw (Ljava/lang/String;)Ljava/lang/String;
-	public abstract fun convertToRaw (Ljava/lang/String;)Ljava/lang/String;
-	public abstract fun determineState (Ljava/lang/String;)Lcom/stripe/android/ui/core/elements/TextFieldState;
-	public abstract fun filter (Ljava/lang/String;)Ljava/lang/String;
-	public abstract fun getCapitalization-IUNYP9k ()I
-	public abstract fun getDebugLabel ()Ljava/lang/String;
-	public abstract fun getKeyboard-PjHm6EE ()I
-	public abstract fun getLabel ()I
-	public abstract fun getVisualTransformation ()Landroidx/compose/ui/text/input/VisualTransformation;
-}
-
-public final class com/stripe/android/ui/core/elements/TextFieldController : com/stripe/android/ui/core/elements/InputController, com/stripe/android/ui/core/elements/SectionFieldErrorController {
-	public static final field $stable I
-	public fun <init> (Lcom/stripe/android/ui/core/elements/TextFieldConfig;ZLjava/lang/String;)V
-	public synthetic fun <init> (Lcom/stripe/android/ui/core/elements/TextFieldConfig;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getCapitalization-IUNYP9k ()I
-	public final fun getDebugLabel ()Ljava/lang/String;
-	public fun getError ()Lkotlinx/coroutines/flow/Flow;
-	public fun getFieldValue ()Lkotlinx/coroutines/flow/Flow;
-	public fun getFormFieldValue ()Lkotlinx/coroutines/flow/Flow;
-	public final fun getKeyboardType-PjHm6EE ()I
-	public fun getLabel ()I
-	public fun getRawFieldValue ()Lkotlinx/coroutines/flow/Flow;
-	public fun getShowOptionalLabel ()Z
-	public final fun getVisibleError ()Lkotlinx/coroutines/flow/Flow;
-	public final fun getVisualTransformation ()Landroidx/compose/ui/text/input/VisualTransformation;
-	public fun isComplete ()Lkotlinx/coroutines/flow/Flow;
-	public final fun isFull ()Lkotlinx/coroutines/flow/Flow;
-	public final fun onFocusChange (Z)V
-	public fun onRawValueChange (Ljava/lang/String;)V
-	public final fun onValueChange (Ljava/lang/String;)V
-}
-
-public abstract interface class com/stripe/android/ui/core/elements/TextFieldState {
-	public abstract fun getError ()Lcom/stripe/android/ui/core/elements/FieldError;
-	public abstract fun isBlank ()Z
-	public abstract fun isFull ()Z
-	public abstract fun isValid ()Z
-	public abstract fun shouldShowError (Z)Z
 }
 
 public final class com/stripe/android/ui/core/forms/AfterpayClearpaySpecKt {
@@ -835,21 +188,6 @@ public final class com/stripe/android/ui/core/forms/BancontactSpecKt {
 public final class com/stripe/android/ui/core/forms/EpsSpecKt {
 	public static final fun getEpsForm ()Lcom/stripe/android/ui/core/elements/LayoutSpec;
 	public static final fun getEpsParamKey ()Ljava/util/Map;
-}
-
-public final class com/stripe/android/ui/core/forms/FormFieldEntry {
-	public static final field $stable I
-	public fun <init> (Ljava/lang/String;Z)V
-	public synthetic fun <init> (Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Z
-	public final fun copy (Ljava/lang/String;Z)Lcom/stripe/android/ui/core/forms/FormFieldEntry;
-	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/forms/FormFieldEntry;Ljava/lang/String;ZILjava/lang/Object;)Lcom/stripe/android/ui/core/forms/FormFieldEntry;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getValue ()Ljava/lang/String;
-	public fun hashCode ()I
-	public final fun isComplete ()Z
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/stripe/android/ui/core/forms/GiropaySpecKt {
@@ -893,36 +231,11 @@ public final class com/stripe/android/ui/core/forms/TransformSpecToElements {
 	public final fun transform (Ljava/util/List;)Ljava/util/List;
 }
 
-public final class com/stripe/android/ui/core/forms/resources/AsyncResourceRepository : com/stripe/android/ui/core/forms/resources/ResourceRepository {
-	public static final field $stable I
-	public fun <init> (Landroid/content/res/Resources;Lkotlin/coroutines/CoroutineContext;Ljava/util/Locale;)V
-	public fun getAddressRepository ()Lcom/stripe/android/ui/core/address/AddressFieldElementRepository;
-	public fun getBankRepository ()Lcom/stripe/android/ui/core/elements/BankRepository;
-	public fun isLoaded ()Z
-	public fun waitUntilLoaded (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
 public final class com/stripe/android/ui/core/forms/resources/AsyncResourceRepository_Factory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/ui/core/forms/resources/AsyncResourceRepository_Factory;
 	public fun get ()Lcom/stripe/android/ui/core/forms/resources/AsyncResourceRepository;
 	public synthetic fun get ()Ljava/lang/Object;
 	public static fun newInstance (Landroid/content/res/Resources;Lkotlin/coroutines/CoroutineContext;Ljava/util/Locale;)Lcom/stripe/android/ui/core/forms/resources/AsyncResourceRepository;
-}
-
-public abstract interface class com/stripe/android/ui/core/forms/resources/ResourceRepository {
-	public abstract fun getAddressRepository ()Lcom/stripe/android/ui/core/address/AddressFieldElementRepository;
-	public abstract fun getBankRepository ()Lcom/stripe/android/ui/core/elements/BankRepository;
-	public abstract fun isLoaded ()Z
-	public abstract fun waitUntilLoaded (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class com/stripe/android/ui/core/forms/resources/StaticResourceRepository : com/stripe/android/ui/core/forms/resources/ResourceRepository {
-	public static final field $stable I
-	public fun <init> (Lcom/stripe/android/ui/core/elements/BankRepository;Lcom/stripe/android/ui/core/address/AddressFieldElementRepository;)V
-	public fun getAddressRepository ()Lcom/stripe/android/ui/core/address/AddressFieldElementRepository;
-	public fun getBankRepository ()Lcom/stripe/android/ui/core/elements/BankRepository;
-	public fun isLoaded ()Z
-	public fun waitUntilLoaded (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/stripe-core/api/stripe-core.api
+++ b/stripe-core/api/stripe-core.api
@@ -5,16 +5,7 @@ public final class com/stripe/android/core/BuildConfig {
 	public fun <init> ()V
 }
 
-public abstract interface class com/stripe/android/core/Logger {
-	public static final field Companion Lcom/stripe/android/core/Logger$Companion;
-	public abstract fun debug (Ljava/lang/String;)V
-	public abstract fun error (Ljava/lang/String;Ljava/lang/Throwable;)V
-	public abstract fun info (Ljava/lang/String;)V
-	public abstract fun warning (Ljava/lang/String;)V
-}
-
 public final class com/stripe/android/core/Logger$Companion {
-	public final fun getInstance (Z)Lcom/stripe/android/core/Logger;
 	public final fun noop ()Lcom/stripe/android/core/Logger;
 	public final fun real ()Lcom/stripe/android/core/Logger;
 }
@@ -26,8 +17,6 @@ public final class com/stripe/android/core/Logger$DefaultImpls {
 public final class com/stripe/android/core/StripeError : com/stripe/android/core/model/StripeModel, java/io/Serializable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
@@ -61,7 +50,6 @@ public final class com/stripe/android/core/exception/APIConnectionException : co
 }
 
 public final class com/stripe/android/core/exception/APIConnectionException$Companion {
-	public final synthetic fun create (Ljava/io/IOException;Ljava/lang/String;)Lcom/stripe/android/core/exception/APIConnectionException;
 	public static synthetic fun create$default (Lcom/stripe/android/core/exception/APIConnectionException$Companion;Ljava/io/IOException;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/core/exception/APIConnectionException;
 }
 
@@ -70,7 +58,6 @@ public final class com/stripe/android/core/exception/APIException : com/stripe/a
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/core/StripeError;Ljava/lang/String;ILjava/lang/String;Ljava/lang/Throwable;)V
 	public synthetic fun <init> (Lcom/stripe/android/core/StripeError;Ljava/lang/String;ILjava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Ljava/lang/Throwable;)V
 }
 
 public final class com/stripe/android/core/exception/InvalidRequestException : com/stripe/android/core/exception/StripeException {
@@ -95,17 +82,6 @@ public abstract class com/stripe/android/core/exception/StripeException : java/l
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/stripe/android/core/exception/StripeException$Companion {
-	public final fun create (Ljava/lang/Throwable;)Lcom/stripe/android/core/exception/StripeException;
-}
-
-public final class com/stripe/android/core/injection/CoroutineContextModule {
-	public static final field $stable I
-	public fun <init> ()V
-	public final fun provideUIContext ()Lkotlin/coroutines/CoroutineContext;
-	public final fun provideWorkContext ()Lkotlin/coroutines/CoroutineContext;
-}
-
 public final class com/stripe/android/core/injection/CoroutineContextModule_ProvideUIContextFactory : dagger/internal/Factory {
 	public fun <init> (Lcom/stripe/android/core/injection/CoroutineContextModule;)V
 	public static fun create (Lcom/stripe/android/core/injection/CoroutineContextModule;)Lcom/stripe/android/core/injection/CoroutineContextModule_ProvideUIContextFactory;
@@ -122,38 +98,10 @@ public final class com/stripe/android/core/injection/CoroutineContextModule_Prov
 	public static fun provideWorkContext (Lcom/stripe/android/core/injection/CoroutineContextModule;)Lkotlin/coroutines/CoroutineContext;
 }
 
-public abstract interface annotation class com/stripe/android/core/injection/IOContext : java/lang/annotation/Annotation {
-}
-
-public abstract interface class com/stripe/android/core/injection/Injectable {
-	public abstract fun fallbackInitialize (Ljava/lang/Object;)V
-}
-
 public final class com/stripe/android/core/injection/InjectableKtxKt {
-	public static final fun injectWithFallback (Lcom/stripe/android/core/injection/Injectable;Ljava/lang/String;Ljava/lang/Object;)V
-}
-
-public abstract interface class com/stripe/android/core/injection/Injector {
-	public abstract fun inject (Lcom/stripe/android/core/injection/Injectable;)V
-}
-
-public abstract interface annotation class com/stripe/android/core/injection/InjectorKey : java/lang/annotation/Annotation {
 }
 
 public final class com/stripe/android/core/injection/InjectorKt {
-	public static final field DUMMY_INJECTOR_KEY Ljava/lang/String;
-}
-
-public abstract interface class com/stripe/android/core/injection/InjectorRegistry {
-	public abstract fun nextKey (Ljava/lang/String;)Ljava/lang/String;
-	public abstract fun register (Lcom/stripe/android/core/injection/Injector;Ljava/lang/String;)V
-	public abstract fun retrieve (Ljava/lang/String;)Lcom/stripe/android/core/injection/Injector;
-}
-
-public final class com/stripe/android/core/injection/LoggingModule {
-	public static final field $stable I
-	public fun <init> ()V
-	public final fun provideLogger (Z)Lcom/stripe/android/core/Logger;
 }
 
 public final class com/stripe/android/core/injection/LoggingModule_ProvideLoggerFactory : dagger/internal/Factory {
@@ -165,77 +113,9 @@ public final class com/stripe/android/core/injection/LoggingModule_ProvideLogger
 }
 
 public final class com/stripe/android/core/injection/NamedConstantsKt {
-	public static final field ENABLE_LOGGING Ljava/lang/String;
-}
-
-public abstract interface annotation class com/stripe/android/core/injection/UIContext : java/lang/annotation/Annotation {
-}
-
-public final class com/stripe/android/core/injection/WeakMapInjectorRegistry : com/stripe/android/core/injection/InjectorRegistry {
-	public static final field $stable I
-	public static final field INSTANCE Lcom/stripe/android/core/injection/WeakMapInjectorRegistry;
-	public final fun clear ()V
-	public final fun getCURRENT_REGISTER_KEY ()Ljava/util/concurrent/atomic/AtomicInteger;
-	public final fun getStaticCacheMap ()Ljava/util/WeakHashMap;
-	public fun nextKey (Ljava/lang/String;)Ljava/lang/String;
-	public fun register (Lcom/stripe/android/core/injection/Injector;Ljava/lang/String;)V
-	public fun retrieve (Ljava/lang/String;)Lcom/stripe/android/core/injection/Injector;
-}
-
-public final class com/stripe/android/core/model/Country {
-	public static final field $stable I
-	public fun <init> (Lcom/stripe/android/core/model/CountryCode;Ljava/lang/String;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
-	public final fun component1 ()Lcom/stripe/android/core/model/CountryCode;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Lcom/stripe/android/core/model/CountryCode;Ljava/lang/String;)Lcom/stripe/android/core/model/Country;
-	public static synthetic fun copy$default (Lcom/stripe/android/core/model/Country;Lcom/stripe/android/core/model/CountryCode;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/core/model/Country;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getCode ()Lcom/stripe/android/core/model/CountryCode;
-	public final fun getName ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/stripe/android/core/model/CountryCode : android/os/Parcelable {
-	public static final field $stable I
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public static final field Companion Lcom/stripe/android/core/model/CountryCode$Companion;
-	public fun <init> (Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/core/model/CountryCode;
-	public static synthetic fun copy$default (Lcom/stripe/android/core/model/CountryCode;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/core/model/CountryCode;
-	public fun describeContents ()I
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getValue ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
-public final class com/stripe/android/core/model/CountryCode$Companion {
-	public final fun create (Ljava/lang/String;)Lcom/stripe/android/core/model/CountryCode;
-	public final fun getCA ()Lcom/stripe/android/core/model/CountryCode;
-	public final fun getGB ()Lcom/stripe/android/core/model/CountryCode;
-	public final fun getUS ()Lcom/stripe/android/core/model/CountryCode;
-	public final fun isCA (Lcom/stripe/android/core/model/CountryCode;)Z
-	public final fun isGB (Lcom/stripe/android/core/model/CountryCode;)Z
-	public final fun isUS (Lcom/stripe/android/core/model/CountryCode;)Z
 }
 
 public final class com/stripe/android/core/model/CountryCodeKt {
-	public static final fun getCountryCode (Ljava/util/Locale;)Lcom/stripe/android/core/model/CountryCode;
-}
-
-public final class com/stripe/android/core/model/CountryUtils {
-	public static final field $stable I
-	public static final field INSTANCE Lcom/stripe/android/core/model/CountryUtils;
-	public final synthetic fun doesCountryUsePostalCode (Lcom/stripe/android/core/model/CountryCode;)Z
-	public final synthetic fun doesCountryUsePostalCode (Ljava/lang/String;)Z
-	public final synthetic fun getCountryByCode (Lcom/stripe/android/core/model/CountryCode;Ljava/util/Locale;)Lcom/stripe/android/core/model/Country;
-	public final synthetic fun getCountryCodeByName (Ljava/lang/String;Ljava/util/Locale;)Lcom/stripe/android/core/model/CountryCode;
-	public final synthetic fun getDisplayCountry (Lcom/stripe/android/core/model/CountryCode;Ljava/util/Locale;)Ljava/lang/String;
-	public final synthetic fun getOrderedCountries (Ljava/util/Locale;)Ljava/util/List;
 }
 
 public abstract interface class com/stripe/android/core/model/StripeModel : android/os/Parcelable {
@@ -243,47 +123,11 @@ public abstract interface class com/stripe/android/core/model/StripeModel : andr
 	public abstract fun hashCode ()I
 }
 
-public final class com/stripe/android/core/networking/AnalyticsRequest : com/stripe/android/core/networking/StripeRequest {
-	public static final field $stable I
-	public fun <init> (Ljava/util/Map;Ljava/util/Map;)V
-	public final fun component1 ()Ljava/util/Map;
-	public final fun component2 ()Ljava/util/Map;
-	public final fun copy (Ljava/util/Map;Ljava/util/Map;)Lcom/stripe/android/core/networking/AnalyticsRequest;
-	public static synthetic fun copy$default (Lcom/stripe/android/core/networking/AnalyticsRequest;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/core/networking/AnalyticsRequest;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun getHeaders ()Ljava/util/Map;
-	public fun getMethod ()Lcom/stripe/android/core/networking/StripeRequest$Method;
-	public fun getMimeType ()Lcom/stripe/android/core/networking/StripeRequest$MimeType;
-	public final fun getParams ()Ljava/util/Map;
-	public fun getRetryResponseCodes ()Ljava/lang/Iterable;
-	public fun getUrl ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public abstract interface class com/stripe/android/core/networking/AnalyticsRequestExecutor {
-	public abstract fun executeAsync (Lcom/stripe/android/core/networking/AnalyticsRequest;)V
-}
-
-public abstract interface class com/stripe/android/core/networking/ConnectionFactory {
-	public abstract fun create (Lcom/stripe/android/core/networking/StripeRequest;)Lcom/stripe/android/core/networking/StripeConnection;
-	public abstract fun createForFile (Lcom/stripe/android/core/networking/StripeRequest;Ljava/io/File;)Lcom/stripe/android/core/networking/StripeConnection;
-}
-
 public final class com/stripe/android/core/networking/ConnectionFactory$Default : com/stripe/android/core/networking/ConnectionFactory {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/core/networking/ConnectionFactory$Default;
 	public synthetic fun create (Lcom/stripe/android/core/networking/StripeRequest;)Lcom/stripe/android/core/networking/StripeConnection;
 	public fun createForFile (Lcom/stripe/android/core/networking/StripeRequest;Ljava/io/File;)Lcom/stripe/android/core/networking/StripeConnection;
-}
-
-public final class com/stripe/android/core/networking/DefaultAnalyticsRequestExecutor : com/stripe/android/core/networking/AnalyticsRequestExecutor {
-	public static final field $stable I
-	public static final field FIELD_EVENT Ljava/lang/String;
-	public fun <init> ()V
-	public fun <init> (Lcom/stripe/android/core/Logger;Lkotlin/coroutines/CoroutineContext;)V
-	public fun <init> (Lcom/stripe/android/core/networking/StripeNetworkClient;Lkotlin/coroutines/CoroutineContext;Lcom/stripe/android/core/Logger;)V
-	public fun executeAsync (Lcom/stripe/android/core/networking/AnalyticsRequest;)V
 }
 
 public final class com/stripe/android/core/networking/DefaultAnalyticsRequestExecutor_Factory : dagger/internal/Factory {
@@ -294,50 +138,9 @@ public final class com/stripe/android/core/networking/DefaultAnalyticsRequestExe
 	public static fun newInstance (Lcom/stripe/android/core/Logger;Lkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/core/networking/DefaultAnalyticsRequestExecutor;
 }
 
-public final class com/stripe/android/core/networking/DefaultStripeNetworkClient : com/stripe/android/core/networking/StripeNetworkClient {
-	public static final field $stable I
-	public fun <init> ()V
-	public fun <init> (Lkotlin/coroutines/CoroutineContext;)V
-	public fun <init> (Lkotlin/coroutines/CoroutineContext;Lcom/stripe/android/core/networking/ConnectionFactory;)V
-	public fun <init> (Lkotlin/coroutines/CoroutineContext;Lcom/stripe/android/core/networking/ConnectionFactory;Lcom/stripe/android/core/networking/RetryDelaySupplier;)V
-	public fun <init> (Lkotlin/coroutines/CoroutineContext;Lcom/stripe/android/core/networking/ConnectionFactory;Lcom/stripe/android/core/networking/RetryDelaySupplier;I)V
-	public fun <init> (Lkotlin/coroutines/CoroutineContext;Lcom/stripe/android/core/networking/ConnectionFactory;Lcom/stripe/android/core/networking/RetryDelaySupplier;ILcom/stripe/android/core/Logger;)V
-	public synthetic fun <init> (Lkotlin/coroutines/CoroutineContext;Lcom/stripe/android/core/networking/ConnectionFactory;Lcom/stripe/android/core/networking/RetryDelaySupplier;ILcom/stripe/android/core/Logger;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun executeRequest (Lcom/stripe/android/core/networking/StripeRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun executeRequestForFile (Lcom/stripe/android/core/networking/StripeRequest;Ljava/io/File;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
 public final class com/stripe/android/core/networking/NetworkConstantsKt {
 	public static final field HEADER_AUTHORIZATION Ljava/lang/String;
 	public static final field HEADER_CONTENT_TYPE Ljava/lang/String;
-	public static final field HTTP_TOO_MANY_REQUESTS I
-}
-
-public final class com/stripe/android/core/networking/QueryStringFactory {
-	public static final field $stable I
-	public static final field INSTANCE Lcom/stripe/android/core/networking/QueryStringFactory;
-	public final fun compactParams (Ljava/util/Map;)Ljava/util/Map;
-	public final fun create (Ljava/util/Map;)Ljava/lang/String;
-	public final fun createFromParamsWithEmptyValues (Ljava/util/Map;)Ljava/lang/String;
-}
-
-public final class com/stripe/android/core/networking/RequestId {
-	public static final field $stable I
-	public fun <init> (Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/core/networking/RequestId;
-	public static synthetic fun copy$default (Lcom/stripe/android/core/networking/RequestId;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/core/networking/RequestId;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getValue ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/stripe/android/core/networking/RetryDelaySupplier {
-	public static final field $stable I
-	public fun <init> ()V
-	public fun <init> (J)V
-	public final fun getDelayMillis (II)J
 }
 
 public final class com/stripe/android/core/networking/RetryDelaySupplier_Factory : dagger/internal/Factory {
@@ -346,12 +149,6 @@ public final class com/stripe/android/core/networking/RetryDelaySupplier_Factory
 	public fun get ()Lcom/stripe/android/core/networking/RetryDelaySupplier;
 	public synthetic fun get ()Ljava/lang/Object;
 	public static fun newInstance ()Lcom/stripe/android/core/networking/RetryDelaySupplier;
-}
-
-public abstract interface class com/stripe/android/core/networking/StripeConnection : java/io/Closeable {
-	public abstract fun createBodyFromResponseStream (Ljava/io/InputStream;)Ljava/lang/Object;
-	public abstract fun getResponse ()Lcom/stripe/android/core/networking/StripeResponse;
-	public abstract fun getResponseCode ()I
 }
 
 public abstract class com/stripe/android/core/networking/StripeConnection$AbstractConnection : com/stripe/android/core/networking/StripeConnection {
@@ -374,24 +171,6 @@ public final class com/stripe/android/core/networking/StripeConnection$FileConne
 	public synthetic fun createBodyFromResponseStream (Ljava/io/InputStream;)Ljava/lang/Object;
 }
 
-public abstract interface class com/stripe/android/core/networking/StripeNetworkClient {
-	public abstract fun executeRequest (Lcom/stripe/android/core/networking/StripeRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun executeRequestForFile (Lcom/stripe/android/core/networking/StripeRequest;Ljava/io/File;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public abstract class com/stripe/android/core/networking/StripeRequest {
-	public static final field $stable I
-	public fun <init> ()V
-	public abstract fun getHeaders ()Ljava/util/Map;
-	public abstract fun getMethod ()Lcom/stripe/android/core/networking/StripeRequest$Method;
-	public abstract fun getMimeType ()Lcom/stripe/android/core/networking/StripeRequest$MimeType;
-	public fun getPostHeaders ()Ljava/util/Map;
-	public abstract fun getRetryResponseCodes ()Ljava/lang/Iterable;
-	public abstract fun getUrl ()Ljava/lang/String;
-	public fun setPostHeaders (Ljava/util/Map;)V
-	public fun writePostBody (Ljava/io/OutputStream;)V
-}
-
 public final class com/stripe/android/core/networking/StripeRequest$Method : java/lang/Enum {
 	public static final field DELETE Lcom/stripe/android/core/networking/StripeRequest$Method;
 	public static final field GET Lcom/stripe/android/core/networking/StripeRequest$Method;
@@ -411,67 +190,6 @@ public final class com/stripe/android/core/networking/StripeRequest$MimeType : j
 	public static fun values ()[Lcom/stripe/android/core/networking/StripeRequest$MimeType;
 }
 
-public final class com/stripe/android/core/networking/StripeResponse {
-	public static final field $stable I
-	public fun <init> (ILjava/lang/Object;Ljava/util/Map;)V
-	public synthetic fun <init> (ILjava/lang/Object;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()I
-	public final fun component2 ()Ljava/lang/Object;
-	public final fun component3 ()Ljava/util/Map;
-	public final fun copy (ILjava/lang/Object;Ljava/util/Map;)Lcom/stripe/android/core/networking/StripeResponse;
-	public static synthetic fun copy$default (Lcom/stripe/android/core/networking/StripeResponse;ILjava/lang/Object;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/core/networking/StripeResponse;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBody ()Ljava/lang/Object;
-	public final fun getCode ()I
-	public final fun getHeaderValue (Ljava/lang/String;)Ljava/util/List;
-	public final fun getHeaders ()Ljava/util/Map;
-	public final fun getRequestId ()Lcom/stripe/android/core/networking/RequestId;
-	public fun hashCode ()I
-	public final fun isError ()Z
-	public final fun isOk ()Z
-	public final fun isRateLimited ()Z
-	public fun toString ()Ljava/lang/String;
-}
-
 public final class com/stripe/android/core/networking/StripeResponseKtxKt {
-	public static final fun responseJson (Lcom/stripe/android/core/networking/StripeResponse;)Lorg/json/JSONObject;
-}
-
-public final class com/stripe/android/core/storage/SharedPreferencesStorage : com/stripe/android/core/storage/Storage {
-	public static final field $stable I
-	public fun <init> (Landroid/content/Context;Ljava/lang/String;)V
-	public fun clear ()Z
-	public fun getBoolean (Ljava/lang/String;Z)Z
-	public fun getFloat (Ljava/lang/String;F)F
-	public fun getInt (Ljava/lang/String;I)I
-	public fun getLong (Ljava/lang/String;J)J
-	public fun getString (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
-	public fun remove (Ljava/lang/String;)Z
-	public fun storeValue (Ljava/lang/String;F)Z
-	public fun storeValue (Ljava/lang/String;I)Z
-	public fun storeValue (Ljava/lang/String;J)Z
-	public fun storeValue (Ljava/lang/String;Ljava/lang/String;)Z
-	public fun storeValue (Ljava/lang/String;Z)Z
-}
-
-public abstract interface class com/stripe/android/core/storage/Storage {
-	public abstract fun clear ()Z
-	public abstract fun getBoolean (Ljava/lang/String;Z)Z
-	public abstract fun getFloat (Ljava/lang/String;F)F
-	public abstract fun getInt (Ljava/lang/String;I)I
-	public abstract fun getLong (Ljava/lang/String;J)J
-	public abstract fun getString (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
-	public abstract fun remove (Ljava/lang/String;)Z
-	public abstract fun storeValue (Ljava/lang/String;F)Z
-	public abstract fun storeValue (Ljava/lang/String;I)Z
-	public abstract fun storeValue (Ljava/lang/String;J)Z
-	public abstract fun storeValue (Ljava/lang/String;Ljava/lang/String;)Z
-	public abstract fun storeValue (Ljava/lang/String;Z)Z
-}
-
-public final class com/stripe/android/core/storage/StorageFactory {
-	public static final field $stable I
-	public static final field INSTANCE Lcom/stripe/android/core/storage/StorageFactory;
-	public final fun getStorageInstance (Landroid/content/Context;Ljava/lang/String;)Lcom/stripe/android/core/storage/Storage;
 }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
`@RestrictTo` items should be only used internally and not included in the api check. Use `nonPublicMarkers` to mute them.



# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
See https://github.com/Kotlin/binary-compatibility-validator for details


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
