### PR TITLE
Add missing app info to some Stripe API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ## X.X.X - 2022-XX-XX
 ### PaymentSheet
 * [FIXED] [4466](https://github.com/stripe/stripe-android/pull/4466) Fix issues when activities are lost on low resource phones.
+* [FIXED] [4557](https://github.com/stripe/stripe-android/pull/4557) Add missing app info to some Stripe API requests
+
 ### Identity
 ### Card scanning
 * [FIXED] [4548](https://github.com/stripe/stripe-android/pull/4548) Potential work leak when canceling a card scan in StripeCardScan

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -92,7 +92,7 @@ import kotlin.coroutines.CoroutineContext
 internal class StripeApiRepository @JvmOverloads internal constructor(
     context: Context,
     publishableKeyProvider: () -> String,
-    private val appInfo: AppInfo? = null,
+    private val appInfo: AppInfo? = Stripe.appInfo,
     private val logger: Logger = Logger.noop(),
     private val workContext: CoroutineContext = Dispatchers.IO,
     private val productUsageTokens: Set<String> = emptySet(),


### PR DESCRIPTION
# Summary
Add missing app info to the headers of some Stripe API requests.

# Motivation
RUN_MOBILESDK-728

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

Steps taken:
 1. Ensure `Stripe.appInfo` is being set in the app
 2. Run Android Studio and begin observing network requests
 3. Make a payment using FlowController API
 4. Verify `user-agent` and `x-stripe-client-user-agent` request headers include [the AppInfo part](https://github.com/stripe/stripe-android/blob/ebd0616e883bdc8afed74346ea46cab1aed982d0/payments-core/src/main/java/com/stripe/android/AppInfo.kt#L24)