### PR TITLE
Fix `cardValidCallback` being added multiple times in `CardInputWidget`

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -334,6 +334,8 @@ class CardInputWidget @JvmOverloads constructor(
         if (isPostalRequired()) {
             requiredFields.add(postalCodeEditText)
             cardValidCallback?.let {
+                // First remove if it's already added, to make sure it's not added multiple times.
+                postalCodeEditText.removeTextChangedListener(cardValidTextWatcher)
                 postalCodeEditText.addTextChangedListener(cardValidTextWatcher)
             }
         } else {

--- a/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -1636,6 +1636,23 @@ internal class CardInputWidgetTest {
         verify(callback, times(1)).onInputChanged(any(), any())
     }
 
+    @Test
+    fun `Setting postal code requirements multiple times only sets callback once`() {
+        val callback = mock<CardValidCallback>()
+        cardInputWidget.setCardValidCallback(callback)
+
+        cardInputWidget.postalCodeRequired = true
+        cardInputWidget.postalCodeEnabled = true
+        cardInputWidget.postalCodeEnabled = false
+        cardInputWidget.postalCodeRequired = false
+        cardInputWidget.postalCodeRequired = true
+        cardInputWidget.postalCodeEnabled = true
+        postalCodeEditText.setText("54321")
+
+        // Called only when the callback is set and when the text is set.
+        verify(callback, times(2)).onInputChanged(any(), any())
+    }
+
     private fun updateCardNumberAndIdle(cardNumber: String) {
         cardNumberEditText.setText(cardNumber)
         idleLooper()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fixes bug introduced by #4504, where the callback can get added multiple times if there are multiple calls to `updatePostalRequired()`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
RUN_MOBILESDK-724

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Changelog
    - [Fixed] Fix `cardValidCallback` being added multiple times in `CardInputWidget`
