### PR TITLE
[camera-core] Change the camera permission granted/denied callbacks from inheritance to encapsulation

### DIFF
--- a/camera-core/src/main/java/com/stripe/android/camera/CameraPermissionCheckingActivity.kt
+++ b/camera-core/src/main/java/com/stripe/android/camera/CameraPermissionCheckingActivity.kt
@@ -28,12 +28,12 @@ abstract class CameraPermissionCheckingActivity : AppCompatActivity() {
      * The camera permission was granted and camera is ready to use.
      * Note this callback will be invoked on the main thread.
      */
-    protected abstract fun onCameraReady()
+    private lateinit var onCameraReady: () -> Unit
 
     /**
      * The camera permission was denied.
      */
-    protected abstract fun onUserDeniedCameraPermission()
+    private lateinit var onUserDeniedCameraPermission: () -> Unit
 
     private val storage by lazy {
         StorageFactory.getStorageInstance(this, PERMISSION_STORAGE_NAME)
@@ -47,7 +47,12 @@ abstract class CameraPermissionCheckingActivity : AppCompatActivity() {
      * Check the camera permission, invokes [onCameraReady] upon permission grant,
      * invokes [onUserDeniedCameraPermission] otherwise.
      */
-    protected fun ensureCameraPermission() {
+    protected fun ensureCameraPermission(
+        onCameraReady: () -> Unit,
+        onUserDeniedCameraPermission: () -> Unit,
+    ) {
+        this.onCameraReady = onCameraReady
+        this.onUserDeniedCameraPermission = onUserDeniedCameraPermission
         when {
             ContextCompat.checkSelfPermission(
                 this,

--- a/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
@@ -3,7 +3,6 @@ package com.stripe.android.identity
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.util.Size
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
@@ -71,8 +70,8 @@ internal class IdentityActivity : CameraPermissionCheckingActivity() {
         )
     }
 
-    override fun onCameraReady() {
-        // TODO(ccen) notify cameraReady() for Fragments
+//    override fun onCameraReady() {
+    // TODO(ccen) notify cameraReady() for Fragments
 //        cameraAdapter.bindToLifecycle(this)
 //        viewModel.identityScanFlow.startFlow(
 //            context = this,
@@ -82,13 +81,13 @@ internal class IdentityActivity : CameraPermissionCheckingActivity() {
 //            coroutineScope = lifecycleScope,
 //            parameters = 23
 //        )
-    }
+//    }
 
-    override fun onUserDeniedCameraPermission() {
-        Log.d(TAG, "onUserDeniedCameraPermission")
-        // TODO(ccen): determine whether to return Fail or Canceled
-        finishWithResult(VerificationResult.Canceled)
-    }
+//    override fun onUserDeniedCameraPermission() {
+//        Log.d(TAG, "onUserDeniedCameraPermission")
+//        // TODO(ccen): determine whether to return Fail or Canceled
+//        finishWithResult(VerificationResult.Canceled)
+//    }
 
     override fun onBackPressed() {
         finishWithResult(VerificationResult.Canceled)

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/scanui/ScanActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/scanui/ScanActivity.kt
@@ -96,7 +96,10 @@ internal abstract class ScanActivity : CameraPermissionCheckingActivity(), Corou
         }
 
         if (!cameraAdapter.isBoundToLifecycle()) {
-            ensureCameraPermission()
+            ensureCameraPermission(
+                ::onCameraReady,
+                ::onUserDeniedCameraPermission
+            )
         }
     }
 
@@ -204,9 +207,14 @@ internal abstract class ScanActivity : CameraPermissionCheckingActivity(), Corou
     }
 
     /**
+     * The camera permission was granted.
+     */
+    protected abstract fun onCameraReady()
+
+    /**
      * The camera permission was denied.
      */
-    override fun onUserDeniedCameraPermission() {
+    protected fun onUserDeniedCameraPermission() {
         runBlocking { scanStat.trackResult("user_canceled") }
         resultListener.userCanceled(CancellationReason.CameraPermissionDenied)
         closeScanner()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* The two callbacks could only be invoked after `CameraPermissionCheckingActivity#ensureCameraPermission` is called. Changing them as `lateinit` params to make the call more intuitive.

* For Identity, `#ensureCameraPermission` will be called from a Fragment, which handles the granted/denied callback within. Lifting the method overriding from its hosting activity could untangle some logic.
 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Code excellence

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
