### PR TITLE
[Identity] Acquire camera permission and start camera feed from Fragment 

### DIFF
--- a/camera-core/src/main/java/com/stripe/android/camera/CameraPermissionCheckingActivity.kt
+++ b/camera-core/src/main/java/com/stripe/android/camera/CameraPermissionCheckingActivity.kt
@@ -47,7 +47,8 @@ abstract class CameraPermissionCheckingActivity : AppCompatActivity() {
      * Check the camera permission, invokes [onCameraReady] upon permission grant,
      * invokes [onUserDeniedCameraPermission] otherwise.
      */
-    protected fun ensureCameraPermission(
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun ensureCameraPermission(
         onCameraReady: () -> Unit,
         onUserDeniedCameraPermission: () -> Unit,
     ) {

--- a/identity/api/identity.api
+++ b/identity/api/identity.api
@@ -62,6 +62,7 @@ public final class com/stripe/android/identity/databinding/CameraErrorFragmentBi
 }
 
 public final class com/stripe/android/identity/databinding/CameraPermissionDeniedFragmentBinding : androidx/viewbinding/ViewBinding {
+	public final field info Landroid/widget/TextView;
 	public static fun bind (Landroid/view/View;)Lcom/stripe/android/identity/databinding/CameraPermissionDeniedFragmentBinding;
 	public synthetic fun getRoot ()Landroid/view/View;
 	public fun getRoot ()Landroid/widget/FrameLayout;
@@ -181,17 +182,6 @@ public final class com/stripe/android/identity/navigation/CameraErrorFragment$Co
 	public final fun newInstance ()Lcom/stripe/android/identity/navigation/CameraErrorFragment;
 }
 
-public final class com/stripe/android/identity/navigation/CameraPermissionDeniedFragment : androidx/fragment/app/Fragment {
-	public static final field Companion Lcom/stripe/android/identity/navigation/CameraPermissionDeniedFragment$Companion;
-	public fun <init> ()V
-	public fun onActivityCreated (Landroid/os/Bundle;)V
-	public fun onCreateView (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Landroid/os/Bundle;)Landroid/view/View;
-}
-
-public final class com/stripe/android/identity/navigation/CameraPermissionDeniedFragment$Companion {
-	public final fun newInstance ()Lcom/stripe/android/identity/navigation/CameraPermissionDeniedFragment;
-}
-
 public final class com/stripe/android/identity/navigation/ConfirmationFragment : androidx/fragment/app/Fragment {
 	public static final field Companion Lcom/stripe/android/identity/navigation/ConfirmationFragment$Companion;
 	public fun <init> ()V
@@ -223,6 +213,10 @@ public final class com/stripe/android/identity/navigation/DriverLicenseUploadFra
 
 public final class com/stripe/android/identity/navigation/DriverLicenseUploadFragment$Companion {
 	public final fun newInstance ()Lcom/stripe/android/identity/navigation/DriverLicenseUploadFragment;
+}
+
+public final class com/stripe/android/identity/navigation/FragmentKtxKt {
+	public static final fun ensureCameraPermissionFromIdentityActivity (Landroidx/fragment/app/Fragment;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
 }
 
 public final class com/stripe/android/identity/navigation/IDUploadFragment : androidx/fragment/app/Fragment {
@@ -275,10 +269,6 @@ public final class com/stripe/android/identity/viewmodel/DriverLicenseScanViewMo
 }
 
 public final class com/stripe/android/identity/viewmodel/DriverLicenseUploadViewModel : androidx/lifecycle/ViewModel {
-	public fun <init> ()V
-}
-
-public final class com/stripe/android/identity/viewmodel/IDScanViewModel : androidx/lifecycle/ViewModel {
 	public fun <init> ()V
 }
 

--- a/identity/res/layout/camera_permission_denied_fragment.xml
+++ b/identity/res/layout/camera_permission_denied_fragment.xml
@@ -6,8 +6,9 @@
     tools:context=".navigation.CameraPermissionDeniedFragment">
 
     <TextView
+        android:id="@+id/info"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:text="Hello" />
+        android:text="CameraPermissionDenied" />
 
 </FrameLayout>

--- a/identity/res/navigation/identity_nav_graph.xml
+++ b/identity/res/navigation/identity_nav_graph.xml
@@ -87,6 +87,9 @@
         android:name="com.stripe.android.identity.navigation.CameraPermissionDeniedFragment"
         android:label="camera_permission_denied_fragment"
         tools:layout="@layout/camera_permission_denied_fragment">
+        <argument
+            android:name="scanType"
+            app:argType="com.stripe.android.identity.states.ScanState$ScanType" />
         <action
             android:id="@+id/action_cameraPermissionDeniedFragment_to_passportUploadFragment"
             app:destination="@id/passportUploadFragment" />

--- a/identity/src/main/AndroidManifest.xml
+++ b/identity/src/main/AndroidManifest.xml
@@ -7,6 +7,8 @@
     <application>
         <activity
             android:name=".IdentityActivity"
+            android:screenOrientation="portrait"
+            android:configChanges="orientation|keyboardHidden"
             android:exported="false" />
     </application>
 

--- a/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
@@ -3,7 +3,6 @@ package com.stripe.android.identity
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
-import android.util.Size
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
 import androidx.core.os.bundleOf
@@ -21,22 +20,6 @@ internal class IdentityActivity : CameraPermissionCheckingActivity() {
     private val binding by lazy {
         IdentityActivityBinding.inflate(layoutInflater)
     }
-
-    // TODO(ccen) defer cameraAdapter initialization logic to the scanning Fragments
-//    private val cameraView: CameraView by lazy {
-//        binding.cameraView
-//    }
-//    private val cameraAdapter: Camera1Adapter by lazy {
-//        Camera1Adapter(
-//            this,
-//            cameraView.previewFrame,
-//            MINIMUM_RESOLUTION,
-//            DefaultCameraErrorListener(this) { cause ->
-//                Log.d(TAG, "scan fails with exception: $cause")
-//                // TODO(ccen) determine if further handling is required
-//            }
-//        )
-//    }
 
     private val starterArgs: IdentityVerificationSheetContract.Args by lazy {
         requireNotNull(IdentityVerificationSheetContract.Args.fromIntent(intent)) {
@@ -70,25 +53,6 @@ internal class IdentityActivity : CameraPermissionCheckingActivity() {
         )
     }
 
-//    override fun onCameraReady() {
-    // TODO(ccen) notify cameraReady() for Fragments
-//        cameraAdapter.bindToLifecycle(this)
-//        viewModel.identityScanFlow.startFlow(
-//            context = this,
-//            imageStream = cameraAdapter.getImageStream(),
-//            viewFinder = cameraView.viewFinderWindowView.asRect(),
-//            lifecycleOwner = this,
-//            coroutineScope = lifecycleScope,
-//            parameters = 23
-//        )
-//    }
-
-//    override fun onUserDeniedCameraPermission() {
-//        Log.d(TAG, "onUserDeniedCameraPermission")
-//        // TODO(ccen): determine whether to return Fail or Canceled
-//        finishWithResult(VerificationResult.Canceled)
-//    }
-
     override fun onBackPressed() {
         finishWithResult(VerificationResult.Canceled)
     }
@@ -101,15 +65,8 @@ internal class IdentityActivity : CameraPermissionCheckingActivity() {
         finish()
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
-        viewModel.identityScanFlow.cancelFlow()
-    }
-
     private companion object {
-        val TAG: String = IdentityActivity::class.java.simpleName
         const val EMPTY_ARG_ERROR =
             "IdentityActivity was started without arguments"
-        val MINIMUM_RESOLUTION = Size(1067, 600) // TODO: decide what to use
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/IdentityViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityViewModel.kt
@@ -1,61 +1,17 @@
 package com.stripe.android.identity
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import com.stripe.android.camera.framework.AggregateResultListener
-import com.stripe.android.camera.framework.AnalyzerLoopErrorListener
-import com.stripe.android.identity.camera.IDDetectorAggregator
-import com.stripe.android.identity.camera.IdentityScanFlow
-import com.stripe.android.identity.states.ScanState
 
 internal class IdentityViewModel(
     val args: IdentityVerificationSheetContract.Args
-) :
-    ViewModel(),
-    AnalyzerLoopErrorListener,
-    AggregateResultListener<IDDetectorAggregator.InterimResult, IDDetectorAggregator.FinalResult> {
-
-    internal val identityScanFlow = IdentityScanFlow(
-        // TODO(ccen) Pass the correct scan type parameter after moved to separate Fragments
-        scanType = ScanState.ScanType.ID_FRONT,
-        this,
-        this
-    )
-
-    override suspend fun onResult(result: IDDetectorAggregator.FinalResult) {
-        Log.d(TAG, "Final result received: $result")
-    }
-
-    override suspend fun onInterimResult(result: IDDetectorAggregator.InterimResult) {
-        Log.d(TAG, "Interim result received: $result")
-    }
-
-    override suspend fun onReset() {
-        Log.d(TAG, "onReset is called, resetting status")
-    }
-
-    override fun onAnalyzerFailure(t: Throwable): Boolean {
-        Log.d(TAG, "Error executing analyzer : $t, continue analyzing")
-        return false
-    }
-
-    override fun onResultFailure(t: Throwable): Boolean {
-        Log.d(TAG, "Error executing result : $t, stop analyzing")
-        return true
-    }
-
+) : ViewModel() {
     internal class IdentityViewModelFactory(
         private val args: IdentityVerificationSheetContract.Args
-    ) :
-        ViewModelProvider.Factory {
+    ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             return IdentityViewModel(args) as T
         }
-    }
-
-    private companion object {
-        val TAG: String = IdentityViewModel::class.java.simpleName
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/CameraPermissionDeniedFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/CameraPermissionDeniedFragment.kt
@@ -6,28 +6,41 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
-import com.stripe.android.identity.R
+import com.stripe.android.identity.databinding.CameraPermissionDeniedFragmentBinding
+import com.stripe.android.identity.states.ScanState
 import com.stripe.android.identity.viewmodel.CameraPermissionDeniedViewModel
 
-class CameraPermissionDeniedFragment : Fragment() {
-
-    companion object {
-        fun newInstance() = CameraPermissionDeniedFragment()
-    }
-
+/**
+ * Fragment to show user denies camera permission.
+ */
+internal class CameraPermissionDeniedFragment : Fragment() {
     private lateinit var viewModel: CameraPermissionDeniedViewModel
+
+    private lateinit var scanType: ScanState.ScanType
+
+    private lateinit var binding: CameraPermissionDeniedFragmentBinding
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        return inflater.inflate(R.layout.camera_permission_denied_fragment, container, false)
+    ): View {
+        val args = requireNotNull(arguments)
+
+        scanType = args[ARG_SCAN_TYPE] as ScanState.ScanType
+        binding = CameraPermissionDeniedFragmentBinding.inflate(inflater, container, false)
+        binding.info.text = "Camera permission denied, scanType is ${scanType.name}"
+
+        return binding.root
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         viewModel = ViewModelProvider(this).get(CameraPermissionDeniedViewModel::class.java)
         // TODO: Use the ViewModel
+    }
+
+    companion object {
+        const val ARG_SCAN_TYPE = "scanType"
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/FragmentKtx.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/FragmentKtx.kt
@@ -1,0 +1,19 @@
+package com.stripe.android.identity.navigation
+
+import androidx.fragment.app.Fragment
+import com.stripe.android.identity.IdentityActivity
+
+/**
+ * Gets the hosting [IdentityActivity] and invokes [IdentityActivity.ensureCameraPermission].
+ */
+fun Fragment.ensureCameraPermissionFromIdentityActivity(
+    onCameraReady: () -> Unit,
+    onUserDeniedCameraPermission: () -> Unit
+) {
+    requireNotNull(activity as? IdentityActivity) {
+        "Hosting activity is not IdentityActivity."
+    }.ensureCameraPermission(
+        onCameraReady,
+        onUserDeniedCameraPermission
+    )
+}

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IDScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IDScanFragment.kt
@@ -1,36 +1,102 @@
 package com.stripe.android.identity.navigation
 
 import android.os.Bundle
+import android.util.Log
+import android.util.Size
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.fragment.findNavController
+import com.stripe.android.camera.Camera1Adapter
+import com.stripe.android.camera.DefaultCameraErrorListener
+import com.stripe.android.camera.scanui.util.asRect
+import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.IdScanFragmentBinding
-import com.stripe.android.identity.viewmodel.IDScanViewModel
+import com.stripe.android.identity.states.ScanState
+import com.stripe.android.identity.viewmodel.CameraViewModel
 
 /**
  * TODO(ccen) connect the logic to initialize CameraAdapter and call IdentityActivity#ensureCameraPermission
  */
 internal class IDScanFragment : Fragment() {
-
-    companion object {
-        fun newInstance() = IDScanFragment()
-    }
-
-    private lateinit var viewModel: IDScanViewModel
+    private val cameraViewModel: CameraViewModel by viewModels()
+    private lateinit var binding: IdScanFragmentBinding
+    private lateinit var cameraAdapter: Camera1Adapter
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        return IdScanFragmentBinding.inflate(inflater, container, false).root
+        binding = IdScanFragmentBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-        viewModel = ViewModelProvider(this).get(IDScanViewModel::class.java)
-        // TODO: Use the ViewModel
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        cameraViewModel.interimResults.observe(viewLifecycleOwner) {
+            Log.d(TAG, "IDScanFragment get interim result: $it")
+        }
+
+        cameraViewModel.finalResult.observe(viewLifecycleOwner) {
+            Log.d(TAG, "IDScanFragment get final result: $it")
+        }
+
+        cameraViewModel.reset.observe(viewLifecycleOwner) {
+            Log.d(TAG, "IDScanFragment get reset")
+        }
+
+        cameraAdapter = Camera1Adapter(
+            requireNotNull(activity),
+            binding.cameraView.previewFrame,
+            MINIMUM_RESOLUTION,
+            DefaultCameraErrorListener(requireNotNull(activity)) { cause ->
+                Log.d(TAG, "scan fails with exception: $cause")
+                // TODO(ccen) determine if further handling is required
+            }
+        )
+        cameraViewModel.initializeScanFlow(
+            ScanState.ScanType.ID_FRONT // determine how to transition to ID_BACK
+        )
+        ensureCameraPermissionFromIdentityActivity(
+            onCameraReady = {
+                Log.d(TAG, "Camera permission granted")
+                cameraAdapter.bindToLifecycle(this)
+                cameraViewModel.identityScanFlow.startFlow(
+                    context = requireContext(),
+                    imageStream = cameraAdapter.getImageStream(),
+                    viewFinder = binding.cameraView.viewFinderWindowView.asRect(),
+                    lifecycleOwner = this,
+                    coroutineScope = lifecycleScope,
+                    parameters = 23 // TODO(ccen) pass correct parameter
+                )
+            },
+
+            onUserDeniedCameraPermission = {
+                Log.d(TAG, "Camera permission denied")
+                findNavController().navigate(
+                    R.id.action_camera_permission_denied,
+                    bundleOf(
+                        CameraPermissionDeniedFragment.ARG_SCAN_TYPE to ScanState.ScanType.ID_FRONT
+                    )
+                )
+            }
+        )
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        Log.d(TAG, "Cancelling IdentityScanFlow")
+        cameraViewModel.identityScanFlow.cancelFlow()
+    }
+
+    private companion object {
+        val TAG: String = IDScanFragment::class.java.simpleName
+        val MINIMUM_RESOLUTION = Size(1067, 600) // TODO: decide what to use
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/CameraViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/CameraViewModel.kt
@@ -1,0 +1,85 @@
+package com.stripe.android.identity.viewmodel
+
+import android.util.Log
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.stripe.android.camera.framework.AggregateResultListener
+import com.stripe.android.camera.framework.AnalyzerLoopErrorListener
+import com.stripe.android.identity.IdentityVerificationSheetContract
+import com.stripe.android.identity.IdentityViewModel
+import com.stripe.android.identity.camera.IDDetectorAggregator
+import com.stripe.android.identity.camera.IdentityScanFlow
+import com.stripe.android.identity.states.ScanState
+
+/**
+ * ViewModel hosted by all fragments that need to access live camera feed and callbacks.
+ */
+internal class CameraViewModel :
+    ViewModel(),
+    AnalyzerLoopErrorListener,
+    AggregateResultListener<IDDetectorAggregator.InterimResult, IDDetectorAggregator.FinalResult> {
+
+    // liveData for results, subscribed from fragments
+    internal val interimResults = MutableLiveData<IDDetectorAggregator.InterimResult>()
+    internal val finalResult = MutableLiveData<IDDetectorAggregator.FinalResult>()
+    internal val reset = MutableLiveData<Unit>()
+
+    lateinit var identityScanFlow: IdentityScanFlow
+
+    /**
+     * Initialize [identityScanFlow] with the target scanType.
+     *
+     * TODO(ccen): Extract scanType from [IdentityScanFlow]'s constructor, initialize the scan flow
+     * upon [CameraViewModel]'s initialization, add the ability to update scanType of a
+     * [IdentityScanFlow] on the fly.
+     */
+    fun initializeScanFlow(
+        scanType: ScanState.ScanType
+    ) {
+        identityScanFlow = IdentityScanFlow(
+            scanType = scanType,
+            this,
+            this
+        )
+    }
+
+    override suspend fun onResult(result: IDDetectorAggregator.FinalResult) {
+        Log.d(TAG, "Final result received: $result")
+        finalResult.postValue(result)
+    }
+
+    override suspend fun onInterimResult(result: IDDetectorAggregator.InterimResult) {
+        Log.d(TAG, "Interim result received: $result")
+        interimResults.postValue(result)
+    }
+
+    override suspend fun onReset() {
+        Log.d(TAG, "onReset is called, resetting status")
+        reset.postValue(Unit)
+    }
+
+    override fun onAnalyzerFailure(t: Throwable): Boolean {
+        Log.d(TAG, "Error executing analyzer : $t, continue analyzing")
+        return false
+    }
+
+    override fun onResultFailure(t: Throwable): Boolean {
+        Log.d(TAG, "Error executing result : $t, stop analyzing")
+        return true
+    }
+
+    internal class IdentityViewModelFactory(
+        private val args: IdentityVerificationSheetContract.Args
+    ) :
+        ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return IdentityViewModel(args) as T
+        }
+    }
+
+    private companion object {
+        val TAG: String = IdentityViewModel::class.java.simpleName
+    }
+}

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IDScanViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IDScanViewModel.kt
@@ -1,7 +1,0 @@
-package com.stripe.android.identity.viewmodel
-
-import androidx.lifecycle.ViewModel
-
-class IDScanViewModel : ViewModel() {
-    // TODO: Implement the ViewModel
-}

--- a/identity/src/test/java/com/stripe/android/identity/viewmodel/CameraViewModelTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/viewmodel/CameraViewModelTest.kt
@@ -1,0 +1,18 @@
+package com.stripe.android.identity.viewmodel
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.identity.states.ScanState
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CameraViewModelTest {
+    @Test
+    fun `identityScanFlow is not null after initialization`() {
+        val viewModel = CameraViewModel()
+        viewModel.initializeScanFlow(ScanState.ScanType.ID_FRONT)
+
+        assertThat(viewModel.identityScanFlow).isNotNull()
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Identity SDK has a single `IdentityActivity` that hosts different fragments that _might_ need to access live camera feed. This change makes it possible for those fragments able to request the camera permission when needed, and handles its result accordingly. The following changes are made:

* Creates an extension method `Fragment.ensureCameraPermissionFromIdentityActivity` to get activity, cast to IdentityActivity and calls `ensureCameraPermission` with callbacks
* Creates a dedicated `CameraViewModel` that holds a `IdentityScanFlow` instance and registers for all callbacks. The results are exposed through `LiveData`. Each client fragment will host its own `CameraViewModel` instance
* `IDScanFragment` - the first client fragment, all other fragments will follow the similar pattern:
  * Creates a `Camera1Adapter` instance from its `CameraView`
  * Creates a `CameraViewModel` instance
  * Invokes `ensureCameraPermissionFromIdentityActivity` when initialized and binds `cameraAdapter`, starts `cameraViewModel.identityScanFlow` when permission is granted
  * Subscribes to `CameraViewModel`'s `LiveData`s to get `InterimResult`/`FinalResult`






# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Please refer to [this](https://paper.dropbox.com/doc/Navigation-graph-for-Identity-SDK--BbjyuuK7vhOIWs_fbmUPFJPoAg-468m6Z1Kw7ujj3QB3Uqpo) internal doc for more details

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

Will add tests to `CameraViewModel` after `IdentityScanFlow` is refactored to be able to update scanType on the fly.


# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
