### PR TITLE
Take `postalCode` into account in `CardMultilineWidget` validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 ## X.X.X - 2022-XX-XX
 * [FIXED] [4560](https://github.com/stripe/stripe-android/pull/4560) Fix `cardValidCallback` being added multiple times in `CardInputWidget`.
+* [FIXED] [4574](https://github.com/stripe/stripe-android/pull/4574) Take `postalCode` into account in `CardMultilineWidget` validation.
 ### PaymentSheet
 * [FIXED] [4466](https://github.com/stripe/stripe-android/pull/4466) Fix issues when activities are lost on low resource phones.
 * [FIXED] [4557](https://github.com/stripe/stripe-android/pull/4557) Add missing app info to some Stripe API requests

--- a/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -102,6 +102,9 @@ class CardMultilineWidget @JvmOverloads constructor(
                 },
                 CardValidCallback.Fields.Cvc.takeIf {
                     cvcEditText.cvc == null
+                },
+                CardValidCallback.Fields.Postal.takeIf {
+                    isPostalRequired() && postalCodeEditText.postalCode.isNullOrBlank()
                 }
             ).toSet()
         }
@@ -243,7 +246,7 @@ class CardMultilineWidget @JvmOverloads constructor(
 
     private val allFields: Collection<StripeEditText>
         get() {
-            return listOf(
+            return setOf(
                 cardNumberEditText,
                 expiryDateEditText,
                 cvcEditText,
@@ -393,13 +396,9 @@ class CardMultilineWidget @JvmOverloads constructor(
             cardNumberTextInputLayout.isLoading = it
         }
 
-        isEnabled = true
-    }
-
-    override fun onAttachedToWindow() {
-        super.onAttachedToWindow()
         postalCodeEditText.config = PostalCodeEditText.Config.Global
         cvcEditText.hint = null
+        isEnabled = true
     }
 
     /**

--- a/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardMultilineWidget.kt
@@ -397,8 +397,13 @@ class CardMultilineWidget @JvmOverloads constructor(
         }
 
         postalCodeEditText.config = PostalCodeEditText.Config.Global
-        cvcEditText.hint = null
         isEnabled = true
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        // see https://github.com/stripe/stripe-android/pull/3154
+        cvcEditText.hint = null
     }
 
     /**

--- a/payments-core/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardMultilineWidgetTest.kt
@@ -1031,6 +1031,138 @@ internal class CardMultilineWidgetTest {
     }
 
     @Test
+    fun testCardValidCallback_usZipCodeRequired() {
+        cardMultilineWidget.usZipCodeRequired = true
+
+        var currentIsValid = false
+        var currentInvalidFields = emptySet<CardValidCallback.Fields>()
+        cardMultilineWidget.setCardValidCallback { isValid, invalidFields ->
+            currentIsValid = isValid
+            currentInvalidFields = invalidFields
+        }
+
+        assertThat(currentIsValid)
+            .isFalse()
+        assertThat(currentInvalidFields)
+            .containsExactly(
+                CardValidCallback.Fields.Number,
+                CardValidCallback.Fields.Expiry,
+                CardValidCallback.Fields.Cvc,
+                CardValidCallback.Fields.Postal
+            )
+
+        cardMultilineWidget.setCardNumber(VISA_NO_SPACES)
+        assertThat(currentIsValid)
+            .isFalse()
+        assertThat(currentInvalidFields)
+            .containsExactly(
+                CardValidCallback.Fields.Expiry,
+                CardValidCallback.Fields.Cvc,
+                CardValidCallback.Fields.Postal
+            )
+
+        fullGroup.expiryDateEditText.append("12")
+        assertThat(currentIsValid)
+            .isFalse()
+        assertThat(currentInvalidFields)
+            .containsExactly(
+                CardValidCallback.Fields.Expiry,
+                CardValidCallback.Fields.Cvc,
+                CardValidCallback.Fields.Postal
+            )
+
+        fullGroup.expiryDateEditText.append("50")
+        assertThat(currentIsValid)
+            .isFalse()
+        assertThat(currentInvalidFields)
+            .containsExactly(
+                CardValidCallback.Fields.Cvc,
+                CardValidCallback.Fields.Postal
+            )
+
+        fullGroup.cvcEditText.append("123")
+        assertThat(currentIsValid)
+            .isFalse()
+        assertThat(currentInvalidFields)
+            .containsExactly(CardValidCallback.Fields.Postal)
+
+        fullGroup.postalCodeEditText.append("1")
+        assertThat(currentIsValid)
+            .isFalse()
+        assertThat(currentInvalidFields)
+            .containsExactly(CardValidCallback.Fields.Postal)
+
+        fullGroup.postalCodeEditText.append("2345")
+        assertThat(currentIsValid)
+            .isTrue()
+        assertThat(currentInvalidFields)
+            .isEmpty()
+    }
+
+    @Test
+    fun testCardValidCallback_postalCodeRequired() {
+        cardMultilineWidget.postalCodeRequired = true
+
+        var currentIsValid = false
+        var currentInvalidFields = emptySet<CardValidCallback.Fields>()
+        cardMultilineWidget.setCardValidCallback { isValid, invalidFields ->
+            currentIsValid = isValid
+            currentInvalidFields = invalidFields
+        }
+
+        assertThat(currentIsValid)
+            .isFalse()
+        assertThat(currentInvalidFields)
+            .containsExactly(
+                CardValidCallback.Fields.Number,
+                CardValidCallback.Fields.Expiry,
+                CardValidCallback.Fields.Cvc,
+                CardValidCallback.Fields.Postal
+            )
+
+        cardMultilineWidget.setCardNumber(VISA_NO_SPACES)
+        assertThat(currentIsValid)
+            .isFalse()
+        assertThat(currentInvalidFields)
+            .containsExactly(
+                CardValidCallback.Fields.Expiry,
+                CardValidCallback.Fields.Cvc,
+                CardValidCallback.Fields.Postal
+            )
+
+        fullGroup.expiryDateEditText.append("12")
+        assertThat(currentIsValid)
+            .isFalse()
+        assertThat(currentInvalidFields)
+            .containsExactly(
+                CardValidCallback.Fields.Expiry,
+                CardValidCallback.Fields.Cvc,
+                CardValidCallback.Fields.Postal
+            )
+
+        fullGroup.expiryDateEditText.append("50")
+        assertThat(currentIsValid)
+            .isFalse()
+        assertThat(currentInvalidFields)
+            .containsExactly(
+                CardValidCallback.Fields.Cvc,
+                CardValidCallback.Fields.Postal
+            )
+
+        fullGroup.cvcEditText.append("123")
+        assertThat(currentIsValid)
+            .isFalse()
+        assertThat(currentInvalidFields)
+            .containsExactly(CardValidCallback.Fields.Postal)
+
+        fullGroup.postalCodeEditText.setText("A")
+        assertThat(currentIsValid)
+            .isTrue()
+        assertThat(currentInvalidFields)
+            .isEmpty()
+    }
+
+    @Test
     fun shouldShowErrorIcon_shouldBeUpdatedCorrectly() {
         cardMultilineWidget.setExpiryDate(12, 2030)
         cardMultilineWidget.setCvcCode(CVC_VALUE_COMMON)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Take into account the `postalCode` field for `CardValidCallback` validation when it is required in the `CardMultilineWidget`. Same behavior introduced in #4202 for `CardInputWidget`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
RUN_MOBILESDK-724

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

