### PR TITLE
Fix card add display bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Card scanning
 * [FIXED] [4548](https://github.com/stripe/stripe-android/pull/4548) Potential work leak when canceling a card scan in StripeCardScan
 * [ADDED] [4562](https://github.com/stripe/stripe-android/pull/4562) Add an example page for cardscan
+* [FIXED] [4575](https://github.com/stripe/stripe-android/pull/4575) Fix card add display bug
 
 ## 19.1.1 - 2022-01-31
 ### PaymentSheet

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationActivity.kt
@@ -354,7 +354,7 @@ internal open class CardImageVerificationActivity :
     private fun onScanDetailsAvailable(
         requiredCardDetails: RequiredCardDetails?,
     ) {
-        if (requiredCardDetails != null) {
+        if (requiredCardDetails != null && !requiredCardDetails.lastFour.isNullOrEmpty()) {
             this.requiredCardIssuer = requiredCardDetails.cardIssuer
             this.requiredCardLastFour = requiredCardDetails.lastFour
 


### PR DESCRIPTION
# Summary
Make sure the required card text does not show up for scans with no required card.

# Motivation
The new card-add flow will display a required card: `null` without this change.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
[FIXED] [4575](https://github.com/stripe/stripe-android/pull/4575) Fix card add display bug
