### PR TITLE
Enable more unit tests per PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Unit tests
-        run: ./gradlew :payments-core:testDebugUnitTest  :paymentsheet:testDebugUnitTest
+        run: ./gradlew testDebugUnitTest
       - uses: actions/upload-artifact@v2
         if: failure()
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Unit tests
-        run: ./gradlew testDebugUnitTest
+        run: ./gradlew testDebugUnitTest -x :stripe-test-e2e:testDebugUnitTest
       - uses: actions/upload-artifact@v2
         if: failure()
         with:


### PR DESCRIPTION
# Summary
Enable unit tests across all modules for each PR. in the future, we'll limit the number of unit tests that run to just the modules that were modified by the PR.

# Motivation
Currently, many unit tests are never run, which defeats their purpose.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified
