### PR TITLE
Fix crash when no bank is selected in `AddPaymentMethodActivity`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * [CHANGED] [4546](https://github.com/stripe/stripe-android/pull/4546) Update to kotlin 1.6
 * [FIXED] [4560](https://github.com/stripe/stripe-android/pull/4560) Fix `cardValidCallback` being added multiple times in `CardInputWidget`.
 * [FIXED] [4574](https://github.com/stripe/stripe-android/pull/4574) Take `postalCode` into account in `CardMultilineWidget` validation.
+* [FIXED] [4579](https://github.com/stripe/stripe-android/pull/4579) Fix crash when no bank is selected in `AddPaymentMethodActivity`.
 ### PaymentSheet
 * [FIXED] [4466](https://github.com/stripe/stripe-android/pull/4466) Fix issues when activities are lost on low resource phones.
 * [FIXED] [4557](https://github.com/stripe/stripe-android/pull/4557) Add missing app info to some Stripe API requests

--- a/example/src/androidTestDebug/java/com/stripe/example/activity/AddFpxPaymentMethodTest.kt
+++ b/example/src/androidTestDebug/java/com/stripe/example/activity/AddFpxPaymentMethodTest.kt
@@ -50,7 +50,7 @@ class AddFpxPaymentMethodTest {
     fun launchFpxAndConfirmWithoutSelectingBank() {
         launchBankSelector()
 
-        // click on first bank in the list
+        // confirm selection without selecting a bank
         onView(withId(R.id.action_save)).perform(click())
 
         // Nothing should happen as no bank was selected

--- a/example/src/androidTestDebug/java/com/stripe/example/activity/AddFpxPaymentMethodTest.kt
+++ b/example/src/androidTestDebug/java/com/stripe/example/activity/AddFpxPaymentMethodTest.kt
@@ -38,6 +38,25 @@ class AddFpxPaymentMethodTest {
 
     @Test
     fun launchFpxAndSelectBank() {
+        launchBankSelector()
+
+        // click on first bank in the list
+        onView(withId(R.id.bank_list)).perform(
+            RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click())
+        )
+    }
+
+    @Test
+    fun launchFpxAndConfirmWithoutSelectingBank() {
+        launchBankSelector()
+
+        // click on first bank in the list
+        onView(withId(R.id.action_save)).perform(click())
+
+        // Nothing should happen as no bank was selected
+    }
+
+    private fun launchBankSelector() {
         // launch FPX selection activity
         onView(withId(R.id.examples)).perform(
             RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(11, click())
@@ -46,10 +65,5 @@ class AddFpxPaymentMethodTest {
         // click select payment method button
         onView(withId(R.id.select_payment_method_button))
             .perform(click())
-
-        // click on first bank in the list
-        onView(withId(R.id.bank_list)).perform(
-            RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click())
-        )
     }
 }

--- a/example/src/androidTestDebug/java/com/stripe/example/activity/AddNetbankingPaymentMethodTest.kt
+++ b/example/src/androidTestDebug/java/com/stripe/example/activity/AddNetbankingPaymentMethodTest.kt
@@ -44,6 +44,25 @@ class AddNetbankingPaymentMethodTest {
 
     @Test
     fun launchNetbankingAndSelectBank() {
+        launchBankSelector()
+
+        // click on first bank in the list
+        onView(withId(R.id.bank_list)).perform(
+            RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click())
+        )
+    }
+
+    @Test
+    fun launchNetbankingAndConfirmWithoutSelectingBank() {
+        launchBankSelector()
+
+        // click on first bank in the list
+        onView(withId(R.id.action_save)).perform(click())
+
+        // Nothing should happen as no bank was selected
+    }
+
+    private fun launchBankSelector() {
         // launch Netbanking selection activity
         onView(withId(R.id.examples)).perform(
             RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(10, click())
@@ -52,10 +71,5 @@ class AddNetbankingPaymentMethodTest {
         // click select payment method button
         onView(withId(R.id.select_payment_method_button))
             .perform(click())
-
-        // click on first bank in the list
-        onView(withId(R.id.bank_list)).perform(
-            RecyclerViewActions.actionOnItemAtPosition<RecyclerView.ViewHolder>(0, click())
-        )
     }
 }

--- a/example/src/androidTestDebug/java/com/stripe/example/activity/AddNetbankingPaymentMethodTest.kt
+++ b/example/src/androidTestDebug/java/com/stripe/example/activity/AddNetbankingPaymentMethodTest.kt
@@ -56,7 +56,7 @@ class AddNetbankingPaymentMethodTest {
     fun launchNetbankingAndConfirmWithoutSelectingBank() {
         launchBankSelector()
 
-        // click on first bank in the list
+        // confirm selection without selecting a bank
         onView(withId(R.id.action_save)).perform(click())
 
         // Nothing should happen as no bank was selected

--- a/payments-core/src/main/java/com/stripe/android/view/AddPaymentMethodFpxView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/AddPaymentMethodFpxView.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.stripe.android.R
 import com.stripe.android.databinding.BankListPaymentMethodBinding
 import com.stripe.android.model.BankStatuses
@@ -36,11 +37,12 @@ internal class AddPaymentMethodFpxView @JvmOverloads internal constructor(
 
     override val createParams: PaymentMethodCreateParams?
         get() {
-            val fpxBank = FpxBank.values()[fpxAdapter.selectedPosition]
-
-            return PaymentMethodCreateParams.create(
-                PaymentMethodCreateParams.Fpx(bank = fpxBank.code)
-            )
+            return fpxAdapter.selectedPosition.takeIf { it != RecyclerView.NO_POSITION }?.let {
+                val fpxBank = FpxBank.values()[it]
+                PaymentMethodCreateParams.create(
+                    PaymentMethodCreateParams.Fpx(bank = fpxBank.code)
+                )
+            }
         }
 
     init {

--- a/payments-core/src/main/java/com/stripe/android/view/AddPaymentMethodNetbankingView.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/AddPaymentMethodNetbankingView.kt
@@ -4,6 +4,7 @@ import android.util.AttributeSet
 import androidx.fragment.app.FragmentActivity
 import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.stripe.android.R
 import com.stripe.android.databinding.BankListPaymentMethodBinding
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -25,11 +26,14 @@ internal class AddPaymentMethodNetbankingView @JvmOverloads internal constructor
 
     override val createParams: PaymentMethodCreateParams?
         get() {
-            val netbankingBank = NetbankingBank.values()[netbankingAdapter.selectedPosition]
+            return netbankingAdapter.selectedPosition.takeIf { it != RecyclerView.NO_POSITION }
+                ?.let {
+                    val netbankingBank = NetbankingBank.values()[netbankingAdapter.selectedPosition]
 
-            return PaymentMethodCreateParams.create(
-                PaymentMethodCreateParams.Netbanking(bank = netbankingBank.code)
-            )
+                    return PaymentMethodCreateParams.create(
+                        PaymentMethodCreateParams.Netbanking(bank = netbankingBank.code)
+                    )
+                }
         }
 
     init {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fix crash when no bank is selected on FPX and Netbanking bank selector view.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
RUN_MOBILESDK-732

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
