### PR TITLE
[Identity][simpleUI] - finalize ID and passport's aspect ratio

### DIFF
--- a/camera-core/src/main/java/com/stripe/android/camera/scanui/CameraView.kt
+++ b/camera-core/src/main/java/com/stripe/android/camera/scanui/CameraView.kt
@@ -143,6 +143,8 @@ class CameraView @JvmOverloads constructor(
 
     private fun setupBorder() {
         if (borderDrawable != NO_BORDER) {
+            // TODO(ccen) when border is set, need to also set the background of viewFinderWindow
+            // to fill the seam between border and darkened area
             viewFinderBorderView.background = context.getDrawableByRes(borderDrawable)
         }
     }
@@ -209,9 +211,8 @@ class CameraView @JvmOverloads constructor(
          */
         const val FILL_ASPECT_RATIO = ""
         const val CREDIT_CARD_ASPECT_RATIO = "200:126"
-        // TODO(ccen) Finalize the correct aspect ratio for ID and PASSPORT
-        const val ID_ASPECT_RATIO = "1:1"
-        const val PASSPORT_ASPECT_RATIO = "1:2"
+        const val ID_ASPECT_RATIO = "3:2"
+        const val PASSPORT_ASPECT_RATIO = "3:2"
         const val NO_BORDER = -1
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Finalize id and passport's aspect ratio to 3:2

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
