### PR TITLE
[camera-core] Introduce an interface to ensure camera permission

### DIFF
--- a/camera-core/src/main/java/com/stripe/android/camera/CameraPermissionCheckingActivity.kt
+++ b/camera-core/src/main/java/com/stripe/android/camera/CameraPermissionCheckingActivity.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.launch
  * Subclass should override [onCameraReady] and [onUserDeniedCameraPermission].
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-abstract class CameraPermissionCheckingActivity : AppCompatActivity() {
+abstract class CameraPermissionCheckingActivity : AppCompatActivity(), CameraPermissionEnsureable {
 
     /**
      * The camera permission was granted and camera is ready to use.
@@ -43,12 +43,8 @@ abstract class CameraPermissionCheckingActivity : AppCompatActivity() {
 
     private val permissionStat = Stats.trackTask(PERMISSION_STATS_TRACK_NAME)
 
-    /**
-     * Check the camera permission, invokes [onCameraReady] upon permission grant,
-     * invokes [onUserDeniedCameraPermission] otherwise.
-     */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    fun ensureCameraPermission(
+    override fun ensureCameraPermission(
         onCameraReady: () -> Unit,
         onUserDeniedCameraPermission: () -> Unit,
     ) {

--- a/camera-core/src/main/java/com/stripe/android/camera/CameraPermissionEnsureable.kt
+++ b/camera-core/src/main/java/com/stripe/android/camera/CameraPermissionEnsureable.kt
@@ -1,0 +1,19 @@
+package com.stripe.android.camera
+
+import androidx.annotation.RestrictTo
+
+/**
+ * Indicates this class is able to check camera permission and handles the results accordingly.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+interface CameraPermissionEnsureable {
+    /**
+     * Checks if current app has camera permission, prompts the user to grant permission if needed.
+     * Invokes [onCameraReady] when the app already has permission or user grants permission.
+     * Invokes [onUserDeniedCameraPermission] if user denied the permission.
+     */
+    fun ensureCameraPermission(
+        onCameraReady: () -> Unit,
+        onUserDeniedCameraPermission: () -> Unit,
+    )
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Create an interface for camera permission. This won't affect the activity itself, but makes it possible to mock the camera permission logic when testing fragments alone

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Better modularization

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
