### PR TITLE
[Identity] Bound IdentityScanState to IDScanFragment

### DIFF
--- a/identity/api/identity.api
+++ b/identity/api/identity.api
@@ -130,10 +130,14 @@ public final class com/stripe/android/identity/databinding/DriverLicenseUploadFr
 
 public final class com/stripe/android/identity/databinding/IdScanFragmentBinding : androidx/viewbinding/ViewBinding {
 	public final field cameraView Lcom/stripe/android/camera/scanui/CameraView;
-	public final field next Landroid/widget/Button;
+	public final field cameraViewCard Lcom/google/android/material/card/MaterialCardView;
+	public final field checkMarkView Landroid/widget/ImageView;
+	public final field headerTitle Landroid/widget/TextView;
+	public final field kontinue Landroid/widget/Button;
+	public final field message Landroid/widget/TextView;
 	public static fun bind (Landroid/view/View;)Lcom/stripe/android/identity/databinding/IdScanFragmentBinding;
 	public synthetic fun getRoot ()Landroid/view/View;
-	public fun getRoot ()Landroidx/constraintlayout/widget/ConstraintLayout;
+	public fun getRoot ()Landroid/widget/FrameLayout;
 	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/identity/databinding/IdScanFragmentBinding;
 	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/identity/databinding/IdScanFragmentBinding;
 }

--- a/identity/build.gradle
+++ b/identity/build.gradle
@@ -26,6 +26,12 @@ android {
         }
     }
 
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
+
     lintOptions {
         enable "Interoperability"
         disable "CoroutineCreationDuringComposition"
@@ -86,8 +92,12 @@ dependencies {
 
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
+    testImplementation "org.mockito:mockito-inline:$mockitoCoreVersion"
     testImplementation "com.google.truth:truth:$truthVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
+    testImplementation "androidx.fragment:fragment-testing:$fragment_version"
+    testImplementation "androidx.navigation:navigation-testing:$navigationVersion"
+    testImplementation "androidx.arch.core:core-testing:2.1.0"
 
     ktlint "com.pinterest:ktlint:$ktlintVersion"
 }

--- a/identity/res/drawable/check_mark.xml
+++ b/identity/res/drawable/check_mark.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="92dp"
+    android:height="92dp"
+    android:viewportWidth="92"
+    android:viewportHeight="92">
+  <path
+      android:pathData="M92,46C92,71.4051 71.4051,92 46,92C20.5949,92 0,71.4051 0,46C0,20.5949 20.5949,0 46,0C71.4051,0 92,20.5949 92,46ZM71.8605,28.7224C69.615,26.4769 65.9743,26.4769 63.7288,28.7224L40.25,52.2433L29.9409,41.9341C27.6954,39.6886 24.0546,39.6886 21.8091,41.9341C19.5636,44.1796 19.5636,47.8204 21.8091,50.0659L36.1841,64.4409C38.4296,66.6864 42.0703,66.6864 44.3159,64.4409L71.8605,36.8542C74.1061,34.6087 74.1061,30.968 71.8605,28.7224Z"
+      android:fillColor="#FFFFFF"
+      android:fillType="evenOdd"/>
+</vector>

--- a/identity/res/drawable/id_border_found.xml
+++ b/identity/res/drawable/id_border_found.xml
@@ -1,0 +1,38 @@
+<animated-vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector
+            android:name="vector"
+            android:width="180dp"
+            android:height="120dp"
+            android:viewportWidth="300"
+            android:viewportHeight="200">
+            <path
+                android:name="card_border"
+                android:pathData="
+                    M 2.5,20
+                    L 2.5,7.5
+                    a 5,5,0,0,1,5,-5
+                    L 292.5,2.5
+                    a 5,5,0,0,1,5,5
+                    L 297.5,192.5
+                    a 5,5,0,0,1,-5,5
+                    L 7.5,197.5
+                    a 5,5,0,0,1,-5,-5
+                    Z"
+                android:strokeColor="#5469D4"
+                android:strokeWidth="5" />
+        </vector>
+    </aapt:attr>
+    <target android:name="card_border">
+        <aapt:attr name="android:animation">
+            <objectAnimator
+                android:propertyName="trimPathEnd"
+                android:duration="10000"
+                android:valueFrom="0"
+                android:valueTo="1"
+                android:valueType="floatType"
+                android:interpolator="@android:interpolator/fast_out_slow_in" />
+        </aapt:attr>
+    </target>
+</animated-vector>

--- a/identity/res/drawable/id_border_initial.xml
+++ b/identity/res/drawable/id_border_initial.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:name="vector"
+    android:width="180dp"
+    android:height="120dp"
+    android:viewportWidth="300"
+    android:viewportHeight="200">
+    <path
+        android:name="card_border"
+        android:pathData="
+            M 2.5,20
+            L 2.5,7.5
+            a 5,5,0,0,1,5,-5
+            L 292.5,2.5
+            a 5,5,0,0,1,5,5
+            L 297.5,192.5
+            a 5,5,0,0,1,-5,5
+            L 7.5,197.5
+            a 5,5,0,0,1,-5,-5
+            Z"
+        android:strokeColor="@color/id_border_initial_color"
+        android:strokeWidth="@integer/view_finder_border_width"/>
+</vector>

--- a/identity/res/drawable/id_border_satisfied.xml
+++ b/identity/res/drawable/id_border_satisfied.xml
@@ -1,0 +1,49 @@
+<animated-vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector
+            android:name="vector"
+            android:width="180dp"
+            android:height="120dp"
+            android:viewportWidth="300"
+            android:viewportHeight="200">
+            <path
+                android:name="card_border"
+                android:pathData="
+                    M 2.5,20
+                    L 2.5,7.5
+                    a 5,5,0,0,1,5,-5
+                    L 292.5,2.5
+                    a 5,5,0,0,1,5,5
+                    L 297.5,192.5
+                    a 5,5,0,0,1,-5,5
+                    L 7.5,197.5
+                    a 5,5,0,0,1,-5,-5
+                    Z"
+                android:strokeColor="#00FF00"
+                android:strokeWidth="5"/>
+        </vector>
+    </aapt:attr>
+    <target android:name="card_border">
+        <aapt:attr name="android:animation">
+            <set>
+                <objectAnimator
+                    android:propertyName="strokeWidth"
+                    android:duration="250"
+                    android:valueFrom="1"
+                    android:valueTo="10"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/linear_out_slow_in"/>
+                <objectAnimator
+                    android:propertyName="strokeWidth"
+                    android:startOffset="250"
+                    android:duration="250"
+                    android:valueFrom="10"
+                    android:valueTo="1"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/fast_out_slow_in"/>
+            </set>
+        </aapt:attr>
+    </target>
+</animated-vector>

--- a/identity/res/drawable/id_border_unsatisfied.xml
+++ b/identity/res/drawable/id_border_unsatisfied.xml
@@ -1,0 +1,49 @@
+<animated-vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt">
+    <aapt:attr name="android:drawable">
+        <vector
+            android:name="vector"
+            android:width="180dp"
+            android:height="120dp"
+            android:viewportWidth="300"
+            android:viewportHeight="200">
+            <path
+                android:name="card_border"
+                android:pathData="
+                    M 2.5,20
+                    L 2.5,7.5
+                    a 5,5,0,0,1,5,-5
+                    L 292.5,2.5
+                    a 5,5,0,0,1,5,5
+                    L 297.5,192.5
+                    a 5,5,0,0,1,-5,5
+                    L 7.5,197.5
+                    a 5,5,0,0,1,-5,-5
+                    Z"
+                android:strokeColor="#FF0000"
+                android:strokeWidth="1"/>
+        </vector>
+    </aapt:attr>
+    <target android:name="card_border">
+        <aapt:attr name="android:animation">
+            <set>
+                <objectAnimator
+                    android:propertyName="strokeWidth"
+                    android:duration="250"
+                    android:valueFrom="5"
+                    android:valueTo="10"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/linear_out_slow_in"/>
+                <objectAnimator
+                    android:propertyName="strokeWidth"
+                    android:startOffset="250"
+                    android:duration="250"
+                    android:valueFrom="10"
+                    android:valueTo="1"
+                    android:valueType="floatType"
+                    android:interpolator="@android:interpolator/fast_out_slow_in"/>
+            </set>
+        </aapt:attr>
+    </target>
+</animated-vector>

--- a/identity/res/drawable/id_viewfinder_background.xml
+++ b/identity/res/drawable/id_viewfinder_background.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:name="vector"
+    android:width="180dp"
+    android:height="120dp"
+    android:viewportWidth="300"
+    android:viewportHeight="200">
+    <path
+        android:name="card_border"
+        android:pathData="
+            M 2.5,20
+            L 2.5,7.5
+            a 5,5,0,0,1,5,-5
+            L 292.5,2.5
+            a 5,5,0,0,1,5,5
+            L 297.5,192.5
+            a 5,5,0,0,1,-5,5
+            L 7.5,197.5
+            a 5,5,0,0,1,-5,-5
+            L 2.5,20
+            L 0,20
+            L 0,200
+            L 300,200
+            L 300,0
+            L 0,0
+            L 0,20
+            Z"
+        android:fillColor="@color/stripeNotFoundBackground"/>
+</vector>

--- a/identity/res/layout/id_scan_fragment.xml
+++ b/identity/res/layout/id_scan_fragment.xml
@@ -1,26 +1,82 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_marginStart="@dimen/page_horizontal_margin"
+    android:layout_marginEnd="@dimen/page_horizontal_margin"
+    android:layout_marginTop="@dimen/page_vertical_margin"
+    android:layout_marginBottom="@dimen/page_vertical_margin"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <com.stripe.android.camera.scanui.CameraView
-        android:id="@+id/camera_view"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@id/next"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:viewFinderType="creditCard" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_margin="5dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/header_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textStyle="bold"
+            android:text="@string/front_of_id"
+            android:textSize="@dimen/scan_title_text_size"
+            android:layout_marginBottom="20dp"
+            app:layout_constraintBottom_toTopOf="@id/message"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/message"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/page_vertical_margin"
+            android:text="frontID message"
+            app:layout_constraintBottom_toTopOf="@id/camera_view_card"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/header_title" />
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/camera_view_card"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:cardCornerRadius="@dimen/view_finder_corner_radius"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintDimensionRatio="3:2"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/message">
+
+            <com.stripe.android.camera.scanui.CameraView
+                android:id="@+id/camera_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:borderDrawable="@drawable/id_border_initial"
+                app:viewFinderType="id" />
+
+            <ImageView
+                android:id="@+id/check_mark_view"
+                android:padding="60dp"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:src="@drawable/check_mark"
+                android:visibility="gone"
+                android:background="@color/check_mark_background"
+                android:contentDescription="@string/check_mark"
+                app:tint="?android:colorPrimary" />
+
+        </com.google.android.material.card.MaterialCardView>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
 
     <Button
-        android:id="@+id/next"
+        android:id="@+id/kontinue"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/next"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/camera_view" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+        android:layout_gravity="bottom"
+        android:text="@string/kontinue" />
+
+</FrameLayout>

--- a/identity/res/navigation/identity_nav_graph.xml
+++ b/identity/res/navigation/identity_nav_graph.xml
@@ -89,7 +89,7 @@
         tools:layout="@layout/camera_permission_denied_fragment">
         <argument
             android:name="scanType"
-            app:argType="com.stripe.android.identity.states.ScanState$ScanType" />
+            app:argType="com.stripe.android.identity.states.IdentityScanState$ScanType" />
         <action
             android:id="@+id/action_cameraPermissionDeniedFragment_to_passportUploadFragment"
             app:destination="@id/passportUploadFragment" />

--- a/identity/res/values/colors.xml
+++ b/identity/res/values/colors.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="id_border_initial_color">#FFFFFF</color>
+
+    <color name="check_mark_background">#80FFFFFF</color>
+</resources>

--- a/identity/res/values/dimens.xml
+++ b/identity/res/values/dimens.xml
@@ -4,5 +4,7 @@
     <dimen name="page_vertical_margin">24dp</dimen>
     <dimen name="item_vertical_margin">16dp</dimen>
     <dimen name="consent_title_text_size">24sp</dimen>
+    <dimen name="scan_title_text_size">24sp</dimen>
     <dimen name="doc_selection_title_text_size">24sp</dimen>
+    <dimen name="view_finder_corner_radius">10dp</dimen>
 </resources>

--- a/identity/res/values/integers.xml
+++ b/identity/res/values/integers.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="view_finder_border_width">5</integer>
+</resources>

--- a/identity/res/values/strings.xml
+++ b/identity/res/values/strings.xml
@@ -1,10 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="next">next</string>
+    <string name="kontinue">continue</string>
     <string name="agree_and_continue">Agree and continue</string>
     <string name="decline">Decline and use alternative method</string>
     <string name="driver_license">Driver\'s license</string>
     <string name="id_card">Identity card</string>
     <string name="passport">Passport</string>
     <string name="doc_select_title">Which form of identification do you want to use?</string>
+    <string name="front_of_id">Front of ID</string>
+    <string name="position_id_front">Position your ID in the center of the frame</string>
+    <string name="position_id_back">Flip your ID over to the other side</string>
+    <string name="hold_still">Hold still, scanning</string>
+    <string name="scanned">Scanned</string>
+    <string name="help">Help</string>
+    <string name="id_scan_complete">ID scan complete</string>
+
+    <string name="position_id_in_center">Position your id in the center of the frame</string>
+    <string name="check_mark">Check mark to indicate document capture success</string>
 </resources>

--- a/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
@@ -12,6 +12,7 @@ import com.stripe.android.camera.CameraPermissionCheckingActivity
 import com.stripe.android.identity.IdentityVerificationSheet.VerificationResult
 import com.stripe.android.identity.databinding.IdentityActivityBinding
 import com.stripe.android.identity.navigation.ConsentFragment
+import com.stripe.android.identity.navigation.IdentityFragmentFactory
 
 /**
  * Host activity to perform Identity verification.
@@ -40,6 +41,8 @@ internal class IdentityActivity : CameraPermissionCheckingActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
+
+        supportFragmentManager.fragmentFactory = IdentityFragmentFactory(this)
 
         val navHostFragment =
             supportFragmentManager.findFragmentById(R.id.identity_nav_host) as NavHostFragment

--- a/identity/src/main/java/com/stripe/android/identity/camera/IdentityScanFlow.kt
+++ b/identity/src/main/java/com/stripe/android/identity/camera/IdentityScanFlow.kt
@@ -13,7 +13,7 @@ import com.stripe.android.camera.scanui.ScanFlow
 import com.stripe.android.identity.ml.AnalyzerInput
 import com.stripe.android.identity.ml.AnalyzerOutput
 import com.stripe.android.identity.ml.IDDetectorAnalyzer
-import com.stripe.android.identity.states.ScanState
+import com.stripe.android.identity.states.IdentityScanState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
@@ -28,12 +28,12 @@ import kotlinx.coroutines.launch
  * TODO(ccen): merge with [CardScanFlow].
  */
 internal class IdentityScanFlow(
-    scanType: ScanState.ScanType,
+    identityScanType: IdentityScanState.ScanType,
     private val analyzerLoopErrorListener: AnalyzerLoopErrorListener,
     aggregateResultListener: AggregateResultListener<IDDetectorAggregator.InterimResult, IDDetectorAggregator.FinalResult>
 ) : ScanFlow<Int, CameraPreviewImage<Bitmap>> {
     private var aggregator = IDDetectorAggregator(
-        scanType,
+        identityScanType,
         aggregateResultListener
     )
 
@@ -48,7 +48,7 @@ internal class IdentityScanFlow(
     private var analyzerPool:
         AnalyzerPool<
             AnalyzerInput,
-            ScanState,
+            IdentityScanState,
             AnalyzerOutput
             >? = null
 
@@ -58,7 +58,7 @@ internal class IdentityScanFlow(
     private var loop:
         ProcessBoundAnalyzerLoop<
             AnalyzerInput,
-            ScanState,
+            IdentityScanState,
             AnalyzerOutput
             >? = null
 

--- a/identity/src/main/java/com/stripe/android/identity/ml/IDDetectorAnalyzer.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ml/IDDetectorAnalyzer.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import com.stripe.android.camera.framework.Analyzer
 import com.stripe.android.camera.framework.AnalyzerFactory
 import com.stripe.android.camera.framework.image.cropCameraPreviewToSquare
-import com.stripe.android.identity.states.ScanState
+import com.stripe.android.identity.states.IdentityScanState
 import org.tensorflow.lite.DataType
 import org.tensorflow.lite.Interpreter
 import org.tensorflow.lite.support.common.ops.NormalizeOp
@@ -20,7 +20,7 @@ import java.nio.channels.FileChannel
  * TODO(ccen): reimplement with ImageClassifier
  */
 internal class IDDetectorAnalyzer(context: Context) :
-    Analyzer<AnalyzerInput, ScanState, AnalyzerOutput> {
+    Analyzer<AnalyzerInput, IdentityScanState, AnalyzerOutput> {
 
     private val tfliteInterpreter = Interpreter(
         context.assets.openFd(modelName).use { fileDescriptor ->
@@ -34,7 +34,7 @@ internal class IDDetectorAnalyzer(context: Context) :
         }
     )
 
-    override suspend fun analyze(data: AnalyzerInput, state: ScanState): AnalyzerOutput {
+    override suspend fun analyze(data: AnalyzerInput, identityState: IdentityScanState): AnalyzerOutput {
         var tensorImage = TensorImage(INPUT_TENSOR_TYPE)
         val croppedImage = cropCameraPreviewToSquare(
             data.cameraPreviewImage.image,
@@ -98,11 +98,11 @@ internal class IDDetectorAnalyzer(context: Context) :
         private val context: Context
     ) : AnalyzerFactory<
             AnalyzerInput,
-            ScanState,
+            IdentityScanState,
             AnalyzerOutput,
-            Analyzer<AnalyzerInput, ScanState, AnalyzerOutput>
+            Analyzer<AnalyzerInput, IdentityScanState, AnalyzerOutput>
             > {
-        override suspend fun newInstance(): Analyzer<AnalyzerInput, ScanState, AnalyzerOutput> {
+        override suspend fun newInstance(): Analyzer<AnalyzerInput, IdentityScanState, AnalyzerOutput> {
             return IDDetectorAnalyzer(context)
         }
     }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/CameraPermissionDeniedFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/CameraPermissionDeniedFragment.kt
@@ -7,7 +7,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.identity.databinding.CameraPermissionDeniedFragmentBinding
-import com.stripe.android.identity.states.ScanState
+import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.viewmodel.CameraPermissionDeniedViewModel
 
 /**
@@ -16,7 +16,7 @@ import com.stripe.android.identity.viewmodel.CameraPermissionDeniedViewModel
 internal class CameraPermissionDeniedFragment : Fragment() {
     private lateinit var viewModel: CameraPermissionDeniedViewModel
 
-    private lateinit var scanType: ScanState.ScanType
+    private lateinit var identityScanType: IdentityScanState.ScanType
 
     private lateinit var binding: CameraPermissionDeniedFragmentBinding
 
@@ -27,9 +27,9 @@ internal class CameraPermissionDeniedFragment : Fragment() {
     ): View {
         val args = requireNotNull(arguments)
 
-        scanType = args[ARG_SCAN_TYPE] as ScanState.ScanType
+        identityScanType = args[ARG_SCAN_TYPE] as IdentityScanState.ScanType
         binding = CameraPermissionDeniedFragmentBinding.inflate(inflater, container, false)
-        binding.info.text = "Camera permission denied, scanType is ${scanType.name}"
+        binding.info.text = "Camera permission denied, scanType is ${identityScanType.name}"
 
         return binding.root
     }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IDScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IDScanFragment.kt
@@ -6,26 +6,41 @@ import android.util.Size
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.annotation.VisibleForTesting
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.stripe.android.camera.Camera1Adapter
+import com.stripe.android.camera.CameraPermissionEnsureable
 import com.stripe.android.camera.DefaultCameraErrorListener
+import com.stripe.android.camera.scanui.CameraView
 import com.stripe.android.camera.scanui.util.asRect
+import com.stripe.android.camera.scanui.util.startAnimation
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.IdScanFragmentBinding
-import com.stripe.android.identity.states.ScanState
+import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.viewmodel.CameraViewModel
 
 /**
- * TODO(ccen) connect the logic to initialize CameraAdapter and call IdentityActivity#ensureCameraPermission
+ * Fragment to scan the ID.
  */
-internal class IDScanFragment : Fragment() {
-    private val cameraViewModel: CameraViewModel by viewModels()
+internal class IDScanFragment(
+    private val cameraPermissionEnsureable: CameraPermissionEnsureable,
+    private val cameraViewModelFactory: ViewModelProvider.Factory
+) : Fragment() {
+    private val cameraViewModel: CameraViewModel by viewModels { cameraViewModelFactory }
     private lateinit var binding: IdScanFragmentBinding
-    private lateinit var cameraAdapter: Camera1Adapter
+    private lateinit var messageView: TextView
+    private lateinit var cameraView: CameraView
+    private lateinit var checkMarkView: ImageView
+
+    @VisibleForTesting
+    internal lateinit var cameraAdapter: Camera1Adapter
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -33,22 +48,22 @@ internal class IDScanFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         binding = IdScanFragmentBinding.inflate(inflater, container, false)
+        messageView = binding.message
+        cameraView = binding.cameraView
+        checkMarkView = binding.checkMarkView
         return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        cameraViewModel.interimResults.observe(viewLifecycleOwner) {
-            Log.d(TAG, "IDScanFragment get interim result: $it")
-        }
-
         cameraViewModel.finalResult.observe(viewLifecycleOwner) {
-            Log.d(TAG, "IDScanFragment get final result: $it")
+            cameraViewModel.identityScanFlow.cancelFlow()
+            cameraAdapter.unbindFromLifecycle(this)
         }
 
-        cameraViewModel.reset.observe(viewLifecycleOwner) {
-            Log.d(TAG, "IDScanFragment get reset")
+        cameraViewModel.displayStateChanged.observe(viewLifecycleOwner) { (newState, _) ->
+            updateUI(newState)
         }
 
         cameraAdapter = Camera1Adapter(
@@ -61,9 +76,10 @@ internal class IDScanFragment : Fragment() {
             }
         )
         cameraViewModel.initializeScanFlow(
-            ScanState.ScanType.ID_FRONT // determine how to transition to ID_BACK
+            IdentityScanState.ScanType.ID_FRONT // determine how to transition to ID_BACK
         )
-        ensureCameraPermissionFromIdentityActivity(
+
+        cameraPermissionEnsureable.ensureCameraPermission(
             onCameraReady = {
                 Log.d(TAG, "Camera permission granted")
                 cameraAdapter.bindToLifecycle(this)
@@ -71,7 +87,7 @@ internal class IDScanFragment : Fragment() {
                     context = requireContext(),
                     imageStream = cameraAdapter.getImageStream(),
                     viewFinder = binding.cameraView.viewFinderWindowView.asRect(),
-                    lifecycleOwner = this,
+                    lifecycleOwner = viewLifecycleOwner,
                     coroutineScope = lifecycleScope,
                     parameters = 23 // TODO(ccen) pass correct parameter
                 )
@@ -82,11 +98,49 @@ internal class IDScanFragment : Fragment() {
                 findNavController().navigate(
                     R.id.action_camera_permission_denied,
                     bundleOf(
-                        CameraPermissionDeniedFragment.ARG_SCAN_TYPE to ScanState.ScanType.ID_FRONT
+                        CameraPermissionDeniedFragment.ARG_SCAN_TYPE to IdentityScanState.ScanType.ID_FRONT
                     )
                 )
             }
         )
+    }
+
+    private fun updateUI(identityState: IdentityScanState) {
+        when (identityState) {
+            is IdentityScanState.Initial -> {
+                cameraView.viewFinderBackgroundView.visibility = View.VISIBLE
+                cameraView.viewFinderWindowView.visibility = View.VISIBLE
+                cameraView.viewFinderBorderView.visibility = View.VISIBLE
+                checkMarkView.visibility = View.GONE
+
+                messageView.text = requireContext().getText(R.string.position_id_front)
+                cameraView.viewFinderWindowView.setBackgroundResource(R.drawable.id_viewfinder_background)
+                cameraView.viewFinderBorderView.startAnimation(R.drawable.id_border_initial)
+            }
+            is IdentityScanState.Found -> {
+                messageView.text = requireContext().getText(R.string.hold_still)
+                cameraView.viewFinderWindowView.setBackgroundResource(R.drawable.id_viewfinder_background)
+                cameraView.viewFinderBorderView.startAnimation(R.drawable.id_border_found)
+            }
+            is IdentityScanState.Unsatisfied -> {
+                messageView.text = requireContext().getText(R.string.position_id_in_center)
+                cameraView.viewFinderWindowView.setBackgroundResource(R.drawable.id_viewfinder_background)
+                cameraView.viewFinderBorderView.startAnimation(R.drawable.id_border_unsatisfied)
+            }
+            is IdentityScanState.Satisfied -> {
+                messageView.text = requireContext().getText(R.string.scanned)
+                cameraView.viewFinderWindowView.setBackgroundResource(R.drawable.id_viewfinder_background)
+                cameraView.viewFinderBorderView.startAnimation(R.drawable.id_border_satisfied)
+            }
+            is IdentityScanState.Finished -> {
+                cameraView.viewFinderBackgroundView.visibility = View.INVISIBLE
+                cameraView.viewFinderWindowView.visibility = View.INVISIBLE
+                cameraView.viewFinderBorderView.visibility = View.INVISIBLE
+                checkMarkView.visibility = View.VISIBLE
+
+                messageView.text = requireContext().getText(R.string.scanned)
+            }
+        }
     }
 
     override fun onDestroy() {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
@@ -1,0 +1,23 @@
+package com.stripe.android.identity.navigation
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentFactory
+import com.stripe.android.camera.CameraPermissionEnsureable
+import com.stripe.android.identity.viewmodel.CameraViewModel
+
+/**
+ * Factory for creating Identity fragments.
+ */
+internal class IdentityFragmentFactory(
+    private val cameraPermissionEnsureable: CameraPermissionEnsureable
+) : FragmentFactory() {
+    override fun instantiate(classLoader: ClassLoader, className: String): Fragment {
+        return when (className) {
+            IDScanFragment::class.java.name -> IDScanFragment(
+                cameraPermissionEnsureable,
+                CameraViewModel.CameraViewModelFactory()
+            )
+            else -> super.instantiate(classLoader, className)
+        }
+    }
+}

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/CameraViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/CameraViewModel.kt
@@ -6,26 +6,41 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.camera.framework.AggregateResultListener
 import com.stripe.android.camera.framework.AnalyzerLoopErrorListener
-import com.stripe.android.identity.IdentityVerificationSheetContract
+import com.stripe.android.camera.scanui.ScanErrorListener
+import com.stripe.android.camera.scanui.SimpleScanStateful
 import com.stripe.android.identity.IdentityViewModel
 import com.stripe.android.identity.camera.IDDetectorAggregator
 import com.stripe.android.identity.camera.IdentityScanFlow
-import com.stripe.android.identity.states.ScanState
+import com.stripe.android.identity.states.IdentityScanState
 
 /**
- * ViewModel hosted by all fragments that need to access live camera feed and callbacks.
+ * ViewModel hosted by Activities/Fragments that need to access live camera feed and callbacks.
+ *
+ * TODO(ccen): Extract Identity specifics and move to camera-core
  */
 internal class CameraViewModel :
     ViewModel(),
     AnalyzerLoopErrorListener,
-    AggregateResultListener<IDDetectorAggregator.InterimResult, IDDetectorAggregator.FinalResult> {
+    AggregateResultListener<IDDetectorAggregator.InterimResult, IDDetectorAggregator.FinalResult>,
+    SimpleScanStateful<IdentityScanState> {
 
-    // liveData for results, subscribed from fragments
     internal val interimResults = MutableLiveData<IDDetectorAggregator.InterimResult>()
     internal val finalResult = MutableLiveData<IDDetectorAggregator.FinalResult>()
     internal val reset = MutableLiveData<Unit>()
+    internal val displayStateChanged =
+        MutableLiveData<Pair<IdentityScanState, IdentityScanState?>>()
 
     lateinit var identityScanFlow: IdentityScanFlow
+
+    override var scanState: IdentityScanState? = null
+
+    override var scanStatePrevious: IdentityScanState? = null
+
+    override val scanErrorListener = ScanErrorListener()
+
+    override fun displayState(newState: IdentityScanState, previousState: IdentityScanState?) {
+        displayStateChanged.postValue(newState to previousState)
+    }
 
     /**
      * Initialize [identityScanFlow] with the target scanType.
@@ -35,23 +50,30 @@ internal class CameraViewModel :
      * [IdentityScanFlow] on the fly.
      */
     fun initializeScanFlow(
-        scanType: ScanState.ScanType
+        identityScanType: IdentityScanState.ScanType
     ) {
         identityScanFlow = IdentityScanFlow(
-            scanType = scanType,
+            identityScanType = identityScanType,
             this,
             this
         )
     }
 
     override suspend fun onResult(result: IDDetectorAggregator.FinalResult) {
+        Log.d("BGLM", "Final result received: ${result.result.category} - ${result.result.score}")
+
         Log.d(TAG, "Final result received: $result")
         finalResult.postValue(result)
     }
 
     override suspend fun onInterimResult(result: IDDetectorAggregator.InterimResult) {
+        Log.d("BGLM", "Interim result received: ${result.result.category} - ${result.result.score}")
+
         Log.d(TAG, "Interim result received: $result")
         interimResults.postValue(result)
+
+        // This will trigger displayState
+        changeScanState(result.identityState)
     }
 
     override suspend fun onReset() {
@@ -69,13 +91,10 @@ internal class CameraViewModel :
         return true
     }
 
-    internal class IdentityViewModelFactory(
-        private val args: IdentityVerificationSheetContract.Args
-    ) :
-        ViewModelProvider.Factory {
+    internal class CameraViewModelFactory : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return IdentityViewModel(args) as T
+            return CameraViewModel() as T
         }
     }
 

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IDScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IDScanFragmentTest.kt
@@ -1,0 +1,214 @@
+package com.stripe.android.identity.navigation
+
+import android.content.Context
+import android.view.View
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.Navigation
+import androidx.navigation.testing.TestNavHostController
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.camera.CameraPermissionEnsureable
+import com.stripe.android.identity.R
+import com.stripe.android.identity.camera.IDDetectorAggregator
+import com.stripe.android.identity.camera.IdentityScanFlow
+import com.stripe.android.identity.databinding.IdScanFragmentBinding
+import com.stripe.android.identity.states.IdentityScanState
+import com.stripe.android.identity.viewmodel.CameraViewModel
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.same
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class IDScanFragmentTest {
+    // Ensure livedata works properly
+    @get:Rule
+    var rule: TestRule = InstantTaskExecutorRule()
+
+    private val finalResultLiveData = MutableLiveData<IDDetectorAggregator.FinalResult>()
+    private val displayStateChanged = MutableLiveData<Pair<IdentityScanState, IdentityScanState?>>()
+    private val mockScanFlow = mock<IdentityScanFlow>()
+    private val mockCameraPermissionEnsurable = mock<CameraPermissionEnsureable>()
+    private val mockCameraViewModel = mock<CameraViewModel>().also {
+        whenever(it.identityScanFlow).thenReturn(mockScanFlow)
+        whenever(it.finalResult).thenReturn(finalResultLiveData)
+        whenever(it.displayStateChanged).thenReturn(displayStateChanged)
+    }
+
+    private val testCameraPermissionEnsureable = object : CameraPermissionEnsureable {
+        lateinit var onCameraReady: () -> Unit
+        lateinit var onUserDeniedCameraPermission: () -> Unit
+
+        override fun ensureCameraPermission(
+            onCameraReady: () -> Unit,
+            onUserDeniedCameraPermission: () -> Unit
+        ) {
+            this.onCameraReady = onCameraReady
+            this.onUserDeniedCameraPermission = onUserDeniedCameraPermission
+        }
+    }
+
+    private val cameraViewModelFactory = object : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return mockCameraViewModel as T
+        }
+    }
+
+    @Test
+    fun `when created identityScanFlow is initialized and camera permission is requested`() {
+        launchIDScanFragment(mockCameraPermissionEnsurable)
+
+        verify(mockCameraViewModel).initializeScanFlow(eq(IdentityScanState.ScanType.ID_FRONT))
+        verify(mockCameraPermissionEnsurable).ensureCameraPermission(any(), any())
+    }
+
+    @Test
+    fun `when camera permission granted cameraAdapter is bound and identityScanFlow is started`() {
+        launchIDScanFragment(testCameraPermissionEnsureable).onFragment {
+            testCameraPermissionEnsureable.onCameraReady()
+            assertThat(it.cameraAdapter.isBoundToLifecycle()).isTrue()
+            verify(mockScanFlow).startFlow(
+                same(it.requireContext()),
+                any(),
+                any(),
+                same(it.viewLifecycleOwner),
+                same(it.lifecycleScope),
+                eq(23)
+            )
+        }
+    }
+
+    @Test
+    fun `when camera permission denied navigates to permission denied`() {
+        launchIDScanFragment(testCameraPermissionEnsureable).onFragment {
+            val navController = TestNavHostController(
+                ApplicationProvider.getApplicationContext()
+            )
+            navController.setGraph(R.navigation.identity_nav_graph)
+            Navigation.setViewNavController(
+                it.requireView(),
+                navController
+            )
+
+            testCameraPermissionEnsureable.onUserDeniedCameraPermission()
+
+            assertThat(it.cameraAdapter.isBoundToLifecycle()).isFalse()
+            assertThat(navController.currentDestination?.id).isEqualTo(R.id.cameraPermissionDeniedFragment)
+        }
+    }
+
+    @Test
+    fun `when final result is received scanFlow is cancelled and cameraAdapter is unbound`() {
+        launchIDScanFragment(testCameraPermissionEnsureable).onFragment {
+            testCameraPermissionEnsureable.onCameraReady()
+            assertThat(it.cameraAdapter.isBoundToLifecycle()).isTrue()
+
+            finalResultLiveData.postValue(mock())
+
+            verify(mockScanFlow).cancelFlow()
+            assertThat(it.cameraAdapter.isBoundToLifecycle()).isFalse()
+        }
+    }
+
+    @Test
+    fun `when displayStateChanged to Initial UI is properly updated`() {
+        postDisplayStateChangedDataAndVerifyUI(mock<IdentityScanState.Initial>()) { binding, context ->
+            assertThat(binding.cameraView.viewFinderBackgroundView.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.cameraView.viewFinderWindowView.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.cameraView.viewFinderBorderView.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
+            assertThat(binding.message.text).isEqualTo(
+                context.getText(R.string.position_id_front)
+            )
+        }
+    }
+
+    @Test
+    fun `when displayStateChanged to Found UI is properly updated`() {
+        postDisplayStateChangedDataAndVerifyUI(mock<IdentityScanState.Found>()) { binding, context ->
+            assertThat(binding.cameraView.viewFinderBackgroundView.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.cameraView.viewFinderWindowView.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.cameraView.viewFinderBorderView.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
+            assertThat(binding.message.text).isEqualTo(
+                context.getText(R.string.hold_still)
+            )
+        }
+    }
+
+    @Test
+    fun `when displayStateChanged to Unsatisfied UI is properly updated`() {
+        postDisplayStateChangedDataAndVerifyUI(mock<IdentityScanState.Unsatisfied>()) { binding, context ->
+            assertThat(binding.cameraView.viewFinderBackgroundView.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.cameraView.viewFinderWindowView.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.cameraView.viewFinderBorderView.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
+            assertThat(binding.message.text).isEqualTo(
+                context.getText(R.string.position_id_in_center)
+            )
+        }
+    }
+
+    @Test
+    fun `when displayStateChanged to Satisfied UI is properly updated`() {
+        postDisplayStateChangedDataAndVerifyUI(mock<IdentityScanState.Satisfied>()) { binding, context ->
+            assertThat(binding.cameraView.viewFinderBackgroundView.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.cameraView.viewFinderWindowView.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.cameraView.viewFinderBorderView.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
+            assertThat(binding.message.text).isEqualTo(
+                context.getText(R.string.scanned)
+            )
+        }
+    }
+
+    @Test
+    fun `when displayStateChanged to Finished UI is properly updated`() {
+        postDisplayStateChangedDataAndVerifyUI(mock<IdentityScanState.Finished>()) { binding, context ->
+            assertThat(binding.cameraView.viewFinderBackgroundView.visibility).isEqualTo(View.INVISIBLE)
+            assertThat(binding.cameraView.viewFinderWindowView.visibility).isEqualTo(View.INVISIBLE)
+            assertThat(binding.cameraView.viewFinderBorderView.visibility).isEqualTo(View.INVISIBLE)
+            assertThat(binding.checkMarkView.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.message.text).isEqualTo(
+                context.getText(R.string.scanned)
+            )
+        }
+    }
+
+    private fun launchIDScanFragment(
+        cameraPermissionEnsureable: CameraPermissionEnsureable
+    ) = launchFragmentInContainer(
+        themeResId = R.style.Theme_MaterialComponents
+    ) {
+        IDScanFragment(
+            cameraPermissionEnsureable,
+            cameraViewModelFactory
+        )
+    }
+
+    private fun postDisplayStateChangedDataAndVerifyUI(
+        newScanState: IdentityScanState,
+        check: (binding: IdScanFragmentBinding, context: Context) -> Unit
+    ) {
+        launchIDScanFragment(
+            mockCameraPermissionEnsurable
+        ).onFragment {
+
+            displayStateChanged.postValue((newScanState to mock()))
+            check(IdScanFragmentBinding.bind(it.requireView()), it.requireContext())
+        }
+    }
+}

--- a/identity/src/test/java/com/stripe/android/identity/states/IdentityScanStateTests.kt
+++ b/identity/src/test/java/com/stripe/android/identity/states/IdentityScanStateTests.kt
@@ -13,11 +13,11 @@ import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-class ScanStateTests {
+class IdentityScanStateTests {
 
     @Test
     fun `Initial can't transition with unmatched AnalyzerOutput`() {
-        val initialState = ScanState.Initial(ScanState.ScanType.ID_FRONT)
+        val initialState = IdentityScanState.Initial(IdentityScanState.ScanType.ID_FRONT)
         val resultState = initialState.consumeTransition(ID_BACK_OUTPUT)
 
         assertThat(resultState).isSameInstanceAs(initialState)
@@ -25,10 +25,10 @@ class ScanStateTests {
 
     @Test
     fun `Initial transitions to Found with matched AnalyzerOutput`() {
-        val initialState = ScanState.Initial(ScanState.ScanType.ID_FRONT)
+        val initialState = IdentityScanState.Initial(IdentityScanState.ScanType.ID_FRONT)
         val resultState = initialState.consumeTransition(ID_FRONT_OUTPUT)
 
-        assertThat(resultState).isInstanceOf(ScanState.Found::class.java)
+        assertThat(resultState).isInstanceOf(IdentityScanState.Found::class.java)
     }
 
     // TODO(ccen) add test for Found -> Unsatisfied when #isUnsatisfied is implemented
@@ -39,7 +39,7 @@ class ScanStateTests {
         val mockClockMark: ClockMark = mock()
         whenever(mockClockMark.elapsedSince()).thenReturn(DURATION_BEFORE_TIMEOUT)
 
-        val initialState = ScanState.Satisfied(ScanState.ScanType.ID_FRONT, mockClockMark)
+        val initialState = IdentityScanState.Satisfied(IdentityScanState.ScanType.ID_FRONT, mockClockMark)
         val resultState = initialState.consumeTransition(ID_FRONT_OUTPUT)
 
         assertThat(resultState).isSameInstanceAs(initialState)
@@ -50,11 +50,11 @@ class ScanStateTests {
         val mockClockMark: ClockMark = mock()
         whenever(mockClockMark.elapsedSince()).thenReturn(DURATION_AFTER_TIMEOUT)
 
-        val initialScanType = ScanState.ScanType.ID_FRONT
-        val initialState = ScanState.Satisfied(initialScanType, mockClockMark)
+        val initialScanType = IdentityScanState.ScanType.ID_FRONT
+        val initialState = IdentityScanState.Satisfied(initialScanType, mockClockMark)
         val resultState = initialState.consumeTransition(ID_FRONT_OUTPUT)
 
-        assertThat(resultState).isInstanceOf(ScanState.Finished::class.java)
+        assertThat(resultState).isInstanceOf(IdentityScanState.Finished::class.java)
         assertThat(resultState.type).isEqualTo(initialScanType)
     }
 
@@ -64,7 +64,7 @@ class ScanStateTests {
         whenever(mockClockMark.elapsedSince()).thenReturn(DURATION_BEFORE_TIMEOUT)
 
         val initialState =
-            ScanState.Unsatisfied("reason", ScanState.ScanType.ID_FRONT, mockClockMark)
+            IdentityScanState.Unsatisfied("reason", IdentityScanState.ScanType.ID_FRONT, mockClockMark)
         val resultState = initialState.consumeTransition(ID_FRONT_OUTPUT)
 
         assertThat(resultState).isSameInstanceAs(initialState)
@@ -75,11 +75,11 @@ class ScanStateTests {
         val mockClockMark: ClockMark = mock()
         whenever(mockClockMark.elapsedSince()).thenReturn(DURATION_AFTER_TIMEOUT)
 
-        val initialScanType = ScanState.ScanType.ID_FRONT
-        val initialState = ScanState.Unsatisfied("reason", initialScanType, mockClockMark)
+        val initialScanType = IdentityScanState.ScanType.ID_FRONT
+        val initialState = IdentityScanState.Unsatisfied("reason", initialScanType, mockClockMark)
         val resultState = initialState.consumeTransition(ID_FRONT_OUTPUT)
 
-        assertThat(resultState).isInstanceOf(ScanState.Initial::class.java)
+        assertThat(resultState).isInstanceOf(IdentityScanState.Initial::class.java)
         assertThat(resultState.type).isEqualTo(initialScanType)
     }
 

--- a/identity/src/test/java/com/stripe/android/identity/viewmodel/CameraViewModelTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/viewmodel/CameraViewModelTest.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.identity.viewmodel
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.identity.states.ScanState
+import com.stripe.android.identity.states.IdentityScanState
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -11,7 +11,7 @@ class CameraViewModelTest {
     @Test
     fun `identityScanFlow is not null after initialization`() {
         val viewModel = CameraViewModel()
-        viewModel.initializeScanFlow(ScanState.ScanType.ID_FRONT)
+        viewModel.initializeScanFlow(IdentityScanState.ScanType.ID_FRONT)
 
         assertThat(viewModel.identityScanFlow).isNotNull()
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Bound `IdentityScanState` to `IDScanFragment` through `CameraViewModel#displayStateChanged`, adding corresponding UI transition and animation logic.
  * Note the animations are not finalized are subject to change.
* Introduced a `IdentityFragmentFactory` for Fragments transition, making it possible to inject dependencies to Fragments
* Added a test for the `IDScanFragment`, the test takes advantage of #4590 and `IdentityFragmentFactory` to provide test dependencies


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Identity SDK - IDScan

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
