### PR TITLE
Add fragment handling to stripecardscan and update READMEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### PaymentSheet
 ### Identity
 ### Card scanning
+[ADDED] [4592](https://github.com/stripe/stripe-android/pull/4592) Add support for launching card scan from fragments.
 
 ## 19.2.0 - 2022-02-14
 This release includes several bug fixes and upgrades Kotlin to 1.6.

--- a/stripecardscan/api/stripecardscan.api
+++ b/stripecardscan/api/stripecardscan.api
@@ -33,11 +33,13 @@ public final class com/stripe/android/stripecardscan/cardimageverification/CardI
 	public static final field Companion Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
+	public static final fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
 	public final fun present (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Companion {
 	public final fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
+	public final fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
 }
 
 public abstract interface class com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheetResult : android/os/Parcelable {
@@ -150,11 +152,13 @@ public final class com/stripe/android/stripecardscan/cardscan/CardScanSheet {
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun attachCardScanFragment (Landroidx/lifecycle/LifecycleOwner;Landroidx/fragment/app/FragmentManager;ILkotlin/jvm/functions/Function1;)V
 	public static final fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;)Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet;
+	public static final fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;)Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet;
 	public final fun present (Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class com/stripe/android/stripecardscan/cardscan/CardScanSheet$Companion {
 	public final fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;)Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet;
+	public final fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;)Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet;
 	public final fun removeCardScanFragment (Landroidx/fragment/app/FragmentManager;)V
 }
 

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet.kt
@@ -6,6 +6,7 @@ import android.os.Parcelable
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContract
+import androidx.fragment.app.Fragment
 import com.stripe.android.stripecardscan.cardimageverification.exception.UnknownScanException
 import com.stripe.android.stripecardscan.payment.card.ScannedCard
 import com.stripe.android.stripecardscan.scanui.CancellationReason
@@ -47,11 +48,37 @@ class CardImageVerificationSheet private constructor(private val stripePublishab
          * This API registers an [ActivityResultLauncher] into the
          * [ComponentActivity], it must be called before the [ComponentActivity]
          * is created (in the onCreate method).
-         *
-         * see https://github.com/stripe/stripe-android/blob/3e92b79190834dc3aab1c2d9ac2dfb7bc343afd2/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncher.kt#L52
          */
         @JvmStatic
         fun create(from: ComponentActivity, stripePublishableKey: String) =
+            CardImageVerificationSheet(stripePublishableKey).apply {
+                launcher = from.registerForActivityResult(
+                    object : ActivityResultContract<
+                        CardImageVerificationSheetParams,
+                        CardImageVerificationSheetResult
+                        >() {
+                        override fun createIntent(
+                            context: Context,
+                            input: CardImageVerificationSheetParams,
+                        ) = this@Companion.createIntent(context, input)
+
+                        override fun parseResult(
+                            resultCode: Int,
+                            intent: Intent?,
+                        ) = this@Companion.parseResult(requireNotNull(intent))
+                    },
+                    ::onResult,
+                )
+            }
+
+        /**
+         * Create a [CardImageVerificationSheet] instance with [Fragment].
+         *
+         * This API registers an [ActivityResultLauncher] into the [Fragment], it must be called
+         * before the [Fragment] is created (in the onCreate method).
+         */
+        @JvmStatic
+        fun create(from: Fragment, stripePublishableKey: String) =
             CardImageVerificationSheet(stripePublishableKey).apply {
                 launcher = from.registerForActivityResult(
                     object : ActivityResultContract<

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet.kt
@@ -52,23 +52,7 @@ class CardImageVerificationSheet private constructor(private val stripePublishab
         @JvmStatic
         fun create(from: ComponentActivity, stripePublishableKey: String) =
             CardImageVerificationSheet(stripePublishableKey).apply {
-                launcher = from.registerForActivityResult(
-                    object : ActivityResultContract<
-                        CardImageVerificationSheetParams,
-                        CardImageVerificationSheetResult
-                        >() {
-                        override fun createIntent(
-                            context: Context,
-                            input: CardImageVerificationSheetParams,
-                        ) = this@Companion.createIntent(context, input)
-
-                        override fun parseResult(
-                            resultCode: Int,
-                            intent: Intent?,
-                        ) = this@Companion.parseResult(requireNotNull(intent))
-                    },
-                    ::onResult,
-                )
+                launcher = from.registerForActivityResult(activityResultContract, ::onResult)
             }
 
         /**
@@ -80,23 +64,7 @@ class CardImageVerificationSheet private constructor(private val stripePublishab
         @JvmStatic
         fun create(from: Fragment, stripePublishableKey: String) =
             CardImageVerificationSheet(stripePublishableKey).apply {
-                launcher = from.registerForActivityResult(
-                    object : ActivityResultContract<
-                        CardImageVerificationSheetParams,
-                        CardImageVerificationSheetResult
-                        >() {
-                        override fun createIntent(
-                            context: Context,
-                            input: CardImageVerificationSheetParams,
-                        ) = this@Companion.createIntent(context, input)
-
-                        override fun parseResult(
-                            resultCode: Int,
-                            intent: Intent?,
-                        ) = this@Companion.parseResult(requireNotNull(intent))
-                    },
-                    ::onResult,
-                )
+                launcher = from.registerForActivityResult(activityResultContract, ::onResult)
             }
 
         private fun createIntent(context: Context, input: CardImageVerificationSheetParams) =
@@ -108,6 +76,21 @@ class CardImageVerificationSheet private constructor(private val stripePublishab
                 ?: CardImageVerificationSheetResult.Failed(
                     UnknownScanException("No data in the result intent")
                 )
+
+        private val activityResultContract = object : ActivityResultContract<
+            CardImageVerificationSheetParams,
+            CardImageVerificationSheetResult
+            >() {
+            override fun createIntent(
+                context: Context,
+                input: CardImageVerificationSheetParams,
+            ) = this@Companion.createIntent(context, input)
+
+            override fun parseResult(
+                resultCode: Int,
+                intent: Intent?,
+            ) = this@Companion.parseResult(requireNotNull(intent))
+        }
     }
 
     /**

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanSheet.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanSheet.kt
@@ -58,23 +58,7 @@ class CardScanSheet private constructor(private val stripePublishableKey: String
         @JvmStatic
         fun create(from: ComponentActivity, stripePublishableKey: String) =
             CardScanSheet(stripePublishableKey).apply {
-                launcher = from.registerForActivityResult(
-                    object : ActivityResultContract<
-                        CardScanSheetParams,
-                        CardScanSheetResult
-                        >() {
-                        override fun createIntent(
-                            context: Context,
-                            input: CardScanSheetParams,
-                        ) = this@Companion.createIntent(context, input)
-
-                        override fun parseResult(
-                            resultCode: Int,
-                            intent: Intent?,
-                        ) = this@Companion.parseResult(requireNotNull(intent))
-                    },
-                    ::onResult,
-                )
+                launcher = from.registerForActivityResult(activityResultContract, ::onResult)
             }
 
         /**
@@ -86,23 +70,7 @@ class CardScanSheet private constructor(private val stripePublishableKey: String
         @JvmStatic
         fun create(from: Fragment, stripePublishableKey: String) =
             CardScanSheet(stripePublishableKey).apply {
-                launcher = from.registerForActivityResult(
-                    object : ActivityResultContract<
-                        CardScanSheetParams,
-                        CardScanSheetResult
-                        >() {
-                        override fun createIntent(
-                            context: Context,
-                            input: CardScanSheetParams,
-                        ) = this@Companion.createIntent(context, input)
-
-                        override fun parseResult(
-                            resultCode: Int,
-                            intent: Intent?,
-                        ) = this@Companion.parseResult(requireNotNull(intent))
-                    },
-                    ::onResult,
-                )
+                launcher = from.registerForActivityResult(activityResultContract, ::onResult)
             }
 
         private fun createIntent(context: Context, input: CardScanSheetParams) =
@@ -125,6 +93,21 @@ class CardScanSheet private constructor(private val stripePublishableKey: String
                     remove(fragment)
                 }
             }
+        }
+
+        private val activityResultContract = object : ActivityResultContract<
+            CardScanSheetParams,
+            CardScanSheetResult
+            >() {
+            override fun createIntent(
+                context: Context,
+                input: CardScanSheetParams,
+            ) = this@Companion.createIntent(context, input)
+
+            override fun parseResult(
+                resultCode: Int,
+                intent: Intent?,
+            ) = this@Companion.parseResult(requireNotNull(intent))
         }
     }
 

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanSheet.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanSheet.kt
@@ -8,6 +8,7 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.annotation.IdRes
 import androidx.core.os.bundleOf
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.add
 import androidx.fragment.app.commit
@@ -53,11 +54,37 @@ class CardScanSheet private constructor(private val stripePublishableKey: String
          * This API registers an [ActivityResultLauncher] into the
          * [ComponentActivity], it must be called before the [ComponentActivity]
          * is created (in the onCreate method).
-         *
-         * see https://github.com/stripe/stripe-android/blob/3e92b79190834dc3aab1c2d9ac2dfb7bc343afd2/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncher.kt#L52
          */
         @JvmStatic
         fun create(from: ComponentActivity, stripePublishableKey: String) =
+            CardScanSheet(stripePublishableKey).apply {
+                launcher = from.registerForActivityResult(
+                    object : ActivityResultContract<
+                        CardScanSheetParams,
+                        CardScanSheetResult
+                        >() {
+                        override fun createIntent(
+                            context: Context,
+                            input: CardScanSheetParams,
+                        ) = this@Companion.createIntent(context, input)
+
+                        override fun parseResult(
+                            resultCode: Int,
+                            intent: Intent?,
+                        ) = this@Companion.parseResult(requireNotNull(intent))
+                    },
+                    ::onResult,
+                )
+            }
+
+        /**
+         * Create a [CardScanSheet] instance with [Fragment].
+         *
+         * This API registers an [ActivityResultLauncher] into the [Fragment], it must be called
+         * before the [Fragment] is created (in the onCreate method).
+         */
+        @JvmStatic
+        fun create(from: Fragment, stripePublishableKey: String) =
             CardScanSheet(stripePublishableKey).apply {
                 launcher = from.registerForActivityResult(
                     object : ActivityResultContract<


### PR DESCRIPTION
# Summary
Add the ability to launch cardscan and cardimageverification from fragments
Update the readme with an example for cardscan

# Motivation
DoorDash needs to launch CIV from a fragment. Additionally, we needed an example for card scan in the README.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
