### PR TITLE
[Identity] use hit rate to determin a good image

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/states/IdentityScanState.kt
+++ b/identity/src/main/java/com/stripe/android/identity/states/IdentityScanState.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.identity.states
 
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import com.stripe.android.camera.framework.time.Clock
 import com.stripe.android.camera.framework.time.ClockMark
 import com.stripe.android.camera.framework.time.milliseconds
@@ -52,12 +53,6 @@ internal sealed class IdentityScanState(val type: ScanType, isFinal: Boolean) : 
                 )
                 this
             }
-
-        private fun Category.matchesScanType(scanType: ScanType): Boolean {
-            return this == Category.ID_BACK && scanType == ScanType.ID_BACK ||
-                this == Category.ID_FRONT && scanType == ScanType.ID_FRONT ||
-                this == Category.PASSPORT && scanType == ScanType.PASSPORT
-        }
     }
 
     /**
@@ -65,17 +60,44 @@ internal sealed class IdentityScanState(val type: ScanType, isFinal: Boolean) : 
      * while if more image needs to be processed to reach the next state.
      */
     internal class Found(type: ScanType) : IdentityScanState(type, false) {
-        override fun consumeTransition(analyzerOutput: AnalyzerOutput) =
-            when {
+        // number of consecutive hits
+        @VisibleForTesting
+        internal var hitsCount = 0
+
+        // saves the results of previous certain number of frames
+        @VisibleForTesting
+        internal val results = ArrayDeque<Boolean>()
+
+        override fun consumeTransition(analyzerOutput: AnalyzerOutput): IdentityScanState {
+            val isHit = analyzerOutput.category.matchesScanType(type)
+            if (isHit) {
+                hitsCount++
+            }
+            results.addLast(isHit)
+            // only save the last certain number of frames, dropping the first one if it goes beyond
+            // If the first result is a hit, then decrease the hitsCount
+            if (results.size > FRAMES_REQUIRED) {
+                val firstResultIsHit = results.removeFirst()
+                if (firstResultIsHit) {
+                    hitsCount--
+                }
+            }
+
+            return when {
                 isUnsatisfied() -> {
-                    val reason = "unsatisfied reason"
+                    val reason =
+                        "hit ratio below expected: ${hitsCount.toFloat().div(FRAMES_REQUIRED)}"
                     Log.d(
-                        TAG, "Satisfaction check fails due to $reason, transition to Unsatisfied."
+                        TAG,
+                        "Satisfaction check fails due to $reason, transition to Unsatisfied."
                     )
                     Unsatisfied(reason, type)
                 }
                 moreResultsRequired() -> {
-                    Log.d(TAG, "More results needed, stay in Found.")
+                    Log.d(
+                        TAG,
+                        "More results needed, stay in Found, currently ${results.size} results are collected"
+                    )
                     this
                 }
                 else -> {
@@ -83,23 +105,38 @@ internal sealed class IdentityScanState(val type: ScanType, isFinal: Boolean) : 
                     Satisfied(type)
                 }
             }
+        }
 
         /**
          * Determine if more images should be processed before reaching [Satisfied].
          *
-         * TODO(ccen) - Introduce conditions that requires more results
+         * Need to collect [FRAMES_REQUIRED] results.
          */
         private fun moreResultsRequired(): Boolean {
-            return false
+            return results.size < FRAMES_REQUIRED
         }
 
         /**
          * Determine if satisfaction failed and should transition to [Unsatisfied].
          *
-         * TODO(ccen) - Introduce unsatisfied reasons
+         * Transfers to when the previous [FRAMES_REQUIRED] number of frames has a hit ratio
+         * below [HIT_RATIO].
          */
         private fun isUnsatisfied(): Boolean {
-            return false
+            return (results.size == FRAMES_REQUIRED) && (
+                hitsCount.toFloat()
+                    .div(FRAMES_REQUIRED) < HIT_RATIO
+                )
+        }
+
+        @VisibleForTesting
+        internal companion object {
+            // The number of frames needs to collected to determine if a model has found the
+            // correct item.
+            const val FRAMES_REQUIRED = 100
+
+            // The ratio to determine if the model has found the correct item.
+            const val HIT_RATIO = 0.5
         }
     }
 
@@ -130,7 +167,8 @@ internal sealed class IdentityScanState(val type: ScanType, isFinal: Boolean) : 
      * State when satisfaction checking failed.
      */
     internal class Unsatisfied(
-        private val reason: String,
+        @VisibleForTesting
+        internal val reason: String,
         type: ScanType,
         private val reachedStateAt: ClockMark = Clock.markNow()
     ) : IdentityScanState(type, false) {
@@ -160,4 +198,10 @@ internal sealed class IdentityScanState(val type: ScanType, isFinal: Boolean) : 
     private companion object {
         val TAG: String = IdentityScanState::class.java.simpleName
     }
+}
+
+private fun Category.matchesScanType(scanType: IdentityScanState.ScanType): Boolean {
+    return this == Category.ID_BACK && scanType == IdentityScanState.ScanType.ID_BACK ||
+        this == Category.ID_FRONT && scanType == IdentityScanState.ScanType.ID_FRONT ||
+        this == Category.PASSPORT && scanType == IdentityScanState.ScanType.PASSPORT
 }

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/CameraViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/CameraViewModel.kt
@@ -60,15 +60,11 @@ internal class CameraViewModel :
     }
 
     override suspend fun onResult(result: IDDetectorAggregator.FinalResult) {
-        Log.d("BGLM", "Final result received: ${result.result.category} - ${result.result.score}")
-
         Log.d(TAG, "Final result received: $result")
         finalResult.postValue(result)
     }
 
     override suspend fun onInterimResult(result: IDDetectorAggregator.InterimResult) {
-        Log.d("BGLM", "Interim result received: ${result.result.category} - ${result.result.score}")
-
         Log.d(TAG, "Interim result received: $result")
         interimResults.postValue(result)
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
For the previous 100 frames processed, if over 50 of them is the required category(a "hit"), then transitions the state machine from `Found` to `Satisfied`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This would ensure the client has hold the camera still before we collect am image, this somehow ensures the image quality.

This logic is subject to change in the future


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
