### PR TITLE
[Identity] - Make IDScanFragment able to scan both sides

### DIFF
--- a/identity/res/layout/confirmation_fragment.xml
+++ b/identity/res/layout/confirmation_fragment.xml
@@ -8,6 +8,6 @@
     <TextView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:text="Hello" />
+        android:text="Confirmation!" />
 
 </FrameLayout>

--- a/identity/res/layout/id_scan_fragment.xml
+++ b/identity/res/layout/id_scan_fragment.xml
@@ -77,6 +77,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
+        android:enabled="false"
         android:text="@string/kontinue" />
 
 </FrameLayout>

--- a/identity/res/navigation/identity_nav_graph.xml
+++ b/identity/res/navigation/identity_nav_graph.xml
@@ -20,9 +20,11 @@
         tools:layout="@layout/consent_fragment">
         <argument
             android:name="consentContext"
+            android:defaultValue=""
             app:argType="string" />
         <argument
             android:name="merchantLogo"
+            android:defaultValue="0"
             app:argType="integer" />
         <action
             android:id="@+id/action_consentFragment_to_docSelectionFragment"
@@ -34,7 +36,7 @@
         android:label="id_scan_fragment"
         tools:layout="@layout/id_scan_fragment">
         <action
-            android:id="@+id/action_IDScanFragment_to_confirmationFragment2"
+            android:id="@+id/action_IDScanFragment_to_confirmationFragment"
             app:destination="@id/confirmationFragment" />
     </fragment>
     <fragment

--- a/identity/res/values/strings.xml
+++ b/identity/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="passport">Passport</string>
     <string name="doc_select_title">Which form of identification do you want to use?</string>
     <string name="front_of_id">Front of ID</string>
+    <string name="back_of_id">Back of ID</string>
     <string name="position_id_front">Position your ID in the center of the frame</string>
     <string name="position_id_back">Flip your ID over to the other side</string>
     <string name="hold_still">Hold still, scanning</string>
@@ -15,6 +16,5 @@
     <string name="help">Help</string>
     <string name="id_scan_complete">ID scan complete</string>
 
-    <string name="position_id_in_center">Position your id in the center of the frame</string>
     <string name="check_mark">Check mark to indicate document capture success</string>
 </resources>

--- a/identity/src/main/java/com/stripe/android/identity/camera/IdentityScanFlow.kt
+++ b/identity/src/main/java/com/stripe/android/identity/camera/IdentityScanFlow.kt
@@ -28,14 +28,10 @@ import kotlinx.coroutines.launch
  * TODO(ccen): merge with [CardScanFlow].
  */
 internal class IdentityScanFlow(
-    identityScanType: IdentityScanState.ScanType,
     private val analyzerLoopErrorListener: AnalyzerLoopErrorListener,
-    aggregateResultListener: AggregateResultListener<IDDetectorAggregator.InterimResult, IDDetectorAggregator.FinalResult>
-) : ScanFlow<Int, CameraPreviewImage<Bitmap>> {
-    private var aggregator = IDDetectorAggregator(
-        identityScanType,
-        aggregateResultListener
-    )
+    private val aggregateResultListener: AggregateResultListener<IDDetectorAggregator.InterimResult, IDDetectorAggregator.FinalResult>
+) : ScanFlow<IdentityScanState.ScanType, CameraPreviewImage<Bitmap>> {
+    internal var aggregator: IDDetectorAggregator? = null
 
     /**
      * If this is true, do not start the flow.
@@ -73,13 +69,18 @@ internal class IdentityScanFlow(
         viewFinder: Rect,
         lifecycleOwner: LifecycleOwner,
         coroutineScope: CoroutineScope,
-        parameters: Int
+        parameters: IdentityScanState.ScanType
     ) {
         coroutineScope.launch {
             if (canceled) {
                 return@launch
             }
-            aggregator.bindToLifecycle(lifecycleOwner)
+            aggregator = IDDetectorAggregator(
+                parameters,
+                aggregateResultListener
+            )
+
+            requireNotNull(aggregator).bindToLifecycle(lifecycleOwner)
 
             analyzerPool = AnalyzerPool.of(
                 IDDetectorAnalyzer.Factory(context)
@@ -87,7 +88,7 @@ internal class IdentityScanFlow(
 
             loop = ProcessBoundAnalyzerLoop(
                 analyzerPool = requireNotNull(analyzerPool),
-                resultHandler = aggregator,
+                resultHandler = requireNotNull(aggregator),
                 analyzerLoopErrorListener = analyzerLoopErrorListener
             )
 
@@ -100,13 +101,23 @@ internal class IdentityScanFlow(
         }
     }
 
-    override fun cancelFlow() {
-        canceled = true
-        aggregator.run { cancel() }
-        stopFlow()
+    /**
+     * Reset the flow to the initial state, ready to be started again
+     */
+    internal fun resetFlow() {
+        canceled = false
+        cleanUp()
     }
 
-    private fun stopFlow() {
+    override fun cancelFlow() {
+        canceled = true
+        cleanUp()
+    }
+
+    private fun cleanUp() {
+        aggregator?.run { cancel() }
+        aggregator = null
+
         loop?.unsubscribe()
         loop = null
 

--- a/identity/src/main/java/com/stripe/android/identity/camera/IdentityScanFlow.kt
+++ b/identity/src/main/java/com/stripe/android/identity/camera/IdentityScanFlow.kt
@@ -31,7 +31,7 @@ internal class IdentityScanFlow(
     private val analyzerLoopErrorListener: AnalyzerLoopErrorListener,
     private val aggregateResultListener: AggregateResultListener<IDDetectorAggregator.InterimResult, IDDetectorAggregator.FinalResult>
 ) : ScanFlow<IdentityScanState.ScanType, CameraPreviewImage<Bitmap>> {
-    internal var aggregator: IDDetectorAggregator? = null
+    private var aggregator: IDDetectorAggregator? = null
 
     /**
      * If this is true, do not start the flow.

--- a/identity/src/main/java/com/stripe/android/identity/states/IdentityScanState.kt
+++ b/identity/src/main/java/com/stripe/android/identity/states/IdentityScanState.kt
@@ -60,7 +60,6 @@ internal sealed class IdentityScanState(val type: ScanType, isFinal: Boolean) : 
      * while if more image needs to be processed to reach the next state.
      */
     internal class Found(type: ScanType) : IdentityScanState(type, false) {
-        // number of consecutive hits
         @VisibleForTesting
         internal var hitsCount = 0
 

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/CameraViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/CameraViewModel.kt
@@ -26,11 +26,18 @@ internal class CameraViewModel :
 
     internal val interimResults = MutableLiveData<IDDetectorAggregator.InterimResult>()
     internal val finalResult = MutableLiveData<IDDetectorAggregator.FinalResult>()
-    internal val reset = MutableLiveData<Unit>()
+    private val reset = MutableLiveData<Unit>()
     internal val displayStateChanged =
         MutableLiveData<Pair<IdentityScanState, IdentityScanState?>>()
 
-    lateinit var identityScanFlow: IdentityScanFlow
+    /**
+     * The target ScanType of current scan.
+     *
+     * TODO(ccen): Move this to a subclass, make CameraViewModel ScanType agnostic.
+     */
+    internal var targetScanType: IdentityScanState.ScanType? = null
+
+    internal val identityScanFlow = IdentityScanFlow(this, this)
 
     override var scanState: IdentityScanState? = null
 
@@ -40,23 +47,6 @@ internal class CameraViewModel :
 
     override fun displayState(newState: IdentityScanState, previousState: IdentityScanState?) {
         displayStateChanged.postValue(newState to previousState)
-    }
-
-    /**
-     * Initialize [identityScanFlow] with the target scanType.
-     *
-     * TODO(ccen): Extract scanType from [IdentityScanFlow]'s constructor, initialize the scan flow
-     * upon [CameraViewModel]'s initialization, add the ability to update scanType of a
-     * [IdentityScanFlow] on the fly.
-     */
-    fun initializeScanFlow(
-        identityScanType: IdentityScanState.ScanType
-    ) {
-        identityScanFlow = IdentityScanFlow(
-            identityScanType = identityScanType,
-            this,
-            this
-        )
     }
 
     override suspend fun onResult(result: IDDetectorAggregator.FinalResult) {

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IDScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IDScanFragmentTest.kt
@@ -71,7 +71,6 @@ internal class IDScanFragmentTest {
     fun `when created identityScanFlow is initialized and camera permission is requested`() {
         launchIDScanFragment(mockCameraPermissionEnsurable)
 
-        verify(mockCameraViewModel).initializeScanFlow(eq(IdentityScanState.ScanType.ID_FRONT))
         verify(mockCameraPermissionEnsurable).ensureCameraPermission(any(), any())
     }
 
@@ -86,8 +85,81 @@ internal class IDScanFragmentTest {
                 any(),
                 same(it.viewLifecycleOwner),
                 same(it.lifecycleScope),
-                eq(23)
+                eq(IdentityScanState.ScanType.ID_FRONT)
             )
+        }
+    }
+
+    @Test
+    fun `when front is scanned clicking button triggers back scan`() {
+        launchIDScanFragment(testCameraPermissionEnsureable).onFragment {
+            testCameraPermissionEnsureable.onCameraReady()
+            // mock success of front scan
+            finalResultLiveData.postValue(mock())
+
+            // stopScanning() is called
+            verify(mockScanFlow).resetFlow()
+            assertThat(it.cameraAdapter.isBoundToLifecycle()).isFalse()
+
+            // mock viewModel target change
+            whenever(mockCameraViewModel.targetScanType)
+                .thenReturn(IdentityScanState.ScanType.ID_FRONT)
+
+            // button clicked
+            IdScanFragmentBinding.bind(it.requireView()).kontinue.callOnClick()
+
+            // verify start to scan back
+            assertThat(it.cameraAdapter.isBoundToLifecycle()).isTrue()
+            verify(mockScanFlow).startFlow(
+                same(it.requireContext()),
+                any(),
+                any(),
+                same(it.viewLifecycleOwner),
+                same(it.lifecycleScope),
+                eq(IdentityScanState.ScanType.ID_BACK)
+            )
+        }
+    }
+
+    @Test
+    fun `when both sides are scanned clicking button triggers navigation`() {
+        launchIDScanFragment(testCameraPermissionEnsureable).onFragment {
+            val navController = TestNavHostController(
+                ApplicationProvider.getApplicationContext()
+            )
+            navController.setGraph(
+                R.navigation.identity_nav_graph
+            )
+            navController.setCurrentDestination(R.id.IDScanFragment)
+            Navigation.setViewNavController(
+                it.requireView(),
+                navController
+            )
+
+            // scan front
+            testCameraPermissionEnsureable.onCameraReady()
+
+            // mock success of front scan
+            finalResultLiveData.postValue(mock())
+
+            // mock viewModel target change
+            whenever(mockCameraViewModel.targetScanType)
+                .thenReturn(IdentityScanState.ScanType.ID_FRONT)
+
+            // click continue, scan back
+            val binding = IdScanFragmentBinding.bind(it.requireView())
+            binding.kontinue.callOnClick()
+
+            // mock success of back scan
+            finalResultLiveData.postValue(mock())
+
+            // mock viewModel target change
+            whenever(mockCameraViewModel.targetScanType)
+                .thenReturn(IdentityScanState.ScanType.ID_BACK)
+
+            // click continue, navigates
+            binding.kontinue.callOnClick()
+            assertThat(navController.currentDestination?.id).isEqualTo(R.id.confirmationFragment)
         }
     }
 
@@ -98,6 +170,7 @@ internal class IDScanFragmentTest {
                 ApplicationProvider.getApplicationContext()
             )
             navController.setGraph(R.navigation.identity_nav_graph)
+
             Navigation.setViewNavController(
                 it.requireView(),
                 navController
@@ -111,27 +184,50 @@ internal class IDScanFragmentTest {
     }
 
     @Test
-    fun `when final result is received scanFlow is cancelled and cameraAdapter is unbound`() {
+    fun `when final result is received scanFlow is reset and cameraAdapter is unbound`() {
         launchIDScanFragment(testCameraPermissionEnsureable).onFragment {
             testCameraPermissionEnsureable.onCameraReady()
             assertThat(it.cameraAdapter.isBoundToLifecycle()).isTrue()
 
             finalResultLiveData.postValue(mock())
 
-            verify(mockScanFlow).cancelFlow()
+            verify(mockScanFlow).resetFlow()
             assertThat(it.cameraAdapter.isBoundToLifecycle()).isFalse()
         }
     }
 
     @Test
-    fun `when displayStateChanged to Initial UI is properly updated`() {
+    fun `when displayStateChanged to Initial UI is properly updated for ID_FRONT`() {
+        whenever(mockCameraViewModel.targetScanType).thenReturn(IdentityScanState.ScanType.ID_FRONT)
         postDisplayStateChangedDataAndVerifyUI(mock<IdentityScanState.Initial>()) { binding, context ->
             assertThat(binding.cameraView.viewFinderBackgroundView.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.cameraView.viewFinderWindowView.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.cameraView.viewFinderBorderView.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
+            assertThat(binding.kontinue.isEnabled).isFalse()
+            assertThat(binding.headerTitle.text).isEqualTo(
+                context.getText(R.string.front_of_id)
+            )
             assertThat(binding.message.text).isEqualTo(
                 context.getText(R.string.position_id_front)
+            )
+        }
+    }
+
+    @Test
+    fun `when displayStateChanged to Initial UI is properly updated for ID_BACK`() {
+        whenever(mockCameraViewModel.targetScanType).thenReturn(IdentityScanState.ScanType.ID_BACK)
+        postDisplayStateChangedDataAndVerifyUI(mock<IdentityScanState.Initial>()) { binding, context ->
+            assertThat(binding.cameraView.viewFinderBackgroundView.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.cameraView.viewFinderWindowView.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.cameraView.viewFinderBorderView.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
+            assertThat(binding.kontinue.isEnabled).isFalse()
+            assertThat(binding.headerTitle.text).isEqualTo(
+                context.getText(R.string.back_of_id)
+            )
+            assertThat(binding.message.text).isEqualTo(
+                context.getText(R.string.position_id_back)
             )
         }
     }
@@ -143,6 +239,7 @@ internal class IDScanFragmentTest {
             assertThat(binding.cameraView.viewFinderWindowView.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.cameraView.viewFinderBorderView.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
+            assertThat(binding.kontinue.isEnabled).isFalse()
             assertThat(binding.message.text).isEqualTo(
                 context.getText(R.string.hold_still)
             )
@@ -150,14 +247,31 @@ internal class IDScanFragmentTest {
     }
 
     @Test
-    fun `when displayStateChanged to Unsatisfied UI is properly updated`() {
+    fun `when displayStateChanged to Unsatisfied UI is properly updated for ID_FRONT`() {
+        whenever(mockCameraViewModel.targetScanType).thenReturn(IdentityScanState.ScanType.ID_FRONT)
         postDisplayStateChangedDataAndVerifyUI(mock<IdentityScanState.Unsatisfied>()) { binding, context ->
             assertThat(binding.cameraView.viewFinderBackgroundView.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.cameraView.viewFinderWindowView.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.cameraView.viewFinderBorderView.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
+            assertThat(binding.kontinue.isEnabled).isFalse()
             assertThat(binding.message.text).isEqualTo(
-                context.getText(R.string.position_id_in_center)
+                context.getText(R.string.position_id_front)
+            )
+        }
+    }
+
+    @Test
+    fun `when displayStateChanged to Unsatisfied UI is properly updated for ID_BACK`() {
+        whenever(mockCameraViewModel.targetScanType).thenReturn(IdentityScanState.ScanType.ID_BACK)
+        postDisplayStateChangedDataAndVerifyUI(mock<IdentityScanState.Unsatisfied>()) { binding, context ->
+            assertThat(binding.cameraView.viewFinderBackgroundView.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.cameraView.viewFinderWindowView.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.cameraView.viewFinderBorderView.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
+            assertThat(binding.kontinue.isEnabled).isFalse()
+            assertThat(binding.message.text).isEqualTo(
+                context.getText(R.string.position_id_back)
             )
         }
     }
@@ -169,6 +283,7 @@ internal class IDScanFragmentTest {
             assertThat(binding.cameraView.viewFinderWindowView.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.cameraView.viewFinderBorderView.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
+            assertThat(binding.kontinue.isEnabled).isFalse()
             assertThat(binding.message.text).isEqualTo(
                 context.getText(R.string.scanned)
             )
@@ -182,6 +297,7 @@ internal class IDScanFragmentTest {
             assertThat(binding.cameraView.viewFinderWindowView.visibility).isEqualTo(View.INVISIBLE)
             assertThat(binding.cameraView.viewFinderBorderView.visibility).isEqualTo(View.INVISIBLE)
             assertThat(binding.checkMarkView.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.kontinue.isEnabled).isTrue()
             assertThat(binding.message.text).isEqualTo(
                 context.getText(R.string.scanned)
             )
@@ -206,7 +322,6 @@ internal class IDScanFragmentTest {
         launchIDScanFragment(
             mockCameraPermissionEnsurable
         ).onFragment {
-
             displayStateChanged.postValue((newScanState to mock()))
             check(IdScanFragmentBinding.bind(it.requireView()), it.requireContext())
         }

--- a/identity/src/test/java/com/stripe/android/identity/viewmodel/CameraViewModelTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/viewmodel/CameraViewModelTest.kt
@@ -1,18 +1,9 @@
 package com.stripe.android.identity.viewmodel
 
-import com.google.common.truth.Truth.assertThat
-import com.stripe.android.identity.states.IdentityScanState
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class CameraViewModelTest {
-    @Test
-    fun `identityScanFlow is not null after initialization`() {
-        val viewModel = CameraViewModel()
-        viewModel.initializeScanFlow(IdentityScanState.ScanType.ID_FRONT)
-
-        assertThat(viewModel.identityScanFlow).isNotNull()
-    }
+    // TODO(ccen) Add tests when CameraViewModel becomes Identity agnostic
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Introduce a `IdentityScanFlow.resetFlow()` method that doesn't cancel the flow but reset the internal status, so that `startFlow()` could be called again on the same object later
* Create a new `IDDetectorAggregator` when `IdentityScanFlow.start` is called with the parameter `IdentityScanState.ScanType` passed in

The above two change makes it possible to let `CameraViewModel` holds a single instance of `IdentityScanFlow`, and reuse the same instance to perform multiple scans. This change is used to capture both the front and back of the ID int he same Fragment.

Note: `CameraViewModel` will be simplified later to become Identity agnostic, its unit test is left empty intentionally for now

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
IDScanFragment


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
