### PR TITLE
[Identity][simpleUI] extract common camera scan fragment logic to an abstract class

### DIFF
--- a/identity/res/layout/id_scan_fragment.xml
+++ b/identity/res/layout/id_scan_fragment.xml
@@ -33,7 +33,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/page_vertical_margin"
-            android:text="frontID message"
+            android:text="@string/position_id_front"
             app:layout_constraintBottom_toTopOf="@id/camera_view_card"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IDScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IDScanFragment.kt
@@ -2,50 +2,36 @@ package com.stripe.android.identity.navigation
 
 import android.os.Bundle
 import android.util.Log
-import android.util.Size
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.ImageView
 import android.widget.TextView
-import androidx.annotation.VisibleForTesting
 import androidx.core.os.bundleOf
-import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
-import com.stripe.android.camera.Camera1Adapter
 import com.stripe.android.camera.CameraPermissionEnsureable
-import com.stripe.android.camera.DefaultCameraErrorListener
-import com.stripe.android.camera.scanui.CameraView
-import com.stripe.android.camera.scanui.util.asRect
 import com.stripe.android.camera.scanui.util.startAnimation
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.IdScanFragmentBinding
 import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.states.IdentityScanState.ScanType.ID_BACK
 import com.stripe.android.identity.states.IdentityScanState.ScanType.ID_FRONT
-import com.stripe.android.identity.viewmodel.CameraViewModel
 
 /**
  * Fragment to scan the ID.
  */
 internal class IDScanFragment(
-    private val cameraPermissionEnsureable: CameraPermissionEnsureable,
-    private val cameraViewModelFactory: ViewModelProvider.Factory
-) : Fragment() {
-    private val cameraViewModel: CameraViewModel by viewModels { cameraViewModelFactory }
+    cameraPermissionEnsureable: CameraPermissionEnsureable,
+    cameraViewModelFactory: ViewModelProvider.Factory
+) : IdentityCameraScanFragment(cameraPermissionEnsureable, cameraViewModelFactory) {
     private lateinit var binding: IdScanFragmentBinding
     private lateinit var headerTitle: TextView
     private lateinit var messageView: TextView
-    private lateinit var cameraView: CameraView
+
     private lateinit var checkMarkView: ImageView
     private lateinit var continueButton: Button
-
-    @VisibleForTesting
-    internal lateinit var cameraAdapter: Camera1Adapter
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -53,9 +39,9 @@ internal class IDScanFragment(
         savedInstanceState: Bundle?
     ): View {
         binding = IdScanFragmentBinding.inflate(inflater, container, false)
+        cameraView = binding.cameraView
         headerTitle = binding.headerTitle
         messageView = binding.message
-        cameraView = binding.cameraView
         checkMarkView = binding.checkMarkView
         continueButton = binding.kontinue
         return binding.root
@@ -63,7 +49,6 @@ internal class IDScanFragment(
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
         continueButton.setOnClickListener {
             when (cameraViewModel.targetScanType) {
                 ID_FRONT -> {
@@ -78,71 +63,24 @@ internal class IDScanFragment(
                 }
             }
         }
+    }
 
-        cameraViewModel.finalResult.observe(viewLifecycleOwner) {
-            stopScanning()
-        }
+    override fun onCameraReady() {
+        cameraViewModel.targetScanType = ID_FRONT
+        startScanning(ID_FRONT)
+    }
 
-        cameraViewModel.displayStateChanged.observe(viewLifecycleOwner) { (newState, _) ->
-            updateUI(newState)
-        }
-
-        cameraAdapter = Camera1Adapter(
-            requireNotNull(activity),
-            binding.cameraView.previewFrame,
-            MINIMUM_RESOLUTION,
-            DefaultCameraErrorListener(requireNotNull(activity)) { cause ->
-                Log.e(TAG, "scan fails with exception: $cause")
-            }
-        )
-
-        cameraPermissionEnsureable.ensureCameraPermission(
-            onCameraReady = {
-                Log.d(TAG, "Camera permission granted")
-                cameraViewModel.targetScanType = ID_FRONT
-                startScanning(ID_FRONT)
-            },
-
-            onUserDeniedCameraPermission = {
-                Log.d(TAG, "Camera permission denied")
-                findNavController().navigate(
-                    R.id.action_camera_permission_denied,
-                    bundleOf(
-                        CameraPermissionDeniedFragment.ARG_SCAN_TYPE to ID_FRONT
-                    )
-                )
-            }
+    override fun onUserDeniedCameraPermission() {
+        findNavController().navigate(
+            R.id.action_camera_permission_denied,
+            bundleOf(
+                CameraPermissionDeniedFragment.ARG_SCAN_TYPE to IdentityScanState.ScanType.ID_FRONT
+            )
         )
     }
 
-    /**
-     * Start scanning for the required scan type.
-     */
-    private fun startScanning(scanType: IdentityScanState.ScanType) {
-        cameraAdapter.bindToLifecycle(this)
-        // TODO(ccen): pack this logic into a IdentitySpecific CameraViewModel
-        cameraViewModel.scanState = null
-        cameraViewModel.scanStatePrevious = null
-        cameraViewModel.identityScanFlow.startFlow(
-            context = requireContext(),
-            imageStream = cameraAdapter.getImageStream(),
-            viewFinder = binding.cameraView.viewFinderWindowView.asRect(),
-            lifecycleOwner = viewLifecycleOwner,
-            coroutineScope = lifecycleScope,
-            parameters = scanType
-        )
-    }
-
-    /**
-     * Stop scanning, may start again later.
-     */
-    private fun stopScanning() {
-        cameraViewModel.identityScanFlow.resetFlow()
-        cameraAdapter.unbindFromLifecycle(this)
-    }
-
-    private fun updateUI(identityState: IdentityScanState) {
-        when (identityState) {
+    override fun updateUI(identityScanState: IdentityScanState) {
+        when (identityScanState) {
             is IdentityScanState.Initial -> {
                 cameraView.viewFinderBackgroundView.visibility = View.VISIBLE
                 cameraView.viewFinderWindowView.visibility = View.VISIBLE
@@ -165,7 +103,6 @@ internal class IDScanFragment(
                         )
                     }
                 }
-
                 cameraView.viewFinderWindowView.setBackgroundResource(R.drawable.id_viewfinder_background)
                 cameraView.viewFinderBorderView.startAnimation(R.drawable.id_border_initial)
             }
@@ -209,14 +146,7 @@ internal class IDScanFragment(
         }
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
-        Log.d(TAG, "Cancelling IdentityScanFlow")
-        cameraViewModel.identityScanFlow.cancelFlow()
-    }
-
     private companion object {
         val TAG: String = IDScanFragment::class.java.simpleName
-        val MINIMUM_RESOLUTION = Size(1067, 600) // TODO: decide what to use
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IDScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IDScanFragment.kt
@@ -74,7 +74,7 @@ internal class IDScanFragment(
         findNavController().navigate(
             R.id.action_camera_permission_denied,
             bundleOf(
-                CameraPermissionDeniedFragment.ARG_SCAN_TYPE to IdentityScanState.ScanType.ID_FRONT
+                CameraPermissionDeniedFragment.ARG_SCAN_TYPE to ID_FRONT
             )
         )
     }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
@@ -1,0 +1,119 @@
+package com.stripe.android.identity.navigation
+
+import android.os.Bundle
+import android.util.Log
+import android.util.Size
+import android.view.View
+import androidx.annotation.VisibleForTesting
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
+import com.stripe.android.camera.Camera1Adapter
+import com.stripe.android.camera.CameraPermissionEnsureable
+import com.stripe.android.camera.DefaultCameraErrorListener
+import com.stripe.android.camera.scanui.CameraView
+import com.stripe.android.camera.scanui.util.asRect
+import com.stripe.android.identity.states.IdentityScanState
+import com.stripe.android.identity.viewmodel.CameraViewModel
+
+/**
+ * An abstract [Fragment] class to access camera scanning for Identity.
+ *
+ * Subclasses are responsible for populating [cameraView] in its [Fragment.onCreateView] method.
+ *
+ * When the fragment's view is created, [cameraPermissionEnsureable] is used to check camera
+ * permission. Subclasses are responsible for implementing [onCameraReady] and
+ * [onUserDeniedCameraPermission] to handle the permission callbacks.
+ *
+ */
+internal abstract class IdentityCameraScanFragment(
+    private val cameraPermissionEnsureable: CameraPermissionEnsureable,
+    private val cameraViewModelFactory: ViewModelProvider.Factory
+) : Fragment() {
+    protected val cameraViewModel: CameraViewModel by viewModels { cameraViewModelFactory }
+
+    @VisibleForTesting
+    internal lateinit var cameraAdapter: Camera1Adapter
+
+    /**
+     * [CameraView] to initialize [Camera1Adapter], subclasses needs to set its value in
+     * [Fragment.onCreateView].
+     */
+    protected lateinit var cameraView: CameraView
+
+    /**
+     * Called back once after at end of [onViewCreated] when permission is granted.
+     */
+    protected abstract fun onCameraReady()
+
+    /**
+     * Called back once after at end of [onViewCreated] when permission is denied.
+     */
+    protected abstract fun onUserDeniedCameraPermission()
+
+    /**
+     * Called back each time when [CameraViewModel.displayStateChanged] is changed.
+     */
+    protected abstract fun updateUI(identityScanState: IdentityScanState)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        cameraViewModel.displayStateChanged.observe(viewLifecycleOwner) { (newState, _) ->
+            updateUI(newState)
+        }
+        cameraViewModel.finalResult.observe(viewLifecycleOwner) {
+            stopScanning()
+        }
+        cameraAdapter = Camera1Adapter(
+            requireNotNull(activity),
+            cameraView.previewFrame,
+            MINIMUM_RESOLUTION,
+            DefaultCameraErrorListener(requireNotNull(activity)) { cause ->
+                Log.e(TAG, "scan fails with exception: $cause")
+            }
+        )
+
+        cameraPermissionEnsureable.ensureCameraPermission(
+            ::onCameraReady,
+            ::onUserDeniedCameraPermission
+        )
+    }
+
+    /**
+     * Start scanning for the required scan type.
+     */
+    protected fun startScanning(scanType: IdentityScanState.ScanType) {
+        cameraAdapter.bindToLifecycle(this)
+        // TODO(ccen): pack this logic into a IdentitySpecific CameraViewModel
+        cameraViewModel.scanState = null
+        cameraViewModel.scanStatePrevious = null
+        cameraViewModel.identityScanFlow.startFlow(
+            context = requireContext(),
+            imageStream = cameraAdapter.getImageStream(),
+            viewFinder = cameraView.viewFinderWindowView.asRect(),
+            lifecycleOwner = viewLifecycleOwner,
+            coroutineScope = lifecycleScope,
+            parameters = scanType
+        )
+    }
+
+    /**
+     * Stop scanning, may start again later.
+     */
+    private fun stopScanning() {
+        cameraViewModel.identityScanFlow.resetFlow()
+        cameraAdapter.unbindFromLifecycle(this)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        Log.d(TAG, "Cancelling IdentityScanFlow")
+        cameraViewModel.identityScanFlow.cancelFlow()
+    }
+
+    private companion object {
+        val TAG: String = IdentityCameraScanFragment::class.java.simpleName
+        val MINIMUM_RESOLUTION = Size(1067, 600) // TODO: decide what to use
+    }
+}

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IDScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IDScanFragmentTest.kt
@@ -68,7 +68,7 @@ internal class IDScanFragmentTest {
     }
 
     @Test
-    fun `when created identityScanFlow is initialized and camera permission is requested`() {
+    fun `when created camera permission is requested`() {
         launchIDScanFragment(mockCameraPermissionEnsurable)
 
         verify(mockCameraPermissionEnsurable).ensureCameraPermission(any(), any())

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IdentityCameraScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IdentityCameraScanFragmentTest.kt
@@ -1,0 +1,152 @@
+package com.stripe.android.identity.navigation
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.camera.CameraPermissionEnsureable
+import com.stripe.android.camera.scanui.CameraView
+import com.stripe.android.identity.R
+import com.stripe.android.identity.camera.IDDetectorAggregator
+import com.stripe.android.identity.camera.IdentityScanFlow
+import com.stripe.android.identity.states.IdentityScanState
+import com.stripe.android.identity.viewmodel.CameraViewModel
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class IdentityCameraScanFragmentTest {
+    @get:Rule
+    var rule: TestRule = InstantTaskExecutorRule()
+
+    private val mockPreviewFrame = mock<FrameLayout>()
+    private val mockCameraView = mock<CameraView>().also {
+        whenever(it.previewFrame).thenReturn(mockPreviewFrame)
+    }
+
+    private val finalResultLiveData = MutableLiveData<IDDetectorAggregator.FinalResult>()
+    private val displayStateChanged = MutableLiveData<Pair<IdentityScanState, IdentityScanState?>>()
+    private val mockScanFlow = mock<IdentityScanFlow>()
+    private val mockCameraViewModel = mock<CameraViewModel>().also {
+        whenever(it.identityScanFlow).thenReturn(mockScanFlow)
+        whenever(it.finalResult).thenReturn(finalResultLiveData)
+        whenever(it.displayStateChanged).thenReturn(displayStateChanged)
+    }
+
+    private val testCameraPermissionEnsureable = object : CameraPermissionEnsureable {
+        lateinit var onCameraReady: () -> Unit
+        lateinit var onUserDeniedCameraPermission: () -> Unit
+
+        override fun ensureCameraPermission(
+            onCameraReady: () -> Unit,
+            onUserDeniedCameraPermission: () -> Unit
+        ) {
+            this.onCameraReady = onCameraReady
+            this.onUserDeniedCameraPermission = onUserDeniedCameraPermission
+        }
+    }
+    private val cameraViewModelFactory = object : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return mockCameraViewModel as T
+        }
+    }
+
+    internal class TestFragment(
+        cameraPermissionEnsureable: CameraPermissionEnsureable,
+        cameraViewModelFactory: ViewModelProvider.Factory,
+        private val cameraViewParam: CameraView
+    ) : IdentityCameraScanFragment(
+        cameraPermissionEnsureable, cameraViewModelFactory
+    ) {
+        var onCameraReadyCalled = false
+        var onUserDeniedCameraPermissionCalled = false
+        var currentState: IdentityScanState? = null
+
+        override fun onCreateView(
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?
+        ): View {
+            cameraView = cameraViewParam
+            return View(context)
+        }
+
+        override fun onCameraReady() {
+            onCameraReadyCalled = true
+        }
+
+        override fun onUserDeniedCameraPermission() {
+            onUserDeniedCameraPermissionCalled = true
+        }
+
+        override fun updateUI(identityScanState: IdentityScanState) {
+            currentState = identityScanState
+        }
+    }
+
+    @Test
+    fun `when camera permission granted onCameraReady is called`() {
+        launchIDScanFragment(testCameraPermissionEnsureable).onFragment {
+            testCameraPermissionEnsureable.onCameraReady()
+
+            assertThat(it.cameraAdapter).isNotNull()
+            assertThat(it.onCameraReadyCalled).isTrue()
+        }
+    }
+
+    @Test
+    fun `when camera permission denied onUserDeniedCameraPermissionCalled is called`() {
+        launchIDScanFragment(testCameraPermissionEnsureable).onFragment {
+            testCameraPermissionEnsureable.onUserDeniedCameraPermission()
+
+            assertThat(it.cameraAdapter).isNotNull()
+            assertThat(it.onUserDeniedCameraPermissionCalled).isTrue()
+        }
+    }
+
+    @Test
+    fun `when displayStateChanged updateUI is called`() {
+        launchIDScanFragment(testCameraPermissionEnsureable).onFragment {
+            val newState = mock<IdentityScanState.Initial>()
+            displayStateChanged.postValue((newState to mock()))
+
+            assertThat(it.currentState).isEqualTo(newState)
+        }
+    }
+
+    @Test
+    fun `when finalResult is posted scan is stopped`() {
+        launchIDScanFragment(testCameraPermissionEnsureable).onFragment {
+            finalResultLiveData.postValue(mock())
+
+            verify(mockScanFlow).resetFlow()
+            assertThat(it.cameraAdapter.isBoundToLifecycle()).isFalse()
+        }
+    }
+
+    private fun launchIDScanFragment(
+        cameraPermissionEnsureable: CameraPermissionEnsureable
+    ) = launchFragmentInContainer(
+        themeResId = R.style.Theme_MaterialComponents
+    ) {
+        TestFragment(
+            cameraPermissionEnsureable,
+            cameraViewModelFactory,
+            mockCameraView
+        )
+    }
+}

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IdentityCameraScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IdentityCameraScanFragmentTest.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -136,6 +137,12 @@ class IdentityCameraScanFragmentTest {
             verify(mockScanFlow).resetFlow()
             assertThat(it.cameraAdapter.isBoundToLifecycle()).isFalse()
         }
+    }
+
+    @Test
+    fun `when destroyed scanFlow is cancelled`() {
+        launchIDScanFragment(testCameraPermissionEnsureable).moveToState(Lifecycle.State.DESTROYED)
+        verify(mockScanFlow).cancelFlow()
     }
 
     private fun launchIDScanFragment(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Extract the camera logic to `IdentityCameraScanFragment`, so we can use them to build fragments scanning other documents

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
