### PR TITLE
[Identity][simpleUI] Add fragment for DriverLicenseScanFragment

### DIFF
--- a/identity/api/identity.api
+++ b/identity/api/identity.api
@@ -113,6 +113,12 @@ public final class com/stripe/android/identity/databinding/DocSelectionFragmentB
 }
 
 public final class com/stripe/android/identity/databinding/DriverLicenseScanFragmentBinding : androidx/viewbinding/ViewBinding {
+	public final field cameraView Lcom/stripe/android/camera/scanui/CameraView;
+	public final field cameraViewCard Lcom/google/android/material/card/MaterialCardView;
+	public final field checkMarkView Landroid/widget/ImageView;
+	public final field headerTitle Landroid/widget/TextView;
+	public final field kontinue Landroid/widget/Button;
+	public final field message Landroid/widget/TextView;
 	public static fun bind (Landroid/view/View;)Lcom/stripe/android/identity/databinding/DriverLicenseScanFragmentBinding;
 	public synthetic fun getRoot ()Landroid/view/View;
 	public fun getRoot ()Landroid/widget/FrameLayout;
@@ -197,17 +203,6 @@ public final class com/stripe/android/identity/navigation/ConfirmationFragment$C
 	public final fun newInstance ()Lcom/stripe/android/identity/navigation/ConfirmationFragment;
 }
 
-public final class com/stripe/android/identity/navigation/DriverLicenseScanFragment : androidx/fragment/app/Fragment {
-	public static final field Companion Lcom/stripe/android/identity/navigation/DriverLicenseScanFragment$Companion;
-	public fun <init> ()V
-	public fun onActivityCreated (Landroid/os/Bundle;)V
-	public fun onCreateView (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Landroid/os/Bundle;)Landroid/view/View;
-}
-
-public final class com/stripe/android/identity/navigation/DriverLicenseScanFragment$Companion {
-	public final fun newInstance ()Lcom/stripe/android/identity/navigation/DriverLicenseScanFragment;
-}
-
 public final class com/stripe/android/identity/navigation/DriverLicenseUploadFragment : androidx/fragment/app/Fragment {
 	public static final field Companion Lcom/stripe/android/identity/navigation/DriverLicenseUploadFragment$Companion;
 	public fun <init> ()V
@@ -261,10 +256,6 @@ public final class com/stripe/android/identity/viewmodel/CameraPermissionDeniedV
 }
 
 public final class com/stripe/android/identity/viewmodel/ConfirmationViewModel : androidx/lifecycle/ViewModel {
-	public fun <init> ()V
-}
-
-public final class com/stripe/android/identity/viewmodel/DriverLicenseScanViewModel : androidx/lifecycle/ViewModel {
 	public fun <init> ()V
 }
 

--- a/identity/res/layout/driver_license_scan_fragment.xml
+++ b/identity/res/layout/driver_license_scan_fragment.xml
@@ -1,13 +1,83 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".navigation.DriverLicenseScanFragment">
 
-    <TextView
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_marginStart="@dimen/page_horizontal_margin"
+    android:layout_marginEnd="@dimen/page_horizontal_margin"
+    android:layout_marginTop="@dimen/page_vertical_margin"
+    android:layout_marginBottom="@dimen/page_vertical_margin"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_margin="5dp"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:text="Driver license scan" />
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/header_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textStyle="bold"
+            android:text="@string/front_of_dl"
+            android:textSize="@dimen/scan_title_text_size"
+            android:layout_marginBottom="20dp"
+            app:layout_constraintBottom_toTopOf="@id/message"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/message"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/page_vertical_margin"
+            android:text="@string/position_dl_front"
+            app:layout_constraintBottom_toTopOf="@id/camera_view_card"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/header_title" />
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/camera_view_card"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:cardCornerRadius="@dimen/view_finder_corner_radius"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintDimensionRatio="3:2"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/message">
+
+            <com.stripe.android.camera.scanui.CameraView
+                android:id="@+id/camera_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:borderDrawable="@drawable/id_border_initial"
+                app:viewFinderType="id" />
+
+            <ImageView
+                android:id="@+id/check_mark_view"
+                android:padding="60dp"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:src="@drawable/check_mark"
+                android:visibility="gone"
+                android:background="@color/check_mark_background"
+                android:contentDescription="@string/check_mark"
+                app:tint="?android:colorPrimary" />
+
+        </com.google.android.material.card.MaterialCardView>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+    <Button
+        android:id="@+id/kontinue"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:enabled="false"
+        android:text="@string/kontinue" />
 
 </FrameLayout>

--- a/identity/res/values/strings.xml
+++ b/identity/res/values/strings.xml
@@ -11,6 +11,10 @@
     <string name="back_of_id">Back of ID</string>
     <string name="position_id_front">Position your ID in the center of the frame</string>
     <string name="position_id_back">Flip your ID over to the other side</string>
+    <string name="front_of_dl">Front of driver license</string>
+    <string name="back_of_dl">Back of driver license</string>
+    <string name="position_dl_front">Position your driver license in the center of the frame</string>
+    <string name="position_dl_back">Flip your driver license over to the other side</string>
     <string name="hold_still">Hold still, scanning</string>
     <string name="scanned">Scanned</string>
     <string name="help">Help</string>

--- a/identity/src/main/java/com/stripe/android/identity/navigation/DriverLicenseScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/DriverLicenseScanFragment.kt
@@ -1,33 +1,152 @@
 package com.stripe.android.identity.navigation
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
+import android.widget.Button
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.core.os.bundleOf
 import androidx.lifecycle.ViewModelProvider
+import androidx.navigation.fragment.findNavController
+import com.stripe.android.camera.CameraPermissionEnsureable
+import com.stripe.android.camera.scanui.util.startAnimation
 import com.stripe.android.identity.R
-import com.stripe.android.identity.viewmodel.DriverLicenseScanViewModel
+import com.stripe.android.identity.databinding.DriverLicenseScanFragmentBinding
+import com.stripe.android.identity.states.IdentityScanState
 
-class DriverLicenseScanFragment : Fragment() {
-
-    companion object {
-        fun newInstance() = DriverLicenseScanFragment()
-    }
-
-    private lateinit var viewModel: DriverLicenseScanViewModel
+/**
+ * Fragment to scan the Driver's license.
+ */
+internal class DriverLicenseScanFragment(
+    cameraPermissionEnsureable: CameraPermissionEnsureable,
+    cameraViewModelFactory: ViewModelProvider.Factory
+) : IdentityCameraScanFragment(cameraPermissionEnsureable, cameraViewModelFactory) {
+    private lateinit var binding: DriverLicenseScanFragmentBinding
+    private lateinit var headerTitle: TextView
+    private lateinit var messageView: TextView
+    private lateinit var checkMarkView: ImageView
+    private lateinit var continueButton: Button
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        return inflater.inflate(R.layout.driver_license_scan_fragment, container, false)
+    ): View {
+        binding = DriverLicenseScanFragmentBinding.inflate(inflater, container, false)
+        cameraView = binding.cameraView
+
+        headerTitle = binding.headerTitle
+        messageView = binding.message
+        checkMarkView = binding.checkMarkView
+        continueButton = binding.kontinue
+        return binding.root
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-        viewModel = ViewModelProvider(this).get(DriverLicenseScanViewModel::class.java)
-        // TODO: Use the ViewModel
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        continueButton.setOnClickListener {
+            when (cameraViewModel.targetScanType) {
+                IdentityScanState.ScanType.ID_FRONT -> {
+                    startScanning(IdentityScanState.ScanType.ID_BACK)
+                    cameraViewModel.targetScanType = IdentityScanState.ScanType.ID_BACK
+                }
+                IdentityScanState.ScanType.ID_BACK -> {
+                    findNavController().navigate(R.id.action_driverLicenseScanFragment_to_confirmationFragment)
+                }
+                else -> {
+                    Log.e(TAG, "Incorrect target scan type: ${cameraViewModel.targetScanType}")
+                }
+            }
+        }
+    }
+
+    override fun onCameraReady() {
+        cameraViewModel.targetScanType = IdentityScanState.ScanType.ID_FRONT
+        startScanning(IdentityScanState.ScanType.ID_FRONT)
+    }
+
+    override fun onUserDeniedCameraPermission() {
+        findNavController().navigate(
+            R.id.action_camera_permission_denied,
+            bundleOf(
+                CameraPermissionDeniedFragment.ARG_SCAN_TYPE to IdentityScanState.ScanType.ID_FRONT
+            )
+        )
+    }
+
+    override fun updateUI(identityScanState: IdentityScanState) {
+        when (identityScanState) {
+            is IdentityScanState.Initial -> {
+                cameraView.viewFinderBackgroundView.visibility = View.VISIBLE
+                cameraView.viewFinderWindowView.visibility = View.VISIBLE
+                cameraView.viewFinderBorderView.visibility = View.VISIBLE
+                continueButton.isEnabled = false
+                checkMarkView.visibility = View.GONE
+                when (cameraViewModel.targetScanType) {
+                    IdentityScanState.ScanType.ID_FRONT -> {
+                        headerTitle.text = requireContext().getText(R.string.front_of_dl)
+                        messageView.text = requireContext().getText(R.string.position_dl_front)
+                    }
+                    IdentityScanState.ScanType.ID_BACK -> {
+                        headerTitle.text = requireContext().getText(R.string.back_of_dl)
+                        messageView.text = requireContext().getText(R.string.position_dl_back)
+                    }
+                    else -> {
+                        Log.e(
+                            TAG,
+                            "Incorrect target scan type: ${cameraViewModel.targetScanType}"
+                        )
+                    }
+                }
+
+                cameraView.viewFinderWindowView.setBackgroundResource(R.drawable.id_viewfinder_background)
+                cameraView.viewFinderBorderView.startAnimation(R.drawable.id_border_initial)
+            }
+            is IdentityScanState.Found -> {
+                messageView.text = requireContext().getText(R.string.hold_still)
+                cameraView.viewFinderWindowView.setBackgroundResource(R.drawable.id_viewfinder_background)
+                cameraView.viewFinderBorderView.startAnimation(R.drawable.id_border_found)
+            }
+            is IdentityScanState.Unsatisfied -> {
+                when (cameraViewModel.targetScanType) {
+                    IdentityScanState.ScanType.ID_FRONT -> {
+                        messageView.text = requireContext().getText(R.string.position_dl_front)
+                    }
+                    IdentityScanState.ScanType.ID_BACK -> {
+                        messageView.text = requireContext().getText(R.string.position_dl_back)
+                    }
+                    else -> {
+                        Log.e(
+                            TAG,
+                            "Incorrect target scan type: ${cameraViewModel.targetScanType}"
+                        )
+                    }
+                }
+                cameraView.viewFinderWindowView.setBackgroundResource(R.drawable.id_viewfinder_background)
+                cameraView.viewFinderBorderView.startAnimation(R.drawable.id_border_unsatisfied)
+            }
+            is IdentityScanState.Satisfied -> {
+                messageView.text = requireContext().getText(R.string.scanned)
+                cameraView.viewFinderWindowView.setBackgroundResource(R.drawable.id_viewfinder_background)
+                cameraView.viewFinderBorderView.startAnimation(R.drawable.id_border_satisfied)
+            }
+            is IdentityScanState.Finished -> {
+                cameraView.viewFinderBackgroundView.visibility = View.INVISIBLE
+                cameraView.viewFinderWindowView.visibility = View.INVISIBLE
+                cameraView.viewFinderBorderView.visibility = View.INVISIBLE
+                checkMarkView.visibility = View.VISIBLE
+                continueButton.isEnabled = true
+
+                messageView.text = requireContext().getText(R.string.scanned)
+            }
+        }
+    }
+
+    private companion object {
+        val TAG: String = DriverLicenseScanFragment::class.java.simpleName
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
@@ -11,11 +11,17 @@ import com.stripe.android.identity.viewmodel.CameraViewModel
 internal class IdentityFragmentFactory(
     private val cameraPermissionEnsureable: CameraPermissionEnsureable
 ) : FragmentFactory() {
+    private val cameraViewModelFactory = CameraViewModel.CameraViewModelFactory()
+
     override fun instantiate(classLoader: ClassLoader, className: String): Fragment {
         return when (className) {
             IDScanFragment::class.java.name -> IDScanFragment(
                 cameraPermissionEnsureable,
-                CameraViewModel.CameraViewModelFactory()
+                cameraViewModelFactory
+            )
+            DriverLicenseScanFragment::class.java.name -> DriverLicenseScanFragment(
+                cameraPermissionEnsureable,
+                cameraViewModelFactory
             )
             else -> super.instantiate(classLoader, className)
         }

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/DriverLicenseScanViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/DriverLicenseScanViewModel.kt
@@ -1,7 +1,0 @@
-package com.stripe.android.identity.viewmodel
-
-import androidx.lifecycle.ViewModel
-
-class DriverLicenseScanViewModel : ViewModel() {
-    // TODO: Implement the ViewModel
-}

--- a/identity/src/test/java/com/stripe/android/identity/navigation/DriverLicenseScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/DriverLicenseScanFragmentTest.kt
@@ -1,0 +1,352 @@
+package com.stripe.android.identity.navigation
+
+import android.content.Context
+import android.view.View
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.Navigation
+import androidx.navigation.testing.TestNavHostController
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth
+import com.stripe.android.camera.CameraPermissionEnsureable
+import com.stripe.android.identity.R
+import com.stripe.android.identity.camera.IDDetectorAggregator
+import com.stripe.android.identity.camera.IdentityScanFlow
+import com.stripe.android.identity.databinding.DriverLicenseScanFragmentBinding
+import com.stripe.android.identity.states.IdentityScanState
+import com.stripe.android.identity.viewmodel.CameraViewModel
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.same
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class DriverLicenseScanFragmentTest {
+    // Ensure livedata works properly
+    @get:Rule
+    var rule: TestRule = InstantTaskExecutorRule()
+
+    private val finalResultLiveData = MutableLiveData<IDDetectorAggregator.FinalResult>()
+    private val displayStateChanged = MutableLiveData<Pair<IdentityScanState, IdentityScanState?>>()
+    private val mockScanFlow = mock<IdentityScanFlow>()
+    private val mockCameraPermissionEnsurable = mock<CameraPermissionEnsureable>()
+    private val mockCameraViewModel = mock<CameraViewModel>().also {
+        whenever(it.identityScanFlow).thenReturn(mockScanFlow)
+        whenever(it.finalResult).thenReturn(finalResultLiveData)
+        whenever(it.displayStateChanged).thenReturn(displayStateChanged)
+    }
+
+    private val testCameraPermissionEnsureable = object : CameraPermissionEnsureable {
+        lateinit var onCameraReady: () -> Unit
+        lateinit var onUserDeniedCameraPermission: () -> Unit
+
+        override fun ensureCameraPermission(
+            onCameraReady: () -> Unit,
+            onUserDeniedCameraPermission: () -> Unit
+        ) {
+            this.onCameraReady = onCameraReady
+            this.onUserDeniedCameraPermission = onUserDeniedCameraPermission
+        }
+    }
+
+    private val cameraViewModelFactory = object : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return mockCameraViewModel as T
+        }
+    }
+
+    @Test
+    fun `when created camera permission is requested`() {
+        launchDriverLicenseFragment(mockCameraPermissionEnsurable)
+
+        verify(mockCameraPermissionEnsurable).ensureCameraPermission(any(), any())
+    }
+
+    @Test
+    fun `when camera permission granted cameraAdapter is bound and identityScanFlow is started`() {
+        launchDriverLicenseFragment(testCameraPermissionEnsureable).onFragment {
+            testCameraPermissionEnsureable.onCameraReady()
+            Truth.assertThat(it.cameraAdapter.isBoundToLifecycle()).isTrue()
+            verify(mockScanFlow).startFlow(
+                same(it.requireContext()),
+                any(),
+                any(),
+                same(it.viewLifecycleOwner),
+                same(it.lifecycleScope),
+                eq(IdentityScanState.ScanType.ID_FRONT)
+            )
+        }
+    }
+
+    @Test
+    fun `when front is scanned clicking button triggers back scan`() {
+        launchDriverLicenseFragment(testCameraPermissionEnsureable).onFragment {
+            testCameraPermissionEnsureable.onCameraReady()
+            // mock success of front scan
+            finalResultLiveData.postValue(mock())
+
+            // stopScanning() is called
+            verify(mockScanFlow).resetFlow()
+            Truth.assertThat(it.cameraAdapter.isBoundToLifecycle()).isFalse()
+
+            // mock viewModel target change
+            whenever(mockCameraViewModel.targetScanType)
+                .thenReturn(IdentityScanState.ScanType.ID_FRONT)
+
+            // button clicked
+            DriverLicenseScanFragmentBinding.bind(it.requireView()).kontinue.callOnClick()
+
+            // verify start to scan back
+            Truth.assertThat(it.cameraAdapter.isBoundToLifecycle()).isTrue()
+            verify(mockScanFlow).startFlow(
+                same(it.requireContext()),
+                any(),
+                any(),
+                same(it.viewLifecycleOwner),
+                same(it.lifecycleScope),
+                eq(IdentityScanState.ScanType.ID_BACK)
+            )
+        }
+    }
+
+    @Test
+    fun `when both sides are scanned clicking button triggers navigation`() {
+        launchDriverLicenseFragment(testCameraPermissionEnsureable).onFragment {
+            val navController = TestNavHostController(
+                ApplicationProvider.getApplicationContext()
+            )
+            navController.setGraph(
+                R.navigation.identity_nav_graph
+            )
+            navController.setCurrentDestination(R.id.driverLicenseScanFragment)
+            Navigation.setViewNavController(
+                it.requireView(),
+                navController
+            )
+
+            // scan front
+            testCameraPermissionEnsureable.onCameraReady()
+
+            // mock success of front scan
+            finalResultLiveData.postValue(mock())
+
+            // mock viewModel target change
+            whenever(mockCameraViewModel.targetScanType)
+                .thenReturn(IdentityScanState.ScanType.ID_FRONT)
+
+            // click continue, scan back
+            val binding = DriverLicenseScanFragmentBinding.bind(it.requireView())
+            binding.kontinue.callOnClick()
+
+            // mock success of back scan
+            finalResultLiveData.postValue(mock())
+
+            // mock viewModel target change
+            whenever(mockCameraViewModel.targetScanType)
+                .thenReturn(IdentityScanState.ScanType.ID_BACK)
+
+            // click continue, navigates
+            binding.kontinue.callOnClick()
+            Truth.assertThat(navController.currentDestination?.id)
+                .isEqualTo(R.id.confirmationFragment)
+        }
+    }
+
+    @Test
+    fun `when camera permission denied navigates to permission denied`() {
+        launchDriverLicenseFragment(testCameraPermissionEnsureable).onFragment {
+            val navController = TestNavHostController(
+                ApplicationProvider.getApplicationContext()
+            )
+            navController.setGraph(R.navigation.identity_nav_graph)
+
+            Navigation.setViewNavController(
+                it.requireView(),
+                navController
+            )
+
+            testCameraPermissionEnsureable.onUserDeniedCameraPermission()
+
+            Truth.assertThat(it.cameraAdapter.isBoundToLifecycle()).isFalse()
+            Truth.assertThat(navController.currentDestination?.id)
+                .isEqualTo(R.id.cameraPermissionDeniedFragment)
+        }
+    }
+
+    @Test
+    fun `when final result is received scanFlow is reset and cameraAdapter is unbound`() {
+        launchDriverLicenseFragment(testCameraPermissionEnsureable).onFragment {
+            testCameraPermissionEnsureable.onCameraReady()
+            Truth.assertThat(it.cameraAdapter.isBoundToLifecycle()).isTrue()
+
+            finalResultLiveData.postValue(mock())
+
+            verify(mockScanFlow).resetFlow()
+            Truth.assertThat(it.cameraAdapter.isBoundToLifecycle()).isFalse()
+        }
+    }
+
+    @Test
+    fun `when displayStateChanged to Initial UI is properly updated for ID_FRONT`() {
+        whenever(mockCameraViewModel.targetScanType).thenReturn(IdentityScanState.ScanType.ID_FRONT)
+        postDisplayStateChangedDataAndVerifyUI(mock<IdentityScanState.Initial>()) { binding, context ->
+            Truth.assertThat(binding.cameraView.viewFinderBackgroundView.visibility)
+                .isEqualTo(View.VISIBLE)
+            Truth.assertThat(binding.cameraView.viewFinderWindowView.visibility)
+                .isEqualTo(View.VISIBLE)
+            Truth.assertThat(binding.cameraView.viewFinderBorderView.visibility)
+                .isEqualTo(View.VISIBLE)
+            Truth.assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
+            Truth.assertThat(binding.kontinue.isEnabled).isFalse()
+            Truth.assertThat(binding.headerTitle.text).isEqualTo(
+                context.getText(R.string.front_of_dl)
+            )
+            Truth.assertThat(binding.message.text).isEqualTo(
+                context.getText(R.string.position_dl_front)
+            )
+        }
+    }
+
+    @Test
+    fun `when displayStateChanged to Initial UI is properly updated for ID_BACK`() {
+        whenever(mockCameraViewModel.targetScanType).thenReturn(IdentityScanState.ScanType.ID_BACK)
+        postDisplayStateChangedDataAndVerifyUI(mock<IdentityScanState.Initial>()) { binding, context ->
+            Truth.assertThat(binding.cameraView.viewFinderBackgroundView.visibility)
+                .isEqualTo(View.VISIBLE)
+            Truth.assertThat(binding.cameraView.viewFinderWindowView.visibility)
+                .isEqualTo(View.VISIBLE)
+            Truth.assertThat(binding.cameraView.viewFinderBorderView.visibility)
+                .isEqualTo(View.VISIBLE)
+            Truth.assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
+            Truth.assertThat(binding.kontinue.isEnabled).isFalse()
+            Truth.assertThat(binding.headerTitle.text).isEqualTo(
+                context.getText(R.string.back_of_dl)
+            )
+            Truth.assertThat(binding.message.text).isEqualTo(
+                context.getText(R.string.position_dl_back)
+            )
+        }
+    }
+
+    @Test
+    fun `when displayStateChanged to Found UI is properly updated`() {
+        postDisplayStateChangedDataAndVerifyUI(mock<IdentityScanState.Found>()) { binding, context ->
+            Truth.assertThat(binding.cameraView.viewFinderBackgroundView.visibility)
+                .isEqualTo(View.VISIBLE)
+            Truth.assertThat(binding.cameraView.viewFinderWindowView.visibility)
+                .isEqualTo(View.VISIBLE)
+            Truth.assertThat(binding.cameraView.viewFinderBorderView.visibility)
+                .isEqualTo(View.VISIBLE)
+            Truth.assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
+            Truth.assertThat(binding.kontinue.isEnabled).isFalse()
+            Truth.assertThat(binding.message.text).isEqualTo(
+                context.getText(R.string.hold_still)
+            )
+        }
+    }
+
+    @Test
+    fun `when displayStateChanged to Unsatisfied UI is properly updated for ID_FRONT`() {
+        whenever(mockCameraViewModel.targetScanType).thenReturn(IdentityScanState.ScanType.ID_FRONT)
+        postDisplayStateChangedDataAndVerifyUI(mock<IdentityScanState.Unsatisfied>()) { binding, context ->
+            Truth.assertThat(binding.cameraView.viewFinderBackgroundView.visibility)
+                .isEqualTo(View.VISIBLE)
+            Truth.assertThat(binding.cameraView.viewFinderWindowView.visibility)
+                .isEqualTo(View.VISIBLE)
+            Truth.assertThat(binding.cameraView.viewFinderBorderView.visibility)
+                .isEqualTo(View.VISIBLE)
+            Truth.assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
+            Truth.assertThat(binding.kontinue.isEnabled).isFalse()
+            Truth.assertThat(binding.message.text).isEqualTo(
+                context.getText(R.string.position_dl_front)
+            )
+        }
+    }
+
+    @Test
+    fun `when displayStateChanged to Unsatisfied UI is properly updated for ID_BACK`() {
+        whenever(mockCameraViewModel.targetScanType).thenReturn(IdentityScanState.ScanType.ID_BACK)
+        postDisplayStateChangedDataAndVerifyUI(mock<IdentityScanState.Unsatisfied>()) { binding, context ->
+            Truth.assertThat(binding.cameraView.viewFinderBackgroundView.visibility)
+                .isEqualTo(View.VISIBLE)
+            Truth.assertThat(binding.cameraView.viewFinderWindowView.visibility)
+                .isEqualTo(View.VISIBLE)
+            Truth.assertThat(binding.cameraView.viewFinderBorderView.visibility)
+                .isEqualTo(View.VISIBLE)
+            Truth.assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
+            Truth.assertThat(binding.kontinue.isEnabled).isFalse()
+            Truth.assertThat(binding.message.text).isEqualTo(
+                context.getText(R.string.position_dl_back)
+            )
+        }
+    }
+
+    @Test
+    fun `when displayStateChanged to Satisfied UI is properly updated`() {
+        postDisplayStateChangedDataAndVerifyUI(mock<IdentityScanState.Satisfied>()) { binding, context ->
+            Truth.assertThat(binding.cameraView.viewFinderBackgroundView.visibility)
+                .isEqualTo(View.VISIBLE)
+            Truth.assertThat(binding.cameraView.viewFinderWindowView.visibility)
+                .isEqualTo(View.VISIBLE)
+            Truth.assertThat(binding.cameraView.viewFinderBorderView.visibility)
+                .isEqualTo(View.VISIBLE)
+            Truth.assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
+            Truth.assertThat(binding.kontinue.isEnabled).isFalse()
+            Truth.assertThat(binding.message.text).isEqualTo(
+                context.getText(R.string.scanned)
+            )
+        }
+    }
+
+    @Test
+    fun `when displayStateChanged to Finished UI is properly updated`() {
+        postDisplayStateChangedDataAndVerifyUI(mock<IdentityScanState.Finished>()) { binding, context ->
+            Truth.assertThat(binding.cameraView.viewFinderBackgroundView.visibility)
+                .isEqualTo(View.INVISIBLE)
+            Truth.assertThat(binding.cameraView.viewFinderWindowView.visibility)
+                .isEqualTo(View.INVISIBLE)
+            Truth.assertThat(binding.cameraView.viewFinderBorderView.visibility)
+                .isEqualTo(View.INVISIBLE)
+            Truth.assertThat(binding.checkMarkView.visibility).isEqualTo(View.VISIBLE)
+            Truth.assertThat(binding.kontinue.isEnabled).isTrue()
+            Truth.assertThat(binding.message.text).isEqualTo(
+                context.getText(R.string.scanned)
+            )
+        }
+    }
+
+    private fun launchDriverLicenseFragment(
+        cameraPermissionEnsureable: CameraPermissionEnsureable
+    ) = launchFragmentInContainer(
+        themeResId = R.style.Theme_MaterialComponents
+    ) {
+        DriverLicenseScanFragment(
+            cameraPermissionEnsureable,
+            cameraViewModelFactory
+        )
+    }
+
+    private fun postDisplayStateChangedDataAndVerifyUI(
+        newScanState: IdentityScanState,
+        check: (binding: DriverLicenseScanFragmentBinding, context: Context) -> Unit
+    ) {
+        launchDriverLicenseFragment(
+            mockCameraPermissionEnsurable
+        ).onFragment {
+            displayStateChanged.postValue((newScanState to mock()))
+            check(DriverLicenseScanFragmentBinding.bind(it.requireView()), it.requireContext())
+        }
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
`DriverLicenseScanFragment` is virtually the same with `IDScanFragment`, only difference is the UI text copies.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
