### PR TITLE
Keep status bar color in PaymentLauncher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # CHANGELOG
 ## X.X.X - 2022-XX-XX
+[FIXED] [4606](https://github.com/stripe/stripe-android/pull/4606) Keep status bar color in PaymentLauncher.
 ### PaymentSheet
 ### Identity
 ### Card scanning

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -5191,27 +5191,30 @@ public abstract interface class com/stripe/android/payments/paymentlauncher/Paym
 
 public abstract class com/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args : android/os/Parcelable {
 	public static final field $stable I
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/Integer;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getEnableLogging ()Z
 	public fun getInjectorKey ()Ljava/lang/String;
 	public fun getProductUsage ()Ljava/util/Set;
 	public fun getPublishableKey ()Ljava/lang/String;
+	public fun getStatusBarColor ()Ljava/lang/Integer;
 	public fun getStripeAccountId ()Ljava/lang/String;
+	public fun setStatusBarColor (Ljava/lang/Integer;)V
 	public final fun toBundle ()Landroid/os/Bundle;
 }
 
 public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$IntentConfirmationArgs : com/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Lcom/stripe/android/model/ConfirmStripeIntentParams;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Z
 	public final fun component5 ()Ljava/util/Set;
 	public final fun component6 ()Lcom/stripe/android/model/ConfirmStripeIntentParams;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Lcom/stripe/android/model/ConfirmStripeIntentParams;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$IntentConfirmationArgs;
-	public static synthetic fun copy$default (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$IntentConfirmationArgs;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Lcom/stripe/android/model/ConfirmStripeIntentParams;ILjava/lang/Object;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$IntentConfirmationArgs;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Lcom/stripe/android/model/ConfirmStripeIntentParams;Ljava/lang/Integer;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$IntentConfirmationArgs;
+	public static synthetic fun copy$default (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$IntentConfirmationArgs;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Lcom/stripe/android/model/ConfirmStripeIntentParams;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$IntentConfirmationArgs;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConfirmStripeIntentParams ()Lcom/stripe/android/model/ConfirmStripeIntentParams;
@@ -5219,8 +5222,10 @@ public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherCo
 	public fun getInjectorKey ()Ljava/lang/String;
 	public fun getProductUsage ()Ljava/util/Set;
 	public fun getPublishableKey ()Ljava/lang/String;
+	public fun getStatusBarColor ()Ljava/lang/Integer;
 	public fun getStripeAccountId ()Ljava/lang/String;
 	public fun hashCode ()I
+	public fun setStatusBarColor (Ljava/lang/Integer;)V
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
@@ -5228,15 +5233,15 @@ public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherCo
 public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$PaymentIntentNextActionArgs : com/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Z
 	public final fun component5 ()Ljava/util/Set;
 	public final fun component6 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$PaymentIntentNextActionArgs;
-	public static synthetic fun copy$default (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$PaymentIntentNextActionArgs;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$PaymentIntentNextActionArgs;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;Ljava/lang/Integer;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$PaymentIntentNextActionArgs;
+	public static synthetic fun copy$default (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$PaymentIntentNextActionArgs;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$PaymentIntentNextActionArgs;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getEnableLogging ()Z
@@ -5244,8 +5249,10 @@ public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherCo
 	public final fun getPaymentIntentClientSecret ()Ljava/lang/String;
 	public fun getProductUsage ()Ljava/util/Set;
 	public fun getPublishableKey ()Ljava/lang/String;
+	public fun getStatusBarColor ()Ljava/lang/Integer;
 	public fun getStripeAccountId ()Ljava/lang/String;
 	public fun hashCode ()I
+	public fun setStatusBarColor (Ljava/lang/Integer;)V
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
@@ -5253,15 +5260,15 @@ public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherCo
 public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$SetupIntentNextActionArgs : com/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Z
 	public final fun component5 ()Ljava/util/Set;
 	public final fun component6 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$SetupIntentNextActionArgs;
-	public static synthetic fun copy$default (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$SetupIntentNextActionArgs;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$SetupIntentNextActionArgs;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;Ljava/lang/Integer;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$SetupIntentNextActionArgs;
+	public static synthetic fun copy$default (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$SetupIntentNextActionArgs;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Set;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$SetupIntentNextActionArgs;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getEnableLogging ()Z
@@ -5269,8 +5276,10 @@ public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherCo
 	public fun getProductUsage ()Ljava/util/Set;
 	public fun getPublishableKey ()Ljava/lang/String;
 	public final fun getSetupIntentClientSecret ()Ljava/lang/String;
+	public fun getStatusBarColor ()Ljava/lang/Integer;
 	public fun getStripeAccountId ()Ljava/lang/String;
 	public fun hashCode ()I
+	public fun setStatusBarColor (Ljava/lang/Integer;)V
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
@@ -57,6 +57,10 @@ internal class PaymentLauncherConfirmationActivity : AppCompatActivity() {
             return
         }
 
+        args.statusBarColor?.let {
+            window.statusBarColor = it
+        }
+
         viewModel.paymentLauncherResult.observe(this, ::finishWithResult)
 
         // [viewModel.hasStarted] could be true if the app process is killed by system, then

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherContract.kt
@@ -1,9 +1,11 @@
 package com.stripe.android.payments.paymentlauncher
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
+import androidx.annotation.ColorInt
 import androidx.annotation.RestrictTo
 import androidx.core.os.bundleOf
 import com.stripe.android.core.injection.InjectorKey
@@ -17,6 +19,7 @@ import kotlinx.parcelize.Parcelize
 class PaymentLauncherContract :
     ActivityResultContract<PaymentLauncherContract.Args, PaymentResult>() {
     override fun createIntent(context: Context, input: Args): Intent {
+        input.statusBarColor = (context as? Activity)?.window?.statusBarColor
         return Intent(
             context,
             PaymentLauncherConfirmationActivity::class.java
@@ -32,39 +35,64 @@ class PaymentLauncherContract :
         open val publishableKey: String,
         open val stripeAccountId: String?,
         open val enableLogging: Boolean,
-        open val productUsage: Set<String>
+        open val productUsage: Set<String>,
+        @ColorInt open var statusBarColor: Int? = null
     ) : Parcelable {
         fun toBundle() = bundleOf(EXTRA_ARGS to this)
 
         @Parcelize
-        data class IntentConfirmationArgs(
+        data class IntentConfirmationArgs internal constructor(
             @InjectorKey override val injectorKey: String,
             override val publishableKey: String,
             override val stripeAccountId: String?,
             override val enableLogging: Boolean,
             override val productUsage: Set<String>,
-            val confirmStripeIntentParams: ConfirmStripeIntentParams
-        ) : Args(injectorKey, publishableKey, stripeAccountId, enableLogging, productUsage)
+            val confirmStripeIntentParams: ConfirmStripeIntentParams,
+            @ColorInt override var statusBarColor: Int? = null
+        ) : Args(
+            injectorKey,
+            publishableKey,
+            stripeAccountId,
+            enableLogging,
+            productUsage,
+            statusBarColor
+        )
 
         @Parcelize
-        data class PaymentIntentNextActionArgs(
+        data class PaymentIntentNextActionArgs internal constructor(
             @InjectorKey override val injectorKey: String,
             override val publishableKey: String,
             override val stripeAccountId: String?,
             override val enableLogging: Boolean,
             override val productUsage: Set<String>,
-            val paymentIntentClientSecret: String
-        ) : Args(injectorKey, publishableKey, stripeAccountId, enableLogging, productUsage)
+            val paymentIntentClientSecret: String,
+            @ColorInt override var statusBarColor: Int? = null
+        ) : Args(
+            injectorKey,
+            publishableKey,
+            stripeAccountId,
+            enableLogging,
+            productUsage,
+            statusBarColor
+        )
 
         @Parcelize
-        data class SetupIntentNextActionArgs(
+        data class SetupIntentNextActionArgs internal constructor(
             @InjectorKey override val injectorKey: String,
             override val publishableKey: String,
             override val stripeAccountId: String?,
             override val enableLogging: Boolean,
             override val productUsage: Set<String>,
-            val setupIntentClientSecret: String
-        ) : Args(injectorKey, publishableKey, stripeAccountId, enableLogging, productUsage)
+            val setupIntentClientSecret: String,
+            @ColorInt override var statusBarColor: Int? = null
+        ) : Args(
+            injectorKey,
+            publishableKey,
+            stripeAccountId,
+            enableLogging,
+            productUsage,
+            statusBarColor
+        )
 
         internal companion object {
             private const val EXTRA_ARGS = "extra_args"

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivityTest.kt
@@ -28,7 +28,7 @@ class PaymentLauncherConfirmationActivityTest {
     private val testFactory = TestUtils.viewModelFactoryFor(viewModel)
 
     @Test
-    fun `statusBarColor is properly set`() {
+    fun `statusBarColor is set on window`() {
         val color = Color.CYAN
         mockViewModelActivityScenario().launch(
             Intent(

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivityTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.payments.paymentlauncher
 
 import android.content.Intent
+import android.graphics.Color
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
@@ -25,6 +26,31 @@ class PaymentLauncherConfirmationActivityTest {
         whenever(it.paymentLauncherResult).thenReturn(mock())
     }
     private val testFactory = TestUtils.viewModelFactoryFor(viewModel)
+
+    @Test
+    fun `statusBarColor is properly set`() {
+        val color = Color.CYAN
+        mockViewModelActivityScenario().launch(
+            Intent(
+                ApplicationProvider.getApplicationContext(),
+                PaymentLauncherConfirmationActivity::class.java
+            ).putExtras(
+                PaymentLauncherContract.Args.IntentConfirmationArgs(
+                    INJECTOR_KEY,
+                    ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                    TEST_STRIPE_ACCOUNT_ID,
+                    false,
+                    PRODUCT_USAGE,
+                    mock(),
+                    color
+                ).toBundle()
+            )
+        ).use {
+            it.onActivity {
+                assertThat(it.window.statusBarColor).isEqualTo(color)
+            }
+        }
+    }
 
     @ExperimentalCoroutinesApi
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Read `statusBarColor` from window and set it in `PaymentLauncherConfirmationActivity`.
Make `PaymentLauncherContract.Args` subclasses constructors internal as they shouldn't be public.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Status bar changed color when confirming a payment.
RUN_MOBILESDK-753

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
