### PR TITLE
[Identity][simpleUI] add passportScanFragment

### DIFF
--- a/identity/api/identity.api
+++ b/identity/api/identity.api
@@ -166,6 +166,12 @@ public final class com/stripe/android/identity/databinding/IdentityActivityBindi
 }
 
 public final class com/stripe/android/identity/databinding/PassportScanFragmentBinding : androidx/viewbinding/ViewBinding {
+	public final field cameraView Lcom/stripe/android/camera/scanui/CameraView;
+	public final field cameraViewCard Lcom/google/android/material/card/MaterialCardView;
+	public final field checkMarkView Landroid/widget/ImageView;
+	public final field headerTitle Landroid/widget/TextView;
+	public final field kontinue Landroid/widget/Button;
+	public final field message Landroid/widget/TextView;
 	public static fun bind (Landroid/view/View;)Lcom/stripe/android/identity/databinding/PassportScanFragmentBinding;
 	public synthetic fun getRoot ()Landroid/view/View;
 	public fun getRoot ()Landroid/widget/FrameLayout;
@@ -225,17 +231,6 @@ public final class com/stripe/android/identity/navigation/IDUploadFragment$Compa
 	public final fun newInstance ()Lcom/stripe/android/identity/navigation/IDUploadFragment;
 }
 
-public final class com/stripe/android/identity/navigation/PassportScanFragment : androidx/fragment/app/Fragment {
-	public static final field Companion Lcom/stripe/android/identity/navigation/PassportScanFragment$Companion;
-	public fun <init> ()V
-	public fun onActivityCreated (Landroid/os/Bundle;)V
-	public fun onCreateView (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Landroid/os/Bundle;)Landroid/view/View;
-}
-
-public final class com/stripe/android/identity/navigation/PassportScanFragment$Companion {
-	public final fun newInstance ()Lcom/stripe/android/identity/navigation/PassportScanFragment;
-}
-
 public final class com/stripe/android/identity/navigation/PassportUploadFragment : androidx/fragment/app/Fragment {
 	public static final field Companion Lcom/stripe/android/identity/navigation/PassportUploadFragment$Companion;
 	public fun <init> ()V
@@ -264,10 +259,6 @@ public final class com/stripe/android/identity/viewmodel/DriverLicenseUploadView
 }
 
 public final class com/stripe/android/identity/viewmodel/IDUploadViewModel : androidx/lifecycle/ViewModel {
-	public fun <init> ()V
-}
-
-public final class com/stripe/android/identity/viewmodel/PassportScanViewModel : androidx/lifecycle/ViewModel {
 	public fun <init> ()V
 }
 

--- a/identity/res/layout/passport_scan_fragment.xml
+++ b/identity/res/layout/passport_scan_fragment.xml
@@ -1,13 +1,82 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_marginStart="@dimen/page_horizontal_margin"
+    android:layout_marginEnd="@dimen/page_horizontal_margin"
+    android:layout_marginTop="@dimen/page_vertical_margin"
+    android:layout_marginBottom="@dimen/page_vertical_margin"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".navigation.PassportScanFragment">
+    android:layout_height="match_parent">
 
-    <TextView
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_margin="5dp"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:text="Passport scan" />
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/header_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textStyle="bold"
+            android:text="@string/passport"
+            android:textSize="@dimen/scan_title_text_size"
+            android:layout_marginBottom="20dp"
+            app:layout_constraintBottom_toTopOf="@id/message"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/message"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/page_vertical_margin"
+            android:text="@string/position_passport"
+            app:layout_constraintBottom_toTopOf="@id/camera_view_card"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/header_title" />
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/camera_view_card"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            app:cardCornerRadius="@dimen/view_finder_corner_radius"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintDimensionRatio="3:2"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/message">
+
+            <com.stripe.android.camera.scanui.CameraView
+                android:id="@+id/camera_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:borderDrawable="@drawable/id_border_initial"
+                app:viewFinderType="id" />
+
+            <ImageView
+                android:id="@+id/check_mark_view"
+                android:padding="60dp"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:src="@drawable/check_mark"
+                android:visibility="gone"
+                android:background="@color/check_mark_background"
+                android:contentDescription="@string/check_mark"
+                app:tint="?android:colorPrimary" />
+
+        </com.google.android.material.card.MaterialCardView>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+    <Button
+        android:id="@+id/kontinue"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:enabled="false"
+        android:text="@string/kontinue" />
 
 </FrameLayout>

--- a/identity/res/values/strings.xml
+++ b/identity/res/values/strings.xml
@@ -5,16 +5,21 @@
     <string name="decline">Decline and use alternative method</string>
     <string name="driver_license">Driver\'s license</string>
     <string name="id_card">Identity card</string>
-    <string name="passport">Passport</string>
     <string name="doc_select_title">Which form of identification do you want to use?</string>
+
     <string name="front_of_id">Front of ID</string>
     <string name="back_of_id">Back of ID</string>
     <string name="position_id_front">Position your ID in the center of the frame</string>
     <string name="position_id_back">Flip your ID over to the other side</string>
+
     <string name="front_of_dl">Front of driver license</string>
     <string name="back_of_dl">Back of driver license</string>
     <string name="position_dl_front">Position your driver license in the center of the frame</string>
     <string name="position_dl_back">Flip your driver license over to the other side</string>
+
+    <string name="passport">Passport</string>
+    <string name="position_passport">Position your Passport in the center of the frame</string>
+
     <string name="hold_still">Hold still, scanning</string>
     <string name="scanned">Scanned</string>
     <string name="help">Help</string>

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
@@ -23,6 +23,10 @@ internal class IdentityFragmentFactory(
                 cameraPermissionEnsureable,
                 cameraViewModelFactory
             )
+            PassportScanFragment::class.java.name -> PassportScanFragment(
+                cameraPermissionEnsureable,
+                cameraViewModelFactory
+            )
             else -> super.instantiate(classLoader, className)
         }
     }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/PassportScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/PassportScanFragment.kt
@@ -4,30 +4,105 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
+import android.widget.Button
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.core.os.bundleOf
 import androidx.lifecycle.ViewModelProvider
+import androidx.navigation.fragment.findNavController
+import com.stripe.android.camera.CameraPermissionEnsureable
+import com.stripe.android.camera.scanui.util.startAnimation
 import com.stripe.android.identity.R
-import com.stripe.android.identity.viewmodel.PassportScanViewModel
+import com.stripe.android.identity.databinding.PassportScanFragmentBinding
+import com.stripe.android.identity.states.IdentityScanState
 
-class PassportScanFragment : Fragment() {
+/**
+ * Fragment to scan passport.
+ */
+internal class PassportScanFragment(
+    cameraPermissionEnsureable: CameraPermissionEnsureable,
+    cameraViewModelFactory: ViewModelProvider.Factory
+) : IdentityCameraScanFragment(cameraPermissionEnsureable, cameraViewModelFactory) {
+    private lateinit var binding: PassportScanFragmentBinding
+    private lateinit var headerTitle: TextView
+    private lateinit var messageView: TextView
 
-    companion object {
-        fun newInstance() = PassportScanFragment()
-    }
-
-    private lateinit var viewModel: PassportScanViewModel
+    private lateinit var checkMarkView: ImageView
+    private lateinit var continueButton: Button
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        return inflater.inflate(R.layout.passport_scan_fragment, container, false)
+    ): View {
+        binding = PassportScanFragmentBinding.inflate(inflater, container, false)
+        cameraView = binding.cameraView
+        headerTitle = binding.headerTitle
+        messageView = binding.message
+        checkMarkView = binding.checkMarkView
+        continueButton = binding.kontinue
+        return binding.root
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-        viewModel = ViewModelProvider(this).get(PassportScanViewModel::class.java)
-        // TODO: Use the ViewModel
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        continueButton.setOnClickListener {
+            findNavController().navigate(R.id.action_passportScanFragment_to_confirmationFragment)
+        }
+    }
+
+    override fun onCameraReady() {
+        cameraViewModel.targetScanType = IdentityScanState.ScanType.PASSPORT
+        startScanning(IdentityScanState.ScanType.PASSPORT)
+    }
+
+    override fun onUserDeniedCameraPermission() {
+        findNavController().navigate(
+            R.id.action_camera_permission_denied,
+            bundleOf(
+                CameraPermissionDeniedFragment.ARG_SCAN_TYPE to IdentityScanState.ScanType.PASSPORT
+            )
+        )
+    }
+
+    override fun updateUI(identityScanState: IdentityScanState) {
+        when (identityScanState) {
+            is IdentityScanState.Initial -> {
+                cameraView.viewFinderBackgroundView.visibility = View.VISIBLE
+                cameraView.viewFinderWindowView.visibility = View.VISIBLE
+                cameraView.viewFinderBorderView.visibility = View.VISIBLE
+                continueButton.isEnabled = false
+                checkMarkView.visibility = View.GONE
+
+                headerTitle.text = requireContext().getText(R.string.passport)
+
+                cameraView.viewFinderWindowView.setBackgroundResource(R.drawable.id_viewfinder_background)
+                cameraView.viewFinderBorderView.startAnimation(R.drawable.id_border_initial)
+            }
+            is IdentityScanState.Found -> {
+                messageView.text = requireContext().getText(R.string.hold_still)
+                cameraView.viewFinderWindowView.setBackgroundResource(R.drawable.id_viewfinder_background)
+                cameraView.viewFinderBorderView.startAnimation(R.drawable.id_border_found)
+            }
+            is IdentityScanState.Unsatisfied -> {
+                messageView.text = requireContext().getText(R.string.position_passport)
+                cameraView.viewFinderWindowView.setBackgroundResource(R.drawable.id_viewfinder_background)
+                cameraView.viewFinderBorderView.startAnimation(R.drawable.id_border_unsatisfied)
+            }
+            is IdentityScanState.Satisfied -> {
+                messageView.text = requireContext().getText(R.string.scanned)
+                cameraView.viewFinderWindowView.setBackgroundResource(R.drawable.id_viewfinder_background)
+                cameraView.viewFinderBorderView.startAnimation(R.drawable.id_border_satisfied)
+            }
+            is IdentityScanState.Finished -> {
+                cameraView.viewFinderBackgroundView.visibility = View.INVISIBLE
+                cameraView.viewFinderWindowView.visibility = View.INVISIBLE
+                cameraView.viewFinderBorderView.visibility = View.INVISIBLE
+                checkMarkView.visibility = View.VISIBLE
+                continueButton.isEnabled = true
+
+                messageView.text = requireContext().getText(R.string.scanned)
+            }
+        }
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/PassportScanViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/PassportScanViewModel.kt
@@ -1,7 +1,0 @@
-package com.stripe.android.identity.viewmodel
-
-import androidx.lifecycle.ViewModel
-
-class PassportScanViewModel : ViewModel() {
-    // TODO: Implement the ViewModel
-}

--- a/identity/src/test/java/com/stripe/android/identity/navigation/DriverLicenseScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/DriverLicenseScanFragmentTest.kt
@@ -11,7 +11,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.Navigation
 import androidx.navigation.testing.TestNavHostController
 import androidx.test.core.app.ApplicationProvider
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
 import com.stripe.android.camera.CameraPermissionEnsureable
 import com.stripe.android.identity.R
 import com.stripe.android.identity.camera.IDDetectorAggregator
@@ -78,7 +78,7 @@ internal class DriverLicenseScanFragmentTest {
     fun `when camera permission granted cameraAdapter is bound and identityScanFlow is started`() {
         launchDriverLicenseFragment(testCameraPermissionEnsureable).onFragment {
             testCameraPermissionEnsureable.onCameraReady()
-            Truth.assertThat(it.cameraAdapter.isBoundToLifecycle()).isTrue()
+            assertThat(it.cameraAdapter.isBoundToLifecycle()).isTrue()
             verify(mockScanFlow).startFlow(
                 same(it.requireContext()),
                 any(),
@@ -99,7 +99,7 @@ internal class DriverLicenseScanFragmentTest {
 
             // stopScanning() is called
             verify(mockScanFlow).resetFlow()
-            Truth.assertThat(it.cameraAdapter.isBoundToLifecycle()).isFalse()
+            assertThat(it.cameraAdapter.isBoundToLifecycle()).isFalse()
 
             // mock viewModel target change
             whenever(mockCameraViewModel.targetScanType)
@@ -109,7 +109,7 @@ internal class DriverLicenseScanFragmentTest {
             DriverLicenseScanFragmentBinding.bind(it.requireView()).kontinue.callOnClick()
 
             // verify start to scan back
-            Truth.assertThat(it.cameraAdapter.isBoundToLifecycle()).isTrue()
+            assertThat(it.cameraAdapter.isBoundToLifecycle()).isTrue()
             verify(mockScanFlow).startFlow(
                 same(it.requireContext()),
                 any(),
@@ -159,7 +159,7 @@ internal class DriverLicenseScanFragmentTest {
 
             // click continue, navigates
             binding.kontinue.callOnClick()
-            Truth.assertThat(navController.currentDestination?.id)
+            assertThat(navController.currentDestination?.id)
                 .isEqualTo(R.id.confirmationFragment)
         }
     }
@@ -179,9 +179,16 @@ internal class DriverLicenseScanFragmentTest {
 
             testCameraPermissionEnsureable.onUserDeniedCameraPermission()
 
-            Truth.assertThat(it.cameraAdapter.isBoundToLifecycle()).isFalse()
-            Truth.assertThat(navController.currentDestination?.id)
+            assertThat(it.cameraAdapter.isBoundToLifecycle()).isFalse()
+            assertThat(navController.currentDestination?.id)
                 .isEqualTo(R.id.cameraPermissionDeniedFragment)
+
+            assertThat(
+                navController.backStack.last()
+                    .arguments!![CameraPermissionDeniedFragment.ARG_SCAN_TYPE]
+            ).isEqualTo(
+                IdentityScanState.ScanType.ID_FRONT
+            )
         }
     }
 
@@ -189,12 +196,12 @@ internal class DriverLicenseScanFragmentTest {
     fun `when final result is received scanFlow is reset and cameraAdapter is unbound`() {
         launchDriverLicenseFragment(testCameraPermissionEnsureable).onFragment {
             testCameraPermissionEnsureable.onCameraReady()
-            Truth.assertThat(it.cameraAdapter.isBoundToLifecycle()).isTrue()
+            assertThat(it.cameraAdapter.isBoundToLifecycle()).isTrue()
 
             finalResultLiveData.postValue(mock())
 
             verify(mockScanFlow).resetFlow()
-            Truth.assertThat(it.cameraAdapter.isBoundToLifecycle()).isFalse()
+            assertThat(it.cameraAdapter.isBoundToLifecycle()).isFalse()
         }
     }
 
@@ -202,18 +209,18 @@ internal class DriverLicenseScanFragmentTest {
     fun `when displayStateChanged to Initial UI is properly updated for ID_FRONT`() {
         whenever(mockCameraViewModel.targetScanType).thenReturn(IdentityScanState.ScanType.ID_FRONT)
         postDisplayStateChangedDataAndVerifyUI(mock<IdentityScanState.Initial>()) { binding, context ->
-            Truth.assertThat(binding.cameraView.viewFinderBackgroundView.visibility)
+            assertThat(binding.cameraView.viewFinderBackgroundView.visibility)
                 .isEqualTo(View.VISIBLE)
-            Truth.assertThat(binding.cameraView.viewFinderWindowView.visibility)
+            assertThat(binding.cameraView.viewFinderWindowView.visibility)
                 .isEqualTo(View.VISIBLE)
-            Truth.assertThat(binding.cameraView.viewFinderBorderView.visibility)
+            assertThat(binding.cameraView.viewFinderBorderView.visibility)
                 .isEqualTo(View.VISIBLE)
-            Truth.assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
-            Truth.assertThat(binding.kontinue.isEnabled).isFalse()
-            Truth.assertThat(binding.headerTitle.text).isEqualTo(
+            assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
+            assertThat(binding.kontinue.isEnabled).isFalse()
+            assertThat(binding.headerTitle.text).isEqualTo(
                 context.getText(R.string.front_of_dl)
             )
-            Truth.assertThat(binding.message.text).isEqualTo(
+            assertThat(binding.message.text).isEqualTo(
                 context.getText(R.string.position_dl_front)
             )
         }
@@ -223,18 +230,18 @@ internal class DriverLicenseScanFragmentTest {
     fun `when displayStateChanged to Initial UI is properly updated for ID_BACK`() {
         whenever(mockCameraViewModel.targetScanType).thenReturn(IdentityScanState.ScanType.ID_BACK)
         postDisplayStateChangedDataAndVerifyUI(mock<IdentityScanState.Initial>()) { binding, context ->
-            Truth.assertThat(binding.cameraView.viewFinderBackgroundView.visibility)
+            assertThat(binding.cameraView.viewFinderBackgroundView.visibility)
                 .isEqualTo(View.VISIBLE)
-            Truth.assertThat(binding.cameraView.viewFinderWindowView.visibility)
+            assertThat(binding.cameraView.viewFinderWindowView.visibility)
                 .isEqualTo(View.VISIBLE)
-            Truth.assertThat(binding.cameraView.viewFinderBorderView.visibility)
+            assertThat(binding.cameraView.viewFinderBorderView.visibility)
                 .isEqualTo(View.VISIBLE)
-            Truth.assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
-            Truth.assertThat(binding.kontinue.isEnabled).isFalse()
-            Truth.assertThat(binding.headerTitle.text).isEqualTo(
+            assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
+            assertThat(binding.kontinue.isEnabled).isFalse()
+            assertThat(binding.headerTitle.text).isEqualTo(
                 context.getText(R.string.back_of_dl)
             )
-            Truth.assertThat(binding.message.text).isEqualTo(
+            assertThat(binding.message.text).isEqualTo(
                 context.getText(R.string.position_dl_back)
             )
         }
@@ -243,15 +250,15 @@ internal class DriverLicenseScanFragmentTest {
     @Test
     fun `when displayStateChanged to Found UI is properly updated`() {
         postDisplayStateChangedDataAndVerifyUI(mock<IdentityScanState.Found>()) { binding, context ->
-            Truth.assertThat(binding.cameraView.viewFinderBackgroundView.visibility)
+            assertThat(binding.cameraView.viewFinderBackgroundView.visibility)
                 .isEqualTo(View.VISIBLE)
-            Truth.assertThat(binding.cameraView.viewFinderWindowView.visibility)
+            assertThat(binding.cameraView.viewFinderWindowView.visibility)
                 .isEqualTo(View.VISIBLE)
-            Truth.assertThat(binding.cameraView.viewFinderBorderView.visibility)
+            assertThat(binding.cameraView.viewFinderBorderView.visibility)
                 .isEqualTo(View.VISIBLE)
-            Truth.assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
-            Truth.assertThat(binding.kontinue.isEnabled).isFalse()
-            Truth.assertThat(binding.message.text).isEqualTo(
+            assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
+            assertThat(binding.kontinue.isEnabled).isFalse()
+            assertThat(binding.message.text).isEqualTo(
                 context.getText(R.string.hold_still)
             )
         }
@@ -261,15 +268,15 @@ internal class DriverLicenseScanFragmentTest {
     fun `when displayStateChanged to Unsatisfied UI is properly updated for ID_FRONT`() {
         whenever(mockCameraViewModel.targetScanType).thenReturn(IdentityScanState.ScanType.ID_FRONT)
         postDisplayStateChangedDataAndVerifyUI(mock<IdentityScanState.Unsatisfied>()) { binding, context ->
-            Truth.assertThat(binding.cameraView.viewFinderBackgroundView.visibility)
+            assertThat(binding.cameraView.viewFinderBackgroundView.visibility)
                 .isEqualTo(View.VISIBLE)
-            Truth.assertThat(binding.cameraView.viewFinderWindowView.visibility)
+            assertThat(binding.cameraView.viewFinderWindowView.visibility)
                 .isEqualTo(View.VISIBLE)
-            Truth.assertThat(binding.cameraView.viewFinderBorderView.visibility)
+            assertThat(binding.cameraView.viewFinderBorderView.visibility)
                 .isEqualTo(View.VISIBLE)
-            Truth.assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
-            Truth.assertThat(binding.kontinue.isEnabled).isFalse()
-            Truth.assertThat(binding.message.text).isEqualTo(
+            assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
+            assertThat(binding.kontinue.isEnabled).isFalse()
+            assertThat(binding.message.text).isEqualTo(
                 context.getText(R.string.position_dl_front)
             )
         }
@@ -279,15 +286,15 @@ internal class DriverLicenseScanFragmentTest {
     fun `when displayStateChanged to Unsatisfied UI is properly updated for ID_BACK`() {
         whenever(mockCameraViewModel.targetScanType).thenReturn(IdentityScanState.ScanType.ID_BACK)
         postDisplayStateChangedDataAndVerifyUI(mock<IdentityScanState.Unsatisfied>()) { binding, context ->
-            Truth.assertThat(binding.cameraView.viewFinderBackgroundView.visibility)
+            assertThat(binding.cameraView.viewFinderBackgroundView.visibility)
                 .isEqualTo(View.VISIBLE)
-            Truth.assertThat(binding.cameraView.viewFinderWindowView.visibility)
+            assertThat(binding.cameraView.viewFinderWindowView.visibility)
                 .isEqualTo(View.VISIBLE)
-            Truth.assertThat(binding.cameraView.viewFinderBorderView.visibility)
+            assertThat(binding.cameraView.viewFinderBorderView.visibility)
                 .isEqualTo(View.VISIBLE)
-            Truth.assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
-            Truth.assertThat(binding.kontinue.isEnabled).isFalse()
-            Truth.assertThat(binding.message.text).isEqualTo(
+            assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
+            assertThat(binding.kontinue.isEnabled).isFalse()
+            assertThat(binding.message.text).isEqualTo(
                 context.getText(R.string.position_dl_back)
             )
         }
@@ -296,15 +303,15 @@ internal class DriverLicenseScanFragmentTest {
     @Test
     fun `when displayStateChanged to Satisfied UI is properly updated`() {
         postDisplayStateChangedDataAndVerifyUI(mock<IdentityScanState.Satisfied>()) { binding, context ->
-            Truth.assertThat(binding.cameraView.viewFinderBackgroundView.visibility)
+            assertThat(binding.cameraView.viewFinderBackgroundView.visibility)
                 .isEqualTo(View.VISIBLE)
-            Truth.assertThat(binding.cameraView.viewFinderWindowView.visibility)
+            assertThat(binding.cameraView.viewFinderWindowView.visibility)
                 .isEqualTo(View.VISIBLE)
-            Truth.assertThat(binding.cameraView.viewFinderBorderView.visibility)
+            assertThat(binding.cameraView.viewFinderBorderView.visibility)
                 .isEqualTo(View.VISIBLE)
-            Truth.assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
-            Truth.assertThat(binding.kontinue.isEnabled).isFalse()
-            Truth.assertThat(binding.message.text).isEqualTo(
+            assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
+            assertThat(binding.kontinue.isEnabled).isFalse()
+            assertThat(binding.message.text).isEqualTo(
                 context.getText(R.string.scanned)
             )
         }
@@ -313,15 +320,15 @@ internal class DriverLicenseScanFragmentTest {
     @Test
     fun `when displayStateChanged to Finished UI is properly updated`() {
         postDisplayStateChangedDataAndVerifyUI(mock<IdentityScanState.Finished>()) { binding, context ->
-            Truth.assertThat(binding.cameraView.viewFinderBackgroundView.visibility)
+            assertThat(binding.cameraView.viewFinderBackgroundView.visibility)
                 .isEqualTo(View.INVISIBLE)
-            Truth.assertThat(binding.cameraView.viewFinderWindowView.visibility)
+            assertThat(binding.cameraView.viewFinderWindowView.visibility)
                 .isEqualTo(View.INVISIBLE)
-            Truth.assertThat(binding.cameraView.viewFinderBorderView.visibility)
+            assertThat(binding.cameraView.viewFinderBorderView.visibility)
                 .isEqualTo(View.INVISIBLE)
-            Truth.assertThat(binding.checkMarkView.visibility).isEqualTo(View.VISIBLE)
-            Truth.assertThat(binding.kontinue.isEnabled).isTrue()
-            Truth.assertThat(binding.message.text).isEqualTo(
+            assertThat(binding.checkMarkView.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.kontinue.isEnabled).isTrue()
+            assertThat(binding.message.text).isEqualTo(
                 context.getText(R.string.scanned)
             )
         }

--- a/identity/src/test/java/com/stripe/android/identity/navigation/PassportScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/PassportScanFragmentTest.kt
@@ -16,7 +16,7 @@ import com.stripe.android.camera.CameraPermissionEnsureable
 import com.stripe.android.identity.R
 import com.stripe.android.identity.camera.IDDetectorAggregator
 import com.stripe.android.identity.camera.IdentityScanFlow
-import com.stripe.android.identity.databinding.IdScanFragmentBinding
+import com.stripe.android.identity.databinding.PassportScanFragmentBinding
 import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.viewmodel.CameraViewModel
 import org.junit.Rule
@@ -32,7 +32,7 @@ import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-internal class IDScanFragmentTest {
+class PassportScanFragmentTest {
     // Ensure livedata works properly
     @get:Rule
     var rule: TestRule = InstantTaskExecutorRule()
@@ -69,14 +69,14 @@ internal class IDScanFragmentTest {
 
     @Test
     fun `when created camera permission is requested`() {
-        launchIDScanFragment(mockCameraPermissionEnsurable)
+        launchPassportScanFragment(mockCameraPermissionEnsurable)
 
         verify(mockCameraPermissionEnsurable).ensureCameraPermission(any(), any())
     }
 
     @Test
     fun `when camera permission granted cameraAdapter is bound and identityScanFlow is started`() {
-        launchIDScanFragment(testCameraPermissionEnsureable).onFragment {
+        launchPassportScanFragment(testCameraPermissionEnsureable).onFragment {
             testCameraPermissionEnsureable.onCameraReady()
             assertThat(it.cameraAdapter.isBoundToLifecycle()).isTrue()
             verify(mockScanFlow).startFlow(
@@ -85,113 +85,66 @@ internal class IDScanFragmentTest {
                 any(),
                 same(it.viewLifecycleOwner),
                 same(it.lifecycleScope),
-                eq(IdentityScanState.ScanType.ID_FRONT)
+                eq(IdentityScanState.ScanType.PASSPORT)
             )
         }
     }
 
     @Test
-    fun `when front is scanned clicking button triggers back scan`() {
-        launchIDScanFragment(testCameraPermissionEnsureable).onFragment {
-            testCameraPermissionEnsureable.onCameraReady()
-            // mock success of front scan
-            finalResultLiveData.postValue(mock())
-
-            // stopScanning() is called
-            verify(mockScanFlow).resetFlow()
-            assertThat(it.cameraAdapter.isBoundToLifecycle()).isFalse()
-
-            // mock viewModel target change
-            whenever(mockCameraViewModel.targetScanType)
-                .thenReturn(IdentityScanState.ScanType.ID_FRONT)
-
-            // button clicked
-            IdScanFragmentBinding.bind(it.requireView()).kontinue.callOnClick()
-
-            // verify start to scan back
-            assertThat(it.cameraAdapter.isBoundToLifecycle()).isTrue()
-            verify(mockScanFlow).startFlow(
-                same(it.requireContext()),
-                any(),
-                any(),
-                same(it.viewLifecycleOwner),
-                same(it.lifecycleScope),
-                eq(IdentityScanState.ScanType.ID_BACK)
-            )
-        }
-    }
-
-    @Test
-    fun `when both sides are scanned clicking button triggers navigation`() {
-        launchIDScanFragment(testCameraPermissionEnsureable).onFragment {
+    fun `when scanned clicking button triggers navigation`() {
+        launchPassportScanFragment(testCameraPermissionEnsureable).onFragment {
             val navController = TestNavHostController(
                 ApplicationProvider.getApplicationContext()
             )
             navController.setGraph(
                 R.navigation.identity_nav_graph
             )
-            navController.setCurrentDestination(R.id.IDScanFragment)
+            navController.setCurrentDestination(R.id.passportScanFragment)
             Navigation.setViewNavController(
                 it.requireView(),
                 navController
             )
-
-            // scan front
+            // start scan
             testCameraPermissionEnsureable.onCameraReady()
 
-            // mock success of front scan
+            // mock success of scan
             finalResultLiveData.postValue(mock())
 
-            // mock viewModel target change
-            whenever(mockCameraViewModel.targetScanType)
-                .thenReturn(IdentityScanState.ScanType.ID_FRONT)
-
-            // click continue, scan back
-            val binding = IdScanFragmentBinding.bind(it.requireView())
+            // click continue, trigger navigation
+            val binding = PassportScanFragmentBinding.bind(it.requireView())
             binding.kontinue.callOnClick()
-
-            // mock success of back scan
-            finalResultLiveData.postValue(mock())
-
-            // mock viewModel target change
-            whenever(mockCameraViewModel.targetScanType)
-                .thenReturn(IdentityScanState.ScanType.ID_BACK)
-
-            // click continue, navigates
-            binding.kontinue.callOnClick()
-            assertThat(navController.currentDestination?.id).isEqualTo(R.id.confirmationFragment)
+            assertThat(navController.currentDestination?.id)
+                .isEqualTo(R.id.confirmationFragment)
         }
     }
 
     @Test
     fun `when camera permission denied navigates to permission denied`() {
-        launchIDScanFragment(testCameraPermissionEnsureable).onFragment {
+        launchPassportScanFragment(testCameraPermissionEnsureable).onFragment {
             val navController = TestNavHostController(
                 ApplicationProvider.getApplicationContext()
             )
             navController.setGraph(R.navigation.identity_nav_graph)
-
             Navigation.setViewNavController(
                 it.requireView(),
                 navController
             )
-
             testCameraPermissionEnsureable.onUserDeniedCameraPermission()
-
             assertThat(it.cameraAdapter.isBoundToLifecycle()).isFalse()
-            assertThat(navController.currentDestination?.id).isEqualTo(R.id.cameraPermissionDeniedFragment)
+            assertThat(navController.currentDestination?.id)
+                .isEqualTo(R.id.cameraPermissionDeniedFragment)
             assertThat(
                 navController.backStack.last()
                     .arguments!![CameraPermissionDeniedFragment.ARG_SCAN_TYPE]
             ).isEqualTo(
-                IdentityScanState.ScanType.ID_FRONT
+                IdentityScanState.ScanType.PASSPORT
             )
         }
     }
 
     @Test
     fun `when final result is received scanFlow is reset and cameraAdapter is unbound`() {
-        launchIDScanFragment(testCameraPermissionEnsureable).onFragment {
+        launchPassportScanFragment(testCameraPermissionEnsureable).onFragment {
             testCameraPermissionEnsureable.onCameraReady()
             assertThat(it.cameraAdapter.isBoundToLifecycle()).isTrue()
 
@@ -203,8 +156,7 @@ internal class IDScanFragmentTest {
     }
 
     @Test
-    fun `when displayStateChanged to Initial UI is properly updated for ID_FRONT`() {
-        whenever(mockCameraViewModel.targetScanType).thenReturn(IdentityScanState.ScanType.ID_FRONT)
+    fun `when displayStateChanged to Initial UI is properly updated`() {
         postDisplayStateChangedDataAndVerifyUI(mock<IdentityScanState.Initial>()) { binding, context ->
             assertThat(binding.cameraView.viewFinderBackgroundView.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.cameraView.viewFinderWindowView.visibility).isEqualTo(View.VISIBLE)
@@ -212,28 +164,10 @@ internal class IDScanFragmentTest {
             assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
             assertThat(binding.kontinue.isEnabled).isFalse()
             assertThat(binding.headerTitle.text).isEqualTo(
-                context.getText(R.string.front_of_id)
+                context.getText(R.string.passport)
             )
             assertThat(binding.message.text).isEqualTo(
-                context.getText(R.string.position_id_front)
-            )
-        }
-    }
-
-    @Test
-    fun `when displayStateChanged to Initial UI is properly updated for ID_BACK`() {
-        whenever(mockCameraViewModel.targetScanType).thenReturn(IdentityScanState.ScanType.ID_BACK)
-        postDisplayStateChangedDataAndVerifyUI(mock<IdentityScanState.Initial>()) { binding, context ->
-            assertThat(binding.cameraView.viewFinderBackgroundView.visibility).isEqualTo(View.VISIBLE)
-            assertThat(binding.cameraView.viewFinderWindowView.visibility).isEqualTo(View.VISIBLE)
-            assertThat(binding.cameraView.viewFinderBorderView.visibility).isEqualTo(View.VISIBLE)
-            assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
-            assertThat(binding.kontinue.isEnabled).isFalse()
-            assertThat(binding.headerTitle.text).isEqualTo(
-                context.getText(R.string.back_of_id)
-            )
-            assertThat(binding.message.text).isEqualTo(
-                context.getText(R.string.position_id_back)
+                context.getText(R.string.position_passport)
             )
         }
     }
@@ -253,8 +187,7 @@ internal class IDScanFragmentTest {
     }
 
     @Test
-    fun `when displayStateChanged to Unsatisfied UI is properly updated for ID_FRONT`() {
-        whenever(mockCameraViewModel.targetScanType).thenReturn(IdentityScanState.ScanType.ID_FRONT)
+    fun `when displayStateChanged to Unsatisfied UI is properly updated`() {
         postDisplayStateChangedDataAndVerifyUI(mock<IdentityScanState.Unsatisfied>()) { binding, context ->
             assertThat(binding.cameraView.viewFinderBackgroundView.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.cameraView.viewFinderWindowView.visibility).isEqualTo(View.VISIBLE)
@@ -262,22 +195,7 @@ internal class IDScanFragmentTest {
             assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
             assertThat(binding.kontinue.isEnabled).isFalse()
             assertThat(binding.message.text).isEqualTo(
-                context.getText(R.string.position_id_front)
-            )
-        }
-    }
-
-    @Test
-    fun `when displayStateChanged to Unsatisfied UI is properly updated for ID_BACK`() {
-        whenever(mockCameraViewModel.targetScanType).thenReturn(IdentityScanState.ScanType.ID_BACK)
-        postDisplayStateChangedDataAndVerifyUI(mock<IdentityScanState.Unsatisfied>()) { binding, context ->
-            assertThat(binding.cameraView.viewFinderBackgroundView.visibility).isEqualTo(View.VISIBLE)
-            assertThat(binding.cameraView.viewFinderWindowView.visibility).isEqualTo(View.VISIBLE)
-            assertThat(binding.cameraView.viewFinderBorderView.visibility).isEqualTo(View.VISIBLE)
-            assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
-            assertThat(binding.kontinue.isEnabled).isFalse()
-            assertThat(binding.message.text).isEqualTo(
-                context.getText(R.string.position_id_back)
+                context.getText(R.string.position_passport)
             )
         }
     }
@@ -310,12 +228,12 @@ internal class IDScanFragmentTest {
         }
     }
 
-    private fun launchIDScanFragment(
+    private fun launchPassportScanFragment(
         cameraPermissionEnsureable: CameraPermissionEnsureable
     ) = launchFragmentInContainer(
         themeResId = R.style.Theme_MaterialComponents
     ) {
-        IDScanFragment(
+        PassportScanFragment(
             cameraPermissionEnsureable,
             cameraViewModelFactory
         )
@@ -323,13 +241,13 @@ internal class IDScanFragmentTest {
 
     private fun postDisplayStateChangedDataAndVerifyUI(
         newScanState: IdentityScanState,
-        check: (binding: IdScanFragmentBinding, context: Context) -> Unit
+        check: (binding: PassportScanFragmentBinding, context: Context) -> Unit
     ) {
-        launchIDScanFragment(
+        launchPassportScanFragment(
             mockCameraPermissionEnsurable
         ).onFragment {
             displayStateChanged.postValue((newScanState to mock()))
-            check(IdScanFragmentBinding.bind(it.requireView()), it.requireContext())
+            check(PassportScanFragmentBinding.bind(it.requireView()), it.requireContext())
         }
     }
 }

--- a/identity/src/test/java/com/stripe/android/identity/viewmodel/CameraViewModelTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/viewmodel/CameraViewModelTest.kt
@@ -1,9 +1,0 @@
-package com.stripe.android.identity.viewmodel
-
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-
-@RunWith(RobolectricTestRunner::class)
-class CameraViewModelTest {
-    // TODO(ccen) Add tests when CameraViewModel becomes Identity agnostic
-}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add `PassportScanFragment`, this is mostly the same with `IDScanFragment`, except it only scans one image instead of two

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
