### PR TITLE
Add OTP element

### DIFF
--- a/link/src/main/java/com/stripe/android/link/ui/verification/VerificationScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/verification/VerificationScreen.kt
@@ -4,21 +4,13 @@ import android.app.Application
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
-import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -27,7 +19,7 @@ import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.R
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.link.theme.linkTextFieldColors
-import com.stripe.android.ui.core.elements.SectionCard
+import com.stripe.android.ui.core.elements.OTPElementUI
 
 @Preview
 @Composable
@@ -87,7 +79,10 @@ internal fun VerificationBody(
             textAlign = TextAlign.Center,
             style = MaterialTheme.typography.body1
         )
-        VerificationCodeInput(onCodeEntered)
+        OTPElementUI(
+            colors = linkTextFieldColors(),
+            onComplete = { onCodeEntered(it) }
+        )
         TextButton(
             onClick = onResendCodeClick,
             modifier = Modifier.padding(top = 30.dp)
@@ -95,43 +90,6 @@ internal fun VerificationBody(
             Text(
                 text = stringResource(id = R.string.verification_resend),
                 style = MaterialTheme.typography.button
-            )
-        }
-    }
-}
-
-@Composable
-private fun VerificationCodeInput(
-    onCodeEntered: (String) -> Unit
-) {
-    // TODO(brnunes-stripe): Migrate to OTP collection element
-    var code by remember { mutableStateOf("") }
-
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        SectionCard {
-            TextField(
-                modifier = Modifier
-                    .fillMaxWidth(),
-                value = code,
-                onValueChange = {
-                    code = it
-                    if (code.length == 6) {
-                        onCodeEntered(code)
-                    }
-                },
-                label = {
-                    Text(text = "<Code>")
-                },
-                shape = MaterialTheme.shapes.medium,
-                colors = linkTextFieldColors(),
-                keyboardOptions = KeyboardOptions(
-                    keyboardType = KeyboardType.Number,
-                    imeAction = ImeAction.Go
-                ),
-                singleLine = true
             )
         }
     }

--- a/link/src/main/java/com/stripe/android/link/ui/verification/VerificationScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/verification/VerificationScreen.kt
@@ -8,9 +8,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -22,20 +19,21 @@ import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.R
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.link.theme.linkTextFieldColors
-import com.stripe.android.ui.core.elements.OTPController
+import com.stripe.android.ui.core.elements.OTPElement
 import com.stripe.android.ui.core.elements.OTPElementUI
+import com.stripe.android.ui.core.elements.OTPSpec
 
-//@Preview
-//@Composable
-//private fun VerificationBodyPreview() {
-//    DefaultLinkTheme {
-//        VerificationBody(
-//            redactedPhoneNumber = "+1********23",
-//            onCodeEntered = { },
-//            onResendCodeClick = { }
-//        )
-//    }
-//}
+@Preview
+@Composable
+private fun VerificationBodyPreview() {
+    DefaultLinkTheme {
+        VerificationBody(
+            redactedPhoneNumber = "+1********23",
+            otpElement = OTPSpec.transform(),
+            onResendCodeClick = { }
+        )
+    }
+}
 
 @Composable
 internal fun VerificationBody(
@@ -49,20 +47,19 @@ internal fun VerificationBody(
         )
     )
 
-    VerificationBody(viewModel)
+    VerificationBody(
+        redactedPhoneNumber = viewModel.linkAccount.redactedPhoneNumber,
+        otpElement = viewModel.otpElement,
+        onResendCodeClick = viewModel::onResendCodeClicked
+    )
 }
 
 @Composable
 internal fun VerificationBody(
-    viewModel: VerificationViewModel
+    redactedPhoneNumber: String,
+    otpElement: OTPElement,
+    onResendCodeClick: () -> Unit
 ) {
-    val otpValue by viewModel.otpController.rawFieldValue.collectAsState("")
-
-    LaunchedEffect(otpValue) {
-        if (otpValue.length == 6) {
-            viewModel.onVerificationCodeEntered(otpValue)
-        }
-    }
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -77,7 +74,7 @@ internal fun VerificationBody(
             style = MaterialTheme.typography.h2
         )
         Text(
-            text = stringResource(R.string.verification_message, viewModel.linkAccount.redactedPhoneNumber),
+            text = stringResource(R.string.verification_message, redactedPhoneNumber),
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(top = 4.dp, bottom = 30.dp),
@@ -86,10 +83,10 @@ internal fun VerificationBody(
         )
         OTPElementUI(
             colors = linkTextFieldColors(),
-            controller = viewModel.otpController
+            element = otpElement
         )
         TextButton(
-            onClick = viewModel::onResendCodeClicked,
+            onClick = { onResendCodeClick() },
             modifier = Modifier.padding(top = 30.dp)
         ) {
             Text(

--- a/link/src/main/java/com/stripe/android/link/ui/verification/VerificationScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/verification/VerificationScreen.kt
@@ -8,6 +8,9 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -19,19 +22,20 @@ import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.R
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.link.theme.linkTextFieldColors
+import com.stripe.android.ui.core.elements.OTPController
 import com.stripe.android.ui.core.elements.OTPElementUI
 
-@Preview
-@Composable
-private fun VerificationBodyPreview() {
-    DefaultLinkTheme {
-        VerificationBody(
-            redactedPhoneNumber = "+1********23",
-            onCodeEntered = { },
-            onResendCodeClick = { }
-        )
-    }
-}
+//@Preview
+//@Composable
+//private fun VerificationBodyPreview() {
+//    DefaultLinkTheme {
+//        VerificationBody(
+//            redactedPhoneNumber = "+1********23",
+//            onCodeEntered = { },
+//            onResendCodeClick = { }
+//        )
+//    }
+//}
 
 @Composable
 internal fun VerificationBody(
@@ -45,19 +49,20 @@ internal fun VerificationBody(
         )
     )
 
-    VerificationBody(
-        redactedPhoneNumber = viewModel.linkAccount.redactedPhoneNumber,
-        onCodeEntered = viewModel::onVerificationCodeEntered,
-        onResendCodeClick = viewModel::onResendCodeClicked
-    )
+    VerificationBody(viewModel)
 }
 
 @Composable
 internal fun VerificationBody(
-    redactedPhoneNumber: String,
-    onCodeEntered: (String) -> Unit,
-    onResendCodeClick: () -> Unit
+    viewModel: VerificationViewModel
 ) {
+    val otpValue by viewModel.otpController.rawFieldValue.collectAsState("")
+
+    LaunchedEffect(otpValue) {
+        if (otpValue.length == 6) {
+            viewModel.onVerificationCodeEntered(otpValue)
+        }
+    }
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -72,7 +77,7 @@ internal fun VerificationBody(
             style = MaterialTheme.typography.h2
         )
         Text(
-            text = stringResource(R.string.verification_message, redactedPhoneNumber),
+            text = stringResource(R.string.verification_message, viewModel.linkAccount.redactedPhoneNumber),
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(top = 4.dp, bottom = 30.dp),
@@ -81,10 +86,10 @@ internal fun VerificationBody(
         )
         OTPElementUI(
             colors = linkTextFieldColors(),
-            onComplete = { onCodeEntered(it) }
+            controller = viewModel.otpController
         )
         TextButton(
-            onClick = onResendCodeClick,
+            onClick = viewModel::onResendCodeClicked,
             modifier = Modifier.padding(top = 30.dp)
         ) {
             Text(

--- a/link/src/main/java/com/stripe/android/link/ui/verification/VerificationViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/verification/VerificationViewModel.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.link.ui.verification
 
 import android.app.Application
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -14,7 +16,16 @@ import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.injection.DaggerLinkViewModelFactoryComponent
 import com.stripe.android.link.injection.LinkViewModelSubcomponent
 import com.stripe.android.link.model.Navigator
+import com.stripe.android.ui.core.elements.EmailSpec
+import com.stripe.android.ui.core.elements.EmailSpec.transform
+import com.stripe.android.ui.core.elements.IdentifierSpec
+import com.stripe.android.ui.core.elements.OTPController
+import com.stripe.android.ui.core.elements.OTPElement
+import com.stripe.android.ui.core.elements.OTPSpec
+import com.stripe.android.ui.core.elements.SectionFieldElement
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import org.intellij.lang.annotations.Identifier
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -31,6 +42,8 @@ internal class VerificationViewModel @Inject constructor(
         // The Link account is already loaded in linkAccountManager when we get to Verification
         requireNotNull(linkAccountManager.linkAccount)
     }
+
+    val otpController = OTPController()
 
     fun onVerificationCodeEntered(code: String) {
         viewModelScope.launch {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/InputController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/InputController.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.Flow
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 sealed interface InputController : SectionFieldErrorController {
-    val label: Int
+    val label: Int?
     val fieldValue: Flow<String>
     val rawFieldValue: Flow<String?>
     val isComplete: Flow<Boolean>

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPCellConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPCellConfig.kt
@@ -1,0 +1,56 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.annotation.RestrictTo
+import androidx.annotation.StringRes
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.VisualTransformation
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class OTPCellConfig : TextFieldConfig {
+    private var currentValue = ""
+
+    override val capitalization: KeyboardCapitalization = KeyboardCapitalization.None
+    override val debugLabel = "OTP"
+
+    @StringRes
+    override val label: Int? = null
+    override val keyboard = KeyboardType.Number
+    override val visualTransformation: VisualTransformation? = null
+
+    // Prevent the callback from being called twice when updating the field programmatically
+    private var valueChangedCallbackEnabled = true
+
+    override fun filter(userTyped: String): String {
+        val filtered = userTyped.filter { VALID_INPUT_RANGES.contains(it) }
+        if (valueChangedCallbackEnabled) {
+            valueChangedCallbackEnabled = false
+            if (filtered.length == 2) {
+                val val1 = filtered.getOrNull(0)?.toString() ?: ""
+                val val2 = filtered.getOrNull(1)?.toString() ?: ""
+                currentValue = if (currentValue == val1) val2 else val1
+                return currentValue
+            } else {
+                currentValue = filtered
+            }
+        }
+
+        valueChangedCallbackEnabled = true
+        return currentValue
+    }
+
+    override fun convertToRaw(displayName: String) = displayName
+
+    override fun convertFromRaw(rawValue: String) = rawValue
+
+    override fun determineState(input: String): TextFieldState {
+        return when {
+            input.isEmpty() -> TextFieldStateConstants.Error.Blank
+            else -> TextFieldStateConstants.Valid.Full
+        }
+    }
+
+    private companion object {
+        val VALID_INPUT_RANGES = ('0'..'9')
+    }
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPController.kt
@@ -1,40 +1,27 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
-import androidx.core.text.isDigitsOnly
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class OTPController(
-    val otpLength: Int = 6
-) : Controller  {
-    private val _fieldValue = MutableStateFlow((0 until otpLength).map { "" })
-    val rawFieldValue: Flow<String> = _fieldValue.map {
+    val otpLength: Int = 6,
+) : Controller {
+    val textFieldControllers = (0 until otpLength).map {
+        TextFieldController(OTPCellConfig())
+    }
+
+    val fieldValue: Flow<List<String>> = combine(textFieldControllers.map { it.fieldValue }) {
+        it.toList()
+    }
+
+    val rawFieldValue: Flow<String> = fieldValue.map {
         it.joinToString("")
     }
-    val fieldValue: Flow<List<String>> = _fieldValue
 
-    // Prevent the callback from being called twice when updating the field programmatically
-    var valueChangedCallbackEnabled = true
-
-    fun onValueChange(index: Int, value: String) {
-        if (valueChangedCallbackEnabled && value.isDigitsOnly()) {
-            valueChangedCallbackEnabled = false
-            val newList = _fieldValue.value.toMutableList()
-            if (value.length > 1) {
-                val val1 = value.getOrNull(0)?.toString() ?: ""
-                val val2 = value.getOrNull(1)?.toString() ?: ""
-                val newValue = if (_fieldValue.value[index] == val1) val2 else val1
-                newList[index] = newValue
-                _fieldValue.value = newList
-                return
-            } else {
-                newList[index] = value
-            }
-            _fieldValue.value = newList
-        }
-        valueChangedCallbackEnabled = true
+    fun onDelete(index: Int) {
+        textFieldControllers[index].onValueChange("")
     }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPController.kt
@@ -1,0 +1,40 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.annotation.RestrictTo
+import androidx.core.text.isDigitsOnly
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class OTPController(
+    val otpLength: Int = 6
+) : Controller  {
+    private val _fieldValue = MutableStateFlow((0 until otpLength).map { "" })
+    val rawFieldValue: Flow<String> = _fieldValue.map {
+        it.joinToString("")
+    }
+    val fieldValue: Flow<List<String>> = _fieldValue
+
+    // Prevent the callback from being called twice when updating the field programmatically
+    var valueChangedCallbackEnabled = true
+
+    fun onValueChange(index: Int, value: String) {
+        if (valueChangedCallbackEnabled && value.isDigitsOnly()) {
+            valueChangedCallbackEnabled = false
+            val newList = _fieldValue.value.toMutableList()
+            if (value.length > 1) {
+                val val1 = value.getOrNull(0)?.toString() ?: ""
+                val val2 = value.getOrNull(1)?.toString() ?: ""
+                val newValue = if (_fieldValue.value[index] == val1) val2 else val1
+                newList[index] = newValue
+                _fieldValue.value = newList
+                return
+            } else {
+                newList[index] = value
+            }
+            _fieldValue.value = newList
+        }
+        valueChangedCallbackEnabled = true
+    }
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPElement.kt
@@ -1,0 +1,18 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.ui.core.forms.FormFieldEntry
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class OTPElement(
+    override val identifier: IdentifierSpec,
+    override val controller: OTPController,
+) : FormElement()  {
+    override fun getFormFieldValueFlow(): Flow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
+        return controller.rawFieldValue.map {
+            listOf(identifier to FormFieldEntry(it, it.length == 6))
+        }
+    }
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPElement.kt
@@ -9,10 +9,10 @@ import kotlinx.coroutines.flow.map
 data class OTPElement(
     override val identifier: IdentifierSpec,
     override val controller: OTPController,
-) : FormElement()  {
+) : FormElement() {
     override fun getFormFieldValueFlow(): Flow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
         return controller.rawFieldValue.map {
-            listOf(identifier to FormFieldEntry(it, it.length == 6))
+            listOf(identifier to FormFieldEntry(it, it.length == controller.otpLength))
         }
     }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPElementUI.kt
@@ -6,14 +6,10 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.LocalTextStyle
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextFieldColors
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -24,34 +20,30 @@ import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun OTPElementUI(
-    colors: TextFieldColors,
-    controller: OTPController
+    element: OTPElement,
+    colors: TextFieldColors? = null
 ) {
-    val codes by controller.fieldValue.collectAsState(
-        initial = (0 until controller.otpLength).map { "" }
-    )
-    val width = LocalConfiguration.current.screenWidthDp.dp / (controller.otpLength + 2)
+    val width = LocalConfiguration.current.screenWidthDp.dp / (element.controller.otpLength + 2)
     val focusManager = LocalFocusManager.current
 
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
-        (0 until controller.otpLength).map { index ->
+        (0 until element.controller.otpLength).map { index ->
             OTPCell(
                 modifier = Modifier
                     .width(width)
                     .onKeyEvent { event ->
                         if (event.type == KeyEventType.KeyUp) {
                             if (event.nativeKeyEvent.keyCode == KeyEvent.KEYCODE_DEL) {
+                                element.controller.onDelete(index)
                                 focusManager.moveFocus(FocusDirection.Previous)
                             } else {
                                 focusManager.moveFocus(FocusDirection.Next)
@@ -60,10 +52,7 @@ fun OTPElementUI(
                         false
                     },
                 colors = colors,
-                value = codes[index],
-                onValueChange = { value ->
-                    controller.onValueChange(index, value)
-                },
+                textFieldController = element.controller.textFieldControllers[index],
             )
         }
     }
@@ -72,18 +61,16 @@ fun OTPElementUI(
 @Composable
 private fun OTPCell(
     modifier: Modifier,
-    value: String,
-    colors: TextFieldColors,
-    onValueChange: (String) -> Unit,
+    colors: TextFieldColors?,
+    textFieldController: TextFieldController,
 ) {
     val placeholder = remember { mutableStateOf("●") }
     SectionCard {
-        androidx.compose.material.TextField(
+        TextField(
+            textFieldController = textFieldController,
             modifier = modifier.onFocusChanged {
                 placeholder.value = if (!it.hasFocus) "●" else ""
             },
-            maxLines = 1,
-            value = value,
             placeholder = {
                 Text(
                     modifier = Modifier.fillMaxWidth(),
@@ -91,14 +78,9 @@ private fun OTPCell(
                     textAlign = TextAlign.Center
                 )
             },
-            onValueChange = { onValueChange(it) },
-            shape = MaterialTheme.shapes.medium,
             colors = colors,
             textStyle = LocalTextStyle.current.copy(textAlign = TextAlign.Center),
-            keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Number,
-                imeAction = ImeAction.Next
-            ),
+            enabled = true
         )
     }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPElementUI.kt
@@ -1,0 +1,138 @@
+package com.stripe.android.ui.core.elements
+
+import android.view.KeyEvent
+import androidx.annotation.RestrictTo
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.LocalTextStyle
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TextFieldColors
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusOrder
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.core.text.isDigitsOnly
+
+@Composable
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun OTPElementUI(
+    colors: TextFieldColors,
+    onComplete: (String) -> Unit
+) {
+    val otpLength = 6
+    val codes = remember {
+        mutableStateListOf(*((0 until otpLength).map { "" }.toTypedArray() ))
+    }
+    val focusRequesters: List<FocusRequester> = remember {
+        (0 until otpLength).map { FocusRequester() }
+    }
+
+    val width = LocalConfiguration.current.screenWidthDp.dp / (otpLength + 2)
+
+    // Prevent the callback from being called twice when updating the field programmatically
+    var valueChangedCallbackEnabled = true
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        (0 until otpLength).map { index ->
+            if (index == 0) {
+                LaunchedEffect(Unit) {
+                    focusRequesters[0].requestFocus()
+                }
+            }
+            OTPCell(
+                modifier = Modifier
+                    .width(width)
+                    .onKeyEvent { event ->
+                        val value = codes[index]
+                        if (event.type == KeyEventType.KeyUp) {
+                            if (event.nativeKeyEvent.keyCode == KeyEvent.KEYCODE_DEL && value.isEmpty()) {
+                                focusRequesters.getOrNull(index - 1)?.requestFocus()
+                            } else if (value.isNotEmpty()) {
+                                focusRequesters.getOrNull(index + 1)?.requestFocus()
+                            }
+                        }
+                        false
+                    }
+                    .focusOrder(focusRequesters[index])
+                    .focusRequester(focusRequesters[index]),
+                colors = colors,
+                value = codes[index],
+
+                onValueChange = { value ->
+                    if (valueChangedCallbackEnabled && value.isDigitsOnly()) {
+                        valueChangedCallbackEnabled = false
+                        if (value.length > 1) {
+                            val val1 = value.getOrNull(0)?.toString() ?: ""
+                            val val2 = value.getOrNull(1)?.toString() ?: ""
+                            codes[index] = if (codes[index] == val1) val2 else val1
+                            return@OTPCell
+                        }
+
+                        codes[index] = value
+
+                        val currentCode = codes.joinToString("")
+                        if (currentCode.length == otpLength) {
+                            onComplete(codes.joinToString(""))
+                        }
+                    }
+                    valueChangedCallbackEnabled = true
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun OTPCell(
+    modifier: Modifier,
+    value: String,
+    colors: TextFieldColors,
+    onValueChange: (String) -> Unit,
+) {
+    val placeholder = remember { mutableStateOf("●") }
+    SectionCard {
+        androidx.compose.material.TextField(
+            modifier = modifier.onFocusChanged {
+                placeholder.value = if (!it.hasFocus) "●" else ""
+            },
+            maxLines = 1,
+            value = value,
+            placeholder = {
+                Text(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = placeholder.value,
+                    textAlign = TextAlign.Center
+                )
+            },
+            onValueChange = { onValueChange(it) },
+            shape = MaterialTheme.shapes.medium,
+            colors = colors,
+            textStyle = LocalTextStyle.current.copy(textAlign = TextAlign.Center),
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Number,
+                imeAction = ImeAction.Next
+            ),
+        )
+    }
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPSpec.kt
@@ -1,11 +1,13 @@
 package com.stripe.android.ui.core.elements
 
+import androidx.annotation.RestrictTo
 import kotlinx.parcelize.Parcelize
 
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Parcelize
-data class OTPSpec(
+object OTPSpec : FormItemSpec(), RequiredItemSpec {
     override val identifier: IdentifierSpec
-) : FormItemSpec(), RequiredItemSpec {
+        get() = IdentifierSpec.Generic("otp")
     fun transform(): OTPElement {
         return OTPElement(
             identifier = identifier,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPSpec.kt
@@ -1,0 +1,15 @@
+package com.stripe.android.ui.core.elements
+
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class OTPSpec(
+    override val identifier: IdentifierSpec
+) : FormItemSpec(), RequiredItemSpec {
+    fun transform(): OTPElement {
+        return OTPElement(
+            identifier = identifier,
+            controller = OTPController()
+        )
+    }
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldConfig.kt
@@ -14,7 +14,7 @@ sealed interface TextFieldConfig {
     val debugLabel: String
 
     /** This is the label to describe the field */
-    val label: Int
+    val label: Int?
 
     /** This is the type of keyboard to use for this field */
     val keyboard: KeyboardType

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldController.kt
@@ -21,14 +21,14 @@ import kotlinx.coroutines.flow.map
 class TextFieldController constructor(
     private val textFieldConfig: TextFieldConfig,
     override val showOptionalLabel: Boolean = false,
-    initialValue: String? = null
+    initialValue: String? = null,
 ) : InputController, SectionFieldErrorController {
     val capitalization: KeyboardCapitalization = textFieldConfig.capitalization
     val keyboardType: KeyboardType = textFieldConfig.keyboard
     val visualTransformation = textFieldConfig.visualTransformation ?: VisualTransformation.None
 
     @StringRes
-    override val label: Int = textFieldConfig.label
+    override val label: Int? = textFieldConfig.label
     val debugLabel = textFieldConfig.debugLabel
 
     /** This is all the information that can be observed on the element */

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
@@ -1,12 +1,14 @@
 package com.stripe.android.ui.core.elements
 
 import android.util.Log
+import androidx.annotation.RestrictTo
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.LocalContentAlpha
 import androidx.compose.material.LocalContentColor
+import androidx.compose.material.LocalTextStyle
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
@@ -24,6 +26,7 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import com.stripe.android.ui.core.R
 
@@ -32,7 +35,8 @@ internal fun imeAction(nextFocusRequester: FocusRequester?): ImeAction = nextFoc
     ImeAction.Next
 } ?: ImeAction.Done
 
-internal data class TextFieldColors(
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class TextFieldColors(
     private val isDarkMode: Boolean,
     private val defaultTextColor: Color,
     val textColor: Color = if (isDarkMode) {
@@ -58,6 +62,9 @@ internal fun TextField(
     textFieldController: TextFieldController,
     modifier: Modifier = Modifier,
     enabled: Boolean,
+    placeholder: @Composable (() -> Unit)? = null,
+    colors: androidx.compose.material.TextFieldColors? = null,
+    textStyle: TextStyle? = null,
 ) {
     Log.d("Construct", "SimpleTextFieldElement ${textFieldController.debugLabel}")
 
@@ -70,7 +77,7 @@ internal fun TextField(
         isSystemInDarkTheme(),
         LocalContentColor.current.copy(LocalContentAlpha.current)
     )
-    val colors = TextFieldDefaults.textFieldColors(
+    val themedColors = colors ?: TextFieldDefaults.textFieldColors(
         textColor = if (shouldShowError) {
             MaterialTheme.colors.error
         } else {
@@ -87,18 +94,20 @@ internal fun TextField(
         value = value,
         onValueChange = { textFieldController.onValueChange(it) },
         isError = shouldShowError,
-        label = {
-            Text(
-                text = if (textFieldController.showOptionalLabel) {
-                    stringResource(
-                        R.string.form_label_optional,
+        label = if (textFieldController.label != null) {
+            {
+                Text(
+                    text = if (textFieldController.showOptionalLabel) {
+                        stringResource(
+                            R.string.form_label_optional,
+                            stringResource(textFieldController.label)
+                        )
+                    } else {
                         stringResource(textFieldController.label)
-                    )
-                } else {
-                    stringResource(textFieldController.label)
-                }
-            )
-        },
+                    }
+                )
+            }
+        } else null,
         modifier = modifier
             .fillMaxWidth()
             .onFocusChanged {
@@ -120,9 +129,11 @@ internal fun TextField(
             capitalization = textFieldController.capitalization,
             imeAction = ImeAction.Next
         ),
-        colors = colors,
+        colors = themedColors,
         maxLines = 1,
         singleLine = true,
-        enabled = enabled
+        enabled = enabled,
+        placeholder = placeholder,
+        textStyle = textStyle ?: LocalTextStyle.current,
     )
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/TransformSpecToElements.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/TransformSpecToElements.kt
@@ -20,6 +20,7 @@ import com.stripe.android.ui.core.elements.IbanSpec
 import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.ui.core.elements.KlarnaCountrySpec
 import com.stripe.android.ui.core.elements.LayoutSpec
+import com.stripe.android.ui.core.elements.OTPSpec
 import com.stripe.android.ui.core.elements.SaveForFutureUseSpec
 import com.stripe.android.ui.core.elements.SectionController
 import com.stripe.android.ui.core.elements.SectionElement
@@ -65,6 +66,7 @@ class TransformSpecToElements(
                     it.transform()
                 is EmptyFormSpec -> EmptyFormElement()
                 is AuBecsDebitMandateTextSpec -> it.transform(merchantName)
+                is OTPSpec -> it.transform()
             }
         }
 

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/OTPCellConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/OTPCellConfigTest.kt
@@ -1,0 +1,28 @@
+package com.stripe.android.ui.core.elements
+
+import com.google.common.truth.Truth
+import org.junit.Test
+
+class OTPCellConfigTest {
+    private val otpConfig = OTPCellConfig()
+
+    @Test
+    fun `verify only numbers are allowed in the field`() {
+        Truth.assertThat(otpConfig.filter("g"))
+            .isEqualTo("")
+    }
+
+    @Test
+    fun `verify blank otp cell returns blank state`() {
+        Truth.assertThat(otpConfig.determineState(""))
+            .isEqualTo(TextFieldStateConstants.Error.Blank)
+    }
+
+    @Test
+    fun `verify valid BSB is in valid state`() {
+        Truth.assertThat(otpConfig.determineState("1"))
+            .isInstanceOf(TextFieldStateConstants.Valid.Full::class.java)
+        Truth.assertThat(otpConfig.determineState("12"))
+            .isInstanceOf(TextFieldStateConstants.Valid.Full::class.java)
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/Settings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/Settings.kt
@@ -32,8 +32,8 @@ class Settings(context: Context) {
          */
         private const val BASE_URL =
 //            "https://capricious-ballistic-anaconda.glitch.me/"
-            "https://knowledgeable-oasis-hide.glitch.me/"
-//            "https://stripe-mobile-payment-sheet-test-playground-v6.glitch.me/"
+//            "https://knowledgeable-oasis-hide.glitch.me/"
+            "https://stripe-mobile-payment-sheet-test-playground-v6.glitch.me/"
 
         private const val METADATA_KEY_BACKEND_URL_KEY =
             "com.stripe.android.paymentsheet.example.metadata.backend_url"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormUI.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -24,6 +25,8 @@ import com.stripe.android.ui.core.elements.AuBecsDebitMandateElementUI
 import com.stripe.android.ui.core.elements.AuBecsDebitMandateTextElement
 import com.stripe.android.ui.core.elements.FormElement
 import com.stripe.android.ui.core.elements.IdentifierSpec
+import com.stripe.android.ui.core.elements.OTPElement
+import com.stripe.android.ui.core.elements.OTPElementUI
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
 import com.stripe.android.ui.core.elements.SaveForFutureUseElementUI
 import com.stripe.android.ui.core.elements.SectionElement
@@ -73,6 +76,11 @@ internal fun FormInternal(
                         )
                         is AuBecsDebitMandateTextElement -> AuBecsDebitMandateElementUI(element)
                         is AffirmHeaderElement -> AffirmElementUI()
+                        is OTPElement -> OTPElementUI(
+                            // TODO: Think about how to make this compatible with LINK
+                            colors = TextFieldDefaults.textFieldColors(),
+                            controller = element.controller
+                        )
                     }
                 }
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormUI.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.CircularProgressIndicator
-import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -76,11 +75,7 @@ internal fun FormInternal(
                         )
                         is AuBecsDebitMandateTextElement -> AuBecsDebitMandateElementUI(element)
                         is AffirmHeaderElement -> AffirmElementUI()
-                        is OTPElement -> OTPElementUI(
-                            // TODO: Think about how to make this compatible with LINK
-                            colors = TextFieldDefaults.textFieldColors(),
-                            controller = element.controller
-                        )
+                        is OTPElement -> OTPElementUI(element)
                     }
                 }
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingAddressView.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingAddressView.kt
@@ -384,7 +384,8 @@ internal class BillingAddressView @JvmOverloads constructor(
         }
 
     private fun getLocale(): Locale {
-        return ConfigurationCompat.getLocales(context.resources.configuration)[0]
+        // TODO: revert this change, needed to compile
+        return ConfigurationCompat.getLocales(context.resources.configuration)[0]!!
     }
 
     internal sealed class PostalCodeConfig {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Here are the iOS designs: https://www.figma.com/file/HZeWCWoHS4CBY1buHDNyCU/Link-Mobile?node-id=2484%3A60735

Add OTP element for Link verification screen. The new OTP field consists of 6 individual textfields that handles next and previous focus change and calls the `onCodeEntered` when all 6 values are entered.

There is a small bug in TextField compose that causes the keyboard to change types between focus change https://issuetracker.google.com/issues/187746439 which was fixed. I tested by updating to 1.2.0 alpha and the issue was gone.

I want to note that this element does not use our internal TextField, it uses the base Android compose TextField because there is a lot of logic to jump between the next or previous TextFields. Our internal implementation only allows for validation. The validation needed for this new element are as follows:
- 1 character max in the TextField
- Bullet placeholder should disappear when focused

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

The current OTP field is just a plain textfield with some basic validation. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

<img src="https://user-images.githubusercontent.com/99316447/156083182-5926ee2b-2b74-4de5-a0e5-476362fda5fa.gif" height=400/>


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
