### PR TITLE
[stripe-core] pass a provider for `ApiRequest.Options`

### DIFF
--- a/stripe-core/api/stripe-core.api
+++ b/stripe-core/api/stripe-core.api
@@ -150,14 +150,6 @@ public final class com/stripe/android/core/networking/NetworkConstantsKt {
 	public static final fun getDEFAULT_RETRY_CODES ()Ljava/lang/Iterable;
 }
 
-public class com/stripe/android/core/networking/RequestHeadersFactory$BaseApiHeadersFactory : com/stripe/android/core/networking/RequestHeadersFactory {
-	public static final field $stable I
-	public fun <init> (Lcom/stripe/android/core/networking/ApiRequest$Options;Lcom/stripe/android/core/InternalAppInfo;Ljava/util/Locale;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Lcom/stripe/android/core/networking/ApiRequest$Options;Lcom/stripe/android/core/InternalAppInfo;Ljava/util/Locale;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	protected fun getExtraHeaders ()Ljava/util/Map;
-	protected fun getUserAgent ()Ljava/lang/String;
-}
-
 public final class com/stripe/android/core/networking/RetryDelaySupplier_Factory : dagger/internal/Factory {
 	public fun <init> ()V
 	public static fun create ()Lcom/stripe/android/core/networking/RetryDelaySupplier_Factory;

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/RequestHeadersFactoriesTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/RequestHeadersFactoriesTest.kt
@@ -103,7 +103,7 @@ class RequestHeadersFactoriesTest {
         appInfo: InternalAppInfo? = null
     ): Map<String, String> {
         return RequestHeadersFactory.BaseApiHeadersFactory(
-            options = options,
+            optionsProvider = { options },
             appInfo = appInfo,
             locale = locale
         ).create()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
For some of the request, we need to change the `ApiRequest.Options` values each time `#create` is called, passing an provider to make it mutable.


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Flexible API header creation


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
