### PR TITLE
[stripecardscan][stripe-core] Move some Jason parsing logic to stripe-core

### DIFF
--- a/stripe-core/api/stripe-core.api
+++ b/stripe-core/api/stripe-core.api
@@ -146,6 +146,9 @@ public final class com/stripe/android/core/networking/DefaultAnalyticsRequestExe
 	public static fun newInstance (Lcom/stripe/android/core/Logger;Lkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/core/networking/DefaultAnalyticsRequestExecutor;
 }
 
+public final class com/stripe/android/core/networking/JsonUtilsKt {
+}
+
 public final class com/stripe/android/core/networking/NetworkConstantsKt {
 	public static final fun getDEFAULT_RETRY_CODES ()Ljava/lang/Iterable;
 }

--- a/stripe-core/build.gradle
+++ b/stripe-core/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'checkstyle'
     id 'org.jetbrains.dokka'
     id 'org.jetbrains.kotlin.plugin.parcelize'
+    id 'org.jetbrains.kotlin.plugin.serialization' version '1.6.10'
 }
 
 assemble.dependsOn('lint')
@@ -27,6 +28,7 @@ dependencies {
 
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinSerializationVersion"
 
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/InvalidSerializationException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/InvalidSerializationException.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.stripecardscan.framework.exception
+package com.stripe.android.core.exception
 
 internal class InvalidSerializationException(type: String) :
     Exception("Serialization result $type is not supported")

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/JsonUtils.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/JsonUtils.kt
@@ -1,0 +1,45 @@
+package com.stripe.android.core.networking
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.core.exception.InvalidSerializationException
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * Convert a [JsonElement] to a [Map<String, *>] so it's compatible with [QueryStringFactory]. Note
+ * that this only supports [JsonObject]s currently. Other types will result in an
+ * [InvalidSerializationException].
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun JsonElement.toMap(): Map<String, *> = when (this) {
+    is JsonObject -> toMap()
+    else -> throw InvalidSerializationException(this::class.java.simpleName)
+}
+
+/**
+ * Recursively convert a [JsonElement] to its equivalent primitive kotlin values.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun JsonElement.toPrimitives(): Any? = when (this) {
+    JsonNull -> null
+    is JsonArray -> toPrimitives()
+    is JsonObject -> toMap()
+    is JsonPrimitive -> content.replace(Regex("^\"|\"$"), "") // remove "" around strings
+}
+
+/**
+ * Convert all elements of an array to their equivalent kotlin primitives.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun JsonArray.toPrimitives(): List<*> = map { it.toPrimitives() }
+
+/**
+ * Convert a [JsonObject] to a [Map<String, *>] so it's compatible with [QueryStringFactory].
+ *
+ * Adapted from https://stackoverflow.com/questions/44870961/how-to-map-a-json-string-to-kotlin-map
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun JsonObject.toMap(): Map<String, *> = map { it.key to it.value.toPrimitives() }.toMap()

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/util/Encode.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/util/Encode.kt
@@ -1,16 +1,11 @@
 package com.stripe.android.stripecardscan.framework.util
 
 import android.util.Base64
-import com.stripe.android.stripecardscan.framework.NetworkConfig
 import com.stripe.android.core.networking.QueryStringFactory
-import com.stripe.android.stripecardscan.framework.exception.InvalidSerializationException
+import com.stripe.android.core.networking.toMap
+import com.stripe.android.stripecardscan.framework.NetworkConfig
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerializationStrategy
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNull
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
 import java.nio.charset.Charset
 
 internal fun b64Encode(s: String): String =
@@ -25,38 +20,6 @@ internal fun b64Encode(b: ByteArray): String =
  */
 internal fun <T> encodeToXWWWFormUrl(serializer: SerializationStrategy<T>, value: T): String =
     QueryStringFactory.create(NetworkConfig.json.encodeToJsonElement(serializer, value).toMap())
-
-/**
- * Convert a [JsonElement] to a [Map<String, *>] so it's compatible with [QueryStringFactory]. Note
- * that this only supports [JsonObject]s currently. Other types will result in an
- * [InvalidSerializationException].
- */
-private fun JsonElement.toMap(): Map<String, *> = when (this) {
-    is JsonObject -> toMap()
-    else -> throw InvalidSerializationException(this::class.java.simpleName)
-}
-
-/**
- * Recursively convert a [JsonElement] to its equivalent primitive kotlin values.
- */
-private fun JsonElement.toPrimitives(): Any? = when (this) {
-    JsonNull -> null
-    is JsonArray -> toPrimitives()
-    is JsonObject -> toMap()
-    is JsonPrimitive -> content.replace(Regex("^\"|\"$"), "") // remove "" around strings
-}
-
-/**
- * Convert all elements of an array to their equivalent kotlin primitives.
- */
-private fun JsonArray.toPrimitives(): List<*> = map { it.toPrimitives() }
-
-/**
- * Convert a [JsonObject] to a [Map<String, *>] so it's compatible with [QueryStringFactory].
- *
- * Adapted from https://stackoverflow.com/questions/44870961/how-to-map-a-json-string-to-kotlin-map
- */
-private fun JsonObject.toMap(): Map<String, *> = map { it.key to it.value.toPrimitives() }.toMap()
 
 /**
  * Encode a serializable object to a JSON string


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Move some json parsing methods from `cardscan` to `stripe-core`, these utils are used for `QueryStringFactory` that's already in `stripe-core`, and they could be shared with other modules when building their own network parsers

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Code reuse

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
