### PR TITLE
[payments][stripe-core] move `StripeErrorJsonParser` to stripe-core

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/GooglePayResult.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/GooglePayResult.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.model
 
 import android.os.Parcelable
-import com.stripe.android.model.StripeJsonUtils.optString
+import com.stripe.android.core.model.StripeJsonUtils.optString
 import com.stripe.android.model.parsers.TokenJsonParser
 import kotlinx.parcelize.Parcelize
 import org.json.JSONException

--- a/payments-core/src/main/java/com/stripe/android/model/SourceParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/SourceParams.kt
@@ -4,6 +4,7 @@ import android.os.Parcel
 import android.os.Parcelable
 import androidx.annotation.IntRange
 import androidx.annotation.Size
+import com.stripe.android.core.model.StripeJsonUtils
 import com.stripe.android.model.Source.Companion.asSourceType
 import com.stripe.android.model.Source.SourceType
 import kotlinx.parcelize.Parceler

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/AccountRangeJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/AccountRangeJsonParser.kt
@@ -1,8 +1,9 @@
 package com.stripe.android.model.parsers
 
+import com.stripe.android.core.model.StripeJsonUtils
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.AccountRange
 import com.stripe.android.model.BinRange
-import com.stripe.android.model.StripeJsonUtils
 import org.json.JSONObject
 
 internal class AccountRangeJsonParser : ModelJsonParser<AccountRange> {

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/AddressJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/AddressJsonParser.kt
@@ -3,8 +3,9 @@ package com.stripe.android.model.parsers
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.PACKAGE_PRIVATE
+import com.stripe.android.core.model.StripeJsonUtils
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.Address
-import com.stripe.android.model.StripeJsonUtils
 import org.json.JSONObject
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/BankAccountJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/BankAccountJsonParser.kt
@@ -1,7 +1,8 @@
 package com.stripe.android.model.parsers
 
+import com.stripe.android.core.model.StripeJsonUtils
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.BankAccount
-import com.stripe.android.model.StripeJsonUtils
 import org.json.JSONObject
 
 internal class BankAccountJsonParser : ModelJsonParser<BankAccount> {

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/CardJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/CardJsonParser.kt
@@ -1,8 +1,9 @@
 package com.stripe.android.model.parsers
 
+import com.stripe.android.core.model.StripeJsonUtils
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.Card
 import com.stripe.android.model.CardFunding
-import com.stripe.android.model.StripeJsonUtils
 import com.stripe.android.model.TokenizationMethod
 import org.json.JSONObject
 

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/CardMetadataJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/CardMetadataJsonParser.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model.parsers
 
 import com.stripe.android.cards.Bin
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.CardMetadata
 import org.json.JSONArray
 import org.json.JSONObject

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/ConsumerSessionJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/ConsumerSessionJsonParser.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.model.parsers
 
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.ConsumerSession
 import org.json.JSONObject
 

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/ConsumerSessionLookupJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/ConsumerSessionLookupJsonParser.kt
@@ -1,8 +1,9 @@
 package com.stripe.android.model.parsers
 
+import com.stripe.android.core.model.StripeJsonUtils.optBoolean
+import com.stripe.android.core.model.StripeJsonUtils.optString
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.ConsumerSessionLookup
-import com.stripe.android.model.StripeJsonUtils.optBoolean
-import com.stripe.android.model.StripeJsonUtils.optString
 import org.json.JSONObject
 
 internal class ConsumerSessionLookupJsonParser : ModelJsonParser<ConsumerSessionLookup> {

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/CustomerJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/CustomerJsonParser.kt
@@ -1,9 +1,10 @@
 package com.stripe.android.model.parsers
 
+import com.stripe.android.core.model.StripeJsonUtils
+import com.stripe.android.core.model.StripeJsonUtils.optString
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.Customer
 import com.stripe.android.model.CustomerPaymentSource
-import com.stripe.android.model.StripeJsonUtils
-import com.stripe.android.model.StripeJsonUtils.optString
 import com.stripe.android.model.TokenizationMethod
 import org.json.JSONArray
 import org.json.JSONObject

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/CustomerPaymentSourceJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/CustomerPaymentSourceJsonParser.kt
@@ -1,10 +1,11 @@
 package com.stripe.android.model.parsers
 
+import com.stripe.android.core.model.StripeJsonUtils.optString
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.CustomerBankAccount
 import com.stripe.android.model.CustomerCard
 import com.stripe.android.model.CustomerPaymentSource
 import com.stripe.android.model.CustomerSource
-import com.stripe.android.model.StripeJsonUtils.optString
 import org.json.JSONObject
 
 internal class CustomerPaymentSourceJsonParser : ModelJsonParser<CustomerPaymentSource> {

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/EphemeralKeyJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/EphemeralKeyJsonParser.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model.parsers
 
 import com.stripe.android.EphemeralKey
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import org.json.JSONObject
 
 internal class EphemeralKeyJsonParser : ModelJsonParser<EphemeralKey> {

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/FpxBankStatusesJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/FpxBankStatusesJsonParser.kt
@@ -1,7 +1,8 @@
 package com.stripe.android.model.parsers
 
+import com.stripe.android.core.model.StripeJsonUtils
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.BankStatuses
-import com.stripe.android.model.StripeJsonUtils
 import org.json.JSONObject
 
 internal class FpxBankStatusesJsonParser : ModelJsonParser<BankStatuses> {

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/FraudDetectionDataJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/FraudDetectionDataJsonParser.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model.parsers
 
-import com.stripe.android.model.StripeJsonUtils.optString
+import com.stripe.android.core.model.StripeJsonUtils.optString
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.networking.FraudDetectionData
 import org.json.JSONObject
 

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/IssuingCardPinJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/IssuingCardPinJsonParser.kt
@@ -1,7 +1,8 @@
 package com.stripe.android.model.parsers
 
+import com.stripe.android.core.model.StripeJsonUtils.optString
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.IssuingCardPin
-import com.stripe.android.model.StripeJsonUtils.optString
 import org.json.JSONObject
 
 internal class IssuingCardPinJsonParser : ModelJsonParser<IssuingCardPin> {

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/NextActionDataParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/NextActionDataParser.kt
@@ -1,9 +1,10 @@
 package com.stripe.android.model.parsers
 
 import android.net.Uri
+import com.stripe.android.core.model.StripeJsonUtils
+import com.stripe.android.core.model.StripeJsonUtils.optString
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.model.StripeJsonUtils
-import com.stripe.android.model.StripeJsonUtils.optString
 import com.stripe.android.model.WeChat
 import org.json.JSONObject
 

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentIntentJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentIntentJsonParser.kt
@@ -1,11 +1,12 @@
 package com.stripe.android.model.parsers
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.model.StripeJsonUtils
+import com.stripe.android.core.model.StripeJsonUtils.optString
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.model.StripeJsonUtils
-import com.stripe.android.model.StripeJsonUtils.optString
 import org.json.JSONObject
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentMethodJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentMethodJsonParser.kt
@@ -1,9 +1,10 @@
 package com.stripe.android.model.parsers
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.model.StripeJsonUtils
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.model.StripeJsonUtils
 import org.json.JSONObject
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentMethodPreferenceJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentMethodPreferenceJsonParser.kt
@@ -1,9 +1,10 @@
 package com.stripe.android.model.parsers
 
+import com.stripe.android.core.model.StripeJsonUtils
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.model.StripeJsonUtils
 import org.json.JSONObject
 
 internal sealed class PaymentMethodPreferenceJsonParser<out StripeIntentType : StripeIntent> :

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentMethodsListJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentMethodsListJsonParser.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.model.parsers
 
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.PaymentMethodsList
 import org.json.JSONArray
 import org.json.JSONObject

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/RadarSessionJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/RadarSessionJsonParser.kt
@@ -1,7 +1,8 @@
 package com.stripe.android.model.parsers
 
+import com.stripe.android.core.model.StripeJsonUtils
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.RadarSession
-import com.stripe.android.model.StripeJsonUtils
 import org.json.JSONObject
 
 internal class RadarSessionJsonParser : ModelJsonParser<RadarSession> {

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/SetupIntentJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/SetupIntentJsonParser.kt
@@ -1,9 +1,10 @@
 package com.stripe.android.model.parsers
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.model.StripeJsonUtils.optString
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.model.StripeJsonUtils.optString
 import org.json.JSONObject
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) // For paymentsheet

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/ShippingInformationJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/ShippingInformationJsonParser.kt
@@ -1,7 +1,8 @@
 package com.stripe.android.model.parsers
 
+import com.stripe.android.core.model.StripeJsonUtils
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.ShippingInformation
-import com.stripe.android.model.StripeJsonUtils
 import org.json.JSONObject
 
 internal class ShippingInformationJsonParser : ModelJsonParser<ShippingInformation> {

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/SourceCardDataJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/SourceCardDataJsonParser.kt
@@ -1,9 +1,10 @@
 package com.stripe.android.model.parsers
 
+import com.stripe.android.core.model.StripeJsonUtils
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.Card
 import com.stripe.android.model.CardFunding
 import com.stripe.android.model.SourceTypeModel
-import com.stripe.android.model.StripeJsonUtils
 import com.stripe.android.model.TokenizationMethod
 import org.json.JSONObject
 

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/SourceJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/SourceJsonParser.kt
@@ -1,11 +1,12 @@
 package com.stripe.android.model.parsers
 
 import androidx.annotation.Size
+import com.stripe.android.core.model.StripeJsonUtils
+import com.stripe.android.core.model.StripeJsonUtils.optString
 import com.stripe.android.core.model.StripeModel
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.Source
 import com.stripe.android.model.SourceTypeModel
-import com.stripe.android.model.StripeJsonUtils
-import com.stripe.android.model.StripeJsonUtils.optString
 import org.json.JSONObject
 
 internal class SourceJsonParser : ModelJsonParser<Source> {

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/SourceOrderJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/SourceOrderJsonParser.kt
@@ -1,7 +1,8 @@
 package com.stripe.android.model.parsers
 
+import com.stripe.android.core.model.StripeJsonUtils
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.SourceOrder
-import com.stripe.android.model.StripeJsonUtils
 import org.json.JSONArray
 import org.json.JSONObject
 

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/SourceOwnerJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/SourceOwnerJsonParser.kt
@@ -1,7 +1,8 @@
 package com.stripe.android.model.parsers
 
+import com.stripe.android.core.model.StripeJsonUtils
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.Source
-import com.stripe.android.model.StripeJsonUtils
 import org.json.JSONObject
 
 internal class SourceOwnerJsonParser : ModelJsonParser<Source.Owner> {

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/SourceSepaDebitDataJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/SourceSepaDebitDataJsonParser.kt
@@ -1,7 +1,8 @@
 package com.stripe.android.model.parsers
 
+import com.stripe.android.core.model.StripeJsonUtils
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.SourceTypeModel
-import com.stripe.android.model.StripeJsonUtils
 import org.json.JSONObject
 
 internal class SourceSepaDebitDataJsonParser : ModelJsonParser<SourceTypeModel.SepaDebit> {

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/Stripe3ds2AuthResultJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/Stripe3ds2AuthResultJsonParser.kt
@@ -1,7 +1,8 @@
 package com.stripe.android.model.parsers
 
+import com.stripe.android.core.model.StripeJsonUtils.optString
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.Stripe3ds2AuthResult
-import com.stripe.android.model.StripeJsonUtils.optString
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -60,7 +61,8 @@ internal class Stripe3ds2AuthResultJsonParser : ModelJsonParser<Stripe3ds2AuthRe
         }
     }
 
-    internal class MessageExtensionJsonParser : ModelJsonParser<Stripe3ds2AuthResult.MessageExtension> {
+    internal class MessageExtensionJsonParser :
+        ModelJsonParser<Stripe3ds2AuthResult.MessageExtension> {
         fun parse(jsonArray: JSONArray): List<Stripe3ds2AuthResult.MessageExtension> {
             return (0 until jsonArray.length())
                 .mapNotNull { jsonArray.optJSONObject(it) }

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/StripeFileJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/StripeFileJsonParser.kt
@@ -1,10 +1,11 @@
 package com.stripe.android.model.parsers
 
+import com.stripe.android.core.model.StripeJsonUtils.optInteger
+import com.stripe.android.core.model.StripeJsonUtils.optLong
+import com.stripe.android.core.model.StripeJsonUtils.optString
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.StripeFile
 import com.stripe.android.model.StripeFilePurpose
-import com.stripe.android.model.StripeJsonUtils.optInteger
-import com.stripe.android.model.StripeJsonUtils.optLong
-import com.stripe.android.model.StripeJsonUtils.optString
 import org.json.JSONObject
 
 internal class StripeFileJsonParser : ModelJsonParser<StripeFile> {

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/TokenJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/TokenJsonParser.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model.parsers
 
-import com.stripe.android.model.StripeJsonUtils
+import com.stripe.android.core.model.StripeJsonUtils
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.Token
 import com.stripe.android.model.Token.Type
 import org.json.JSONObject

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/WalletJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/WalletJsonParser.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model.parsers
 
-import com.stripe.android.model.StripeJsonUtils.optString
+import com.stripe.android.core.model.StripeJsonUtils.optString
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.wallets.Wallet
 import org.json.JSONObject
 

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/WeChatJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/WeChatJsonParser.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model.parsers
 
-import com.stripe.android.model.StripeJsonUtils
+import com.stripe.android.core.model.StripeJsonUtils
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.WeChat
 import org.json.JSONObject
 

--- a/payments-core/src/main/java/com/stripe/android/networking/FraudDetectionDataRequest.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/FraudDetectionDataRequest.kt
@@ -1,10 +1,10 @@
 package com.stripe.android.networking
 
 import com.stripe.android.core.exception.InvalidRequestException
+import com.stripe.android.core.model.StripeJsonUtils
 import com.stripe.android.core.networking.DEFAULT_RETRY_CODES
 import com.stripe.android.core.networking.RequestHeadersFactory
 import com.stripe.android.core.networking.StripeRequest
-import com.stripe.android.model.StripeJsonUtils
 import java.io.OutputStream
 import java.io.UnsupportedEncodingException
 

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -17,6 +17,8 @@ import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.model.StripeModel
+import com.stripe.android.core.model.parsers.ModelJsonParser
+import com.stripe.android.core.model.parsers.StripeErrorJsonParser
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.ApiRequest
@@ -52,7 +54,6 @@ import com.stripe.android.model.Source
 import com.stripe.android.model.SourceParams
 import com.stripe.android.model.Stripe3ds2AuthParams
 import com.stripe.android.model.Stripe3ds2AuthResult
-import com.stripe.android.model.StripeErrorJsonParser
 import com.stripe.android.model.StripeFile
 import com.stripe.android.model.StripeFileParams
 import com.stripe.android.model.StripeIntent
@@ -64,7 +65,6 @@ import com.stripe.android.model.parsers.ConsumerSessionLookupJsonParser
 import com.stripe.android.model.parsers.CustomerJsonParser
 import com.stripe.android.model.parsers.FpxBankStatusesJsonParser
 import com.stripe.android.model.parsers.IssuingCardPinJsonParser
-import com.stripe.android.model.parsers.ModelJsonParser
 import com.stripe.android.model.parsers.PaymentIntentJsonParser
 import com.stripe.android.model.parsers.PaymentMethodJsonParser
 import com.stripe.android.model.parsers.PaymentMethodPreferenceForPaymentIntentJsonParser

--- a/payments-core/src/main/java/com/stripe/android/view/BecsDebitBanks.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/BecsDebitBanks.kt
@@ -3,7 +3,7 @@ package com.stripe.android.view
 import android.content.Context
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
-import com.stripe.android.model.StripeJsonUtils
+import com.stripe.android.core.model.StripeJsonUtils
 import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 import java.util.Scanner

--- a/payments-core/src/test/java/com/stripe/android/GooglePayJsonFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/GooglePayJsonFactoryTest.kt
@@ -2,7 +2,7 @@ package com.stripe.android
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.ApiVersion
-import com.stripe.android.model.StripeJsonUtils
+import com.stripe.android.core.model.StripeJsonUtils
 import org.json.JSONObject
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner

--- a/payments-core/src/test/java/com/stripe/android/StripeErrorFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripeErrorFixtures.kt
@@ -1,8 +1,6 @@
 package com.stripe.android
 
 import com.stripe.android.core.StripeError
-import com.stripe.android.model.StripeErrorJsonParser
-import org.json.JSONObject
 
 internal object StripeErrorFixtures {
     @JvmField
@@ -13,21 +11,5 @@ internal object StripeErrorFixtures {
         "type",
         "",
         ""
-    )
-
-    val INVALID_CARD_NUMBER = StripeErrorJsonParser().parse(
-        JSONObject(
-            """
-        {
-            "error": {
-                "code": "incorrect_number",
-                "doc_url": "https:\/\/stripe.com\/docs\/error-codes\/incorrect-number",
-                "message": "Your card number is incorrect.",
-                "param": "number",
-                "type": "card_error"
-            }
-        }
-            """.trimIndent()
-        )
     )
 }

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/StripeGooglePayViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/StripeGooglePayViewModelTest.kt
@@ -5,11 +5,11 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.model.StripeJsonUtils
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.GooglePayFixtures.GOOGLE_PAY_RESULT_WITH_NO_BILLING_ADDRESS
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
-import com.stripe.android.model.StripeJsonUtils
 import com.stripe.android.networking.AbsFakeStripeRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/PaymentMethodPreferenceJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/PaymentMethodPreferenceJsonParserTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model.parsers
 
 import com.google.common.truth.Truth
+import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.PaymentMethodPreferenceFixtures
 import org.junit.Test
 

--- a/stripe-core/src/main/java/com/stripe/android/core/model/StripeJsonUtils.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/model/StripeJsonUtils.kt
@@ -1,5 +1,6 @@
-package com.stripe.android.model
+package com.stripe.android.core.model
 
+import androidx.annotation.RestrictTo
 import androidx.annotation.Size
 import org.json.JSONArray
 import org.json.JSONException
@@ -8,7 +9,8 @@ import org.json.JSONObject
 /**
  * A set of JSON parsing utility functions.
  */
-internal object StripeJsonUtils {
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+object StripeJsonUtils {
     private const val NULL = "null"
 
     /**
@@ -20,7 +22,7 @@ internal object StripeJsonUtils {
      * @return the value stored in the requested field, or `false` if the key is not present
      */
     @JvmSynthetic
-    internal fun optBoolean(
+    fun optBoolean(
         jsonObject: JSONObject,
         @Size(min = 1) fieldName: String
     ): Boolean {
@@ -36,7 +38,7 @@ internal object StripeJsonUtils {
      * @return the value stored in the requested field, or `null` if the key is not present
      */
     @JvmSynthetic
-    internal fun optInteger(
+    fun optInteger(
         jsonObject: JSONObject,
         @Size(min = 1) fieldName: String
     ): Int? {
@@ -56,7 +58,7 @@ internal object StripeJsonUtils {
      * @return the value stored in the requested field, or `null` if the key is not present
      */
     @JvmSynthetic
-    internal fun optLong(
+    fun optLong(
         jsonObject: JSONObject,
         @Size(min = 1) fieldName: String
     ): Long? {
@@ -94,7 +96,7 @@ internal object StripeJsonUtils {
      */
     @JvmSynthetic
     @Size(2)
-    internal fun optCountryCode(
+    fun optCountryCode(
         jsonObject: JSONObject,
         @Size(min = 1) fieldName: String
     ): String? {
@@ -112,7 +114,7 @@ internal object StripeJsonUtils {
      */
     @JvmStatic
     @Size(3)
-    internal fun optCurrency(
+    fun optCurrency(
         jsonObject: JSONObject,
         @Size(min = 1) fieldName: String
     ): String? {
@@ -128,7 +130,7 @@ internal object StripeJsonUtils {
      * @return the value stored in the requested field, or `null` if the key is not present
      */
     @JvmSynthetic
-    internal fun optMap(
+    fun optMap(
         jsonObject: JSONObject,
         @Size(min = 1) fieldName: String
     ): Map<String, Any?>? {
@@ -145,7 +147,7 @@ internal object StripeJsonUtils {
      * @return the value stored in the requested field, or `null` if the key is not present
      */
     @JvmSynthetic
-    internal fun optHash(
+    fun optHash(
         jsonObject: JSONObject,
         @Size(min = 1) fieldName: String
     ): Map<String, String>? {
@@ -161,7 +163,7 @@ internal object StripeJsonUtils {
      * @return a [Map] representing the input, or `null` if the input is `null`
      */
     @JvmSynthetic
-    internal fun jsonObjectToMap(jsonObject: JSONObject?): Map<String, Any?>? {
+    fun jsonObjectToMap(jsonObject: JSONObject?): Map<String, Any?>? {
         if (jsonObject == null) {
             return null
         }
@@ -196,7 +198,7 @@ internal object StripeJsonUtils {
      * @return a [Map] representing the input, or `null` if the input is `null`
      */
     @JvmSynthetic
-    internal fun jsonObjectToStringMap(jsonObject: JSONObject?): Map<String, String>? {
+    fun jsonObjectToStringMap(jsonObject: JSONObject?): Map<String, String>? {
         if (jsonObject == null) {
             return null
         }
@@ -222,7 +224,7 @@ internal object StripeJsonUtils {
      * @return a [List] representing the input, or `null` if said input is `null`
      */
     @JvmSynthetic
-    internal fun jsonArrayToList(jsonArray: JSONArray?): List<Any>? {
+    fun jsonArrayToList(jsonArray: JSONArray?): List<Any>? {
         if (jsonArray == null) {
             return null
         }
@@ -252,7 +254,7 @@ internal object StripeJsonUtils {
      * @return a [JSONObject] representing the input map, or `null` if the input
      * object is `null`
      */
-    internal fun mapToJsonObject(mapObject: Map<String, *>?): JSONObject? {
+    fun mapToJsonObject(mapObject: Map<String, *>?): JSONObject? {
         if (mapObject == null) {
             return null
         }
@@ -317,7 +319,7 @@ internal object StripeJsonUtils {
     }
 
     @JvmSynthetic
-    internal fun nullIfNullOrEmpty(possibleNull: String?): String? {
+    fun nullIfNullOrEmpty(possibleNull: String?): String? {
         return possibleNull?.let { s ->
             s.takeUnless { NULL == it || it.isEmpty() }
         }

--- a/stripe-core/src/main/java/com/stripe/android/core/model/parsers/ModelJsonParser.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/model/parsers/ModelJsonParser.kt
@@ -1,14 +1,17 @@
-package com.stripe.android.model.parsers
+package com.stripe.android.core.model.parsers
 
+import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeModel
 import org.json.JSONArray
 import org.json.JSONObject
 
-internal interface ModelJsonParser<out ModelType : StripeModel> {
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+interface ModelJsonParser<out ModelType : StripeModel> {
     fun parse(json: JSONObject): ModelType?
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
-        internal fun jsonArrayToList(jsonArray: JSONArray?): List<String> {
+        fun jsonArrayToList(jsonArray: JSONArray?): List<String> {
             return jsonArray?.let {
                 (0 until jsonArray.length()).map { jsonArray.getString(it) }
             } ?: emptyList()

--- a/stripe-core/src/main/java/com/stripe/android/core/model/parsers/StripeErrorJsonParser.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/model/parsers/StripeErrorJsonParser.kt
@@ -1,12 +1,13 @@
-package com.stripe.android.model
+package com.stripe.android.core.model.parsers
 
+import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.core.StripeError
-import com.stripe.android.model.StripeJsonUtils.optString
-import com.stripe.android.model.parsers.ModelJsonParser
+import com.stripe.android.core.model.StripeJsonUtils.optString
 import org.json.JSONObject
 
-internal class StripeErrorJsonParser : ModelJsonParser<StripeError> {
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class StripeErrorJsonParser : ModelJsonParser<StripeError> {
 
     override fun parse(json: JSONObject): StripeError {
         return runCatching {
@@ -28,9 +29,11 @@ internal class StripeErrorJsonParser : ModelJsonParser<StripeError> {
         )
     }
 
-    internal companion object {
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    companion object {
         @VisibleForTesting
-        internal const val MALFORMED_RESPONSE_MESSAGE = "An improperly formatted error response was found."
+        internal const val MALFORMED_RESPONSE_MESSAGE =
+            "An improperly formatted error response was found."
 
         private const val FIELD_CHARGE = "charge"
         private const val FIELD_CODE = "code"

--- a/stripe-core/src/test/java/com/stripe/android/core/StripeErrorFixtures.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/StripeErrorFixtures.kt
@@ -1,5 +1,8 @@
 package com.stripe.android.core
 
+import com.stripe.android.core.model.parsers.StripeErrorJsonParser
+import org.json.JSONObject
+
 internal object StripeErrorFixtures {
     @JvmField
     val INVALID_REQUEST_ERROR = StripeError(
@@ -9,5 +12,21 @@ internal object StripeErrorFixtures {
         "type",
         "",
         ""
+    )
+
+    val INVALID_CARD_NUMBER = StripeErrorJsonParser().parse(
+        JSONObject(
+            """
+        {
+            "error": {
+                "code": "incorrect_number",
+                "doc_url": "https:\/\/stripe.com\/docs\/error-codes\/incorrect-number",
+                "message": "Your card number is incorrect.",
+                "param": "number",
+                "type": "card_error"
+            }
+        }
+            """.trimIndent()
+        )
     )
 }

--- a/stripe-core/src/test/java/com/stripe/android/core/model/StripeJsonUtilsTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/model/StripeJsonUtilsTest.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.model
+package com.stripe.android.core.model
 
 import org.json.JSONArray
 import org.json.JSONObject

--- a/stripe-core/src/test/java/com/stripe/android/core/model/parsers/StripeErrorJsonParserTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/model/parsers/StripeErrorJsonParserTest.kt
@@ -1,8 +1,8 @@
-package com.stripe.android
+package com.stripe.android.core.model.parsers
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.StripeError
-import com.stripe.android.model.StripeErrorJsonParser
+import com.stripe.android.core.StripeErrorFixtures
 import org.json.JSONObject
 import kotlin.test.Test
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Move `StripeErrorJsonParser` to stripe-core, along with its tests and utils.

Apart from moving files around, there is no logic change in this PR

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
The parser is used to parse the `StripeError` object that can be shared across all SDKs.


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
