### PR TITLE
Fix Link tests

### DIFF
--- a/link/src/androidTest/java/com/stripe/android/link/AndroidComposeTestRule.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/AndroidComposeTestRule.kt
@@ -1,0 +1,38 @@
+package com.stripe.android.link
+
+import android.content.Context
+import android.content.Intent
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.AndroidComposeTestRule
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+
+/**
+ * Factory method to provide android specific implementation of createComposeRule, for a given
+ * activity class type A that needs to be launched via an intent.
+ *
+ * @param intentFactory A lambda that provides a Context that can used to create an intent. A intent needs to be returned.
+ */
+inline fun <A : ComponentActivity> createAndroidIntentComposeRule(intentFactory: (context: Context) -> Intent): AndroidComposeTestRule<ActivityScenarioRule<A>, A> {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val intent = intentFactory(context)
+
+    return AndroidComposeTestRule(
+        activityRule = ActivityScenarioRule(intent),
+        activityProvider = { scenarioRule -> scenarioRule.getActivity() }
+    )
+}
+
+/**
+ * Gets the activity from a scenarioRule.
+ *
+ * https://androidx.tech/artifacts/compose.ui/ui-test-junit4/1.0.0-alpha11-source/androidx/compose/ui/test/junit4/AndroidComposeTestRule.kt.html
+ */
+fun <A : ComponentActivity> ActivityScenarioRule<A>.getActivity(): A {
+    var activity: A? = null
+
+    scenario.onActivity { activity = it }
+
+    return activity
+        ?: throw IllegalStateException("Activity was not set in the ActivityScenarioRule!")
+}

--- a/link/src/androidTest/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
@@ -1,15 +1,18 @@
 package com.stripe.android.link.ui.signup
 
+import android.content.Intent
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.link.LinkActivity
+import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.R
+import com.stripe.android.link.createAndroidIntentComposeRule
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.ui.core.elements.EmailSpec
 import org.junit.Rule
@@ -20,7 +23,19 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 internal class SignUpScreenTest {
     @get:Rule
-    val composeTestRule = createAndroidComposeRule<LinkActivity>()
+    val composeTestRule = createAndroidIntentComposeRule<LinkActivity> {
+        PaymentConfiguration.init(it, "publishable_key")
+        Intent(it, LinkActivity::class.java).apply {
+            putExtra(
+                LinkActivityContract.EXTRA_ARGS,
+                LinkActivityContract.Args(
+                    "Merchant, Inc",
+                    "customer@email.com",
+                    null
+                )
+            )
+        }
+    }
 
     @Test
     fun status_inputting_email_shows_only_email_field() {
@@ -67,7 +82,7 @@ internal class SignUpScreenTest {
         onPhoneField().performTextInput("12345")
         onSignUpButton().assertIsNotEnabled()
 
-        onPhoneField().performTextInput("1234567890")
+        onPhoneField().performTextInput("67890")
         onSignUpButton().assertIsEnabled()
     }
 

--- a/link/src/androidTest/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
@@ -28,11 +28,7 @@ internal class SignUpScreenTest {
         Intent(it, LinkActivity::class.java).apply {
             putExtra(
                 LinkActivityContract.EXTRA_ARGS,
-                LinkActivityContract.Args(
-                    "Merchant, Inc",
-                    "customer@email.com",
-                    null
-                )
+                LinkActivityContract.Args("Merchant, Inc")
             )
         }
     }

--- a/link/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
@@ -45,9 +45,12 @@ internal class SignUpViewModel @Inject constructor(
     /**
      * Emits the email entered in the form if valid, null otherwise.
      */
-    private val consumerEmail: StateFlow<String?> = emailElement.getFormFieldValueFlow().map {
-        it.firstOrNull()?.second?.takeIf { formFieldEntry -> formFieldEntry.isComplete }?.value
-    }.stateIn(viewModelScope, SharingStarted.Lazily, args.customerEmail)
+    private val consumerEmail: StateFlow<String?> =
+        emailElement.getFormFieldValueFlow().map { formFieldsList ->
+            // formFieldsList contains only one element, for the email. Take the second value of
+            // the pair, which is the FormFieldEntry containing the value entered by the user.
+            formFieldsList.firstOrNull()?.second?.takeIf { it.isComplete }?.value
+        }.stateIn(viewModelScope, SharingStarted.Lazily, args.customerEmail)
 
     private val _signUpStatus = MutableStateFlow(SignUpState.InputtingEmail)
     val signUpState: StateFlow<SignUpState> = _signUpStatus

--- a/link/src/test/java/com/stripe/android/link/LinkActivityTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkActivityTest.kt
@@ -3,8 +3,10 @@ package com.stripe.android.link
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.link.utils.InjectableActivityScenario
 import com.stripe.android.link.utils.injectableActivityScenario
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -16,6 +18,11 @@ class LinkActivityTest {
         context,
         LinkActivityContract.Args("Example, Inc.")
     )
+
+    @Before
+    fun before() {
+        PaymentConfiguration.init(context, "publishable_key")
+    }
 
     @Test
     fun `Activity launches sign up UI`() {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Instrumentation test was failing because LinkActivity requires intent arguments.
Comment logic for retrieving email from email element.
Fix LinkActivityTest which requires PaymentConfiguration to be initialized.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix instrumentation tests.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
   
