### PR TITLE
Extract common logic to AnalyticsRequestFactory.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsEvent.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsEvent.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.networking
 
-internal enum class PaymentAnalyticsEvent(internal val code: String) {
+import com.stripe.android.core.networking.AnalyticsEvent
+
+internal enum class PaymentAnalyticsEvent(override val code: String) : AnalyticsEvent {
     // Token
     TokenCreate("token_creation"),
 

--- a/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsRequestFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsRequestFactory.kt
@@ -9,6 +9,7 @@ import androidx.annotation.VisibleForTesting
 import com.stripe.android.BuildConfig
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.networking.AnalyticsRequest
+import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.RequestHeadersFactory
 import com.stripe.android.core.version.StripeSdkVersion
@@ -31,7 +32,13 @@ class PaymentAnalyticsRequestFactory @VisibleForTesting internal constructor(
     private val packageName: String,
     private val publishableKeyProvider: Provider<String>,
     internal val defaultProductUsageTokens: Set<String> = emptySet()
+) : AnalyticsRequestFactory(
+    packageManager,
+    packageInfo,
+    packageName,
+    publishableKeyProvider
 ) {
+
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     constructor(
         context: Context,
@@ -181,13 +188,9 @@ class PaymentAnalyticsRequestFactory @VisibleForTesting internal constructor(
         event: String,
         deviceId: String
     ): AnalyticsRequest {
-        return AnalyticsRequest(
-            createParams(
-                event
-            ).plus(
-                FIELD_DEVICE_ID to deviceId
-            ),
-            RequestHeadersFactory.Analytics.create()
+        return createRequest(
+            event,
+            mapOf(FIELD_DEVICE_ID to deviceId)
         )
     }
 
@@ -199,42 +202,30 @@ class PaymentAnalyticsRequestFactory @VisibleForTesting internal constructor(
         tokenType: Token.Type? = null,
         threeDS2UiType: ThreeDS2UiType? = null
     ): AnalyticsRequest {
-        return AnalyticsRequest(
-            createParams(
-                event.toString(),
-                productUsageTokens,
-                sourceType,
-                tokenType,
-                threeDS2UiType
-            ),
-            RequestHeadersFactory.Analytics.create()
+        return createRequest(
+            event,
+            additionalParams(
+                productUsageTokens = productUsageTokens,
+                sourceType = sourceType,
+                tokenType = tokenType,
+                threeDS2UiType = threeDS2UiType
+            )
         )
     }
 
-    private fun createParams(
-        event: String,
+    private fun additionalParams(
         productUsageTokens: Set<String> = emptySet(),
         @Source.SourceType sourceType: String? = null,
         tokenType: Token.Type? = null,
         threeDS2UiType: ThreeDS2UiType? = null
     ): Map<String, Any> {
-        return createStandardParams(event)
-            .plus(createAppDataParams())
-            .plus(
-                defaultProductUsageTokens.plus(productUsageTokens)
-                    .takeUnless { it.isEmpty() }?.let {
-                        mapOf(FIELD_PRODUCT_USAGE to it.toList())
-                    }.orEmpty()
-            )
+        return defaultProductUsageTokens
+            .plus(productUsageTokens)
+            .takeUnless { it.isEmpty() }?.let { mapOf(FIELD_PRODUCT_USAGE to it.toList()) }
+            .orEmpty()
             .plus(sourceType?.let { mapOf(FIELD_SOURCE_TYPE to it) }.orEmpty())
             .plus(createTokenTypeParam(sourceType, tokenType))
-            .plus(
-                threeDS2UiType?.let {
-                    mapOf(
-                        FIELD_3DS2_UI_TYPE to it.toString()
-                    )
-                }.orEmpty()
-            )
+            .plus(threeDS2UiType?.let { mapOf(FIELD_3DS2_UI_TYPE to it.toString()) }.orEmpty())
     }
 
     private fun createTokenTypeParam(
@@ -252,45 +243,6 @@ class PaymentAnalyticsRequestFactory @VisibleForTesting internal constructor(
         return value?.let {
             mapOf(FIELD_TOKEN_TYPE to it)
         }.orEmpty()
-    }
-
-    private fun createStandardParams(
-        event: String
-    ): Map<String, Any> {
-        return mapOf(
-            FIELD_ANALYTICS_UA to ANALYTICS_UA,
-            FIELD_EVENT to event,
-            FIELD_PUBLISHABLE_KEY to runCatching {
-                publishableKeyProvider.get()
-            }.getOrDefault(ApiRequest.Options.UNDEFINED_PUBLISHABLE_KEY),
-            FIELD_OS_NAME to Build.VERSION.CODENAME,
-            FIELD_OS_RELEASE to Build.VERSION.RELEASE,
-            FIELD_OS_VERSION to Build.VERSION.SDK_INT,
-            FIELD_DEVICE_TYPE to DEVICE_TYPE,
-            FIELD_BINDINGS_VERSION to StripeSdkVersion.VERSION_NAME,
-            FIELD_IS_DEVELOPMENT to BuildConfig.DEBUG
-        )
-    }
-
-    internal fun createAppDataParams(): Map<String, Any> {
-        return when {
-            packageManager != null && packageInfo != null -> {
-                mapOf(
-                    FIELD_APP_NAME to getAppName(packageInfo, packageManager),
-                    FIELD_APP_VERSION to packageInfo.versionCode
-                )
-            }
-            else -> emptyMap()
-        }
-    }
-
-    private fun getAppName(
-        packageInfo: PackageInfo?,
-        packageManager: PackageManager
-    ): CharSequence {
-        return packageInfo?.applicationInfo?.loadLabel(packageManager).takeUnless {
-            it.isNullOrBlank()
-        } ?: packageName
     }
 
     internal enum class ThreeDS2UiType(
@@ -314,37 +266,10 @@ class PaymentAnalyticsRequestFactory @VisibleForTesting internal constructor(
     }
 
     internal companion object {
-        internal const val FIELD_PRODUCT_USAGE = "product_usage"
-        internal const val FIELD_ANALYTICS_UA = "analytics_ua"
-        internal const val FIELD_APP_NAME = "app_name"
-        internal const val FIELD_APP_VERSION = "app_version"
-        internal const val FIELD_BINDINGS_VERSION = "bindings_version"
-        internal const val FIELD_IS_DEVELOPMENT = "is_development"
+        internal const val FIELD_TOKEN_TYPE = "token_type"
         internal const val FIELD_DEVICE_ID = "device_id"
-        internal const val FIELD_DEVICE_TYPE = "device_type"
-        internal const val FIELD_EVENT = "event"
-        internal const val FIELD_OS_NAME = "os_name"
-        internal const val FIELD_OS_RELEASE = "os_release"
-        internal const val FIELD_OS_VERSION = "os_version"
-        internal const val FIELD_PUBLISHABLE_KEY = "publishable_key"
+        internal const val FIELD_PRODUCT_USAGE = "product_usage"
         internal const val FIELD_SOURCE_TYPE = "source_type"
         internal const val FIELD_3DS2_UI_TYPE = "3ds2_ui_type"
-        internal const val FIELD_TOKEN_TYPE = "token_type"
-
-        @JvmSynthetic
-        internal val VALID_PARAM_FIELDS: Set<String> = setOf(
-            FIELD_ANALYTICS_UA, FIELD_APP_NAME, FIELD_APP_VERSION, FIELD_BINDINGS_VERSION,
-            FIELD_IS_DEVELOPMENT, FIELD_DEVICE_TYPE, FIELD_EVENT, FIELD_OS_VERSION, FIELD_OS_NAME,
-            FIELD_OS_RELEASE, FIELD_PRODUCT_USAGE, FIELD_PUBLISHABLE_KEY, FIELD_SOURCE_TYPE,
-            FIELD_TOKEN_TYPE
-        )
-
-        private const val ANALYTICS_PREFIX = "analytics"
-        private const val ANALYTICS_NAME = "stripe_android"
-        private const val ANALYTICS_VERSION = "1.0"
-
-        private val DEVICE_TYPE: String = "${Build.MANUFACTURER}_${Build.BRAND}_${Build.MODEL}"
-
-        internal const val ANALYTICS_UA = "$ANALYTICS_PREFIX.$ANALYTICS_NAME-$ANALYTICS_VERSION"
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/PaymentAnalyticsRequestFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentAnalyticsRequestFactoryTest.kt
@@ -6,7 +6,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.Source
@@ -45,9 +45,9 @@ class PaymentAnalyticsRequestFactoryTest {
 
         // Size is SIZE-1 because tokens don't have a source_type field
         assertThat(params)
-            .hasSize(PaymentAnalyticsRequestFactory.VALID_PARAM_FIELDS.size - 1)
+            .hasSize(VALID_PARAM_FIELDS.size - 1)
 
-        assertThat(params[PaymentAnalyticsRequestFactory.FIELD_EVENT])
+        assertThat(params[AnalyticsRequestFactory.FIELD_EVENT])
             .isEqualTo(expectedEvent)
         assertThat(params[PaymentAnalyticsRequestFactory.FIELD_TOKEN_TYPE])
             .isEqualTo(Token.Type.Pii.code)
@@ -65,8 +65,8 @@ class PaymentAnalyticsRequestFactoryTest {
 
         // Size is SIZE-1 because tokens don't have a source_type field
         assertThat(params)
-            .hasSize(PaymentAnalyticsRequestFactory.VALID_PARAM_FIELDS.size - 1)
-        assertEquals(expectedEventName, params[PaymentAnalyticsRequestFactory.FIELD_EVENT])
+            .hasSize(VALID_PARAM_FIELDS.size - 1)
+        assertEquals(expectedEventName, params[AnalyticsRequestFactory.FIELD_EVENT])
         assertEquals(Token.Type.CvcUpdate.code, params[PaymentAnalyticsRequestFactory.FIELD_TOKEN_TYPE])
     }
 
@@ -79,20 +79,20 @@ class PaymentAnalyticsRequestFactoryTest {
 
         // Size is SIZE-1 because tokens don't have a token_type field
         assertThat(loggingParams)
-            .hasSize(PaymentAnalyticsRequestFactory.VALID_PARAM_FIELDS.size - 1)
+            .hasSize(VALID_PARAM_FIELDS.size - 1)
 
         assertEquals(
             Source.SourceType.SEPA_DEBIT,
             loggingParams[PaymentAnalyticsRequestFactory.FIELD_SOURCE_TYPE]
         )
-        assertEquals(API_KEY, loggingParams[PaymentAnalyticsRequestFactory.FIELD_PUBLISHABLE_KEY])
+        assertEquals(API_KEY, loggingParams[AnalyticsRequestFactory.FIELD_PUBLISHABLE_KEY])
         assertEquals(
             PaymentAnalyticsEvent.SourceCreate.toString(),
-            loggingParams[PaymentAnalyticsRequestFactory.FIELD_EVENT]
+            loggingParams[AnalyticsRequestFactory.FIELD_EVENT]
         )
         assertEquals(
-            PaymentAnalyticsRequestFactory.ANALYTICS_UA,
-            loggingParams[PaymentAnalyticsRequestFactory.FIELD_ANALYTICS_UA]
+            AnalyticsRequestFactory.ANALYTICS_UA,
+            loggingParams[AnalyticsRequestFactory.FIELD_ANALYTICS_UA]
         )
     }
 
@@ -131,13 +131,13 @@ class PaymentAnalyticsRequestFactoryTest {
             ).params
 
         assertThat(loggingParams)
-            .hasSize(PaymentAnalyticsRequestFactory.VALID_PARAM_FIELDS.size - 2)
-        assertThat(loggingParams[PaymentAnalyticsRequestFactory.FIELD_PUBLISHABLE_KEY])
+            .hasSize(VALID_PARAM_FIELDS.size - 2)
+        assertThat(loggingParams[AnalyticsRequestFactory.FIELD_PUBLISHABLE_KEY])
             .isEqualTo(API_KEY)
-        assertThat(loggingParams[PaymentAnalyticsRequestFactory.FIELD_EVENT])
+        assertThat(loggingParams[AnalyticsRequestFactory.FIELD_EVENT])
             .isEqualTo(PaymentAnalyticsEvent.PaymentIntentConfirm.toString())
-        assertThat(loggingParams[PaymentAnalyticsRequestFactory.FIELD_ANALYTICS_UA])
-            .isEqualTo(PaymentAnalyticsRequestFactory.ANALYTICS_UA)
+        assertThat(loggingParams[AnalyticsRequestFactory.FIELD_ANALYTICS_UA])
+            .isEqualTo(AnalyticsRequestFactory.ANALYTICS_UA)
     }
 
     @Test
@@ -147,15 +147,15 @@ class PaymentAnalyticsRequestFactoryTest {
         ).params
 
         assertThat(loggingParams)
-            .hasSize(PaymentAnalyticsRequestFactory.VALID_PARAM_FIELDS.size - 2)
-        assertEquals(API_KEY, loggingParams[PaymentAnalyticsRequestFactory.FIELD_PUBLISHABLE_KEY])
+            .hasSize(VALID_PARAM_FIELDS.size - 2)
+        assertEquals(API_KEY, loggingParams[AnalyticsRequestFactory.FIELD_PUBLISHABLE_KEY])
         assertEquals(
             PaymentAnalyticsEvent.PaymentIntentRetrieve.toString(),
-            loggingParams[PaymentAnalyticsRequestFactory.FIELD_EVENT]
+            loggingParams[AnalyticsRequestFactory.FIELD_EVENT]
         )
         assertEquals(
-            PaymentAnalyticsRequestFactory.ANALYTICS_UA,
-            loggingParams[PaymentAnalyticsRequestFactory.FIELD_ANALYTICS_UA]
+            AnalyticsRequestFactory.ANALYTICS_UA,
+            loggingParams[AnalyticsRequestFactory.FIELD_ANALYTICS_UA]
         )
     }
 
@@ -173,7 +173,7 @@ class PaymentAnalyticsRequestFactoryTest {
     fun getEventLoggingParams_withProductUsage_createsAllFields() {
         // Correctness of these methods will be tested elsewhere. Assume validity for this test.
         val expectedEventName = PaymentAnalyticsEvent.TokenCreate.toString()
-        val expectedUaName = PaymentAnalyticsRequestFactory.ANALYTICS_UA
+        val expectedUaName = AnalyticsRequestFactory.ANALYTICS_UA
 
         val versionCode = 20
         val packageName = BuildConfig.LIBRARY_PACKAGE_NAME
@@ -194,24 +194,24 @@ class PaymentAnalyticsRequestFactoryTest {
         ).params
 
         assertThat(params)
-            .hasSize(PaymentAnalyticsRequestFactory.VALID_PARAM_FIELDS.size - 1)
-        assertEquals(API_KEY, params[PaymentAnalyticsRequestFactory.FIELD_PUBLISHABLE_KEY])
+            .hasSize(VALID_PARAM_FIELDS.size - 1)
+        assertEquals(API_KEY, params[AnalyticsRequestFactory.FIELD_PUBLISHABLE_KEY])
         assertEquals(ATTRIBUTION.toList(), params[PaymentAnalyticsRequestFactory.FIELD_PRODUCT_USAGE])
         assertEquals(Token.Type.Card.code, params[PaymentAnalyticsRequestFactory.FIELD_TOKEN_TYPE])
-        assertEquals(Build.VERSION.SDK_INT, params[PaymentAnalyticsRequestFactory.FIELD_OS_VERSION])
-        assertNotNull(params[PaymentAnalyticsRequestFactory.FIELD_OS_RELEASE])
-        assertNotNull(params[PaymentAnalyticsRequestFactory.FIELD_OS_NAME])
-        assertEquals(versionCode, params[PaymentAnalyticsRequestFactory.FIELD_APP_VERSION])
-        assertThat(params[PaymentAnalyticsRequestFactory.FIELD_APP_NAME])
+        assertEquals(Build.VERSION.SDK_INT, params[AnalyticsRequestFactory.FIELD_OS_VERSION])
+        assertNotNull(params[AnalyticsRequestFactory.FIELD_OS_RELEASE])
+        assertNotNull(params[AnalyticsRequestFactory.FIELD_OS_NAME])
+        assertEquals(versionCode, params[AnalyticsRequestFactory.FIELD_APP_VERSION])
+        assertThat(params[AnalyticsRequestFactory.FIELD_APP_NAME])
             .isEqualTo(BuildConfig.LIBRARY_PACKAGE_NAME)
 
-        assertEquals(StripeSdkVersion.VERSION_NAME, params[PaymentAnalyticsRequestFactory.FIELD_BINDINGS_VERSION])
-        assertEquals(expectedEventName, params[PaymentAnalyticsRequestFactory.FIELD_EVENT])
-        assertEquals(expectedUaName, params[PaymentAnalyticsRequestFactory.FIELD_ANALYTICS_UA])
+        assertEquals(StripeSdkVersion.VERSION_NAME, params[AnalyticsRequestFactory.FIELD_BINDINGS_VERSION])
+        assertEquals(expectedEventName, params[AnalyticsRequestFactory.FIELD_EVENT])
+        assertEquals(expectedUaName, params[AnalyticsRequestFactory.FIELD_ANALYTICS_UA])
 
         assertEquals(
             "robolectric_robolectric_robolectric",
-            params[PaymentAnalyticsRequestFactory.FIELD_DEVICE_TYPE]
+            params[AnalyticsRequestFactory.FIELD_DEVICE_TYPE]
         )
     }
 
@@ -219,58 +219,34 @@ class PaymentAnalyticsRequestFactoryTest {
     fun getEventLoggingParams_withoutProductUsage_createsOnlyNeededFields() {
         // Correctness of these methods will be tested elsewhere. Assume validity for this test.
         val expectedEventName = PaymentAnalyticsEvent.SourceCreate.toString()
-        val expectedUaName = PaymentAnalyticsRequestFactory.ANALYTICS_UA
+        val expectedUaName = AnalyticsRequestFactory.ANALYTICS_UA
 
         val params = analyticsRequestFactory.createSourceCreation(
             Source.SourceType.SEPA_DEBIT
         ).params
 
         assertThat(params)
-            .hasSize(PaymentAnalyticsRequestFactory.VALID_PARAM_FIELDS.size - 2)
-        assertEquals(API_KEY, params[PaymentAnalyticsRequestFactory.FIELD_PUBLISHABLE_KEY])
+            .hasSize(VALID_PARAM_FIELDS.size - 2)
+        assertEquals(API_KEY, params[AnalyticsRequestFactory.FIELD_PUBLISHABLE_KEY])
         assertEquals(
             Source.SourceType.SEPA_DEBIT,
             params[PaymentAnalyticsRequestFactory.FIELD_SOURCE_TYPE]
         )
 
-        assertEquals(Build.VERSION.SDK_INT, params[PaymentAnalyticsRequestFactory.FIELD_OS_VERSION])
-        assertNotNull(params[PaymentAnalyticsRequestFactory.FIELD_OS_RELEASE])
-        assertNotNull(params[PaymentAnalyticsRequestFactory.FIELD_OS_NAME])
+        assertEquals(Build.VERSION.SDK_INT, params[AnalyticsRequestFactory.FIELD_OS_VERSION])
+        assertNotNull(params[AnalyticsRequestFactory.FIELD_OS_RELEASE])
+        assertNotNull(params[AnalyticsRequestFactory.FIELD_OS_NAME])
 
-        assertEquals(StripeSdkVersion.VERSION_NAME, params[PaymentAnalyticsRequestFactory.FIELD_BINDINGS_VERSION])
-        assertEquals(expectedEventName, params[PaymentAnalyticsRequestFactory.FIELD_EVENT])
-        assertEquals(expectedUaName, params[PaymentAnalyticsRequestFactory.FIELD_ANALYTICS_UA])
+        assertEquals(StripeSdkVersion.VERSION_NAME, params[AnalyticsRequestFactory.FIELD_BINDINGS_VERSION])
+        assertEquals(expectedEventName, params[AnalyticsRequestFactory.FIELD_EVENT])
+        assertEquals(expectedUaName, params[AnalyticsRequestFactory.FIELD_ANALYTICS_UA])
 
         assertEquals(
             "robolectric_robolectric_robolectric",
-            params[PaymentAnalyticsRequestFactory.FIELD_DEVICE_TYPE]
+            params[AnalyticsRequestFactory.FIELD_DEVICE_TYPE]
         )
     }
 
-    @Test
-    fun createAppDataParams_whenPackageNameIsEmpty_returnsEmptyMap() {
-        val factory = PaymentAnalyticsRequestFactory(
-            null,
-            null,
-            "",
-            { API_KEY }
-        )
-        assertThat(factory.createAppDataParams())
-            .isEmpty()
-    }
-
-    @Test
-    fun createAppDataParams_whenPackageInfoNotFound_returnsEmptyMap() {
-        val packageName = "fake_package"
-        val factory = PaymentAnalyticsRequestFactory(
-            packageManager,
-            null,
-            packageName,
-            { API_KEY }
-        )
-        assertThat(factory.createAppDataParams())
-            .isEmpty()
-    }
 
     @Test
     fun getEventParamName_withTokenCreation_createsExpectedParameter() {
@@ -279,12 +255,6 @@ class PaymentAnalyticsRequestFactoryTest {
             expectedEventParam,
             PaymentAnalyticsEvent.TokenCreate.toString()
         )
-    }
-
-    @Test
-    fun getAnalyticsUa_returnsExpectedValue() {
-        assertThat(PaymentAnalyticsRequestFactory.ANALYTICS_UA)
-            .isEqualTo("analytics.stripe_android-1.0")
     }
 
     @Test
@@ -306,18 +276,6 @@ class PaymentAnalyticsRequestFactoryTest {
 
         assertThat(params)
             .containsEntry("3ds2_ui_type", "none")
-    }
-
-    @Test
-    fun `when publishable key is unavailable, create params with undefined key`() {
-        val factory = PaymentAnalyticsRequestFactory(
-            context,
-            publishableKeyProvider = { throw RuntimeException() }
-        )
-        val params = factory.createRequest(PaymentAnalyticsEvent.SourceRetrieve).params
-
-        assertThat(params["publishable_key"])
-            .isEqualTo(ApiRequest.Options.UNDEFINED_PUBLISHABLE_KEY)
     }
 
     @Test
@@ -393,5 +351,23 @@ class PaymentAnalyticsRequestFactoryTest {
     private companion object {
         private const val API_KEY = "pk_abc123"
         private val ATTRIBUTION = setOf("CardInputView")
+
+        @JvmSynthetic
+        private val VALID_PARAM_FIELDS: Set<String> = setOf(
+            AnalyticsRequestFactory.FIELD_ANALYTICS_UA,
+            AnalyticsRequestFactory.FIELD_APP_NAME,
+            AnalyticsRequestFactory.FIELD_APP_VERSION,
+            AnalyticsRequestFactory.FIELD_BINDINGS_VERSION,
+            AnalyticsRequestFactory.FIELD_IS_DEVELOPMENT,
+            AnalyticsRequestFactory.FIELD_DEVICE_TYPE,
+            AnalyticsRequestFactory.FIELD_EVENT,
+            AnalyticsRequestFactory.FIELD_OS_VERSION,
+            AnalyticsRequestFactory.FIELD_OS_NAME,
+            AnalyticsRequestFactory.FIELD_OS_RELEASE,
+            AnalyticsRequestFactory.FIELD_PUBLISHABLE_KEY,
+            PaymentAnalyticsRequestFactory.FIELD_PRODUCT_USAGE,
+            PaymentAnalyticsRequestFactory.FIELD_SOURCE_TYPE,
+            PaymentAnalyticsRequestFactory.FIELD_TOKEN_TYPE
+        )
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticatorTest.kt
@@ -10,6 +10,7 @@ import com.stripe.android.StripePaymentController.Companion.SETUP_REQUEST_CODE
 import com.stripe.android.auth.PaymentBrowserAuthContract
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
+import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.SetupIntentFixtures
@@ -166,7 +167,7 @@ class WebIntentAuthenticatorTest {
             .executeAsync(analyticsRequestArgumentCaptor.capture())
         val analyticsRequest = analyticsRequestArgumentCaptor.firstValue
         assertThat(
-            analyticsRequest.params?.get(PaymentAnalyticsRequestFactory.FIELD_EVENT)
+            analyticsRequest.params.get(AnalyticsRequestFactory.FIELD_EVENT)
         ).isEqualTo(event.toString())
     }
 

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestFactory.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestFactory.kt
@@ -1,0 +1,127 @@
+package com.stripe.android.core.networking
+
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.annotation.RestrictTo
+import com.stripe.android.core.BuildConfig
+import com.stripe.android.core.version.StripeSdkVersion
+import javax.inject.Provider
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+open class AnalyticsRequestFactory(
+    private val packageManager: PackageManager?,
+    private val packageInfo: PackageInfo?,
+    private val packageName: String,
+    private val publishableKeyProvider: Provider<String>,
+    internal val defaultProductUsageTokens: Set<String> = emptySet()
+) {
+
+    /**
+     * Builds an Analytics request for the given [AnalyticsEvent],
+     * including common params + event-specific params defined in [AnalyticsEvent.params]
+     *
+     * @param  additionalParams any extra parameters that should be sent with this event.
+     * Ensure this common parameters are not already included in [standardParams].
+     *
+     */
+    fun createRequest(
+        event: AnalyticsEvent,
+        additionalParams: Map<String, Any>
+    ): AnalyticsRequest {
+        return AnalyticsRequest(
+            params = createParams(event) + additionalParams,
+            headers = RequestHeadersFactory.Analytics.create()
+        )
+    }
+
+    /**
+     * Backwards compatible for events not inheriting [AnalyticsEvent].
+     *
+     * @see createRequest
+     */
+    @Deprecated("use {@link #createRequest(AnalyticsEvent, Map<String, Any>)}")
+    fun createRequest(
+        event: String,
+        additionalParams: Map<String, Any>
+    ): AnalyticsRequest {
+        return createRequest(
+            object : AnalyticsEvent {
+                override val code: String = event
+            },
+            additionalParams = additionalParams
+        )
+    }
+
+    private fun createParams(
+        event: AnalyticsEvent
+    ): Map<String, Any> {
+        return standardParams() + appDataParams() + event.params()
+    }
+
+    private fun AnalyticsEvent.params(): Map<String, String> {
+        return mapOf(FIELD_EVENT to this.toString())
+    }
+
+    private fun standardParams(
+    ): Map<String, Any> = mapOf(
+        FIELD_ANALYTICS_UA to ANALYTICS_UA,
+        FIELD_PUBLISHABLE_KEY to runCatching {
+            publishableKeyProvider.get()
+        }.getOrDefault(ApiRequest.Options.UNDEFINED_PUBLISHABLE_KEY),
+        FIELD_OS_NAME to Build.VERSION.CODENAME,
+        FIELD_OS_RELEASE to Build.VERSION.RELEASE,
+        FIELD_OS_VERSION to Build.VERSION.SDK_INT,
+        FIELD_DEVICE_TYPE to DEVICE_TYPE,
+        FIELD_BINDINGS_VERSION to StripeSdkVersion.VERSION_NAME,
+        FIELD_IS_DEVELOPMENT to BuildConfig.DEBUG
+    )
+
+    internal fun appDataParams(): Map<String, Any> {
+        return when {
+            packageManager != null && packageInfo != null -> {
+                mapOf(
+                    FIELD_APP_NAME to getAppName(packageInfo, packageManager),
+                    FIELD_APP_VERSION to packageInfo.versionCode
+                )
+            }
+            else -> emptyMap()
+        }
+    }
+
+    private fun getAppName(
+        packageInfo: PackageInfo?,
+        packageManager: PackageManager
+    ): CharSequence {
+        return packageInfo?.applicationInfo?.loadLabel(packageManager).takeUnless {
+            it.isNullOrBlank()
+        } ?: packageName
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    companion object {
+        const val FIELD_ANALYTICS_UA = "analytics_ua"
+        const val FIELD_APP_NAME = "app_name"
+        const val FIELD_APP_VERSION = "app_version"
+        const val FIELD_BINDINGS_VERSION = "bindings_version"
+        const val FIELD_IS_DEVELOPMENT = "is_development"
+        const val FIELD_DEVICE_TYPE = "device_type"
+        const val FIELD_EVENT = "event"
+        const val FIELD_OS_NAME = "os_name"
+        const val FIELD_OS_RELEASE = "os_release"
+        const val FIELD_OS_VERSION = "os_version"
+        const val FIELD_PUBLISHABLE_KEY = "publishable_key"
+        private const val ANALYTICS_PREFIX = "analytics"
+        private const val ANALYTICS_NAME = "stripe_android"
+        private const val ANALYTICS_VERSION = "1.0"
+
+        private val DEVICE_TYPE: String = "${Build.MANUFACTURER}_${Build.BRAND}_${Build.MODEL}"
+
+        const val ANALYTICS_UA = "$ANALYTICS_PREFIX.$ANALYTICS_NAME-$ANALYTICS_VERSION"
+    }
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+interface AnalyticsEvent {
+    val code: String
+}

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestFactoryTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestFactoryTest.kt
@@ -1,0 +1,122 @@
+package com.stripe.android.core.networking
+
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.BuildConfig
+import com.stripe.android.core.version.StripeSdkVersion
+import junit.framework.TestCase
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AnalyticsRequestFactoryTest : TestCase() {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    private val packageManager = mock<PackageManager>()
+    private val packageName = "com.stripe.android.test"
+    private val apiKey = "pk_abc123"
+
+    private val mockEvent = object : AnalyticsEvent {
+        override val code: String = "randomEvent"
+        override fun toString(): String = code
+    }
+
+    val factory = AnalyticsRequestFactory(
+        context.applicationContext.packageManager,
+        runCatching {
+            context.applicationContext.packageManager.getPackageInfo(packageName, 0)
+        }.getOrNull(),
+        context.applicationContext.packageName.orEmpty(),
+        { apiKey }
+    )
+
+    @Test
+    fun `when publishable key is unavailable, create params with undefined key`() {
+        val factory = AnalyticsRequestFactory(
+            mock(),
+            null,
+            packageName,
+            { throw RuntimeException() }
+        )
+
+        val params = factory.createRequest(mockEvent, emptyMap()).params
+
+        assertThat(params["publishable_key"])
+            .isEqualTo(ApiRequest.Options.UNDEFINED_PUBLISHABLE_KEY)
+    }
+
+    @Test
+    fun getEventLoggingParams_withProductUsage_createsAllFields() {
+        val expectedUaName = AnalyticsRequestFactory.ANALYTICS_UA
+
+        val versionCode = 20
+        val packageName = BuildConfig.LIBRARY_PACKAGE_NAME
+        val packageInfo = PackageInfo().also {
+            it.versionCode = versionCode
+            it.packageName = BuildConfig.LIBRARY_PACKAGE_NAME
+        }
+
+        val factory = AnalyticsRequestFactory(
+            packageManager,
+            packageInfo,
+            packageName,
+            { apiKey }
+        )
+        val params = factory.createRequest(mockEvent, emptyMap()).params
+
+        assertThat(apiKey)
+            .isEqualTo(params[AnalyticsRequestFactory.FIELD_PUBLISHABLE_KEY])
+        assertThat(Build.VERSION.SDK_INT)
+            .isEqualTo(params[AnalyticsRequestFactory.FIELD_OS_VERSION])
+        assertThat(versionCode)
+            .isEqualTo(params[AnalyticsRequestFactory.FIELD_APP_VERSION])
+        assertThat(params[AnalyticsRequestFactory.FIELD_APP_NAME])
+            .isEqualTo(BuildConfig.LIBRARY_PACKAGE_NAME)
+        assertThat(StripeSdkVersion.VERSION_NAME)
+            .isEqualTo(params[AnalyticsRequestFactory.FIELD_BINDINGS_VERSION])
+        assertThat(mockEvent.toString())
+            .isEqualTo(params[AnalyticsRequestFactory.FIELD_EVENT])
+        assertThat(expectedUaName)
+            .isEqualTo(params[AnalyticsRequestFactory.FIELD_ANALYTICS_UA])
+        assertThat("unknown_generic_x86_robolectric")
+            .isEqualTo(params[AnalyticsRequestFactory.FIELD_DEVICE_TYPE])
+        assertNotNull(params[AnalyticsRequestFactory.FIELD_OS_RELEASE])
+        assertNotNull(params[AnalyticsRequestFactory.FIELD_OS_NAME])
+    }
+
+    @Test
+    fun createAppDataParams_whenPackageInfoNotFound_returnsEmptyMap() {
+        val packageName = "fake_package"
+        val factory = AnalyticsRequestFactory(
+            mock(),
+            null,
+            packageName,
+            { apiKey }
+        )
+        assertThat(factory.appDataParams()).isEmpty()
+    }
+
+    @Test
+    fun createAppDataParams_whenPackageNameIsEmpty_returnsEmptyMap() {
+        val factory = AnalyticsRequestFactory(
+            null,
+            null,
+            "",
+            { apiKey }
+        )
+        assertThat(factory.appDataParams()).isEmpty()
+    }
+
+    @Test
+    fun getAnalyticsUa_returnsExpectedValue() {
+        assertThat(AnalyticsRequestFactory.ANALYTICS_UA)
+            .isEqualTo("analytics.stripe_android-1.0")
+    }
+}


### PR DESCRIPTION
# Summary
- Extracts common param construction logic from `PaymentsRequestFactory`
- Moves it to `:stripe-core`, created a new `AnalyticsRequestFactory`.

# Motivation
Other SDKs would benefit from the common analytics setup that now lives in `AnalyticsRequestFactory`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [ ] Manually verified
