### PR TITLE
[Identity] Network & UI - 1 of 3: `ConsentFragment`

### DIFF
--- a/identity/api/identity.api
+++ b/identity/api/identity.api
@@ -87,17 +87,18 @@ public final class com/stripe/android/identity/databinding/ConfirmationFragmentB
 
 public final class com/stripe/android/identity/databinding/ConsentFragmentBinding : androidx/viewbinding/ViewBinding {
 	public final field agree Landroid/widget/Button;
+	public final field body Landroid/widget/TextView;
 	public final field buttons Landroid/widget/LinearLayout;
 	public final field decline Landroid/widget/Button;
 	public final field divider Landroid/view/View;
-	public final field howContent Landroid/widget/TextView;
-	public final field howTitle Landroid/widget/TextView;
-	public final field learnMore1 Landroid/widget/TextView;
-	public final field learnMore2 Landroid/widget/TextView;
+	public final field loadings Landroid/widget/LinearLayout;
 	public final field merchantLogo Landroid/widget/ImageView;
 	public final field plus Landroid/widget/ImageView;
+	public final field privacyPolicy Landroid/widget/TextView;
+	public final field progressCircular Lcom/google/android/material/progressindicator/CircularProgressIndicator;
 	public final field stripeLogo Landroid/widget/ImageView;
-	public final field timeTakes Landroid/widget/TextView;
+	public final field texts Landroid/widget/ScrollView;
+	public final field timeEstimate Landroid/widget/TextView;
 	public final field titleIcons Landroid/widget/LinearLayout;
 	public final field titleText Landroid/widget/TextView;
 	public static fun bind (Landroid/view/View;)Lcom/stripe/android/identity/databinding/ConsentFragmentBinding;

--- a/identity/res/drawable/ic_exclamation_square_16.xml
+++ b/identity/res/drawable/ic_exclamation_square_16.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="16dp"
+    android:viewportHeight="16"
+    android:viewportWidth="16"
+    android:width="16dp">
+    <path
+        android:fillColor="#30313D"
+        android:fillType="evenOdd"
+        android:pathData="M12.5,2H3.5C2.6716,2 2,2.6716 2,3.5V12.5C2,13.3284 2.6716,14 3.5,14H12.5C13.3284,14 14,13.3284 14,12.5V3.5C14,2.6716 13.3284,2 12.5,2ZM3.5,0.5C1.8432,0.5 0.5,1.8432 0.5,3.5V12.5C0.5,14.1569 1.8432,15.5 3.5,15.5H12.5C14.1569,15.5 15.5,14.1569 15.5,12.5V3.5C15.5,1.8432 14.1569,0.5 12.5,0.5H3.5Z" />
+    <path
+        android:fillColor="#30313D"
+        android:pathData="M7,6.5C6.5858,6.5 6.25,6.8358 6.25,7.25C6.25,7.6642 6.5858,8 7,8H7.25V11.75C7.25,12.1642 7.5858,12.5 8,12.5C8.4142,12.5 8.75,12.1642 8.75,11.75V7.25C8.75,6.8358 8.4142,6.5 8,6.5H7Z" />
+    <path
+        android:fillColor="#30313D"
+        android:pathData="M7,4.5C7,3.95 7.45,3.5 8,3.5C8.55,3.5 9,3.95 9,4.5C9,5.05 8.55,5.5 8,5.5C7.45,5.51 7,5.06 7,4.5Z" />
+</vector>

--- a/identity/res/layout/consent_fragment.xml
+++ b/identity/res/layout/consent_fragment.xml
@@ -7,28 +7,53 @@
     android:layout_marginTop="@dimen/page_vertical_margin"
     android:layout_marginBottom="@dimen/page_vertical_margin"
     android:orientation="vertical"
+    android:gravity="center"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <LinearLayout
+        android:id="@+id/loadings"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:gravity="center_horizontal"
+        android:visibility="visible">
+
+        <com.google.android.material.progressindicator.CircularProgressIndicator
+            android:id="@+id/progress_circular"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:indeterminate="true"
+            android:layout_marginBottom="32dp"
+            app:indicatorSize="32dp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="@dimen/consent_title_text_size"
+            android:text="@string/loading" />
+    </LinearLayout>
+
+
     <ScrollView
+        android:id="@+id/texts"
+        android:visibility="gone"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:orientation="vertical"
             tools:context=".navigation.ConsentFragment">
 
             <LinearLayout
                 android:id="@+id/title_icons"
-                android:layout_width="0dp"
+                android:layout_width="match_parent"
                 android:gravity="center_vertical"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent">
+                android:orientation="horizontal">
 
                 <ImageView
                     android:id="@+id/merchant_logo"
@@ -51,26 +76,24 @@
 
             <TextView
                 android:id="@+id/title_text"
-                android:layout_width="0dp"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/item_vertical_margin"
                 android:textSize="@dimen/consent_title_text_size"
                 android:textStyle="bold"
-                android:text="XXX uses Stripe to verify your information"
                 android:layout_marginBottom="42dp"
-                app:layout_constraintBottom_toTopOf="@id/time_takes"
+                app:layout_constraintBottom_toTopOf="@id/time_estimate"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/title_icons"
                 tools:text="XXX uses Stripe to verify your information" />
 
             <TextView
-                android:id="@+id/time_takes"
-                android:layout_width="0dp"
+                android:id="@+id/time_estimate"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Takes about 1-2 minutes"
                 android:textStyle="bold"
-                android:layout_marginBottom="@dimen/item_vertical_margin"
+                android:layout_marginBottom="12dp"
                 android:drawablePadding="6dp"
                 app:drawableStartCompat="@drawable/ic_clock_16"
                 app:layout_constraintBottom_toTopOf="@id/divider"
@@ -79,73 +102,35 @@
                 app:layout_constraintTop_toBottomOf="@+id/title_text"
                 tools:text="Takes about 1-2 minutes" />
 
+            <TextView
+                android:id="@+id/privacy_policy"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textStyle="bold"
+                android:layout_marginBottom="@dimen/item_vertical_margin"
+                android:drawablePadding="6dp"
+                app:drawableStartCompat="@drawable/ic_exclamation_square_16"
+                tools:text="@string/sample_privacy_policy" />
+
             <View
                 android:id="@+id/divider"
                 android:layout_width="match_parent"
                 android:layout_height="1dp"
                 android:layout_marginBottom="@dimen/item_vertical_margin"
-                android:background="?android:attr/listDivider"
-                app:layout_constraintBottom_toTopOf="@id/how_title"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/time_takes" />
+                android:background="?android:attr/listDivider" />
 
             <TextView
-                android:id="@+id/how_title"
-                android:layout_width="0dp"
+                android:id="@+id/body"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:textStyle="bold"
-                android:text="How Stripe will verify your identity"
                 android:layout_marginBottom="@dimen/item_vertical_margin"
-                app:layout_constraintBottom_toTopOf="@id/how_content"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/divider"
-                tools:text="How Stripe will verify your identity" />
-
-            <TextView
-                android:id="@+id/how_content"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:text="Stripe will use biometric technology(on images of you and your IDs) and other data sources to confirm your identity and for fraud and security purposes."
-                android:layout_marginBottom="@dimen/item_vertical_margin"
-                android:lineSpacingExtra="2sp"
-                app:layout_constraintBottom_toTopOf="@id/learn_more_1"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/how_title"
-                tools:text="Stripe will use biometric technology(on images of you and your IDs) and other data sources to confirm your identity and for fraud and security purposes." />
-
-            <TextView
-                android:id="@+id/learn_more_1"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:text="Lean about Stripe"
-                android:textColor="?android:colorPrimary"
-                android:textStyle="bold"
-                app:layout_constraintBottom_toTopOf="@id/learn_more_2"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/how_content"
-                tools:text="Lean about Stripe" />
-
-            <TextView
-                android:id="@+id/learn_more_2"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:text="Lean how stripe identity works"
-                android:textColor="?android:colorPrimary"
-                android:layout_marginTop="@dimen/item_vertical_margin"
-                android:textStyle="bold"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/learn_more_1"
-                tools:text="Lean how stripe identity works" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+                tools:text="@string/sample_consent_body_response" />
+        </LinearLayout>
     </ScrollView>
 
     <LinearLayout
         android:id="@+id/buttons"
+        android:visibility="gone"
         android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/identity/res/navigation/identity_nav_graph.xml
+++ b/identity/res/navigation/identity_nav_graph.xml
@@ -22,14 +22,6 @@
         android:name="com.stripe.android.identity.navigation.ConsentFragment"
         android:label="consent_fragment"
         tools:layout="@layout/consent_fragment">
-        <argument
-            android:name="consentContext"
-            android:defaultValue=""
-            app:argType="string" />
-        <argument
-            android:name="merchantLogo"
-            android:defaultValue="0"
-            app:argType="integer" />
         <action
             android:id="@+id/action_consentFragment_to_docSelectionFragment"
             app:destination="@id/docSelectionFragment" />

--- a/identity/res/values/strings.xml
+++ b/identity/res/values/strings.xml
@@ -59,6 +59,7 @@
     <string name="unexpected_error_try_again">There was an unexpected error — try again in a few seconds</string>
     <string name="go_back">Go Back</string>
     <string name="description_exclamation_mark">Exclamation point for error page</string>
-
-
+    <string name="loading">Loading</string>
+    <string name="sample_consent_body_response"><![CDATA[<p><strong>How Stripe will verify your identity</strong></p>\n\n<p>Stripe will use biometric technology (on images of you and your IDs) and other data sources to confirm your identity and for fraud and security purposes. Stripe will store these images and the results of this check and share them with mlgb.band.</p>\n\n<p><a href=\"https://stripe.com/about\">Learn about Stripe</a></p><p><a href=\"https://stripe.com/privacy-center/legal#stripe-identity\">Learn how Stripe Identity works</a></p>]]></string>
+    <string name="sample_privacy_policy"><![CDATA[Data will be stored and may be used according to the <a href=\"http://stripe.com/privacy\">Stripe Privacy Policy</a> and <a href=\"\">mlgb.band</a> Privacy Policy.]]></string>
 </resources>

--- a/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
@@ -5,13 +5,11 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
-import androidx.core.os.bundleOf
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.NavHostFragment
 import com.stripe.android.camera.CameraPermissionCheckingActivity
 import com.stripe.android.identity.IdentityVerificationSheet.VerificationResult
 import com.stripe.android.identity.databinding.IdentityActivityBinding
-import com.stripe.android.identity.navigation.ConsentFragment
 import com.stripe.android.identity.navigation.IdentityFragmentFactory
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 
@@ -29,37 +27,34 @@ internal class IdentityActivity : CameraPermissionCheckingActivity() {
         }
     }
 
-    @VisibleForTesting
-    internal val viewModelFactory: ViewModelProvider.Factory by lazy {
-        IdentityViewModel.IdentityViewModelFactory(
+    private val identityFragmentFactory: IdentityFragmentFactory by lazy {
+        IdentityFragmentFactory(
+            this,
+            this,
+            this,
             starterArgs
         )
     }
 
     @VisibleForTesting
-    internal val viewModel: IdentityViewModel by viewModels { viewModelFactory }
+    internal val viewModelFactory: ViewModelProvider.Factory by lazy {
+        identityFragmentFactory.identityViewModelFactory
+    }
+
+    @VisibleForTesting
+    internal val identityViewModel: IdentityViewModel by viewModels { viewModelFactory }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
 
-        supportFragmentManager.fragmentFactory = IdentityFragmentFactory(
-            this,
-            this,
-            this,
-            starterArgs
-        )
+        supportFragmentManager.fragmentFactory = identityFragmentFactory
 
         val navHostFragment =
             supportFragmentManager.findFragmentById(R.id.identity_nav_host) as NavHostFragment
-        navHostFragment.navController.setGraph(
-            R.navigation.identity_nav_graph,
-            bundleOf(
-                ConsentFragment.ARG_CONSENT_CONTEXT to "This is some context string that tells user how stripe will" +
-                    " verify their identity. It could be in html format. It's sent from server",
-                ConsentFragment.ARG_MERCHANT_LOGO to starterArgs.merchantLogo
-            )
-        )
+        navHostFragment.navController.setGraph(R.navigation.identity_nav_graph)
+
+        identityViewModel.retrieveAndBufferVerificationPage()
     }
 
     override fun onBackPressed() {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
@@ -6,41 +6,122 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.ConsentFragmentBinding
+import com.stripe.android.identity.navigation.ErrorFragment.Companion.navigateToErrorFragmentWithDefaultValues
+import com.stripe.android.identity.navigation.ErrorFragment.Companion.navigateToErrorFragmentWithRequirementErrorAndDestination
+import com.stripe.android.identity.networking.models.CollectedDataParam
+import com.stripe.android.identity.networking.models.ConsentParam
+import com.stripe.android.identity.networking.models.VerificationPageData
+import com.stripe.android.identity.networking.models.VerificationPageStaticContentConsentPage
+import com.stripe.android.identity.utils.setHtmlString
+import com.stripe.android.identity.viewmodel.IdentityViewModel
+import kotlinx.coroutines.launch
 
 /**
  * The start screen of Identification flow, prompt for client's consent.
  *
  */
-internal class ConsentFragment : Fragment() {
+internal class ConsentFragment(
+    private val identityViewModelFactory: ViewModelProvider.Factory
+) : Fragment() {
+    private lateinit var binding: ConsentFragmentBinding
+
+    private val identityViewModel: IdentityViewModel by activityViewModels {
+        identityViewModelFactory
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val binding = ConsentFragmentBinding.inflate(inflater, container, false)
-        val args = requireNotNull(arguments)
+        binding = ConsentFragmentBinding.inflate(inflater, container, false)
 
-        binding.merchantLogo.setImageResource(args[ARG_MERCHANT_LOGO] as Int)
-
-        // TODO(ccen) set the text of other field, decide if we should get separate values from different fields or a single value as an html string
-        binding.howContent.text = args[ARG_CONSENT_CONTEXT] as String
+        binding.merchantLogo.setImageResource(identityViewModel.args.merchantLogo)
 
         binding.agree.setOnClickListener {
-            findNavController().navigate(R.id.action_consentFragment_to_docSelectionFragment)
+            postVerificationPageData(
+                CollectedDataParam(
+                    consent = ConsentParam(biometric = true)
+                )
+            )
         }
         binding.decline.setOnClickListener {
-            Log.d(TAG, "declined")
+            postVerificationPageData(
+                CollectedDataParam(
+                    consent = ConsentParam(biometric = false)
+                )
+            )
+        }
+        binding.progressCircular.setOnClickListener {
+            setLoadingFinishedUI()
         }
         return binding.root
     }
 
-    internal companion object {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        identityViewModel.verificationPage.observe(viewLifecycleOwner) {
+            setLoadingFinishedUI()
+            bindViewData(it.biometricConsent)
+        }
+
+        identityViewModel.verificationPageApiError.observe(
+            viewLifecycleOwner,
+            ::navigateOnApiError
+        )
+    }
+
+    private fun postVerificationPageData(collectedDataParam: CollectedDataParam) {
+        lifecycleScope.launch {
+            runCatching {
+                identityViewModel.postVerificationPageData(
+                    collectedDataParam
+                )
+            }.fold(
+                onSuccess = ::navigateOnVerificationPageData,
+                onFailure = ::navigateOnApiError
+            )
+        }
+    }
+
+    private fun bindViewData(consentPage: VerificationPageStaticContentConsentPage) {
+        binding.titleText.text = consentPage.title
+        binding.privacyPolicy.setHtmlString(consentPage.privacyPolicy)
+        binding.timeEstimate.text = consentPage.timeEstimate
+        binding.body.setHtmlString(consentPage.body)
+        binding.agree.text = consentPage.acceptButtonText
+        binding.decline.text = consentPage.declineButtonText
+    }
+
+    private fun setLoadingFinishedUI() {
+        binding.loadings.visibility = View.GONE
+        binding.texts.visibility = View.VISIBLE
+        binding.buttons.visibility = View.VISIBLE
+    }
+
+    private fun navigateOnVerificationPageData(verificationPageData: VerificationPageData) {
+        if (verificationPageData.requirements.errors.isEmpty()) {
+            findNavController().navigate(R.id.action_consentFragment_to_docSelectionFragment)
+        } else {
+            findNavController().navigateToErrorFragmentWithRequirementErrorAndDestination(
+                verificationPageData.requirements.errors[0],
+                R.id.action_errorFragment_to_consentFragment
+            )
+        }
+    }
+
+    private fun navigateOnApiError(throwable: Throwable) {
+        Log.d(TAG, "API Error occurred: $throwable, navigate to general error fragment")
+        findNavController().navigateToErrorFragmentWithDefaultValues(requireContext())
+    }
+
+    private companion object {
         val TAG: String = ConsentFragment::class.java.simpleName
-        const val ARG_CONSENT_CONTEXT = "consentContext"
-        const val ARG_MERCHANT_LOGO = "merchantLogo"
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
@@ -9,6 +9,7 @@ import com.stripe.android.identity.IdentityVerificationSheetContract
 import com.stripe.android.identity.networking.DefaultIdentityRepository
 import com.stripe.android.identity.viewmodel.CameraViewModel
 import com.stripe.android.identity.viewmodel.FrontBackUploadViewModel
+import com.stripe.android.identity.viewmodel.IdentityViewModel
 import com.stripe.android.identity.viewmodel.PassportUploadViewModel
 
 /**
@@ -32,6 +33,11 @@ internal class IdentityFragmentFactory(
             identityRepository,
             verificationArgs
         )
+
+    internal val identityViewModelFactory = IdentityViewModel.IdentityViewModelFactory(
+        verificationArgs,
+        identityRepository
+    )
 
     override fun instantiate(classLoader: ClassLoader, className: String): Fragment {
         return when (className) {
@@ -58,6 +64,9 @@ internal class IdentityFragmentFactory(
             )
             PassportUploadFragment::class.java.name -> PassportUploadFragment(
                 passportUploadViewModelFactory
+            )
+            ConsentFragment::class.java.name -> ConsentFragment(
+                identityViewModelFactory
             )
             else -> super.instantiate(classLoader, className)
         }

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/ConsentParam.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/ConsentParam.kt
@@ -6,5 +6,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 internal data class ConsentParam(
     @SerialName("biometric")
-    val biometric: kotlin.Boolean? = null
+    val biometric: Boolean? = null
 )

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPage.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPage.kt
@@ -40,7 +40,7 @@ internal data class VerificationPage(
     @SerialName("unsupported_client")
     val unsupportedClient: Boolean,
     @SerialName("welcome")
-    val welcome: VerificationPageStaticContentTextPage
+    val welcome: VerificationPageStaticContentTextPage? = null
 ) {
     @Serializable
     internal enum class Status {

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageStaticContentConsentPage.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageStaticContentConsentPage.kt
@@ -12,5 +12,9 @@ internal data class VerificationPageStaticContentConsentPage(
     @SerialName("decline_button_text")
     val declineButtonText: String,
     @SerialName("title")
-    val title: String
+    val title: String,
+    @SerialName("privacy_policy")
+    val privacyPolicy: String,
+    @SerialName("time_estimate")
+    val timeEstimate: String,
 )

--- a/identity/src/main/java/com/stripe/android/identity/utils/TextUtils.kt
+++ b/identity/src/main/java/com/stripe/android/identity/utils/TextUtils.kt
@@ -1,0 +1,13 @@
+package com.stripe.android.identity.utils
+
+import android.text.method.LinkMovementMethod
+import android.widget.TextView
+import androidx.core.text.HtmlCompat
+
+/**
+ * Set a html string to this TextView and make links clickable.
+ */
+internal fun TextView.setHtmlString(htmlString: String) {
+    this.text = HtmlCompat.fromHtml(htmlString, HtmlCompat.FROM_HTML_MODE_LEGACY)
+    this.movementMethod = LinkMovementMethod.getInstance()
+}

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
@@ -1,18 +1,92 @@
 package com.stripe.android.identity.viewmodel
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.stripe.android.core.exception.APIConnectionException
+import com.stripe.android.core.exception.APIException
 import com.stripe.android.identity.IdentityVerificationSheetContract
+import com.stripe.android.identity.networking.IdentityRepository
+import com.stripe.android.identity.networking.models.CollectedDataParam
+import com.stripe.android.identity.networking.models.VerificationPage
+import com.stripe.android.identity.networking.models.VerificationPageData
+import kotlinx.coroutines.launch
 
+/**
+ * ViewModel hosted by IdentityActivity, shared across fragments.
+ */
 internal class IdentityViewModel(
-    val args: IdentityVerificationSheetContract.Args
+    internal val args: IdentityVerificationSheetContract.Args,
+    private val identityRepository: IdentityRepository
 ) : ViewModel() {
+
+    /**
+     * Response for initial VerificationPage, used for building UI.
+     */
+    private val _verificationPage = MutableLiveData<VerificationPage>()
+    val verificationPage: LiveData<VerificationPage> = _verificationPage
+
+    /**
+     * API request fails, could be [APIException] if the request returns with an error response,
+     * or [APIConnectionException] if the request fails.
+     */
+    private val _verificationPageApiError = MutableLiveData<Throwable>()
+    val verificationPageApiError: LiveData<Throwable> = _verificationPageApiError
+
+    /**
+     * Retrieve the VerificationPage data and post it as [verificationPage]
+     * or error result as [verificationPageApiError].
+     */
+    fun retrieveAndBufferVerificationPage() {
+        viewModelScope.launch {
+            runCatching {
+                identityRepository.retrieveVerificationPage(
+                    args.verificationSessionId,
+                    args.ephemeralKeySecret
+                )
+            }.fold(
+                onSuccess = _verificationPage::postValue,
+                onFailure = _verificationPageApiError::postValue
+            )
+        }
+    }
+
+    /**
+     * Post collected [CollectedDataParam] to update [VerificationPageData].
+     */
+    @Throws(
+        APIConnectionException::class,
+        APIException::class
+    )
+    suspend fun postVerificationPageData(collectedDataParam: CollectedDataParam) =
+        identityRepository.postVerificationPageData(
+            args.verificationSessionId,
+            args.ephemeralKeySecret,
+            collectedDataParam
+        )
+
+    /**
+     * Submit the final [VerificationPageData].
+     */
+    @Throws(
+        APIConnectionException::class,
+        APIException::class
+    )
+    suspend fun postVerificationPageSubmit() =
+        identityRepository.postVerificationPageSubmit(
+            args.verificationSessionId,
+            args.ephemeralKeySecret
+        )
+
     internal class IdentityViewModelFactory(
-        private val args: IdentityVerificationSheetContract.Args
+        private val args: IdentityVerificationSheetContract.Args,
+        private val identityRepository: IdentityRepository,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return IdentityViewModel(args) as T
+            return IdentityViewModel(args, identityRepository) as T
         }
     }
 }

--- a/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
@@ -1,0 +1,246 @@
+package com.stripe.android.identity.navigation
+
+import android.view.View
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.lifecycle.MutableLiveData
+import androidx.navigation.Navigation
+import androidx.navigation.testing.TestNavHostController
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.exception.APIException
+import com.stripe.android.identity.IdentityVerificationSheetContract
+import com.stripe.android.identity.R
+import com.stripe.android.identity.databinding.ConsentFragmentBinding
+import com.stripe.android.identity.networking.models.VerificationPage
+import com.stripe.android.identity.networking.models.VerificationPageData
+import com.stripe.android.identity.networking.models.VerificationPageDataRequirementError
+import com.stripe.android.identity.networking.models.VerificationPageDataRequirements
+import com.stripe.android.identity.networking.models.VerificationPageStaticContentConsentPage
+import com.stripe.android.identity.viewModelFactoryFor
+import com.stripe.android.identity.viewmodel.IdentityViewModel
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class ConsentFragmentTest {
+    @get:Rule
+    var rule: TestRule = InstantTaskExecutorRule()
+
+    private val verificationPage = mock<VerificationPage>().also {
+        whenever(it.biometricConsent).thenReturn(
+            VerificationPageStaticContentConsentPage(
+                acceptButtonText = CONSENT_ACCEPT_TEXT,
+                title = CONSENT_TITLE,
+                privacyPolicy = CONSENT_PRIVACY_POLICY,
+                timeEstimate = CONSENT_TIME_ESTIMATE,
+                body = CONSENT_BODY,
+                declineButtonText = CONSENT_DECLINE_TEXT
+            )
+        )
+    }
+
+    private val correctVerificationData = mock<VerificationPageData>().also {
+        whenever(it.requirements).thenReturn(
+            VerificationPageDataRequirements(
+                errors = emptyList(),
+                missing = emptyList()
+            )
+        )
+    }
+
+    private val incorrectVerificationData = mock<VerificationPageData>().also {
+        whenever(it.requirements).thenReturn(
+            VerificationPageDataRequirements(
+                errors = listOf(
+                    VerificationPageDataRequirementError(
+                        body = ERROR_BODY,
+                        buttonText = ERROR_BUTTON_TEXT,
+                        requirement = VerificationPageDataRequirementError.Requirement.BIOMETRICCONSENT,
+                        title = ERROR_TITLE
+                    )
+                ),
+                missing = emptyList()
+            )
+        )
+    }
+
+    private val verificationPageLiveData = MutableLiveData<VerificationPage>()
+    private val verificationApiErrorLiveData = MutableLiveData<Throwable>()
+    private val mockIdentityViewModel = mock<IdentityViewModel>().also {
+        whenever(it.verificationPage).thenReturn(verificationPageLiveData)
+        whenever(it.verificationPageApiError).thenReturn(verificationApiErrorLiveData)
+        whenever(it.args).thenReturn(
+            IdentityVerificationSheetContract.Args(
+                verificationSessionId = VERIFICATION_SESSION_ID,
+                ephemeralKeySecret = EPHEMERAL_KEY,
+                merchantLogo = MERCHANT_LOGO
+            )
+        )
+    }
+
+    @Test
+    fun `when waiting verificationPage UI shows progress circular`() {
+        launchConsentFragment { binding, _ ->
+            assertThat(binding.loadings.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.texts.visibility).isEqualTo(View.GONE)
+            assertThat(binding.buttons.visibility).isEqualTo(View.GONE)
+        }
+    }
+
+    @Test
+    fun `when verificationPage is ready UI is bound correctly`() {
+        launchConsentFragment { binding, _ ->
+            verificationPageLiveData.postValue(verificationPage)
+
+            assertThat(binding.loadings.visibility).isEqualTo(View.GONE)
+            assertThat(binding.texts.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.buttons.visibility).isEqualTo(View.VISIBLE)
+
+            assertThat(binding.merchantLogo.sourceLayoutResId).isEqualTo(MERCHANT_LOGO)
+            assertThat(binding.titleText.text).isEqualTo(CONSENT_TITLE)
+            assertThat(binding.privacyPolicy.text.toString()).isEqualTo(CONSENT_PRIVACY_POLICY)
+            assertThat(binding.timeEstimate.text).isEqualTo(CONSENT_TIME_ESTIMATE)
+            assertThat(binding.body.text.toString()).isEqualTo(CONSENT_BODY)
+            assertThat(binding.agree.text).isEqualTo(CONSENT_ACCEPT_TEXT)
+            assertThat(binding.decline.text).isEqualTo(CONSENT_DECLINE_TEXT)
+        }
+    }
+
+    @Test
+    fun `when verificationApiErrorLiveData is ready transitions to errorFragment`() {
+        launchConsentFragment { _, navController ->
+            verificationApiErrorLiveData.postValue(mock())
+
+            assertThat(navController.currentDestination?.id)
+                .isEqualTo(R.id.errorFragment)
+        }
+    }
+
+    @Test
+    fun `when accepted and postVerificationData success transitions to docSelectionFragment`() {
+        runBlocking {
+            whenever(
+                mockIdentityViewModel.postVerificationPageData(any())
+            ).thenReturn(correctVerificationData)
+
+            launchConsentFragment { binding, navController ->
+
+                verificationPageLiveData.postValue(verificationPage)
+
+                binding.agree.callOnClick()
+
+                assertThat(navController.currentDestination?.id)
+                    .isEqualTo(R.id.docSelectionFragment)
+            }
+        }
+    }
+
+    @Test
+    fun `when accepted and postVerificationData fails transitions to errorFragment`() {
+        runBlocking {
+            whenever(
+                mockIdentityViewModel.postVerificationPageData(any())
+            ).thenThrow(APIException())
+
+            launchConsentFragment { binding, navController ->
+                verificationPageLiveData.postValue(verificationPage)
+                binding.agree.callOnClick()
+
+                assertThat(navController.currentDestination?.id)
+                    .isEqualTo(R.id.errorFragment)
+            }
+        }
+    }
+
+    @Test
+    fun `when declined and postVerificationData success transitions to errorFragment with returned value`() {
+        runBlocking {
+            whenever(
+                mockIdentityViewModel.postVerificationPageData(any())
+            ).thenReturn(incorrectVerificationData)
+
+            launchConsentFragment { binding, navController ->
+                verificationPageLiveData.postValue(verificationPage)
+                binding.decline.callOnClick()
+
+                requireNotNull(navController.backStack.last().arguments).let { arguments ->
+                    assertThat(arguments[ErrorFragment.ARG_ERROR_TITLE])
+                        .isEqualTo(ERROR_TITLE)
+                    assertThat(arguments[ErrorFragment.ARG_ERROR_CONTENT])
+                        .isEqualTo(ERROR_BODY)
+                    assertThat(arguments[ErrorFragment.ARG_GO_BACK_BUTTON_DESTINATION])
+                        .isEqualTo(R.id.action_errorFragment_to_consentFragment)
+                    assertThat(arguments[ErrorFragment.ARG_GO_BACK_BUTTON_TEXT])
+                        .isEqualTo(ERROR_BUTTON_TEXT)
+                }
+
+                assertThat(navController.currentDestination?.id)
+                    .isEqualTo(R.id.errorFragment)
+            }
+        }
+    }
+
+    @Test
+    fun `when declined and postVerificationData fails transitions to errorFragment`() {
+        runBlocking {
+            whenever(
+                mockIdentityViewModel.postVerificationPageData(any())
+            ).thenThrow(APIException())
+
+            launchConsentFragment { binding, navController ->
+                verificationPageLiveData.postValue(verificationPage)
+                binding.decline.callOnClick()
+
+                assertThat(navController.currentDestination?.id)
+                    .isEqualTo(R.id.errorFragment)
+            }
+        }
+    }
+
+    private fun launchConsentFragment(
+        testBlock: (binding: ConsentFragmentBinding, navController: TestNavHostController) -> Unit
+    ) = launchFragmentInContainer(
+        themeResId = R.style.Theme_MaterialComponents
+    ) {
+        ConsentFragment(viewModelFactoryFor(mockIdentityViewModel))
+    }.onFragment {
+        val navController = TestNavHostController(
+            ApplicationProvider.getApplicationContext()
+        )
+        navController.setGraph(
+            R.navigation.identity_nav_graph
+        )
+        navController.setCurrentDestination(R.id.consentFragment)
+        Navigation.setViewNavController(
+            it.requireView(),
+            navController
+        )
+        testBlock(ConsentFragmentBinding.bind(it.requireView()), navController)
+    }
+
+    private companion object {
+        const val CONSENT_TITLE = "title"
+        const val CONSENT_PRIVACY_POLICY = "privacy policy"
+        const val CONSENT_TIME_ESTIMATE = "time estimate"
+        const val CONSENT_BODY = "this is the consent body"
+        const val CONSENT_ACCEPT_TEXT = "yes"
+        const val CONSENT_DECLINE_TEXT = "no"
+
+        const val ERROR_BODY = "error body"
+        const val ERROR_BUTTON_TEXT = "go back to consent"
+
+        const val ERROR_TITLE = "error title"
+
+        const val VERIFICATION_SESSION_ID = "id_5678"
+        const val EPHEMERAL_KEY = "eak_5678"
+        val MERCHANT_LOGO = R.drawable.check_mark
+    }
+}

--- a/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.identity.networking.models.VerificationPageStaticConte
 import com.stripe.android.identity.viewModelFactoryFor
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 import kotlinx.coroutines.runBlocking
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
@@ -86,6 +87,19 @@ internal class ConsentFragmentTest {
         )
     }
 
+    @Before
+    fun setup() {
+        whenever(mockIdentityViewModel.verificationPage).thenReturn(verificationPageLiveData)
+        whenever(mockIdentityViewModel.verificationPageApiError).thenReturn(verificationApiErrorLiveData)
+        whenever(mockIdentityViewModel.args).thenReturn(
+            IdentityVerificationSheetContract.Args(
+                verificationSessionId = VERIFICATION_SESSION_ID,
+                ephemeralKeySecret = EPHEMERAL_KEY,
+                merchantLogo = MERCHANT_LOGO
+            )
+        )
+    }
+
     @Test
     fun `when waiting verificationPage UI shows progress circular`() {
         launchConsentFragment { binding, _ ->
@@ -104,7 +118,6 @@ internal class ConsentFragmentTest {
             assertThat(binding.texts.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.buttons.visibility).isEqualTo(View.VISIBLE)
 
-            assertThat(binding.merchantLogo.sourceLayoutResId).isEqualTo(MERCHANT_LOGO)
             assertThat(binding.titleText.text).isEqualTo(CONSENT_TITLE)
             assertThat(binding.privacyPolicy.text.toString()).isEqualTo(CONSENT_PRIVACY_POLICY)
             assertThat(binding.timeEstimate.text).isEqualTo(CONSENT_TIME_ESTIMATE)

--- a/identity/src/test/java/com/stripe/android/identity/navigation/DriverLicenseScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/DriverLicenseScanFragmentTest.kt
@@ -5,8 +5,6 @@ import android.view.View
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.Navigation
 import androidx.navigation.testing.TestNavHostController
@@ -18,6 +16,7 @@ import com.stripe.android.identity.camera.IDDetectorAggregator
 import com.stripe.android.identity.camera.IdentityScanFlow
 import com.stripe.android.identity.databinding.DriverLicenseScanFragmentBinding
 import com.stripe.android.identity.states.IdentityScanState
+import com.stripe.android.identity.viewModelFactoryFor
 import com.stripe.android.identity.viewmodel.CameraViewModel
 import org.junit.Rule
 import org.junit.Test
@@ -57,13 +56,6 @@ internal class DriverLicenseScanFragmentTest {
         ) {
             this.onCameraReady = onCameraReady
             this.onUserDeniedCameraPermission = onUserDeniedCameraPermission
-        }
-    }
-
-    private val cameraViewModelFactory = object : ViewModelProvider.Factory {
-        @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return mockCameraViewModel as T
         }
     }
 
@@ -341,7 +333,7 @@ internal class DriverLicenseScanFragmentTest {
     ) {
         DriverLicenseScanFragment(
             cameraPermissionEnsureable,
-            cameraViewModelFactory
+            viewModelFactoryFor(mockCameraViewModel)
         )
     }
 

--- a/identity/src/test/java/com/stripe/android/identity/navigation/FrontBackUploadFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/FrontBackUploadFragmentTest.kt
@@ -7,7 +7,6 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.Navigation
 import androidx.navigation.testing.TestNavHostController
@@ -17,6 +16,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.FrontBackUploadFragmentBinding
 import com.stripe.android.identity.states.IdentityScanState
+import com.stripe.android.identity.viewModelFactoryFor
 import com.stripe.android.identity.viewmodel.FrontBackUploadViewModel
 import org.junit.Rule
 import org.junit.Test
@@ -45,13 +45,6 @@ class FrontBackUploadFragmentTest {
         whenever(it.frontUploaded).thenReturn(frontUploaded)
         whenever(it.backUploaded).thenReturn(backUploaded)
         whenever(it.uploadFinished).thenReturn(uploadFinished)
-    }
-
-    private val idUploadFragmentViewModelFactory = object : ViewModelProvider.Factory {
-        @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return mockFrontBackUploadViewModel as T
-        }
     }
 
     @Test
@@ -243,7 +236,7 @@ class FrontBackUploadFragmentTest {
     private fun launchFragment() = launchFragmentInContainer(
         themeResId = R.style.Theme_MaterialComponents
     ) {
-        TestFragment(idUploadFragmentViewModelFactory)
+        TestFragment(viewModelFactoryFor(mockFrontBackUploadViewModel))
     }
 
     internal class TestFragment(frontBackUploadViewModelFactory: ViewModelProvider.Factory) :

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IDScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IDScanFragmentTest.kt
@@ -5,8 +5,6 @@ import android.view.View
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.Navigation
 import androidx.navigation.testing.TestNavHostController
@@ -18,6 +16,7 @@ import com.stripe.android.identity.camera.IDDetectorAggregator
 import com.stripe.android.identity.camera.IdentityScanFlow
 import com.stripe.android.identity.databinding.IdScanFragmentBinding
 import com.stripe.android.identity.states.IdentityScanState
+import com.stripe.android.identity.viewModelFactoryFor
 import com.stripe.android.identity.viewmodel.CameraViewModel
 import org.junit.Rule
 import org.junit.Test
@@ -57,13 +56,6 @@ internal class IDScanFragmentTest {
         ) {
             this.onCameraReady = onCameraReady
             this.onUserDeniedCameraPermission = onUserDeniedCameraPermission
-        }
-    }
-
-    private val cameraViewModelFactory = object : ViewModelProvider.Factory {
-        @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return mockCameraViewModel as T
         }
     }
 
@@ -317,7 +309,7 @@ internal class IDScanFragmentTest {
     ) {
         IDScanFragment(
             cameraPermissionEnsureable,
-            cameraViewModelFactory
+            viewModelFactoryFor(mockCameraViewModel)
         )
     }
 

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IdentityCameraScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IdentityCameraScanFragmentTest.kt
@@ -9,7 +9,6 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.camera.CameraPermissionEnsureable
@@ -18,6 +17,7 @@ import com.stripe.android.identity.R
 import com.stripe.android.identity.camera.IDDetectorAggregator
 import com.stripe.android.identity.camera.IdentityScanFlow
 import com.stripe.android.identity.states.IdentityScanState
+import com.stripe.android.identity.viewModelFactoryFor
 import com.stripe.android.identity.viewmodel.CameraViewModel
 import org.junit.Rule
 import org.junit.Test
@@ -57,12 +57,6 @@ class IdentityCameraScanFragmentTest {
         ) {
             this.onCameraReady = onCameraReady
             this.onUserDeniedCameraPermission = onUserDeniedCameraPermission
-        }
-    }
-    private val cameraViewModelFactory = object : ViewModelProvider.Factory {
-        @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return mockCameraViewModel as T
         }
     }
 
@@ -152,7 +146,7 @@ class IdentityCameraScanFragmentTest {
     ) {
         TestFragment(
             cameraPermissionEnsureable,
-            cameraViewModelFactory,
+            viewModelFactoryFor(mockCameraViewModel),
             mockCameraView
         )
     }

--- a/identity/src/test/java/com/stripe/android/identity/navigation/PassportScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/PassportScanFragmentTest.kt
@@ -5,8 +5,6 @@ import android.view.View
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.Navigation
 import androidx.navigation.testing.TestNavHostController
@@ -18,6 +16,7 @@ import com.stripe.android.identity.camera.IDDetectorAggregator
 import com.stripe.android.identity.camera.IdentityScanFlow
 import com.stripe.android.identity.databinding.PassportScanFragmentBinding
 import com.stripe.android.identity.states.IdentityScanState
+import com.stripe.android.identity.viewModelFactoryFor
 import com.stripe.android.identity.viewmodel.CameraViewModel
 import org.junit.Rule
 import org.junit.Test
@@ -57,13 +56,6 @@ class PassportScanFragmentTest {
         ) {
             this.onCameraReady = onCameraReady
             this.onUserDeniedCameraPermission = onUserDeniedCameraPermission
-        }
-    }
-
-    private val cameraViewModelFactory = object : ViewModelProvider.Factory {
-        @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return mockCameraViewModel as T
         }
     }
 
@@ -235,7 +227,7 @@ class PassportScanFragmentTest {
     ) {
         PassportScanFragment(
             cameraPermissionEnsureable,
-            cameraViewModelFactory
+            viewModelFactoryFor(mockCameraViewModel)
         )
     }
 

--- a/identity/src/test/java/com/stripe/android/identity/navigation/PassportUploadFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/PassportUploadFragmentTest.kt
@@ -6,8 +6,6 @@ import android.widget.Button
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.Navigation
 import androidx.navigation.testing.TestNavHostController
 import androidx.test.core.app.ApplicationProvider
@@ -15,6 +13,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.PassportUploadFragmentBinding
+import com.stripe.android.identity.viewModelFactoryFor
 import com.stripe.android.identity.viewmodel.PassportUploadViewModel
 import org.junit.Rule
 import org.junit.Test
@@ -39,13 +38,6 @@ class PassportUploadFragmentTest {
 
     private val mockPassportUploadViewModel = mock<PassportUploadViewModel>().also {
         whenever(it.uploaded).thenReturn(uploaded)
-    }
-
-    private val passportUploadViewModelFactory = object : ViewModelProvider.Factory {
-        @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return mockPassportUploadViewModel as T
-        }
     }
 
     @Test
@@ -160,6 +152,6 @@ class PassportUploadFragmentTest {
     private fun launchFragment() = launchFragmentInContainer(
         themeResId = R.style.Theme_MaterialComponents
     ) {
-        PassportUploadFragment(passportUploadViewModelFactory)
+        PassportUploadFragment(viewModelFactoryFor(mockPassportUploadViewModel))
     }
 }

--- a/identity/src/test/java/com/stripe/android/identity/networking/IdentityNetworkResponseFixtures.kt
+++ b/identity/src/test/java/com/stripe/android/identity/networking/IdentityNetworkResponseFixtures.kt
@@ -27,7 +27,9 @@ internal val VERIFICATION_PAGE_JSON_STRING = """
         "accept_button_text": "Accept and continue",
         "body": "Stripe will confirm your identity using biometric technology that uses images of you and your identification, and other data sources. The results will be shared with mlgb.band.",
         "decline_button_text": "No, don't verify",
-        "title": "How Stripe will verify your identity"
+        "title": "How Stripe will verify your identity",
+        "privacy_policy": "This is privacy policy",
+        "time_estimate": "Takes about 1-2 minutes"
       },
       "document_capture": {
         "autocapture_timeout": 8000,

--- a/identity/src/test/java/com/stripe/android/identity/testUtils.kt
+++ b/identity/src/test/java/com/stripe/android/identity/testUtils.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.identity
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+
+internal fun viewModelFactoryFor(viewModel: ViewModel) = object : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        return viewModel as T
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Bind the Identity network response to `ConsentFragment` UI
  * redirect to `DocSelectionFragment` when consent is given
  * redirect to `ErrorFragment` when consent is declined 
  * redirect to `ErrorFragment` when network fails

* Build a `IdentityViewModel` as an activity viewmodel, share the same instance across all fragments

* Still need to bind UI for
  * DocSelectionFragment
  * ConfirmationFragment

* Note: the copies from the screenshot is from network response and rendered as HTML, they looked a bit off now, will need to update backend copies to format them correctly

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Identity SDK

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
![consent](https://user-images.githubusercontent.com/79880926/156945629-713f0823-1fb9-4029-9fa4-d0a33e177f43.png)
