### PR TITLE
[AnalyticsRequestFactory] Fixes event name.

### DIFF
--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestFactory.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestFactory.kt
@@ -60,7 +60,7 @@ open class AnalyticsRequestFactory(
     }
 
     private fun AnalyticsEvent.params(): Map<String, String> {
-        return mapOf(AnalyticsFields.EVENT to this.toString())
+        return mapOf(AnalyticsFields.EVENT to this.eventName)
     }
 
     private fun standardParams(): Map<String, Any> = mapOf(

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestFactoryTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestFactoryTest.kt
@@ -75,7 +75,7 @@ class AnalyticsRequestFactoryTest : TestCase() {
         assertThat(versionCode).isEqualTo(params[AnalyticsFields.APP_VERSION])
         assertThat(params[AnalyticsFields.APP_NAME]).isEqualTo(BuildConfig.LIBRARY_PACKAGE_NAME)
         assertThat(StripeSdkVersion.VERSION_NAME).isEqualTo(params[AnalyticsFields.BINDINGS_VERSION])
-        assertThat(mockEvent.toString()).isEqualTo(params[AnalyticsFields.EVENT])
+        assertThat(mockEvent.eventName).isEqualTo(params[AnalyticsFields.EVENT])
         assertThat(expectedUaName).isEqualTo(params[AnalyticsFields.ANALYTICS_UA])
         assertThat("unknown_generic_x86_robolectric").isEqualTo(params[AnalyticsFields.DEVICE_TYPE])
         assertNotNull(params[AnalyticsFields.OS_RELEASE])

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestFactoryTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestFactoryTest.kt
@@ -110,4 +110,12 @@ class AnalyticsRequestFactoryTest : TestCase() {
         assertThat(AnalyticsRequestFactory.ANALYTICS_UA)
             .isEqualTo("analytics.stripe_android-1.0")
     }
+
+    @Test
+    fun `createEvent(String) - event name field matches passed string`() {
+        val event = "my_event_name"
+        val request = factory.createRequest(event, emptyMap())
+
+        assertThat(request.params["event"]).isEqualTo(event)
+    }
 }


### PR DESCRIPTION
# Summary
- Issue: As the `event_name` field we were sending `event#toString`, that existing events override to customize event name as needed.
- Events using the deprecated `createRequest(eventName: String)` are creating a mock `AnalyticsEvent`, that was not overriding "toString". 
- Solution: send `eventName` instead of `toString` as event name.