### PR TITLE
[Identity] Network & UI - 2 of 3: `DocumentSelectionFragment`

### DIFF
--- a/identity/api/identity.api
+++ b/identity/api/identity.api
@@ -110,8 +110,15 @@ public final class com/stripe/android/identity/databinding/ConsentFragmentBindin
 
 public final class com/stripe/android/identity/databinding/DocSelectionFragmentBinding : androidx/viewbinding/ViewBinding {
 	public final field dl Lcom/google/android/material/button/MaterialButton;
+	public final field dlSeparator Landroid/view/View;
 	public final field id Lcom/google/android/material/button/MaterialButton;
+	public final field idSeparator Landroid/view/View;
+	public final field multiSelectionContent Landroid/widget/LinearLayout;
 	public final field passport Lcom/google/android/material/button/MaterialButton;
+	public final field passportSeparator Landroid/view/View;
+	public final field singleSelectionBody Landroid/widget/TextView;
+	public final field singleSelectionContent Landroid/widget/LinearLayout;
+	public final field singleSelectionContinue Lcom/google/android/material/button/MaterialButton;
 	public final field title Landroid/widget/TextView;
 	public static fun bind (Landroid/view/View;)Lcom/stripe/android/identity/databinding/DocSelectionFragmentBinding;
 	public synthetic fun getRoot ()Landroid/view/View;

--- a/identity/res/layout/doc_selection_fragment.xml
+++ b/identity/res/layout/doc_selection_fragment.xml
@@ -6,6 +6,8 @@
     android:orientation="vertical"
     android:layout_marginStart="@dimen/page_horizontal_margin"
     android:layout_marginEnd="@dimen/page_horizontal_margin"
+    android:layout_marginTop="@dimen/page_vertical_margin"
+    android:layout_marginBottom="@dimen/page_vertical_margin"
     tools:context=".navigation.DocSelectionFragment">
 
     <TextView
@@ -18,54 +20,95 @@
         android:layout_marginBottom="32dp"
         android:text="@string/doc_select_title" />
 
-    <View
+    <LinearLayout
+        android:id="@+id/multi_selection_content"
         android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:layout_marginBottom="@dimen/item_vertical_margin"
-        android:background="?android:attr/listDivider" />
-
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/dl"
-        android:textColor="?android:textColorPrimary"
-        android:background="@android:color/transparent"
-        android:text="@string/driver_license"
-        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/item_vertical_margin" />
+        android:orientation="vertical">
 
-    <View
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginBottom="@dimen/item_vertical_margin"
+            android:background="?android:attr/listDivider" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/dl"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:visibility="gone"
+            android:textColor="?android:textColorPrimary"
+            android:text="@string/driver_license"
+            android:gravity="center_vertical"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/item_vertical_margin" />
+
+        <View
+            android:id="@+id/dl_separator"
+            android:visibility="gone"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginBottom="@dimen/item_vertical_margin"
+            android:background="?android:attr/listDivider" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/id"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:visibility="gone"
+            android:textColor="?android:textColorPrimary"
+            android:text="@string/id_card"
+            android:layout_marginBottom="@dimen/item_vertical_margin"
+            android:gravity="center_vertical"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <View
+            android:id="@+id/id_separator"
+            android:visibility="gone"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginBottom="@dimen/item_vertical_margin"
+            android:background="?android:attr/listDivider" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/passport"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:visibility="gone"
+            android:textColor="?android:textColorPrimary"
+            android:text="@string/passport"
+            android:layout_marginBottom="@dimen/item_vertical_margin"
+            android:gravity="center_vertical"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <View
+            android:id="@+id/passport_separator"
+            android:visibility="gone"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="?android:attr/listDivider" />
+    </LinearLayout>
+
+
+    <LinearLayout
+        android:id="@+id/single_selection_content"
         android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:layout_marginBottom="@dimen/item_vertical_margin"
-        android:background="?android:attr/listDivider" />
+        android:layout_height="match_parent"
+        android:visibility="gone"
+        android:orientation="vertical">
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/id"
-        android:background="@android:color/transparent"
-        android:textColor="?android:textColorPrimary"
-        android:text="@string/id_card"
-        android:layout_marginBottom="@dimen/item_vertical_margin"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
+        <TextView
+            android:id="@+id/single_selection_body"
+            android:layout_weight="1"
+            android:layout_width="match_parent"
+            android:layout_height="0dp" />
 
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:layout_marginBottom="@dimen/item_vertical_margin"
-        android:background="?android:attr/listDivider" />
-
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/passport"
-        android:background="@android:color/transparent"
-        android:textColor="?android:textColorPrimary"
-        android:text="@string/passport"
-        android:layout_marginBottom="@dimen/item_vertical_margin"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
-
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="?android:attr/listDivider" />
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/single_selection_continue"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/kontinue"
+            android:visibility="visible" />
+    </LinearLayout>
 
 </LinearLayout>

--- a/identity/res/navigation/identity_nav_graph.xml
+++ b/identity/res/navigation/identity_nav_graph.xml
@@ -17,6 +17,10 @@
         android:id="@+id/action_global_errorFragment"
         app:destination="@id/errorFragment" />
 
+    <action
+        android:id="@+id/action_global_confirmationFragment"
+        app:destination="@id/confirmationFragment" />
+
     <fragment
         android:id="@+id/consentFragment"
         android:name="com.stripe.android.identity.navigation.ConsentFragment"
@@ -122,6 +126,15 @@
         <action
             android:id="@+id/action_docSelectionFragment_to_driverLicenseScanFragment"
             app:destination="@id/driverLicenseScanFragment" />
+        <action
+            android:id="@+id/action_docSelectionFragment_to_passportUploadFragment"
+            app:destination="@id/passportUploadFragment" />
+        <action
+            android:id="@+id/action_docSelectionFragment_to_IDUploadFragment"
+            app:destination="@id/IDUploadFragment" />
+        <action
+            android:id="@+id/action_docSelectionFragment_to_driverLicenseUploadFragment"
+            app:destination="@id/driverLicenseUploadFragment" />
     </fragment>
     <fragment
         android:id="@+id/errorFragment"

--- a/identity/res/values/strings.xml
+++ b/identity/res/values/strings.xml
@@ -62,4 +62,8 @@
     <string name="loading">Loading</string>
     <string name="sample_consent_body_response"><![CDATA[<p><strong>How Stripe will verify your identity</strong></p>\n\n<p>Stripe will use biometric technology (on images of you and your IDs) and other data sources to confirm your identity and for fraud and security purposes. Stripe will store these images and the results of this check and share them with mlgb.band.</p>\n\n<p><a href=\"https://stripe.com/about\">Learn about Stripe</a></p><p><a href=\"https://stripe.com/privacy-center/legal#stripe-identity\">Learn how Stripe Identity works</a></p>]]></string>
     <string name="sample_privacy_policy"><![CDATA[Data will be stored and may be used according to the <a href=\"http://stripe.com/privacy\">Stripe Privacy Policy</a> and <a href=\"\">mlgb.band</a> Privacy Policy.]]></string>
+
+    <string name="single_selection_body_content_dl">You will need to take photos of the front and back in the following steps.</string>
+    <string name="single_selection_body_content_id">You will need to take photos of the front and back in the following steps.</string>
+    <string name="single_selection_body_content_passport">You will need to take a photo of the passport in the following steps.</string>
 </resources>

--- a/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
@@ -1,37 +1,283 @@
 package com.stripe.android.identity.navigation
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.IdRes
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
+import com.stripe.android.core.exception.InvalidRequestException
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.DocSelectionFragmentBinding
+import com.stripe.android.identity.networking.Status
+import com.stripe.android.identity.networking.models.CollectedDataParam
+import com.stripe.android.identity.networking.models.IdDocumentParam
+import com.stripe.android.identity.networking.models.IdDocumentParam.Type
+import com.stripe.android.identity.networking.models.VerificationPageData.Companion.isMissingBackOrFront
+import com.stripe.android.identity.utils.navigateToDefaultErrorFragment
+import com.stripe.android.identity.utils.postVerificationPageDataAndMaybeSubmit
+import com.stripe.android.identity.viewmodel.IdentityViewModel
+import kotlinx.coroutines.launch
 
 /**
  * Screen to select type of ID to scan.
  */
-internal class DocSelectionFragment : Fragment() {
+internal class DocSelectionFragment(
+    private val identityViewModelFactory: ViewModelProvider.Factory
+) : Fragment() {
+
+    private val identityViewModel: IdentityViewModel by activityViewModels {
+        identityViewModelFactory
+    }
+
+    private lateinit var binding: DocSelectionFragmentBinding
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val binding = DocSelectionFragmentBinding.inflate(inflater, container, false)
-        binding.dl.setOnClickListener {
-            findNavController().navigate(R.id.action_docSelectionFragment_to_driverLicenseScanFragment)
-        }
-
-        binding.id.setOnClickListener {
-            findNavController().navigate(R.id.action_docSelectionFragment_to_IDScanFragment)
-        }
-
-        binding.passport.setOnClickListener {
-            findNavController().navigate(R.id.action_docSelectionFragment_to_passportScanFragment)
-        }
-
+        binding = DocSelectionFragmentBinding.inflate(inflater, container, false)
         return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        identityViewModel.verificationPage.observe(viewLifecycleOwner) { verificationPage ->
+            when (verificationPage.status) {
+                Status.SUCCESS -> {
+                    binding.title.text = requireNotNull(verificationPage.data).documentSelect.title
+                    when (requireNotNull(verificationPage.data).documentSelect.idDocumentTypeAllowlist.count()) {
+                        0 -> {
+                            toggleMultiSelectionUI()
+                        }
+                        1 -> {
+                            requireNotNull(verificationPage.data).documentSelect.let { documentSelect ->
+                                toggleSingleSelectionUI(
+                                    documentSelect.idDocumentTypeAllowlist.entries.first().key,
+                                    documentSelect.buttonText
+                                )
+                            }
+                        }
+                        else -> {
+                            toggleMultiSelectionUI(requireNotNull(verificationPage.data).documentSelect.idDocumentTypeAllowlist)
+                        }
+                    }
+                }
+                Status.LOADING -> {} // no-np
+                Status.ERROR -> {
+                    navigateToDefaultErrorFragment()
+                }
+            }
+        }
+    }
+
+    /**
+     * Toggle UI to show multiple selection types. If idDocumentTypeAllowlist from server is null,
+     * show all three types with default values.
+     */
+    private fun toggleMultiSelectionUI(idDocumentTypeAllowlist: Map<String, String>? = null) {
+        binding.multiSelectionContent.visibility = View.VISIBLE
+        binding.singleSelectionContent.visibility = View.GONE
+        idDocumentTypeAllowlist?.let {
+            for ((allowedType, allowedTypeValue) in idDocumentTypeAllowlist) {
+                when (allowedType) {
+                    PASSPORT_KEY -> {
+                        binding.passport.text = allowedTypeValue
+                        binding.passport.visibility = View.VISIBLE
+                        binding.passport.setOnClickListener {
+                            disableButtonAndNavigate(it, Type.PASSPORT)
+                        }
+                        binding.passportSeparator.visibility = View.VISIBLE
+                    }
+                    DRIVING_LICENSE_KEY -> {
+                        binding.dl.text = allowedTypeValue
+                        binding.dl.visibility = View.VISIBLE
+                        binding.dl.setOnClickListener {
+                            disableButtonAndNavigate(it, Type.DRIVINGLICENSE)
+                        }
+                        binding.dlSeparator.visibility = View.VISIBLE
+                    }
+                    ID_CARD_KEY -> {
+                        binding.id.text = allowedTypeValue
+                        binding.id.visibility = View.VISIBLE
+                        binding.id.setOnClickListener {
+                            disableButtonAndNavigate(it, Type.IDCARD)
+                        }
+                        binding.idSeparator.visibility = View.VISIBLE
+                    }
+                    else -> {
+                        throw InvalidRequestException(message = "Unknown allow type: $allowedType")
+                    }
+                }
+            }
+        } ?: run {
+            listOf(
+                binding.dl,
+                binding.dlSeparator,
+                binding.id,
+                binding.idSeparator,
+                binding.passport,
+                binding.passportSeparator
+            ).forEach {
+                it.visibility = View.VISIBLE
+            }
+            binding.passport.setOnClickListener {
+                disableButtonAndNavigate(it, Type.PASSPORT)
+            }
+            binding.dl.setOnClickListener {
+                disableButtonAndNavigate(it, Type.DRIVINGLICENSE)
+            }
+            binding.id.setOnClickListener {
+                disableButtonAndNavigate(it, Type.IDCARD)
+            }
+        }
+    }
+
+    /**
+     * Toggle UI to show single selection type.
+     */
+    private fun toggleSingleSelectionUI(allowedType: String, buttonText: String) {
+        binding.multiSelectionContent.visibility = View.GONE
+        binding.singleSelectionContent.visibility = View.VISIBLE
+        binding.singleSelectionContinue.text = buttonText
+
+        when (allowedType) {
+            PASSPORT_KEY -> {
+                binding.singleSelectionBody.text =
+                    getString(R.string.single_selection_body_content_passport)
+                binding.singleSelectionContinue.setOnClickListener {
+                    disableButtonAndNavigate(it, Type.PASSPORT)
+                }
+            }
+            DRIVING_LICENSE_KEY -> {
+                binding.singleSelectionBody.text =
+                    getString(R.string.single_selection_body_content_dl)
+                binding.singleSelectionContinue.setOnClickListener {
+                    disableButtonAndNavigate(it, Type.DRIVINGLICENSE)
+                }
+            }
+            ID_CARD_KEY -> {
+                binding.singleSelectionBody.text =
+                    getString(R.string.single_selection_body_content_id)
+                binding.singleSelectionContinue.setOnClickListener {
+                    disableButtonAndNavigate(it, Type.IDCARD)
+                }
+            }
+            else -> {
+                throw InvalidRequestException(message = "Unknown allow type: $allowedType")
+            }
+        }
+    }
+
+    /**
+     * Disable the button view and try navigate to this type.
+     *
+     * TODO(ccen): add CircularProgressIndicator to button
+     * Note: no need to it back to enabled, as it will navigate to another Fragment.
+     */
+    private fun disableButtonAndNavigate(view: View, type: Type) {
+        view.isEnabled = false
+        postVerificationPageDataAndNavigate(type)
+    }
+
+    /**
+     * Post VerificationPageData with the type and navigate base on its result.
+     */
+    private fun postVerificationPageDataAndNavigate(type: Type) {
+        lifecycleScope.launch {
+            postVerificationPageDataAndMaybeSubmit(
+                identityViewModel,
+                CollectedDataParam(idDocument = IdDocumentParam(type = type)),
+                shouldNotSubmit = { verificationPageData ->
+                    verificationPageData.isMissingBackOrFront()
+                },
+                notSubmitBlock = {
+                    // TODO(ccen) Also check camera permission here
+                    identityViewModel.idDetectorModelFile.observe(viewLifecycleOwner) { modelResource ->
+                        when (modelResource.status) {
+                            Status.SUCCESS -> {
+                                navigateToScanFragment(type)
+                            }
+                            Status.ERROR -> {
+                                tryNavigateToUploadFragment(type)
+                            }
+                            Status.LOADING -> {} // no-op
+                        }
+                    }
+                }
+            )
+        }
+    }
+
+    /**
+     * Navigate to the corresponding type's scan fragment.
+     */
+    private fun navigateToScanFragment(type: Type) {
+        findNavController().navigate(type.toScanDestinationId())
+    }
+
+    /**
+     * Navigate to the corresponding type's upload fragment.
+     */
+    private fun navigateToUploadFragment(type: Type) {
+        findNavController().navigate(type.toUploadDestinationId())
+    }
+
+    /**
+     * Navigate to the corresponding type's upload fragment, or to [ErrorFragment]
+     * if required data is not available.
+     */
+    private fun tryNavigateToUploadFragment(type: Type) {
+        identityViewModel.verificationPage.observe(
+            viewLifecycleOwner
+        ) { verificationPageResource ->
+            when (verificationPageResource.status) {
+                Status.SUCCESS -> {
+                    if (requireNotNull(
+                            verificationPageResource.data
+                        ).documentCapture.requireLiveCapture
+                    ) {
+                        Log.e(TAG, "Can't access camera and client has required live capture.")
+                        navigateToDefaultErrorFragment()
+                    } else {
+                        navigateToUploadFragment(type)
+                    }
+                }
+                Status.ERROR -> {
+                    Log.e(TAG, "Failed to get VerificationPage.")
+                    navigateToDefaultErrorFragment()
+                }
+                Status.LOADING -> {} // no-op
+            }
+        }
+    }
+
+    internal companion object {
+        const val PASSPORT_KEY = "passport"
+        const val DRIVING_LICENSE_KEY = "driving_license"
+        const val ID_CARD_KEY = "id_card"
+        val TAG: String = DocSelectionFragment::class.java.simpleName
+
+        @IdRes
+        fun Type.toScanDestinationId() =
+            when (this) {
+                Type.IDCARD -> R.id.action_docSelectionFragment_to_IDScanFragment
+                Type.PASSPORT -> R.id.action_docSelectionFragment_to_passportScanFragment
+                Type.DRIVINGLICENSE -> R.id.action_docSelectionFragment_to_driverLicenseScanFragment
+            }
+
+        @IdRes
+        fun Type.toUploadDestinationId() =
+            when (this) {
+                Type.IDCARD -> R.id.action_docSelectionFragment_to_IDUploadFragment
+                Type.PASSPORT -> R.id.action_docSelectionFragment_to_passportUploadFragment
+                Type.DRIVINGLICENSE -> R.id.action_docSelectionFragment_to_driverLicenseUploadFragment
+            }
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
@@ -71,6 +71,9 @@ internal class IdentityFragmentFactory(
             ConsentFragment::class.java.name -> ConsentFragment(
                 identityViewModelFactory
             )
+            DocSelectionFragment::class.java.name -> DocSelectionFragment(
+                identityViewModelFactory
+            )
             else -> super.instantiate(classLoader, className)
         }
     }

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/IdDocumentParam.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/IdDocumentParam.kt
@@ -5,12 +5,10 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 internal data class IdDocumentParam(
-
     @SerialName("back")
     val back: DocumentUploadParam? = null,
     @SerialName("front")
     val front: DocumentUploadParam? = null,
-
     @SerialName("type")
     val type: Type? = null
 ) {

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPage.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPage.kt
@@ -56,4 +56,9 @@ internal data class VerificationPage(
         @SerialName("verified")
         VERIFIED;
     }
+
+    internal companion object {
+        fun VerificationPage.isMissingBiometricConsent() =
+            requirements.missing.contains(VerificationPageRequirements.Missing.BIOMETRICCONSENT)
+    }
 }

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageData.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageData.kt
@@ -42,4 +42,15 @@ internal data class VerificationPageData(
         @SerialName("verified")
         VERIFIED
     }
+
+    internal companion object {
+        fun VerificationPageData.isMissingDocumentType() =
+            requirements.missing.contains(VerificationPageDataRequirements.Missing.IDDOCUMENTTYPE)
+
+        fun VerificationPageData.isMissingBackOrFront() =
+            requirements.missing.contains(VerificationPageDataRequirements.Missing.IDDOCUMENTFRONT) ||
+                requirements.missing.contains(VerificationPageDataRequirements.Missing.IDDOCUMENTBACK)
+
+        fun VerificationPageData.hasError() = requirements.errors.isNotEmpty()
+    }
 }

--- a/identity/src/main/java/com/stripe/android/identity/utils/navigationUtils.kt
+++ b/identity/src/main/java/com/stripe/android/identity/utils/navigationUtils.kt
@@ -1,0 +1,93 @@
+package com.stripe.android.identity.utils
+
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import com.stripe.android.identity.R
+import com.stripe.android.identity.navigation.ErrorFragment
+import com.stripe.android.identity.navigation.ErrorFragment.Companion.navigateToErrorFragmentWithDefaultValues
+import com.stripe.android.identity.navigation.ErrorFragment.Companion.navigateToErrorFragmentWithRequirementErrorAndDestination
+import com.stripe.android.identity.networking.models.CollectedDataParam
+import com.stripe.android.identity.networking.models.VerificationPageData
+import com.stripe.android.identity.networking.models.VerificationPageData.Companion.hasError
+import com.stripe.android.identity.networking.models.VerificationPageDataRequirementError
+import com.stripe.android.identity.viewmodel.IdentityViewModel
+
+/**
+ * A util method for a [Fragment] to post [CollectedDataParam] and resolve its [VerificationPageData].
+ *
+ * * If the initial post fails, navigate to [ErrorFragment] with default values.
+ * * If the initial post succeeds, check if the response [VerificationPageData] has error.
+ *    * If it has error, then navigate to [ErrorFragment] with the error data.
+ *    * Otherwise, check [shouldNotSubmit].
+ *      * If it's true invoke [notSubmitBlock]
+ *      * If it's false, post submit
+ *        * If submit succeeds, navigate to [ConfirmationFragment]
+ *        * If submit fails, navigate to [ErrorFragment]
+ *
+ *
+ * @param identityViewModel: [IdentityViewModel] to fire requests.
+ * @param collectedDataParam: parameter collected from UI response, posted to [IdentityViewModel.postVerificationPageData].
+ * @param shouldNotSubmit: A condition check block to decide when [VerificationPageData]
+ * is returned, whether to continue submit by [IdentityViewModel.postVerificationPageSubmit].
+ * @param notSubmitBlock: A block to execute when [shouldNotSubmit] returns true.
+ */
+internal suspend fun Fragment.postVerificationPageDataAndMaybeSubmit(
+    identityViewModel: IdentityViewModel,
+    collectedDataParam: CollectedDataParam,
+    shouldNotSubmit: (verificationPageData: VerificationPageData) -> Boolean = { true },
+    notSubmitBlock: (verificationPageData: VerificationPageData) -> Unit
+) {
+    runCatching {
+        identityViewModel.postVerificationPageData(collectedDataParam)
+    }.fold(
+        onSuccess = { postedVerificationPageData ->
+            if (postedVerificationPageData.hasError()) {
+                navigateToRequirementErrorFragment(postedVerificationPageData.requirements.errors[0])
+            } else {
+                if (shouldNotSubmit(postedVerificationPageData)) {
+                    notSubmitBlock(postedVerificationPageData)
+                } else {
+                    runCatching {
+                        identityViewModel.postVerificationPageSubmit()
+                    }.fold(
+                        onSuccess = { submittedVerificationPageData ->
+                            if (submittedVerificationPageData.hasError()) {
+                                navigateToRequirementErrorFragment(submittedVerificationPageData.requirements.errors[0])
+                            } else {
+                                findNavController()
+                                    .navigate(R.id.action_global_confirmationFragment)
+                            }
+                        },
+                        onFailure = {
+                            navigateToDefaultErrorFragment()
+                        }
+                    )
+                }
+            }
+        },
+        onFailure = {
+            navigateToDefaultErrorFragment()
+        }
+    )
+}
+
+/**
+ * Navigate to [ErrorFragment] with [VerificationPageDataRequirementError].
+ */
+private fun Fragment.navigateToRequirementErrorFragment(
+    requirementError: VerificationPageDataRequirementError
+) {
+    findNavController()
+        .navigateToErrorFragmentWithRequirementErrorAndDestination(
+            requirementError,
+            // TODO(ccen) Determine the if the destination of the back button is always ConsentFragment
+            R.id.action_errorFragment_to_consentFragment
+        )
+}
+
+/**
+ * Navigate to [ErrorFragment] with default values.
+ */
+internal fun Fragment.navigateToDefaultErrorFragment() {
+    findNavController().navigateToErrorFragmentWithDefaultValues(requireContext())
+}

--- a/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
@@ -17,6 +17,7 @@ import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPageData
 import com.stripe.android.identity.networking.models.VerificationPageDataRequirementError
 import com.stripe.android.identity.networking.models.VerificationPageDataRequirements
+import com.stripe.android.identity.networking.models.VerificationPageRequirements
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentConsentPage
 import com.stripe.android.identity.viewModelFactoryFor
 import com.stripe.android.identity.viewmodel.IdentityViewModel
@@ -46,13 +47,20 @@ internal class ConsentFragmentTest {
                 declineButtonText = CONSENT_DECLINE_TEXT
             )
         )
+        whenever(it.requirements).thenReturn(
+            VerificationPageRequirements(
+                missing = listOf(
+                    VerificationPageRequirements.Missing.BIOMETRICCONSENT
+                )
+            )
+        )
     }
 
     private val correctVerificationData = mock<VerificationPageData>().also {
         whenever(it.requirements).thenReturn(
             VerificationPageDataRequirements(
                 errors = emptyList(),
-                missing = emptyList()
+                missing = listOf(VerificationPageDataRequirements.Missing.IDDOCUMENTTYPE)
             )
         )
     }
@@ -91,6 +99,21 @@ internal class ConsentFragmentTest {
             assertThat(binding.loadings.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.texts.visibility).isEqualTo(View.GONE)
             assertThat(binding.buttons.visibility).isEqualTo(View.GONE)
+        }
+    }
+
+    @Test
+    fun `when not missing biometricConsent navigate to docSelectionFragment`() {
+        whenever(verificationPage.requirements).thenReturn(
+            VerificationPageRequirements(
+                missing = emptyList()
+            )
+        )
+        launchConsentFragment { _, navController ->
+            verificationPageLiveData.postValue(Resource.success(verificationPage))
+
+            assertThat(navController.currentDestination?.id)
+                .isEqualTo(R.id.docSelectionFragment)
         }
     }
 

--- a/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
@@ -1,0 +1,347 @@
+package com.stripe.android.identity.navigation
+
+import android.view.View
+import androidx.annotation.StringRes
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.lifecycle.MutableLiveData
+import androidx.navigation.Navigation
+import androidx.navigation.testing.TestNavHostController
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.identity.R
+import com.stripe.android.identity.databinding.DocSelectionFragmentBinding
+import com.stripe.android.identity.navigation.DocSelectionFragment.Companion.DRIVING_LICENSE_KEY
+import com.stripe.android.identity.navigation.DocSelectionFragment.Companion.ID_CARD_KEY
+import com.stripe.android.identity.navigation.DocSelectionFragment.Companion.PASSPORT_KEY
+import com.stripe.android.identity.networking.Resource
+import com.stripe.android.identity.networking.models.VerificationPage
+import com.stripe.android.identity.networking.models.VerificationPageData
+import com.stripe.android.identity.networking.models.VerificationPageDataRequirements
+import com.stripe.android.identity.networking.models.VerificationPageStaticContentDocumentCapturePage
+import com.stripe.android.identity.networking.models.VerificationPageStaticContentDocumentSelectPage
+import com.stripe.android.identity.viewModelFactoryFor
+import com.stripe.android.identity.viewmodel.IdentityViewModel
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class DocSelectionFragmentTest {
+    @get:Rule
+    var rule: TestRule = InstantTaskExecutorRule()
+
+    private val verificationPage = mock<VerificationPage>()
+    private val verificationPageLiveData = MutableLiveData<Resource<VerificationPage>>()
+    private val mockIdentityViewModel = mock<IdentityViewModel>().also {
+        whenever(it.verificationPage).thenReturn(verificationPageLiveData)
+    }
+
+    @Test
+    fun `errorVerificationPage navigates to errorFragment`() {
+        launchDocSelectionFragment { _, navController, _ ->
+            verificationPageLiveData.postValue(
+                Resource.error()
+            )
+
+            assertThat(navController.currentDestination?.id)
+                .isEqualTo(R.id.errorFragment)
+        }
+    }
+
+    @Test
+    fun `multi choice UI is correctly bound with values from response`() {
+        launchDocSelectionFragment { binding, _, _ ->
+            whenever(verificationPage.documentSelect).thenReturn(
+                DOC_SELECT_MULTI_CHOICE
+            )
+            verificationPageLiveData.postValue(
+                Resource.success(verificationPage)
+            )
+
+            assertThat(binding.title.text).isEqualTo(DOCUMENT_SELECT_TITLE)
+            assertThat(binding.multiSelectionContent.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.singleSelectionContent.visibility).isEqualTo(View.GONE)
+
+            assertThat(binding.passport.text).isEqualTo(PASSPORT_BUTTON_TEXT)
+            assertThat(binding.passport.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.passportSeparator.visibility).isEqualTo(View.VISIBLE)
+
+            assertThat(binding.dl.text).isEqualTo(DRIVING_LICENSE_BUTTON_TEXT)
+            assertThat(binding.dl.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.dlSeparator.visibility).isEqualTo(View.VISIBLE)
+
+            assertThat(binding.id.text).isEqualTo(ID_BUTTON_TEXT)
+            assertThat(binding.id.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.idSeparator.visibility).isEqualTo(View.VISIBLE)
+        }
+    }
+
+    @Test
+    fun `zero choice UI is correctly bound with values locally`() {
+        launchDocSelectionFragment { binding, _, docSelectFragment ->
+            whenever(verificationPage.documentSelect).thenReturn(
+                DOC_SELECT_ZERO_CHOICE
+            )
+            verificationPageLiveData.postValue(
+                Resource.success(verificationPage)
+            )
+
+            assertThat(binding.title.text).isEqualTo(DOCUMENT_SELECT_TITLE)
+            assertThat(binding.multiSelectionContent.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.singleSelectionContent.visibility).isEqualTo(View.GONE)
+
+            assertThat(binding.passport.text).isEqualTo(
+                docSelectFragment.getString(R.string.passport)
+            )
+            assertThat(binding.passport.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.passportSeparator.visibility).isEqualTo(View.VISIBLE)
+
+            assertThat(binding.dl.text).isEqualTo(
+                docSelectFragment.getString(R.string.driver_license)
+            )
+            assertThat(binding.dl.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.dlSeparator.visibility).isEqualTo(View.VISIBLE)
+
+            assertThat(binding.id.text).isEqualTo(
+                docSelectFragment.getString(R.string.id_card)
+            )
+            assertThat(binding.id.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.idSeparator.visibility).isEqualTo(View.VISIBLE)
+        }
+    }
+
+    @Test
+    fun `Passport single choice UI is correctly bound`() {
+        verifySingleChoiceUI(
+            DOC_SELECT_SINGLE_CHOICE_PASSPORT,
+            R.string.single_selection_body_content_passport
+        )
+    }
+
+    @Test
+    fun `ID single choice UI is correctly bound`() {
+        verifySingleChoiceUI(
+            DOC_SELECT_SINGLE_CHOICE_ID,
+            R.string.single_selection_body_content_id
+        )
+    }
+
+    @Test
+    fun `Driver license single choice UI is correctly bound`() {
+        verifySingleChoiceUI(
+            DOC_SELECT_SINGLE_CHOICE_DL,
+            R.string.single_selection_body_content_dl
+        )
+    }
+
+    @Test
+    fun `when scan is available, clicking continue navigates to scan`() {
+        launchDocSelectionFragment { binding, navController, _ ->
+            whenever(verificationPage.documentSelect).thenReturn(
+                DOC_SELECT_SINGLE_CHOICE_DL
+            )
+            runBlocking {
+                whenever(mockIdentityViewModel.postVerificationPageData(any())).thenReturn(
+                    MISSING_BACK_VERIFICATION_PAGE_DATA
+                )
+            }
+            // mock scan is available
+            // TODO(ccen) add camera permission check later
+            whenever(mockIdentityViewModel.idDetectorModelFile).thenReturn(
+                MutableLiveData(
+                    Resource.success(
+                        mock()
+                    )
+                )
+            )
+            verificationPageLiveData.postValue(
+                Resource.success(verificationPage)
+            )
+            binding.singleSelectionContinue.callOnClick()
+
+            assertThat(navController.currentDestination?.id)
+                .isEqualTo(R.id.driverLicenseScanFragment)
+        }
+    }
+
+    @Test
+    fun `when scan is unavailable, clicking continue navigates to upload when requireLiveCapture is false`() {
+        launchDocSelectionFragment { binding, navController, _ ->
+            whenever(verificationPage.documentSelect).thenReturn(
+                DOC_SELECT_SINGLE_CHOICE_DL
+            )
+            val mockDocumentCapture =
+                mock<VerificationPageStaticContentDocumentCapturePage>().also {
+                    whenever(it.requireLiveCapture).thenReturn(false)
+                }
+            whenever(verificationPage.documentCapture).thenReturn(
+                mockDocumentCapture
+            )
+            runBlocking {
+                whenever(mockIdentityViewModel.postVerificationPageData(any())).thenReturn(
+                    MISSING_BACK_VERIFICATION_PAGE_DATA
+                )
+            }
+            // mock scan is not available
+            // TODO(ccen) add camera permission check later
+            whenever(mockIdentityViewModel.idDetectorModelFile).thenReturn(
+                MutableLiveData(Resource.error())
+            )
+            verificationPageLiveData.postValue(
+                Resource.success(verificationPage)
+            )
+            binding.singleSelectionContinue.callOnClick()
+
+            assertThat(navController.currentDestination?.id)
+                .isEqualTo(R.id.driverLicenseUploadFragment)
+        }
+    }
+
+    @Test
+    fun `when scan is unavailable, clicking continue navigates to error when requireLiveCapture is true`() {
+        launchDocSelectionFragment { binding, navController, _ ->
+            whenever(verificationPage.documentSelect).thenReturn(
+                DOC_SELECT_SINGLE_CHOICE_DL
+            )
+            val mockDocumentCapture =
+                mock<VerificationPageStaticContentDocumentCapturePage>().also {
+                    whenever(it.requireLiveCapture).thenReturn(true)
+                }
+            whenever(verificationPage.documentCapture).thenReturn(
+                mockDocumentCapture
+            )
+            runBlocking {
+                whenever(mockIdentityViewModel.postVerificationPageData(any())).thenReturn(
+                    MISSING_BACK_VERIFICATION_PAGE_DATA
+                )
+            }
+            // mock scan is not available
+            // TODO(ccen) add camera permission check later
+            whenever(mockIdentityViewModel.idDetectorModelFile).thenReturn(
+                MutableLiveData(Resource.error())
+            )
+            verificationPageLiveData.postValue(
+                Resource.success(verificationPage)
+            )
+            binding.singleSelectionContinue.callOnClick()
+
+            assertThat(navController.currentDestination?.id)
+                .isEqualTo(R.id.errorFragment)
+        }
+    }
+
+    private fun verifySingleChoiceUI(
+        docSelect: VerificationPageStaticContentDocumentSelectPage,
+        @StringRes expectedBodyStringRes: Int
+    ) {
+        launchDocSelectionFragment { binding, _, docSelectionFragment ->
+            whenever(verificationPage.documentSelect).thenReturn(
+                docSelect
+            )
+            verificationPageLiveData.postValue(
+                Resource.success(verificationPage)
+            )
+
+            assertThat(binding.title.text).isEqualTo(DOCUMENT_SELECT_TITLE)
+            assertThat(binding.multiSelectionContent.visibility).isEqualTo(View.GONE)
+            assertThat(binding.singleSelectionContent.visibility).isEqualTo(View.VISIBLE)
+
+            assertThat(binding.singleSelectionBody.text).isEqualTo(
+                docSelectionFragment.getString(expectedBodyStringRes)
+            )
+
+            assertThat(binding.singleSelectionContinue.text).isEqualTo(DOCUMENT_SELECT_BUTTON_TEXT)
+        }
+    }
+
+    private fun launchDocSelectionFragment(
+        testBlock: (
+            binding: DocSelectionFragmentBinding,
+            navController: TestNavHostController,
+            docSelectionFragment: DocSelectionFragment
+        ) -> Unit
+    ) = launchFragmentInContainer(
+        themeResId = R.style.Theme_MaterialComponents
+    ) {
+        DocSelectionFragment(viewModelFactoryFor(mockIdentityViewModel))
+    }.onFragment {
+        val navController = TestNavHostController(
+            ApplicationProvider.getApplicationContext()
+        )
+        navController.setGraph(
+            R.navigation.identity_nav_graph
+        )
+        navController.setCurrentDestination(R.id.docSelectionFragment)
+        Navigation.setViewNavController(
+            it.requireView(),
+            navController
+        )
+        testBlock(DocSelectionFragmentBinding.bind(it.requireView()), navController, it)
+    }
+
+    private companion object {
+        const val DOCUMENT_SELECT_TITLE = "title"
+        const val DOCUMENT_SELECT_BUTTON_TEXT = "button text"
+        const val PASSPORT_BUTTON_TEXT = "Passport"
+        const val ID_BUTTON_TEXT = "ID"
+        const val DRIVING_LICENSE_BUTTON_TEXT = "Driver's license"
+
+        val DOC_SELECT_MULTI_CHOICE = VerificationPageStaticContentDocumentSelectPage(
+            title = DOCUMENT_SELECT_TITLE,
+            idDocumentTypeAllowlist = mapOf(
+                PASSPORT_KEY to PASSPORT_BUTTON_TEXT,
+                ID_CARD_KEY to ID_BUTTON_TEXT,
+                DRIVING_LICENSE_KEY to DRIVING_LICENSE_BUTTON_TEXT
+            ),
+            buttonText = DOCUMENT_SELECT_BUTTON_TEXT
+        )
+
+        val DOC_SELECT_SINGLE_CHOICE_PASSPORT = VerificationPageStaticContentDocumentSelectPage(
+            title = DOCUMENT_SELECT_TITLE,
+            idDocumentTypeAllowlist = mapOf(
+                PASSPORT_KEY to PASSPORT_BUTTON_TEXT,
+            ),
+            buttonText = DOCUMENT_SELECT_BUTTON_TEXT
+        )
+
+        val DOC_SELECT_SINGLE_CHOICE_ID = VerificationPageStaticContentDocumentSelectPage(
+            title = DOCUMENT_SELECT_TITLE,
+            idDocumentTypeAllowlist = mapOf(
+                ID_CARD_KEY to ID_BUTTON_TEXT,
+            ),
+            buttonText = DOCUMENT_SELECT_BUTTON_TEXT
+        )
+
+        val DOC_SELECT_SINGLE_CHOICE_DL = VerificationPageStaticContentDocumentSelectPage(
+            title = DOCUMENT_SELECT_TITLE,
+            idDocumentTypeAllowlist = mapOf(
+                DRIVING_LICENSE_KEY to DRIVING_LICENSE_BUTTON_TEXT
+            ),
+            buttonText = DOCUMENT_SELECT_BUTTON_TEXT
+        )
+
+        val DOC_SELECT_ZERO_CHOICE = VerificationPageStaticContentDocumentSelectPage(
+            title = DOCUMENT_SELECT_TITLE,
+            idDocumentTypeAllowlist = emptyMap(),
+            buttonText = DOCUMENT_SELECT_BUTTON_TEXT
+        )
+
+        val MISSING_BACK_VERIFICATION_PAGE_DATA = VerificationPageData(
+            id = "id",
+            objectType = "type",
+            requirements = VerificationPageDataRequirements(
+                errors = emptyList(),
+                missing = listOf(VerificationPageDataRequirements.Missing.IDDOCUMENTBACK)
+            ),
+            status = VerificationPageData.Status.VERIFIED,
+            submitted = false
+        )
+    }
+}

--- a/identity/src/test/java/com/stripe/android/identity/utils/NavigationUtilsTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/utils/NavigationUtilsTest.kt
@@ -1,0 +1,291 @@
+package com.stripe.android.identity.utils
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.navigation.Navigation
+import androidx.navigation.testing.TestNavHostController
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.exception.APIException
+import com.stripe.android.identity.R
+import com.stripe.android.identity.navigation.ErrorFragment
+import com.stripe.android.identity.networking.models.CollectedDataParam
+import com.stripe.android.identity.networking.models.VerificationPageData
+import com.stripe.android.identity.networking.models.VerificationPageDataRequirementError
+import com.stripe.android.identity.networking.models.VerificationPageDataRequirements
+import com.stripe.android.identity.viewmodel.IdentityViewModel
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class NavigationUtilsTest {
+    @Test
+    fun `postVerificationPageDataAndMaybeSubmit navigates to error fragment when has error`() {
+        runBlocking {
+            val mockIdentityViewModel = mock<IdentityViewModel>().also {
+                whenever(it.postVerificationPageData(any())).thenReturn(
+                    ERROR_VERIFICATION_PAGE_DATA
+                )
+            }
+            val mockCollectedDataParam = mock<CollectedDataParam>()
+
+            launchFragment { navController, fragment ->
+                fragment.postVerificationPageDataAndMaybeSubmit(
+                    mockIdentityViewModel,
+                    mockCollectedDataParam,
+                    { true },
+                    {}
+                )
+
+                requireNotNull(navController.backStack.last().arguments).let { arguments ->
+                    assertThat(arguments[ErrorFragment.ARG_ERROR_TITLE])
+                        .isEqualTo(ERROR_TITLE)
+                    assertThat(arguments[ErrorFragment.ARG_ERROR_CONTENT])
+                        .isEqualTo(ERROR_BODY)
+                    assertThat(arguments[ErrorFragment.ARG_GO_BACK_BUTTON_DESTINATION])
+                        .isEqualTo(R.id.action_errorFragment_to_consentFragment)
+                    assertThat(arguments[ErrorFragment.ARG_GO_BACK_BUTTON_TEXT])
+                        .isEqualTo(ERROR_BUTTON_TEXT)
+                }
+                assertThat(navController.currentDestination?.id)
+                    .isEqualTo(R.id.errorFragment)
+            }
+        }
+    }
+
+    @Test
+    fun `postVerificationPageDataAndMaybeSubmit navigates to general error fragment when fails`() {
+        runBlocking {
+            val mockIdentityViewModel = mock<IdentityViewModel>().also {
+                whenever(it.postVerificationPageData(any())).thenThrow(
+                    APIException()
+                )
+            }
+            val mockCollectedDataParam = mock<CollectedDataParam>()
+
+            launchFragment { navController, fragment ->
+                fragment.postVerificationPageDataAndMaybeSubmit(
+                    mockIdentityViewModel,
+                    mockCollectedDataParam,
+                    { true },
+                    {}
+                )
+
+                assertThat(navController.currentDestination?.id)
+                    .isEqualTo(R.id.errorFragment)
+            }
+        }
+    }
+
+    @Test
+    fun `postVerificationPageDataAndMaybeSubmit executes notSubmitBlock when shouldNotSubmit`() {
+        runBlocking {
+            val mockIdentityViewModel = mock<IdentityViewModel>().also {
+                whenever(it.postVerificationPageData(any())).thenReturn(
+                    CORRECT_VERIFICATION_PAGE_DATA
+                )
+            }
+            var blockExecuted = false
+
+            launchFragment { _, fragment ->
+                fragment.postVerificationPageDataAndMaybeSubmit(
+                    mockIdentityViewModel,
+                    mock(),
+                    { true },
+                    {
+                        blockExecuted = true
+                    }
+                )
+
+                assertThat(blockExecuted).isEqualTo(true)
+            }
+        }
+    }
+
+    @Test
+    fun `postVerificationPageDataAndMaybeSubmit submits when shouldNotSubmit is false`() {
+        runBlocking {
+            val mockIdentityViewModel = mock<IdentityViewModel>().also {
+                whenever(it.postVerificationPageData(any())).thenReturn(
+                    CORRECT_VERIFICATION_PAGE_DATA
+                )
+                whenever(it.postVerificationPageSubmit()).thenReturn(
+                    CORRECT_VERIFICATION_PAGE_DATA
+                )
+            }
+
+            launchFragment { _, fragment ->
+                fragment.postVerificationPageDataAndMaybeSubmit(
+                    mockIdentityViewModel,
+                    mock(),
+                    { false },
+                    {}
+                )
+
+                verify(mockIdentityViewModel).postVerificationPageSubmit()
+            }
+        }
+    }
+
+    @Test
+    fun `postVerificationPageDataAndMaybeSubmit submits success with error then navigates to errorFragment with error data`() {
+        runBlocking {
+            val mockIdentityViewModel = mock<IdentityViewModel>().also {
+                whenever(it.postVerificationPageData(any())).thenReturn(
+                    CORRECT_VERIFICATION_PAGE_DATA
+                )
+
+                whenever(it.postVerificationPageSubmit()).thenReturn(
+                    ERROR_VERIFICATION_PAGE_DATA
+                )
+            }
+
+            launchFragment { navController, fragment ->
+                fragment.postVerificationPageDataAndMaybeSubmit(
+                    mockIdentityViewModel,
+                    mock(),
+                    { false },
+                    {}
+                )
+
+                requireNotNull(navController.backStack.last().arguments).let { arguments ->
+                    assertThat(arguments[ErrorFragment.ARG_ERROR_TITLE])
+                        .isEqualTo(ERROR_TITLE)
+                    assertThat(arguments[ErrorFragment.ARG_ERROR_CONTENT])
+                        .isEqualTo(ERROR_BODY)
+                    assertThat(arguments[ErrorFragment.ARG_GO_BACK_BUTTON_DESTINATION])
+                        .isEqualTo(R.id.action_errorFragment_to_consentFragment)
+                    assertThat(arguments[ErrorFragment.ARG_GO_BACK_BUTTON_TEXT])
+                        .isEqualTo(ERROR_BUTTON_TEXT)
+                }
+                assertThat(navController.currentDestination?.id)
+                    .isEqualTo(R.id.errorFragment)
+            }
+        }
+    }
+
+    @Test
+    fun `postVerificationPageDataAndMaybeSubmit submits success then navigates to ConfirmationFragment`() {
+        runBlocking {
+            val mockIdentityViewModel = mock<IdentityViewModel>().also {
+                whenever(it.postVerificationPageData(any())).thenReturn(
+                    CORRECT_VERIFICATION_PAGE_DATA
+                )
+
+                whenever(it.postVerificationPageSubmit()).thenReturn(
+                    CORRECT_VERIFICATION_PAGE_DATA
+                )
+            }
+
+            launchFragment { navController, fragment ->
+                fragment.postVerificationPageDataAndMaybeSubmit(
+                    mockIdentityViewModel,
+                    mock(),
+                    { false },
+                    {}
+                )
+
+                assertThat(navController.currentDestination?.id)
+                    .isEqualTo(R.id.confirmationFragment)
+            }
+        }
+    }
+
+    @Test
+    fun `postVerificationPageDataAndMaybeSubmit submits fails then navigates to general ErrorFragment`() {
+        runBlocking {
+            val mockIdentityViewModel = mock<IdentityViewModel>().also {
+                whenever(it.postVerificationPageData(any())).thenReturn(
+                    CORRECT_VERIFICATION_PAGE_DATA
+                )
+
+                whenever(it.postVerificationPageSubmit()).thenThrow(
+                    APIException()
+                )
+            }
+
+            launchFragment { navController, fragment ->
+                fragment.postVerificationPageDataAndMaybeSubmit(
+                    mockIdentityViewModel,
+                    mock(),
+                    { false },
+                    {}
+                )
+
+                assertThat(navController.currentDestination?.id)
+                    .isEqualTo(R.id.errorFragment)
+            }
+        }
+    }
+
+    private fun launchFragment(testBlock: suspend (navController: TestNavHostController, fragment: Fragment) -> Unit) {
+        launchFragmentInContainer<TestFragment>().onFragment {
+            val navController = TestNavHostController(
+                ApplicationProvider.getApplicationContext()
+            )
+            navController.setGraph(
+                R.navigation.identity_nav_graph
+            )
+            Navigation.setViewNavController(
+                it.requireView(),
+                navController
+            )
+            runBlocking {
+                testBlock(navController, it)
+            }
+        }
+    }
+
+    internal class TestFragment : Fragment() {
+        override fun onCreateView(
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?
+        ) = View(context)
+    }
+
+    private companion object {
+        const val ERROR_BODY = "errorBody"
+        const val ERROR_BUTTON_TEXT = "error button text"
+        const val ERROR_TITLE = "errorTitle"
+
+        val CORRECT_VERIFICATION_PAGE_DATA = VerificationPageData(
+            id = "id",
+            objectType = "type",
+            requirements = VerificationPageDataRequirements(
+                errors = emptyList(),
+                missing = emptyList()
+            ),
+            status = VerificationPageData.Status.VERIFIED,
+            submitted = false
+        )
+
+        val ERROR_VERIFICATION_PAGE_DATA = VerificationPageData(
+            id = "id",
+            objectType = "type",
+            requirements = VerificationPageDataRequirements(
+                errors = listOf(
+                    VerificationPageDataRequirementError(
+                        body = ERROR_BODY,
+                        buttonText = ERROR_BUTTON_TEXT,
+                        requirement = VerificationPageDataRequirementError.Requirement.BIOMETRICCONSENT,
+                        title = ERROR_TITLE
+                    )
+                ),
+                missing = emptyList()
+            ),
+            status = VerificationPageData.Status.VERIFIED,
+            submitted = false
+        )
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Bind the Identity network response to DocumentSelectionFragment UI
  * based on user's selection, redirect to the scan or upload fragment of ID/Passport/Driver license
* Added a reusable extension method to post collected params from UI to server, parse its response and navigate to corresponding fragments. Please refer to `Fragment.postVerificationPageDataAndMaybeSubmit`'s kDoc for details.
* Still need to build UI for 
  * `ConfirmationFragment`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Identity SDK

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Single option | Multiple options |
| ------------- | ------------- |
| ![singleSelect](https://user-images.githubusercontent.com/79880926/157375092-ba71b602-917d-4381-99af-0da054345c14.png)|  ![multiSelect](https://user-images.githubusercontent.com/79880926/157375112-459d07d6-338d-44b3-9ae9-cdb85968df27.png)|

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
