### PR TITLE
Add country list to card and sepa billing spec.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
-### xx.x.x - YYYY-MM-DD
-[FIXED] [4646](https://github.com/stripe/stripe-android/pull/4646) Update 3ds2 to latest version 6.1.4, see PR for specific issues addressed. 
+## xx.x.x - YYYY-MM-DD
+[FIXED] [4646](https://github.com/stripe/stripe-android/pull/4646) Update 3ds2 to latest version 6.1.4, see PR for specific issues addressed.
+
+### PaymentSheet
+[FIXED] [4669](https://github.com/stripe/stripe-android/pull/4669) Restrict the list of SEPA debit supported countries.
 
 ## 19.2.2 - 2022-03-01
 [FIXED] [4606](https://github.com/stripe/stripe-android/pull/4606) Keep status bar color in PaymentLauncher

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
@@ -6,6 +6,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 internal data class AddressSpec(
     override val identifier: IdentifierSpec,
+    val countryCodes: Set<String>
 ) : SectionFieldSpec(identifier) {
     fun transform(
         initialValues: Map<IdentifierSpec, String?>,
@@ -14,6 +15,7 @@ internal data class AddressSpec(
         AddressElement(
             IdentifierSpec.Generic("billing"),
             addressRepository,
-            initialValues
+            initialValues,
+            countryCodes = countryCodes
         )
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BillingSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BillingSpec.kt
@@ -15,3 +15,26 @@ internal val billingParams: MutableMap<String, Any?> = mutableMapOf(
     "email" to null,
     "phone" to null,
 )
+
+// This comes from: stripe-js-v3/blob/master/src/lib/shared/checkoutSupportedCountries.js
+internal val supportedBillingCountries = setOf(
+    "AD", "AE", "AF", "AG", "AI", "AL", "AM", "AO", "AQ", "AR", "AT", "AU", "AW", "AX",
+    "AZ", "BA", "BB", "BD", "BE", "BF", "BG", "BH", "BI", "BJ", "BL", "BM", "BN", "BO",
+    "BQ", "BR", "BS", "BT", "BV", "BW", "BY", "BZ", "CA", "CD", "CF", "CG", "CH", "CI",
+    "CK", "CL", "CM", "CN", "CO", "CR", "CV", "CW", "CY", "CZ", "DE", "DJ", "DK", "DM",
+    "DO", "DZ", "EC", "EE", "EG", "EH", "ER", "ES", "ET", "FI", "FJ", "FK", "FO", "FR",
+    "GA", "GB", "GD", "GE", "GF", "GG", "GH", "GI", "GL", "GM", "GN", "GP", "GQ", "GR",
+    "GS", "GT", "GU", "GW", "GY", "HK", "HN", "HR", "HT", "HU", "ID", "IE", "IL", "IM",
+    "IN", "IO", "IQ", "IS", "IT", "JE", "JM", "JO", "JP", "KE", "KG", "KH", "KI", "KM",
+    "KN", "KR", "KW", "KY", "KZ", "LA", "LB", "LC", "LI", "LK", "LR", "LS", "LT", "LU",
+    "LV", "LY", "MA", "MC", "MD", "ME", "MF", "MG", "MK", "ML", "MM", "MN", "MO", "MQ",
+    "MR", "MS", "MT", "MU", "MV", "MW", "MX", "MY", "MZ", "NA", "NC", "NE", "NG", "NI",
+    "NL", "NO", "NP", "NR", "NU", "NZ", "OM", "PA", "PE", "PF", "PG", "PH", "PK", "PL",
+    "PM", "PN", "PR", "PS", "PT", "PY", "QA", "RE", "RO", "RS", "RU", "RW", "SA", "SB",
+    "SC", "SE", "SG", "SH", "SI", "SJ", "SK", "SL", "SM", "SN", "SO", "SR", "SS", "ST",
+    "SV", "SX", "SZ", "TA", "TC", "TD", "TF", "TG", "TH", "TJ", "TK", "TL", "TM", "TN",
+    "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VA", "VC", "VE",
+    "VG", "VN", "VU", "WF", "WS", "XK", "YE", "YT", "ZA", "ZM", "ZW",
+)
+
+

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BillingSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BillingSpec.kt
@@ -36,5 +36,3 @@ internal val supportedBillingCountries = setOf(
     "TO", "TR", "TT", "TV", "TW", "TZ", "UA", "UG", "US", "UY", "UZ", "VA", "VC", "VE",
     "VG", "VN", "VU", "WF", "WS", "XK", "YE", "YT", "ZA", "ZM", "ZW",
 )
-
-

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingSpec.kt
@@ -4,11 +4,15 @@ import com.stripe.android.ui.core.address.AddressFieldElementRepository
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-internal object CardBillingSpec : SectionFieldSpec(IdentifierSpec.Generic("card_billing")) {
+internal data class CardBillingSpec(
+    override val identifier: IdentifierSpec = IdentifierSpec.Generic("card_billing"),
+    val countryCodes: Set<String>
+) : SectionFieldSpec(identifier) {
     fun transform(
         addressRepository: AddressFieldElementRepository
     ) = CardBillingAddressElement(
         IdentifierSpec.Generic("credit_billing"),
-        addressRepository
+        addressRepository,
+        countryCodes = countryCodes
     )
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/AfterpayClearpaySpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/AfterpayClearpaySpec.kt
@@ -10,6 +10,7 @@ import com.stripe.android.ui.core.elements.LayoutSpec
 import com.stripe.android.ui.core.elements.SectionSpec
 import com.stripe.android.ui.core.elements.SimpleTextSpec
 import com.stripe.android.ui.core.elements.billingParams
+import com.stripe.android.ui.core.elements.supportedBillingCountries
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 val AfterpayClearpayParamKey: MutableMap<String, Any?> = mutableMapOf(
@@ -29,7 +30,10 @@ internal val afterpayClearpayEmailSection =
 
 internal val afterpayClearpayBillingSection = SectionSpec(
     IdentifierSpec.Generic("address_section"),
-    AddressSpec(IdentifierSpec.Generic("address")),
+    AddressSpec(
+        IdentifierSpec.Generic("address"),
+        supportedBillingCountries
+    ),
     R.string.billing_details
 )
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/CardSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/CardSpec.kt
@@ -9,6 +9,7 @@ import com.stripe.android.ui.core.elements.LayoutSpec
 import com.stripe.android.ui.core.elements.SaveForFutureUseSpec
 import com.stripe.android.ui.core.elements.SectionSpec
 import com.stripe.android.ui.core.elements.billingParams
+import com.stripe.android.ui.core.elements.supportedBillingCountries
 
 internal val cardParams: MutableMap<String, Any?> = mutableMapOf(
     "number" to null,
@@ -31,7 +32,9 @@ internal val creditDetailsSection = SectionSpec(
 
 internal val creditBillingSection = SectionSpec(
     IdentifierSpec.Generic("credit_billing_section"),
-    CardBillingSpec,
+    CardBillingSpec(
+        countryCodes = supportedBillingCountries
+    ),
     R.string.billing_details
 )
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/SepaDebitSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/SepaDebitSpec.kt
@@ -12,6 +12,7 @@ import com.stripe.android.ui.core.elements.SectionSpec
 import com.stripe.android.ui.core.elements.SimpleTextSpec
 import com.stripe.android.ui.core.elements.StaticTextSpec
 import com.stripe.android.ui.core.elements.billingParams
+import com.stripe.android.ui.core.elements.supportedBillingCountries
 
 internal val sepaDebitParams: MutableMap<String, Any?> = mutableMapOf(
     "iban" to null
@@ -43,7 +44,10 @@ internal val sepaDebitMandate = StaticTextSpec(
 )
 internal val sepaBillingSection = SectionSpec(
     IdentifierSpec.Generic("billing_section"),
-    AddressSpec(IdentifierSpec.Generic("address")),
+    AddressSpec(
+        IdentifierSpec.Generic("address"),
+        countryCodes = supportedBillingCountries
+    ),
     R.string.billing_details
 )
 

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CountryConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CountryConfigTest.kt
@@ -58,8 +58,5 @@ class CountryConfigTest {
         assertThat(
             supportedCountries.size
         ).isEqualTo(233)
-
-
     }
-
 }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CountryConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CountryConfigTest.kt
@@ -28,4 +28,38 @@ class CountryConfigTest {
             ).getDisplayItems()[0]
         ).isEqualTo("Austria")
     }
+
+    @Test
+    fun `test country list `() {
+        val defaultCountries = CountryConfig(
+            onlyShowCountryCodes = emptySet(),
+            locale = Locale.US
+        ).getDisplayItems()
+        val supportedCountries = CountryConfig(
+            onlyShowCountryCodes = supportedBillingCountries,
+            locale = Locale.US
+        ).getDisplayItems()
+
+        val excludedCountries = setOf(
+            "American Samoa", "Christmas Island", "Cocos (Keeling) Islands", "Cuba",
+            "Heard & McDonald Islands", "Iran", "Marshall Islands", "Micronesia",
+            "Norfolk Island", "North Korea", "Northern Mariana Islands", "Palau", "Sudan", "Syria",
+            "U.S. Outlying Islands", "U.S. Virgin Islands"
+        )
+
+        excludedCountries.forEach {
+            assertThat(supportedCountries.contains(it)).isFalse()
+        }
+
+        assertThat(
+            defaultCountries.size
+        ).isEqualTo(249)
+
+        assertThat(
+            supportedCountries.size
+        ).isEqualTo(233)
+
+
+    }
+
 }

--- a/payments-ui-core/src/test/java/com/stripe/android/utils/TestUtils.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/utils/TestUtils.kt
@@ -9,7 +9,7 @@ object TestUtils {
     fun idleLooper() = ShadowLooper.idleMainLooper()
 
     fun viewModelFactoryFor(viewModel: ViewModel) = object : ViewModelProvider.Factory {
-        override fun <T : ViewModel?> create(modelClass: Class<T>): T {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
             return viewModel as T
         }
     }


### PR DESCRIPTION
# Summary
Restrict the list of supported countries for SEPA debit and cards to the same list used in Checkout and UPE.


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
Restricted the supported countries for SEPA debit.
