### PR TITLE
[DO NOT MERGE] release identity SDK

### DIFF
--- a/identity/build.gradle
+++ b/identity/build.gradle
@@ -129,3 +129,29 @@ task ktlintFormat(type: JavaExec, group: "formatting") {
     classpath = configurations.ktlint
     args "-F", "src/**/*.kt"
 }
+
+// DO NOT MERGE: Temporarily enable stripe identity release
+// to release identity to maven local, run
+// ./gradlew :identity:publishReleasePublicationToMavenLocal
+// verify ~/.m2/repository/com/stripe/stripe-identity is created
+
+// from the app, add mavenLocal() to settings.gradle:
+//dependencyResolutionManagement {
+//    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+//    repositories {
+//        google()
+//        mavenCentral()
+//        mavenLocal()
+//        jcenter() // Warning: this repository is going to shut down soon
+//    }
+//}
+//rootProject.name = "My Application"
+//include ':app'
+
+ext {
+    artifactId = "stripe-identity"
+    artifactName = "stripe-identity"
+    artifactDescrption = "Stripe Android SDK"
+}
+
+apply from: "${rootDir}/deploy/deploy.gradle"


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Temporarily enable identity SDK release to test locally. To release identity sdk locally,
1. clone `https://github.com/stripe/stripe-android.git` locally, check out this branch `releaseIdentityToLocal`
2. run `./gradlew :identity:publishReleasePublicationToMavenLocal` at project root
3. verify ` ~/.m2/repository/com/stripe/stripe-identity` is created
4. in the test app, add `mavenLocal()` to `settings.gradle`, now it should look like this:
  ```
  dependencyResolutionManagement {
    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
    repositories {
        google()
        mavenCentral() // <- newly added
        mavenLocal()
        jcenter() // Warning: this repository is going to shut down soon
    }
  }
  rootProject.name = "My Application"
  include ':app'
  ```
5. add `implementation 'com.stripe:stripe-identity:19.2.2'` to app's `build.gradle`