### PR TITLE
[Github Actions] Fix end-to-end tests on critical paths.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - master
   pull_request:
+
+env:
+  STRIPE_END_TO_END_TESTS_BACKEND_URL: ${{ secrets.STRIPE_END_TO_END_TESTS_BACKEND_URL }}
+
 jobs:
   check:
     name: Check
@@ -83,8 +87,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: End-to-end tests
-        env:
-          STRIPE_END_TO_END_TESTS_BACKEND_URL: ${{ secrets.STRIPE_END_TO_END_TESTS_BACKEND_URL }}
         run: ./gradlew :stripe-test-e2e:testDebugUnitTest
       - uses: actions/upload-artifact@v2
         if: failure()


### PR DESCRIPTION
# Summary

- Issue: After switching to [run just affected tests script](https://github.com/stripe/stripe-android/pull/4635), when a critical path is affected we run the top-level `testDebugUnitTests` task, that will run unit tests on all modules. That includes e2e tests. The required env variables to run e2e tests are just declared within the `end-to-end` job.
  - Example of PR failing (gradle file changes, then all tests are executed): https://github.com/stripe/stripe-android/runs/5479755154?check_suite_focus=true
- Solution: Declare the environment at top-level so that any job can access it. 

Note we're still running e2e tests twice on situations like this. we could always explicitly exclude the `:stripe-test-e2e:testDebugUnitTest` when running the all-tests task:

`./gradlew testDebugUnitTest -x :stripe-test-e2e:testDebugUnitTest`.