### PR TITLE
[Identity] Always send Initial for the first frame

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/states/IdentityScanState.kt
+++ b/identity/src/main/java/com/stripe/android/identity/states/IdentityScanState.kt
@@ -87,7 +87,7 @@ internal sealed class IdentityScanState(val type: ScanType, isFinal: Boolean) : 
             return when {
                 isUnsatisfied() -> {
                     val reason =
-                        "hit ratio below expected: ${hitsCount.toFloat().div(FRAMES_REQUIRED)}"
+                        "hits count below expected: $hitsCount"
                     Log.d(
                         TAG,
                         "Satisfaction check fails due to $reason, transition to Unsatisfied."
@@ -120,14 +120,11 @@ internal sealed class IdentityScanState(val type: ScanType, isFinal: Boolean) : 
         /**
          * Determine if satisfaction failed and should transition to [Unsatisfied].
          *
-         * Transfers to when the previous [FRAMES_REQUIRED] number of frames has a hit ratio
-         * below [HIT_RATIO].
+         * Transfers to when the previous [FRAMES_REQUIRED] number of frames has hits below
+         * [HITS_REQUIRED].
          */
         private fun isUnsatisfied(): Boolean {
-            return (results.size == FRAMES_REQUIRED) && (
-                hitsCount.toFloat()
-                    .div(FRAMES_REQUIRED) < HIT_RATIO
-                )
+            return (results.size == FRAMES_REQUIRED) && (hitsCount < HITS_REQUIRED)
         }
 
         @VisibleForTesting
@@ -136,8 +133,8 @@ internal sealed class IdentityScanState(val type: ScanType, isFinal: Boolean) : 
             // correct item.
             const val FRAMES_REQUIRED = 100
 
-            // The ratio to determine if the model has found the correct item.
-            const val HIT_RATIO = 0.5
+            // The number of hits to determine if the model has found the correct item.
+            const val HITS_REQUIRED = 50
         }
     }
 

--- a/identity/src/test/java/com/stripe/android/identity/states/IdentityScanStateTests.kt
+++ b/identity/src/test/java/com/stripe/android/identity/states/IdentityScanStateTests.kt
@@ -7,7 +7,7 @@ import com.stripe.android.identity.ml.AnalyzerOutput
 import com.stripe.android.identity.ml.BoundingBox
 import com.stripe.android.identity.ml.Category
 import com.stripe.android.identity.states.IdentityScanState.Found.Companion.FRAMES_REQUIRED
-import com.stripe.android.identity.states.IdentityScanState.Found.Companion.HIT_RATIO
+import com.stripe.android.identity.states.IdentityScanState.Found.Companion.HITS_REQUIRED
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
@@ -35,7 +35,7 @@ class IdentityScanStateTests {
 
     @Test
     fun `Found transitions to Unsatisfied with bad hit rate`() {
-        val badHitCount = (FRAMES_REQUIRED * HIT_RATIO).toInt() - 10
+        val badHitCount = HITS_REQUIRED - 10
 
         val initialState = IdentityScanState.Found(IdentityScanState.ScanType.ID_FRONT).also {
             // hits count below required
@@ -48,13 +48,13 @@ class IdentityScanStateTests {
 
         assertThat(resultState).isInstanceOf(IdentityScanState.Unsatisfied::class.java)
         assertThat((resultState as IdentityScanState.Unsatisfied).reason).isEqualTo(
-            "hit ratio below expected: ${badHitCount.toFloat().div(FRAMES_REQUIRED)}"
+            "hits count below expected: $badHitCount"
         )
     }
 
     @Test
     fun `Found transitions to Satisfied with good hit rate`() {
-        val goodHitCount = (FRAMES_REQUIRED * HIT_RATIO).toInt() + 10
+        val goodHitCount = HITS_REQUIRED + 10
 
         val initialState = IdentityScanState.Found(IdentityScanState.ScanType.ID_FRONT).also {
             // hits count below required


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
For the first frame, always send the initial state from the `IDDetectorAggregator`. This would avoid the case where the _very first frame_ of camera feed is a hit and `previousState.consumeTransition` returns a non-Initial state and breaks [UI](https://github.com/stripe/stripe-android/blob/3f632b03d26853077d47ba80ecf6123664793d0c/identity/src/main/java/com/stripe/android/identity/navigation/IDScanFragment.kt#L87), which expects Initial to be received first.

Also piggy back a change to check number of frame hits instead of hit ratio, avoiding `Float` and `div`


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Identity SDK
# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
