### PR TITLE
[Identity] Fix the case when no image is chosen or no photo is taken

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/utils/ImageChooser.kt
+++ b/identity/src/main/java/com/stripe/android/identity/utils/ImageChooser.kt
@@ -16,13 +16,11 @@ internal class ImageChooser(
     private val chooseImageLauncher = activityResultCaller.registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) {
-        requireNotNull(onImageChosen) {
-            "onImageChosen callback is not set."
-        }(
-            requireNotNull(it?.data?.data) {
-                "Intent is null after a image is chosen."
-            }
-        )
+        it.data?.data?.let { uri ->
+            requireNotNull(onImageChosen) {
+                "onImageChosen callback is not set."
+            }(uri)
+        }
     }
 
     /**

--- a/identity/src/main/java/com/stripe/android/identity/utils/PhotoTaker.kt
+++ b/identity/src/main/java/com/stripe/android/identity/utils/PhotoTaker.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.identity.utils
 
+import android.app.Activity.RESULT_OK
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -23,13 +24,15 @@ internal class PhotoTaker(
         activityResultCaller.registerForActivityResult(
             ActivityResultContracts.StartActivityForResult()
         ) {
-            requireNotNull(onPhotoTaken) {
-                "onPhotoTaken callback is not set."
-            }(
-                requireNotNull(newPhotoTakenUri) {
-                    "newPhotoTakeUri is still null after a photo is taken."
-                }
-            )
+            if (it.resultCode == RESULT_OK) {
+                requireNotNull(onPhotoTaken) {
+                    "onPhotoTaken callback is not set."
+                }(
+                    requireNotNull(newPhotoTakenUri) {
+                        "newPhotoTakeUri is still null after a photo is taken."
+                    }
+                )
+            }
         }
 
     /**


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
When user cancels from gallery or camera, we should not post the uri.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
