### PR TITLE
Don't show CVC error when CardBrand is unknown

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcConfig.kt
@@ -22,7 +22,10 @@ internal class CvcConfig : CardDetailsTextFieldConfig {
         return if (number.isEmpty()) {
             TextFieldStateConstants.Error.Blank
         } else if (brand == CardBrand.Unknown) {
-            TextFieldStateConstants.Error.Invalid(R.string.invalid_card_number)
+            when (number.length) {
+                numberAllowedDigits -> TextFieldStateConstants.Valid.Full
+                else -> TextFieldStateConstants.Valid.Limitless
+            }
         } else if (isDigitLimit && number.length < numberAllowedDigits) {
             TextFieldStateConstants.Error.Incomplete(R.string.invalid_cvc)
         } else if (isDigitLimit && number.length > numberAllowedDigits) {

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CvcConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CvcConfigTest.kt
@@ -24,10 +24,7 @@ class CvcConfigTest {
     fun `card brand is invalid`() {
         val state = cvcConfig.determineState(CardBrand.Unknown, "0", CardBrand.Unknown.maxCvcLength)
         Truth.assertThat(state)
-            .isInstanceOf(TextFieldStateConstants.Error.Invalid::class.java)
-        Truth.assertThat(
-            state.getError()?.errorMessage
-        ).isEqualTo(R.string.invalid_card_number)
+            .isInstanceOf(TextFieldStateConstants.Valid.Limitless::class.java)
     }
 
     @Test


### PR DESCRIPTION
# Summary
Don't show CVC error when CardBrand is unknown.