### PR TITLE
Stop accessibility talkback from reading textfields twice

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
@@ -32,7 +32,9 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.editableText
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.ImeAction
 import com.stripe.android.ui.core.R
 
@@ -147,6 +149,7 @@ internal fun TextField(
             }
             .semantics {
                 this.contentDescription = contentDescription
+                this.editableText = AnnotatedString("")
             },
         keyboardActions = KeyboardActions(
             onNext = {


### PR DESCRIPTION
# Summary
Stop accessibility talkback from reading textfields twice
