### PR TITLE
[Identity] File upload 1 of 2: Upload file from camera or local file

### DIFF
--- a/camera-core/api/camera-core.api
+++ b/camera-core/api/camera-core.api
@@ -27,6 +27,7 @@ public final class com/stripe/android/camera/framework/image/BitmapExtensionsKt 
 	public static synthetic fun scale$default (Landroid/graphics/Bitmap;FZILjava/lang/Object;)Landroid/graphics/Bitmap;
 	public static synthetic fun scale$default (Landroid/graphics/Bitmap;Landroid/util/Size;ZILjava/lang/Object;)Landroid/graphics/Bitmap;
 	public static synthetic fun scaleAndCrop$default (Landroid/graphics/Bitmap;Landroid/util/Size;ZILjava/lang/Object;)Landroid/graphics/Bitmap;
+	public static synthetic fun toJpeg$default (Landroid/graphics/Bitmap;IILjava/lang/Object;)[B
 }
 
 public final class com/stripe/android/camera/framework/image/ImageKt {

--- a/camera-core/src/main/java/com/stripe/android/camera/framework/image/BitmapExtensions.kt
+++ b/camera-core/src/main/java/com/stripe/android/camera/framework/image/BitmapExtensions.kt
@@ -35,9 +35,9 @@ fun Bitmap.toWebP(): ByteArray =
 
 @CheckResult
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-fun Bitmap.toJpeg(): ByteArray =
+fun Bitmap.toJpeg(quality: Int = 92): ByteArray =
     ByteArrayOutputStream().use {
-        this.compress(Bitmap.CompressFormat.JPEG, 92, it)
+        this.compress(Bitmap.CompressFormat.JPEG, quality, it)
         it.flush()
         it.toByteArray()
     }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
@@ -48,7 +48,8 @@ internal class DocSelectionFragment(
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        identityViewModel.observeForVerificationPage(viewLifecycleOwner,
+        identityViewModel.observeForVerificationPage(
+            viewLifecycleOwner,
             onSuccess = { verificationPage ->
                 binding.title.text = verificationPage.documentSelect.title
                 when (verificationPage.documentSelect.idDocumentTypeAllowlist.count()) {
@@ -231,7 +232,8 @@ internal class DocSelectionFragment(
      * if required data is not available.
      */
     private fun tryNavigateToUploadFragment(type: Type) {
-        identityViewModel.observeForVerificationPage(viewLifecycleOwner,
+        identityViewModel.observeForVerificationPage(
+            viewLifecycleOwner,
             onSuccess = { verificationPage ->
                 if (verificationPage.documentCapture.requireLiveCapture
                 ) {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/DriverLicenseUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/DriverLicenseUploadFragment.kt
@@ -7,8 +7,10 @@ import com.stripe.android.identity.states.IdentityScanState
 /**
  * Fragment to upload Driver license.
  */
-internal class DriverLicenseUploadFragment(frontBackUploadViewModelFactory: ViewModelProvider.Factory) :
-    FrontBackUploadFragment(frontBackUploadViewModelFactory) {
+internal class DriverLicenseUploadFragment(
+    frontBackUploadViewModelFactory: ViewModelProvider.Factory,
+    identityViewModelFactory: ViewModelProvider.Factory
+) : FrontBackUploadFragment(frontBackUploadViewModelFactory, identityViewModelFactory) {
     override val titleRes = R.string.file_upload
     override val contextRes = R.string.file_upload_content_dl
     override val frontTextRes = R.string.front_of_dl

--- a/identity/src/main/java/com/stripe/android/identity/navigation/FrontBackUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/FrontBackUploadFragment.kt
@@ -9,15 +9,27 @@ import android.view.ViewGroup
 import android.widget.Button
 import androidx.annotation.IdRes
 import androidx.annotation.StringRes
+import androidx.annotation.VisibleForTesting
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.FrontBackUploadFragmentBinding
+import com.stripe.android.identity.networking.Status
+import com.stripe.android.identity.networking.models.CollectedDataParam
+import com.stripe.android.identity.networking.models.DocumentUploadParam
+import com.stripe.android.identity.networking.models.IdDocumentParam
+import com.stripe.android.identity.networking.models.VerificationPageStaticContentDocumentCapturePage
 import com.stripe.android.identity.states.IdentityScanState
+import com.stripe.android.identity.utils.navigateToDefaultErrorFragment
+import com.stripe.android.identity.utils.postVerificationPageDataAndMaybeSubmit
 import com.stripe.android.identity.viewmodel.FrontBackUploadViewModel
+import com.stripe.android.identity.viewmodel.IdentityViewModel
+import kotlinx.coroutines.launch
 
 /**
  * Fragment to upload front and back of a document.
@@ -25,7 +37,8 @@ import com.stripe.android.identity.viewmodel.FrontBackUploadViewModel
  * TODO(ccen): check camera permission and enable camera only when permission is granted.
  */
 internal abstract class FrontBackUploadFragment(
-    private val frontBackUploadViewModelFactory: ViewModelProvider.Factory
+    private val frontBackUploadViewModelFactory: ViewModelProvider.Factory,
+    private val identityViewModelFactory: ViewModelProvider.Factory
 ) : Fragment() {
 
     @get:StringRes
@@ -57,6 +70,8 @@ internal abstract class FrontBackUploadFragment(
 
     private val frontBackUploadViewModel: FrontBackUploadViewModel by viewModels { frontBackUploadViewModelFactory }
 
+    private val identityViewModel: IdentityViewModel by activityViewModels { identityViewModelFactory }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         frontBackUploadViewModel.registerActivityResultCaller(this)
@@ -83,25 +98,96 @@ internal abstract class FrontBackUploadFragment(
         binding.selectFront.setOnClickListener {
             buildBottomSheetDialog(frontScanType).show()
         }
-        binding.kontinue.setOnClickListener {
-            findNavController().navigate(continueButtonNavigationId)
-        }
         return binding.root
     }
+
+    private fun IdentityScanState.ScanType.toType(): IdDocumentParam.Type =
+        when (this) {
+            IdentityScanState.ScanType.ID_FRONT -> IdDocumentParam.Type.IDCARD
+            IdentityScanState.ScanType.ID_BACK -> IdDocumentParam.Type.IDCARD
+            IdentityScanState.ScanType.PASSPORT -> IdDocumentParam.Type.PASSPORT
+            IdentityScanState.ScanType.DL_FRONT -> IdDocumentParam.Type.DRIVINGLICENSE
+            IdentityScanState.ScanType.DL_BACK -> IdDocumentParam.Type.DRIVINGLICENSE
+            else -> {
+                throw IllegalArgumentException("Unknown type: $this")
+            }
+        }
+
+
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         frontBackUploadViewModel.frontUploaded.observe(viewLifecycleOwner) {
-            showFrontDone()
+            when (it.status) {
+                Status.SUCCESS -> {
+                    showFrontDone()
+                }
+                Status.ERROR -> {
+                    Log.e(TAG, "error uploading front image: $it")
+                    navigateToDefaultErrorFragment()
+                }
+                Status.LOADING -> {
+                    showFrontUploading()
+                }
+            }
         }
 
         frontBackUploadViewModel.backUploaded.observe(viewLifecycleOwner) {
-            showBackDone()
+            when (it.status) {
+                Status.SUCCESS -> {
+                    showBackDone()
+                }
+                Status.ERROR -> {
+                    Log.e(TAG, "error uploading front image: $it")
+                    navigateToDefaultErrorFragment()
+                }
+                Status.LOADING -> {
+                    showBackUploading()
+                }
+            }
         }
 
         frontBackUploadViewModel.uploadFinished.observe(viewLifecycleOwner) {
-            enableContinue()
+            binding.kontinue.isEnabled = true
+            binding.kontinue.setOnClickListener {
+                lifecycleScope.launch {
+                    runCatching {
+                        val front =
+                            requireNotNull(frontBackUploadViewModel.frontUploaded.value?.data) {
+                                "frontUploaded value is still null"
+                            }
+                        val back =
+                            requireNotNull(frontBackUploadViewModel.backUploaded.value?.data) {
+                                "backUploaded value is still null"
+                            }
+                        postVerificationPageDataAndMaybeSubmit(
+                            identityViewModel = identityViewModel,
+                            collectedDataParam = CollectedDataParam(
+                                idDocument = IdDocumentParam(
+                                    front = DocumentUploadParam(
+                                        highResImage = requireNotNull(front.first.id) {
+                                            "front uploaded file id is null"
+                                        },
+                                        uploadMethod = front.second
+                                    ),
+                                    back = DocumentUploadParam(
+                                        highResImage = requireNotNull(back.first.id) {
+                                            "back uploaded file id is null"
+                                        },
+                                        uploadMethod = back.second
+                                    ),
+                                    type = frontScanType.toType()
+                                )
+                            ),
+                            shouldNotSubmit = { false }
+                        )
+                    }.onFailure {
+                        Log.d(TAG, "fail to submit uploaded files: $it")
+                        navigateToDefaultErrorFragment()
+                    }
+                }
+            }
         }
     }
 
@@ -116,30 +202,64 @@ internal abstract class FrontBackUploadFragment(
             Log.d(TAG, "Take photo")
             dialog.dismiss()
             if (scanType == frontScanType) {
-                frontBackUploadViewModel.takePhotoFront(requireContext(), ::uploadFront)
+                frontBackUploadViewModel.takePhotoFront(requireContext()) {
+                    uploadFront(it, DocumentUploadParam.UploadMethod.MANUALCAPTURE)
+                }
             } else if (scanType == backScanType) {
-                frontBackUploadViewModel.takePhotoBack(requireContext(), ::uploadBack)
+                frontBackUploadViewModel.takePhotoBack(requireContext()) {
+                    uploadBack(it, DocumentUploadParam.UploadMethod.MANUALCAPTURE)
+                }
             }
         }
         dialog.findViewById<Button>(R.id.choose_file)?.setOnClickListener {
             Log.d(TAG, "Choose a file")
             dialog.dismiss()
             if (scanType == frontScanType) {
-                frontBackUploadViewModel.chooseImageFront(::uploadFront)
+                frontBackUploadViewModel.chooseImageFront {
+                    uploadFront(it, DocumentUploadParam.UploadMethod.FILEUPLOAD)
+                }
             } else if (scanType == backScanType) {
-                frontBackUploadViewModel.chooseImageBack(::uploadBack)
+                frontBackUploadViewModel.chooseImageBack() {
+                    uploadBack(it, DocumentUploadParam.UploadMethod.FILEUPLOAD)
+                }
             }
         }
     }
 
-    private fun uploadFront(frontUri: Uri) {
-        showFrontUploading()
-        frontBackUploadViewModel.uploadImageFront(frontUri, requireContext())
+    private fun observeForDocumentCaptureModels(
+        onSuccess: (VerificationPageStaticContentDocumentCapturePage) -> Unit
+    ) {
+        identityViewModel.observeForVerificationPage(viewLifecycleOwner,
+            onSuccess = {
+                onSuccess(it.documentCapture)
+            },
+            onFailure = {
+                navigateToDefaultErrorFragment()
+            }
+        )
     }
 
-    private fun uploadBack(backUri: Uri) {
-        showBackUploading()
-        frontBackUploadViewModel.uploadImageBack(backUri, requireContext())
+    private fun uploadFront(frontUri: Uri, uploadMethod: DocumentUploadParam.UploadMethod) {
+        observeForDocumentCaptureModels { documentCaptureModels ->
+            frontBackUploadViewModel.uploadImageFront(
+                frontUri,
+                requireContext(),
+                documentCaptureModels,
+                uploadMethod
+            )
+        }
+
+    }
+
+    private fun uploadBack(backUri: Uri, uploadMethod: DocumentUploadParam.UploadMethod) {
+        observeForDocumentCaptureModels { documentCaptureModels ->
+            frontBackUploadViewModel.uploadImageBack(
+                backUri,
+                requireContext(),
+                documentCaptureModels,
+                uploadMethod
+            )
+        }
     }
 
     private fun showFrontUploading() {
@@ -164,10 +284,6 @@ internal abstract class FrontBackUploadFragment(
         binding.selectBack.visibility = View.GONE
         binding.progressCircularBack.visibility = View.GONE
         binding.finishedCheckMarkBack.visibility = View.VISIBLE
-    }
-
-    private fun enableContinue() {
-        binding.kontinue.isEnabled = true
     }
 
     companion object {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/FrontBackUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/FrontBackUploadFragment.kt
@@ -9,13 +9,11 @@ import android.view.ViewGroup
 import android.widget.Button
 import androidx.annotation.IdRes
 import androidx.annotation.StringRes
-import androidx.annotation.VisibleForTesting
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
-import androidx.navigation.fragment.findNavController
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.FrontBackUploadFragmentBinding
@@ -112,8 +110,6 @@ internal abstract class FrontBackUploadFragment(
                 throw IllegalArgumentException("Unknown type: $this")
             }
         }
-
-
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -229,7 +225,8 @@ internal abstract class FrontBackUploadFragment(
     private fun observeForDocumentCaptureModels(
         onSuccess: (VerificationPageStaticContentDocumentCapturePage) -> Unit
     ) {
-        identityViewModel.observeForVerificationPage(viewLifecycleOwner,
+        identityViewModel.observeForVerificationPage(
+            viewLifecycleOwner,
             onSuccess = {
                 onSuccess(it.documentCapture)
             },
@@ -248,7 +245,6 @@ internal abstract class FrontBackUploadFragment(
                 uploadMethod
             )
         }
-
     }
 
     private fun uploadBack(backUri: Uri, uploadMethod: DocumentUploadParam.UploadMethod) {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IDUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IDUploadFragment.kt
@@ -8,8 +8,9 @@ import com.stripe.android.identity.states.IdentityScanState
  * Fragment to upload ID.
  */
 internal class IDUploadFragment(
-    frontBackUploadViewModelFactory: ViewModelProvider.Factory
-) : FrontBackUploadFragment(frontBackUploadViewModelFactory) {
+    frontBackUploadViewModelFactory: ViewModelProvider.Factory,
+    identityViewModelFactory: ViewModelProvider.Factory
+) : FrontBackUploadFragment(frontBackUploadViewModelFactory, identityViewModelFactory) {
     override val titleRes = R.string.file_upload
     override val contextRes = R.string.file_upload_content_id
     override val frontTextRes = R.string.front_of_id

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
@@ -60,13 +60,16 @@ internal class IdentityFragmentFactory(
                 appSettingsOpenable
             )
             IDUploadFragment::class.java.name -> IDUploadFragment(
-                frontBackUploadViewModelFactory
+                frontBackUploadViewModelFactory,
+                identityViewModelFactory
             )
             DriverLicenseUploadFragment::class.java.name -> DriverLicenseUploadFragment(
-                frontBackUploadViewModelFactory
+                frontBackUploadViewModelFactory,
+                identityViewModelFactory
             )
             PassportUploadFragment::class.java.name -> PassportUploadFragment(
-                passportUploadViewModelFactory
+                passportUploadViewModelFactory,
+                identityViewModelFactory
             )
             ConsentFragment::class.java.name -> ConsentFragment(
                 identityViewModelFactory

--- a/identity/src/main/java/com/stripe/android/identity/navigation/PassportUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/PassportUploadFragment.kt
@@ -101,7 +101,8 @@ internal class PassportUploadFragment(
     }
 
     private fun upload(passport: Uri, uploadMethod: DocumentUploadParam.UploadMethod) {
-        identityViewModel.observeForVerificationPage(this,
+        identityViewModel.observeForVerificationPage(
+            this,
             onSuccess = { verificationPage ->
                 passportUploadViewModel.uploadImage(
                     passport,

--- a/identity/src/main/java/com/stripe/android/identity/navigation/PassportUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/PassportUploadFragment.kt
@@ -2,30 +2,46 @@ package com.stripe.android.identity.navigation
 
 import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
-import androidx.navigation.fragment.findNavController
+import androidx.lifecycle.lifecycleScope
 import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.stripe.android.core.model.InternalStripeFile
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.PassportUploadFragmentBinding
+import com.stripe.android.identity.networking.Status
+import com.stripe.android.identity.networking.models.CollectedDataParam
+import com.stripe.android.identity.networking.models.DocumentUploadParam
+import com.stripe.android.identity.networking.models.IdDocumentParam
+import com.stripe.android.identity.utils.navigateToDefaultErrorFragment
+import com.stripe.android.identity.utils.postVerificationPageDataAndMaybeSubmit
+import com.stripe.android.identity.viewmodel.IdentityViewModel
 import com.stripe.android.identity.viewmodel.PassportUploadViewModel
+import kotlinx.coroutines.launch
 
 /**
  * Fragment to upload passport.
  */
 internal class PassportUploadFragment(
-    private val passportUploadViewModelFactory: ViewModelProvider.Factory
+    private val passportUploadViewModelFactory: ViewModelProvider.Factory,
+    private val identityViewModelFactory: ViewModelProvider.Factory
 ) : Fragment() {
 
     lateinit var binding: PassportUploadFragmentBinding
 
     private val passportUploadViewModel: PassportUploadViewModel by viewModels {
         passportUploadViewModelFactory
+    }
+
+    private val identityViewModel: IdentityViewModel by activityViewModels {
+        identityViewModelFactory
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -44,9 +60,6 @@ internal class PassportUploadFragment(
             buildBottomSheetDialog().show()
         }
 
-        binding.kontinue.setOnClickListener {
-            findNavController().navigate(R.id.action_passportUploadFragment_to_confirmationFragment)
-        }
         return binding.root
     }
 
@@ -54,7 +67,18 @@ internal class PassportUploadFragment(
         super.onViewCreated(view, savedInstanceState)
 
         passportUploadViewModel.uploaded.observe(viewLifecycleOwner) {
-            showUploadDone()
+            when (it.status) {
+                Status.SUCCESS -> {
+                    showUploadDone(it.data)
+                }
+                Status.ERROR -> {
+                    Log.e(TAG, "error uploading passport image: $it")
+                    navigateToDefaultErrorFragment()
+                }
+                Status.LOADING -> {
+                    showUploading()
+                }
+            }
         }
     }
 
@@ -64,29 +88,73 @@ internal class PassportUploadFragment(
         }
         dialog.findViewById<Button>(R.id.take_photo)?.setOnClickListener {
             dialog.dismiss()
-            passportUploadViewModel.takePhoto(requireContext(), ::upload)
+            passportUploadViewModel.takePhoto(requireContext()) {
+                upload(it, DocumentUploadParam.UploadMethod.MANUALCAPTURE)
+            }
         }
         dialog.findViewById<Button>(R.id.choose_file)?.setOnClickListener {
             dialog.dismiss()
-            passportUploadViewModel.chooseImage(::upload)
+            passportUploadViewModel.chooseImage {
+                upload(it, DocumentUploadParam.UploadMethod.FILEUPLOAD)
+            }
         }
     }
 
-    private fun upload(frontUri: Uri) {
-        showFrontUploading()
-        passportUploadViewModel.uploadImage(frontUri, requireContext())
+    private fun upload(passport: Uri, uploadMethod: DocumentUploadParam.UploadMethod) {
+        identityViewModel.observeForVerificationPage(this,
+            onSuccess = { verificationPage ->
+                passportUploadViewModel.uploadImage(
+                    passport,
+                    requireContext(),
+                    verificationPage.documentCapture,
+                    uploadMethod
+                )
+            },
+            onFailure = {
+                navigateToDefaultErrorFragment()
+            }
+        )
     }
 
-    private fun showFrontUploading() {
+    private fun showUploading() {
         binding.select.visibility = View.GONE
         binding.progressCircular.visibility = View.VISIBLE
         binding.finishedCheckMark.visibility = View.GONE
     }
 
-    private fun showUploadDone() {
+    private fun showUploadDone(passportImage: Pair<InternalStripeFile, DocumentUploadParam.UploadMethod>?) {
         binding.select.visibility = View.GONE
         binding.progressCircular.visibility = View.GONE
         binding.finishedCheckMark.visibility = View.VISIBLE
         binding.kontinue.isEnabled = true
+        binding.kontinue.setOnClickListener {
+            lifecycleScope.launch {
+                runCatching {
+                    requireNotNull(passportImage)
+                    postVerificationPageDataAndMaybeSubmit(
+                        identityViewModel = identityViewModel,
+                        collectedDataParam = CollectedDataParam(
+                            idDocument = IdDocumentParam(
+                                front = DocumentUploadParam(
+                                    highResImage = requireNotNull(passportImage.first.id) {
+                                        "front uploaded file id is null"
+                                    },
+                                    uploadMethod = passportImage.second
+                                ),
+                                type = IdDocumentParam.Type.PASSPORT
+                            )
+                        ),
+                        shouldNotSubmit = { false }
+                    )
+                }.onFailure {
+                    Log.d(TAG, "fail to submit uploaded files: $it")
+                    navigateToDefaultErrorFragment()
+                }
+            }
+        }
+    }
+
+    private companion object {
+        val TAG: String = PassportUploadFragment::class.java.simpleName
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/utils/navigationUtils.kt
+++ b/identity/src/main/java/com/stripe/android/identity/utils/navigationUtils.kt
@@ -28,14 +28,14 @@ import com.stripe.android.identity.viewmodel.IdentityViewModel
  * @param identityViewModel: [IdentityViewModel] to fire requests.
  * @param collectedDataParam: parameter collected from UI response, posted to [IdentityViewModel.postVerificationPageData].
  * @param shouldNotSubmit: A condition check block to decide when [VerificationPageData]
- * is returned, whether to continue submit by [IdentityViewModel.postVerificationPageSubmit].
+ * is returned without error, whether to continue submit by [IdentityViewModel.postVerificationPageSubmit].
  * @param notSubmitBlock: A block to execute when [shouldNotSubmit] returns true.
  */
 internal suspend fun Fragment.postVerificationPageDataAndMaybeSubmit(
     identityViewModel: IdentityViewModel,
     collectedDataParam: CollectedDataParam,
     shouldNotSubmit: (verificationPageData: VerificationPageData) -> Boolean = { true },
-    notSubmitBlock: (verificationPageData: VerificationPageData) -> Unit
+    notSubmitBlock: ((verificationPageData: VerificationPageData) -> Unit)? = null
 ) {
     runCatching {
         identityViewModel.postVerificationPageData(collectedDataParam)
@@ -45,7 +45,7 @@ internal suspend fun Fragment.postVerificationPageDataAndMaybeSubmit(
                 navigateToRequirementErrorFragment(postedVerificationPageData.requirements.errors[0])
             } else {
                 if (shouldNotSubmit(postedVerificationPageData)) {
-                    notSubmitBlock(postedVerificationPageData)
+                    notSubmitBlock?.invoke(postedVerificationPageData)
                 } else {
                     runCatching {
                         identityViewModel.postVerificationPageSubmit()

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/FrontBackUploadViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/FrontBackUploadViewModel.kt
@@ -40,7 +40,7 @@ internal class FrontBackUploadViewModel(
         MutableLiveData<Resource<Pair<InternalStripeFile, UploadMethod>>>()
     val frontUploaded:
         LiveData<Resource<Pair<InternalStripeFile, UploadMethod>>> =
-        _frontUploaded
+            _frontUploaded
 
     /**
      * The ID back image has been uploaded
@@ -218,7 +218,6 @@ internal class FrontBackUploadViewModel(
             )
         }
     }
-
 
     internal class FrontBackUploadViewModelFactory(
         private val identityRepository: IdentityRepository,

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/FrontBackUploadViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/FrontBackUploadViewModel.kt
@@ -10,13 +10,19 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.stripe.android.core.model.InternalStripeFile
 import com.stripe.android.core.model.InternalStripeFilePurpose
 import com.stripe.android.identity.IdentityVerificationSheetContract
 import com.stripe.android.identity.networking.IdentityRepository
+import com.stripe.android.identity.networking.Resource
+import com.stripe.android.identity.networking.Status
+import com.stripe.android.identity.networking.models.DocumentUploadParam.UploadMethod
+import com.stripe.android.identity.networking.models.VerificationPageStaticContentDocumentCapturePage
 import com.stripe.android.identity.utils.ImageChooser
 import com.stripe.android.identity.utils.PhotoTaker
 import com.stripe.android.identity.utils.resizeUriAndCreateFileToUpload
 import kotlinx.coroutines.launch
+import java.io.File
 
 /**
  * ViewModel to upload front and back image of a document either through camera or from local
@@ -30,14 +36,19 @@ internal class FrontBackUploadViewModel(
     /**
      * The ID front image has been uploaded
      */
-    private val _frontUploaded = MutableLiveData<Unit>()
-    val frontUploaded: LiveData<Unit> = _frontUploaded
+    private val _frontUploaded =
+        MutableLiveData<Resource<Pair<InternalStripeFile, UploadMethod>>>()
+    val frontUploaded:
+        LiveData<Resource<Pair<InternalStripeFile, UploadMethod>>> =
+        _frontUploaded
 
     /**
      * The ID back image has been uploaded
      */
-    private val _backUploaded = MutableLiveData<Unit>()
-    val backUploaded: LiveData<Unit> = _backUploaded
+    private val _backUploaded =
+        MutableLiveData<Resource<Pair<InternalStripeFile, UploadMethod>>>()
+    val backUploaded: LiveData<Resource<Pair<InternalStripeFile, UploadMethod>>> =
+        _backUploaded
 
     /**
      * Both front and back of ID are uploaded
@@ -48,12 +59,16 @@ internal class FrontBackUploadViewModel(
 
         init {
             addSource(this@FrontBackUploadViewModel.frontUploaded) {
-                frontUploaded = true
-                postValueWhenBothUploaded()
+                if (it.status == Status.SUCCESS) {
+                    frontUploaded = true
+                    postValueWhenBothUploaded()
+                }
             }
             addSource(this@FrontBackUploadViewModel.backUploaded) {
-                backUploaded = true
-                postValueWhenBothUploaded()
+                if (it.status == Status.SUCCESS) {
+                    backUploaded = true
+                    postValueWhenBothUploaded()
+                }
             }
         }
 
@@ -124,26 +139,25 @@ internal class FrontBackUploadViewModel(
      */
     fun uploadImageFront(
         uri: Uri,
-        context: Context
+        context: Context,
+        documentCaptureModels: VerificationPageStaticContentDocumentCapturePage,
+        uploadMethod: UploadMethod
     ) {
-        viewModelScope.launch {
-            identityRepository.uploadImage(
-                verificationId = verificationArgs.verificationSessionId,
-                ephemeralKey = verificationArgs.ephemeralKeySecret,
-                imageFile = resizeUriAndCreateFileToUpload(
-                    context,
-                    uri,
-                    verificationArgs.verificationSessionId,
-                    // TODO(ccen) upload both full frame and non full frame
-                    true,
-                    FRONT
-                ),
-                // TODO(ccen) pass it over from VerificationPage response
-                filePurpose = InternalStripeFilePurpose.IdentityPrivate
-            )
-
-            _frontUploaded.postValue(Unit)
-        }
+        _frontUploaded.postValue(Resource.loading())
+        uploadImage(
+            imageFile = resizeUriAndCreateFileToUpload(
+                context,
+                uri,
+                verificationArgs.verificationSessionId,
+                true,
+                FRONT,
+                maxDimension = documentCaptureModels.highResImageMaxDimension,
+                compressionQuality = documentCaptureModels.highResImageCompressionQuality
+            ),
+            filePurpose = documentCaptureModels.filePurpose,
+            resultLiveData = _frontUploaded,
+            uploadMethod = uploadMethod
+        )
     }
 
     /**
@@ -152,27 +166,59 @@ internal class FrontBackUploadViewModel(
      */
     fun uploadImageBack(
         uri: Uri,
-        context: Context
+        context: Context,
+        documentCaptureModels: VerificationPageStaticContentDocumentCapturePage,
+        uploadMethod: UploadMethod
+    ) {
+        _backUploaded.postValue(Resource.loading())
+        uploadImage(
+            imageFile = resizeUriAndCreateFileToUpload(
+                context,
+                uri,
+                verificationArgs.verificationSessionId,
+                true,
+                BACK,
+                maxDimension = documentCaptureModels.highResImageMaxDimension,
+                compressionQuality = documentCaptureModels.highResImageCompressionQuality
+            ),
+            filePurpose = documentCaptureModels.filePurpose,
+            resultLiveData = _backUploaded,
+            uploadMethod = uploadMethod
+        )
+    }
+
+    private fun uploadImage(
+        imageFile: File,
+        filePurpose: String,
+        resultLiveData: MutableLiveData<Resource<Pair<InternalStripeFile, UploadMethod>>>,
+        uploadMethod: UploadMethod
     ) {
         viewModelScope.launch {
-            identityRepository.uploadImage(
-                verificationId = verificationArgs.verificationSessionId,
-                ephemeralKey = verificationArgs.ephemeralKeySecret,
-                imageFile = resizeUriAndCreateFileToUpload(
-                    context,
-                    uri,
-                    verificationArgs.verificationSessionId,
-                    // TODO(ccen) upload both full frame and non full frame
-                    true,
-                    BACK
-                ),
-                // TODO(ccen) pass it over from VerificationPage response
-                filePurpose = InternalStripeFilePurpose.IdentityPrivate
+            runCatching {
+                identityRepository.uploadImage(
+                    verificationId = verificationArgs.verificationSessionId,
+                    ephemeralKey = verificationArgs.ephemeralKeySecret,
+                    imageFile = imageFile,
+                    filePurpose = requireNotNull(
+                        InternalStripeFilePurpose.fromCode(filePurpose)
+                    )
+                )
+            }.fold(
+                onSuccess = {
+                    resultLiveData.postValue(Resource.success(Pair(it, uploadMethod)))
+                },
+                onFailure = {
+                    resultLiveData.postValue(
+                        Resource.error(
+                            "Failed to upload file : ${imageFile.name}",
+                            throwable = it
+                        )
+                    )
+                }
             )
-
-            _backUploaded.postValue(Unit)
         }
     }
+
 
     internal class FrontBackUploadViewModelFactory(
         private val identityRepository: IdentityRepository,

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
@@ -56,9 +56,8 @@ internal class IdentityViewModel(
                     Log.e(TAG, "Fail to get VerificationPage")
                     onFailure(resource.throwable)
                 }
-                Status.LOADING -> {}// no-op
+                Status.LOADING -> {} // no-op
             }
-
         }
     }
 

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.identity.viewmodel
 
+import android.util.Log
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -10,6 +12,7 @@ import com.stripe.android.core.exception.APIException
 import com.stripe.android.identity.IdentityVerificationSheetContract
 import com.stripe.android.identity.networking.IdentityRepository
 import com.stripe.android.identity.networking.Resource
+import com.stripe.android.identity.networking.Status
 import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPageData
@@ -35,6 +38,29 @@ internal class IdentityViewModel(
      */
     private val _idDetectorModelFile = MutableLiveData<Resource<File>>()
     val idDetectorModelFile: LiveData<Resource<File>> = _idDetectorModelFile
+
+    /**
+     * Simple wrapper for observing [verificationPage].
+     */
+    fun observeForVerificationPage(
+        owner: LifecycleOwner,
+        onSuccess: (VerificationPage) -> Unit,
+        onFailure: (Throwable?) -> Unit,
+    ) {
+        verificationPage.observe(owner) { resource ->
+            when (resource.status) {
+                Status.SUCCESS -> {
+                    onSuccess(requireNotNull(resource.data))
+                }
+                Status.ERROR -> {
+                    Log.e(TAG, "Fail to get VerificationPage")
+                    onFailure(resource.throwable)
+                }
+                Status.LOADING -> {}// no-op
+            }
+
+        }
+    }
 
     /**
      * Retrieve the VerificationPage data and post its value to [verificationPage]
@@ -126,5 +152,9 @@ internal class IdentityViewModel(
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             return IdentityViewModel(args, identityRepository) as T
         }
+    }
+
+    private companion object {
+        val TAG: String = IdentityViewModel::class.java.simpleName
     }
 }

--- a/identity/src/test/java/com/stripe/android/identity/TestFixtures.kt
+++ b/identity/src/test/java/com/stripe/android/identity/TestFixtures.kt
@@ -1,0 +1,39 @@
+package com.stripe.android.identity
+
+import com.stripe.android.identity.networking.models.VerificationPageData
+import com.stripe.android.identity.networking.models.VerificationPageDataRequirementError
+import com.stripe.android.identity.networking.models.VerificationPageDataRequirements
+
+
+internal const val ERROR_BODY = "errorBody"
+internal const val ERROR_BUTTON_TEXT = "error button text"
+internal const val ERROR_TITLE = "errorTitle"
+
+internal val CORRECT_VERIFICATION_PAGE_DATA = VerificationPageData(
+    id = "id",
+    objectType = "type",
+    requirements = VerificationPageDataRequirements(
+        errors = emptyList(),
+        missing = emptyList()
+    ),
+    status = VerificationPageData.Status.VERIFIED,
+    submitted = false
+)
+
+internal val ERROR_VERIFICATION_PAGE_DATA = VerificationPageData(
+    id = "id",
+    objectType = "type",
+    requirements = VerificationPageDataRequirements(
+        errors = listOf(
+            VerificationPageDataRequirementError(
+                body = ERROR_BODY,
+                buttonText = ERROR_BUTTON_TEXT,
+                requirement = VerificationPageDataRequirementError.Requirement.BIOMETRICCONSENT,
+                title = ERROR_TITLE
+            )
+        ),
+        missing = emptyList()
+    ),
+    status = VerificationPageData.Status.VERIFIED,
+    submitted = false
+)

--- a/identity/src/test/java/com/stripe/android/identity/TestFixtures.kt
+++ b/identity/src/test/java/com/stripe/android/identity/TestFixtures.kt
@@ -4,7 +4,6 @@ import com.stripe.android.identity.networking.models.VerificationPageData
 import com.stripe.android.identity.networking.models.VerificationPageDataRequirementError
 import com.stripe.android.identity.networking.models.VerificationPageDataRequirements
 
-
 internal const val ERROR_BODY = "errorBody"
 internal const val ERROR_BUTTON_TEXT = "error button text"
 internal const val ERROR_TITLE = "errorTitle"

--- a/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
@@ -27,8 +27,12 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
 import org.junit.runner.RunWith
+import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 
@@ -38,17 +42,37 @@ internal class DocSelectionFragmentTest {
     var rule: TestRule = InstantTaskExecutorRule()
 
     private val verificationPage = mock<VerificationPage>()
-    private val verificationPageLiveData = MutableLiveData<Resource<VerificationPage>>()
-    private val mockIdentityViewModel = mock<IdentityViewModel>().also {
-        whenever(it.verificationPage).thenReturn(verificationPageLiveData)
+    private val mockIdentityViewModel = mock<IdentityViewModel>()
+
+    private fun setUpErrorVerificationPage() {
+        val failureCaptor: KArgumentCaptor<(Throwable?) -> Unit> = argumentCaptor()
+        verify(
+            mockIdentityViewModel
+        ).observeForVerificationPage(
+            any(),
+            any(),
+            failureCaptor.capture()
+        )
+        failureCaptor.firstValue(null)
+    }
+
+    private fun setUpSuccessVerificationPage(times: Int = 1) {
+        val successCaptor: KArgumentCaptor<(VerificationPage) -> Unit> = argumentCaptor()
+        verify(
+            mockIdentityViewModel,
+            times(times)
+        ).observeForVerificationPage(
+            any(),
+            successCaptor.capture(),
+            any()
+        )
+        successCaptor.lastValue(verificationPage)
     }
 
     @Test
     fun `errorVerificationPage navigates to errorFragment`() {
         launchDocSelectionFragment { _, navController, _ ->
-            verificationPageLiveData.postValue(
-                Resource.error()
-            )
+            setUpErrorVerificationPage()
 
             assertThat(navController.currentDestination?.id)
                 .isEqualTo(R.id.errorFragment)
@@ -61,9 +85,7 @@ internal class DocSelectionFragmentTest {
             whenever(verificationPage.documentSelect).thenReturn(
                 DOC_SELECT_MULTI_CHOICE
             )
-            verificationPageLiveData.postValue(
-                Resource.success(verificationPage)
-            )
+            setUpSuccessVerificationPage()
 
             assertThat(binding.title.text).isEqualTo(DOCUMENT_SELECT_TITLE)
             assertThat(binding.multiSelectionContent.visibility).isEqualTo(View.VISIBLE)
@@ -89,9 +111,7 @@ internal class DocSelectionFragmentTest {
             whenever(verificationPage.documentSelect).thenReturn(
                 DOC_SELECT_ZERO_CHOICE
             )
-            verificationPageLiveData.postValue(
-                Resource.success(verificationPage)
-            )
+            setUpSuccessVerificationPage()
 
             assertThat(binding.title.text).isEqualTo(DOCUMENT_SELECT_TITLE)
             assertThat(binding.multiSelectionContent.visibility).isEqualTo(View.VISIBLE)
@@ -161,9 +181,7 @@ internal class DocSelectionFragmentTest {
                     )
                 )
             )
-            verificationPageLiveData.postValue(
-                Resource.success(verificationPage)
-            )
+            setUpSuccessVerificationPage()
             binding.singleSelectionContinue.callOnClick()
 
             assertThat(navController.currentDestination?.id)
@@ -194,10 +212,9 @@ internal class DocSelectionFragmentTest {
             whenever(mockIdentityViewModel.idDetectorModelFile).thenReturn(
                 MutableLiveData(Resource.error())
             )
-            verificationPageLiveData.postValue(
-                Resource.success(verificationPage)
-            )
+            setUpSuccessVerificationPage()
             binding.singleSelectionContinue.callOnClick()
+            setUpSuccessVerificationPage(2)
 
             assertThat(navController.currentDestination?.id)
                 .isEqualTo(R.id.driverLicenseUploadFragment)
@@ -227,10 +244,9 @@ internal class DocSelectionFragmentTest {
             whenever(mockIdentityViewModel.idDetectorModelFile).thenReturn(
                 MutableLiveData(Resource.error())
             )
-            verificationPageLiveData.postValue(
-                Resource.success(verificationPage)
-            )
+            setUpSuccessVerificationPage()
             binding.singleSelectionContinue.callOnClick()
+            setUpSuccessVerificationPage(2)
 
             assertThat(navController.currentDestination?.id)
                 .isEqualTo(R.id.errorFragment)
@@ -245,9 +261,7 @@ internal class DocSelectionFragmentTest {
             whenever(verificationPage.documentSelect).thenReturn(
                 docSelect
             )
-            verificationPageLiveData.postValue(
-                Resource.success(verificationPage)
-            )
+            setUpSuccessVerificationPage()
 
             assertThat(binding.title.text).isEqualTo(DOCUMENT_SELECT_TITLE)
             assertThat(binding.multiSelectionContent.visibility).isEqualTo(View.GONE)

--- a/identity/src/test/java/com/stripe/android/identity/navigation/FrontBackUploadFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/FrontBackUploadFragmentTest.kt
@@ -23,8 +23,6 @@ import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.networking.models.DocumentUploadParam
 import com.stripe.android.identity.networking.models.IdDocumentParam
 import com.stripe.android.identity.networking.models.VerificationPage
-import com.stripe.android.identity.networking.models.VerificationPageData
-import com.stripe.android.identity.networking.models.VerificationPageDataRequirements
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentDocumentCapturePage
 import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.viewModelFactoryFor
@@ -143,7 +141,6 @@ class FrontBackUploadFragmentTest {
                 .isEqualTo(R.id.errorFragment)
         }
     }
-
 
     @Test
     fun `verify uploadFinished updates UI`() {
@@ -389,7 +386,6 @@ class FrontBackUploadFragmentTest {
         override val frontScanType = IdentityScanState.ScanType.ID_FRONT
         override val backScanType = IdentityScanState.ScanType.ID_BACK
     }
-
 
     private companion object {
         val DOCUMENT_CAPTURE =

--- a/identity/src/test/java/com/stripe/android/identity/navigation/FrontBackUploadFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/FrontBackUploadFragmentTest.kt
@@ -13,17 +13,32 @@ import androidx.navigation.testing.TestNavHostController
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.model.InternalStripeFile
+import com.stripe.android.core.model.InternalStripeFilePurpose
+import com.stripe.android.identity.CORRECT_VERIFICATION_PAGE_DATA
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.FrontBackUploadFragmentBinding
+import com.stripe.android.identity.networking.Resource
+import com.stripe.android.identity.networking.models.CollectedDataParam
+import com.stripe.android.identity.networking.models.DocumentUploadParam
+import com.stripe.android.identity.networking.models.IdDocumentParam
+import com.stripe.android.identity.networking.models.VerificationPage
+import com.stripe.android.identity.networking.models.VerificationPageData
+import com.stripe.android.identity.networking.models.VerificationPageDataRequirements
+import com.stripe.android.identity.networking.models.VerificationPageStaticContentDocumentCapturePage
 import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.viewModelFactoryFor
 import com.stripe.android.identity.viewmodel.FrontBackUploadViewModel
+import com.stripe.android.identity.viewmodel.IdentityViewModel
+import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 import org.mockito.kotlin.KArgumentCaptor
+import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.same
 import org.mockito.kotlin.verify
@@ -36,10 +51,22 @@ class FrontBackUploadFragmentTest {
     @get:Rule
     var rule: TestRule = InstantTaskExecutorRule()
 
-    private val frontUploaded = MutableLiveData<Unit>()
-    private val backUploaded = MutableLiveData<Unit>()
+    private val frontUploaded =
+        MutableLiveData<Resource<Pair<InternalStripeFile, DocumentUploadParam.UploadMethod>>>()
+    private val backUploaded =
+        MutableLiveData<Resource<Pair<InternalStripeFile, DocumentUploadParam.UploadMethod>>>()
     private val uploadFinished = MediatorLiveData<Unit>()
     private val mockUri = mock<Uri>()
+    private val verificationPage = mock<VerificationPage>().also {
+        whenever(it.documentCapture).thenReturn(DOCUMENT_CAPTURE)
+    }
+
+    private val mockIdentityViewModel = mock<IdentityViewModel>().also {
+        val successCaptor: KArgumentCaptor<(VerificationPage) -> Unit> = argumentCaptor()
+        whenever(it.observeForVerificationPage(any(), successCaptor.capture(), any())).then {
+            successCaptor.firstValue(verificationPage)
+        }
+    }
 
     private val mockFrontBackUploadViewModel = mock<FrontBackUploadViewModel>().also {
         whenever(it.frontUploaded).thenReturn(frontUploaded)
@@ -49,10 +76,8 @@ class FrontBackUploadFragmentTest {
 
     @Test
     fun `when initialized viewmodel registers activityResultCaller and UI is correct`() {
-        launchFragment().onFragment {
-            verify(mockFrontBackUploadViewModel).registerActivityResultCaller(same(it))
-
-            val binding = FrontBackUploadFragmentBinding.bind(it.requireView())
+        launchFragment { binding, _, fragment ->
+            verify(mockFrontBackUploadViewModel).registerActivityResultCaller(same(fragment))
 
             assertThat(binding.selectFront.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.progressCircularFront.visibility).isEqualTo(View.GONE)
@@ -62,12 +87,20 @@ class FrontBackUploadFragmentTest {
             assertThat(binding.finishedCheckMarkBack.visibility).isEqualTo(View.GONE)
             assertThat(binding.kontinue.isEnabled).isEqualTo(false)
 
-            assertThat(binding.titleText.text).isEqualTo(it.getString(R.string.file_upload))
-            assertThat(binding.contentText.text).isEqualTo(it.getString(R.string.file_upload_content_id))
-            assertThat(binding.labelFront.text).isEqualTo(it.getString(R.string.front_of_id))
-            assertThat(binding.labelBack.text).isEqualTo(it.getString(R.string.back_of_id))
-            assertThat(binding.finishedCheckMarkFront.contentDescription).isEqualTo(it.getString(R.string.front_of_id_selected))
-            assertThat(binding.finishedCheckMarkBack.contentDescription).isEqualTo(it.getString(R.string.back_of_id_selected))
+            assertThat(binding.titleText.text).isEqualTo(fragment.getString(R.string.file_upload))
+            assertThat(binding.contentText.text).isEqualTo(fragment.getString(R.string.file_upload_content_id))
+            assertThat(binding.labelFront.text).isEqualTo(fragment.getString(R.string.front_of_id))
+            assertThat(binding.labelBack.text).isEqualTo(fragment.getString(R.string.back_of_id))
+            assertThat(binding.finishedCheckMarkFront.contentDescription).isEqualTo(
+                fragment.getString(
+                    R.string.front_of_id_selected
+                )
+            )
+            assertThat(binding.finishedCheckMarkBack.contentDescription).isEqualTo(
+                fragment.getString(
+                    R.string.back_of_id_selected
+                )
+            )
         }
     }
 
@@ -92,36 +125,46 @@ class FrontBackUploadFragmentTest {
     }
 
     @Test
-    fun `verify front upload updates UI`() {
-        launchFragment().onFragment {
-            frontUploaded.postValue(Unit)
-            val binding = FrontBackUploadFragmentBinding.bind(it.requireView())
+    fun `verify front upload failure navigates to error fragment `() {
+        launchFragment { _, navController, _ ->
+            frontUploaded.postValue(Resource.error())
 
-            assertThat(binding.selectFront.visibility).isEqualTo(View.GONE)
-            assertThat(binding.progressCircularFront.visibility).isEqualTo(View.GONE)
-            assertThat(binding.finishedCheckMarkFront.visibility).isEqualTo(View.VISIBLE)
+            assertThat(navController.currentDestination?.id)
+                .isEqualTo(R.id.errorFragment)
         }
     }
 
     @Test
-    fun `verify back upload updates UI`() {
-        launchFragment().onFragment {
-            backUploaded.postValue(Unit)
-            val binding = FrontBackUploadFragmentBinding.bind(it.requireView())
+    fun `verify back upload failure navigates to error fragment `() {
+        launchFragment { _, navController, _ ->
+            backUploaded.postValue(Resource.error())
 
-            assertThat(binding.selectBack.visibility).isEqualTo(View.GONE)
-            assertThat(binding.progressCircularBack.visibility).isEqualTo(View.GONE)
-            assertThat(binding.finishedCheckMarkBack.visibility).isEqualTo(View.VISIBLE)
+            assertThat(navController.currentDestination?.id)
+                .isEqualTo(R.id.errorFragment)
         }
     }
+
 
     @Test
     fun `verify uploadFinished updates UI`() {
-        launchFragment().onFragment {
-            frontUploaded.postValue(Unit)
-            backUploaded.postValue(Unit)
+        launchFragment { binding, _, _ ->
+            frontUploaded.postValue(
+                Resource.success(
+                    Pair(
+                        InternalStripeFile(id = FRONT_UPLOADED_ID),
+                        DocumentUploadParam.UploadMethod.FILEUPLOAD
+                    )
+                )
+            )
+            backUploaded.postValue(
+                Resource.success(
+                    Pair(
+                        InternalStripeFile(id = BACK_UPLOADED_ID),
+                        DocumentUploadParam.UploadMethod.FILEUPLOAD
+                    )
+                )
+            )
             uploadFinished.postValue(Unit)
-            val binding = FrontBackUploadFragmentBinding.bind(it.requireView())
 
             assertThat(binding.selectFront.visibility).isEqualTo(View.GONE)
             assertThat(binding.progressCircularFront.visibility).isEqualTo(View.GONE)
@@ -135,34 +178,75 @@ class FrontBackUploadFragmentTest {
     }
 
     @Test
-    fun `verify when kontinue is clicked navigates to confirmation`() {
-        launchFragment().onFragment {
-            val navController = TestNavHostController(
-                ApplicationProvider.getApplicationContext()
-            )
-            navController.setGraph(
-                R.navigation.identity_nav_graph
-            )
-            navController.setCurrentDestination(R.id.IDUploadFragment)
-            Navigation.setViewNavController(
-                it.requireView(),
-                navController
-            )
+    fun `verify when kontinue is clicked and post succeeds navigates to confirmation`() {
+        launchFragment { binding, navController, _ ->
+            runBlocking {
+                frontUploaded.postValue(
+                    Resource.success(
+                        Pair(
+                            InternalStripeFile(id = FRONT_UPLOADED_ID),
+                            DocumentUploadParam.UploadMethod.FILEUPLOAD
+                        )
+                    )
+                )
+                backUploaded.postValue(
+                    Resource.success(
+                        Pair(
+                            InternalStripeFile(id = BACK_UPLOADED_ID),
+                            DocumentUploadParam.UploadMethod.FILEUPLOAD
+                        )
+                    )
+                )
+                uploadFinished.postValue(Unit)
 
-            frontUploaded.postValue(Unit)
-            backUploaded.postValue(Unit)
+                val collectedDataParamCaptor: KArgumentCaptor<CollectedDataParam> = argumentCaptor()
+                whenever(
+                    mockIdentityViewModel.postVerificationPageData(collectedDataParamCaptor.capture())
+                ).thenReturn(
+                    CORRECT_VERIFICATION_PAGE_DATA
+                )
+                whenever(mockIdentityViewModel.postVerificationPageSubmit()).thenReturn(
+                    CORRECT_VERIFICATION_PAGE_DATA
+                )
+
+                binding.kontinue.callOnClick()
+
+                assertThat(collectedDataParamCaptor.firstValue).isEqualTo(
+                    CollectedDataParam(
+                        idDocument = IdDocumentParam(
+                            front = DocumentUploadParam(
+                                highResImage = FRONT_UPLOADED_ID,
+                                uploadMethod = DocumentUploadParam.UploadMethod.FILEUPLOAD
+                            ),
+                            back = DocumentUploadParam(
+                                highResImage = BACK_UPLOADED_ID,
+                                uploadMethod = DocumentUploadParam.UploadMethod.FILEUPLOAD
+                            ),
+                            type = IdDocumentParam.Type.IDCARD
+                        )
+                    )
+                )
+                assertThat(navController.currentDestination?.id)
+                    .isEqualTo(R.id.confirmationFragment)
+            }
+        }
+    }
+
+    @Test
+    fun `verify when kontinue is clicked and data is null navigates to error`() {
+        launchFragment { binding, navController, _ ->
+            // leave frontUploaded and backUploaded null
             uploadFinished.postValue(Unit)
-            val binding = FrontBackUploadFragmentBinding.bind(it.requireView())
+
             binding.kontinue.callOnClick()
 
             assertThat(navController.currentDestination?.id)
-                .isEqualTo(R.id.confirmationFragment)
+                .isEqualTo(R.id.errorFragment)
         }
     }
 
     private fun verifyFlow(scanType: IdentityScanState.ScanType, isTakePhoto: Boolean) {
-        launchFragment().onFragment {
-            val binding = FrontBackUploadFragmentBinding.bind(it.requireView())
+        launchFragment { binding, _, fragment ->
             // click select front button
             if (scanType == IdentityScanState.ScanType.ID_FRONT) {
                 binding.selectFront.callOnClick()
@@ -186,26 +270,29 @@ class FrontBackUploadFragmentTest {
             assertThat(dialog.isShowing).isFalse()
 
             // viewmodel triggers
-
             val callbackCaptor: KArgumentCaptor<(Uri) -> Unit> = argumentCaptor()
 
             if (isTakePhoto) {
                 if (scanType == IdentityScanState.ScanType.ID_FRONT) {
                     verify(mockFrontBackUploadViewModel).takePhotoFront(
-                        same(it.requireContext()),
+                        same(fragment.requireContext()),
                         callbackCaptor.capture()
                     )
+                    frontUploaded.postValue(Resource.loading())
                 } else if (scanType == IdentityScanState.ScanType.ID_BACK) {
                     verify(mockFrontBackUploadViewModel).takePhotoBack(
-                        same(it.requireContext()),
+                        same(fragment.requireContext()),
                         callbackCaptor.capture()
                     )
+                    backUploaded.postValue(Resource.loading())
                 }
             } else {
                 if (scanType == IdentityScanState.ScanType.ID_FRONT) {
                     verify(mockFrontBackUploadViewModel).chooseImageFront(callbackCaptor.capture())
+                    frontUploaded.postValue(Resource.loading())
                 } else if (scanType == IdentityScanState.ScanType.ID_BACK) {
                     verify(mockFrontBackUploadViewModel).chooseImageBack(callbackCaptor.capture())
+                    backUploaded.postValue(Resource.loading())
                 }
             }
 
@@ -216,7 +303,12 @@ class FrontBackUploadFragmentTest {
             if (scanType == IdentityScanState.ScanType.ID_FRONT) {
                 verify(mockFrontBackUploadViewModel).uploadImageFront(
                     same(mockUri),
-                    same(it.requireContext())
+                    same(fragment.requireContext()),
+                    same(DOCUMENT_CAPTURE),
+                    if (isTakePhoto)
+                        eq(DocumentUploadParam.UploadMethod.MANUALCAPTURE)
+                    else
+                        eq(DocumentUploadParam.UploadMethod.FILEUPLOAD)
                 )
                 assertThat(binding.selectFront.visibility).isEqualTo(View.GONE)
                 assertThat(binding.progressCircularFront.visibility).isEqualTo(View.VISIBLE)
@@ -224,23 +316,68 @@ class FrontBackUploadFragmentTest {
             } else if (scanType == IdentityScanState.ScanType.ID_BACK) {
                 verify(mockFrontBackUploadViewModel).uploadImageBack(
                     same(mockUri),
-                    same(it.requireContext())
+                    same(fragment.requireContext()),
+                    same(DOCUMENT_CAPTURE),
+                    if (isTakePhoto)
+                        eq(DocumentUploadParam.UploadMethod.MANUALCAPTURE)
+                    else
+                        eq(DocumentUploadParam.UploadMethod.FILEUPLOAD)
                 )
                 assertThat(binding.selectBack.visibility).isEqualTo(View.GONE)
                 assertThat(binding.progressCircularBack.visibility).isEqualTo(View.VISIBLE)
                 assertThat(binding.finishedCheckMarkBack.visibility).isEqualTo(View.GONE)
             }
+
+            // mock file uploaded
+            if (scanType == IdentityScanState.ScanType.ID_FRONT) {
+                frontUploaded.postValue(Resource.success(mock()))
+
+                assertThat(binding.selectFront.visibility).isEqualTo(View.GONE)
+                assertThat(binding.progressCircularFront.visibility).isEqualTo(View.GONE)
+                assertThat(binding.finishedCheckMarkFront.visibility).isEqualTo(View.VISIBLE)
+            } else if (scanType == IdentityScanState.ScanType.ID_BACK) {
+                backUploaded.postValue(Resource.success(mock()))
+
+                assertThat(binding.selectBack.visibility).isEqualTo(View.GONE)
+                assertThat(binding.progressCircularBack.visibility).isEqualTo(View.GONE)
+                assertThat(binding.finishedCheckMarkBack.visibility).isEqualTo(View.VISIBLE)
+            }
         }
     }
 
-    private fun launchFragment() = launchFragmentInContainer(
+    private fun launchFragment(
+        testBlock: (
+            binding: FrontBackUploadFragmentBinding,
+            navController: TestNavHostController,
+            fragment: FrontBackUploadFragment
+        ) -> Unit
+    ) = launchFragmentInContainer(
         themeResId = R.style.Theme_MaterialComponents
     ) {
-        TestFragment(viewModelFactoryFor(mockFrontBackUploadViewModel))
+        TestFragment(
+            viewModelFactoryFor(mockFrontBackUploadViewModel),
+            viewModelFactoryFor(mockIdentityViewModel)
+        )
+    }.onFragment {
+        val navController = TestNavHostController(
+            ApplicationProvider.getApplicationContext()
+        )
+        navController.setGraph(
+            R.navigation.identity_nav_graph
+        )
+        navController.setCurrentDestination(R.id.IDUploadFragment)
+        Navigation.setViewNavController(
+            it.requireView(),
+            navController
+        )
+        testBlock(FrontBackUploadFragmentBinding.bind(it.requireView()), navController, it)
     }
 
-    internal class TestFragment(frontBackUploadViewModelFactory: ViewModelProvider.Factory) :
-        FrontBackUploadFragment(frontBackUploadViewModelFactory) {
+    internal class TestFragment(
+        frontBackUploadViewModelFactory: ViewModelProvider.Factory,
+        identityViewModelFactory: ViewModelProvider.Factory
+    ) :
+        FrontBackUploadFragment(frontBackUploadViewModelFactory, identityViewModelFactory) {
         override val titleRes = R.string.file_upload
         override val contextRes = R.string.file_upload_content_id
         override val frontTextRes = R.string.front_of_id
@@ -251,5 +388,24 @@ class FrontBackUploadFragmentTest {
             R.id.action_IDUploadFragment_to_confirmationFragment
         override val frontScanType = IdentityScanState.ScanType.ID_FRONT
         override val backScanType = IdentityScanState.ScanType.ID_BACK
+    }
+
+
+    private companion object {
+        val DOCUMENT_CAPTURE =
+            VerificationPageStaticContentDocumentCapturePage(
+                autocaptureTimeout = 0,
+                filePurpose = InternalStripeFilePurpose.IdentityPrivate.code,
+                highResImageCompressionQuality = 0.9f,
+                highResImageCropPadding = 0f,
+                highResImageMaxDimension = 512,
+                lowResImageCompressionQuality = 0f,
+                lowResImageMaxDimension = 0,
+                models = mock(),
+                requireLiveCapture = false
+            )
+
+        const val FRONT_UPLOADED_ID = "id_front"
+        const val BACK_UPLOADED_ID = "id_back"
     }
 }

--- a/identity/src/test/java/com/stripe/android/identity/navigation/PassportUploadFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/PassportUploadFragmentTest.kt
@@ -11,16 +11,28 @@ import androidx.navigation.testing.TestNavHostController
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.model.InternalStripeFile
+import com.stripe.android.core.model.InternalStripeFilePurpose
+import com.stripe.android.identity.CORRECT_VERIFICATION_PAGE_DATA
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.PassportUploadFragmentBinding
+import com.stripe.android.identity.networking.Resource
+import com.stripe.android.identity.networking.models.CollectedDataParam
+import com.stripe.android.identity.networking.models.DocumentUploadParam.UploadMethod
+import com.stripe.android.identity.networking.models.VerificationPage
+import com.stripe.android.identity.networking.models.VerificationPageStaticContentDocumentCapturePage
 import com.stripe.android.identity.viewModelFactoryFor
+import com.stripe.android.identity.viewmodel.IdentityViewModel
 import com.stripe.android.identity.viewmodel.PassportUploadViewModel
+import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 import org.mockito.kotlin.KArgumentCaptor
+import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.same
 import org.mockito.kotlin.verify
@@ -33,19 +45,29 @@ class PassportUploadFragmentTest {
     @get:Rule
     var rule: TestRule = InstantTaskExecutorRule()
 
-    private val uploaded = MutableLiveData<Unit>()
+    private val uploaded =
+        MutableLiveData<Resource<Pair<InternalStripeFile, UploadMethod>>>()
     private val mockUri = mock<Uri>()
 
     private val mockPassportUploadViewModel = mock<PassportUploadViewModel>().also {
         whenever(it.uploaded).thenReturn(uploaded)
     }
 
+    private val verificationPage = mock<VerificationPage>().also {
+        whenever(it.documentCapture).thenReturn(DOCUMENT_CAPTURE)
+    }
+
+    private val mockIdentityViewModel = mock<IdentityViewModel>().also {
+        val successCaptor: KArgumentCaptor<(VerificationPage) -> Unit> = argumentCaptor()
+        whenever(it.observeForVerificationPage(any(), successCaptor.capture(), any())).then {
+            successCaptor.firstValue(verificationPage)
+        }
+    }
+
     @Test
     fun `when initialized viewmodel registers activityResultCaller and UI is correct`() {
-        launchFragment().onFragment {
-            verify(mockPassportUploadViewModel).registerActivityResultCaller(same(it))
-
-            val binding = PassportUploadFragmentBinding.bind(it.requireView())
+        launchFragment { binding, _, fragment ->
+            verify(mockPassportUploadViewModel).registerActivityResultCaller(same(fragment))
 
             assertThat(binding.select.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.progressCircular.visibility).isEqualTo(View.GONE)
@@ -65,45 +87,48 @@ class PassportUploadFragmentTest {
     }
 
     @Test
-    fun `verify upload updates UI`() {
-        launchFragment().onFragment {
-            uploaded.postValue(Unit)
-            val binding = PassportUploadFragmentBinding.bind(it.requireView())
+    fun `verify upload failure navigates to error fragment `() {
+        launchFragment { _, navController, _ ->
+            uploaded.postValue(Resource.error())
 
-            assertThat(binding.select.visibility).isEqualTo(View.GONE)
-            assertThat(binding.progressCircular.visibility).isEqualTo(View.GONE)
-            assertThat(binding.finishedCheckMark.visibility).isEqualTo(View.VISIBLE)
-            assertThat(binding.kontinue.isEnabled).isTrue()
+            assertThat(navController.currentDestination?.id)
+                .isEqualTo(R.id.errorFragment)
         }
     }
 
     @Test
     fun `verify when kontinue is clicked navigates to confirmation`() {
-        launchFragment().onFragment {
-            val navController = TestNavHostController(
-                ApplicationProvider.getApplicationContext()
-            )
-            navController.setGraph(
-                R.navigation.identity_nav_graph
-            )
-            navController.setCurrentDestination(R.id.passportUploadFragment)
-            Navigation.setViewNavController(
-                it.requireView(),
-                navController
-            )
+        launchFragment { binding, navController, _ ->
+            runBlocking {
+                uploaded.postValue(
+                    Resource.success(
+                        Pair(
+                            InternalStripeFile(id = FILE_ID),
+                            UploadMethod.FILEUPLOAD
+                        )
+                    )
+                )
 
-            uploaded.postValue(Unit)
-            val binding = PassportUploadFragmentBinding.bind(it.requireView())
-            binding.kontinue.callOnClick()
+                val collectedDataParamCaptor: KArgumentCaptor<CollectedDataParam> = argumentCaptor()
+                whenever(
+                    mockIdentityViewModel.postVerificationPageData(collectedDataParamCaptor.capture())
+                ).thenReturn(
+                    CORRECT_VERIFICATION_PAGE_DATA
+                )
+                whenever(mockIdentityViewModel.postVerificationPageSubmit()).thenReturn(
+                    CORRECT_VERIFICATION_PAGE_DATA
+                )
 
-            assertThat(navController.currentDestination?.id)
-                .isEqualTo(R.id.confirmationFragment)
+                binding.kontinue.callOnClick()
+
+                assertThat(navController.currentDestination?.id)
+                    .isEqualTo(R.id.confirmationFragment)
+            }
         }
     }
 
     private fun verifyFlow(isTakePhoto: Boolean) {
-        launchFragment().onFragment {
-            val binding = PassportUploadFragmentBinding.bind(it.requireView())
+        launchFragment { binding, _, fragment ->
             binding.select.callOnClick()
 
             val dialog = ShadowDialog.getLatestDialog()
@@ -123,17 +148,17 @@ class PassportUploadFragmentTest {
             assertThat(dialog.isShowing).isFalse()
 
             // viewmodel triggers
-
             val callbackCaptor: KArgumentCaptor<(Uri) -> Unit> = argumentCaptor()
 
             if (isTakePhoto) {
                 verify(mockPassportUploadViewModel).takePhoto(
-                    same(it.requireContext()),
+                    same(fragment.requireContext()),
                     callbackCaptor.capture()
                 )
             } else {
                 verify(mockPassportUploadViewModel).chooseImage(callbackCaptor.capture())
             }
+            uploaded.postValue(Resource.loading())
 
             // mock photo taken/image chosen
             callbackCaptor.firstValue(mockUri)
@@ -141,17 +166,69 @@ class PassportUploadFragmentTest {
             // viewmodel triggers and UI updates
             verify(mockPassportUploadViewModel).uploadImage(
                 same(mockUri),
-                same(it.requireContext())
+                same(fragment.requireContext()),
+                same(DOCUMENT_CAPTURE),
+                if (isTakePhoto)
+                    eq(UploadMethod.MANUALCAPTURE)
+                else
+                    eq(UploadMethod.FILEUPLOAD)
             )
             assertThat(binding.select.visibility).isEqualTo(View.GONE)
             assertThat(binding.progressCircular.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.finishedCheckMark.visibility).isEqualTo(View.GONE)
+
+            // mock file uploaded
+            uploaded.postValue(Resource.success(mock()))
+
+            assertThat(binding.select.visibility).isEqualTo(View.GONE)
+            assertThat(binding.progressCircular.visibility).isEqualTo(View.GONE)
+            assertThat(binding.finishedCheckMark.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.kontinue.isEnabled).isTrue()
         }
     }
 
-    private fun launchFragment() = launchFragmentInContainer(
+    private fun launchFragment(
+        testBlock: (
+            binding: PassportUploadFragmentBinding,
+            navController: TestNavHostController,
+            fragment: PassportUploadFragment
+        ) -> Unit
+    ) = launchFragmentInContainer(
         themeResId = R.style.Theme_MaterialComponents
     ) {
-        PassportUploadFragment(viewModelFactoryFor(mockPassportUploadViewModel))
+        PassportUploadFragment(
+            viewModelFactoryFor(mockPassportUploadViewModel),
+            viewModelFactoryFor(mockIdentityViewModel)
+        )
+    }.onFragment {
+        val navController = TestNavHostController(
+            ApplicationProvider.getApplicationContext()
+        )
+        navController.setGraph(
+            R.navigation.identity_nav_graph
+        )
+        navController.setCurrentDestination(R.id.passportUploadFragment)
+        Navigation.setViewNavController(
+            it.requireView(),
+            navController
+        )
+        testBlock(PassportUploadFragmentBinding.bind(it.requireView()), navController, it)
+    }
+
+    private companion object {
+        val DOCUMENT_CAPTURE =
+            VerificationPageStaticContentDocumentCapturePage(
+                autocaptureTimeout = 0,
+                filePurpose = InternalStripeFilePurpose.IdentityPrivate.code,
+                highResImageCompressionQuality = 0.9f,
+                highResImageCropPadding = 0f,
+                highResImageMaxDimension = 512,
+                lowResImageCompressionQuality = 0f,
+                lowResImageMaxDimension = 0,
+                models = mock(),
+                requireLiveCapture = false
+            )
+
+        val FILE_ID = "file_id"
     }
 }

--- a/identity/src/test/java/com/stripe/android/identity/utils/NavigationUtilsTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/utils/NavigationUtilsTest.kt
@@ -11,12 +11,14 @@ import androidx.navigation.testing.TestNavHostController
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.exception.APIException
+import com.stripe.android.identity.CORRECT_VERIFICATION_PAGE_DATA
+import com.stripe.android.identity.ERROR_BODY
+import com.stripe.android.identity.ERROR_BUTTON_TEXT
+import com.stripe.android.identity.ERROR_TITLE
+import com.stripe.android.identity.ERROR_VERIFICATION_PAGE_DATA
 import com.stripe.android.identity.R
 import com.stripe.android.identity.navigation.ErrorFragment
 import com.stripe.android.identity.networking.models.CollectedDataParam
-import com.stripe.android.identity.networking.models.VerificationPageData
-import com.stripe.android.identity.networking.models.VerificationPageDataRequirementError
-import com.stripe.android.identity.networking.models.VerificationPageDataRequirements
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
@@ -252,40 +254,5 @@ internal class NavigationUtilsTest {
             container: ViewGroup?,
             savedInstanceState: Bundle?
         ) = View(context)
-    }
-
-    private companion object {
-        const val ERROR_BODY = "errorBody"
-        const val ERROR_BUTTON_TEXT = "error button text"
-        const val ERROR_TITLE = "errorTitle"
-
-        val CORRECT_VERIFICATION_PAGE_DATA = VerificationPageData(
-            id = "id",
-            objectType = "type",
-            requirements = VerificationPageDataRequirements(
-                errors = emptyList(),
-                missing = emptyList()
-            ),
-            status = VerificationPageData.Status.VERIFIED,
-            submitted = false
-        )
-
-        val ERROR_VERIFICATION_PAGE_DATA = VerificationPageData(
-            id = "id",
-            objectType = "type",
-            requirements = VerificationPageDataRequirements(
-                errors = listOf(
-                    VerificationPageDataRequirementError(
-                        body = ERROR_BODY,
-                        buttonText = ERROR_BUTTON_TEXT,
-                        requirement = VerificationPageDataRequirementError.Requirement.BIOMETRICCONSENT,
-                        title = ERROR_TITLE
-                    )
-                ),
-                missing = emptyList()
-            ),
-            status = VerificationPageData.Status.VERIFIED,
-            submitted = false
-        )
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Upload file when live capture(camera feed) is not avaialble or disabled by the client, the upload feature is implemented in `PassportUploadFragment`(only 1 image is need), and `IDUploadFragment`/`DriverLicenseUploadFragment`(2 images, back and front are needed)

* When upload is finished, post the uploaded file id to server.

* Note this PR also changed camera-core's `Bitmap.toJpeg` method with a selective compression quality, as Identity needs to compress the uploaded image based on quality param sent from backend.

* Still need to upload files from live capture.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Identity SDK

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
