### PR TITLE
Link cookie storage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,7 @@ ext {
     androidxNavigationVersion = '2.4.1'
     androidxPreferenceVersion = '1.2.0'
     androidxRecyclerviewVersion = '1.2.1'
+    androidxSecurityVersion = '1.1.0-alpha03'
 
     kotlinCoroutinesVersion = '1.6.0'
     kotlinSerializationVersion = '1.3.2'

--- a/link/build.gradle
+++ b/link/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$androidxConstraintlayoutVersion"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$androidxLifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$androidxLifecycleVersion"
+    implementation "androidx.security:security-crypto:$androidxSecurityVersion"
     implementation "com.google.android.material:material:$materialVersion"
     implementation "com.google.dagger:dagger:$daggerVersion"
     kapt "com.google.dagger:dagger-compiler:$daggerVersion"

--- a/link/src/main/java/com/stripe/android/link/account/CookieStore.kt
+++ b/link/src/main/java/com/stripe/android/link/account/CookieStore.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.link.account
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Persistent cookies storage.
+ */
+@Singleton
+internal class CookieStore @Inject constructor(
+    val store: EncryptedStore
+) {
+    /**
+     * Update authentication session cookie according to the following rules:
+     *
+     * +-----------------------------+---------+
+     * |  cookie                     | Action  |
+     * +-----------------------------+---------+
+     * |  null                       | No-op   |
+     * |-----------------------------|---------|
+     * |  Empty (zero-length) string | Delete  |
+     * |-----------------------------|---------|
+     * |  Any other value            | Store   |
+     * +-----------------------------+---------+
+     */
+    fun updateAuthSessionCookie(cookie: String?) = cookie?.let {
+        if (it.isEmpty()) {
+            store.delete(AUTH_SESSION_COOKIE)
+        } else {
+            store.write(AUTH_SESSION_COOKIE, it)
+        }
+    }
+
+    /**
+     * Retrieve and return the current authentication session cookie.
+     */
+    fun getAuthSessionCookie() = store.read(AUTH_SESSION_COOKIE)
+
+    companion object {
+        const val AUTH_SESSION_COOKIE = "auth_session_cookie"
+    }
+}

--- a/link/src/main/java/com/stripe/android/link/account/EncryptedStore.kt
+++ b/link/src/main/java/com/stripe/android/link/account/EncryptedStore.kt
@@ -1,0 +1,51 @@
+package com.stripe.android.link.account
+
+import android.content.Context
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Persistent key-value storage encrypted at rest, backed by [EncryptedSharedPreferences].
+ */
+@Singleton
+internal class EncryptedStore @Inject constructor(
+    val context: Context
+) {
+    private val keyGenParameterSpec = MasterKeys.AES256_GCM_SPEC
+    private val mainKeyAlias = MasterKeys.getOrCreate(keyGenParameterSpec)
+    private val sharedPreferences = EncryptedSharedPreferences.create(
+        FILE_NAME,
+        mainKeyAlias,
+        context.applicationContext,
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+    )
+
+    /**
+     * Write a key-value pair to the encrypted SharedPreferences
+     */
+    fun write(key: String, value: String) = with(sharedPreferences.edit()) {
+        putString(key, value)
+        apply()
+    }
+
+    /**
+     * Read a String value from the encrypted SharedPreferences.
+     * Returns null if value doesn't exist.
+     */
+    fun read(key: String) = sharedPreferences.getString(key, null)
+
+    /**
+     * Delete a value from the encrypted SharedPreferences.
+     */
+    fun delete(key: String) = with(sharedPreferences.edit()) {
+        remove(key)
+        apply()
+    }
+
+    private companion object {
+        const val FILE_NAME = "LinkStore"
+    }
+}

--- a/link/src/main/java/com/stripe/android/link/model/LinkAccount.kt
+++ b/link/src/main/java/com/stripe/android/link/model/LinkAccount.kt
@@ -13,6 +13,8 @@ internal class LinkAccount(consumerSession: ConsumerSession) {
     val isVerified: Boolean = consumerSession.containsVerifiedSMSSession() ||
         consumerSession.isVerifiedForSignup()
 
+    fun getAuthSessionCookie() = consumerSession.authSessionClientSecret
+
     private fun ConsumerSession.containsVerifiedSMSSession() = verificationSessions.find {
         it.type == ConsumerSession.VerificationSession.SessionType.Sms &&
             it.state == ConsumerSession.VerificationSession.SessionState.Verified

--- a/link/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/link/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -29,11 +29,15 @@ internal class LinkApiRepository @Inject constructor(
     private val locale: Locale?
 ) : LinkRepository {
 
-    override suspend fun lookupConsumer(email: String): Result<ConsumerSessionLookup> =
+    override suspend fun lookupConsumer(
+        email: String,
+        authSessionCookie: String?
+    ): Result<ConsumerSessionLookup> =
         withContext(workContext) {
             runCatching {
                 stripeRepository.lookupConsumerSession(
                     email,
+                    authSessionCookie,
                     ApiRequest.Options(
                         publishableKeyProvider(),
                         stripeAccountIdProvider()
@@ -55,7 +59,8 @@ internal class LinkApiRepository @Inject constructor(
     override suspend fun consumerSignUp(
         email: String,
         phone: String,
-        country: String
+        country: String,
+        authSessionCookie: String?
     ): Result<ConsumerSession> =
         withContext(workContext) {
             runCatching {
@@ -63,7 +68,7 @@ internal class LinkApiRepository @Inject constructor(
                     email,
                     phone,
                     country,
-                    null,
+                    authSessionCookie,
                     ApiRequest.Options(
                         publishableKeyProvider(),
                         stripeAccountIdProvider()
@@ -83,13 +88,14 @@ internal class LinkApiRepository @Inject constructor(
         }
 
     override suspend fun startVerification(
-        consumerSessionClientSecret: String
+        consumerSessionClientSecret: String,
+        authSessionCookie: String?
     ): Result<ConsumerSession> = withContext(workContext) {
         runCatching {
             stripeRepository.startConsumerVerification(
                 consumerSessionClientSecret,
                 locale ?: Locale.US,
-                null,
+                authSessionCookie,
                 ApiRequest.Options(
                     publishableKeyProvider(),
                     stripeAccountIdProvider()
@@ -110,13 +116,14 @@ internal class LinkApiRepository @Inject constructor(
 
     override suspend fun confirmVerification(
         consumerSessionClientSecret: String,
-        verificationCode: String
+        verificationCode: String,
+        authSessionCookie: String?
     ): Result<ConsumerSession> = withContext(workContext) {
         runCatching {
             stripeRepository.confirmConsumerVerification(
                 consumerSessionClientSecret,
                 verificationCode,
-                null,
+                authSessionCookie,
                 ApiRequest.Options(
                     publishableKeyProvider(),
                     stripeAccountIdProvider()

--- a/link/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
+++ b/link/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
@@ -13,7 +13,8 @@ internal interface LinkRepository {
      * Check if the email already has a link account.
      */
     suspend fun lookupConsumer(
-        email: String
+        email: String,
+        authSessionCookie: String?
     ): Result<ConsumerSessionLookup>
 
     /**
@@ -22,14 +23,16 @@ internal interface LinkRepository {
     suspend fun consumerSignUp(
         email: String,
         phone: String,
-        country: String
+        country: String,
+        authSessionCookie: String?
     ): Result<ConsumerSession>
 
     /**
      * Start an SMS verification.
      */
     suspend fun startVerification(
-        consumerSessionClientSecret: String
+        consumerSessionClientSecret: String,
+        authSessionCookie: String?
     ): Result<ConsumerSession>
 
     /**
@@ -37,7 +40,8 @@ internal interface LinkRepository {
      */
     suspend fun confirmVerification(
         consumerSessionClientSecret: String,
-        verificationCode: String
+        verificationCode: String,
+        authSessionCookie: String?
     ): Result<ConsumerSession>
 
     /**

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -3,10 +3,12 @@ package com.stripe.android.link.ui.wallet
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -120,8 +122,14 @@ internal fun WalletBody(
     Column(
         modifier = Modifier
             .fillMaxWidth()
+            .fillMaxHeight()
             .padding(20.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = if (paymentDetails.isEmpty()) {
+            Arrangement.Center
+        } else {
+            Arrangement.Top
+        }
     ) {
         if (paymentDetails.isEmpty()) {
             CircularProgressIndicator()

--- a/link/src/test/java/com/stripe/android/link/account/CookieStoreTest.kt
+++ b/link/src/test/java/com/stripe/android/link/account/CookieStoreTest.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.link.account
+
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+
+class CookieStoreTest {
+    private val store = mock<EncryptedStore>()
+
+    @Test
+    fun `updateAuthSessionCookie with null value does nothing`() {
+        val cookieStore = createCookieStore()
+        cookieStore.updateAuthSessionCookie(null)
+
+        verify(store, never()).write(any(), anyOrNull())
+        verify(store, never()).delete(any())
+    }
+
+    @Test
+    fun `updateAuthSessionCookie with empty value deletes value`() {
+        val cookieStore = createCookieStore()
+        val cookie = ""
+        cookieStore.updateAuthSessionCookie(cookie)
+
+        verify(store).delete(any())
+    }
+
+    @Test
+    fun `updateAuthSessionCookie with non-empty value stores value`() {
+        val cookieStore = createCookieStore()
+        val cookie = "cookie"
+        cookieStore.updateAuthSessionCookie(cookie)
+
+        verify(store).write(any(), eq(cookie))
+    }
+
+    private fun createCookieStore() = CookieStore(store)
+}

--- a/link/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/link/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -15,7 +15,6 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.eq
-import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -37,10 +36,12 @@ class LinkApiRepositoryTest {
     @Test
     fun `lookupConsumer sends correct parameters`() = runTest {
         val email = "email@example.com"
-        linkRepository.lookupConsumer(email)
+        val cookie = "cookie1"
+        linkRepository.lookupConsumer(email, cookie)
 
         verify(stripeRepository).lookupConsumerSession(
             eq(email),
+            eq(cookie),
             eq(ApiRequest.Options(PUBLISHABLE_KEY, STRIPE_ACCOUNT_ID))
         )
     }
@@ -48,10 +49,10 @@ class LinkApiRepositoryTest {
     @Test
     fun `lookupConsumer returns successful result`() = runTest {
         val consumerSessionLookup = mock<ConsumerSessionLookup>()
-        whenever(stripeRepository.lookupConsumerSession(any(), any()))
+        whenever(stripeRepository.lookupConsumerSession(any(), any(), any()))
             .thenReturn(consumerSessionLookup)
 
-        val result = linkRepository.lookupConsumer("email")
+        val result = linkRepository.lookupConsumer("email", "cookie")
 
         assertThat(result.isSuccess).isTrue()
         assertThat(result.getOrNull()).isEqualTo(consumerSessionLookup)
@@ -59,10 +60,10 @@ class LinkApiRepositoryTest {
 
     @Test
     fun `lookupConsumer catches exception and returns failure`() = runTest {
-        whenever(stripeRepository.lookupConsumerSession(any(), any()))
+        whenever(stripeRepository.lookupConsumerSession(any(), any(), any()))
             .thenThrow(RuntimeException("error"))
 
-        val result = linkRepository.lookupConsumer("email")
+        val result = linkRepository.lookupConsumer("email", "cookie")
 
         assertThat(result.isFailure).isTrue()
     }
@@ -72,13 +73,14 @@ class LinkApiRepositoryTest {
         val email = "email@example.com"
         val phone = "phone"
         val country = "US"
-        linkRepository.consumerSignUp(email, phone, country)
+        val cookie = "cookie2"
+        linkRepository.consumerSignUp(email, phone, country, cookie)
 
         verify(stripeRepository).consumerSignUp(
             eq(email),
             eq(phone),
             eq(country),
-            isNull(),
+            eq(cookie),
             eq(ApiRequest.Options(PUBLISHABLE_KEY, STRIPE_ACCOUNT_ID))
         )
     }
@@ -89,7 +91,7 @@ class LinkApiRepositoryTest {
         whenever(stripeRepository.consumerSignUp(any(), any(), any(), anyOrNull(), any()))
             .thenReturn(consumerSession)
 
-        val result = linkRepository.consumerSignUp("email", "phone", "country")
+        val result = linkRepository.consumerSignUp("email", "phone", "country", "cookie")
 
         assertThat(result.isSuccess).isTrue()
         assertThat(result.getOrNull()).isEqualTo(consumerSession)
@@ -100,7 +102,7 @@ class LinkApiRepositoryTest {
         whenever(stripeRepository.consumerSignUp(any(), any(), any(), anyOrNull(), any()))
             .thenThrow(RuntimeException("error"))
 
-        val result = linkRepository.consumerSignUp("email", "phone", "country")
+        val result = linkRepository.consumerSignUp("email", "phone", "country", "cookie")
 
         assertThat(result.isFailure).isTrue()
     }
@@ -108,12 +110,13 @@ class LinkApiRepositoryTest {
     @Test
     fun `startVerification sends correct parameters`() = runTest {
         val secret = "secret"
-        linkRepository.startVerification(secret)
+        val cookie = "cookie1"
+        linkRepository.startVerification(secret, cookie)
 
         verify(stripeRepository).startConsumerVerification(
             eq(secret),
             eq(Locale.US),
-            isNull(),
+            eq(cookie),
             eq(ApiRequest.Options(PUBLISHABLE_KEY, STRIPE_ACCOUNT_ID))
         )
     }
@@ -124,7 +127,7 @@ class LinkApiRepositoryTest {
         whenever(stripeRepository.startConsumerVerification(any(), any(), anyOrNull(), any()))
             .thenReturn(consumerSession)
 
-        val result = linkRepository.startVerification("secret")
+        val result = linkRepository.startVerification("secret", "cookie")
 
         assertThat(result.isSuccess).isTrue()
         assertThat(result.getOrNull()).isEqualTo(consumerSession)
@@ -135,7 +138,7 @@ class LinkApiRepositoryTest {
         whenever(stripeRepository.startConsumerVerification(any(), any(), anyOrNull(), any()))
             .thenThrow(RuntimeException("error"))
 
-        val result = linkRepository.startVerification("secret")
+        val result = linkRepository.startVerification("secret", "cookie")
 
         assertThat(result.isFailure).isTrue()
     }
@@ -144,12 +147,13 @@ class LinkApiRepositoryTest {
     fun `confirmVerification sends correct parameters`() = runTest {
         val secret = "secret"
         val code = "code"
-        linkRepository.confirmVerification(secret, code)
+        val cookie = "cookie2"
+        linkRepository.confirmVerification(secret, code, cookie)
 
         verify(stripeRepository).confirmConsumerVerification(
             eq(secret),
             eq(code),
-            isNull(),
+            eq(cookie),
             eq(ApiRequest.Options(PUBLISHABLE_KEY, STRIPE_ACCOUNT_ID))
         )
     }
@@ -160,7 +164,7 @@ class LinkApiRepositoryTest {
         whenever(stripeRepository.confirmConsumerVerification(any(), any(), anyOrNull(), any()))
             .thenReturn(consumerSession)
 
-        val result = linkRepository.confirmVerification("secret", "code")
+        val result = linkRepository.confirmVerification("secret", "code", "cookie")
 
         assertThat(result.isSuccess).isTrue()
         assertThat(result.getOrNull()).isEqualTo(consumerSession)
@@ -171,7 +175,7 @@ class LinkApiRepositoryTest {
         whenever(stripeRepository.confirmConsumerVerification(any(), any(), anyOrNull(), any()))
             .thenThrow(RuntimeException("error"))
 
-        val result = linkRepository.confirmVerification("secret", "code")
+        val result = linkRepository.confirmVerification("secret", "code", "cookie")
 
         assertThat(result.isFailure).isTrue()
     }

--- a/payments-core/src/main/java/com/stripe/android/model/ConsumerSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConsumerSession.kt
@@ -14,7 +14,8 @@ data class ConsumerSession internal constructor(
     val clientSecret: String,
     val emailAddress: String,
     val redactedPhoneNumber: String,
-    val verificationSessions: List<VerificationSession>
+    val verificationSessions: List<VerificationSession>,
+    val authSessionClientSecret: String?
 ) : StripeModel {
 
     @Parcelize

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/ConsumerSessionJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/ConsumerSessionJsonParser.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.model.parsers
 
+import com.stripe.android.core.model.StripeJsonUtils.optString
 import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.ConsumerSession
 import org.json.JSONObject
@@ -20,7 +21,8 @@ internal class ConsumerSessionJsonParser : ModelJsonParser<ConsumerSession> {
             consumerSessionJson.getString(FIELD_CONSUMER_SESSION_SECRET),
             consumerSessionJson.getString(FIELD_CONSUMER_SESSION_EMAIL),
             consumerSessionJson.getString(FIELD_CONSUMER_SESSION_PHONE),
-            verificationSession
+            verificationSession,
+            optString(json, FIELD_CONSUMER_SESSION_AUTH_SESSION_SECRET)
         )
     }
 
@@ -41,6 +43,7 @@ internal class ConsumerSessionJsonParser : ModelJsonParser<ConsumerSession> {
         private const val FIELD_CONSUMER_SESSION_EMAIL = "email_address"
         private const val FIELD_CONSUMER_SESSION_PHONE = "redacted_phone_number"
         private const val FIELD_CONSUMER_SESSION_VERIFICATION_SESSIONS = "verification_sessions"
+        private const val FIELD_CONSUMER_SESSION_AUTH_SESSION_SECRET = "auth_session_client_secret"
 
         private const val FIELD_VERIFICATION_SESSION_TYPE = "type"
         private const val FIELD_VERIFICATION_SESSION_STATE = "state"

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1158,6 +1158,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
      */
     override suspend fun lookupConsumerSession(
         email: String,
+        authSessionCookie: String?,
         requestOptions: ApiRequest.Options
     ): ConsumerSessionLookup? {
         return fetchStripeModel(
@@ -1165,6 +1166,14 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                 consumerSessionLookupUrl,
                 requestOptions,
                 mapOf("email_address" to email.lowercase())
+                    .plus(
+                        authSessionCookie?.let {
+                            mapOf(
+                                "cookies" to
+                                    mapOf("verification_session_client_secrets" to listOf(it))
+                            )
+                        } ?: emptyMap()
+                    )
             ),
             ConsumerSessionLookupJsonParser()
         ) {
@@ -1179,7 +1188,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
         email: String,
         phoneNumber: String,
         country: String,
-        cookies: String?,
+        authSessionCookie: String?,
         requestOptions: ApiRequest.Options
     ): ConsumerSession? {
         return fetchStripeModel(
@@ -1191,9 +1200,12 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                     "phone_number" to phoneNumber,
                     "country" to country
                 ).plus(
-                    cookies?.let {
-                        listOf("cookies" to it)
-                    } ?: emptyList()
+                    authSessionCookie?.let {
+                        mapOf(
+                            "cookies" to
+                                mapOf("verification_session_client_secrets" to listOf(it))
+                        )
+                    } ?: emptyMap()
                 )
             ),
             ConsumerSessionJsonParser()
@@ -1208,7 +1220,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
     override suspend fun startConsumerVerification(
         consumerSessionClientSecret: String,
         locale: Locale,
-        cookies: String?,
+        authSessionCookie: String?,
         requestOptions: ApiRequest.Options
     ): ConsumerSession? {
         return fetchStripeModel(
@@ -1222,9 +1234,12 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                     "type" to "SMS",
                     "locale" to locale.toLanguageTag()
                 ).plus(
-                    cookies?.let {
-                        listOf("cookies" to it)
-                    } ?: emptyList()
+                    authSessionCookie?.let {
+                        mapOf(
+                            "cookies" to
+                                mapOf("verification_session_client_secrets" to listOf(it))
+                        )
+                    } ?: emptyMap()
                 )
             ),
             ConsumerSessionJsonParser()
@@ -1239,7 +1254,7 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
     override suspend fun confirmConsumerVerification(
         consumerSessionClientSecret: String,
         verificationCode: String,
-        cookies: String?,
+        authSessionCookie: String?,
         requestOptions: ApiRequest.Options
     ): ConsumerSession? {
         return fetchStripeModel(
@@ -1254,9 +1269,12 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                     "code" to verificationCode,
                     "client_type" to "MOBILE_SDK"
                 ).plus(
-                    cookies?.let {
-                        listOf("cookies" to it)
-                    } ?: emptyList()
+                    authSessionCookie?.let {
+                        mapOf(
+                            "cookies" to
+                                mapOf("verification_session_client_secrets" to listOf(it))
+                        )
+                    } ?: emptyMap()
                 )
             ),
             ConsumerSessionJsonParser()

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -396,6 +396,7 @@ abstract class StripeRepository {
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     abstract suspend fun lookupConsumerSession(
         email: String,
+        authSessionCookie: String?,
         requestOptions: ApiRequest.Options
     ): ConsumerSessionLookup?
 
@@ -404,7 +405,7 @@ abstract class StripeRepository {
         email: String,
         phoneNumber: String,
         country: String,
-        cookies: String?,
+        authSessionCookie: String?,
         requestOptions: ApiRequest.Options
     ): ConsumerSession?
 
@@ -412,7 +413,7 @@ abstract class StripeRepository {
     abstract suspend fun startConsumerVerification(
         consumerSessionClientSecret: String,
         locale: Locale,
-        cookies: String?,
+        authSessionCookie: String?,
         requestOptions: ApiRequest.Options
     ): ConsumerSession?
 
@@ -420,7 +421,7 @@ abstract class StripeRepository {
     abstract suspend fun confirmConsumerVerification(
         consumerSessionClientSecret: String,
         verificationCode: String,
-        cookies: String?,
+        authSessionCookie: String?,
         requestOptions: ApiRequest.Options
     ): ConsumerSession?
 

--- a/payments-core/src/test/java/com/stripe/android/model/ConsumerFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ConsumerFixtures.kt
@@ -22,6 +22,7 @@ object ConsumerFixtures {
     val EXISTING_CONSUMER_JSON = JSONObject(
         """
             {
+              "auth_session_client_secret": null,
               "consumer_session": {
                 "client_secret": "secret",
                 "email_address": "email@example.com",
@@ -44,6 +45,7 @@ object ConsumerFixtures {
     val CONSUMER_VERIFICATION_STARTED_JSON = JSONObject(
         """
             {
+              "auth_session_client_secret": "21yKkFYNnhMVTlXbXdBQUFJRmEaJDNmZDE1",
               "consumer_session": {
                 "client_secret": "12oBEhVjc21yKkFYNnhMVTlXbXdBQUFJRmEaJDNmZDE1MjA5LTM1YjctND",
                 "email_address": "test@stripe.com",
@@ -72,6 +74,7 @@ object ConsumerFixtures {
     val CONSUMER_VERIFIED_JSON = JSONObject(
         """
             {
+              "auth_session_client_secret": null,
               "consumer_session": {
                 "client_secret": "12oBEhVjc21yKkFYNnhMVTlXbXdBQUFJRmEaJDUzNTFkNjNhLTZkNGMtND",
                 "email_address": "test@stripe.com",
@@ -102,6 +105,7 @@ object ConsumerFixtures {
     val CONSUMER_SIGNUP_STARTED_JSON = JSONObject(
         """
             {
+              "auth_session_client_secret": null,
               "consumer_session": {
                 "client_secret": "12oBEhVjc21yKkFYNmNWT0JmaFFBQUFLUXcaJDk5OGFjYTFlLTkxMWYtND",
                 "email_address": "test@stripe.com",

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerSessionJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerSessionJsonParserTest.kt
@@ -20,7 +20,8 @@ class ConsumerSessionJsonParserTest {
                         type = ConsumerSession.VerificationSession.SessionType.Sms,
                         state = ConsumerSession.VerificationSession.SessionState.Started
                     )
-                )
+                ),
+                authSessionClientSecret = "21yKkFYNnhMVTlXbXdBQUFJRmEaJDNmZDE1"
             )
         )
     }
@@ -38,7 +39,8 @@ class ConsumerSessionJsonParserTest {
                         type = ConsumerSession.VerificationSession.SessionType.Sms,
                         state = ConsumerSession.VerificationSession.SessionState.Verified
                     )
-                )
+                ),
+                authSessionClientSecret = null
             )
         )
     }
@@ -56,7 +58,8 @@ class ConsumerSessionJsonParserTest {
                         type = ConsumerSession.VerificationSession.SessionType.SignUp,
                         state = ConsumerSession.VerificationSession.SessionState.Started
                     )
-                )
+                ),
+                authSessionClientSecret = null
             )
         )
     }

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerSessionLookupJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerSessionLookupJsonParserTest.kt
@@ -30,7 +30,8 @@ class ConsumerSessionLookupJsonParserTest {
                     clientSecret = "secret",
                     emailAddress = "email@example.com",
                     redactedPhoneNumber = "+1********68",
-                    verificationSessions = emptyList()
+                    verificationSessions = emptyList(),
+                    authSessionClientSecret = null
                 ),
                 errorMessage = null
             )

--- a/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
@@ -281,6 +281,7 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
 
     override suspend fun lookupConsumerSession(
         email: String,
+        authSessionCookie: String?,
         requestOptions: ApiRequest.Options
     ): ConsumerSessionLookup? {
         return null
@@ -290,7 +291,7 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         email: String,
         phoneNumber: String,
         country: String,
-        cookies: String?,
+        authSessionCookie: String?,
         requestOptions: ApiRequest.Options
     ): ConsumerSession? {
         return null
@@ -299,7 +300,7 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
     override suspend fun startConsumerVerification(
         consumerSessionClientSecret: String,
         locale: Locale,
-        cookies: String?,
+        authSessionCookie: String?,
         requestOptions: ApiRequest.Options
     ): ConsumerSession? {
         return null
@@ -308,7 +309,7 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
     override suspend fun confirmConsumerVerification(
         consumerSessionClientSecret: String,
         verificationCode: String,
-        cookies: String?,
+        authSessionCookie: String?,
         requestOptions: ApiRequest.Options
     ): ConsumerSession? {
         return null

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -1594,14 +1594,19 @@ internal class StripeApiRepositoryTest {
                 .thenReturn(stripeResponse)
 
             val email = "email@example.com"
+            val cookie = "cookie1"
             create().lookupConsumerSession(
                 email,
+                cookie,
                 DEFAULT_OPTIONS
             )
 
             verify(stripeNetworkClient).executeRequest(apiRequestArgumentCaptor.capture())
             val params = requireNotNull(apiRequestArgumentCaptor.firstValue.params)
             assertEquals(params["email_address"], email)
+            val cookies = params["cookies"] as Map<*, *>
+            val secret = cookies["verification_session_client_secrets"] as Collection<*>
+            assertThat(secret).containsExactly(cookie)
         }
 
     @Test
@@ -1618,12 +1623,12 @@ internal class StripeApiRepositoryTest {
             val email = "email@example.com"
             val phoneNumber = "phone number"
             val country = "US"
-            val cookies = "cookie1,cookie2"
+            val cookie = "cookie1"
             create().consumerSignUp(
                 email,
                 phoneNumber,
                 country,
-                cookies,
+                cookie,
                 DEFAULT_OPTIONS
             )
 
@@ -1632,7 +1637,9 @@ internal class StripeApiRepositoryTest {
             assertEquals(params["email_address"], email)
             assertEquals(params["phone_number"], phoneNumber)
             assertEquals(params["country"], country)
-            assertEquals(params["cookies"], cookies)
+            val cookies = params["cookies"] as Map<*, *>
+            val secret = cookies["verification_session_client_secrets"] as Collection<*>
+            assertThat(secret).containsExactly(cookie)
         }
 
     @Test
@@ -1648,11 +1655,11 @@ internal class StripeApiRepositoryTest {
 
             val clientSecret = "secret"
             val locale = Locale.US
-            val cookies = "cookie1,cookie2"
+            val cookie = "cookie2"
             create().startConsumerVerification(
                 clientSecret,
                 locale,
-                cookies,
+                cookie,
                 DEFAULT_OPTIONS
             )
 
@@ -1662,7 +1669,9 @@ internal class StripeApiRepositoryTest {
             assertEquals(credentials["consumer_session_client_secret"], clientSecret)
             assertEquals(params["type"], "SMS")
             assertEquals(params["locale"], locale.toLanguageTag())
-            assertEquals(params["cookies"], cookies)
+            val cookies = params["cookies"] as Map<*, *>
+            val secret = cookies["verification_session_client_secrets"] as Collection<*>
+            assertThat(secret).containsExactly(cookie)
         }
 
     @Test
@@ -1678,11 +1687,11 @@ internal class StripeApiRepositoryTest {
 
             val clientSecret = "secret"
             val verificationCode = "1234"
-            val cookies = "cookie1,cookie2"
+            val cookie = "cookie1"
             create().confirmConsumerVerification(
                 clientSecret,
                 verificationCode,
-                cookies,
+                cookie,
                 DEFAULT_OPTIONS
             )
 
@@ -1692,7 +1701,9 @@ internal class StripeApiRepositoryTest {
             assertEquals(credentials["consumer_session_client_secret"], clientSecret)
             assertEquals(params["type"], "SMS")
             assertEquals(params["code"], verificationCode)
-            assertEquals(params["cookies"], cookies)
+            val cookies = params["cookies"] as Map<*, *>
+            val secret = cookies["verification_session_client_secrets"] as Collection<*>
+            assertThat(secret).containsExactly(cookie)
         }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Store cookies in encrypted SharedPreferences so user session is persisted.
Send cookies in API calls.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Persist user sign in status.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
