### PR TITLE
[Identity] Add a constructor to create from Fragment

### DIFF
--- a/identity/api/identity.api
+++ b/identity/api/identity.api
@@ -12,6 +12,7 @@ public abstract interface class com/stripe/android/identity/IdentityVerification
 
 public final class com/stripe/android/identity/IdentityVerificationSheet$Companion {
 	public final fun create (Landroidx/activity/ComponentActivity;Lcom/stripe/android/identity/IdentityVerificationSheet$Configuration;)Lcom/stripe/android/identity/IdentityVerificationSheet;
+	public final fun create (Landroidx/fragment/app/Fragment;Lcom/stripe/android/identity/IdentityVerificationSheet$Configuration;)Lcom/stripe/android/identity/IdentityVerificationSheet;
 }
 
 public final class com/stripe/android/identity/IdentityVerificationSheet$Configuration {

--- a/identity/src/main/java/com/stripe/android/identity/IdentityVerificationSheet.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityVerificationSheet.kt
@@ -3,8 +3,10 @@ package com.stripe.android.identity
 import android.content.Intent
 import android.os.Parcelable
 import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.DrawableRes
 import androidx.core.os.bundleOf
+import androidx.fragment.app.Fragment
 import kotlinx.parcelize.Parcelize
 
 interface IdentityVerificationSheet {
@@ -43,7 +45,7 @@ interface IdentityVerificationSheet {
     }
 
     /**
-     * Start the verification flow
+     * Starts the verification flow.
      */
     fun present(
         verificationSessionId: String,
@@ -53,10 +55,25 @@ interface IdentityVerificationSheet {
 
     companion object {
         /**
-         * Factory method to create a [IdentityVerificationSheet] instance.
+         * Creates a [IdentityVerificationSheet] instance with [ComponentActivity].
+         *
+         * This API registers an [ActivityResultLauncher] into the
+         * [ComponentActivity], it must be called before the [ComponentActivity]
+         * is created (in the onCreate method).
          */
         fun create(
             from: ComponentActivity,
+            configuration: Configuration,
+        ): IdentityVerificationSheet = StripeIdentityVerificationSheet(from, configuration)
+
+        /**
+         * Creates a [IdentityVerificationSheet] instance with [Fragment].
+         *
+         * This API registers an [ActivityResultLauncher] into the [Fragment], it must be called
+         * before the [Fragment] is created (in the onCreate method).
+         */
+        fun create(
+            from: Fragment,
             configuration: Configuration,
         ): IdentityVerificationSheet = StripeIdentityVerificationSheet(from, configuration)
     }

--- a/identity/src/main/java/com/stripe/android/identity/StripeIdentityVerificationSheet.kt
+++ b/identity/src/main/java/com/stripe/android/identity/StripeIdentityVerificationSheet.kt
@@ -1,15 +1,27 @@
 package com.stripe.android.identity
 
 import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
+import androidx.fragment.app.Fragment
 
-internal class StripeIdentityVerificationSheet(
-    from: ComponentActivity,
+internal class StripeIdentityVerificationSheet private constructor(
+    activityResultCaller: ActivityResultCaller,
     private val configuration: IdentityVerificationSheet.Configuration
 ) : IdentityVerificationSheet {
 
+    constructor(
+        from: ComponentActivity,
+        configuration: IdentityVerificationSheet.Configuration
+    ) : this(from as ActivityResultCaller, configuration)
+
+    constructor(
+        from: Fragment,
+        configuration: IdentityVerificationSheet.Configuration
+    ) : this(from as ActivityResultCaller, configuration)
+
     private val activityResultLauncher: ActivityResultLauncher<IdentityVerificationSheetContract.Args> =
-        from.registerForActivityResult(
+        activityResultCaller.registerForActivityResult(
             IdentityVerificationSheetContract(),
             ::onResult
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add a constructor method to create `IdentityVerificationSheet` from `Fragment`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Let Identity SDK be able to use from a [Fragment]

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
