### PR TITLE
[Identity] Network & UI - 3 of 3: `ConfirmationFragment`

### DIFF
--- a/identity/res/layout/confirmation_fragment.xml
+++ b/identity/res/layout/confirmation_fragment.xml
@@ -30,7 +30,8 @@
                 android:background="?android:colorPrimary"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
-                app:tint="@android:color/white" />
+                app:tint="@android:color/white"
+                android:contentDescription="@string/description_clock"/>
 
             <TextView
                 android:id="@+id/title_text"

--- a/identity/res/values/strings.xml
+++ b/identity/res/values/strings.xml
@@ -59,6 +59,7 @@
     <string name="unexpected_error_try_again">There was an unexpected error — try again in a few seconds</string>
     <string name="go_back">Go Back</string>
     <string name="description_exclamation_mark">Exclamation point for error page</string>
+    <string name="description_clock">Clock icon</string>
     <string name="loading">Loading</string>
     <string name="sample_consent_body_response"><![CDATA[<p><strong>How Stripe will verify your identity</strong></p>\n\n<p>Stripe will use biometric technology (on images of you and your IDs) and other data sources to confirm your identity and for fraud and security purposes. Stripe will store these images and the results of this check and share them with mlgb.band.</p>\n\n<p><a href=\"https://stripe.com/about\">Learn about Stripe</a></p><p><a href=\"https://stripe.com/privacy-center/legal#stripe-identity\">Learn how Stripe Identity works</a></p>]]></string>
     <string name="sample_privacy_policy"><![CDATA[Data will be stored and may be used according to the <a href=\"http://stripe.com/privacy\">Stripe Privacy Policy</a> and <a href=\"\">mlgb.band</a> Privacy Policy.]]></string>

--- a/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
@@ -16,7 +16,7 @@ import com.stripe.android.identity.viewmodel.IdentityViewModel
 /**
  * Host activity to perform Identity verification.
  */
-internal class IdentityActivity : CameraPermissionCheckingActivity() {
+internal class IdentityActivity : CameraPermissionCheckingActivity(), VerificationFlowFinishable {
     private val binding by lazy {
         IdentityActivityBinding.inflate(layoutInflater)
     }
@@ -32,7 +32,8 @@ internal class IdentityActivity : CameraPermissionCheckingActivity() {
             this,
             this,
             this,
-            starterArgs
+            starterArgs,
+            this
         )
     }
 
@@ -61,7 +62,7 @@ internal class IdentityActivity : CameraPermissionCheckingActivity() {
         finishWithResult(VerificationResult.Canceled)
     }
 
-    private fun finishWithResult(result: VerificationResult) {
+    override fun finishWithResult(result: VerificationResult) {
         setResult(
             Activity.RESULT_OK,
             Intent().putExtras(result.toBundle())

--- a/identity/src/main/java/com/stripe/android/identity/VerificationFlowFinishable.kt
+++ b/identity/src/main/java/com/stripe/android/identity/VerificationFlowFinishable.kt
@@ -1,0 +1,8 @@
+package com.stripe.android.identity
+
+/**
+ * An interface to indicate this class is able to finish verification flow with result.
+ */
+internal fun interface VerificationFlowFinishable {
+    fun finishWithResult(result: IdentityVerificationSheet.VerificationResult)
+}

--- a/identity/src/main/java/com/stripe/android/identity/navigation/ConfirmationFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ConfirmationFragment.kt
@@ -1,25 +1,66 @@
 package com.stripe.android.identity.navigation
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.ViewModelProvider
+import com.stripe.android.identity.IdentityVerificationSheet
+import com.stripe.android.identity.VerificationFlowFinishable
 import com.stripe.android.identity.databinding.ConfirmationFragmentBinding
+import com.stripe.android.identity.utils.navigateToDefaultErrorFragment
+import com.stripe.android.identity.utils.setHtmlString
+import com.stripe.android.identity.viewmodel.IdentityViewModel
 
 /**
  * Fragment for confirmation.
  */
-internal class ConfirmationFragment : Fragment() {
+internal class ConfirmationFragment(
+    private val identityViewModelFactory: ViewModelProvider.Factory,
+    private val verificationFlowFinishable: VerificationFlowFinishable
+) : Fragment() {
+
+    private val identityViewModel: IdentityViewModel by activityViewModels {
+        identityViewModelFactory
+    }
+
+    private lateinit var binding: ConfirmationFragmentBinding
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val binding = ConfirmationFragmentBinding.inflate(inflater, container, false)
-        // TODO(ccen) set text to bindings from network response
-
+        binding = ConfirmationFragmentBinding.inflate(inflater, container, false)
+        binding.kontinue.setOnClickListener {
+            verificationFlowFinishable.finishWithResult(
+                IdentityVerificationSheet.VerificationResult.Completed
+            )
+        }
         return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        identityViewModel.observeForVerificationPage(
+            viewLifecycleOwner,
+            onSuccess = { verificationPage ->
+                binding.titleText.text = verificationPage.success.title
+                binding.contentText.setHtmlString(verificationPage.success.body)
+                binding.kontinue.text = verificationPage.success.buttonText
+            },
+            onFailure = {
+                Log.e(TAG, "Failed to get VerificationPage")
+                navigateToDefaultErrorFragment()
+            }
+        )
+    }
+
+    private companion object {
+        val TAG: String = ConfirmationFragment::class.java.simpleName
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
@@ -6,6 +6,7 @@ import androidx.fragment.app.FragmentFactory
 import com.stripe.android.camera.AppSettingsOpenable
 import com.stripe.android.camera.CameraPermissionEnsureable
 import com.stripe.android.identity.IdentityVerificationSheetContract
+import com.stripe.android.identity.VerificationFlowFinishable
 import com.stripe.android.identity.networking.DefaultIdentityRepository
 import com.stripe.android.identity.viewmodel.CameraViewModel
 import com.stripe.android.identity.viewmodel.FrontBackUploadViewModel
@@ -19,7 +20,8 @@ internal class IdentityFragmentFactory(
     context: Context,
     private val cameraPermissionEnsureable: CameraPermissionEnsureable,
     private val appSettingsOpenable: AppSettingsOpenable,
-    verificationArgs: IdentityVerificationSheetContract.Args
+    verificationArgs: IdentityVerificationSheetContract.Args,
+    private val verificationFlowFinishable: VerificationFlowFinishable
 ) : FragmentFactory() {
     private val identityRepository = DefaultIdentityRepository(context)
     private val cameraViewModelFactory = CameraViewModel.CameraViewModelFactory()
@@ -76,6 +78,10 @@ internal class IdentityFragmentFactory(
             )
             DocSelectionFragment::class.java.name -> DocSelectionFragment(
                 identityViewModelFactory
+            )
+            ConfirmationFragment::class.java.name -> ConfirmationFragment(
+                identityViewModelFactory,
+                verificationFlowFinishable
             )
             else -> super.instantiate(classLoader, className)
         }

--- a/identity/src/main/java/com/stripe/android/identity/utils/navigationUtils.kt
+++ b/identity/src/main/java/com/stripe/android/identity/utils/navigationUtils.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.identity.utils
 
+import android.util.Log
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.stripe.android.identity.R
@@ -51,11 +52,18 @@ internal suspend fun Fragment.postVerificationPageDataAndMaybeSubmit(
                         identityViewModel.postVerificationPageSubmit()
                     }.fold(
                         onSuccess = { submittedVerificationPageData ->
-                            if (submittedVerificationPageData.hasError()) {
-                                navigateToRequirementErrorFragment(submittedVerificationPageData.requirements.errors[0])
-                            } else {
-                                findNavController()
-                                    .navigate(R.id.action_global_confirmationFragment)
+                            when {
+                                submittedVerificationPageData.hasError() -> {
+                                    navigateToRequirementErrorFragment(submittedVerificationPageData.requirements.errors[0])
+                                }
+                                submittedVerificationPageData.submitted -> {
+                                    findNavController()
+                                        .navigate(R.id.action_global_confirmationFragment)
+                                }
+                                else -> {
+                                    Log.e(TAG, "VerificationPage submit failed")
+                                    navigateToDefaultErrorFragment()
+                                }
                             }
                         },
                         onFailure = {
@@ -91,3 +99,5 @@ private fun Fragment.navigateToRequirementErrorFragment(
 internal fun Fragment.navigateToDefaultErrorFragment() {
     findNavController().navigateToErrorFragmentWithDefaultValues(requireContext())
 }
+
+private const val TAG = "NAVIGATION_UTIL"

--- a/identity/src/test/java/com/stripe/android/identity/TestFixtures.kt
+++ b/identity/src/test/java/com/stripe/android/identity/TestFixtures.kt
@@ -8,7 +8,7 @@ internal const val ERROR_BODY = "errorBody"
 internal const val ERROR_BUTTON_TEXT = "error button text"
 internal const val ERROR_TITLE = "errorTitle"
 
-internal val CORRECT_VERIFICATION_PAGE_DATA = VerificationPageData(
+internal val CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA = VerificationPageData(
     id = "id",
     objectType = "type",
     requirements = VerificationPageDataRequirements(
@@ -17,6 +17,17 @@ internal val CORRECT_VERIFICATION_PAGE_DATA = VerificationPageData(
     ),
     status = VerificationPageData.Status.VERIFIED,
     submitted = false
+)
+
+internal val CORRECT_WITH_SUBMITTED_SUCCESS_VERIFICATION_PAGE_DATA = VerificationPageData(
+    id = "id",
+    objectType = "type",
+    requirements = VerificationPageDataRequirements(
+        errors = emptyList(),
+        missing = emptyList()
+    ),
+    status = VerificationPageData.Status.VERIFIED,
+    submitted = true
 )
 
 internal val ERROR_VERIFICATION_PAGE_DATA = VerificationPageData(

--- a/identity/src/test/java/com/stripe/android/identity/navigation/ConfirmationFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/ConfirmationFragmentTest.kt
@@ -1,0 +1,133 @@
+package com.stripe.android.identity.navigation
+
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.navigation.Navigation
+import androidx.navigation.testing.TestNavHostController
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.identity.IdentityVerificationSheet
+import com.stripe.android.identity.R
+import com.stripe.android.identity.VerificationFlowFinishable
+import com.stripe.android.identity.databinding.ConfirmationFragmentBinding
+import com.stripe.android.identity.networking.models.VerificationPage
+import com.stripe.android.identity.networking.models.VerificationPageStaticContentTextPage
+import com.stripe.android.identity.viewModelFactoryFor
+import com.stripe.android.identity.viewmodel.IdentityViewModel
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.KArgumentCaptor
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ConfirmationFragmentTest {
+
+    private val mockVerificationFlowFinishable = mock<VerificationFlowFinishable>()
+
+    private val mockIdentityViewModel = mock<IdentityViewModel>()
+
+    private val verificationPage = mock<VerificationPage>().also {
+        whenever(it.success).thenReturn(
+            VerificationPageStaticContentTextPage(
+                body = CONFIRMATION_BODY,
+                buttonText = CONFIRMATION_BUTTON_TEXT,
+                title = CONFIRMATION_TITLE
+            )
+        )
+    }
+
+    private fun setUpSuccessVerificationPage() {
+        val successCaptor: KArgumentCaptor<(VerificationPage) -> Unit> = argumentCaptor()
+        verify(
+            mockIdentityViewModel,
+            times(1)
+        ).observeForVerificationPage(
+            any(),
+            successCaptor.capture(),
+            any()
+        )
+        successCaptor.lastValue(verificationPage)
+    }
+
+    private fun setUpErrorVerificationPage() {
+        val failureCaptor: KArgumentCaptor<(Throwable?) -> Unit> = argumentCaptor()
+        verify(
+            mockIdentityViewModel
+        ).observeForVerificationPage(
+            any(),
+            any(),
+            failureCaptor.capture()
+        )
+        failureCaptor.firstValue(null)
+    }
+
+    @Test
+    fun `when verification page is available UI is bound correctly`() {
+        launchConfirmationFragment { binding, _ ->
+            setUpSuccessVerificationPage()
+
+            assertThat(binding.titleText.text).isEqualTo(CONFIRMATION_TITLE)
+            assertThat(binding.contentText.text.toString()).isEqualTo(CONFIRMATION_BODY)
+            assertThat(binding.kontinue.text).isEqualTo(CONFIRMATION_BUTTON_TEXT)
+        }
+    }
+
+    @Test
+    fun `when finish button clicked then finish with completed`() {
+        launchConfirmationFragment { binding, _ ->
+            setUpSuccessVerificationPage()
+            binding.kontinue.callOnClick()
+
+            verify(mockVerificationFlowFinishable).finishWithResult(
+                eq(IdentityVerificationSheet.VerificationResult.Completed)
+            )
+        }
+    }
+
+    @Test
+    fun `when verification page is not available navigates to error`() {
+        launchConfirmationFragment { _, navController ->
+            setUpErrorVerificationPage()
+
+            assertThat(navController.currentDestination?.id)
+                .isEqualTo(R.id.errorFragment)
+        }
+    }
+
+    private fun launchConfirmationFragment(
+        testBlock: (binding: ConfirmationFragmentBinding, navController: TestNavHostController) -> Unit
+    ) = launchFragmentInContainer(
+        themeResId = R.style.Theme_MaterialComponents
+    ) {
+        ConfirmationFragment(
+            viewModelFactoryFor(mockIdentityViewModel),
+            mockVerificationFlowFinishable
+        )
+    }.onFragment {
+        val navController = TestNavHostController(
+            ApplicationProvider.getApplicationContext()
+        )
+        navController.setGraph(
+            R.navigation.identity_nav_graph
+        )
+        navController.setCurrentDestination(R.id.consentFragment)
+        Navigation.setViewNavController(
+            it.requireView(),
+            navController
+        )
+
+        testBlock(ConfirmationFragmentBinding.bind(it.requireView()), navController)
+    }
+
+    private companion object {
+        const val CONFIRMATION_TITLE = "title"
+        const val CONFIRMATION_BODY = "this is the confirmation body"
+        const val CONFIRMATION_BUTTON_TEXT = "confirmation"
+    }
+}

--- a/identity/src/test/java/com/stripe/android/identity/navigation/FrontBackUploadFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/FrontBackUploadFragmentTest.kt
@@ -15,7 +15,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.model.InternalStripeFile
 import com.stripe.android.core.model.InternalStripeFilePurpose
-import com.stripe.android.identity.CORRECT_VERIFICATION_PAGE_DATA
+import com.stripe.android.identity.CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.FrontBackUploadFragmentBinding
 import com.stripe.android.identity.networking.Resource
@@ -200,10 +200,10 @@ class FrontBackUploadFragmentTest {
                 whenever(
                     mockIdentityViewModel.postVerificationPageData(collectedDataParamCaptor.capture())
                 ).thenReturn(
-                    CORRECT_VERIFICATION_PAGE_DATA
+                    CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
                 )
                 whenever(mockIdentityViewModel.postVerificationPageSubmit()).thenReturn(
-                    CORRECT_VERIFICATION_PAGE_DATA
+                    CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
                 )
 
                 binding.kontinue.callOnClick()

--- a/identity/src/test/java/com/stripe/android/identity/navigation/FrontBackUploadFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/FrontBackUploadFragmentTest.kt
@@ -16,6 +16,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.model.InternalStripeFile
 import com.stripe.android.core.model.InternalStripeFilePurpose
 import com.stripe.android.identity.CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
+import com.stripe.android.identity.CORRECT_WITH_SUBMITTED_SUCCESS_VERIFICATION_PAGE_DATA
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.FrontBackUploadFragmentBinding
 import com.stripe.android.identity.networking.Resource
@@ -203,7 +204,7 @@ class FrontBackUploadFragmentTest {
                     CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
                 )
                 whenever(mockIdentityViewModel.postVerificationPageSubmit()).thenReturn(
-                    CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
+                    CORRECT_WITH_SUBMITTED_SUCCESS_VERIFICATION_PAGE_DATA
                 )
 
                 binding.kontinue.callOnClick()

--- a/identity/src/test/java/com/stripe/android/identity/navigation/PassportUploadFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/PassportUploadFragmentTest.kt
@@ -13,7 +13,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.model.InternalStripeFile
 import com.stripe.android.core.model.InternalStripeFilePurpose
-import com.stripe.android.identity.CORRECT_VERIFICATION_PAGE_DATA
+import com.stripe.android.identity.CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.PassportUploadFragmentBinding
 import com.stripe.android.identity.networking.Resource
@@ -113,10 +113,10 @@ class PassportUploadFragmentTest {
                 whenever(
                     mockIdentityViewModel.postVerificationPageData(collectedDataParamCaptor.capture())
                 ).thenReturn(
-                    CORRECT_VERIFICATION_PAGE_DATA
+                    CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
                 )
                 whenever(mockIdentityViewModel.postVerificationPageSubmit()).thenReturn(
-                    CORRECT_VERIFICATION_PAGE_DATA
+                    CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
                 )
 
                 binding.kontinue.callOnClick()

--- a/identity/src/test/java/com/stripe/android/identity/navigation/PassportUploadFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/PassportUploadFragmentTest.kt
@@ -14,6 +14,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.model.InternalStripeFile
 import com.stripe.android.core.model.InternalStripeFilePurpose
 import com.stripe.android.identity.CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
+import com.stripe.android.identity.CORRECT_WITH_SUBMITTED_SUCCESS_VERIFICATION_PAGE_DATA
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.PassportUploadFragmentBinding
 import com.stripe.android.identity.networking.Resource
@@ -116,7 +117,7 @@ class PassportUploadFragmentTest {
                     CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
                 )
                 whenever(mockIdentityViewModel.postVerificationPageSubmit()).thenReturn(
-                    CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
+                    CORRECT_WITH_SUBMITTED_SUCCESS_VERIFICATION_PAGE_DATA
                 )
 
                 binding.kontinue.callOnClick()

--- a/identity/src/test/java/com/stripe/android/identity/utils/NavigationUtilsTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/utils/NavigationUtilsTest.kt
@@ -11,7 +11,8 @@ import androidx.navigation.testing.TestNavHostController
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.exception.APIException
-import com.stripe.android.identity.CORRECT_VERIFICATION_PAGE_DATA
+import com.stripe.android.identity.CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
+import com.stripe.android.identity.CORRECT_WITH_SUBMITTED_SUCCESS_VERIFICATION_PAGE_DATA
 import com.stripe.android.identity.ERROR_BODY
 import com.stripe.android.identity.ERROR_BUTTON_TEXT
 import com.stripe.android.identity.ERROR_TITLE
@@ -94,7 +95,7 @@ internal class NavigationUtilsTest {
         runBlocking {
             val mockIdentityViewModel = mock<IdentityViewModel>().also {
                 whenever(it.postVerificationPageData(any())).thenReturn(
-                    CORRECT_VERIFICATION_PAGE_DATA
+                    CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
                 )
             }
             var blockExecuted = false
@@ -119,10 +120,10 @@ internal class NavigationUtilsTest {
         runBlocking {
             val mockIdentityViewModel = mock<IdentityViewModel>().also {
                 whenever(it.postVerificationPageData(any())).thenReturn(
-                    CORRECT_VERIFICATION_PAGE_DATA
+                    CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
                 )
                 whenever(it.postVerificationPageSubmit()).thenReturn(
-                    CORRECT_VERIFICATION_PAGE_DATA
+                    CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
                 )
             }
 
@@ -144,7 +145,7 @@ internal class NavigationUtilsTest {
         runBlocking {
             val mockIdentityViewModel = mock<IdentityViewModel>().also {
                 whenever(it.postVerificationPageData(any())).thenReturn(
-                    CORRECT_VERIFICATION_PAGE_DATA
+                    CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
                 )
 
                 whenever(it.postVerificationPageSubmit()).thenReturn(
@@ -177,15 +178,15 @@ internal class NavigationUtilsTest {
     }
 
     @Test
-    fun `postVerificationPageDataAndMaybeSubmit submits success then navigates to ConfirmationFragment`() {
+    fun `postVerificationPageDataAndMaybeSubmit submits success with submitted success then navigates to general ErrorFragment`() {
         runBlocking {
             val mockIdentityViewModel = mock<IdentityViewModel>().also {
                 whenever(it.postVerificationPageData(any())).thenReturn(
-                    CORRECT_VERIFICATION_PAGE_DATA
+                    CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
                 )
 
                 whenever(it.postVerificationPageSubmit()).thenReturn(
-                    CORRECT_VERIFICATION_PAGE_DATA
+                    CORRECT_WITH_SUBMITTED_SUCCESS_VERIFICATION_PAGE_DATA
                 )
             }
 
@@ -204,11 +205,38 @@ internal class NavigationUtilsTest {
     }
 
     @Test
+    fun `postVerificationPageDataAndMaybeSubmit submits success with submitted failure then navigates to ConfirmationFragment`() {
+        runBlocking {
+            val mockIdentityViewModel = mock<IdentityViewModel>().also {
+                whenever(it.postVerificationPageData(any())).thenReturn(
+                    CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
+                )
+
+                whenever(it.postVerificationPageSubmit()).thenReturn(
+                    CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
+                )
+            }
+
+            launchFragment { navController, fragment ->
+                fragment.postVerificationPageDataAndMaybeSubmit(
+                    mockIdentityViewModel,
+                    mock(),
+                    { false },
+                    {}
+                )
+
+                assertThat(navController.currentDestination?.id)
+                    .isEqualTo(R.id.errorFragment)
+            }
+        }
+    }
+
+    @Test
     fun `postVerificationPageDataAndMaybeSubmit submits fails then navigates to general ErrorFragment`() {
         runBlocking {
             val mockIdentityViewModel = mock<IdentityViewModel>().also {
                 whenever(it.postVerificationPageData(any())).thenReturn(
-                    CORRECT_VERIFICATION_PAGE_DATA
+                    CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
                 )
 
                 whenever(it.postVerificationPageSubmit()).thenThrow(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Bind the Identity network response to `ConfirmationFragment` UI
* Add a `VerificationFlowFinishable` to finish the verification flow directly

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
IDentity SDK

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

![confirmation](https://user-images.githubusercontent.com/79880926/157966028-f03aa828-2d64-408f-9024-f2c01271544c.png)


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
