### PR TITLE
Miscellaneous color theme fixes

### DIFF
--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -181,6 +181,9 @@ public final class com/stripe/android/ui/core/elements/SectionElementUIKt {
 public final class com/stripe/android/ui/core/elements/SectionUIKt {
 }
 
+public final class com/stripe/android/ui/core/elements/SimpleDialogElementUIKt {
+}
+
 public final class com/stripe/android/ui/core/elements/SimpleTextSpec$Companion {
 	public final fun getNAME ()Lcom/stripe/android/ui/core/elements/SimpleTextSpec;
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressElementUI.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import com.stripe.android.ui.core.PaymentsTheme
 
 @Composable
 internal fun AddressElementUI(
@@ -20,10 +21,10 @@ internal fun AddressElementUI(
                 SectionFieldElementUI(enabled, field)
                 if (index != fieldList.size - 1) {
                     Divider(
-                        color = CardStyle.cardDividerColor,
-                        thickness = CardStyle.cardBorderWidth,
+                        color = PaymentsTheme.colors.colorComponentBorder,
+                        thickness = PaymentsTheme.shapes.borderStrokeWidth,
                         modifier = Modifier.padding(
-                            horizontal = CardStyle.cardBorderWidth
+                            horizontal = PaymentsTheme.shapes.borderStrokeWidth
                         )
                     )
                 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/RowElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/RowElementUI.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.stripe.android.ui.core.PaymentsTheme
 
 @Composable
 internal fun RowElementUI(
@@ -38,8 +39,8 @@ internal fun RowElementUI(
             )
             if (!lastItem) {
                 VeriticalDivider(
-                    color = CardStyle.cardDividerColor,
-                    thickness = CardStyle.cardBorderWidth
+                    color = PaymentsTheme.colors.colorComponentBorder,
+                    thickness = PaymentsTheme.shapes.borderStrokeWidth
                 )
             }
         }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionElementUI.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import com.stripe.android.ui.core.PaymentsTheme
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -34,10 +35,10 @@ fun SectionElementUI(
                 SectionFieldElementUI(enabled, field)
                 if (index != element.fields.size - 1) {
                     Divider(
-                        color = CardStyle.cardBorderColor,
-                        thickness = CardStyle.cardBorderWidth,
+                        color = PaymentsTheme.colors.colorComponentBorder,
+                        thickness = PaymentsTheme.shapes.borderStrokeWidth,
                         modifier = Modifier.padding(
-                            horizontal = CardStyle.cardBorderWidth
+                            horizontal = PaymentsTheme.shapes.borderStrokeWidth
                         )
                     )
                 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionUI.kt
@@ -2,60 +2,29 @@ package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
 import androidx.annotation.StringRes
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Card
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.stripe.android.ui.core.PaymentsTheme
 
 /**
- * This is the style for the section card
- */
-
-internal object CardStyle {
-    val cardBorderColor: Color
-        @Composable
-        @ReadOnlyComposable
-        get() = PaymentsTheme.colors.colorComponentBorder
-
-    val cardDividerColor: Color
-        @Composable
-        @ReadOnlyComposable
-        get() = PaymentsTheme.colors.colorComponentDivider
-
-    val cardBorderWidth: Dp
-        @Composable
-        @ReadOnlyComposable
-        get() = PaymentsTheme.shapes.borderStrokeWidth
-
-    val cardElevation: Dp = 0.dp
-}
-
-/**
  * This is the style for the section title.
  *
  * Once credit card is converted use one of the default material theme styles.
+ * todo skyler: remove this once we centralize fonts.
  */
 internal object SectionTitle {
-    val color: Color
-        @Composable
-        @ReadOnlyComposable
-        get() = PaymentsTheme.colors.colorTextSecondary
-
     val fontWeight: FontWeight = FontWeight.Bold
     val letterSpacing: TextUnit = (-0.01f).sp
     val fontSize: TextUnit = 13.sp
@@ -73,7 +42,7 @@ internal fun Section(
 ) {
     Column(modifier = Modifier.padding(vertical = 8.dp)) {
         SectionTitle(title)
-        SectionCard(content)
+        SectionCard(content = content)
         if (error != null) {
             SectionError(error)
         }
@@ -88,7 +57,7 @@ internal fun SectionTitle(@StringRes titleText: Int?) {
     titleText?.let {
         Text(
             text = stringResource(titleText),
-            color = SectionTitle.color,
+            color = PaymentsTheme.colors.colorTextSecondary,
             style = MaterialTheme.typography.h6.copy(
                 fontSize = SectionTitle.fontSize,
                 fontWeight = SectionTitle.fontWeight,
@@ -109,15 +78,18 @@ internal fun SectionTitle(@StringRes titleText: Int?) {
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun SectionCard(
+    modifier: Modifier = Modifier,
+    isSelected: Boolean = false,
     content: @Composable () -> Unit
 ) {
     Card(
-        border = BorderStroke(CardStyle.cardBorderWidth, CardStyle.cardBorderColor),
-        elevation = CardStyle.cardElevation,
+        border = PaymentsTheme.getBorderStroke(isSelected),
+        // todo skyler: this will change when we add shadow configurations.
+        elevation = if (isSelected) 1.5.dp else 0.dp,
+        backgroundColor = PaymentsTheme.colors.colorComponentBackground,
+        modifier = modifier
     ) {
-        Column {
-            content()
-        }
+        content()
     }
 }
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SimpleDialogElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SimpleDialogElementUI.kt
@@ -1,0 +1,67 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.annotation.RestrictTo
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.ui.unit.sp
+import com.stripe.android.ui.core.PaymentsTheme
+
+@Composable
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun SimpleDialogElementUI(
+    openDialog: MutableState<Boolean>,
+    titleText: String,
+    messageText: String,
+    confirmText: String,
+    dismissText: String,
+    onConfirmListener: (() -> Unit) = {},
+    onDismissListener: (() -> Unit) = {}
+) {
+
+    if (openDialog.value) {
+        PaymentsTheme {
+            AlertDialog(
+                onDismissRequest = {
+                    openDialog.value = false
+                },
+                title = {
+                    Text(
+                        text = titleText,
+                        fontSize = 20.sp,
+                        color = PaymentsTheme.colors.material.onPrimary
+                    )
+                },
+                text = {
+                    Text(
+                        text = messageText,
+                        fontSize = 13.sp,
+                        color = PaymentsTheme.colors.colorTextSecondary
+                    )
+                },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            openDialog.value = false
+                            onConfirmListener()
+                        }
+                    ) {
+                        Text(confirmText)
+                    }
+                },
+                dismissButton = {
+                    TextButton(
+                        onClick = {
+                            openDialog.value = false
+                            onDismissListener()
+                        }
+                    ) {
+                        Text(dismissText)
+                    }
+                }
+            )
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
@@ -8,14 +8,12 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import androidx.annotation.VisibleForTesting
-import androidx.appcompat.app.AlertDialog
 import androidx.compose.ui.graphics.toArgb
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.stripe.android.paymentsheet.databinding.FragmentPaymentsheetPaymentMethodsListBinding
 import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.model.SupportedPaymentMethod
 import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.ui.core.PaymentsThemeConfig
@@ -151,30 +149,10 @@ internal abstract class BasePaymentMethodsListFragment(
         sheetViewModel.updateSelection(paymentSelection)
     }
 
-    private fun deletePaymentMethod(item: PaymentOptionsAdapter.Item.SavedPaymentMethod) =
-        AlertDialog.Builder(requireActivity())
-            .setTitle(
-                resources.getString(
-                    R.string.stripe_paymentsheet_remove_pm,
-                    SupportedPaymentMethod.fromCode(item.paymentMethod.type?.code)
-                        ?.run {
-                            resources.getString(
-                                displayNameResource
-                            )
-                        }
-                )
-            )
-            .setMessage(item.getDescription(resources))
-            .setCancelable(true)
-            .setNegativeButton(R.string.cancel) { dialog, _ ->
-                dialog.dismiss()
-            }
-            .setPositiveButton(R.string.remove) { _, _ ->
-                adapter.removeItem(item)
-                sheetViewModel.removePaymentMethod(item.paymentMethod)
-            }
-            .create()
-            .show()
+    private fun deletePaymentMethod(item: PaymentOptionsAdapter.Item.SavedPaymentMethod) {
+        adapter.removeItem(item)
+        sheetViewModel.removePaymentMethod(item.paymentMethod)
+    }
 
     private companion object {
         private const val IS_EDITING = "is_editing"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentMethodsUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentMethodsUI.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.selection.selectable
-import androidx.compose.material.Card
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
@@ -26,6 +25,7 @@ import androidx.compose.ui.unit.dp
 import com.stripe.android.paymentsheet.model.SupportedPaymentMethod
 import com.stripe.android.paymentsheet.ui.LpmSelectorText
 import com.stripe.android.ui.core.PaymentsTheme
+import com.stripe.android.ui.core.elements.SectionCard
 
 internal const val ADD_PM_DEFAULT_PADDING = 12.0f
 internal const val CARD_HORIZONTAL_PADDING = 6.0f
@@ -124,10 +124,8 @@ internal fun PaymentMethodUI(
     modifier: Modifier = Modifier,
     onItemSelectedListener: (Int) -> Unit
 ) {
-    Card(
-        border = PaymentsTheme.getBorderStroke(isSelected),
-        elevation = if (isSelected) 1.5.dp else 0.dp,
-        backgroundColor = PaymentsTheme.colors.colorComponentBackground,
+    SectionCard(
+        isSelected = isSelected,
         modifier = modifier
             .alpha(alpha = if (isEnabled) 1.0F else 0.6F)
             .height(60.dp)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
@@ -16,8 +16,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.Card
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -25,6 +26,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
@@ -37,10 +39,13 @@ import com.stripe.android.paymentsheet.PaymentOptionsAdapter.Companion.PM_OPTION
 import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
+import com.stripe.android.paymentsheet.model.SupportedPaymentMethod
 import com.stripe.android.paymentsheet.ui.LpmSelectorText
 import com.stripe.android.paymentsheet.ui.getLabel
 import com.stripe.android.paymentsheet.ui.getSavedPaymentMethodIcon
 import com.stripe.android.ui.core.PaymentsTheme
+import com.stripe.android.ui.core.elements.SectionCard
+import com.stripe.android.ui.core.elements.SimpleDialogElementUI
 import kotlin.properties.Delegates
 
 @SuppressLint("NotifyDataSetChanged")
@@ -291,6 +296,15 @@ internal class PaymentOptionsAdapter(
         ) {
             val savedPaymentMethod = item as Item.SavedPaymentMethod
             val labelText = savedPaymentMethod.paymentMethod.getLabel(itemView.resources) ?: return
+            val removeTitle = itemView.resources.getString(
+                R.string.stripe_paymentsheet_remove_pm,
+                SupportedPaymentMethod.fromCode(item.paymentMethod.type?.code)
+                    ?.run {
+                        itemView.resources.getString(
+                            displayNameResource
+                        )
+                    }
+            )
 
             composeView.setContent {
                 PaymentOptionUi(
@@ -300,7 +314,8 @@ internal class PaymentOptionsAdapter(
                     isEnabled = isEnabled,
                     iconRes = savedPaymentMethod.paymentMethod.getSavedPaymentMethodIcon() ?: 0,
                     labelText = labelText,
-                    accessibilityDescription = item.getDescription(itemView.resources),
+                    onRemoveTitle = removeTitle,
+                    description = item.getDescription(itemView.resources),
                     onRemoveListener = { onRemoveListener(position) },
                     onRemoveAccessibilityDescription =
                     savedPaymentMethod.getRemoveDescription(itemView.resources),
@@ -343,7 +358,7 @@ internal class PaymentOptionsAdapter(
                     ),
                     iconRes = R.drawable.stripe_ic_paymentsheet_add,
                     onItemSelectedListener = { onItemSelectedListener() },
-                    accessibilityDescription =
+                    description =
                     itemView.resources.getString(R.string.add_new_payment_method),
                 )
             }
@@ -383,7 +398,7 @@ internal class PaymentOptionsAdapter(
                     isEnabled = isEnabled,
                     iconRes = R.drawable.stripe_google_pay_mark,
                     labelText = itemView.resources.getString(R.string.google_pay),
-                    accessibilityDescription = itemView.resources.getString(R.string.google_pay),
+                    description = itemView.resources.getString(R.string.google_pay),
                     onItemSelectedListener = { onItemSelectedListener(position, true) },
                 )
             }
@@ -482,8 +497,9 @@ internal fun PaymentOptionUi(
     isEditing: Boolean,
     isEnabled: Boolean,
     iconRes: Int,
-    accessibilityDescription: String,
     labelText: String = "",
+    onRemoveTitle: String = "",
+    description: String,
     onRemoveListener: (() -> Unit)? = null,
     onRemoveAccessibilityDescription: String = "",
     onItemSelectedListener: (() -> Unit)
@@ -500,10 +516,8 @@ internal fun PaymentOptionUi(
             })
     ) {
         val (checkIcon, deleteIcon, label, card) = createRefs()
-        Card(
-            border = PaymentsTheme.getBorderStroke(isSelected),
-            elevation = 2.dp,
-            backgroundColor = PaymentsTheme.colors.colorComponentBackground,
+        SectionCard(
+            isSelected = isSelected,
             modifier = Modifier
                 .height(64.dp)
                 .padding(horizontal = PM_OPTIONS_DEFAULT_PADDING.dp)
@@ -527,7 +541,6 @@ internal fun PaymentOptionUi(
                 )
             }
         }
-
         if (isSelected) {
             Image(
                 painter = painterResource(R.drawable.stripe_ic_check_circle),
@@ -544,6 +557,17 @@ internal fun PaymentOptionUi(
             )
         }
         if (isEditing && onRemoveListener != null) {
+            val openDialog = remember { mutableStateOf(false) }
+
+            SimpleDialogElementUI(
+                openDialog = openDialog,
+                titleText = onRemoveTitle,
+                messageText = description,
+                confirmText = stringResource(R.string.remove),
+                dismissText = stringResource(R.string.cancel),
+                onConfirmListener = onRemoveListener
+            )
+
             Image(
                 painter = painterResource(R.drawable.stripe_ic_delete_symbol),
                 contentDescription = onRemoveAccessibilityDescription,
@@ -557,7 +581,7 @@ internal fun PaymentOptionUi(
                     .background(color = PaymentsTheme.colors.material.error)
                     .clickable(
                         onClick = {
-                            onRemoveListener()
+                            openDialog.value = true
                         }
                     )
             )
@@ -581,7 +605,7 @@ internal fun PaymentOptionUi(
                     // This makes the screen reader read out numbers digit by digit
                     // one one one one vs one thousand one hundred eleven
                     this.contentDescription =
-                        accessibilityDescription.replace("\\d".toRegex(), "$0 ")
+                        description.replace("\\d".toRegex(), "$0 ")
                 },
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet
 
 import android.os.Looper.getMainLooper
-import androidx.appcompat.app.AlertDialog
 import androidx.core.os.bundleOf
 import androidx.core.view.children
 import androidx.core.view.isVisible
@@ -35,7 +34,6 @@ import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
-import org.robolectric.shadows.ShadowAlertDialog
 
 @RunWith(RobolectricTestRunner::class)
 internal class PaymentSheetListFragmentTest : PaymentSheetViewModelTestInjection() {
@@ -292,11 +290,6 @@ internal class PaymentSheetListFragmentTest : PaymentSheetViewModelTestInjection
             adapter.paymentMethodDeleteListener(
                 adapter.items[3] as PaymentOptionsAdapter.Item.SavedPaymentMethod
             )
-
-            val dialog = ShadowAlertDialog.getShownDialogs().first() as AlertDialog
-            dialog.getButton(AlertDialog.BUTTON_POSITIVE).performClick()
-
-            idleLooper()
 
             assertThat(adapter.itemCount).isEqualTo(3)
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Remove nested config objects. Now everything should point towards our custom theme object. 
* Made our remove dialog composable and styled it to match the currently applied style
* Unified card UI logic in all of all payment selectors.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
* Spring cleaning
* We need our remove dialog to match the style of the rest of the sheet. Will sync with JJ before pushing, but this is an improvement because it actually matches colors. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
|![oldDialogDark](https://user-images.githubusercontent.com/89166418/157985008-93013a50-5054-46f9-bcd0-963d8d549322.png)|![newDialogDark](https://user-images.githubusercontent.com/89166418/157984999-4d12e5e1-9f2c-4fa1-8f93-9115e6097633.png)|
|![oldDialogLight](https://user-images.githubusercontent.com/89166418/157985009-e561e771-e4d1-4dac-a5da-0242c9f70382.png)|![newDialogLight](https://user-images.githubusercontent.com/89166418/157985007-c24aa6c4-d7d2-4922-8e2c-47b2deb6f4e5.png)|




