### PR TITLE
[Identity] send clear_data param when postVerificationPageData

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.ConsentFragmentBinding
+import com.stripe.android.identity.networking.models.ClearDataParam
 import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.networking.models.ConsentParam
 import com.stripe.android.identity.networking.models.VerificationPage.Companion.isMissingBiometricConsent
@@ -90,6 +91,7 @@ internal class ConsentFragment(
             postVerificationPageDataAndMaybeSubmit(
                 identityViewModel,
                 collectedDataParam,
+                ClearDataParam.CONSENT_TO_DOC_SELECT,
                 shouldNotSubmit = { true },
                 notSubmitBlock = { verificationPageData ->
                     if (verificationPageData.isMissingDocumentType()) {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
@@ -15,6 +15,7 @@ import com.stripe.android.core.exception.InvalidRequestException
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.DocSelectionFragmentBinding
 import com.stripe.android.identity.networking.Status
+import com.stripe.android.identity.networking.models.ClearDataParam
 import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.networking.models.IdDocumentParam
 import com.stripe.android.identity.networking.models.IdDocumentParam.Type
@@ -190,8 +191,9 @@ internal class DocSelectionFragment(
     private fun postVerificationPageDataAndNavigate(type: Type) {
         lifecycleScope.launch {
             postVerificationPageDataAndMaybeSubmit(
-                identityViewModel,
-                CollectedDataParam(idDocument = IdDocumentParam(type = type)),
+                identityViewModel = identityViewModel,
+                collectedDataParam = CollectedDataParam(idDocument = IdDocumentParam(type = type)),
+                clearDataParam = ClearDataParam.DOC_SELECT_TO_UPLOAD,
                 shouldNotSubmit = { verificationPageData ->
                     verificationPageData.isMissingBackOrFront()
                 },

--- a/identity/src/main/java/com/stripe/android/identity/navigation/FrontBackUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/FrontBackUploadFragment.kt
@@ -18,6 +18,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.FrontBackUploadFragmentBinding
 import com.stripe.android.identity.networking.Status
+import com.stripe.android.identity.networking.models.ClearDataParam
 import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.networking.models.DocumentUploadParam
 import com.stripe.android.identity.networking.models.IdDocumentParam
@@ -176,6 +177,7 @@ internal abstract class FrontBackUploadFragment(
                                     type = frontScanType.toType()
                                 )
                             ),
+                            clearDataParam = ClearDataParam.UPLOAD_TO_CONFIRM,
                             shouldNotSubmit = { false }
                         )
                     }.onFailure {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/PassportUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/PassportUploadFragment.kt
@@ -17,6 +17,7 @@ import com.stripe.android.core.model.InternalStripeFile
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.PassportUploadFragmentBinding
 import com.stripe.android.identity.networking.Status
+import com.stripe.android.identity.networking.models.ClearDataParam
 import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.networking.models.DocumentUploadParam
 import com.stripe.android.identity.networking.models.IdDocumentParam
@@ -145,6 +146,7 @@ internal class PassportUploadFragment(
                                 type = IdDocumentParam.Type.PASSPORT
                             )
                         ),
+                        clearDataParam = ClearDataParam.UPLOAD_TO_CONFIRM,
                         shouldNotSubmit = { false }
                     )
                 }.onFailure {

--- a/identity/src/main/java/com/stripe/android/identity/networking/DefaultIdentityRepository.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/DefaultIdentityRepository.kt
@@ -13,11 +13,14 @@ import com.stripe.android.core.model.parsers.StripeErrorJsonParser
 import com.stripe.android.core.model.parsers.StripeFileJsonParser
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
+import com.stripe.android.core.networking.QueryStringFactory
 import com.stripe.android.core.networking.StripeNetworkClient
 import com.stripe.android.core.networking.StripeRequest
 import com.stripe.android.core.networking.responseJson
+import com.stripe.android.identity.networking.models.ClearDataParam
+import com.stripe.android.identity.networking.models.ClearDataParam.Companion.createCollectedDataParamEntry
 import com.stripe.android.identity.networking.models.CollectedDataParam
-import com.stripe.android.identity.networking.models.CollectedDataParam.Companion.createCollectedDataParam
+import com.stripe.android.identity.networking.models.CollectedDataParam.Companion.createCollectedDataParamEntry
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPageData
 import com.stripe.android.identity.utils.createTFLiteFile
@@ -51,12 +54,18 @@ internal class DefaultIdentityRepository(
     override suspend fun postVerificationPageData(
         id: String,
         ephemeralKey: String,
-        collectedDataParam: CollectedDataParam
+        collectedDataParam: CollectedDataParam,
+        clearDataParam: ClearDataParam
     ): VerificationPageData = executeRequestWithKSerializer(
         PostVerificationPageDataRequest(
             id,
             ephemeralKey,
-            collectedDataParam.createCollectedDataParam(json)
+            QueryStringFactory.createFromParamsWithEmptyValues(
+                mapOf(
+                    collectedDataParam.createCollectedDataParamEntry(json),
+                    clearDataParam.createCollectedDataParamEntry(json)
+                )
+            )
         ),
         VerificationPageData.serializer()
     )

--- a/identity/src/main/java/com/stripe/android/identity/networking/IdentityRepository.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/IdentityRepository.kt
@@ -4,6 +4,7 @@ import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.model.InternalStripeFile
 import com.stripe.android.core.model.InternalStripeFilePurpose
+import com.stripe.android.identity.networking.models.ClearDataParam
 import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPageData
@@ -29,7 +30,8 @@ internal interface IdentityRepository {
     suspend fun postVerificationPageData(
         id: String,
         ephemeralKey: String,
-        collectedDataParam: CollectedDataParam
+        collectedDataParam: CollectedDataParam,
+        clearDataParam: ClearDataParam
     ): VerificationPageData
 
     @Throws(

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/ClearDataParam.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/ClearDataParam.kt
@@ -1,0 +1,52 @@
+package com.stripe.android.identity.networking.models
+
+import com.stripe.android.core.networking.toMap
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+@Serializable
+internal data class ClearDataParam(
+    @SerialName("biometric_consent")
+    val biometricConsent: Boolean = false,
+    @SerialName("id_document_type")
+    val idDocumentType: Boolean = false,
+    @SerialName("id_document_front")
+    val idDocumentFront: Boolean = false,
+    @SerialName("id_document_back")
+    val idDocumentBack: Boolean = false
+) {
+    internal companion object {
+        private const val CLEAR_DATA_PARAM = "clear_data"
+
+        /**
+         * Create map entry for encoding into x-www-url-encoded string.
+         */
+        fun ClearDataParam.createCollectedDataParamEntry(json: Json) =
+            CLEAR_DATA_PARAM to json.encodeToJsonElement(
+                serializer(),
+                this
+            ).toMap()
+
+        internal val CONSENT_TO_DOC_SELECT = ClearDataParam(
+            biometricConsent = false,
+            idDocumentType = true,
+            idDocumentFront = true,
+            idDocumentBack = true
+        )
+
+        internal val DOC_SELECT_TO_UPLOAD = ClearDataParam(
+            biometricConsent = false,
+            idDocumentType = false,
+            idDocumentFront = true,
+            idDocumentBack = true
+        )
+
+        internal val UPLOAD_TO_CONFIRM = ClearDataParam(
+            biometricConsent = false,
+            idDocumentType = false,
+            idDocumentFront = false,
+            idDocumentBack = false
+        )
+    }
+}

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/CollectedDataParam.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/CollectedDataParam.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.identity.networking.models
 
-import com.stripe.android.core.networking.QueryStringFactory
 import com.stripe.android.core.networking.toMap
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -18,18 +17,12 @@ internal data class CollectedDataParam(
         private const val COLLECTED_DATA_PARAM = "collected_data"
 
         /**
-         * Create a x-www-url-encoded string of [CollectedDataParam] with [COLLECTED_DATA_PARAM] as
-         * its param name.
+         * Create map entry for encoding into x-www-url-encoded string.
          */
-        fun CollectedDataParam.createCollectedDataParam(json: Json): String {
-            return QueryStringFactory.createFromParamsWithEmptyValues(
-                mapOf(
-                    COLLECTED_DATA_PARAM to json.encodeToJsonElement(
-                        serializer(),
-                        this
-                    ).toMap()
-                )
-            )
-        }
+        fun CollectedDataParam.createCollectedDataParamEntry(json: Json) =
+            COLLECTED_DATA_PARAM to json.encodeToJsonElement(
+                serializer(),
+                this
+            ).toMap()
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/utils/navigationUtils.kt
+++ b/identity/src/main/java/com/stripe/android/identity/utils/navigationUtils.kt
@@ -7,6 +7,7 @@ import com.stripe.android.identity.R
 import com.stripe.android.identity.navigation.ErrorFragment
 import com.stripe.android.identity.navigation.ErrorFragment.Companion.navigateToErrorFragmentWithDefaultValues
 import com.stripe.android.identity.navigation.ErrorFragment.Companion.navigateToErrorFragmentWithRequirementErrorAndDestination
+import com.stripe.android.identity.networking.models.ClearDataParam
 import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.networking.models.VerificationPageData
 import com.stripe.android.identity.networking.models.VerificationPageData.Companion.hasError
@@ -35,11 +36,12 @@ import com.stripe.android.identity.viewmodel.IdentityViewModel
 internal suspend fun Fragment.postVerificationPageDataAndMaybeSubmit(
     identityViewModel: IdentityViewModel,
     collectedDataParam: CollectedDataParam,
+    clearDataParam: ClearDataParam,
     shouldNotSubmit: (verificationPageData: VerificationPageData) -> Boolean = { true },
     notSubmitBlock: ((verificationPageData: VerificationPageData) -> Unit)? = null
 ) {
     runCatching {
-        identityViewModel.postVerificationPageData(collectedDataParam)
+        identityViewModel.postVerificationPageData(collectedDataParam, clearDataParam)
     }.fold(
         onSuccess = { postedVerificationPageData ->
             if (postedVerificationPageData.hasError()) {

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
@@ -13,6 +13,7 @@ import com.stripe.android.identity.IdentityVerificationSheetContract
 import com.stripe.android.identity.networking.IdentityRepository
 import com.stripe.android.identity.networking.Resource
 import com.stripe.android.identity.networking.Status
+import com.stripe.android.identity.networking.models.ClearDataParam
 import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPageData
@@ -123,11 +124,15 @@ internal class IdentityViewModel(
         APIConnectionException::class,
         APIException::class
     )
-    suspend fun postVerificationPageData(collectedDataParam: CollectedDataParam) =
+    suspend fun postVerificationPageData(
+        collectedDataParam: CollectedDataParam,
+        clearDataParam: ClearDataParam
+    ) =
         identityRepository.postVerificationPageData(
             args.verificationSessionId,
             args.ephemeralKeySecret,
-            collectedDataParam
+            collectedDataParam,
+            clearDataParam
         )
 
     /**

--- a/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
@@ -174,7 +174,7 @@ internal class ConsentFragmentTest {
     fun `when accepted and postVerificationData success transitions to docSelectionFragment`() {
         runBlocking {
             whenever(
-                mockIdentityViewModel.postVerificationPageData(any())
+                mockIdentityViewModel.postVerificationPageData(any(), any())
             ).thenReturn(correctVerificationData)
 
             launchConsentFragment { binding, navController ->
@@ -192,7 +192,7 @@ internal class ConsentFragmentTest {
     fun `when accepted and postVerificationData fails transitions to errorFragment`() {
         runBlocking {
             whenever(
-                mockIdentityViewModel.postVerificationPageData(any())
+                mockIdentityViewModel.postVerificationPageData(any(), any())
             ).thenThrow(APIException())
 
             launchConsentFragment { binding, navController ->
@@ -209,7 +209,7 @@ internal class ConsentFragmentTest {
     fun `when declined and postVerificationData success transitions to errorFragment with returned value`() {
         runBlocking {
             whenever(
-                mockIdentityViewModel.postVerificationPageData(any())
+                mockIdentityViewModel.postVerificationPageData(any(), any())
             ).thenReturn(incorrectVerificationData)
 
             launchConsentFragment { binding, navController ->
@@ -237,7 +237,7 @@ internal class ConsentFragmentTest {
     fun `when declined and postVerificationData fails transitions to errorFragment`() {
         runBlocking {
             whenever(
-                mockIdentityViewModel.postVerificationPageData(any())
+                mockIdentityViewModel.postVerificationPageData(any(), any())
             ).thenThrow(APIException())
 
             launchConsentFragment { binding, navController ->

--- a/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
@@ -168,7 +168,7 @@ internal class DocSelectionFragmentTest {
                 DOC_SELECT_SINGLE_CHOICE_DL
             )
             runBlocking {
-                whenever(mockIdentityViewModel.postVerificationPageData(any())).thenReturn(
+                whenever(mockIdentityViewModel.postVerificationPageData(any(), any())).thenReturn(
                     MISSING_BACK_VERIFICATION_PAGE_DATA
                 )
             }
@@ -203,7 +203,7 @@ internal class DocSelectionFragmentTest {
                 mockDocumentCapture
             )
             runBlocking {
-                whenever(mockIdentityViewModel.postVerificationPageData(any())).thenReturn(
+                whenever(mockIdentityViewModel.postVerificationPageData(any(), any())).thenReturn(
                     MISSING_BACK_VERIFICATION_PAGE_DATA
                 )
             }
@@ -235,7 +235,7 @@ internal class DocSelectionFragmentTest {
                 mockDocumentCapture
             )
             runBlocking {
-                whenever(mockIdentityViewModel.postVerificationPageData(any())).thenReturn(
+                whenever(mockIdentityViewModel.postVerificationPageData(any(), any())).thenReturn(
                     MISSING_BACK_VERIFICATION_PAGE_DATA
                 )
             }

--- a/identity/src/test/java/com/stripe/android/identity/navigation/FrontBackUploadFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/FrontBackUploadFragmentTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.identity.CORRECT_WITH_SUBMITTED_SUCCESS_VERIFICATION_P
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.FrontBackUploadFragmentBinding
 import com.stripe.android.identity.networking.Resource
+import com.stripe.android.identity.networking.models.ClearDataParam
 import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.networking.models.DocumentUploadParam
 import com.stripe.android.identity.networking.models.IdDocumentParam
@@ -198,8 +199,12 @@ class FrontBackUploadFragmentTest {
                 uploadFinished.postValue(Unit)
 
                 val collectedDataParamCaptor: KArgumentCaptor<CollectedDataParam> = argumentCaptor()
+                val clearDataParamCaptor: KArgumentCaptor<ClearDataParam> = argumentCaptor()
                 whenever(
-                    mockIdentityViewModel.postVerificationPageData(collectedDataParamCaptor.capture())
+                    mockIdentityViewModel.postVerificationPageData(
+                        collectedDataParamCaptor.capture(),
+                        clearDataParamCaptor.capture()
+                    )
                 ).thenReturn(
                     CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
                 )
@@ -224,6 +229,10 @@ class FrontBackUploadFragmentTest {
                         )
                     )
                 )
+                assertThat(clearDataParamCaptor.firstValue).isEqualTo(
+                    ClearDataParam.UPLOAD_TO_CONFIRM
+                )
+
                 assertThat(navController.currentDestination?.id)
                     .isEqualTo(R.id.confirmationFragment)
             }

--- a/identity/src/test/java/com/stripe/android/identity/navigation/PassportUploadFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/PassportUploadFragmentTest.kt
@@ -18,8 +18,11 @@ import com.stripe.android.identity.CORRECT_WITH_SUBMITTED_SUCCESS_VERIFICATION_P
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.PassportUploadFragmentBinding
 import com.stripe.android.identity.networking.Resource
+import com.stripe.android.identity.networking.models.ClearDataParam
 import com.stripe.android.identity.networking.models.CollectedDataParam
+import com.stripe.android.identity.networking.models.DocumentUploadParam
 import com.stripe.android.identity.networking.models.DocumentUploadParam.UploadMethod
+import com.stripe.android.identity.networking.models.IdDocumentParam
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentDocumentCapturePage
 import com.stripe.android.identity.viewModelFactoryFor
@@ -111,8 +114,13 @@ class PassportUploadFragmentTest {
                 )
 
                 val collectedDataParamCaptor: KArgumentCaptor<CollectedDataParam> = argumentCaptor()
+                val clearDataParamCaptor: KArgumentCaptor<ClearDataParam> = argumentCaptor()
+
                 whenever(
-                    mockIdentityViewModel.postVerificationPageData(collectedDataParamCaptor.capture())
+                    mockIdentityViewModel.postVerificationPageData(
+                        collectedDataParamCaptor.capture(),
+                        clearDataParamCaptor.capture()
+                    )
                 ).thenReturn(
                     CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
                 )
@@ -121,6 +129,21 @@ class PassportUploadFragmentTest {
                 )
 
                 binding.kontinue.callOnClick()
+
+                assertThat(collectedDataParamCaptor.firstValue).isEqualTo(
+                    CollectedDataParam(
+                        idDocument = IdDocumentParam(
+                            front = DocumentUploadParam(
+                                highResImage = FILE_ID,
+                                uploadMethod = UploadMethod.FILEUPLOAD
+                            ),
+                            type = IdDocumentParam.Type.PASSPORT
+                        )
+                    )
+                )
+                assertThat(clearDataParamCaptor.firstValue).isEqualTo(
+                    ClearDataParam.UPLOAD_TO_CONFIRM
+                )
 
                 assertThat(navController.currentDestination?.id)
                     .isEqualTo(R.id.confirmationFragment)

--- a/identity/src/test/java/com/stripe/android/identity/networking/DefaultIdentityRepositoryTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/networking/DefaultIdentityRepositoryTest.kt
@@ -7,13 +7,16 @@ import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.model.InternalStripeFile
 import com.stripe.android.core.model.parsers.StripeErrorJsonParser
 import com.stripe.android.core.networking.HEADER_AUTHORIZATION
+import com.stripe.android.core.networking.QueryStringFactory
 import com.stripe.android.core.networking.StripeNetworkClient
 import com.stripe.android.core.networking.StripeRequest
 import com.stripe.android.core.networking.StripeResponse
 import com.stripe.android.identity.networking.PostVerificationPageDataRequest.Companion.DATA
 import com.stripe.android.identity.networking.PostVerificationPageSubmitRequest.Companion.SUBMIT
+import com.stripe.android.identity.networking.models.ClearDataParam
+import com.stripe.android.identity.networking.models.ClearDataParam.Companion.createCollectedDataParamEntry
 import com.stripe.android.identity.networking.models.CollectedDataParam
-import com.stripe.android.identity.networking.models.CollectedDataParam.Companion.createCollectedDataParam
+import com.stripe.android.identity.networking.models.CollectedDataParam.Companion.createCollectedDataParamEntry
 import com.stripe.android.identity.networking.models.ConsentParam
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPageData
@@ -83,10 +86,14 @@ class DefaultIdentityRepositoryTest {
                     biometric = false
                 )
             )
+
+            val clearDataParam = ClearDataParam()
+
             val verificationPage = identityRepository.postVerificationPageData(
                 TEST_ID,
                 TEST_EPHEMERAL_KEY,
-                collectedDataParam
+                collectedDataParam,
+                clearDataParam
             )
 
             assertThat(verificationPage).isInstanceOf(VerificationPageData::class.java)
@@ -98,7 +105,12 @@ class DefaultIdentityRepositoryTest {
             assertThat(request.url).isEqualTo("$BASE_URL/$IDENTITY_VERIFICATION_PAGES/$TEST_ID/$DATA")
             assertThat(request.headers[HEADER_AUTHORIZATION]).isEqualTo("Bearer $TEST_EPHEMERAL_KEY")
             assertThat((request as PostVerificationPageDataRequest).encodedData).isEqualTo(
-                collectedDataParam.createCollectedDataParam(identityRepository.json)
+                QueryStringFactory.createFromParamsWithEmptyValues(
+                    mapOf(
+                        collectedDataParam.createCollectedDataParamEntry(identityRepository.json),
+                        clearDataParam.createCollectedDataParamEntry(identityRepository.json)
+                    )
+                )
             )
         }
     }

--- a/identity/src/test/java/com/stripe/android/identity/utils/NavigationUtilsTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/utils/NavigationUtilsTest.kt
@@ -19,7 +19,6 @@ import com.stripe.android.identity.ERROR_TITLE
 import com.stripe.android.identity.ERROR_VERIFICATION_PAGE_DATA
 import com.stripe.android.identity.R
 import com.stripe.android.identity.navigation.ErrorFragment
-import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
@@ -36,16 +35,16 @@ internal class NavigationUtilsTest {
     fun `postVerificationPageDataAndMaybeSubmit navigates to error fragment when has error`() {
         runBlocking {
             val mockIdentityViewModel = mock<IdentityViewModel>().also {
-                whenever(it.postVerificationPageData(any())).thenReturn(
+                whenever(it.postVerificationPageData(any(), any())).thenReturn(
                     ERROR_VERIFICATION_PAGE_DATA
                 )
             }
-            val mockCollectedDataParam = mock<CollectedDataParam>()
 
             launchFragment { navController, fragment ->
                 fragment.postVerificationPageDataAndMaybeSubmit(
                     mockIdentityViewModel,
-                    mockCollectedDataParam,
+                    mock(),
+                    mock(),
                     { true },
                     {}
                 )
@@ -70,16 +69,16 @@ internal class NavigationUtilsTest {
     fun `postVerificationPageDataAndMaybeSubmit navigates to general error fragment when fails`() {
         runBlocking {
             val mockIdentityViewModel = mock<IdentityViewModel>().also {
-                whenever(it.postVerificationPageData(any())).thenThrow(
+                whenever(it.postVerificationPageData(any(), any())).thenThrow(
                     APIException()
                 )
             }
-            val mockCollectedDataParam = mock<CollectedDataParam>()
 
             launchFragment { navController, fragment ->
                 fragment.postVerificationPageDataAndMaybeSubmit(
                     mockIdentityViewModel,
-                    mockCollectedDataParam,
+                    mock(),
+                    mock(),
                     { true },
                     {}
                 )
@@ -94,7 +93,7 @@ internal class NavigationUtilsTest {
     fun `postVerificationPageDataAndMaybeSubmit executes notSubmitBlock when shouldNotSubmit`() {
         runBlocking {
             val mockIdentityViewModel = mock<IdentityViewModel>().also {
-                whenever(it.postVerificationPageData(any())).thenReturn(
+                whenever(it.postVerificationPageData(any(), any())).thenReturn(
                     CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
                 )
             }
@@ -103,6 +102,7 @@ internal class NavigationUtilsTest {
             launchFragment { _, fragment ->
                 fragment.postVerificationPageDataAndMaybeSubmit(
                     mockIdentityViewModel,
+                    mock(),
                     mock(),
                     { true },
                     {
@@ -119,7 +119,7 @@ internal class NavigationUtilsTest {
     fun `postVerificationPageDataAndMaybeSubmit submits when shouldNotSubmit is false`() {
         runBlocking {
             val mockIdentityViewModel = mock<IdentityViewModel>().also {
-                whenever(it.postVerificationPageData(any())).thenReturn(
+                whenever(it.postVerificationPageData(any(), any())).thenReturn(
                     CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
                 )
                 whenever(it.postVerificationPageSubmit()).thenReturn(
@@ -130,6 +130,7 @@ internal class NavigationUtilsTest {
             launchFragment { _, fragment ->
                 fragment.postVerificationPageDataAndMaybeSubmit(
                     mockIdentityViewModel,
+                    mock(),
                     mock(),
                     { false },
                     {}
@@ -144,7 +145,7 @@ internal class NavigationUtilsTest {
     fun `postVerificationPageDataAndMaybeSubmit submits success with error then navigates to errorFragment with error data`() {
         runBlocking {
             val mockIdentityViewModel = mock<IdentityViewModel>().also {
-                whenever(it.postVerificationPageData(any())).thenReturn(
+                whenever(it.postVerificationPageData(any(), any())).thenReturn(
                     CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
                 )
 
@@ -156,6 +157,7 @@ internal class NavigationUtilsTest {
             launchFragment { navController, fragment ->
                 fragment.postVerificationPageDataAndMaybeSubmit(
                     mockIdentityViewModel,
+                    mock(),
                     mock(),
                     { false },
                     {}
@@ -181,7 +183,7 @@ internal class NavigationUtilsTest {
     fun `postVerificationPageDataAndMaybeSubmit submits success with submitted success then navigates to general ErrorFragment`() {
         runBlocking {
             val mockIdentityViewModel = mock<IdentityViewModel>().also {
-                whenever(it.postVerificationPageData(any())).thenReturn(
+                whenever(it.postVerificationPageData(any(), any())).thenReturn(
                     CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
                 )
 
@@ -193,6 +195,7 @@ internal class NavigationUtilsTest {
             launchFragment { navController, fragment ->
                 fragment.postVerificationPageDataAndMaybeSubmit(
                     mockIdentityViewModel,
+                    mock(),
                     mock(),
                     { false },
                     {}
@@ -208,7 +211,7 @@ internal class NavigationUtilsTest {
     fun `postVerificationPageDataAndMaybeSubmit submits success with submitted failure then navigates to ConfirmationFragment`() {
         runBlocking {
             val mockIdentityViewModel = mock<IdentityViewModel>().also {
-                whenever(it.postVerificationPageData(any())).thenReturn(
+                whenever(it.postVerificationPageData(any(), any())).thenReturn(
                     CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
                 )
 
@@ -220,6 +223,7 @@ internal class NavigationUtilsTest {
             launchFragment { navController, fragment ->
                 fragment.postVerificationPageDataAndMaybeSubmit(
                     mockIdentityViewModel,
+                    mock(),
                     mock(),
                     { false },
                     {}
@@ -235,7 +239,7 @@ internal class NavigationUtilsTest {
     fun `postVerificationPageDataAndMaybeSubmit submits fails then navigates to general ErrorFragment`() {
         runBlocking {
             val mockIdentityViewModel = mock<IdentityViewModel>().also {
-                whenever(it.postVerificationPageData(any())).thenReturn(
+                whenever(it.postVerificationPageData(any(), any())).thenReturn(
                     CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
                 )
 
@@ -247,6 +251,7 @@ internal class NavigationUtilsTest {
             launchFragment { navController, fragment ->
                 fragment.postVerificationPageDataAndMaybeSubmit(
                     mockIdentityViewModel,
+                    mock(),
                     mock(),
                     { false },
                     {}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Apart from `CollectedData`, we need to send an additional `ClearData` field when submitting for result, this would make sure when user clicking back button during the page and reuploading some data, the data integrity is conserved on backend.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Identity SDK

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
