### PR TITLE
[Identity] when back pressed, cancel the flow when user is on initial fragment, navigates up otherwise

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModelProvider
+import androidx.navigation.findNavController
 import androidx.navigation.fragment.NavHostFragment
 import com.stripe.android.camera.CameraPermissionCheckingActivity
 import com.stripe.android.identity.IdentityVerificationSheet.VerificationResult
@@ -59,7 +60,13 @@ internal class IdentityActivity : CameraPermissionCheckingActivity(), Verificati
     }
 
     override fun onBackPressed() {
-        finishWithResult(VerificationResult.Canceled)
+        findNavController(R.id.identity_nav_host).let { navController ->
+            if (navController.currentDestination?.id == R.id.consentFragment) {
+                finishWithResult(VerificationResult.Canceled)
+            } else {
+                navController.navigateUp()
+            }
+        }
     }
 
     override fun finishWithResult(result: VerificationResult) {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Clicking back button on first fragment(`ConsentFragment`) should cancel the verification, otherwise should navigates up


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
IDentity SDK

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
