### PR TITLE
[Identity] Add loading animation to button clicks that need to wait for network

### DIFF
--- a/identity/api/identity.api
+++ b/identity/api/identity.api
@@ -87,10 +87,10 @@ public final class com/stripe/android/identity/databinding/ConfirmationFragmentB
 }
 
 public final class com/stripe/android/identity/databinding/ConsentFragmentBinding : androidx/viewbinding/ViewBinding {
-	public final field agree Landroid/widget/Button;
+	public final field agree Lcom/stripe/android/identity/ui/LoadingButton;
 	public final field body Landroid/widget/TextView;
 	public final field buttons Landroid/widget/LinearLayout;
-	public final field decline Landroid/widget/Button;
+	public final field decline Lcom/stripe/android/identity/ui/LoadingButton;
 	public final field divider Landroid/view/View;
 	public final field loadings Landroid/widget/LinearLayout;
 	public final field merchantLogo Landroid/widget/ImageView;
@@ -111,15 +111,21 @@ public final class com/stripe/android/identity/databinding/ConsentFragmentBindin
 
 public final class com/stripe/android/identity/databinding/DocSelectionFragmentBinding : androidx/viewbinding/ViewBinding {
 	public final field dl Lcom/google/android/material/button/MaterialButton;
+	public final field dlContainer Landroid/widget/RelativeLayout;
+	public final field dlIndicator Lcom/google/android/material/progressindicator/CircularProgressIndicator;
 	public final field dlSeparator Landroid/view/View;
 	public final field id Lcom/google/android/material/button/MaterialButton;
+	public final field idContainer Landroid/widget/RelativeLayout;
+	public final field idIndicator Lcom/google/android/material/progressindicator/CircularProgressIndicator;
 	public final field idSeparator Landroid/view/View;
 	public final field multiSelectionContent Landroid/widget/LinearLayout;
 	public final field passport Lcom/google/android/material/button/MaterialButton;
+	public final field passportContainer Landroid/widget/RelativeLayout;
+	public final field passportIndicator Lcom/google/android/material/progressindicator/CircularProgressIndicator;
 	public final field passportSeparator Landroid/view/View;
 	public final field singleSelectionBody Landroid/widget/TextView;
 	public final field singleSelectionContent Landroid/widget/LinearLayout;
-	public final field singleSelectionContinue Lcom/google/android/material/button/MaterialButton;
+	public final field singleSelectionContinue Lcom/stripe/android/identity/ui/LoadingButton;
 	public final field title Landroid/widget/TextView;
 	public static fun bind (Landroid/view/View;)Lcom/stripe/android/identity/databinding/DocSelectionFragmentBinding;
 	public synthetic fun getRoot ()Landroid/view/View;
@@ -165,7 +171,7 @@ public final class com/stripe/android/identity/databinding/FrontBackUploadFragme
 	public final field contentText Landroid/widget/TextView;
 	public final field finishedCheckMarkBack Landroid/widget/ImageView;
 	public final field finishedCheckMarkFront Landroid/widget/ImageView;
-	public final field kontinue Lcom/google/android/material/button/MaterialButton;
+	public final field kontinue Lcom/stripe/android/identity/ui/LoadingButton;
 	public final field labelBack Landroid/widget/TextView;
 	public final field labelFront Landroid/widget/TextView;
 	public final field progressCircularBack Lcom/google/android/material/progressindicator/CircularProgressIndicator;
@@ -213,6 +219,14 @@ public final class com/stripe/android/identity/databinding/IdentityActivityBindi
 	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/identity/databinding/IdentityActivityBinding;
 }
 
+public final class com/stripe/android/identity/databinding/LoadingButtonBinding : androidx/viewbinding/ViewBinding {
+	public final field button Lcom/google/android/material/button/MaterialButton;
+	public final field indicator Lcom/google/android/material/progressindicator/CircularProgressIndicator;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/identity/databinding/LoadingButtonBinding;
+	public fun getRoot ()Landroid/view/View;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;)Lcom/stripe/android/identity/databinding/LoadingButtonBinding;
+}
+
 public final class com/stripe/android/identity/databinding/PassportScanFragmentBinding : androidx/viewbinding/ViewBinding {
 	public final field cameraView Lcom/stripe/android/camera/scanui/CameraView;
 	public final field cameraViewCard Lcom/google/android/material/card/MaterialCardView;
@@ -230,7 +244,7 @@ public final class com/stripe/android/identity/databinding/PassportScanFragmentB
 public final class com/stripe/android/identity/databinding/PassportUploadFragmentBinding : androidx/viewbinding/ViewBinding {
 	public final field contentText Landroid/widget/TextView;
 	public final field finishedCheckMark Landroid/widget/ImageView;
-	public final field kontinue Lcom/google/android/material/button/MaterialButton;
+	public final field kontinue Lcom/stripe/android/identity/ui/LoadingButton;
 	public final field label Landroid/widget/TextView;
 	public final field progressCircular Lcom/google/android/material/progressindicator/CircularProgressIndicator;
 	public final field select Lcom/google/android/material/button/MaterialButton;

--- a/identity/res/layout/consent_fragment.xml
+++ b/identity/res/layout/consent_fragment.xml
@@ -136,18 +136,15 @@
         android:layout_height="wrap_content"
         android:layout_gravity="bottom">
 
-        <Button
+        <com.stripe.android.identity.ui.LoadingButton
             android:id="@+id/agree"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/agree_and_continue"
-            android:layout_marginBottom="10dp" />
+            android:layout_height="wrap_content" />
 
-        <Button
+        <com.stripe.android.identity.ui.LoadingButton
             android:id="@+id/decline"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/decline" />
+            android:layout_height="wrap_content" />
     </LinearLayout>
 
 </LinearLayout>

--- a/identity/res/layout/doc_selection_fragment.xml
+++ b/identity/res/layout/doc_selection_fragment.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -32,16 +33,36 @@
             android:layout_marginBottom="@dimen/item_vertical_margin"
             android:background="?android:attr/listDivider" />
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/dl"
-            style="@style/Widget.MaterialComponents.Button.TextButton"
+        <RelativeLayout
+            android:id="@+id/dl_container"
             android:visibility="gone"
-            android:textColor="?android:textColorPrimary"
-            android:text="@string/driver_license"
-            android:gravity="center_vertical"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/item_vertical_margin" />
+            android:layout_height="wrap_content">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/dl"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:textColor="?android:textColorPrimary"
+                android:text="@string/driver_license"
+                android:gravity="center_vertical"
+                android:layout_centerVertical="true"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/item_vertical_margin" />
+
+            <com.google.android.material.progressindicator.CircularProgressIndicator
+                android:id="@+id/dl_indicator"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:indeterminate="true"
+                android:visibility="gone"
+                android:layout_alignParentEnd="true"
+                android:layout_centerVertical="true"
+                android:paddingStart="0dp"
+                android:paddingEnd="4dp"
+                android:elevation="2dp"
+                app:indicatorSize="14dp" />
+        </RelativeLayout>
 
         <View
             android:id="@+id/dl_separator"
@@ -51,16 +72,36 @@
             android:layout_marginBottom="@dimen/item_vertical_margin"
             android:background="?android:attr/listDivider" />
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/id"
-            style="@style/Widget.MaterialComponents.Button.TextButton"
+        <RelativeLayout
+            android:id="@+id/id_container"
             android:visibility="gone"
-            android:textColor="?android:textColorPrimary"
-            android:text="@string/id_card"
-            android:layout_marginBottom="@dimen/item_vertical_margin"
-            android:gravity="center_vertical"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/id"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:textColor="?android:textColorPrimary"
+                android:text="@string/id_card"
+                android:layout_marginBottom="@dimen/item_vertical_margin"
+                android:gravity="center_vertical"
+                android:layout_centerVertical="true"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <com.google.android.material.progressindicator.CircularProgressIndicator
+                android:id="@+id/id_indicator"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:indeterminate="true"
+                android:visibility="gone"
+                android:layout_alignParentEnd="true"
+                android:layout_centerVertical="true"
+                android:paddingStart="0dp"
+                android:paddingEnd="4dp"
+                android:elevation="2dp"
+                app:indicatorSize="14dp" />
+        </RelativeLayout>
 
         <View
             android:id="@+id/id_separator"
@@ -70,16 +111,36 @@
             android:layout_marginBottom="@dimen/item_vertical_margin"
             android:background="?android:attr/listDivider" />
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/passport"
-            style="@style/Widget.MaterialComponents.Button.TextButton"
-            android:visibility="gone"
-            android:textColor="?android:textColorPrimary"
-            android:text="@string/passport"
-            android:layout_marginBottom="@dimen/item_vertical_margin"
-            android:gravity="center_vertical"
+        <RelativeLayout
+            android:id="@+id/passport_container"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:visibility="gone">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/passport"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:textColor="?android:textColorPrimary"
+                android:text="@string/passport"
+                android:layout_marginBottom="@dimen/item_vertical_margin"
+                android:gravity="center_vertical"
+                android:layout_centerVertical="true"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <com.google.android.material.progressindicator.CircularProgressIndicator
+                android:id="@+id/passport__indicator"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:indeterminate="true"
+                android:visibility="gone"
+                android:layout_alignParentEnd="true"
+                android:layout_centerVertical="true"
+                android:paddingStart="0dp"
+                android:paddingEnd="4dp"
+                android:elevation="2dp"
+                app:indicatorSize="14dp" />
+        </RelativeLayout>
 
         <View
             android:id="@+id/passport_separator"
@@ -103,11 +164,10 @@
             android:layout_width="match_parent"
             android:layout_height="0dp" />
 
-        <com.google.android.material.button.MaterialButton
+        <com.stripe.android.identity.ui.LoadingButton
             android:id="@+id/single_selection_continue"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/kontinue"
             android:visibility="visible" />
     </LinearLayout>
 

--- a/identity/res/layout/front_back_upload_fragment.xml
+++ b/identity/res/layout/front_back_upload_fragment.xml
@@ -157,14 +157,11 @@
         </LinearLayout>
     </ScrollView>
 
-
-    <com.google.android.material.button.MaterialButton
+    <com.stripe.android.identity.ui.LoadingButton
         android:id="@+id/kontinue"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/kontinue"
         android:layout_marginBottom="10dp"
-        android:enabled="false"
         android:layout_gravity="bottom" />
 
 </LinearLayout>

--- a/identity/res/layout/loading_button.xml
+++ b/identity/res/layout/loading_button.xml
@@ -6,7 +6,6 @@
         android:id="@+id/button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/agree_and_continue"
         android:layout_centerVertical="true"
         android:layout_marginBottom="10dp" />
 
@@ -18,8 +17,9 @@
         android:visibility="gone"
         android:layout_alignParentEnd="true"
         android:layout_centerVertical="true"
+        android:paddingStart="0dp"
+        android:paddingEnd="4dp"
         android:elevation="2dp"
-        app:indicatorColor="@android:color/white"
-        app:indicatorSize="16dp" />
+        app:indicatorSize="14dp" />
 
 </merge>

--- a/identity/res/layout/loading_button.xml
+++ b/identity/res/layout/loading_button.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/agree_and_continue"
+        android:layout_centerVertical="true"
+        android:layout_marginBottom="10dp" />
+
+    <com.google.android.material.progressindicator.CircularProgressIndicator
+        android:id="@+id/indicator"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        android:visibility="gone"
+        android:layout_alignParentEnd="true"
+        android:layout_centerVertical="true"
+        android:elevation="2dp"
+        app:indicatorColor="@android:color/white"
+        app:indicatorSize="16dp" />
+
+</merge>

--- a/identity/res/layout/passport_upload_fragment.xml
+++ b/identity/res/layout/passport_upload_fragment.xml
@@ -105,15 +105,14 @@
         </LinearLayout>
     </ScrollView>
 
-
-    <com.google.android.material.button.MaterialButton
+    <com.stripe.android.identity.ui.LoadingButton
         android:id="@+id/kontinue"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:text="@string/kontinue"
         android:layout_marginBottom="10dp"
-        android:enabled="false"
         android:layout_gravity="bottom" />
+
 
 </LinearLayout>
 

--- a/identity/res/values/colors.xml
+++ b/identity/res/values/colors.xml
@@ -4,6 +4,8 @@
 
     <color name="check_mark_background">#80FFFFFF</color>
 
+    <color name="loading_button_progress_indicator_color">#80FFFFFF</color>
+
     <color name="exclamation_mark">#88919E</color>
 
     <color name="choose_file_tint">#88919E</color>

--- a/identity/res/values/strings.xml
+++ b/identity/res/values/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="kontinue">continue</string>
-    <string name="agree_and_continue">Agree and continue</string>
     <string name="decline">Decline and use alternative method</string>
     <string name="driver_license">Driver\'s license</string>
     <string name="id_card">Identity card</string>

--- a/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModelProvider
+import androidx.navigation.findNavController
 import androidx.navigation.fragment.NavHostFragment
 import com.stripe.android.camera.CameraPermissionCheckingActivity
 import com.stripe.android.identity.IdentityVerificationSheet.VerificationResult
@@ -59,7 +60,13 @@ internal class IdentityActivity : CameraPermissionCheckingActivity(), Verificati
     }
 
     override fun onBackPressed() {
-        finishWithResult(VerificationResult.Canceled)
+        findNavController(R.id.identity_nav_host).let { navController ->
+            if (navController.currentDestination?.id == R.id.consentFragment) {
+                finishWithResult(VerificationResult.Canceled)
+            } else {
+                navController.navigateUp()
+            }
+        }
     }
 
     override fun finishWithResult(result: VerificationResult) {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
@@ -46,6 +46,8 @@ internal class ConsentFragment(
         binding.merchantLogo.setImageResource(identityViewModel.args.merchantLogo)
 
         binding.agree.setOnClickListener {
+            binding.agree.toggleToLoading()
+            binding.decline.isClickable = false
             postVerificationPageDataAndNavigate(
                 CollectedDataParam(
                     consent = ConsentParam(biometric = true)
@@ -53,6 +55,8 @@ internal class ConsentFragment(
             )
         }
         binding.decline.setOnClickListener {
+            binding.decline.toggleToLoading()
+            binding.agree.isClickable = false
             postVerificationPageDataAndNavigate(
                 CollectedDataParam(
                     consent = ConsentParam(biometric = false)
@@ -114,8 +118,8 @@ internal class ConsentFragment(
         binding.privacyPolicy.setHtmlString(consentPage.privacyPolicy)
         binding.timeEstimate.text = consentPage.timeEstimate
         binding.body.setHtmlString(consentPage.body)
-        binding.agree.text = consentPage.acceptButtonText
-        binding.decline.text = consentPage.declineButtonText
+        binding.agree.setText(consentPage.acceptButtonText)
+        binding.decline.setText(consentPage.declineButtonText)
     }
 
     private fun setLoadingFinishedUI() {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
@@ -88,25 +88,37 @@ internal class DocSelectionFragment(
                 when (allowedType) {
                     PASSPORT_KEY -> {
                         binding.passport.text = allowedTypeValue
-                        binding.passport.visibility = View.VISIBLE
+                        binding.passportContainer.visibility = View.VISIBLE
                         binding.passport.setOnClickListener {
-                            disableButtonAndNavigate(it, Type.PASSPORT)
+                            binding.passport.isEnabled = false
+                            binding.dl.isClickable = false
+                            binding.id.isClickable = false
+                            binding.passportIndicator.visibility = View.VISIBLE
+                            postVerificationPageDataAndNavigate(Type.PASSPORT)
                         }
                         binding.passportSeparator.visibility = View.VISIBLE
                     }
                     DRIVING_LICENSE_KEY -> {
                         binding.dl.text = allowedTypeValue
-                        binding.dl.visibility = View.VISIBLE
+                        binding.dlContainer.visibility = View.VISIBLE
                         binding.dl.setOnClickListener {
-                            disableButtonAndNavigate(it, Type.DRIVINGLICENSE)
+                            binding.dl.isEnabled = false
+                            binding.passport.isClickable = false
+                            binding.id.isClickable = false
+                            binding.dlIndicator.visibility = View.VISIBLE
+                            postVerificationPageDataAndNavigate(Type.DRIVINGLICENSE)
                         }
                         binding.dlSeparator.visibility = View.VISIBLE
                     }
                     ID_CARD_KEY -> {
                         binding.id.text = allowedTypeValue
-                        binding.id.visibility = View.VISIBLE
+                        binding.idContainer.visibility = View.VISIBLE
                         binding.id.setOnClickListener {
-                            disableButtonAndNavigate(it, Type.IDCARD)
+                            binding.id.isEnabled = false
+                            binding.passport.isClickable = false
+                            binding.dl.isClickable = false
+                            binding.idIndicator.visibility = View.VISIBLE
+                            postVerificationPageDataAndNavigate(Type.IDCARD)
                         }
                         binding.idSeparator.visibility = View.VISIBLE
                     }
@@ -116,25 +128,9 @@ internal class DocSelectionFragment(
                 }
             }
         } ?: run {
-            listOf(
-                binding.dl,
-                binding.dlSeparator,
-                binding.id,
-                binding.idSeparator,
-                binding.passport,
-                binding.passportSeparator
-            ).forEach {
-                it.visibility = View.VISIBLE
-            }
-            binding.passport.setOnClickListener {
-                disableButtonAndNavigate(it, Type.PASSPORT)
-            }
-            binding.dl.setOnClickListener {
-                disableButtonAndNavigate(it, Type.DRIVINGLICENSE)
-            }
-            binding.id.setOnClickListener {
-                disableButtonAndNavigate(it, Type.IDCARD)
-            }
+            // Not possible for backend to send an empty list of allowed types.
+            Log.e(TAG, "Received an empty idDocumentTypeAllowlist.")
+            navigateToDefaultErrorFragment()
         }
     }
 
@@ -144,45 +140,37 @@ internal class DocSelectionFragment(
     private fun toggleSingleSelectionUI(allowedType: String, buttonText: String) {
         binding.multiSelectionContent.visibility = View.GONE
         binding.singleSelectionContent.visibility = View.VISIBLE
-        binding.singleSelectionContinue.text = buttonText
+        binding.singleSelectionContinue.setText(buttonText)
 
         when (allowedType) {
             PASSPORT_KEY -> {
                 binding.singleSelectionBody.text =
                     getString(R.string.single_selection_body_content_passport)
                 binding.singleSelectionContinue.setOnClickListener {
-                    disableButtonAndNavigate(it, Type.PASSPORT)
+                    binding.singleSelectionContinue.toggleToLoading()
+                    postVerificationPageDataAndNavigate(Type.PASSPORT)
                 }
             }
             DRIVING_LICENSE_KEY -> {
                 binding.singleSelectionBody.text =
                     getString(R.string.single_selection_body_content_dl)
                 binding.singleSelectionContinue.setOnClickListener {
-                    disableButtonAndNavigate(it, Type.DRIVINGLICENSE)
+                    binding.singleSelectionContinue.toggleToLoading()
+                    postVerificationPageDataAndNavigate(Type.DRIVINGLICENSE)
                 }
             }
             ID_CARD_KEY -> {
                 binding.singleSelectionBody.text =
                     getString(R.string.single_selection_body_content_id)
                 binding.singleSelectionContinue.setOnClickListener {
-                    disableButtonAndNavigate(it, Type.IDCARD)
+                    binding.singleSelectionContinue.toggleToLoading()
+                    postVerificationPageDataAndNavigate(Type.IDCARD)
                 }
             }
             else -> {
                 throw InvalidRequestException(message = "Unknown allow type: $allowedType")
             }
         }
-    }
-
-    /**
-     * Disable the button view and try navigate to this type.
-     *
-     * TODO(ccen): add CircularProgressIndicator to button
-     * Note: no need to it back to enabled, as it will navigate to another Fragment.
-     */
-    private fun disableButtonAndNavigate(view: View, type: Type) {
-        view.isEnabled = false
-        postVerificationPageDataAndNavigate(type)
     }
 
     /**

--- a/identity/src/main/java/com/stripe/android/identity/navigation/FrontBackUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/FrontBackUploadFragment.kt
@@ -97,6 +97,8 @@ internal abstract class FrontBackUploadFragment(
         binding.selectFront.setOnClickListener {
             buildBottomSheetDialog(frontScanType).show()
         }
+        binding.kontinue.isEnabled = false
+        binding.kontinue.setText(getString(R.string.kontinue))
         return binding.root
     }
 
@@ -148,6 +150,7 @@ internal abstract class FrontBackUploadFragment(
         frontBackUploadViewModel.uploadFinished.observe(viewLifecycleOwner) {
             binding.kontinue.isEnabled = true
             binding.kontinue.setOnClickListener {
+                binding.kontinue.toggleToLoading()
                 lifecycleScope.launch {
                     runCatching {
                         val front =

--- a/identity/src/main/java/com/stripe/android/identity/navigation/PassportUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/PassportUploadFragment.kt
@@ -61,6 +61,8 @@ internal class PassportUploadFragment(
             buildBottomSheetDialog().show()
         }
 
+        binding.kontinue.isEnabled = false
+        binding.kontinue.setText(getString(R.string.kontinue))
         return binding.root
     }
 
@@ -130,6 +132,7 @@ internal class PassportUploadFragment(
         binding.finishedCheckMark.visibility = View.VISIBLE
         binding.kontinue.isEnabled = true
         binding.kontinue.setOnClickListener {
+            binding.kontinue.toggleToLoading()
             lifecycleScope.launch {
                 runCatching {
                     requireNotNull(passportImage)

--- a/identity/src/main/java/com/stripe/android/identity/ui/LoadingButton.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/LoadingButton.kt
@@ -24,7 +24,33 @@ internal class LoadingButton @JvmOverloads constructor(
         LoadingButtonBinding.inflate(LayoutInflater.from(context), this)
     }
 
-    internal val button: MaterialButton = findViewById(R.id.button)
+    private val button: MaterialButton = findViewById(R.id.button)
+
+    /**
+     * Set the [OnClickListener] to the button.
+     */
+    override fun setOnClickListener(l: OnClickListener?) {
+        button.setOnClickListener(l)
+    }
+
+    /**
+     * Thes the button's clickable state.
+     */
+    override fun setClickable(clickable: Boolean) {
+        button.isClickable = clickable
+    }
+
+    override fun setEnabled(enabled: Boolean) {
+        super.setEnabled(enabled)
+        button.isEnabled = enabled
+    }
+
+    /**
+     * Sets text to the button.
+     */
+    fun setText(text: CharSequence) {
+        button.text = text
+    }
 
     /**
      * Disable button and show loading indicator.
@@ -40,6 +66,5 @@ internal class LoadingButton @JvmOverloads constructor(
     fun toggleToButton() {
         findViewById<MaterialButton>(R.id.button).isEnabled = true
         findViewById<CircularProgressIndicator>(R.id.indicator).visibility = View.GONE
-
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/ui/LoadingButton.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/LoadingButton.kt
@@ -1,0 +1,45 @@
+package com.stripe.android.identity.ui
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.RelativeLayout
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.progressindicator.CircularProgressIndicator
+import com.stripe.android.identity.R
+import com.stripe.android.identity.databinding.LoadingButtonBinding
+
+/**
+ * A button with a progress indicator.
+ */
+internal class LoadingButton @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : RelativeLayout(
+    context, attrs, defStyleAttr
+) {
+    init {
+        LoadingButtonBinding.inflate(LayoutInflater.from(context), this)
+    }
+
+    internal val button: MaterialButton = findViewById(R.id.button)
+
+    /**
+     * Disable button and show loading indicator.
+     */
+    fun toggleToLoading() {
+        findViewById<MaterialButton>(R.id.button).isEnabled = false
+        findViewById<CircularProgressIndicator>(R.id.indicator).visibility = View.VISIBLE
+    }
+
+    /**
+     * Enable button and hide loading indicator.
+     */
+    fun toggleToButton() {
+        findViewById<MaterialButton>(R.id.button).isEnabled = true
+        findViewById<CircularProgressIndicator>(R.id.indicator).visibility = View.GONE
+
+    }
+}

--- a/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
@@ -6,6 +6,7 @@ import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.navigation.Navigation
 import androidx.navigation.testing.TestNavHostController
 import androidx.test.core.app.ApplicationProvider
+import com.google.android.material.button.MaterialButton
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.identity.IdentityVerificationSheetContract
@@ -155,8 +156,12 @@ internal class ConsentFragmentTest {
             assertThat(binding.privacyPolicy.text.toString()).isEqualTo(CONSENT_PRIVACY_POLICY)
             assertThat(binding.timeEstimate.text).isEqualTo(CONSENT_TIME_ESTIMATE)
             assertThat(binding.body.text.toString()).isEqualTo(CONSENT_BODY)
-            assertThat(binding.agree.text).isEqualTo(CONSENT_ACCEPT_TEXT)
-            assertThat(binding.decline.text).isEqualTo(CONSENT_DECLINE_TEXT)
+            assertThat(binding.agree.findViewById<MaterialButton>(R.id.button).text).isEqualTo(
+                CONSENT_ACCEPT_TEXT
+            )
+            assertThat(binding.decline.findViewById<MaterialButton>(R.id.button).text).isEqualTo(
+                CONSENT_DECLINE_TEXT
+            )
         }
     }
 
@@ -180,7 +185,7 @@ internal class ConsentFragmentTest {
             launchConsentFragment { binding, navController ->
                 setUpSuccessVerificationPage()
 
-                binding.agree.callOnClick()
+                binding.agree.findViewById<MaterialButton>(R.id.button).callOnClick()
 
                 assertThat(navController.currentDestination?.id)
                     .isEqualTo(R.id.docSelectionFragment)
@@ -197,7 +202,7 @@ internal class ConsentFragmentTest {
 
             launchConsentFragment { binding, navController ->
                 setUpSuccessVerificationPage()
-                binding.agree.callOnClick()
+                binding.agree.findViewById<MaterialButton>(R.id.button).callOnClick()
 
                 assertThat(navController.currentDestination?.id)
                     .isEqualTo(R.id.errorFragment)
@@ -214,7 +219,7 @@ internal class ConsentFragmentTest {
 
             launchConsentFragment { binding, navController ->
                 setUpSuccessVerificationPage()
-                binding.decline.callOnClick()
+                binding.decline.findViewById<MaterialButton>(R.id.button).callOnClick()
 
                 requireNotNull(navController.backStack.last().arguments).let { arguments ->
                     assertThat(arguments[ErrorFragment.ARG_ERROR_TITLE])
@@ -242,7 +247,7 @@ internal class ConsentFragmentTest {
 
             launchConsentFragment { binding, navController ->
                 setUpSuccessVerificationPage()
-                binding.decline.callOnClick()
+                binding.decline.findViewById<MaterialButton>(R.id.button).callOnClick()
 
                 assertThat(navController.currentDestination?.id)
                     .isEqualTo(R.id.errorFragment)

--- a/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.navigation.Navigation
 import androidx.navigation.testing.TestNavHostController
 import androidx.test.core.app.ApplicationProvider
+import com.google.android.material.button.MaterialButton
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.DocSelectionFragmentBinding
@@ -92,48 +93,29 @@ internal class DocSelectionFragmentTest {
             assertThat(binding.singleSelectionContent.visibility).isEqualTo(View.GONE)
 
             assertThat(binding.passport.text).isEqualTo(PASSPORT_BUTTON_TEXT)
-            assertThat(binding.passport.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.passportContainer.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.passportSeparator.visibility).isEqualTo(View.VISIBLE)
 
             assertThat(binding.dl.text).isEqualTo(DRIVING_LICENSE_BUTTON_TEXT)
-            assertThat(binding.dl.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.dlContainer.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.dlSeparator.visibility).isEqualTo(View.VISIBLE)
 
             assertThat(binding.id.text).isEqualTo(ID_BUTTON_TEXT)
-            assertThat(binding.id.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.idContainer.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.idSeparator.visibility).isEqualTo(View.VISIBLE)
         }
     }
 
     @Test
-    fun `zero choice UI is correctly bound with values locally`() {
-        launchDocSelectionFragment { binding, _, docSelectFragment ->
+    fun `zero choice navigates to error`() {
+        launchDocSelectionFragment { _, navController, _ ->
             whenever(verificationPage.documentSelect).thenReturn(
                 DOC_SELECT_ZERO_CHOICE
             )
             setUpSuccessVerificationPage()
 
-            assertThat(binding.title.text).isEqualTo(DOCUMENT_SELECT_TITLE)
-            assertThat(binding.multiSelectionContent.visibility).isEqualTo(View.VISIBLE)
-            assertThat(binding.singleSelectionContent.visibility).isEqualTo(View.GONE)
-
-            assertThat(binding.passport.text).isEqualTo(
-                docSelectFragment.getString(R.string.passport)
-            )
-            assertThat(binding.passport.visibility).isEqualTo(View.VISIBLE)
-            assertThat(binding.passportSeparator.visibility).isEqualTo(View.VISIBLE)
-
-            assertThat(binding.dl.text).isEqualTo(
-                docSelectFragment.getString(R.string.driver_license)
-            )
-            assertThat(binding.dl.visibility).isEqualTo(View.VISIBLE)
-            assertThat(binding.dlSeparator.visibility).isEqualTo(View.VISIBLE)
-
-            assertThat(binding.id.text).isEqualTo(
-                docSelectFragment.getString(R.string.id_card)
-            )
-            assertThat(binding.id.visibility).isEqualTo(View.VISIBLE)
-            assertThat(binding.idSeparator.visibility).isEqualTo(View.VISIBLE)
+            assertThat(navController.currentDestination?.id)
+                .isEqualTo(R.id.errorFragment)
         }
     }
 
@@ -182,7 +164,7 @@ internal class DocSelectionFragmentTest {
                 )
             )
             setUpSuccessVerificationPage()
-            binding.singleSelectionContinue.callOnClick()
+            binding.singleSelectionContinue.findViewById<MaterialButton>(R.id.button).callOnClick()
 
             assertThat(navController.currentDestination?.id)
                 .isEqualTo(R.id.driverLicenseScanFragment)
@@ -213,7 +195,7 @@ internal class DocSelectionFragmentTest {
                 MutableLiveData(Resource.error())
             )
             setUpSuccessVerificationPage()
-            binding.singleSelectionContinue.callOnClick()
+            binding.singleSelectionContinue.findViewById<MaterialButton>(R.id.button).callOnClick()
             setUpSuccessVerificationPage(2)
 
             assertThat(navController.currentDestination?.id)
@@ -245,7 +227,7 @@ internal class DocSelectionFragmentTest {
                 MutableLiveData(Resource.error())
             )
             setUpSuccessVerificationPage()
-            binding.singleSelectionContinue.callOnClick()
+            binding.singleSelectionContinue.findViewById<MaterialButton>(R.id.button).callOnClick()
             setUpSuccessVerificationPage(2)
 
             assertThat(navController.currentDestination?.id)
@@ -271,7 +253,11 @@ internal class DocSelectionFragmentTest {
                 docSelectionFragment.getString(expectedBodyStringRes)
             )
 
-            assertThat(binding.singleSelectionContinue.text).isEqualTo(DOCUMENT_SELECT_BUTTON_TEXT)
+            assertThat(
+                binding.singleSelectionContinue.findViewById<MaterialButton>(R.id.button).text
+            ).isEqualTo(
+                DOCUMENT_SELECT_BUTTON_TEXT
+            )
         }
     }
 

--- a/identity/src/test/java/com/stripe/android/identity/navigation/FrontBackUploadFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/FrontBackUploadFragmentTest.kt
@@ -12,6 +12,7 @@ import androidx.navigation.Navigation
 import androidx.navigation.testing.TestNavHostController
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.button.MaterialButton
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.model.InternalStripeFile
 import com.stripe.android.core.model.InternalStripeFilePurpose
@@ -212,7 +213,7 @@ class FrontBackUploadFragmentTest {
                     CORRECT_WITH_SUBMITTED_SUCCESS_VERIFICATION_PAGE_DATA
                 )
 
-                binding.kontinue.callOnClick()
+                binding.kontinue.findViewById<MaterialButton>(R.id.button).callOnClick()
 
                 assertThat(collectedDataParamCaptor.firstValue).isEqualTo(
                     CollectedDataParam(
@@ -245,7 +246,7 @@ class FrontBackUploadFragmentTest {
             // leave frontUploaded and backUploaded null
             uploadFinished.postValue(Unit)
 
-            binding.kontinue.callOnClick()
+            binding.kontinue.findViewById<MaterialButton>(R.id.button).callOnClick()
 
             assertThat(navController.currentDestination?.id)
                 .isEqualTo(R.id.errorFragment)

--- a/identity/src/test/java/com/stripe/android/identity/navigation/PassportUploadFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/PassportUploadFragmentTest.kt
@@ -10,6 +10,7 @@ import androidx.navigation.Navigation
 import androidx.navigation.testing.TestNavHostController
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.button.MaterialButton
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.model.InternalStripeFile
 import com.stripe.android.core.model.InternalStripeFilePurpose
@@ -128,7 +129,7 @@ class PassportUploadFragmentTest {
                     CORRECT_WITH_SUBMITTED_SUCCESS_VERIFICATION_PAGE_DATA
                 )
 
-                binding.kontinue.callOnClick()
+                binding.kontinue.findViewById<MaterialButton>(R.id.button).callOnClick()
 
                 assertThat(collectedDataParamCaptor.firstValue).isEqualTo(
                     CollectedDataParam(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add a circular progress indicator and disable the button. Also disable other button clicks after one button is clicked.


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
IDentity SDK


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots

![loadingButton](https://user-images.githubusercontent.com/79880926/158122685-93991297-580c-4fd5-af1e-c857bf8d59df.gif)


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
