### PR TITLE
Move BrowserCapabilities to stripe-core.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherViewModel.kt
@@ -12,6 +12,8 @@ import androidx.savedstate.SavedStateRegistryOwner
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
 import com.stripe.android.auth.PaymentBrowserAuthContract
+import com.stripe.android.core.browser.BrowserCapabilities
+import com.stripe.android.core.browser.BrowserCapabilitiesSupplier
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
 import com.stripe.android.networking.PaymentAnalyticsEvent

--- a/payments-core/src/test/java/com/stripe/android/payments/StripeBrowserLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/StripeBrowserLauncherViewModelTest.kt
@@ -8,6 +8,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.auth.PaymentBrowserAuthContract
+import com.stripe.android.core.browser.BrowserCapabilities
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory

--- a/stripe-core/build.gradle
+++ b/stripe-core/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     kapt "com.google.dagger:dagger-compiler:$daggerVersion"
 
     implementation "androidx.activity:activity-compose:$androidxActivityVersion"
+    implementation "androidx.browser:browser:$androidxBrowserVersion"
 
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"

--- a/stripe-core/src/main/java/com/stripe/android/core/browser/BrowserCapabilities.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/browser/BrowserCapabilities.kt
@@ -1,10 +1,13 @@
-package com.stripe.android.payments
+package com.stripe.android.core.browser
+
+import androidx.annotation.RestrictTo
 
 /**
  * Representation of the device's browser capabilities. Used for determining how to handle
  * browser-based payment authentication.
  */
-internal enum class BrowserCapabilities {
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+enum class BrowserCapabilities {
     CustomTabs,
     Unknown
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/browser/BrowserCapabilitiesSupplier.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/browser/BrowserCapabilitiesSupplier.kt
@@ -2,6 +2,7 @@ package com.stripe.android.core.browser
 
 import android.content.ComponentName
 import android.content.Context
+import androidx.annotation.RestrictTo
 import androidx.browser.customtabs.CustomTabsClient
 import androidx.browser.customtabs.CustomTabsServiceConnection
 
@@ -11,7 +12,8 @@ import androidx.browser.customtabs.CustomTabsServiceConnection
  * See https://developer.chrome.com/docs/android/custom-tabs/integration-guide/ for more details
  * on Custom Tabs.
  */
-internal class BrowserCapabilitiesSupplier(
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class BrowserCapabilitiesSupplier(
     private val context: Context
 ) {
     fun get(): BrowserCapabilities {

--- a/stripe-core/src/main/java/com/stripe/android/core/browser/BrowserCapabilitiesSupplier.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/browser/BrowserCapabilitiesSupplier.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.payments
+package com.stripe.android.core.browser
 
 import android.content.ComponentName
 import android.content.Context
@@ -35,10 +35,9 @@ internal class BrowserCapabilitiesSupplier(
         override fun onCustomTabsServiceConnected(
             componentName: ComponentName,
             customTabsClient: CustomTabsClient
-        ) {
-        }
+        ) = Unit
 
-        override fun onServiceDisconnected(name: ComponentName) {}
+        override fun onServiceDisconnected(name: ComponentName) = Unit
     }
 
     private companion object {


### PR DESCRIPTION
# Summary
- Moves BrowserCapabilities and related classes to stripe-core
- Moves [androidx-browser](https://androidx.tech/artifacts/browser/browser/) to `stripe-core` 

# Motivation
- Allow non-payments SDKs to check browser availability and features reusing existing logic.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified

