### PR TITLE
[Identity] Handle camera permission correctly

### DIFF
--- a/identity/res/navigation/identity_nav_graph.xml
+++ b/identity/res/navigation/identity_nav_graph.xml
@@ -101,6 +101,9 @@
         <action
             android:id="@+id/action_cameraPermissionDeniedFragment_to_driverLicenseUploadFragment"
             app:destination="@id/driverLicenseUploadFragment" />
+        <action
+            android:id="@+id/action_cameraPermissionDeniedFragment_to_docSelectionFragment"
+            app:destination="@id/docSelectionFragment" />
     </fragment>
     <fragment
         android:id="@+id/cameraErrorFragment"

--- a/identity/res/values/strings.xml
+++ b/identity/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="app_settings">App Settings</string>
     <string name="camera_permission">Camera permission</string>
     <string name="grant_camera_permission_text">We need permission to use your camera. Please allow camera access in app settings.</string>
+    <string name="ok">OK</string>
     <string name="upload_file_text">Alternatively, you may manually upload a photo of your %1$s</string>
 
     <string name="displayname_id">ID</string>

--- a/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
+import androidx.appcompat.app.AlertDialog
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.findNavController
 import androidx.navigation.fragment.NavHostFragment
@@ -75,6 +76,26 @@ internal class IdentityActivity : CameraPermissionCheckingActivity(), Verificati
             Intent().putExtras(result.toBundle())
         )
         finish()
+    }
+
+    /**
+     * Display the permission rational dialog without writing PERMISSION_RATIONALE_SHOWN, this would
+     * prevent [showPermissionDeniedDialog] from being called and always trigger
+     * [CameraPermissionCheckingActivity.requestCameraPermission].
+     */
+    override fun showPermissionRationaleDialog() {
+        val builder = AlertDialog.Builder(this)
+        builder.setMessage(R.string.grant_camera_permission_text)
+            .setPositiveButton(R.string.ok) { _, _ ->
+                requestCameraPermission()
+            }
+        builder.show()
+    }
+
+    // This should have neve been invoked as PERMISSION_RATIONALE_SHOWN is never written.
+    // Identity has its own CameraPermissionDeniedFragment to handle this case.
+    override fun showPermissionDeniedDialog() {
+        // no-op
     }
 
     private companion object {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/CameraPermissionDeniedFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/CameraPermissionDeniedFragment.kt
@@ -4,12 +4,14 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.IdRes
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.stripe.android.camera.AppSettingsOpenable
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.CameraPermissionDeniedFragmentBinding
-import com.stripe.android.identity.states.IdentityScanState
+import com.stripe.android.identity.networking.models.IdDocumentParam
+import com.stripe.android.identity.utils.navigateToUploadFragment
 
 /**
  * Fragment to show user denies camera permission.
@@ -25,7 +27,7 @@ internal class CameraPermissionDeniedFragment(
     ): View {
         val args = requireNotNull(arguments)
 
-        val identityScanType = args[ARG_SCAN_TYPE] as IdentityScanState.ScanType
+        val identityScanType = args[ARG_SCAN_TYPE] as IdDocumentParam.Type
 
         val binding = CameraPermissionDeniedFragmentBinding.inflate(inflater, container, false)
 
@@ -34,47 +36,43 @@ internal class CameraPermissionDeniedFragment(
 
         binding.appSettings.setOnClickListener {
             appSettingsOpenable.openAppSettings()
+            // navigate back to DocSelectFragment, so that when user is back to the app from settings
+            // the camera permission check can be triggered again from there.
+            findNavController().navigate(R.id.action_cameraPermissionDeniedFragment_to_docSelectionFragment)
         }
 
         binding.fileUpload.setOnClickListener {
-            findNavController().navigate(
-                when (identityScanType) {
-                    IdentityScanState.ScanType.ID_FRONT -> R.id.action_cameraPermissionDeniedFragment_to_IDUploadFragment
-                    IdentityScanState.ScanType.DL_FRONT -> R.id.action_cameraPermissionDeniedFragment_to_driverLicenseUploadFragment
-                    IdentityScanState.ScanType.PASSPORT -> R.id.action_cameraPermissionDeniedFragment_to_passportUploadFragment
-                    else -> {
-                        throw IllegalArgumentException("CameraPermissionDeniedFragment receives incorrect ScanType: $identityScanType")
-                    }
-                }
+            navigateToUploadFragment(
+                identityScanType.toUploadDestinationId(),
+                false
             )
         }
 
         return binding.root
     }
 
-    private fun IdentityScanState.ScanType.getDisplayName() =
+    private fun IdDocumentParam.Type.getDisplayName() =
         when (this) {
-            IdentityScanState.ScanType.ID_FRONT -> {
+            IdDocumentParam.Type.IDCARD -> {
                 getString(R.string.displayname_id)
             }
-            IdentityScanState.ScanType.ID_BACK -> {
-                getString(R.string.displayname_id)
-            }
-            IdentityScanState.ScanType.DL_FRONT -> {
+            IdDocumentParam.Type.DRIVINGLICENSE -> {
                 getString(R.string.displayname_dl)
             }
-            IdentityScanState.ScanType.DL_BACK -> {
-                getString(R.string.displayname_dl)
-            }
-            IdentityScanState.ScanType.PASSPORT -> {
+            IdDocumentParam.Type.PASSPORT -> {
                 getString(R.string.displayname_passport)
-            }
-            IdentityScanState.ScanType.SELFIE -> {
-                getString(R.string.displayname_selfie)
             }
         }
 
-    companion object {
+    internal companion object {
         const val ARG_SCAN_TYPE = "scanType"
+
+        @IdRes
+        private fun IdDocumentParam.Type.toUploadDestinationId() =
+            when (this) {
+                IdDocumentParam.Type.IDCARD -> R.id.action_cameraPermissionDeniedFragment_to_IDUploadFragment
+                IdDocumentParam.Type.DRIVINGLICENSE -> R.id.action_cameraPermissionDeniedFragment_to_driverLicenseUploadFragment
+                IdDocumentParam.Type.PASSPORT -> R.id.action_cameraPermissionDeniedFragment_to_passportUploadFragment
+            }
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/DriverLicenseScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/DriverLicenseScanFragment.kt
@@ -8,10 +8,8 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.ImageView
 import android.widget.TextView
-import androidx.core.os.bundleOf
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.findNavController
-import com.stripe.android.camera.CameraPermissionEnsureable
 import com.stripe.android.camera.scanui.util.startAnimation
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.DriverLicenseScanFragmentBinding
@@ -21,11 +19,9 @@ import com.stripe.android.identity.states.IdentityScanState
  * Fragment to scan the Driver's license.
  */
 internal class DriverLicenseScanFragment(
-    cameraPermissionEnsureable: CameraPermissionEnsureable,
     cameraViewModelFactory: ViewModelProvider.Factory,
     identityViewModelFactory: ViewModelProvider.Factory
 ) : IdentityCameraScanFragment(
-    cameraPermissionEnsureable,
     cameraViewModelFactory,
     identityViewModelFactory
 ) {
@@ -72,15 +68,6 @@ internal class DriverLicenseScanFragment(
     override fun onCameraReady() {
         cameraViewModel.targetScanType = IdentityScanState.ScanType.DL_FRONT
         startScanning(IdentityScanState.ScanType.DL_FRONT)
-    }
-
-    override fun onUserDeniedCameraPermission() {
-        findNavController().navigate(
-            R.id.action_camera_permission_denied,
-            bundleOf(
-                CameraPermissionDeniedFragment.ARG_SCAN_TYPE to IdentityScanState.ScanType.DL_FRONT
-            )
-        )
     }
 
     override fun updateUI(identityScanState: IdentityScanState) {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IDScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IDScanFragment.kt
@@ -8,10 +8,8 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.ImageView
 import android.widget.TextView
-import androidx.core.os.bundleOf
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.findNavController
-import com.stripe.android.camera.CameraPermissionEnsureable
 import com.stripe.android.camera.scanui.util.startAnimation
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.IdScanFragmentBinding
@@ -23,11 +21,9 @@ import com.stripe.android.identity.states.IdentityScanState.ScanType.ID_FRONT
  * Fragment to scan the ID.
  */
 internal class IDScanFragment(
-    cameraPermissionEnsureable: CameraPermissionEnsureable,
     cameraViewModelFactory: ViewModelProvider.Factory,
     identityViewModelFactory: ViewModelProvider.Factory
 ) : IdentityCameraScanFragment(
-    cameraPermissionEnsureable,
     cameraViewModelFactory,
     identityViewModelFactory
 ) {
@@ -73,15 +69,6 @@ internal class IDScanFragment(
     override fun onCameraReady() {
         cameraViewModel.targetScanType = ID_FRONT
         startScanning(ID_FRONT)
-    }
-
-    override fun onUserDeniedCameraPermission() {
-        findNavController().navigate(
-            R.id.action_camera_permission_denied,
-            bundleOf(
-                CameraPermissionDeniedFragment.ARG_SCAN_TYPE to ID_FRONT
-            )
-        )
     }
 
     override fun updateUI(identityScanState: IdentityScanState) {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
@@ -11,7 +11,6 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import com.stripe.android.camera.Camera1Adapter
-import com.stripe.android.camera.CameraPermissionEnsureable
 import com.stripe.android.camera.DefaultCameraErrorListener
 import com.stripe.android.camera.scanui.CameraView
 import com.stripe.android.camera.scanui.util.asRect
@@ -32,7 +31,7 @@ import com.stripe.android.identity.viewmodel.IdentityViewModel
  *
  */
 internal abstract class IdentityCameraScanFragment(
-    private val cameraPermissionEnsureable: CameraPermissionEnsureable,
+//    private val cameraPermissionEnsureable: CameraPermissionEnsureable,
     private val cameraViewModelFactory: ViewModelProvider.Factory,
     private val identityViewModelFactory: ViewModelProvider.Factory
 ) : Fragment() {
@@ -52,11 +51,6 @@ internal abstract class IdentityCameraScanFragment(
      * Called back once after at end of [onViewCreated] when permission is granted.
      */
     protected abstract fun onCameraReady()
-
-    /**
-     * Called back once after at end of [onViewCreated] when permission is denied.
-     */
-    protected abstract fun onUserDeniedCameraPermission()
 
     /**
      * Called back each time when [CameraViewModel.displayStateChanged] is changed.
@@ -84,10 +78,9 @@ internal abstract class IdentityCameraScanFragment(
             when (it.status) {
                 Status.SUCCESS -> {
                     cameraViewModel.initializeScanFlow(requireNotNull(it.data))
-                    cameraPermissionEnsureable.ensureCameraPermission(
-                        ::onCameraReady,
-                        ::onUserDeniedCameraPermission
-                    )
+                    cameraView.post {
+                        onCameraReady()
+                    }
                 }
                 Status.LOADING -> {
                     // no-op

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
@@ -24,14 +24,8 @@ import com.stripe.android.identity.viewmodel.IdentityViewModel
  * An abstract [Fragment] class to access camera scanning for Identity.
  *
  * Subclasses are responsible for populating [cameraView] in its [Fragment.onCreateView] method.
- *
- * When the fragment's view is created, [cameraPermissionEnsureable] is used to check camera
- * permission. Subclasses are responsible for implementing [onCameraReady] and
- * [onUserDeniedCameraPermission] to handle the permission callbacks.
- *
  */
 internal abstract class IdentityCameraScanFragment(
-//    private val cameraPermissionEnsureable: CameraPermissionEnsureable,
     private val cameraViewModelFactory: ViewModelProvider.Factory,
     private val identityViewModelFactory: ViewModelProvider.Factory
 ) : Fragment() {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
@@ -76,9 +76,7 @@ internal abstract class IdentityCameraScanFragment(
                         onCameraReady()
                     }
                 }
-                Status.LOADING -> {
-                    // no-op
-                }
+                Status.LOADING -> {} // no-op
                 Status.ERROR -> {
                     throw InvalidResponseException(
                         cause = it.throwable,

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
@@ -44,17 +44,17 @@ internal class IdentityFragmentFactory(
     override fun instantiate(classLoader: ClassLoader, className: String): Fragment {
         return when (className) {
             IDScanFragment::class.java.name -> IDScanFragment(
-                cameraPermissionEnsureable,
+//                cameraPermissionEnsureable,
                 cameraViewModelFactory,
                 identityViewModelFactory
             )
             DriverLicenseScanFragment::class.java.name -> DriverLicenseScanFragment(
-                cameraPermissionEnsureable,
+//                cameraPermissionEnsureable,
                 cameraViewModelFactory,
                 identityViewModelFactory
             )
             PassportScanFragment::class.java.name -> PassportScanFragment(
-                cameraPermissionEnsureable,
+//                cameraPermissionEnsureable,
                 cameraViewModelFactory,
                 identityViewModelFactory
             )
@@ -77,7 +77,8 @@ internal class IdentityFragmentFactory(
                 identityViewModelFactory
             )
             DocSelectionFragment::class.java.name -> DocSelectionFragment(
-                identityViewModelFactory
+                identityViewModelFactory,
+                cameraPermissionEnsureable
             )
             ConfirmationFragment::class.java.name -> ConfirmationFragment(
                 identityViewModelFactory,

--- a/identity/src/main/java/com/stripe/android/identity/navigation/PassportScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/PassportScanFragment.kt
@@ -7,10 +7,8 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.ImageView
 import android.widget.TextView
-import androidx.core.os.bundleOf
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.findNavController
-import com.stripe.android.camera.CameraPermissionEnsureable
 import com.stripe.android.camera.scanui.util.startAnimation
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.PassportScanFragmentBinding
@@ -20,11 +18,9 @@ import com.stripe.android.identity.states.IdentityScanState
  * Fragment to scan passport.
  */
 internal class PassportScanFragment(
-    cameraPermissionEnsureable: CameraPermissionEnsureable,
     cameraViewModelFactory: ViewModelProvider.Factory,
     identityViewModelFactory: ViewModelProvider.Factory
 ) : IdentityCameraScanFragment(
-    cameraPermissionEnsureable,
     cameraViewModelFactory,
     identityViewModelFactory
 ) {
@@ -59,15 +55,6 @@ internal class PassportScanFragment(
     override fun onCameraReady() {
         cameraViewModel.targetScanType = IdentityScanState.ScanType.PASSPORT
         startScanning(IdentityScanState.ScanType.PASSPORT)
-    }
-
-    override fun onUserDeniedCameraPermission() {
-        findNavController().navigate(
-            R.id.action_camera_permission_denied,
-            bundleOf(
-                CameraPermissionDeniedFragment.ARG_SCAN_TYPE to IdentityScanState.ScanType.PASSPORT
-            )
-        )
     }
 
     override fun updateUI(identityScanState: IdentityScanState) {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/PassportUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/PassportUploadFragment.kt
@@ -21,6 +21,7 @@ import com.stripe.android.identity.networking.models.ClearDataParam
 import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.networking.models.DocumentUploadParam
 import com.stripe.android.identity.networking.models.IdDocumentParam
+import com.stripe.android.identity.utils.ARG_SHOULD_SHOW_CAMERA
 import com.stripe.android.identity.utils.navigateToDefaultErrorFragment
 import com.stripe.android.identity.utils.postVerificationPageDataAndMaybeSubmit
 import com.stripe.android.identity.viewmodel.IdentityViewModel
@@ -45,6 +46,8 @@ internal class PassportUploadFragment(
         identityViewModelFactory
     }
 
+    private var shouldShowCamera: Boolean = false
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         passportUploadViewModel.registerActivityResultCaller(this)
@@ -55,6 +58,11 @@ internal class PassportUploadFragment(
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
+        val args = requireNotNull(arguments) {
+            "Argument to PassportUploadFragment is null"
+        }
+        shouldShowCamera = args[ARG_SHOULD_SHOW_CAMERA] as Boolean
+
         binding = PassportUploadFragmentBinding.inflate(layoutInflater, container, false)
 
         binding.select.setOnClickListener {
@@ -88,12 +96,17 @@ internal class PassportUploadFragment(
     private fun buildBottomSheetDialog() = BottomSheetDialog(requireContext()).also { dialog ->
         dialog.setContentView(R.layout.get_local_image_fragment)
         dialog.setOnCancelListener {
+            Log.d(TAG, "dialog cancelled")
         }
-        dialog.findViewById<Button>(R.id.take_photo)?.setOnClickListener {
-            dialog.dismiss()
-            passportUploadViewModel.takePhoto(requireContext()) {
-                upload(it, DocumentUploadParam.UploadMethod.MANUALCAPTURE)
+        if (shouldShowCamera) {
+            dialog.findViewById<Button>(R.id.take_photo)?.setOnClickListener {
+                dialog.dismiss()
+                passportUploadViewModel.takePhoto(requireContext()) {
+                    upload(it, DocumentUploadParam.UploadMethod.MANUALCAPTURE)
+                }
             }
+        } else {
+            requireNotNull(dialog.findViewById(R.id.take_photo)).visibility = View.GONE
         }
         dialog.findViewById<Button>(R.id.choose_file)?.setOnClickListener {
             dialog.dismiss()

--- a/identity/src/main/java/com/stripe/android/identity/utils/navigationUtils.kt
+++ b/identity/src/main/java/com/stripe/android/identity/utils/navigationUtils.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.identity.utils
 
 import android.util.Log
+import androidx.annotation.IdRes
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.stripe.android.identity.R
@@ -101,5 +103,25 @@ private fun Fragment.navigateToRequirementErrorFragment(
 internal fun Fragment.navigateToDefaultErrorFragment() {
     findNavController().navigateToErrorFragmentWithDefaultValues(requireContext())
 }
+
+/**
+ * Navigate to upload fragment with shouldShowCamera argument.
+ */
+internal fun Fragment.navigateToUploadFragment(
+    @IdRes destinationId: Int,
+    shouldShowCamera: Boolean
+) {
+    findNavController().navigate(
+        destinationId,
+        bundleOf(
+            ARG_SHOULD_SHOW_CAMERA to shouldShowCamera
+        )
+    )
+}
+
+/**
+ * Argument to indicate if camera option should be shown when picking an image.
+ */
+internal const val ARG_SHOULD_SHOW_CAMERA = "shouldShowCamera"
 
 private const val TAG = "NAVIGATION_UTIL"

--- a/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
@@ -10,12 +10,15 @@ import androidx.navigation.testing.TestNavHostController
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.material.button.MaterialButton
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.camera.CameraPermissionEnsureable
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.DocSelectionFragmentBinding
+import com.stripe.android.identity.navigation.CameraPermissionDeniedFragment.Companion.ARG_SCAN_TYPE
 import com.stripe.android.identity.navigation.DocSelectionFragment.Companion.DRIVING_LICENSE_KEY
 import com.stripe.android.identity.navigation.DocSelectionFragment.Companion.ID_CARD_KEY
 import com.stripe.android.identity.navigation.DocSelectionFragment.Companion.PASSPORT_KEY
 import com.stripe.android.identity.networking.Resource
+import com.stripe.android.identity.networking.models.IdDocumentParam
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPageData
 import com.stripe.android.identity.networking.models.VerificationPageDataRequirements
@@ -44,6 +47,9 @@ internal class DocSelectionFragmentTest {
 
     private val verificationPage = mock<VerificationPage>()
     private val mockIdentityViewModel = mock<IdentityViewModel>()
+    private val mockCameraPermissionEnsureable = mock<CameraPermissionEnsureable>()
+    private val onCameraReadyCaptor = argumentCaptor<() -> Unit>()
+    private val onUserDeniedCameraPermissionCaptor = argumentCaptor<() -> Unit>()
 
     private fun setUpErrorVerificationPage() {
         val failureCaptor: KArgumentCaptor<(Throwable?) -> Unit> = argumentCaptor()
@@ -154,8 +160,7 @@ internal class DocSelectionFragmentTest {
                     MISSING_BACK_VERIFICATION_PAGE_DATA
                 )
             }
-            // mock scan is available
-            // TODO(ccen) add camera permission check later
+            // mock file is available
             whenever(mockIdentityViewModel.idDetectorModelFile).thenReturn(
                 MutableLiveData(
                     Resource.success(
@@ -166,13 +171,21 @@ internal class DocSelectionFragmentTest {
             setUpSuccessVerificationPage()
             binding.singleSelectionContinue.findViewById<MaterialButton>(R.id.button).callOnClick()
 
+            verify(mockCameraPermissionEnsureable).ensureCameraPermission(
+                onCameraReadyCaptor.capture(),
+                onUserDeniedCameraPermissionCaptor.capture()
+            )
+
+            // trigger permission granted
+            onCameraReadyCaptor.firstValue()
+
             assertThat(navController.currentDestination?.id)
                 .isEqualTo(R.id.driverLicenseScanFragment)
         }
     }
 
     @Test
-    fun `when scan is unavailable, clicking continue navigates to upload when requireLiveCapture is false`() {
+    fun `when modelFile is unavailable and camera permission granted, clicking continue navigates to upload when requireLiveCapture is false`() {
         launchDocSelectionFragment { binding, navController, _ ->
             whenever(verificationPage.documentSelect).thenReturn(
                 DOC_SELECT_SINGLE_CHOICE_DL
@@ -189,13 +202,21 @@ internal class DocSelectionFragmentTest {
                     MISSING_BACK_VERIFICATION_PAGE_DATA
                 )
             }
-            // mock scan is not available
-            // TODO(ccen) add camera permission check later
+            // mock file is not available
             whenever(mockIdentityViewModel.idDetectorModelFile).thenReturn(
                 MutableLiveData(Resource.error())
             )
             setUpSuccessVerificationPage()
             binding.singleSelectionContinue.findViewById<MaterialButton>(R.id.button).callOnClick()
+
+            verify(mockCameraPermissionEnsureable).ensureCameraPermission(
+                onCameraReadyCaptor.capture(),
+                onUserDeniedCameraPermissionCaptor.capture()
+            )
+
+            // trigger permission granted
+            onCameraReadyCaptor.firstValue()
+
             setUpSuccessVerificationPage(2)
 
             assertThat(navController.currentDestination?.id)
@@ -204,7 +225,7 @@ internal class DocSelectionFragmentTest {
     }
 
     @Test
-    fun `when scan is unavailable, clicking continue navigates to error when requireLiveCapture is true`() {
+    fun `when modelFile is unavailable and camera permission granted, clicking continue navigates to error when requireLiveCapture is true`() {
         launchDocSelectionFragment { binding, navController, _ ->
             whenever(verificationPage.documentSelect).thenReturn(
                 DOC_SELECT_SINGLE_CHOICE_DL
@@ -222,12 +243,105 @@ internal class DocSelectionFragmentTest {
                 )
             }
             // mock scan is not available
-            // TODO(ccen) add camera permission check later
             whenever(mockIdentityViewModel.idDetectorModelFile).thenReturn(
                 MutableLiveData(Resource.error())
             )
             setUpSuccessVerificationPage()
             binding.singleSelectionContinue.findViewById<MaterialButton>(R.id.button).callOnClick()
+
+            verify(mockCameraPermissionEnsureable).ensureCameraPermission(
+                onCameraReadyCaptor.capture(),
+                onUserDeniedCameraPermissionCaptor.capture()
+            )
+
+            // trigger permission granted
+            onCameraReadyCaptor.firstValue()
+
+            setUpSuccessVerificationPage(2)
+
+            assertThat(navController.currentDestination?.id)
+                .isEqualTo(R.id.errorFragment)
+        }
+    }
+
+    @Test
+    fun `when camera permission is denied, clicking continue navigates to CameraPermissionDeniedFragment when requireLiveCapture is false`() {
+        launchDocSelectionFragment { binding, navController, _ ->
+            whenever(verificationPage.documentSelect).thenReturn(
+                DOC_SELECT_SINGLE_CHOICE_DL
+            )
+            val mockDocumentCapture =
+                mock<VerificationPageStaticContentDocumentCapturePage>().also {
+                    whenever(it.requireLiveCapture).thenReturn(false)
+                }
+            whenever(verificationPage.documentCapture).thenReturn(
+                mockDocumentCapture
+            )
+            runBlocking {
+                whenever(mockIdentityViewModel.postVerificationPageData(any(), any())).thenReturn(
+                    MISSING_BACK_VERIFICATION_PAGE_DATA
+                )
+            }
+            // mock file is available
+            whenever(mockIdentityViewModel.idDetectorModelFile).thenReturn(
+                MutableLiveData(Resource.success(mock()))
+            )
+            setUpSuccessVerificationPage()
+            binding.singleSelectionContinue.findViewById<MaterialButton>(R.id.button).callOnClick()
+
+            verify(mockCameraPermissionEnsureable).ensureCameraPermission(
+                onCameraReadyCaptor.capture(),
+                onUserDeniedCameraPermissionCaptor.capture()
+            )
+
+            // trigger permission denied
+            onUserDeniedCameraPermissionCaptor.firstValue()
+
+            setUpSuccessVerificationPage(2)
+
+            assertThat(
+                requireNotNull(navController.backStack.last().arguments)
+                [ARG_SCAN_TYPE]
+            ).isEqualTo(IdDocumentParam.Type.DRIVINGLICENSE)
+
+            assertThat(navController.currentDestination?.id)
+                .isEqualTo(R.id.cameraPermissionDeniedFragment)
+        }
+    }
+
+    @Test
+    fun `when camera permission is denied, clicking continue navigates to ErrorFragment when requireLiveCapture is true`() {
+        launchDocSelectionFragment { binding, navController, _ ->
+            whenever(verificationPage.documentSelect).thenReturn(
+                DOC_SELECT_SINGLE_CHOICE_DL
+            )
+            val mockDocumentCapture =
+                mock<VerificationPageStaticContentDocumentCapturePage>().also {
+                    whenever(it.requireLiveCapture).thenReturn(true)
+                }
+            whenever(verificationPage.documentCapture).thenReturn(
+                mockDocumentCapture
+            )
+            runBlocking {
+                whenever(mockIdentityViewModel.postVerificationPageData(any(), any())).thenReturn(
+                    MISSING_BACK_VERIFICATION_PAGE_DATA
+                )
+            }
+            // mock file is available
+            whenever(mockIdentityViewModel.idDetectorModelFile).thenReturn(
+                MutableLiveData(Resource.success(mock()))
+            )
+            setUpSuccessVerificationPage()
+            binding.singleSelectionContinue.findViewById<MaterialButton>(R.id.button).callOnClick()
+
+            verify(mockCameraPermissionEnsureable).ensureCameraPermission(
+                onCameraReadyCaptor.capture(),
+                onUserDeniedCameraPermissionCaptor.capture()
+            )
+
+            // trigger permission denied
+            onUserDeniedCameraPermissionCaptor.firstValue()
+
             setUpSuccessVerificationPage(2)
 
             assertThat(navController.currentDestination?.id)
@@ -270,7 +384,10 @@ internal class DocSelectionFragmentTest {
     ) = launchFragmentInContainer(
         themeResId = R.style.Theme_MaterialComponents
     ) {
-        DocSelectionFragment(viewModelFactoryFor(mockIdentityViewModel))
+        DocSelectionFragment(
+            viewModelFactoryFor(mockIdentityViewModel),
+            mockCameraPermissionEnsureable
+        )
     }.onFragment {
         val navController = TestNavHostController(
             ApplicationProvider.getApplicationContext()

--- a/identity/src/test/java/com/stripe/android/identity/navigation/FrontBackUploadFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/FrontBackUploadFragmentTest.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import android.view.View
 import android.widget.Button
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.core.os.bundleOf
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
@@ -28,6 +29,7 @@ import com.stripe.android.identity.networking.models.IdDocumentParam
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentDocumentCapturePage
 import com.stripe.android.identity.states.IdentityScanState
+import com.stripe.android.identity.utils.ARG_SHOULD_SHOW_CAMERA
 import com.stripe.android.identity.viewModelFactoryFor
 import com.stripe.android.identity.viewmodel.FrontBackUploadViewModel
 import com.stripe.android.identity.viewmodel.IdentityViewModel
@@ -102,6 +104,38 @@ class FrontBackUploadFragmentTest {
                     R.string.back_of_id_selected
                 )
             )
+        }
+    }
+
+    @Test
+    fun `when shouldShowCamera is true UI is correct`() {
+        launchFragment(shouldShowCamera = true) { binding, _, _ ->
+            binding.selectFront.callOnClick()
+            val dialog = ShadowDialog.getLatestDialog()
+
+            // dialog shows up
+            assertThat(dialog.isShowing).isTrue()
+            assertThat(dialog).isInstanceOf(BottomSheetDialog::class.java)
+
+            // assert dialog content
+            assertThat(dialog.findViewById<Button>(R.id.choose_file).visibility).isEqualTo(View.VISIBLE)
+            assertThat(dialog.findViewById<Button>(R.id.take_photo).visibility).isEqualTo(View.VISIBLE)
+        }
+    }
+
+    @Test
+    fun `when shouldShowCamera is false UI is correct`() {
+        launchFragment(shouldShowCamera = false) { binding, _, _ ->
+            binding.selectFront.callOnClick()
+            val dialog = ShadowDialog.getLatestDialog()
+
+            // dialog shows up
+            assertThat(dialog.isShowing).isTrue()
+            assertThat(dialog).isInstanceOf(BottomSheetDialog::class.java)
+
+            // assert dialog content
+            assertThat(dialog.findViewById<Button>(R.id.choose_file).visibility).isEqualTo(View.VISIBLE)
+            assertThat(dialog.findViewById<Button>(R.id.take_photo).visibility).isEqualTo(View.GONE)
         }
     }
 
@@ -354,12 +388,16 @@ class FrontBackUploadFragmentTest {
     }
 
     private fun launchFragment(
+        shouldShowCamera: Boolean = true,
         testBlock: (
             binding: FrontBackUploadFragmentBinding,
             navController: TestNavHostController,
             fragment: FrontBackUploadFragment
         ) -> Unit
     ) = launchFragmentInContainer(
+        fragmentArgs = bundleOf(
+            ARG_SHOULD_SHOW_CAMERA to shouldShowCamera
+        ),
         themeResId = R.style.Theme_MaterialComponents
     ) {
         TestFragment(

--- a/identity/src/test/java/com/stripe/android/identity/navigation/PassportUploadFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/PassportUploadFragmentTest.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import android.view.View
 import android.widget.Button
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.core.os.bundleOf
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.lifecycle.MutableLiveData
 import androidx.navigation.Navigation
@@ -26,6 +27,7 @@ import com.stripe.android.identity.networking.models.DocumentUploadParam.UploadM
 import com.stripe.android.identity.networking.models.IdDocumentParam
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentDocumentCapturePage
+import com.stripe.android.identity.utils.ARG_SHOULD_SHOW_CAMERA
 import com.stripe.android.identity.viewModelFactoryFor
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 import com.stripe.android.identity.viewmodel.PassportUploadViewModel
@@ -78,6 +80,38 @@ class PassportUploadFragmentTest {
             assertThat(binding.progressCircular.visibility).isEqualTo(View.GONE)
             assertThat(binding.finishedCheckMark.visibility).isEqualTo(View.GONE)
             assertThat(binding.kontinue.isEnabled).isEqualTo(false)
+        }
+    }
+
+    @Test
+    fun `when shouldShowCamera is true UI is correct`() {
+        launchFragment(shouldShowCamera = true) { binding, _, _ ->
+            binding.select.callOnClick()
+            val dialog = ShadowDialog.getLatestDialog()
+
+            // dialog shows up
+            assertThat(dialog.isShowing).isTrue()
+            assertThat(dialog).isInstanceOf(BottomSheetDialog::class.java)
+
+            // assert dialog content
+            assertThat(dialog.findViewById<Button>(R.id.choose_file).visibility).isEqualTo(View.VISIBLE)
+            assertThat(dialog.findViewById<Button>(R.id.take_photo).visibility).isEqualTo(View.VISIBLE)
+        }
+    }
+
+    @Test
+    fun `when shouldShowCamera is false UI is correct`() {
+        launchFragment(shouldShowCamera = false) { binding, _, _ ->
+            binding.select.callOnClick()
+            val dialog = ShadowDialog.getLatestDialog()
+
+            // dialog shows up
+            assertThat(dialog.isShowing).isTrue()
+            assertThat(dialog).isInstanceOf(BottomSheetDialog::class.java)
+
+            // assert dialog content
+            assertThat(dialog.findViewById<Button>(R.id.choose_file).visibility).isEqualTo(View.VISIBLE)
+            assertThat(dialog.findViewById<Button>(R.id.take_photo).visibility).isEqualTo(View.GONE)
         }
     }
 
@@ -213,12 +247,16 @@ class PassportUploadFragmentTest {
     }
 
     private fun launchFragment(
+        shouldShowCamera: Boolean = true,
         testBlock: (
             binding: PassportUploadFragmentBinding,
             navController: TestNavHostController,
             fragment: PassportUploadFragment
         ) -> Unit
     ) = launchFragmentInContainer(
+        fragmentArgs = bundleOf(
+            ARG_SHOULD_SHOW_CAMERA to shouldShowCamera
+        ),
         themeResId = R.style.Theme_MaterialComponents
     ) {
         PassportUploadFragment(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Override `Identity#showPermissionRationaleDialog`, as Identity's permission check is a bit different from [CameraPermissionCheckingActivity](https://github.com/stripe/stripe-android/blob/903b76bb673213c0b4916f2aa45244f18b555866/camera-core/src/main/java/com/stripe/android/camera/CameraPermissionCheckingActivity.kt#L24) -
  * We never write the `PERMISSION_RATIONALE_SHOWN` value, so that `Identity#showPermissionDeniedDialog` will never be called. 
  * Instead, Identity has a dedicated `CameraPermissionDeniedFragment` to handle this case, this fragment belongs to the navigation graph and is triggered by `Identity#onUserDeniedCameraPermission`

* Change the camera permission requesting callsites from the actual scan fragments to `DocSelectionFragment`, based on permission grant callbacks, navigate through the following logic.
```
*) if has camera permission
	*) if has model -> navigate to live capture
	*) else no model
		*) if requireLiveCapture -> navigate to error
		*) else -> upload with camera
*) if no permission
	*) if requireLivecaptire -> navigate to error
	*) else 
		*) navigate to camera denied, with two button, file upload or app settings
			*) file upload-> upload without camera
			*) app settings-> to app settings
```

With this change, we always have camera permission when landing on the scan fragments, this would prevent the case when user already denies the camera permission and got redirected to the scan fragments, then immediately got redirected to `CameraPermissionFragment`, causing a flicker.


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Identity SDK


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
|  ![permissionBefore](https://user-images.githubusercontent.com/79880926/158286179-f25c8dac-9da8-4313-bfa2-f55e26b84500.gif) | ![permissionAfter](https://user-images.githubusercontent.com/79880926/158286551-08fcf298-c828-4733-bd00-03e9c8cd3a0e.gif)  |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
