### PR TITLE
Improve performance of dropdown in forms.

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownFieldUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownFieldUI.kt
@@ -47,7 +47,18 @@ import com.stripe.android.ui.core.elements.menu.DropdownMenuItemHorizontalPaddin
 import kotlin.math.max
 import kotlin.math.min
 
-
+/**
+ * This composable will handle the display of dropdown items
+ * in a lazy column.
+ *
+ * Here are some relevant manual tests:
+ *   - Short list of dropdown items
+ *   - long list of dropdown items
+ *   - Varying width of dropdown item
+ *   - Display setting very large
+ *   - Whole row is clickable, not just text
+ *   - Scrolls to the selected item in the list
+ */
 @Composable
 internal fun DropDown(
     controller: DropdownFieldController,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownFieldUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownFieldUI.kt
@@ -181,6 +181,7 @@ internal fun DropdownMenuItem(
                 minWidth = DropdownMenuItemDefaultMinWidth,
                 minHeight = DropdownMenuItemDefaultMinHeight
             )
+            .fillMaxWidth()
             .clickable {
                 onClick()
             }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownFieldUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownFieldUI.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -31,7 +32,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.InputMode
@@ -44,7 +44,6 @@ import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.menu.DropdownMenuItemDefaultMaxWidth
 import com.stripe.android.ui.core.elements.menu.DropdownMenuItemDefaultMinHeight
 import com.stripe.android.ui.core.elements.menu.DropdownMenuItemDefaultMinWidth
-import com.stripe.android.ui.core.elements.menu.DropdownMenuItemHorizontalPadding
 import kotlin.math.max
 import kotlin.math.min
 
@@ -185,12 +184,9 @@ internal fun DropdownMenuItem(
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Start,
         modifier = Modifier
             .fillMaxWidth()
-            .padding(
-                start = DropdownMenuItemHorizontalPadding,
-                end = 0.dp,
-            )
             .requiredSizeIn(
                 minWidth = DropdownMenuItemDefaultMinWidth,
                 minHeight = DropdownMenuItemDefaultMinHeight
@@ -201,7 +197,16 @@ internal fun DropdownMenuItem(
     ) {
         Text(
             text = displayValue,
-            modifier = Modifier.fillMaxWidth(.8f),
+            modifier = Modifier
+                // This padding makes up for the checkmark at the end.
+                .padding(
+                    end = if (isSelected) {
+                        13.dp
+                    } else {
+                        0.dp
+                    }
+                )
+                .fillMaxWidth(.8f),
             color = if (isSelected) {
                 PaymentsTheme.colors.material.primary
             } else {
@@ -214,19 +219,14 @@ internal fun DropdownMenuItem(
             }
         )
 
-        Icon(
-            Icons.Filled.Check,
-            contentDescription = null,
-            modifier = Modifier
-                .height(24.dp)
-                .alpha(
-                    if (isSelected) {
-                        1f
-                    } else {
-                        0f
-                    }
-                ),
-            tint = PaymentsTheme.colors.material.primary
-        )
+        if (isSelected) {
+            Icon(
+                Icons.Filled.Check,
+                contentDescription = null,
+                modifier = Modifier
+                    .height(24.dp),
+                tint = PaymentsTheme.colors.material.primary
+            )
+        }
     }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownFieldUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownFieldUI.kt
@@ -11,16 +11,16 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.requiredSizeIn
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.ContentAlpha
-import androidx.compose.material.DropdownMenu
-import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -30,12 +30,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.R
+
 
 @Composable
 internal fun DropDown(
@@ -58,12 +61,7 @@ internal fun DropDown(
             .value
     }
     val inputModeManager = LocalInputModeManager.current
-    Box(
-        modifier = Modifier
-            .wrapContentSize(Alignment.TopStart)
-            .background(PaymentsTheme.colors.colorComponentBackground)
-    ) {
-        // Click handling happens on the box, so that it is a single accessible item
+    Box {
         Box(
             modifier = Modifier
                 .focusProperties {
@@ -103,23 +101,23 @@ internal fun DropDown(
             }
         }
 
-        DropdownMenu(
+        MyDropdownMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false },
-            modifier = Modifier.background(color = PaymentsTheme.colors.colorComponentBackground)
+            modifier = Modifier
+                .background(color = PaymentsTheme.colors.colorComponentBackground)
+                .requiredSizeIn(maxHeight = DropdownMenuItemDefaultMinHeight * 8.9f)
         ) {
-            items.forEachIndexed { index, displayValue ->
+            itemsIndexed(items) { index, displayValue ->
                 DropdownMenuItem(
+                    displayValue,
+                    isSelected = index == selectedIndex,
+                    currentTextColor,
                     onClick = {
                         controller.onValueChange(index)
                         expanded = false
                     }
-                ) {
-                    Text(
-                        text = displayValue,
-                        color = currentTextColor
-                    )
-                }
+                )
             }
         }
     }
@@ -136,13 +134,59 @@ internal fun DropdownLabel(
     enabled: Boolean
 ) {
     val color = PaymentsTheme.colors.placeholderText
-    val interactionSource = remember { MutableInteractionSource() }
     label?.let {
         Text(
             stringResource(label),
             color = if (enabled) color else color.copy(alpha = ContentAlpha.disabled),
             modifier = Modifier.focusable(false),
             style = MaterialTheme.typography.caption
+        )
+    }
+}
+
+@Composable
+internal fun DropdownMenuItem(
+    displayValue: String,
+    isSelected: Boolean,
+    currentTextColor: Color,
+    onClick: () -> Unit
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .padding(
+                horizontal = DropdownMenuItemHorizontalPadding,
+            )
+            .requiredSizeIn(
+                minWidth = DropdownMenuItemDefaultMinWidth,
+                minHeight = DropdownMenuItemDefaultMinHeight
+            )
+            .clickable {
+                onClick()
+            }
+    ) {
+        if (isSelected) {
+            Icon(
+                Icons.Filled.Check,
+                contentDescription = null,
+                modifier = Modifier
+                    .height(24.dp)
+                    .padding(end = 4.dp),
+                tint = PaymentsTheme.colors.material.primary
+            )
+        }
+        Text(
+            text = displayValue,
+            color = if (isSelected) {
+                PaymentsTheme.colors.material.primary
+            } else {
+                currentTextColor
+            },
+            fontWeight = if (isSelected) {
+                FontWeight.Bold
+            } else {
+                FontWeight.Normal
+            }
         )
     }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownFieldUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownFieldUI.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.ui.core.elements
 
+import DropdownMenu
 import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -12,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredSizeIn
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Icon
@@ -38,6 +40,12 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.R
+import com.stripe.android.ui.core.elements.menu.DropdownMenuItemDefaultMaxWidth
+import com.stripe.android.ui.core.elements.menu.DropdownMenuItemDefaultMinHeight
+import com.stripe.android.ui.core.elements.menu.DropdownMenuItemDefaultMinWidth
+import com.stripe.android.ui.core.elements.menu.DropdownMenuItemHorizontalPadding
+import kotlin.math.max
+import kotlin.math.min
 
 
 @Composable
@@ -60,6 +68,7 @@ internal fun DropDown(
             .indicatorColor(enabled, false, interactionSource)
             .value
     }
+
     val inputModeManager = LocalInputModeManager.current
     Box {
         Box(
@@ -101,11 +110,22 @@ internal fun DropDown(
             }
         }
 
-        MyDropdownMenu(
+        DropdownMenu(
             expanded = expanded,
+
+            // We will show up to two items before
+            initialFirstVisibleItemIndex = if (selectedIndex >= 1) {
+                min(
+                    max(selectedIndex - 2, 0),
+                    max(selectedIndex - 1, 0)
+                )
+            } else {
+                selectedIndex
+            },
             onDismissRequest = { expanded = false },
             modifier = Modifier
                 .background(color = PaymentsTheme.colors.colorComponentBackground)
+                .width(DropdownMenuItemDefaultMaxWidth)
                 .requiredSizeIn(maxHeight = DropdownMenuItemDefaultMinHeight * 8.9f)
         ) {
             itemsIndexed(items) { index, displayValue ->
@@ -114,8 +134,8 @@ internal fun DropDown(
                     isSelected = index == selectedIndex,
                     currentTextColor,
                     onClick = {
-                        controller.onValueChange(index)
                         expanded = false
+                        controller.onValueChange(index)
                     }
                 )
             }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownFieldUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownFieldUI.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.InputMode
@@ -180,35 +181,27 @@ internal fun DropdownMenuItem(
     displayValue: String,
     isSelected: Boolean,
     currentTextColor: Color,
-    onClick: () -> Unit
+    onClick: () -> Unit = {}
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
+            .fillMaxWidth()
             .padding(
-                horizontal = DropdownMenuItemHorizontalPadding,
+                start = DropdownMenuItemHorizontalPadding,
+                end = 0.dp,
             )
             .requiredSizeIn(
                 minWidth = DropdownMenuItemDefaultMinWidth,
                 minHeight = DropdownMenuItemDefaultMinHeight
             )
-            .fillMaxWidth()
             .clickable {
                 onClick()
             }
     ) {
-        if (isSelected) {
-            Icon(
-                Icons.Filled.Check,
-                contentDescription = null,
-                modifier = Modifier
-                    .height(24.dp)
-                    .padding(end = 4.dp),
-                tint = PaymentsTheme.colors.material.primary
-            )
-        }
         Text(
             text = displayValue,
+            modifier = Modifier.fillMaxWidth(.8f),
             color = if (isSelected) {
                 PaymentsTheme.colors.material.primary
             } else {
@@ -219,6 +212,21 @@ internal fun DropdownMenuItem(
             } else {
                 FontWeight.Normal
             }
+        )
+
+        Icon(
+            Icons.Filled.Check,
+            contentDescription = null,
+            modifier = Modifier
+                .height(24.dp)
+                .alpha(
+                    if (isSelected) {
+                        1f
+                    } else {
+                        0f
+                    }
+                ),
+            tint = PaymentsTheme.colors.material.primary
         )
     }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownMenu.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownMenu.kt
@@ -1,0 +1,304 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.updateTransition
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.material.Card
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
+import androidx.compose.ui.window.PopupProperties
+import kotlin.math.max
+import kotlin.math.min
+
+
+@Suppress("ModifierParameter")
+@Composable
+fun MyDropdownMenu(
+    expanded: Boolean,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    offset: DpOffset = DpOffset(0.dp, 0.dp),
+    properties: PopupProperties = PopupProperties(focusable = true),
+    content: LazyListScope.() -> Unit
+) {
+    val expandedStates = remember { MutableTransitionState(false) }
+    expandedStates.targetState = expanded
+
+    if (expandedStates.currentState || expandedStates.targetState) {
+        val transformOriginState = remember { mutableStateOf(TransformOrigin.Center) }
+        val density = LocalDensity.current
+        val popupPositionProvider = DropdownMenuPositionProvider(
+            offset,
+            density
+        ) { parentBounds, menuBounds ->
+            transformOriginState.value =
+                calculateTransformOrigin(parentBounds, menuBounds)
+        }
+
+        Popup(
+            onDismissRequest = onDismissRequest,
+            popupPositionProvider = popupPositionProvider,
+            properties = properties
+        ) {
+            DropdownMenuContent(
+                expandedStates = expandedStates,
+                transformOriginState = transformOriginState,
+                modifier = modifier,
+                content = content
+            )
+        }
+    }
+}
+
+// Size defaults.
+private val MenuElevation = 8.dp
+internal val MenuVerticalMargin = 48.dp
+internal val DropdownMenuItemHorizontalPadding = 16.dp
+internal val DropdownMenuVerticalPadding = 8.dp
+internal val DropdownMenuItemDefaultMinWidth = 112.dp
+internal val DropdownMenuItemDefaultMaxWidth = 280.dp
+internal val DropdownMenuItemDefaultMinHeight = 48.dp
+
+// Menu open/close animation.
+internal const val InTransitionDuration = 120
+internal const val OutTransitionDuration = 75
+
+@Suppress("ModifierParameter")
+@Composable
+internal fun DropdownMenuContent(
+    expandedStates: MutableTransitionState<Boolean>,
+    transformOriginState: MutableState<TransformOrigin>,
+    modifier: Modifier = Modifier,
+    content: LazyListScope.() -> Unit
+) {
+    // Menu open/close animation.
+    val transition = updateTransition(expandedStates, "DropDownMenu")
+
+    val scale by transition.animateFloat(
+        transitionSpec = {
+            if (false isTransitioningTo true) {
+                // Dismissed to expanded
+                tween(
+                    durationMillis = InTransitionDuration,
+                    easing = LinearOutSlowInEasing
+                )
+            } else {
+                // Expanded to dismissed.
+                tween(
+                    durationMillis = 1,
+                    delayMillis = OutTransitionDuration - 1
+                )
+            }
+        }
+    ) {
+        if (it) {
+            // Menu is expanded.
+            1f
+        } else {
+            // Menu is dismissed.
+            0.8f
+        }
+    }
+
+    val alpha by transition.animateFloat(
+        transitionSpec = {
+            if (false isTransitioningTo true) {
+                // Dismissed to expanded
+                tween(durationMillis = 30)
+            } else {
+                // Expanded to dismissed.
+                tween(durationMillis = OutTransitionDuration)
+            }
+        }
+    ) {
+        if (it) {
+            // Menu is expanded.
+            1f
+        } else {
+            // Menu is dismissed.
+            0f
+        }
+    }
+    Card(
+        modifier = Modifier.graphicsLayer {
+            scaleX = scale
+            scaleY = scale
+            this.alpha = alpha
+            transformOrigin = transformOriginState.value
+        },
+        elevation = MenuElevation
+    ) {
+        LazyColumn(
+//        Column(
+            modifier = modifier
+                .padding(vertical = DropdownMenuVerticalPadding),
+//                .width(IntrinsicSize.Max)
+//                .verticalScroll(rememberScrollState()),
+            content = content
+        )
+    }
+}
+
+internal fun calculateTransformOrigin(
+    parentBounds: IntRect,
+    menuBounds: IntRect
+): TransformOrigin {
+    val pivotX = when {
+        menuBounds.left >= parentBounds.right -> 0f
+        menuBounds.right <= parentBounds.left -> 1f
+        menuBounds.width == 0 -> 0f
+        else -> {
+            val intersectionCenter =
+                (
+                    max(parentBounds.left, menuBounds.left) +
+                        min(parentBounds.right, menuBounds.right)
+                    ) / 2
+            (intersectionCenter - menuBounds.left).toFloat() / menuBounds.width
+        }
+    }
+    val pivotY = when {
+        menuBounds.top >= parentBounds.bottom -> 0f
+        menuBounds.bottom <= parentBounds.top -> 1f
+        menuBounds.height == 0 -> 0f
+        else -> {
+            val intersectionCenter =
+                (
+                    max(parentBounds.top, menuBounds.top) +
+                        min(parentBounds.bottom, menuBounds.bottom)
+                    ) / 2
+            (intersectionCenter - menuBounds.top).toFloat() / menuBounds.height
+        }
+    }
+    return TransformOrigin(pivotX, pivotY)
+}
+
+
+class AlignmentOffsetPositionProvider(
+    val alignment: Alignment,
+    val offset: IntOffset
+) : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize
+    ): IntOffset {
+        // TODO: Decide which is the best way to round to result without reimplementing Alignment.align
+        var popupPosition = IntOffset(0, 0)
+
+        // Get the aligned point inside the parent
+        val parentAlignmentPoint = alignment.align(
+            IntSize.Zero,
+            IntSize(anchorBounds.width, anchorBounds.height),
+            layoutDirection
+        )
+        // Get the aligned point inside the child
+        val relativePopupPos = alignment.align(
+            IntSize.Zero,
+            IntSize(popupContentSize.width, popupContentSize.height),
+            layoutDirection
+        )
+
+        // Add the position of the parent
+        popupPosition += IntOffset(anchorBounds.left, anchorBounds.top)
+
+        // Add the distance between the parent's top left corner and the alignment point
+        popupPosition += parentAlignmentPoint
+
+        // Subtract the distance between the children's top left corner and the alignment point
+        popupPosition -= IntOffset(relativePopupPos.x, relativePopupPos.y)
+
+        // Add the user offset
+        val resolvedOffset = IntOffset(
+            offset.x * (if (layoutDirection == LayoutDirection.Ltr) 1 else -1),
+            offset.y
+        )
+        popupPosition += resolvedOffset
+
+        return popupPosition
+    }
+}
+
+@Immutable
+internal data class DropdownMenuPositionProvider(
+    val contentOffset: DpOffset,
+    val density: Density,
+    val onPositionCalculated: (IntRect, IntRect) -> Unit = { _, _ -> }
+) : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize
+    ): IntOffset {
+        // The min margin above and below the menu, relative to the screen.
+        val verticalMargin = with(density) { MenuVerticalMargin.roundToPx() }
+        // The content offset specified using the dropdown offset parameter.
+        val contentOffsetX = with(density) { contentOffset.x.roundToPx() }
+        val contentOffsetY = with(density) { contentOffset.y.roundToPx() }
+
+        // Compute horizontal position.
+        val toRight = anchorBounds.left + contentOffsetX
+        val toLeft = anchorBounds.right - contentOffsetX - popupContentSize.width
+        val toDisplayRight = windowSize.width - popupContentSize.width
+        val toDisplayLeft = 0
+        val x = if (layoutDirection == LayoutDirection.Ltr) {
+            sequenceOf(
+                toRight,
+                toLeft,
+                // If the anchor gets outside of the window on the left, we want to position
+                // toDisplayLeft for proximity to the anchor. Otherwise, toDisplayRight.
+                if (anchorBounds.left >= 0) toDisplayRight else toDisplayLeft
+            )
+        } else {
+            sequenceOf(
+                toLeft,
+                toRight,
+                // If the anchor gets outside of the window on the right, we want to position
+                // toDisplayRight for proximity to the anchor. Otherwise, toDisplayLeft.
+                if (anchorBounds.right <= windowSize.width) toDisplayLeft else toDisplayRight
+            )
+        }.firstOrNull {
+            it >= 0 && it + popupContentSize.width <= windowSize.width
+        } ?: toLeft
+
+        // Compute vertical position.
+        val toBottom = maxOf(anchorBounds.bottom + contentOffsetY, verticalMargin)
+        val toTop = anchorBounds.top - contentOffsetY - popupContentSize.height
+        val toCenter = anchorBounds.top - popupContentSize.height / 2
+        val toDisplayBottom = windowSize.height - popupContentSize.height - verticalMargin
+        val y = sequenceOf(toBottom, toTop, toCenter, toDisplayBottom).firstOrNull {
+            it >= verticalMargin &&
+                it + popupContentSize.height <= windowSize.height - verticalMargin
+        } ?: toTop
+
+        onPositionCalculated(
+            anchorBounds,
+            IntRect(x, y, x + popupContentSize.width, y + popupContentSize.height)
+        )
+        return IntOffset(x, y)
+    }
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/menu/AndroidMenu.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/menu/AndroidMenu.kt
@@ -75,7 +75,7 @@ import com.stripe.android.ui.core.elements.menu.calculateTransformOrigin
  */
 @Suppress("ModifierParameter")
 @Composable
-fun DropdownMenu(
+internal fun DropdownMenu(
     expanded: Boolean,
     initialFirstVisibleItemIndex: Int,
     onDismissRequest: () -> Unit,
@@ -131,7 +131,7 @@ fun DropdownMenu(
  * appearance / behavior of this DropdownMenuItem in different [Interaction]s.
  */
 @Composable
-fun DropdownMenuItem(
+internal fun DropdownMenuItem(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/menu/AndroidMenu.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/menu/AndroidMenu.kt
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
+package androidx.compose.material
+
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.foundation.interaction.Interaction
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -30,11 +32,6 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
-import com.stripe.android.ui.core.elements.menu.DropdownMenuContent
-import com.stripe.android.ui.core.elements.menu.DropdownMenuItemContent
-import com.stripe.android.ui.core.elements.menu.DropdownMenuPositionProvider
-import com.stripe.android.ui.core.elements.menu.MenuDefaults
-import com.stripe.android.ui.core.elements.menu.calculateTransformOrigin
 
 /**
  * <a href="https://material.io/components/menus#dropdown-menu" class="external" target="_blank">Material Design dropdown menu</a>.
@@ -77,12 +74,11 @@ import com.stripe.android.ui.core.elements.menu.calculateTransformOrigin
 @Composable
 fun DropdownMenu(
     expanded: Boolean,
-    initialFirstVisibleItemIndex: Int,
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
     offset: DpOffset = DpOffset(0.dp, 0.dp),
     properties: PopupProperties = PopupProperties(focusable = true),
-    content: LazyListScope.() -> Unit
+    content: @Composable ColumnScope.() -> Unit
 ) {
     val expandedStates = remember { MutableTransitionState(false) }
     expandedStates.targetState = expanded
@@ -104,7 +100,6 @@ fun DropdownMenu(
         ) {
             DropdownMenuContent(
                 expandedStates = expandedStates,
-                initialFirstVisibleItemIndex = initialFirstVisibleItemIndex,
                 transformOriginState = transformOriginState,
                 modifier = modifier,
                 content = content

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/menu/AndroidMenu.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/menu/AndroidMenu.kt
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-package androidx.compose.material
-
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.foundation.interaction.Interaction
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -32,6 +30,11 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
+import com.stripe.android.ui.core.elements.menu.DropdownMenuContent
+import com.stripe.android.ui.core.elements.menu.DropdownMenuItemContent
+import com.stripe.android.ui.core.elements.menu.DropdownMenuPositionProvider
+import com.stripe.android.ui.core.elements.menu.MenuDefaults
+import com.stripe.android.ui.core.elements.menu.calculateTransformOrigin
 
 /**
  * <a href="https://material.io/components/menus#dropdown-menu" class="external" target="_blank">Material Design dropdown menu</a>.
@@ -74,11 +77,12 @@ import androidx.compose.ui.window.PopupProperties
 @Composable
 fun DropdownMenu(
     expanded: Boolean,
+    initialFirstVisibleItemIndex: Int,
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
     offset: DpOffset = DpOffset(0.dp, 0.dp),
     properties: PopupProperties = PopupProperties(focusable = true),
-    content: @Composable ColumnScope.() -> Unit
+    content: LazyListScope.() -> Unit
 ) {
     val expandedStates = remember { MutableTransitionState(false) }
     expandedStates.targetState = expanded
@@ -100,6 +104,7 @@ fun DropdownMenu(
         ) {
             DropdownMenuContent(
                 expandedStates = expandedStates,
+                initialFirstVisibleItemIndex = initialFirstVisibleItemIndex,
                 transformOriginState = transformOriginState,
                 modifier = modifier,
                 content = content

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/menu/AndroidMenu.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/menu/AndroidMenu.kt
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2020 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import androidx.compose.animation.core.MutableTransitionState
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import com.stripe.android.ui.core.elements.menu.DropdownMenuContent
+import com.stripe.android.ui.core.elements.menu.DropdownMenuItemContent
+import com.stripe.android.ui.core.elements.menu.DropdownMenuPositionProvider
+import com.stripe.android.ui.core.elements.menu.MenuDefaults
+import com.stripe.android.ui.core.elements.menu.calculateTransformOrigin
+
+/**
+ * <a href="https://material.io/components/menus#dropdown-menu" class="external" target="_blank">Material Design dropdown menu</a>.
+ *
+ * A dropdown menu is a compact way of displaying multiple choices. It appears upon interaction with
+ * an element (such as an icon or button) or when users perform a specific action.
+ *
+ * ![Menus image](https://developer.android.com/images/reference/androidx/compose/material/menus.png)
+ *
+ * A [DropdownMenu] behaves similarly to a [Popup], and will use the position of the parent layout
+ * to position itself on screen. Commonly a [DropdownMenu] will be placed in a [Box] with a sibling
+ * that will be used as the 'anchor'. Note that a [DropdownMenu] by itself will not take up any
+ * space in a layout, as the menu is displayed in a separate window, on top of other content.
+ *
+ * The [content] of a [DropdownMenu] will typically be [DropdownMenuItem]s, as well as custom
+ * content. Using [DropdownMenuItem]s will result in a menu that matches the Material
+ * specification for menus. Also note that the [content] is placed inside a scrollable [Column],
+ * so using a [LazyColumn] as the root layout inside [content] is unsupported.
+ *
+ * [onDismissRequest] will be called when the menu should close - for example when there is a
+ * tap outside the menu, or when the back key is pressed.
+ *
+ * [DropdownMenu] changes its positioning depending on the available space, always trying to be
+ * fully visible. It will try to expand horizontally, depending on layout direction, to the end of
+ * its parent, then to the start of its parent, and then screen end-aligned. Vertically, it will
+ * try to expand to the bottom of its parent, then from the top of its parent, and then screen
+ * top-aligned. An [offset] can be provided to adjust the positioning of the menu for cases when
+ * the layout bounds of its parent do not coincide with its visual bounds. Note the offset will
+ * be applied in the direction in which the menu will decide to expand.
+ *
+ * Example usage:
+ * @sample androidx.compose.material.samples.MenuSample
+ *
+ * @param expanded Whether the menu is currently open and visible to the user
+ * @param onDismissRequest Called when the user requests to dismiss the menu, such as by
+ * tapping outside the menu's bounds
+ * @param offset [DpOffset] to be added to the position of the menu
+ */
+@Suppress("ModifierParameter")
+@Composable
+fun DropdownMenu(
+    expanded: Boolean,
+    initialFirstVisibleItemIndex: Int,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    offset: DpOffset = DpOffset(0.dp, 0.dp),
+    properties: PopupProperties = PopupProperties(focusable = true),
+    content: LazyListScope.() -> Unit
+) {
+    val expandedStates = remember { MutableTransitionState(false) }
+    expandedStates.targetState = expanded
+
+    if (expandedStates.currentState || expandedStates.targetState) {
+        val transformOriginState = remember { mutableStateOf(TransformOrigin.Center) }
+        val density = LocalDensity.current
+        val popupPositionProvider = DropdownMenuPositionProvider(
+            offset,
+            density
+        ) { parentBounds, menuBounds ->
+            transformOriginState.value = calculateTransformOrigin(parentBounds, menuBounds)
+        }
+
+        Popup(
+            onDismissRequest = onDismissRequest,
+            popupPositionProvider = popupPositionProvider,
+            properties = properties
+        ) {
+            DropdownMenuContent(
+                expandedStates = expandedStates,
+                initialFirstVisibleItemIndex = initialFirstVisibleItemIndex,
+                transformOriginState = transformOriginState,
+                modifier = modifier,
+                content = content
+            )
+        }
+    }
+}
+
+/**
+ * <a href="https://material.io/components/menus#dropdown-menu" class="external" target="_blank">Material Design dropdown menu</a> item.
+ *
+ *
+ * Example usage:
+ * @sample androidx.compose.material.samples.MenuSample
+ *
+ * @param onClick Called when the menu item was clicked
+ * @param modifier The modifier to be applied to the menu item
+ * @param enabled Controls the enabled state of the menu item - when `false`, the menu item
+ * will not be clickable and [onClick] will not be invoked
+ * @param contentPadding the padding applied to the content of this menu item
+ * @param interactionSource the [MutableInteractionSource] representing the stream of
+ * [Interaction]s for this DropdownMenuItem. You can create and pass in your own remembered
+ * [MutableInteractionSource] if you want to observe [Interaction]s and customize the
+ * appearance / behavior of this DropdownMenuItem in different [Interaction]s.
+ */
+@Composable
+fun DropdownMenuItem(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    contentPadding: PaddingValues = MenuDefaults.DropdownMenuItemContentPadding,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    content: @Composable RowScope.() -> Unit
+) {
+    DropdownMenuItemContent(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        contentPadding = contentPadding,
+        interactionSource = interactionSource,
+        content = content
+    )
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/menu/Menu.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/menu/Menu.kt
@@ -30,14 +30,11 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredSizeIn
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Card
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.DropdownMenu
@@ -55,7 +52,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.TransformOrigin
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.IntOffset
@@ -177,7 +173,7 @@ internal fun DropdownMenuItemContent(
             .fillMaxWidth()
             // Preferred min and max width used during the intrinsic measurement.
             .sizeIn(
-                minWidth = DropdownMenuItemDefaultMaxWidth,// use the max width for both
+                minWidth = DropdownMenuItemDefaultMaxWidth, // use the max width for both
                 maxWidth = DropdownMenuItemDefaultMaxWidth,
                 minHeight = DropdownMenuItemDefaultMinHeight
             )
@@ -197,7 +193,7 @@ internal fun DropdownMenuItemContent(
 /**
  * Contains default values used for [DropdownMenuItem].
  */
-object MenuDefaults {
+internal object MenuDefaults {
     /**
      * Default padding used for [DropdownMenuItem].
      */

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/menu/Menu.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/menu/Menu.kt
@@ -1,5 +1,3 @@
-package com.stripe.android.ui.core.elements.menu
-
 /*
  * Copyright 2020 The Android Open Source Project
  *
@@ -16,41 +14,33 @@ package com.stripe.android.ui.core.elements.menu
  * limitations under the License.
  */
 
+package androidx.compose.material
+
 import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.core.updateTransition
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredSizeIn
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListScope
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Card
-import androidx.compose.material.ContentAlpha
-import androidx.compose.material.DropdownMenu
-import androidx.compose.material.DropdownMenuItem
-import androidx.compose.material.LocalContentAlpha
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.ProvideTextStyle
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -64,7 +54,6 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.PopupPositionProvider
-import com.stripe.android.ui.core.elements.CardStyle
 import kotlin.math.max
 import kotlin.math.min
 
@@ -73,9 +62,8 @@ import kotlin.math.min
 internal fun DropdownMenuContent(
     expandedStates: MutableTransitionState<Boolean>,
     transformOriginState: MutableState<TransformOrigin>,
-    initialFirstVisibleItemIndex: Int,
     modifier: Modifier = Modifier,
-    content: LazyListScope.() -> Unit
+    content: @Composable ColumnScope.() -> Unit
 ) {
     // Menu open/close animation.
     val transition = updateTransition(expandedStates, "DropDownMenu")
@@ -125,32 +113,20 @@ internal fun DropdownMenuContent(
             0f
         }
     }
-
-    // TODO: Make sure this gets the rounded corner values
     Card(
-        border = BorderStroke(CardStyle.cardBorderWidth, CardStyle.cardBorderColor),
-        modifier = Modifier,
-//            .graphicsLayer {
-//            scaleX = scale
-//            scaleY = scale
-//            this.alpha = alpha
-//            transformOrigin = transformOriginState.value
-//        }
-//            .requiredSizeIn(maxHeight = DropdownMenuItemDefaultMinHeight * 8.9f)
-//            .width(DropdownMenuItemDefaultMaxWidth),
+        modifier = Modifier.graphicsLayer {
+            scaleX = scale
+            scaleY = scale
+            this.alpha = alpha
+            transformOrigin = transformOriginState.value
+        },
         elevation = MenuElevation
     ) {
-        val lazyListState = rememberLazyListState(
-            initialFirstVisibleItemIndex = initialFirstVisibleItemIndex
-        )
-
-        LazyColumn(
+        Column(
             modifier = modifier
-                .padding(vertical = DropdownMenuVerticalPadding),
-//                .width(DropdownMenuItemDefaultMaxWidth),
-//                .width(IntrinsicSize.Max)
-//                .verticalScroll(rememberScrollState()),
-            state = lazyListState,
+                .padding(vertical = DropdownMenuVerticalPadding)
+                .width(IntrinsicSize.Max)
+                .verticalScroll(rememberScrollState()),
             content = content
         )
     }
@@ -177,7 +153,7 @@ internal fun DropdownMenuItemContent(
             .fillMaxWidth()
             // Preferred min and max width used during the intrinsic measurement.
             .sizeIn(
-                minWidth = DropdownMenuItemDefaultMaxWidth,// use the max width for both
+                minWidth = DropdownMenuItemDefaultMinWidth,
                 maxWidth = DropdownMenuItemDefaultMaxWidth,
                 minHeight = DropdownMenuItemDefaultMinHeight
             )
@@ -210,11 +186,11 @@ object MenuDefaults {
 // Size defaults.
 private val MenuElevation = 8.dp
 internal val MenuVerticalMargin = 48.dp
-internal val DropdownMenuItemHorizontalPadding = 16.dp
+private val DropdownMenuItemHorizontalPadding = 16.dp
 internal val DropdownMenuVerticalPadding = 8.dp
-internal val DropdownMenuItemDefaultMinWidth = 112.dp
-internal val DropdownMenuItemDefaultMaxWidth = 280.dp
-internal val DropdownMenuItemDefaultMinHeight = 48.dp
+private val DropdownMenuItemDefaultMinWidth = 112.dp
+private val DropdownMenuItemDefaultMaxWidth = 280.dp
+private val DropdownMenuItemDefaultMinHeight = 48.dp
 
 // Menu open/close animation.
 internal const val InTransitionDuration = 120

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/menu/Menu.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/menu/Menu.kt
@@ -28,10 +28,8 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -52,6 +50,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.IntOffset
@@ -91,7 +90,7 @@ internal fun DropdownMenuContent(
                     delayMillis = OutTransitionDuration - 1
                 )
             }
-        }
+        }, label = "menu-scale"
     ) {
         if (it) {
             // Menu is expanded.
@@ -111,7 +110,7 @@ internal fun DropdownMenuContent(
                 // Expanded to dismissed.
                 tween(durationMillis = OutTransitionDuration)
             }
-        }
+        }, label = "menu-alpha"
     ) {
         if (it) {
             // Menu is expanded.
@@ -125,15 +124,12 @@ internal fun DropdownMenuContent(
     // TODO: Make sure this gets the rounded corner values
     Card(
         border = BorderStroke(CardStyle.cardBorderWidth, CardStyle.cardBorderColor),
-        modifier = Modifier,
-//            .graphicsLayer {
-//            scaleX = scale
-//            scaleY = scale
-//            this.alpha = alpha
-//            transformOrigin = transformOriginState.value
-//        }
-//            .requiredSizeIn(maxHeight = DropdownMenuItemDefaultMinHeight * 8.9f)
-//            .width(DropdownMenuItemDefaultMaxWidth),
+        modifier = Modifier.graphicsLayer {
+            scaleX = scale
+            scaleY = scale
+            this.alpha = alpha
+            transformOrigin = transformOriginState.value
+        },
         elevation = MenuElevation
     ) {
         val lazyListState = rememberLazyListState(
@@ -143,9 +139,6 @@ internal fun DropdownMenuContent(
         LazyColumn(
             modifier = modifier
                 .padding(vertical = DropdownMenuVerticalPadding),
-//                .width(DropdownMenuItemDefaultMaxWidth),
-//                .width(IntrinsicSize.Max)
-//                .verticalScroll(rememberScrollState()),
             state = lazyListState,
             content = content
         )

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/menu/Menu.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/menu/Menu.kt
@@ -1,3 +1,5 @@
+package com.stripe.android.ui.core.elements.menu
+
 /*
  * Copyright 2020 The Android Open Source Project
  *
@@ -14,33 +16,41 @@
  * limitations under the License.
  */
 
-package androidx.compose.material
-
 import androidx.compose.animation.core.LinearOutSlowInEasing
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.core.updateTransition
-import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSizeIn
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Card
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.ProvideTextStyle
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -54,6 +64,7 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.PopupPositionProvider
+import com.stripe.android.ui.core.elements.CardStyle
 import kotlin.math.max
 import kotlin.math.min
 
@@ -62,8 +73,9 @@ import kotlin.math.min
 internal fun DropdownMenuContent(
     expandedStates: MutableTransitionState<Boolean>,
     transformOriginState: MutableState<TransformOrigin>,
+    initialFirstVisibleItemIndex: Int,
     modifier: Modifier = Modifier,
-    content: @Composable ColumnScope.() -> Unit
+    content: LazyListScope.() -> Unit
 ) {
     // Menu open/close animation.
     val transition = updateTransition(expandedStates, "DropDownMenu")
@@ -113,20 +125,32 @@ internal fun DropdownMenuContent(
             0f
         }
     }
+
+    // TODO: Make sure this gets the rounded corner values
     Card(
-        modifier = Modifier.graphicsLayer {
-            scaleX = scale
-            scaleY = scale
-            this.alpha = alpha
-            transformOrigin = transformOriginState.value
-        },
+        border = BorderStroke(CardStyle.cardBorderWidth, CardStyle.cardBorderColor),
+        modifier = Modifier,
+//            .graphicsLayer {
+//            scaleX = scale
+//            scaleY = scale
+//            this.alpha = alpha
+//            transformOrigin = transformOriginState.value
+//        }
+//            .requiredSizeIn(maxHeight = DropdownMenuItemDefaultMinHeight * 8.9f)
+//            .width(DropdownMenuItemDefaultMaxWidth),
         elevation = MenuElevation
     ) {
-        Column(
+        val lazyListState = rememberLazyListState(
+            initialFirstVisibleItemIndex = initialFirstVisibleItemIndex
+        )
+
+        LazyColumn(
             modifier = modifier
-                .padding(vertical = DropdownMenuVerticalPadding)
-                .width(IntrinsicSize.Max)
-                .verticalScroll(rememberScrollState()),
+                .padding(vertical = DropdownMenuVerticalPadding),
+//                .width(DropdownMenuItemDefaultMaxWidth),
+//                .width(IntrinsicSize.Max)
+//                .verticalScroll(rememberScrollState()),
+            state = lazyListState,
             content = content
         )
     }
@@ -153,7 +177,7 @@ internal fun DropdownMenuItemContent(
             .fillMaxWidth()
             // Preferred min and max width used during the intrinsic measurement.
             .sizeIn(
-                minWidth = DropdownMenuItemDefaultMinWidth,
+                minWidth = DropdownMenuItemDefaultMaxWidth,// use the max width for both
                 maxWidth = DropdownMenuItemDefaultMaxWidth,
                 minHeight = DropdownMenuItemDefaultMinHeight
             )
@@ -186,11 +210,11 @@ object MenuDefaults {
 // Size defaults.
 private val MenuElevation = 8.dp
 internal val MenuVerticalMargin = 48.dp
-private val DropdownMenuItemHorizontalPadding = 16.dp
+internal val DropdownMenuItemHorizontalPadding = 16.dp
 internal val DropdownMenuVerticalPadding = 8.dp
-private val DropdownMenuItemDefaultMinWidth = 112.dp
-private val DropdownMenuItemDefaultMaxWidth = 280.dp
-private val DropdownMenuItemDefaultMinHeight = 48.dp
+internal val DropdownMenuItemDefaultMinWidth = 112.dp
+internal val DropdownMenuItemDefaultMaxWidth = 280.dp
+internal val DropdownMenuItemDefaultMinHeight = 48.dp
 
 // Menu open/close animation.
 internal const val InTransitionDuration = 120


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
        - [ ] Short list of dropdown items
        - [ ] long list of dropdown items
        - [ ] Varying width of dropdown item
        - [ ] Display setting very large (aka small Dpi)
        - [ ] Whole row is clickable, not just text
        - [ ] Scrolls to the selected item in the list

# Screenshots
| Before  | After |
| ------------- | ------------- |
|![original-dropdown](https://user-images.githubusercontent.com/77996191/158406285-c4e6d359-d032-4e15-9e00-74e86bef4774.png) |![Screenshot_20220315_105446](https://user-images.githubusercontent.com/77996191/158405679-3624403d-0c2e-474b-972c-dce61f74b88e.png) |

## Other test scenarios
| Small List | Small Dpi |
| ------------- | ------------- |
|![SmallList](https://user-images.githubusercontent.com/77996191/158406660-ac0aae7c-bbf5-4425-b2e4-b2efbc543df9.png)  | ![dropdown](https://user-images.githubusercontent.com/77996191/158408337-b25f91bf-1a2d-44ba-98d3-73bc9af6e87c.gif) |

* Small Dpi shows small Dpi, clicking anywhere on the row, scroll to the selected item,
