### PR TITLE
Fix delete on empty move to previous.

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
@@ -112,14 +112,16 @@ internal fun TextField(
         },
         modifier = modifier
             .fillMaxWidth()
-            .onKeyEvent { event ->
-                if (event.type == KeyEventType.KeyUp &&
+            .onPreviewKeyEvent { event ->
+                if (event.type == KeyEventType.KeyDown &&
                     event.nativeKeyEvent.keyCode == KeyEvent.KEYCODE_DEL &&
                     value.isEmpty()
                 ) {
                     focusManager.moveFocus(FocusDirection.Previous)
+                    true
+                } else {
+                    false
                 }
-                false
             }
             .onFocusChanged {
                 if (hasFocus != it.isFocused) {


### PR DESCRIPTION
# Summary
Fix a bug where deleting a single character from a text field caused it to move to the previous field.  

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
Before: https://user-images.githubusercontent.com/77996191/158421275-4d4837c5-053a-480e-b0ff-08c178fb3d26.mov
After: https://user-images.githubusercontent.com/77996191/158421102-9c954758-d880-4245-8ac9-020737cb5ede.mov


