### PR TITLE
[Identity][Camera-core] center crop the image sent to IDDetector

### DIFF
--- a/camera-core/api/camera-core.api
+++ b/camera-core/api/camera-core.api
@@ -21,9 +21,7 @@ public final class com/stripe/android/camera/framework/StatTracker$DefaultImpls 
 }
 
 public final class com/stripe/android/camera/framework/image/BitmapExtensionsKt {
-	public static final fun constrainToSize (Landroid/graphics/Bitmap;Landroid/util/Size;Z)Landroid/graphics/Bitmap;
 	public static synthetic fun constrainToSize$default (Landroid/graphics/Bitmap;Landroid/util/Size;ZILjava/lang/Object;)Landroid/graphics/Bitmap;
-	public static final fun scale (Landroid/graphics/Bitmap;Landroid/util/Size;Z)Landroid/graphics/Bitmap;
 	public static synthetic fun scale$default (Landroid/graphics/Bitmap;FZILjava/lang/Object;)Landroid/graphics/Bitmap;
 	public static synthetic fun scale$default (Landroid/graphics/Bitmap;Landroid/util/Size;ZILjava/lang/Object;)Landroid/graphics/Bitmap;
 	public static synthetic fun scaleAndCrop$default (Landroid/graphics/Bitmap;Landroid/util/Size;ZILjava/lang/Object;)Landroid/graphics/Bitmap;

--- a/camera-core/src/main/java/com/stripe/android/camera/framework/image/BitmapExtensions.kt
+++ b/camera-core/src/main/java/com/stripe/android/camera/framework/image/BitmapExtensions.kt
@@ -212,3 +212,10 @@ fun Bitmap.constrainToSize(size: Size, filter: Boolean = false): Bitmap =
         val newSize = this.size().scaleAndCenterWithin(size).size()
         Bitmap.createScaledBitmap(this, newSize.width, newSize.height, filter)
     }
+
+fun Bitmap.shorterEdge(): Int =
+    if (width < height) width else height
+
+fun Bitmap.longerEdge(): Int =
+    if (width > height) width else height
+

--- a/camera-core/src/main/java/com/stripe/android/camera/framework/image/BitmapExtensions.kt
+++ b/camera-core/src/main/java/com/stripe/android/camera/framework/image/BitmapExtensions.kt
@@ -195,6 +195,8 @@ fun Bitmap.zoom(
     return this.rearrangeBySegments(regionMap)
 }
 
+@CheckResult
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun Bitmap.scale(size: Size, filter: Boolean = false): Bitmap =
     if (size.width == width && size.height == height) {
         this
@@ -205,6 +207,8 @@ fun Bitmap.scale(size: Size, filter: Boolean = false): Bitmap =
 /**
  * Constrain a bitmap to a given size, while maintaining its original aspect ratio.
  */
+@CheckResult
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun Bitmap.constrainToSize(size: Size, filter: Boolean = false): Bitmap =
     if (size.width >= width && size.height >= height) {
         this
@@ -213,9 +217,12 @@ fun Bitmap.constrainToSize(size: Size, filter: Boolean = false): Bitmap =
         Bitmap.createScaledBitmap(this, newSize.width, newSize.height, filter)
     }
 
+@CheckResult
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun Bitmap.shorterEdge(): Int =
     if (width < height) width else height
 
+@CheckResult
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun Bitmap.longerEdge(): Int =
     if (width > height) width else height
-

--- a/identity/src/main/java/com/stripe/android/identity/ml/IDDetectorAnalyzer.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ml/IDDetectorAnalyzer.kt
@@ -92,11 +92,11 @@ internal class IDDetectorAnalyzer(modelFile: File) :
     internal class Factory(
         private val modelFile: File
     ) : AnalyzerFactory<
-        AnalyzerInput,
-        IdentityScanState,
-        AnalyzerOutput,
-        Analyzer<AnalyzerInput, IdentityScanState, AnalyzerOutput>
-        > {
+            AnalyzerInput,
+            IdentityScanState,
+            AnalyzerOutput,
+            Analyzer<AnalyzerInput, IdentityScanState, AnalyzerOutput>
+            > {
         override suspend fun newInstance(): Analyzer<AnalyzerInput, IdentityScanState, AnalyzerOutput> {
             return IDDetectorAnalyzer(modelFile)
         }

--- a/identity/src/main/java/com/stripe/android/identity/ml/IDDetectorAnalyzer.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ml/IDDetectorAnalyzer.kt
@@ -1,10 +1,10 @@
 package com.stripe.android.identity.ml
 
-import android.util.Size
 import com.stripe.android.camera.framework.Analyzer
 import com.stripe.android.camera.framework.AnalyzerFactory
 import com.stripe.android.camera.framework.image.cropCenter
-import com.stripe.android.camera.framework.image.shorterEdge
+import com.stripe.android.camera.framework.image.size
+import com.stripe.android.camera.framework.util.maxAspectRatioInSize
 import com.stripe.android.identity.states.IdentityScanState
 import org.tensorflow.lite.DataType
 import org.tensorflow.lite.Interpreter
@@ -31,9 +31,9 @@ internal class IDDetectorAnalyzer(modelFile: File) :
         var tensorImage = TensorImage(INPUT_TENSOR_TYPE)
 
         val croppedImage = data.cameraPreviewImage.image.cropCenter(
-            Size(
-                data.cameraPreviewImage.image.shorterEdge(),
-                data.cameraPreviewImage.image.shorterEdge()
+            maxAspectRatioInSize(
+                data.cameraPreviewImage.image.size(),
+                1f
             )
         )
 
@@ -45,8 +45,7 @@ internal class IDDetectorAnalyzer(modelFile: File) :
                 ResizeOp(INPUT_HEIGHT, INPUT_WIDTH, ResizeOp.ResizeMethod.BILINEAR)
             ).add(
                 NormalizeOp(NORMALIZE_MEAN, NORMALIZE_STD) // normalize to (-1, 1)
-            )
-                .build() // add nomalization
+            ).build() // add normalization
         tensorImage = imageProcessor.process(tensorImage)
 
         // inference - input: (1, 224, 224, 3), output: (1, 4), (1, 5)
@@ -92,11 +91,11 @@ internal class IDDetectorAnalyzer(modelFile: File) :
     internal class Factory(
         private val modelFile: File
     ) : AnalyzerFactory<
-            AnalyzerInput,
-            IdentityScanState,
-            AnalyzerOutput,
-            Analyzer<AnalyzerInput, IdentityScanState, AnalyzerOutput>
-            > {
+        AnalyzerInput,
+        IdentityScanState,
+        AnalyzerOutput,
+        Analyzer<AnalyzerInput, IdentityScanState, AnalyzerOutput>
+        > {
         override suspend fun newInstance(): Analyzer<AnalyzerInput, IdentityScanState, AnalyzerOutput> {
             return IDDetectorAnalyzer(modelFile)
         }

--- a/identity/src/main/java/com/stripe/android/identity/ml/IDDetectorAnalyzer.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ml/IDDetectorAnalyzer.kt
@@ -1,8 +1,10 @@
 package com.stripe.android.identity.ml
 
+import android.util.Size
 import com.stripe.android.camera.framework.Analyzer
 import com.stripe.android.camera.framework.AnalyzerFactory
-import com.stripe.android.camera.framework.image.cropCameraPreviewToSquare
+import com.stripe.android.camera.framework.image.cropCenter
+import com.stripe.android.camera.framework.image.shorterEdge
 import com.stripe.android.identity.states.IdentityScanState
 import org.tensorflow.lite.DataType
 import org.tensorflow.lite.Interpreter
@@ -27,10 +29,12 @@ internal class IDDetectorAnalyzer(modelFile: File) :
         state: IdentityScanState
     ): AnalyzerOutput {
         var tensorImage = TensorImage(INPUT_TENSOR_TYPE)
-        val croppedImage = cropCameraPreviewToSquare(
-            data.cameraPreviewImage.image,
-            data.cameraPreviewImage.viewBounds,
-            data.viewFinderBounds
+
+        val croppedImage = data.cameraPreviewImage.image.cropCenter(
+            Size(
+                data.cameraPreviewImage.image.shorterEdge(),
+                data.cameraPreviewImage.image.shorterEdge()
+            )
         )
 
         tensorImage.load(croppedImage)
@@ -88,11 +92,11 @@ internal class IDDetectorAnalyzer(modelFile: File) :
     internal class Factory(
         private val modelFile: File
     ) : AnalyzerFactory<
-            AnalyzerInput,
-            IdentityScanState,
-            AnalyzerOutput,
-            Analyzer<AnalyzerInput, IdentityScanState, AnalyzerOutput>
-            > {
+        AnalyzerInput,
+        IdentityScanState,
+        AnalyzerOutput,
+        Analyzer<AnalyzerInput, IdentityScanState, AnalyzerOutput>
+        > {
         override suspend fun newInstance(): Analyzer<AnalyzerInput, IdentityScanState, AnalyzerOutput> {
             return IDDetectorAnalyzer(modelFile)
         }

--- a/identity/src/main/java/com/stripe/android/identity/ml/IDDetectorAnalyzer.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ml/IDDetectorAnalyzer.kt
@@ -91,11 +91,11 @@ internal class IDDetectorAnalyzer(modelFile: File) :
     internal class Factory(
         private val modelFile: File
     ) : AnalyzerFactory<
-        AnalyzerInput,
-        IdentityScanState,
-        AnalyzerOutput,
-        Analyzer<AnalyzerInput, IdentityScanState, AnalyzerOutput>
-        > {
+            AnalyzerInput,
+            IdentityScanState,
+            AnalyzerOutput,
+            Analyzer<AnalyzerInput, IdentityScanState, AnalyzerOutput>
+            > {
         override suspend fun newInstance(): Analyzer<AnalyzerInput, IdentityScanState, AnalyzerOutput> {
             return IDDetectorAnalyzer(modelFile)
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Add methods in `BitmapExtension` to get a bitmap's longer and shorter edges
* Use `BitmapExtension` to crop the image correctly - IDDetector needs a square image center cropped from camera preview, with the edge equals to the shorter edge of the preview


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Identity SDK

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
