### PR TITLE
Handle configuration changes while on web AuthFlow

### DIFF
--- a/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetActivity.kt
+++ b/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetActivity.kt
@@ -4,6 +4,9 @@ import android.app.Activity
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.util.Log
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
@@ -16,6 +19,10 @@ import com.stripe.android.connections.databinding.ActivityConnectionsSheetBindin
 import java.security.InvalidParameterException
 
 internal class ConnectionsSheetActivity : AppCompatActivity() {
+
+    private val startForResult = registerForActivityResult(StartActivityForResult()) {
+        viewModel.onActivityResult()
+    }
 
     @VisibleForTesting
     internal val viewBinding by lazy {
@@ -59,6 +66,7 @@ internal class ConnectionsSheetActivity : AppCompatActivity() {
         }
 
         setupObservers()
+        if (savedInstanceState != null) viewModel.onActivityRecreated()
     }
 
     private fun setupObservers() {
@@ -78,7 +86,7 @@ internal class ConnectionsSheetActivity : AppCompatActivity() {
     }
 
     private fun OpenAuthFlowWithUrl.launch() {
-        startActivity(
+        startForResult.launch(
             CustomTabsIntent.Builder()
                 .setShareState(CustomTabsIntent.SHARE_STATE_OFF)
                 .build()

--- a/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetActivity.kt
+++ b/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetActivity.kt
@@ -4,8 +4,6 @@ import android.app.Activity
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import android.util.Log
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting

--- a/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetState.kt
+++ b/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetState.kt
@@ -6,6 +6,7 @@ import com.stripe.android.connections.model.LinkAccountSessionManifest
  *  Class containing all of the data needed to represent the screen.
  */
 internal data class ConnectionsSheetState(
+    val activityRecreated: Boolean = false,
     val manifest: LinkAccountSessionManifest? = null,
     val authFlowActive: Boolean = false
 )

--- a/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetViewModel.kt
+++ b/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetViewModel.kt
@@ -103,6 +103,12 @@ internal class ConnectionsSheetViewModel @Inject constructor(
     // If activity resumes and we did not receive a callback from the custom tabs,
     // then the user hit the back button or closed the custom tabs UI, so return result as
     // canceled.
+
+    /**
+     *  If activity resumes and we did not receive a callback from the custom tabs,
+     *  then the user hit the back button or closed the custom tabs UI, so return result as
+     *  canceled.
+     */
     internal fun onResume() {
         if (_state.value.authFlowActive && _state.value.activityRecreated.not()) {
             viewModelScope.launch {
@@ -111,9 +117,11 @@ internal class ConnectionsSheetViewModel @Inject constructor(
         }
     }
 
-    // If activity receives result and we did not receive a callback from the custom tabs,
-    // if activity got recreated and the auth flow is still active then the user hit
-    // the back button or closed the custom tabs UI, so return result as canceled.
+    /**
+     * If activity receives result and we did not receive a callback from the custom tabs,
+     * if activity got recreated and the auth flow is still active then the user hit
+     * the back button or closed the custom tabs UI, so return result as canceled.
+     */
     fun onActivityResult() {
         if (_state.value.authFlowActive && _state.value.activityRecreated) {
             viewModelScope.launch {

--- a/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetViewModel.kt
+++ b/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetViewModel.kt
@@ -96,13 +96,9 @@ internal class ConnectionsSheetViewModel @Inject constructor(
      * @see onResume (we rely on this on regular flows)
      * @see onActivityResult (we rely on this on config changes)
      */
-    fun onActivityRecreated() {
+    internal fun onActivityRecreated() {
         _state.update { it.copy(activityRecreated = true) }
     }
-
-    // If activity resumes and we did not receive a callback from the custom tabs,
-    // then the user hit the back button or closed the custom tabs UI, so return result as
-    // canceled.
 
     /**
      *  If activity resumes and we did not receive a callback from the custom tabs,
@@ -122,7 +118,7 @@ internal class ConnectionsSheetViewModel @Inject constructor(
      * if activity got recreated and the auth flow is still active then the user hit
      * the back button or closed the custom tabs UI, so return result as canceled.
      */
-    fun onActivityResult() {
+    internal fun onActivityResult() {
         if (_state.value.authFlowActive && _state.value.activityRecreated) {
             viewModelScope.launch {
                 _viewEffect.emit(FinishWithResult(ConnectionsSheetResult.Canceled))

--- a/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetViewModel.kt
+++ b/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetViewModel.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Named
@@ -79,11 +80,42 @@ internal class ConnectionsSheetViewModel @Inject constructor(
         _viewEffect.emit(OpenAuthFlowWithUrl(manifest.hostedAuthUrl))
     }
 
+    /**
+     * Activity recreation changes the lifecycle order:
+     *
+     * - If config change happens while in web flow: onResume -> onNewIntent -> activityResult
+     * - If no config change happens: onActivityResult -> onNewIntent -> onResume
+     *
+     * (note [handleOnNewIntent] will just get called if user completed the web flow and clicked
+     * the deeplink that redirects back to the app)
+     *
+     * We need to rely on a post-onNewIntent lifecycle callback to figure if the user completed
+     * or cancelled the web flow. [ConnectionsSheetState.activityRecreated] will be used to
+     * figure which lifecycle callback happens after onNewIntent.
+     *
+     * @see onResume (we rely on this on regular flows)
+     * @see onActivityResult (we rely on this on config changes)
+     */
+    fun onActivityRecreated() {
+        _state.update { it.copy(activityRecreated = true) }
+    }
+
     // If activity resumes and we did not receive a callback from the custom tabs,
     // then the user hit the back button or closed the custom tabs UI, so return result as
     // canceled.
     internal fun onResume() {
-        if (_state.value.authFlowActive) {
+        if (_state.value.authFlowActive && _state.value.activityRecreated.not()) {
+            viewModelScope.launch {
+                _viewEffect.emit(FinishWithResult(ConnectionsSheetResult.Canceled))
+            }
+        }
+    }
+
+    // If activity receives result and we did not receive a callback from the custom tabs,
+    // if activity got recreated and the auth flow is still active then the user hit
+    // the back button or closed the custom tabs UI, so return result as canceled.
+    fun onActivityResult() {
+        if (_state.value.authFlowActive && _state.value.activityRecreated) {
             viewModelScope.launch {
                 _viewEffect.emit(FinishWithResult(ConnectionsSheetResult.Canceled))
             }
@@ -141,7 +173,7 @@ internal class ConnectionsSheetViewModel @Inject constructor(
      * @param intent the new intent with the redirect URL in the intent data
      */
     internal fun handleOnNewIntent(intent: Intent?) {
-        updateState { copy(authFlowActive = false) }
+        _state.update { it.copy(authFlowActive = false) }
         viewModelScope.launch {
             val manifest = _state.value.manifest
             when (intent?.data.toString()) {
@@ -149,12 +181,6 @@ internal class ConnectionsSheetViewModel @Inject constructor(
                 manifest?.cancelUrl -> onUserCancel()
                 else -> onFatal(Exception("Error processing ConnectionsSheet intent"))
             }
-        }
-    }
-
-    private fun updateState(block: ConnectionsSheetState.() -> ConnectionsSheetState) {
-        viewModelScope.launch {
-            _state.emit(block(_state.value))
         }
     }
 

--- a/connections/src/test/java/com/stripe/android/connections/ConnectionsSheetViewModelTest.kt
+++ b/connections/src/test/java/com/stripe/android/connections/ConnectionsSheetViewModelTest.kt
@@ -183,7 +183,7 @@ class ConnectionsSheetViewModelTest {
         }
 
     @Test
-    fun `onResume - when flow is still active, finish with Result#Cancelled`() {
+    fun `onResume - when flow is still active and no config changes, finish with Result#Cancelled`() {
         runTest {
             // Given
             val viewModel = createViewModel(configuration)
@@ -191,6 +191,25 @@ class ConnectionsSheetViewModelTest {
                 // When
                 // end auth flow (activity resumed without new intent received)
                 viewModel.onResume()
+
+                // Then
+                assertThat(viewModel.state.value.authFlowActive).isTrue()
+                assertThat(awaitItem()).isEqualTo(FinishWithResult(ConnectionsSheetResult.Canceled))
+            }
+        }
+    }
+
+    @Test
+    fun `onActivityResult - when flow is still active and config changed, finish with Result#Cancelled`() {
+        runTest {
+            // Given
+            val viewModel = createViewModel(configuration)
+            viewModel.viewEffect.test {
+                // When
+                // configuration changes, changing lifecycle flow.
+                viewModel.onActivityRecreated()
+                // auth flow ends (activity received result without new intent received)
+                viewModel.onActivityResult()
 
                 // Then
                 assertThat(viewModel.state.value.authFlowActive).isTrue()


### PR DESCRIPTION
# Summary

We need to rely on a post-`onNewIntent` lifecycle callback to figure if the user completed or cancelled the web flow, since `onNewIntent` will get called just if user completes the connections web flow by clicking one of the deeplinks that route back to the app. 

We were assuming `onResume` always happens after `onNewIntent`, but that's not the case on configuration changes (screen rotation, language changes, etc), as it seems like activity recreation changes the lifecycle order:

- If config change happens while in web flow: onResume -> [onNewIntent] -> **activityResult**
- If no config change happens: onActivityResult -> [onNewIntent] -> **onResume**

Solution: rely on a different lifecycle callback depending on if there was a config change during the web flow or not. We're doing that here by checking if configuration changed at `onCreate` time, and if so, storing a flag in the screen state. 

# Testing

Tested on a phew phones / Android versions and all seem to follow this lifecycle.

# Reproducing the issue:

Start with your phone in landscape and launch the connections sheet. Once in the web flow, rotate back to vertical and keep it that way. Complete the flow linking an account.

Before, it'd result as cancelled. Now it should success and show the linked accounts