### PR TITLE
Add the ability to disable the cannot scan button

### DIFF
--- a/stripecardscan/api/stripecardscan.api
+++ b/stripecardscan/api/stripecardscan.api
@@ -25,13 +25,15 @@ public final class com/stripe/android/stripecardscan/cardimageverification/CardI
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
-	public fun <init> (Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration$StrictModeFrameCount;)V
-	public synthetic fun <init> (Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration$StrictModeFrameCount;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration$StrictModeFrameCount;Z)V
+	public synthetic fun <init> (Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration$StrictModeFrameCount;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration$StrictModeFrameCount;
-	public final fun copy (Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration$StrictModeFrameCount;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration;
-	public static synthetic fun copy$default (Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration$StrictModeFrameCount;ILjava/lang/Object;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration;
+	public final fun component2 ()Z
+	public final fun copy (Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration$StrictModeFrameCount;Z)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration;
+	public static synthetic fun copy$default (Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration$StrictModeFrameCount;ZILjava/lang/Object;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnableCannotScanButton ()Z
 	public final fun getStrictModeFrames ()Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration$StrictModeFrameCount;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationActivity.kt
@@ -44,6 +44,7 @@ import com.stripe.android.stripecardscan.scanui.util.getColorByRes
 import com.stripe.android.stripecardscan.scanui.util.getDrawableByRes
 import com.stripe.android.stripecardscan.scanui.util.hide
 import com.stripe.android.stripecardscan.scanui.util.setTextSizeByRes
+import com.stripe.android.stripecardscan.scanui.util.setVisible
 import com.stripe.android.stripecardscan.scanui.util.show
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -406,6 +407,8 @@ internal open class CardImageVerificationActivity :
             resources.getDimensionPixelSize(R.dimen.stripeButtonPadding),
             resources.getDimensionPixelSize(R.dimen.stripeButtonPadding),
         )
+
+        cannotScanTextView.setVisible(params.configuration.enableCannotScanButton)
 
         if (isBackgroundDark()) {
             cannotScanTextView.setTextColor(getColorByRes(R.color.stripeButtonDarkText))

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet.kt
@@ -44,9 +44,18 @@ class CardImageVerificationSheet private constructor(
 
     @Parcelize
     data class Configuration(
-        // The amount of frames that must have a centered, focused card before the scan
-        // is allowed to terminate
+        /**
+         * The amount of frames that must have a centered, focused card before the scan
+         * is allowed to terminate. This is an experimental feature that should only be
+         * used with guidance from Stripe support.
+         */
         val strictModeFrames: StrictModeFrameCount = StrictModeFrameCount.None,
+        /**
+         * Determine if the "I can't scan this card" button should be included in the scan window.
+         * This is an experimental feature that should only be used with guidance from Stripe
+         * support.
+         */
+        val enableCannotScanButton: Boolean = true,
     ) : Parcelable {
         sealed class StrictModeFrameCount(val count: Int) : Parcelable {
             @Parcelize object None : StrictModeFrameCount(0)


### PR DESCRIPTION
# Summary
last-minute request from a customer to allow them to be able to disable the "I can't scan this card" button.

# Motivation
https://jira.corp.stripe.com/browse/BOUNCER-850

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified
