### PR TITLE
Link logout logic

### DIFF
--- a/link/api/link.api
+++ b/link/api/link.api
@@ -85,11 +85,11 @@ public final class com/stripe/android/link/LinkActivityResult$Success : com/stri
 }
 
 public final class com/stripe/android/link/LinkActivityViewModel_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/link/LinkActivityViewModel_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/link/LinkActivityViewModel_Factory;
 	public fun get ()Lcom/stripe/android/link/LinkActivityViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/link/LinkActivityContract$Args;Lcom/stripe/android/link/account/LinkAccountManager;Lcom/stripe/android/link/model/Navigator;)Lcom/stripe/android/link/LinkActivityViewModel;
+	public static fun newInstance (Lcom/stripe/android/link/LinkActivityContract$Args;Lcom/stripe/android/link/account/LinkAccountManager;Lcom/stripe/android/link/account/CookieStore;Lcom/stripe/android/link/model/Navigator;)Lcom/stripe/android/link/LinkActivityViewModel;
 }
 
 public final class com/stripe/android/link/LinkActivityViewModel_Factory_MembersInjector : dagger/MembersInjector {
@@ -202,11 +202,11 @@ public final class com/stripe/android/link/ui/signup/ComposableSingletons$SignUp
 }
 
 public final class com/stripe/android/link/ui/signup/SignUpViewModel_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/link/ui/signup/SignUpViewModel_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/link/ui/signup/SignUpViewModel_Factory;
 	public fun get ()Lcom/stripe/android/link/ui/signup/SignUpViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/link/LinkActivityContract$Args;Lcom/stripe/android/link/account/LinkAccountManager;Lcom/stripe/android/link/model/Navigator;Lcom/stripe/android/core/Logger;)Lcom/stripe/android/link/ui/signup/SignUpViewModel;
+	public static fun newInstance (Lcom/stripe/android/link/LinkActivityContract$Args;Ljava/lang/String;Lcom/stripe/android/link/account/LinkAccountManager;Lcom/stripe/android/link/model/Navigator;Lcom/stripe/android/core/Logger;)Lcom/stripe/android/link/ui/signup/SignUpViewModel;
 }
 
 public final class com/stripe/android/link/ui/signup/SignUpViewModel_Factory_MembersInjector : dagger/MembersInjector {
@@ -214,7 +214,7 @@ public final class com/stripe/android/link/ui/signup/SignUpViewModel_Factory_Mem
 	public static fun create (Ljavax/inject/Provider;)Ldagger/MembersInjector;
 	public fun injectMembers (Lcom/stripe/android/link/ui/signup/SignUpViewModel$Factory;)V
 	public synthetic fun injectMembers (Ljava/lang/Object;)V
-	public static fun injectViewModel (Lcom/stripe/android/link/ui/signup/SignUpViewModel$Factory;Lcom/stripe/android/link/ui/signup/SignUpViewModel;)V
+	public static fun injectSubComponentBuilderProvider (Lcom/stripe/android/link/ui/signup/SignUpViewModel$Factory;Ljavax/inject/Provider;)V
 }
 
 public final class com/stripe/android/link/ui/verification/ComposableSingletons$VerificationScreenKt {
@@ -256,11 +256,11 @@ public final class com/stripe/android/link/ui/wallet/ComposableSingletons$Wallet
 }
 
 public final class com/stripe/android/link/ui/wallet/WalletViewModel_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/link/ui/wallet/WalletViewModel_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/link/ui/wallet/WalletViewModel_Factory;
 	public fun get ()Lcom/stripe/android/link/ui/wallet/WalletViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/link/repositories/LinkRepository;Lcom/stripe/android/link/model/Navigator;Lcom/stripe/android/core/Logger;Lcom/stripe/android/link/model/LinkAccount;)Lcom/stripe/android/link/ui/wallet/WalletViewModel;
+	public static fun newInstance (Lcom/stripe/android/link/repositories/LinkRepository;Lcom/stripe/android/link/account/LinkAccountManager;Lcom/stripe/android/link/model/Navigator;Lcom/stripe/android/core/Logger;Lcom/stripe/android/link/model/LinkAccount;)Lcom/stripe/android/link/ui/wallet/WalletViewModel;
 }
 
 public final class com/stripe/android/link/ui/wallet/WalletViewModel_Factory_MembersInjector : dagger/MembersInjector {

--- a/link/res/values/strings.xml
+++ b/link/res/values/strings.xml
@@ -10,7 +10,9 @@
     <string name="sign_up">Join Link</string>
 
     <string name="verification_header">Enter your verification code</string>
-    <string name="verification_message">Enter the code sent to %1$s to securely use your saved information.</string>
+    <string name="verification_message">Enter the code sent to %1$s to use Link to pay by default.</string>
+    <string name="verification_not_email">Not %1$s?</string>
+    <string name="verification_change_email">Change email</string>
     <string name="verification_resend">Resend code</string>
 
     <string name="wallet_pay_with">Pay with</string>

--- a/link/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -20,18 +20,17 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.link.ui.LinkAppBar
 import com.stripe.android.link.ui.signup.SignUpBody
 import com.stripe.android.link.ui.verification.VerificationBody
 import com.stripe.android.link.ui.wallet.WalletBody
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 
 internal class LinkActivity : ComponentActivity() {
 
@@ -52,6 +51,8 @@ internal class LinkActivity : ComponentActivity() {
         setContent {
             navController = rememberNavController()
 
+            viewModel.navigator.navigationController = navController
+
             DefaultLinkTheme {
                 Surface {
                     Column(
@@ -66,7 +67,7 @@ internal class LinkActivity : ComponentActivity() {
                             onCloseButtonClick = ::dismiss
                         )
 
-                        NavHost(navController, viewModel.startDestination.route) {
+                        NavHost(navController, viewModel.startDestination) {
                             composable(LinkScreen.Loading.route) {
                                 Box(
                                     modifier = Modifier
@@ -77,22 +78,36 @@ internal class LinkActivity : ComponentActivity() {
                                     CircularProgressIndicator()
                                 }
                             }
-                            composable(LinkScreen.SignUp.route) {
-                                SignUpBody(viewModel.injector)
+                            composable(
+                                LinkScreen.SignUp.route,
+                                arguments = listOf(
+                                    navArgument(LinkScreen.SignUp.emailArg) {
+                                        type = NavType.StringType
+                                        nullable = true
+                                    }
+                                )
+                            ) { backStackEntry ->
+                                val email =
+                                    backStackEntry.arguments?.getString(LinkScreen.SignUp.emailArg)
+                                SignUpBody(viewModel.injector, email)
                             }
                             composable(LinkScreen.Verification.route) {
-                                VerificationBody(
-                                    requireNotNull(linkAccount),
-                                    viewModel.injector
-                                )
+                                linkAccount?.let { account ->
+                                    VerificationBody(
+                                        account,
+                                        viewModel.injector
+                                    )
+                                }
                             }
                             composable(LinkScreen.Wallet.route) {
-                                WalletBody(
-                                    requireNotNull(linkAccount),
-                                    viewModel.injector
-                                )
+                                linkAccount?.let { account ->
+                                    WalletBody(
+                                        account,
+                                        viewModel.injector
+                                    )
+                                }
                             }
-                            composable(LinkScreen.AddPaymentMethod.route) {
+                            composable(LinkScreen.PaymentMethod.route) {
                                 Box(
                                     modifier = Modifier
                                         .fillMaxWidth()
@@ -107,11 +122,6 @@ internal class LinkActivity : ComponentActivity() {
                 }
             }
         }
-
-        viewModel.navigator.sharedFlow.onEach {
-            navController.popBackStack()
-            navController.navigate(it.route)
-        }.launchIn(viewModel.viewModelScope)
 
         viewModel.navigator.onDismiss = ::dismiss
     }

--- a/link/src/main/java/com/stripe/android/link/LinkActivityContract.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivityContract.kt
@@ -29,6 +29,7 @@ class LinkActivityContract :
      * @param merchantName The customer-facing business name.
      * @param customerEmail Email of the customer used to pre-fill the form.
      * @param injectionParams Parameters needed to perform dependency injection.
+     *                        If null, a new dependency graph will be created.
      */
     @Parcelize
     data class Args internal constructor(

--- a/link/src/main/java/com/stripe/android/link/LinkScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkScreen.kt
@@ -1,14 +1,29 @@
 package com.stripe.android.link
 
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
 /**
  * All Link screens.
  */
 internal sealed class LinkScreen(
-    val route: String
+    open val route: String
 ) {
     object Loading : LinkScreen("Loading")
-    object SignUp : LinkScreen("SignUp")
     object Verification : LinkScreen("Verification")
     object Wallet : LinkScreen("Wallet")
-    object AddPaymentMethod : LinkScreen("AddPaymentMethod")
+    object PaymentMethod : LinkScreen("PaymentMethod")
+
+    class SignUp(email: String? = null) :
+        LinkScreen("SignUp?${email?.let { "$it=${it.urlEncode()}" }}") {
+        override val route = super.route
+
+        companion object {
+            const val emailArg = "email"
+            const val route = "SignUp?$emailArg={$emailArg}"
+        }
+    }
 }
+
+private fun String.urlEncode(): String =
+    URLEncoder.encode(this, StandardCharsets.UTF_8.toString())

--- a/link/src/main/java/com/stripe/android/link/account/CookieStore.kt
+++ b/link/src/main/java/com/stripe/android/link/account/CookieStore.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.link.account
 
+import java.security.MessageDigest
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -36,7 +37,30 @@ internal class CookieStore @Inject constructor(
      */
     fun getAuthSessionCookie() = store.read(AUTH_SESSION_COOKIE)
 
-    private companion object {
-        const val AUTH_SESSION_COOKIE = "auth_session_cookie"
+    /**
+     * Delete the current authentication session cookie and store the hash of the email so that the
+     * user won't be automatically redirected to the verification screen next time.
+     */
+    fun logout(email: String) {
+        storeLoggedOutEmail(email)
+        store.delete(AUTH_SESSION_COOKIE)
     }
+
+    /**
+     * Check whether this is the most recent logged out email.
+     */
+    fun isEmailLoggedOut(email: String) =
+        store.read(LOGGED_OUT_EMAIL_HASH) == email.sha256()
+
+    private fun storeLoggedOutEmail(email: String) =
+        store.write(LOGGED_OUT_EMAIL_HASH, email.sha256())
+
+    companion object {
+        const val AUTH_SESSION_COOKIE = "auth_session_cookie"
+        const val LOGGED_OUT_EMAIL_HASH = "logged_out_email_hash"
+    }
+
+    private fun String.sha256(): String =
+        MessageDigest.getInstance("SHA-256").digest(toByteArray(Charsets.UTF_8))
+            .joinToString(separator = "") { eachByte -> "%02x".format(eachByte) }
 }

--- a/link/src/main/java/com/stripe/android/link/account/CookieStore.kt
+++ b/link/src/main/java/com/stripe/android/link/account/CookieStore.kt
@@ -47,7 +47,7 @@ internal class CookieStore @Inject constructor(
     }
 
     /**
-     * Check whether this is the most recent logged out email.
+     * Check whether this is the most recently logged out email.
      */
     fun isEmailLoggedOut(email: String) =
         store.read(LOGGED_OUT_EMAIL_HASH) == email.sha256()

--- a/link/src/main/java/com/stripe/android/link/injection/LinkPaymentLauncherModule.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/LinkPaymentLauncherModule.kt
@@ -10,7 +10,8 @@ import javax.inject.Singleton
 
 @Module(
     subcomponents = [
-        SignedInViewModelSubcomponent::class
+        SignedInViewModelSubcomponent::class,
+        SignUpViewModelSubcomponent::class
     ]
 )
 internal interface LinkPaymentLauncherModule {

--- a/link/src/main/java/com/stripe/android/link/injection/SignUpViewModelSubcomponent.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/SignUpViewModelSubcomponent.kt
@@ -1,0 +1,23 @@
+package com.stripe.android.link.injection
+
+import com.stripe.android.link.ui.signup.SignUpViewModel
+import dagger.BindsInstance
+import dagger.Subcomponent
+import javax.inject.Named
+
+/**
+ * Subcomponent used by SignUpViewModel.
+ */
+@Subcomponent
+internal interface SignUpViewModelSubcomponent {
+    val signUpViewModel: SignUpViewModel
+
+    @Subcomponent.Builder
+    interface Builder {
+
+        @BindsInstance
+        fun prefilledEmail(@Named(SignUpViewModel.PREFILLED_EMAIL) prefilledEmail: String?): Builder
+
+        fun build(): SignUpViewModelSubcomponent
+    }
+}

--- a/link/src/main/java/com/stripe/android/link/model/Navigator.kt
+++ b/link/src/main/java/com/stripe/android/link/model/Navigator.kt
@@ -1,22 +1,42 @@
 package com.stripe.android.link.model
 
+import androidx.navigation.NavHostController
 import com.stripe.android.link.LinkScreen
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * Coordinates the navigation between screens.
+ */
 @Singleton
 internal class Navigator @Inject constructor() {
-    private val _sharedFlow =
-        MutableSharedFlow<LinkScreen>(extraBufferCapacity = 1)
-    val sharedFlow = _sharedFlow.asSharedFlow()
-
+    var navigationController: NavHostController? = null
     var onDismiss = {}
 
-    fun navigateTo(target: LinkScreen) {
-        _sharedFlow.tryEmit(target)
+    /**
+     * Navigates to the given [LinkScreen], optionally clearing the back stack.
+     */
+    fun navigateTo(
+        target: LinkScreen,
+        clearBackStack: Boolean = false
+    ) = navigationController?.let { navController ->
+        navController.navigate(target.route) {
+            if (clearBackStack) {
+                popUpTo(navController.backQueue.first().destination.id)
+            }
+        }
     }
+
+    /**
+     * Behaves like a back button, popping the back stack and dismissing the Activity if this was
+     * the last screen.
+     */
+    fun onBack() =
+        navigationController?.let { navController ->
+            if (!navController.popBackStack()) {
+                onDismiss()
+            }
+        }
 
     fun dismiss() {
         onDismiss()

--- a/link/src/main/java/com/stripe/android/link/theme/Type.kt
+++ b/link/src/main/java/com/stripe/android/link/theme/Type.kt
@@ -20,6 +20,12 @@ internal val Typography = Typography(
         fontSize = 16.sp,
         lineHeight = 24.sp
     ),
+    body2 = TextStyle(
+        fontFamily = FontFamily.Default,
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp,
+        lineHeight = 20.sp
+    ),
     button = TextStyle(
         fontFamily = FontFamily.Default,
         fontWeight = FontWeight.Medium,

--- a/link/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
@@ -58,11 +58,13 @@ private fun SignUpBodyPreview() {
 
 @Composable
 internal fun SignUpBody(
-    injector: NonFallbackInjector
+    injector: NonFallbackInjector,
+    email: String?
 ) {
     val signUpViewModel: SignUpViewModel = viewModel(
         factory = SignUpViewModel.Factory(
-            injector
+            injector,
+            email
         )
     )
 

--- a/link/src/main/java/com/stripe/android/link/ui/verification/VerificationScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/verification/VerificationScreen.kt
@@ -1,9 +1,15 @@
 package com.stripe.android.link.ui.verification
 
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
@@ -16,9 +22,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -35,7 +43,10 @@ private fun VerificationBodyPreview() {
     DefaultLinkTheme {
         VerificationBody(
             redactedPhoneNumber = "+1********23",
+            email = "test@stripe.com",
             onCodeEntered = { },
+            onBack = { },
+            onChangeEmailClick = { },
             onResendCodeClick = { }
         )
     }
@@ -55,7 +66,10 @@ internal fun VerificationBody(
 
     VerificationBody(
         redactedPhoneNumber = viewModel.linkAccount.redactedPhoneNumber,
+        email = viewModel.linkAccount.email,
         onCodeEntered = viewModel::onVerificationCodeEntered,
+        onBack = viewModel::onBack,
+        onChangeEmailClick = viewModel::onChangeEmailClicked,
         onResendCodeClick = viewModel::onResendCodeClicked
     )
 }
@@ -63,13 +77,17 @@ internal fun VerificationBody(
 @Composable
 internal fun VerificationBody(
     redactedPhoneNumber: String,
+    email: String,
     onCodeEntered: (String) -> Unit,
+    onBack: () -> Unit,
+    onChangeEmailClick: () -> Unit,
     onResendCodeClick: () -> Unit
 ) {
+    BackHandler(onBack = onBack)
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 20.dp, vertical = 20.dp),
+            .padding(vertical = 20.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
@@ -77,7 +95,8 @@ internal fun VerificationBody(
             modifier = Modifier
                 .padding(vertical = 4.dp),
             textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.h2
+            style = MaterialTheme.typography.h2,
+            color = MaterialTheme.colors.onPrimary
         )
         Text(
             text = stringResource(R.string.verification_message, redactedPhoneNumber),
@@ -85,16 +104,47 @@ internal fun VerificationBody(
                 .fillMaxWidth()
                 .padding(top = 4.dp, bottom = 30.dp),
             textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.body1
+            style = MaterialTheme.typography.body1,
+            color = MaterialTheme.colors.onSecondary
         )
         VerificationCodeInput(onCodeEntered)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 22.dp, bottom = 30.dp),
+            horizontalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = stringResource(id = R.string.verification_not_email, email),
+                style = MaterialTheme.typography.body2,
+                color = MaterialTheme.colors.onSecondary
+            )
+            Text(
+                text = stringResource(id = R.string.verification_change_email),
+                modifier = Modifier
+                    .padding(start = 4.dp)
+                    .clickable(onClick = onChangeEmailClick),
+                style = MaterialTheme.typography.body2
+                    .merge(TextStyle(textDecoration = TextDecoration.Underline)),
+                color = MaterialTheme.colors.onSecondary
+            )
+        }
         TextButton(
             onClick = onResendCodeClick,
-            modifier = Modifier.padding(top = 30.dp)
+            modifier = Modifier
+                .border(
+                    width = 1.dp,
+                    color = MaterialTheme.colors.onBackground,
+                    shape = MaterialTheme.shapes.medium
+                ),
+            colors = ButtonDefaults.buttonColors(
+                backgroundColor = MaterialTheme.colors.background
+            )
         ) {
             Text(
                 text = stringResource(id = R.string.verification_resend),
-                style = MaterialTheme.typography.button
+                style = MaterialTheme.typography.button,
+                color = MaterialTheme.colors.onPrimary
             )
         }
     }

--- a/link/src/main/java/com/stripe/android/link/ui/verification/VerificationViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/verification/VerificationViewModel.kt
@@ -29,7 +29,7 @@ internal class VerificationViewModel @Inject constructor(
         viewModelScope.launch {
             linkAccountManager.confirmVerification(code).fold(
                 onSuccess = {
-                    navigator.navigateTo(LinkScreen.Wallet)
+                    navigator.navigateTo(LinkScreen.Wallet, clearBackStack = true)
                 },
                 onFailure = ::onError
             )
@@ -45,6 +45,16 @@ internal class VerificationViewModel @Inject constructor(
                 onFailure = ::onError
             )
         }
+    }
+
+    fun onBack() {
+        navigator.onBack()
+        linkAccountManager.logout()
+    }
+
+    fun onChangeEmailClicked() {
+        navigator.navigateTo(LinkScreen.SignUp(), clearBackStack = true)
+        linkAccountManager.logout()
     }
 
     private fun onError(error: Throwable) {

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.stripe.android.core.Logger
 import com.stripe.android.link.LinkScreen
+import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.injection.NonFallbackInjectable
 import com.stripe.android.link.injection.NonFallbackInjector
 import com.stripe.android.link.injection.SignedInViewModelSubcomponent
@@ -20,6 +21,7 @@ import javax.inject.Provider
 
 internal class WalletViewModel @Inject constructor(
     private val linkRepository: LinkRepository,
+    private val linkAccountManager: LinkAccountManager,
     private val navigator: Navigator,
     private val logger: Logger,
     val linkAccount: LinkAccount
@@ -52,10 +54,11 @@ internal class WalletViewModel @Inject constructor(
 
     fun payAnotherWay() {
         navigator.dismiss()
+        linkAccountManager.logout()
     }
 
     fun addNewPaymentMethod() {
-        navigator.navigateTo(LinkScreen.AddPaymentMethod)
+        navigator.navigateTo(LinkScreen.PaymentMethod)
     }
 
     private fun onError(error: Throwable) {

--- a/link/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -5,9 +5,10 @@ import androidx.lifecycle.Lifecycle
 import androidx.savedstate.SavedStateRegistry
 import androidx.savedstate.SavedStateRegistryOwner
 import androidx.test.core.app.ApplicationProvider
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.injection.Injectable
 import com.stripe.android.core.injection.WeakMapInjectorRegistry
+import com.stripe.android.link.account.CookieStore
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.injection.NonFallbackInjector
 import com.stripe.android.link.model.LinkAccount
@@ -19,6 +20,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argWhere
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.times
@@ -43,10 +45,20 @@ class LinkActivityViewModelTest {
     )
 
     private val linkAccountManager = mock<LinkAccountManager>()
+    private val cookieStore = mock<CookieStore>()
     private val navigator = mock<Navigator>()
 
     init {
         FakeAndroidKeyStore.setup()
+    }
+
+    @Test
+    fun `When consumer is logged out then start destination is SignUp screen`() = runTest {
+        whenever(cookieStore.isEmailLoggedOut(CUSTOMER_EMAIL)).thenReturn(true)
+
+        val viewModel = createViewModel()
+
+        assertThat(viewModel.startDestination).isEqualTo(LinkScreen.SignUp.route)
     }
 
     @Test
@@ -58,7 +70,7 @@ class LinkActivityViewModelTest {
 
         createViewModel()
 
-        verify(navigator).navigateTo(LinkScreen.Wallet)
+        verify(navigator).navigateTo(LinkScreen.Wallet, true)
     }
 
     @Test
@@ -70,7 +82,7 @@ class LinkActivityViewModelTest {
 
         createViewModel()
 
-        verify(navigator).navigateTo(LinkScreen.Verification)
+        verify(navigator).navigateTo(LinkScreen.Verification, true)
     }
 
     @Test
@@ -80,7 +92,11 @@ class LinkActivityViewModelTest {
 
         createViewModel()
 
-        verify(navigator).navigateTo(LinkScreen.SignUp)
+        verify(navigator).navigateTo(
+            argWhere {
+                it.route == LinkScreen.SignUp(CUSTOMER_EMAIL).route
+            }, eq(true)
+        )
     }
 
     @Test
@@ -102,7 +118,7 @@ class LinkActivityViewModelTest {
         val factorySpy = spy(factory)
         val createdViewModel = factorySpy.create(LinkActivityViewModel::class.java)
         verify(factorySpy, times(0)).fallbackInitialize(any())
-        Truth.assertThat(createdViewModel).isEqualTo(vmToBeReturned)
+        assertThat(createdViewModel).isEqualTo(vmToBeReturned)
 
         WeakMapInjectorRegistry.staticCacheMap.clear()
     }
@@ -135,6 +151,7 @@ class LinkActivityViewModelTest {
     private fun createViewModel() = LinkActivityViewModel(
         defaultArgs,
         linkAccountManager,
+        cookieStore,
         navigator
     )
 

--- a/link/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -95,7 +95,8 @@ class LinkActivityViewModelTest {
         verify(navigator).navigateTo(
             argWhere {
                 it.route == LinkScreen.SignUp(CUSTOMER_EMAIL).route
-            }, eq(true)
+            },
+            eq(true)
         )
     }
 

--- a/link/src/test/java/com/stripe/android/link/ui/signup/SignUpViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/signup/SignUpViewModelTest.kt
@@ -1,5 +1,8 @@
 package com.stripe.android.link.ui.signup
 
+import androidx.lifecycle.Lifecycle
+import androidx.savedstate.SavedStateRegistry
+import androidx.savedstate.SavedStateRegistryOwner
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.Injectable
@@ -8,6 +11,7 @@ import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.LinkScreen
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.injection.NonFallbackInjector
+import com.stripe.android.link.injection.SignUpViewModelSubcomponent
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.model.Navigator
 import com.stripe.android.link.ui.signup.SignUpViewModel.Companion.LOOKUP_DEBOUNCE_MS
@@ -24,6 +28,7 @@ import kotlinx.coroutines.test.setMain
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.mock
@@ -33,6 +38,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
+import javax.inject.Provider
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 
@@ -41,7 +47,7 @@ import kotlin.test.BeforeTest
 class SignUpViewModelTest {
     private val defaultArgs = LinkActivityContract.Args(
         MERCHANT_NAME,
-        CUSTOMER_EMAIL,
+        LinkScreen.SignUp.route,
         LinkActivityContract.Args.InjectionParams(
             INJECTOR_KEY,
             setOf(PRODUCT_USAGE),
@@ -66,7 +72,7 @@ class SignUpViewModelTest {
     @Test
     fun `When email is valid then lookup is triggered with delay`() =
         runTest(UnconfinedTestDispatcher()) {
-            val viewModel = createViewModel(defaultArgs.copy(customerEmail = null))
+            val viewModel = createViewModel(prefilledEmail = null)
             assertThat(viewModel.signUpState.value).isEqualTo(SignUpState.InputtingEmail)
 
             viewModel.emailElement.setRawValue(mapOf(IdentifierSpec.Email to "valid@email.com"))
@@ -89,7 +95,7 @@ class SignUpViewModelTest {
     @Test
     fun `When multiple valid emails entered quickly then lookup is triggered only for last one`() =
         runTest(UnconfinedTestDispatcher()) {
-            val viewModel = createViewModel(defaultArgs.copy(customerEmail = null))
+            val viewModel = createViewModel(prefilledEmail = null)
             viewModel.emailElement.setRawValue(mapOf(IdentifierSpec.Email to "first@email.com"))
             advanceTimeBy(LOOKUP_DEBOUNCE_MS / 2)
 
@@ -122,7 +128,7 @@ class SignUpViewModelTest {
     @Test
     fun `When email is provided it should not trigger lookup and should collect phone number`() =
         runTest(UnconfinedTestDispatcher()) {
-            val viewModel = createViewModel(defaultArgs)
+            val viewModel = createViewModel()
             assertThat(viewModel.signUpState.value).isEqualTo(SignUpState.InputtingPhone)
 
             verify(linkAccountManager, times(0)).lookupConsumer(any())
@@ -131,7 +137,7 @@ class SignUpViewModelTest {
     @Test
     fun `When signed up with unverified account then it navigates to Verification screen`() =
         runTest(UnconfinedTestDispatcher()) {
-            val viewModel = createViewModel(defaultArgs)
+            val viewModel = createViewModel()
 
             val linkAccount = LinkAccount(
                 mockConsumerSessionWithVerificationSession(
@@ -146,12 +152,13 @@ class SignUpViewModelTest {
             viewModel.onSignUpClick("phone")
 
             verify(navigator).navigateTo(LinkScreen.Verification)
+            assertThat(viewModel.signUpState.value).isEqualTo(SignUpState.InputtingEmail)
         }
 
     @Test
     fun `When signed up with verified account then it navigates to Wallet screen`() =
         runTest(UnconfinedTestDispatcher()) {
-            val viewModel = createViewModel(defaultArgs)
+            val viewModel = createViewModel()
 
             val linkAccount = LinkAccount(
                 mockConsumerSessionWithVerificationSession(
@@ -165,22 +172,37 @@ class SignUpViewModelTest {
 
             viewModel.onSignUpClick("phone")
 
-            verify(navigator).navigateTo(LinkScreen.Wallet)
+            verify(navigator).navigateTo(LinkScreen.Wallet, true)
         }
 
     @Test
     fun `Factory gets initialized by Injector when Injector is available`() {
+        val mockBuilder = mock<SignUpViewModelSubcomponent.Builder>()
+        val mockSubComponent = mock<SignUpViewModelSubcomponent>()
         val vmToBeReturned = mock<SignUpViewModel>()
+
+        whenever(mockBuilder.prefilledEmail(anyOrNull())).thenReturn(mockBuilder)
+        whenever(mockBuilder.build()).thenReturn(mockSubComponent)
+        whenever((mockSubComponent.signUpViewModel)).thenReturn(vmToBeReturned)
+
+        val mockSavedStateRegistryOwner = mock<SavedStateRegistryOwner>()
+        val mockSavedStateRegistry = mock<SavedStateRegistry>()
+        val mockLifeCycle = mock<Lifecycle>()
+
+        whenever(mockSavedStateRegistryOwner.savedStateRegistry).thenReturn(mockSavedStateRegistry)
+        whenever(mockSavedStateRegistryOwner.lifecycle).thenReturn(mockLifeCycle)
+        whenever(mockLifeCycle.currentState).thenReturn(Lifecycle.State.CREATED)
 
         val injector = object : NonFallbackInjector {
             override fun inject(injectable: Injectable<*>) {
                 val factory = injectable as SignUpViewModel.Factory
-                factory.viewModel = vmToBeReturned
+                factory.subComponentBuilderProvider = Provider { mockBuilder }
             }
         }
         WeakMapInjectorRegistry.register(injector, INJECTOR_KEY)
         val factory = SignUpViewModel.Factory(
-            injector
+            injector,
+            null
         )
         val factorySpy = spy(factory)
         val createdViewModel = factorySpy.create(SignUpViewModel::class.java)
@@ -189,8 +211,12 @@ class SignUpViewModelTest {
         WeakMapInjectorRegistry.staticCacheMap.clear()
     }
 
-    private fun createViewModel(args: LinkActivityContract.Args = defaultArgs) = SignUpViewModel(
+    private fun createViewModel(
+        prefilledEmail: String? = CUSTOMER_EMAIL,
+        args: LinkActivityContract.Args = defaultArgs
+    ) = SignUpViewModel(
         args = args,
+        prefilledEmail = prefilledEmail,
         linkAccountManager = linkAccountManager,
         logger = Logger.noop(),
         navigator = navigator

--- a/link/src/test/java/com/stripe/android/link/ui/signup/SignUpViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/signup/SignUpViewModelTest.kt
@@ -47,7 +47,7 @@ import kotlin.test.BeforeTest
 class SignUpViewModelTest {
     private val defaultArgs = LinkActivityContract.Args(
         MERCHANT_NAME,
-        LinkScreen.SignUp.route,
+        CUSTOMER_EMAIL,
         LinkActivityContract.Args.InjectionParams(
             INJECTOR_KEY,
             setOf(PRODUCT_USAGE),

--- a/link/src/test/java/com/stripe/android/link/ui/verification/VerificationViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/verification/VerificationViewModelTest.kt
@@ -60,7 +60,6 @@ class VerificationViewModelTest {
     fun `onChangeEmailClicked triggers logout`() = runTest {
         createViewModel().onChangeEmailClicked()
         verify(linkAccountManager).logout()
-
     }
 
     @Test

--- a/link/src/test/java/com/stripe/android/link/ui/verification/VerificationViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/verification/VerificationViewModelTest.kt
@@ -46,14 +46,27 @@ class VerificationViewModelTest {
     }
 
     @Test
-    fun `onVerificationCodeEntered succeeds then it navigates to Wallet`() = runTest {
+    fun `When onVerificationCodeEntered succeeds then it navigates to Wallet`() = runTest {
         whenever(linkAccountManager.confirmVerification(any()))
             .thenReturn(Result.success(mock()))
 
         val viewModel = createViewModel()
         viewModel.onVerificationCodeEntered("code")
 
-        verify(navigator).navigateTo(LinkScreen.Wallet)
+        verify(navigator).navigateTo(LinkScreen.Wallet, true)
+    }
+
+    @Test
+    fun `onChangeEmailClicked triggers logout`() = runTest {
+        createViewModel().onChangeEmailClicked()
+        verify(linkAccountManager).logout()
+
+    }
+
+    @Test
+    fun `onBack triggers logout`() = runTest {
+        createViewModel().onBack()
+        verify(linkAccountManager).logout()
     }
 
     @Test

--- a/link/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -23,7 +23,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
@@ -70,7 +69,7 @@ class WalletViewModelTest {
 
         createViewModel()
 
-        verify(navigator).navigateTo(eq(LinkScreen.PaymentMethod))
+        verify(navigator).navigateTo(LinkScreen.PaymentMethod, false)
     }
 
     @Test
@@ -88,7 +87,7 @@ class WalletViewModelTest {
 
         viewModel.addNewPaymentMethod()
 
-        verify(navigator).navigateTo(eq(LinkScreen.PaymentMethod))
+        verify(navigator).navigateTo(LinkScreen.PaymentMethod, false)
     }
 
     @Test

--- a/link/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.core.injection.DUMMY_INJECTOR_KEY
 import com.stripe.android.core.injection.Injectable
 import com.stripe.android.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.link.LinkScreen
+import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.injection.NonFallbackInjector
 import com.stripe.android.link.injection.SignedInViewModelSubcomponent
 import com.stripe.android.link.model.LinkAccount
@@ -34,6 +35,7 @@ import javax.inject.Provider
 @RunWith(RobolectricTestRunner::class)
 class WalletViewModelTest {
     private lateinit var linkRepository: LinkRepository
+    private val linkAccountManager = mock<LinkAccountManager>()
     private val navigator = mock<Navigator>()
     private val logger = Logger.noop()
     private val linkAccount = mock<LinkAccount>()
@@ -68,7 +70,7 @@ class WalletViewModelTest {
 
         createViewModel()
 
-        verify(navigator).navigateTo(eq(LinkScreen.AddPaymentMethod))
+        verify(navigator).navigateTo(eq(LinkScreen.PaymentMethod))
     }
 
     @Test
@@ -86,7 +88,7 @@ class WalletViewModelTest {
 
         viewModel.addNewPaymentMethod()
 
-        verify(navigator).navigateTo(eq(LinkScreen.AddPaymentMethod))
+        verify(navigator).navigateTo(eq(LinkScreen.PaymentMethod))
     }
 
     @Test
@@ -125,5 +127,6 @@ class WalletViewModelTest {
         WeakMapInjectorRegistry.staticCacheMap.clear()
     }
 
-    private fun createViewModel() = WalletViewModel(linkRepository, navigator, logger, linkAccount)
+    private fun createViewModel() =
+        WalletViewModel(linkRepository, linkAccountManager, navigator, logger, linkAccount)
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
- Implement user logout, with last logged out email persisted in cookies storage so that the user is not prompted for verification again.
- Explicitly pass the email as an argument in `SignUpScreen` route, allowing it to display a different email than the one received in the arguments

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Link login/logout logic

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
