### PR TITLE
[Identity] Add Intersection Over Union(IoU) algorithm to determine blurry image

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/states/IOUTransitioner.kt
+++ b/identity/src/main/java/com/stripe/android/identity/states/IOUTransitioner.kt
@@ -1,0 +1,103 @@
+package com.stripe.android.identity.states
+
+import com.stripe.android.identity.ml.AnalyzerOutput
+import com.stripe.android.identity.ml.BoundingBox
+import com.stripe.android.identity.states.IdentityScanState.Satisfied
+import com.stripe.android.identity.states.IdentityScanState.Unsatisfied
+import kotlin.math.max
+import kotlin.math.min
+
+/**
+ * Decide transition based on the Intersection Over Union(IoU) score of bounding boxes.
+ *
+ * If over [hitsRequired] consecutive hits with IoU over [iouThreshold], then transitions to [Satisfied].
+ * Otherwise transition to [Unsatisfied].
+ */
+internal class IOUTransitioner(
+    private val hitsRequired: Int = DEFAULT_HITS_REQUIRED,
+    private val iouThreshold: Float = DEFAULT_IOU_THRESHOLD
+) : IdentityFoundStateTransitioner {
+    private var previousBoundingBox: BoundingBox? = null
+    private var consecutiveHitCount = 0
+
+    override fun transition(
+        foundState: IdentityScanState.Found,
+        analyzerOutput: AnalyzerOutput
+    ): IdentityScanState {
+        return when {
+            !analyzerOutput.category.matchesScanType(foundState.type) -> Unsatisfied(
+                "Type ${analyzerOutput.category} doesn't match ${foundState.type}",
+                foundState.type
+            )
+            !iOUCheckPass(analyzerOutput.boundingBox) -> Unsatisfied(
+                "IoU below threshold",
+                foundState.type
+            )
+            moreResultsRequired() -> foundState
+            else -> {
+                Satisfied(foundState.type)
+            }
+        }
+    }
+
+    /**
+     * Calculate the IoU between new box and old box.
+     *
+     * returns true if previous box is null or the result is above the threshold,
+     * returns false otherwise.
+     */
+    private fun iOUCheckPass(newBoundingBox: BoundingBox): Boolean {
+        return previousBoundingBox?.let { previousBox ->
+            val iou = intersectionOverUnion(newBoundingBox, previousBox)
+            previousBoundingBox = newBoundingBox
+            iou >= iouThreshold
+        } ?: run {
+            previousBoundingBox = newBoundingBox
+            true
+        }
+    }
+
+    private fun moreResultsRequired(): Boolean {
+        return (consecutiveHitCount++) < hitsRequired
+    }
+
+
+    /**
+     * Calculate IoU of two boxes, see https://stackoverflow.com/a/41660682/802372
+     */
+    private fun intersectionOverUnion(boxA: BoundingBox, boxB: BoundingBox): Float {
+        val aLeft = boxA.left
+        val aRight = boxA.left + boxA.width
+        val aTop = boxA.top
+        val aBottom = boxA.top + boxA.height
+
+        val bLeft = boxB.left
+        val bRight = boxB.left + boxB.width
+        val bTop = boxB.top
+        val bBottom = boxB.top + boxB.height
+
+        // determine the (x, y)-coordinates of the intersection rectangle
+        val xA = max(aLeft, bLeft)
+        val yA = max(aTop, bTop)
+        val xB = min(aRight, bRight)
+        val yB = min(aBottom, bBottom)
+
+        // compute the area of intersection rectangle
+        val interArea = (xB - xA) * (yB - yA)
+
+        // compute the area of both the prediction and ground-truth
+        // rectangles
+        val boxAArea = (aRight - aLeft) * (aBottom - aTop)
+        val boxBArea = (bRight - bLeft) * (bBottom - bTop)
+
+        // compute the intersection over union by taking the intersection
+        // area and dividing it by the sum of prediction + ground-truth
+        // areas - the intersection area
+        return interArea / (boxAArea + boxBArea - interArea)
+    }
+
+    private companion object {
+        const val DEFAULT_HITS_REQUIRED = 5
+        const val DEFAULT_IOU_THRESHOLD = 0.95f
+    }
+}

--- a/identity/src/main/java/com/stripe/android/identity/states/IOUTransitioner.kt
+++ b/identity/src/main/java/com/stripe/android/identity/states/IOUTransitioner.kt
@@ -61,7 +61,6 @@ internal class IOUTransitioner(
         return (consecutiveHitCount++) < hitsRequired
     }
 
-
     /**
      * Calculate IoU of two boxes, see https://stackoverflow.com/a/41660682/802372
      */

--- a/identity/src/main/java/com/stripe/android/identity/states/IdentityFoundStateTransitioner.kt
+++ b/identity/src/main/java/com/stripe/android/identity/states/IdentityFoundStateTransitioner.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.identity.states
+
+import com.stripe.android.identity.ml.AnalyzerOutput
+import com.stripe.android.identity.states.IdentityScanState.Found
+
+/**
+ * Interface to determine how to transition from [IdentityScanState.Found] to next state.
+ */
+internal interface IdentityFoundStateTransitioner {
+    fun transition(foundState: Found, analyzerOutput: AnalyzerOutput): IdentityScanState
+}

--- a/identity/src/main/java/com/stripe/android/identity/states/IdentityScanState.kt
+++ b/identity/src/main/java/com/stripe/android/identity/states/IdentityScanState.kt
@@ -35,7 +35,11 @@ internal sealed class IdentityScanState(val type: ScanType, isFinal: Boolean) : 
     /**
      * Initial state when scan starts, no documents have been detected yet.
      */
-    internal class Initial(type: ScanType) : IdentityScanState(type, false) {
+    internal class Initial(
+        type: ScanType,
+        private val transitioner: IdentityFoundStateTransitioner = IOUTransitioner()
+    ) :
+        IdentityScanState(type, false) {
         /**
          * Only transitions to [Found] when ML output type matches scan type
          */
@@ -46,7 +50,7 @@ internal sealed class IdentityScanState(val type: ScanType, isFinal: Boolean) : 
                     "Matching model output detected with score ${analyzerOutput.resultScore}, " +
                         "transition to Found."
                 )
-                Found(type)
+                Found(type, transitioner)
             } else {
                 Log.d(
                     TAG,
@@ -61,80 +65,13 @@ internal sealed class IdentityScanState(val type: ScanType, isFinal: Boolean) : 
      * State when scan has found the required type, the machine could stay in this state for a
      * while if more image needs to be processed to reach the next state.
      */
-    internal class Found(type: ScanType) : IdentityScanState(type, false) {
+    internal class Found(
+        type: ScanType,
         @VisibleForTesting
-        internal var hitsCount = 0
-
-        // saves the results of previous certain number of frames
-        @VisibleForTesting
-        internal val results = ArrayDeque<Boolean>()
-
+        internal val transitioner: IdentityFoundStateTransitioner
+    ) : IdentityScanState(type, false) {
         override fun consumeTransition(analyzerOutput: AnalyzerOutput): IdentityScanState {
-            val isHit = analyzerOutput.category.matchesScanType(type)
-            if (isHit) {
-                hitsCount++
-            }
-            results.addLast(isHit)
-            // only save the last certain number of frames, dropping the first one if it goes beyond
-            // If the first result is a hit, then decrease the hitsCount
-            if (results.size > FRAMES_REQUIRED) {
-                val firstResultIsHit = results.removeFirst()
-                if (firstResultIsHit) {
-                    hitsCount--
-                }
-            }
-
-            return when {
-                isUnsatisfied() -> {
-                    val reason =
-                        "hits count below expected: $hitsCount"
-                    Log.d(
-                        TAG,
-                        "Satisfaction check fails due to $reason, transition to Unsatisfied."
-                    )
-                    Unsatisfied(reason, type)
-                }
-                moreResultsRequired() -> {
-                    Log.d(
-                        TAG,
-                        "More results needed, stay in Found, currently ${results.size} results are collected"
-                    )
-                    this
-                }
-                else -> {
-                    Log.d(TAG, "Satisfaction check succeeds, transition to Satisfied.")
-                    Satisfied(type)
-                }
-            }
-        }
-
-        /**
-         * Determine if more images should be processed before reaching [Satisfied].
-         *
-         * Need to collect [FRAMES_REQUIRED] results.
-         */
-        private fun moreResultsRequired(): Boolean {
-            return results.size < FRAMES_REQUIRED
-        }
-
-        /**
-         * Determine if satisfaction failed and should transition to [Unsatisfied].
-         *
-         * Transfers to when the previous [FRAMES_REQUIRED] number of frames has hits below
-         * [HITS_REQUIRED].
-         */
-        private fun isUnsatisfied(): Boolean {
-            return (results.size == FRAMES_REQUIRED) && (hitsCount < HITS_REQUIRED)
-        }
-
-        @VisibleForTesting
-        internal companion object {
-            // The number of frames needs to collected to determine if a model has found the
-            // correct item.
-            const val FRAMES_REQUIRED = 100
-
-            // The number of hits to determine if the model has found the correct item.
-            const val HITS_REQUIRED = 50
+            return transitioner.transition(this, analyzerOutput)
         }
     }
 
@@ -165,7 +102,6 @@ internal sealed class IdentityScanState(val type: ScanType, isFinal: Boolean) : 
      * State when satisfaction checking failed.
      */
     internal class Unsatisfied(
-        @VisibleForTesting
         internal val reason: String,
         type: ScanType,
         private val reachedStateAt: ClockMark = Clock.markNow()
@@ -202,7 +138,7 @@ internal sealed class IdentityScanState(val type: ScanType, isFinal: Boolean) : 
  * Checks if [Category] matches [IdentityScanState].
  * Note: the ML model will output ID_FRONT or ID_BACK for both ID and Driver License.
  */
-private fun Category.matchesScanType(scanType: IdentityScanState.ScanType): Boolean {
+internal fun Category.matchesScanType(scanType: IdentityScanState.ScanType): Boolean {
     return this == Category.ID_BACK && scanType == IdentityScanState.ScanType.ID_BACK ||
         this == Category.ID_FRONT && scanType == IdentityScanState.ScanType.ID_FRONT ||
         this == Category.ID_BACK && scanType == IdentityScanState.ScanType.DL_BACK ||

--- a/identity/src/main/java/com/stripe/android/identity/states/LookBackWindowTransitioner.kt
+++ b/identity/src/main/java/com/stripe/android/identity/states/LookBackWindowTransitioner.kt
@@ -1,0 +1,104 @@
+package com.stripe.android.identity.states
+
+import android.util.Log
+import androidx.annotation.VisibleForTesting
+import com.stripe.android.identity.ml.AnalyzerOutput
+import com.stripe.android.identity.states.IdentityScanState.Found
+import com.stripe.android.identity.states.IdentityScanState.Satisfied
+import com.stripe.android.identity.states.IdentityScanState.Unsatisfied
+
+/**
+ * Keep a look back window of [frameRequired] number of frames, decide transition when the window is full.
+ *
+ * Stay in [Found] state before required number of frames is processed.
+ * When required number of frames is processed,
+ *   If equal or more than [hitsRequired] number of frames matches required type, transition to [Satisfied].
+ *   If less than [hitsRequired] number of frames matches required type, transition to [Unsatisfied].
+ */
+internal class LookBackWindowTransitioner(
+    private val frameRequired: Int = DEFAULT_FRAMES_REQUIRED,
+    private val hitsRequired: Int = DEFAULT_HITS_REQUIRED
+) : IdentityFoundStateTransitioner {
+    @VisibleForTesting
+    internal var hitsCount = 0
+
+    // saves the results of previous certain number of frames
+    @VisibleForTesting
+    internal val results = ArrayDeque<Boolean>()
+
+
+    override fun transition(
+        foundState: Found,
+        analyzerOutput: AnalyzerOutput
+    ): IdentityScanState {
+        val isHit = analyzerOutput.category.matchesScanType(foundState.type)
+        if (isHit) {
+            hitsCount++
+        }
+        results.addLast(isHit)
+        // only save the last certain number of frames, dropping the first one if it goes beyond
+        // If the first result is a hit, then decrease the hitsCount
+        if (results.size > frameRequired) {
+            val firstResultIsHit = results.removeFirst()
+            if (firstResultIsHit) {
+                hitsCount--
+            }
+        }
+
+        return when {
+            isUnsatisfied() -> {
+                val reason =
+                    "hits count below expected: $hitsCount"
+                Log.d(
+                    TAG,
+                    "Satisfaction check fails due to $reason, transition to Unsatisfied."
+                )
+                Unsatisfied(reason, foundState.type)
+            }
+            moreResultsRequired() -> {
+                Log.d(
+                    TAG,
+                    "More results needed, stay in Found, currently ${results.size} results are collected"
+                )
+                foundState
+            }
+            else -> {
+                Log.d(
+                    TAG,
+                    "Satisfaction check succeeds, transition to Satisfied."
+                )
+                Satisfied(foundState.type)
+            }
+        }
+    }
+
+    /**
+     * Determine if more images should be processed before reaching [Satisfied].
+     *
+     * Need to collect [frameRequired] results.
+     */
+    private fun moreResultsRequired(): Boolean {
+        return results.size < frameRequired
+    }
+
+    /**
+     * Determine if satisfaction failed and should transition to [Unsatisfied].
+     *
+     * Transfers to when the previous [frameRequired] number of frames has hits below
+     * [hitsRequired].
+     */
+    private fun isUnsatisfied(): Boolean {
+        return (results.size == frameRequired) && (hitsCount < hitsRequired)
+    }
+
+    internal companion object {
+        val TAG: String = LookBackWindowTransitioner::class.java.simpleName
+
+        // The number of frames needs to collected to determine if a model has found the
+        // correct item.
+        const val DEFAULT_FRAMES_REQUIRED = 100
+
+        // The number of hits to determine if the model has found the correct item.
+        const val DEFAULT_HITS_REQUIRED = 50
+    }
+}

--- a/identity/src/main/java/com/stripe/android/identity/states/LookBackWindowTransitioner.kt
+++ b/identity/src/main/java/com/stripe/android/identity/states/LookBackWindowTransitioner.kt
@@ -26,7 +26,6 @@ internal class LookBackWindowTransitioner(
     @VisibleForTesting
     internal val results = ArrayDeque<Boolean>()
 
-
     override fun transition(
         foundState: Found,
         analyzerOutput: AnalyzerOutput

--- a/identity/src/test/java/com/stripe/android/identity/states/IOUTransitionerTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/states/IOUTransitionerTest.kt
@@ -1,0 +1,174 @@
+package com.stripe.android.identity.states
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.identity.ml.AnalyzerOutput
+import com.stripe.android.identity.ml.BoundingBox
+import com.stripe.android.identity.ml.Category
+import com.stripe.android.identity.states.IdentityScanState.ScanType
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class IOUTransitionerTest {
+    @Test
+    fun `transitions to Unsatisfied when no match`() {
+        val transitioner = IOUTransitioner()
+
+        val resultState = transitioner.transition(mock<IdentityScanState.Found>().also {
+            whenever(it.type).thenReturn(ScanType.ID_BACK)
+        }, INITIAL_ID_FRONT_OUTPUT)
+
+
+        assertThat(resultState).isInstanceOf(IdentityScanState.Unsatisfied::class.java)
+        assertThat((resultState as IdentityScanState.Unsatisfied).reason).isEqualTo(
+            "Type ${INITIAL_ID_FRONT_OUTPUT.category} doesn't match ${ScanType.ID_BACK}",
+        )
+        assertThat(resultState.type).isEqualTo(ScanType.ID_BACK)
+    }
+
+    @Test
+    fun `transitions to Found with first matching result`() {
+        val transitioner = IOUTransitioner()
+
+        val mockFoundState = mock<IdentityScanState.Found>().also {
+            whenever(it.type).thenReturn(ScanType.ID_FRONT)
+        }
+
+        val resultState = transitioner.transition(mockFoundState, INITIAL_ID_FRONT_OUTPUT)
+
+        assertThat(resultState).isSameInstanceAs(mockFoundState)
+    }
+
+    @Test
+    fun `transitions to Unsatisfied when iOUCheckPass failed`() {
+        val transitioner = IOUTransitioner()
+
+        val mockFoundState = mock<IdentityScanState.Found>().also {
+            whenever(it.type).thenReturn(ScanType.ID_FRONT)
+        }
+
+        // initialize previousBoundingBox
+        transitioner.transition(mockFoundState, INITIAL_ID_FRONT_OUTPUT)
+        // send a low IOU result
+        val resultState =
+            transitioner.transition(
+                mockFoundState,
+                createAnalyzerOutputWithLowIOU(INITIAL_ID_FRONT_OUTPUT)
+            )
+
+        assertThat(resultState).isInstanceOf(IdentityScanState.Unsatisfied::class.java)
+        assertThat((resultState as IdentityScanState.Unsatisfied).reason).isEqualTo(
+            "IoU below threshold",
+        )
+        assertThat(resultState.type).isEqualTo(ScanType.ID_FRONT)
+    }
+
+    @Test
+    fun `transitions to Found when moreResultsRequired and Satisfied when hitsRequired is met`() {
+        val hitsRequired = 10
+        val transitioner = IOUTransitioner(hitsRequired = 10)
+
+        val mockFoundState = mock<IdentityScanState.Found>().also {
+            whenever(it.type).thenReturn(ScanType.ID_FRONT)
+        }
+
+        var result = createAnalyzerOutputWithHighIOU(INITIAL_ID_FRONT_OUTPUT)
+        for (i in 1..hitsRequired) {
+            // send a high IOU result
+            assertThat(
+                transitioner.transition(
+                    mockFoundState,
+                    result
+                )
+            ).isSameInstanceAs(mockFoundState)
+            result = createAnalyzerOutputWithHighIOU(result)
+        }
+
+        // send another high IOU result, transition to satisfied
+        val resultState = transitioner.transition(
+            mockFoundState,
+            createAnalyzerOutputWithHighIOU(result)
+        )
+
+
+        assertThat(resultState).isInstanceOf(IdentityScanState.Satisfied::class.java)
+        assertThat((resultState as IdentityScanState.Satisfied).type).isEqualTo(
+            ScanType.ID_FRONT
+        )
+    }
+
+
+    @Test
+    fun `transitions to Found when moreResultsRequired and Unsatisfied when IOU check fails before hitsRequired is met`() {
+        val hitsRequired = 10
+        val transitioner = IOUTransitioner(hitsRequired = 10)
+
+        val mockFoundState = mock<IdentityScanState.Found>().also {
+            whenever(it.type).thenReturn(ScanType.ID_FRONT)
+        }
+
+        var result = createAnalyzerOutputWithHighIOU(INITIAL_ID_FRONT_OUTPUT)
+        for (i in 1..(hitsRequired - 5)) {
+            // send a high IOU result
+            assertThat(
+                transitioner.transition(
+                    mockFoundState,
+                    result
+                )
+            ).isSameInstanceAs(mockFoundState)
+            result = createAnalyzerOutputWithHighIOU(result)
+        }
+
+        // send a low IOU result, break the hit streak, transitions to Unsatisfied
+        val resultState = transitioner.transition(
+            mockFoundState,
+            createAnalyzerOutputWithLowIOU(result)
+        )
+
+
+        assertThat(resultState).isInstanceOf(IdentityScanState.Unsatisfied::class.java)
+        assertThat((resultState as IdentityScanState.Unsatisfied).reason).isEqualTo(
+            "IoU below threshold",
+        )
+        assertThat(resultState.type).isEqualTo(ScanType.ID_FRONT)
+    }
+
+    private fun createAnalyzerOutputWithHighIOU(previousAnalyzerOutput: AnalyzerOutput) =
+        AnalyzerOutput(
+            boundingBox = BoundingBox(
+                previousAnalyzerOutput.boundingBox.left + 1,
+                previousAnalyzerOutput.boundingBox.top + 1,
+                previousAnalyzerOutput.boundingBox.width + 1,
+                previousAnalyzerOutput.boundingBox.height + 1,
+            ),
+            previousAnalyzerOutput.category,
+            previousAnalyzerOutput.resultScore,
+            previousAnalyzerOutput.allScores
+        )
+
+    private fun createAnalyzerOutputWithLowIOU(previousAnalyzerOutput: AnalyzerOutput) =
+        AnalyzerOutput(
+            boundingBox = BoundingBox(
+                previousAnalyzerOutput.boundingBox.left + 500f,
+                previousAnalyzerOutput.boundingBox.top + 500f,
+                previousAnalyzerOutput.boundingBox.width + 500f,
+                previousAnalyzerOutput.boundingBox.height + 500f,
+            ),
+            previousAnalyzerOutput.category,
+            previousAnalyzerOutput.resultScore,
+            previousAnalyzerOutput.allScores
+        )
+
+    private companion object {
+        val INITIAL_BOUNDING_BOX = BoundingBox(0f, 0f, 500f, 500f)
+        val INITIAL_ID_FRONT_OUTPUT = AnalyzerOutput(
+            INITIAL_BOUNDING_BOX,
+            Category.ID_FRONT,
+            0f,
+            listOf()
+        )
+    }
+}

--- a/identity/src/test/java/com/stripe/android/identity/states/IOUTransitionerTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/states/IOUTransitionerTest.kt
@@ -17,10 +17,12 @@ internal class IOUTransitionerTest {
     fun `transitions to Unsatisfied when no match`() {
         val transitioner = IOUTransitioner()
 
-        val resultState = transitioner.transition(mock<IdentityScanState.Found>().also {
-            whenever(it.type).thenReturn(ScanType.ID_BACK)
-        }, INITIAL_ID_FRONT_OUTPUT)
-
+        val resultState = transitioner.transition(
+            mock<IdentityScanState.Found>().also {
+                whenever(it.type).thenReturn(ScanType.ID_BACK)
+            },
+            INITIAL_ID_FRONT_OUTPUT
+        )
 
         assertThat(resultState).isInstanceOf(IdentityScanState.Unsatisfied::class.java)
         assertThat((resultState as IdentityScanState.Unsatisfied).reason).isEqualTo(
@@ -93,13 +95,11 @@ internal class IOUTransitionerTest {
             createAnalyzerOutputWithHighIOU(result)
         )
 
-
         assertThat(resultState).isInstanceOf(IdentityScanState.Satisfied::class.java)
         assertThat((resultState as IdentityScanState.Satisfied).type).isEqualTo(
             ScanType.ID_FRONT
         )
     }
-
 
     @Test
     fun `transitions to Found when moreResultsRequired and Unsatisfied when IOU check fails before hitsRequired is met`() {
@@ -127,7 +127,6 @@ internal class IOUTransitionerTest {
             mockFoundState,
             createAnalyzerOutputWithLowIOU(result)
         )
-
 
         assertThat(resultState).isInstanceOf(IdentityScanState.Unsatisfied::class.java)
         assertThat((resultState as IdentityScanState.Unsatisfied).reason).isEqualTo(

--- a/identity/src/test/java/com/stripe/android/identity/states/IdentityScanStateTests.kt
+++ b/identity/src/test/java/com/stripe/android/identity/states/IdentityScanStateTests.kt
@@ -6,13 +6,13 @@ import com.stripe.android.camera.framework.time.milliseconds
 import com.stripe.android.identity.ml.AnalyzerOutput
 import com.stripe.android.identity.ml.BoundingBox
 import com.stripe.android.identity.ml.Category
-import com.stripe.android.identity.states.IdentityScanState.Found.Companion.FRAMES_REQUIRED
-import com.stripe.android.identity.states.IdentityScanState.Found.Companion.HITS_REQUIRED
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertSame
 
 @RunWith(RobolectricTestRunner::class)
 class IdentityScanStateTests {
@@ -35,50 +35,14 @@ class IdentityScanStateTests {
 
     @Test
     fun `Found transitions to Unsatisfied with bad hit rate`() {
-        val badHitCount = HITS_REQUIRED - 10
-
-        val initialState = IdentityScanState.Found(IdentityScanState.ScanType.ID_FRONT).also {
-            // hits count below required
-            it.hitsCount = badHitCount
-            for (i in 1..FRAMES_REQUIRED) {
-                it.results.addLast(true)
-            }
+        val mockTargetState = mock<IdentityScanState>()
+        val mockTransitioner = mock<IdentityFoundStateTransitioner>().also {
+            whenever(it.transition(any(), any())).thenReturn(mockTargetState)
         }
-        val resultState = initialState.consumeTransition(ID_FRONT_OUTPUT)
 
-        assertThat(resultState).isInstanceOf(IdentityScanState.Unsatisfied::class.java)
-        assertThat((resultState as IdentityScanState.Unsatisfied).reason).isEqualTo(
-            "hits count below expected: $badHitCount"
-        )
-    }
-
-    @Test
-    fun `Found transitions to Satisfied with good hit rate`() {
-        val goodHitCount = HITS_REQUIRED + 10
-
-        val initialState = IdentityScanState.Found(IdentityScanState.ScanType.ID_FRONT).also {
-            // hits count below required
-            it.hitsCount = goodHitCount
-            for (i in 1..FRAMES_REQUIRED) {
-                it.results.addLast(true)
-            }
-        }
-        val resultState = initialState.consumeTransition(ID_FRONT_OUTPUT)
-
-        assertThat(resultState).isInstanceOf(IdentityScanState.Satisfied::class.java)
-    }
-
-    @Test
-    fun `Found transitions to Found when more results are required`() {
-        val initialState = IdentityScanState.Found(IdentityScanState.ScanType.ID_FRONT).also {
-            // hits count below required
-            for (i in 1..(FRAMES_REQUIRED - 10)) {
-                it.results.addLast(true)
-            }
-        }
-        val resultState = initialState.consumeTransition(ID_FRONT_OUTPUT)
-
-        assertThat(resultState).isSameInstanceAs(initialState)
+        val initialState =
+            IdentityScanState.Found(IdentityScanState.ScanType.ID_FRONT, mockTransitioner)
+        assertSame(initialState.consumeTransition(ID_FRONT_OUTPUT), mockTargetState)
     }
 
     @Test

--- a/identity/src/test/java/com/stripe/android/identity/states/LookBackWindowTransitionerTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/states/LookBackWindowTransitionerTest.kt
@@ -1,0 +1,77 @@
+package com.stripe.android.identity.states
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.identity.ml.AnalyzerOutput
+import com.stripe.android.identity.ml.BoundingBox
+import com.stripe.android.identity.ml.Category
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class LookBackWindowTransitionerTest {
+    @Test
+    fun `transitions to Unsatisfied with bad hit rate`() {
+        val transitioner = LookBackWindowTransitioner()
+
+        val badHitCount = LookBackWindowTransitioner.DEFAULT_HITS_REQUIRED - 10
+        transitioner.hitsCount = badHitCount
+        for (i in 1..LookBackWindowTransitioner.DEFAULT_FRAMES_REQUIRED) {
+            transitioner.results.addLast(true)
+        }
+
+        val resultState = transitioner.transition(mock<IdentityScanState.Found>().also {
+            whenever(it.type).thenReturn(IdentityScanState.ScanType.ID_FRONT)
+        }, ID_FRONT_OUTPUT)
+
+
+        assertThat(resultState).isInstanceOf(IdentityScanState.Unsatisfied::class.java)
+        assertThat((resultState as IdentityScanState.Unsatisfied).reason).isEqualTo(
+            "hits count below expected: $badHitCount"
+        )
+    }
+
+    @Test
+    fun `transitions to Satisfied with good hit rate`() {
+        val transitioner = LookBackWindowTransitioner()
+
+        val goodHitCount = LookBackWindowTransitioner.DEFAULT_HITS_REQUIRED + 10
+        transitioner.hitsCount = goodHitCount
+        for (i in 1..LookBackWindowTransitioner.DEFAULT_FRAMES_REQUIRED) {
+            transitioner.results.addLast(true)
+        }
+
+        val resultState = transitioner.transition(mock<IdentityScanState.Found>().also {
+            whenever(it.type).thenReturn(IdentityScanState.ScanType.ID_FRONT)
+        }, ID_FRONT_OUTPUT)
+
+        assertThat(resultState).isInstanceOf(IdentityScanState.Satisfied::class.java)
+    }
+
+    @Test
+    fun `transitions to Found when more results are required`() {
+        val initialState = IdentityScanState.Found(
+            IdentityScanState.ScanType.ID_FRONT,
+            LookBackWindowTransitioner()
+        ).also {
+            // hits count below required
+            for (i in 1..(LookBackWindowTransitioner.DEFAULT_FRAMES_REQUIRED - 10)) {
+                (it.transitioner as LookBackWindowTransitioner).results.addLast(true)
+            }
+        }
+        val resultState = initialState.consumeTransition(ID_FRONT_OUTPUT)
+
+        assertThat(resultState).isSameInstanceAs(initialState)
+    }
+
+    private companion object {
+        val ID_FRONT_OUTPUT = AnalyzerOutput(
+            BoundingBox(0f, 0f, 0f, 0f),
+            Category.ID_FRONT,
+            0f,
+            listOf()
+        )
+    }
+}

--- a/identity/src/test/java/com/stripe/android/identity/states/LookBackWindowTransitionerTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/states/LookBackWindowTransitionerTest.kt
@@ -22,10 +22,12 @@ internal class LookBackWindowTransitionerTest {
             transitioner.results.addLast(true)
         }
 
-        val resultState = transitioner.transition(mock<IdentityScanState.Found>().also {
-            whenever(it.type).thenReturn(IdentityScanState.ScanType.ID_FRONT)
-        }, ID_FRONT_OUTPUT)
-
+        val resultState = transitioner.transition(
+            mock<IdentityScanState.Found>().also {
+                whenever(it.type).thenReturn(IdentityScanState.ScanType.ID_FRONT)
+            },
+            ID_FRONT_OUTPUT
+        )
 
         assertThat(resultState).isInstanceOf(IdentityScanState.Unsatisfied::class.java)
         assertThat((resultState as IdentityScanState.Unsatisfied).reason).isEqualTo(
@@ -43,9 +45,12 @@ internal class LookBackWindowTransitionerTest {
             transitioner.results.addLast(true)
         }
 
-        val resultState = transitioner.transition(mock<IdentityScanState.Found>().also {
-            whenever(it.type).thenReturn(IdentityScanState.ScanType.ID_FRONT)
-        }, ID_FRONT_OUTPUT)
+        val resultState = transitioner.transition(
+            mock<IdentityScanState.Found>().also {
+                whenever(it.type).thenReturn(IdentityScanState.ScanType.ID_FRONT)
+            },
+            ID_FRONT_OUTPUT
+        )
 
         assertThat(resultState).isInstanceOf(IdentityScanState.Satisfied::class.java)
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Create an interface `IdentityFoundStateTransitioner` to determine the transition logic from `Found` to other state.
* Pack the previous logic into a `LookBackWindowTransitioner` - where we look at previous 100 frames and decide based on how many of the frames is a hit
* Create a new `IOUTransitioner` to look at the IOU score of consecutive bounding boxes between frames, if they are too far away from each other, then it's blurry and transition to `Unsatisfied`. If a consecutive number of frames have hight IOU scores, it means they are not blurry and transition to `Satisfied`
* Use `IOUTransitioner` as default transitioner


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
