### PR TITLE
[Identity] Disable the other button when one button is clicked

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
@@ -49,7 +49,7 @@ internal class ConsentFragment(
 
         binding.agree.setOnClickListener {
             binding.agree.toggleToLoading()
-            binding.decline.isClickable = false
+            binding.decline.isEnabled = false
             postVerificationPageDataAndNavigate(
                 CollectedDataParam(
                     consent = ConsentParam(biometric = true)
@@ -58,7 +58,7 @@ internal class ConsentFragment(
         }
         binding.decline.setOnClickListener {
             binding.decline.toggleToLoading()
-            binding.agree.isClickable = false
+            binding.agree.isEnabled = false
             postVerificationPageDataAndNavigate(
                 CollectedDataParam(
                     consent = ConsentParam(biometric = false)

--- a/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
@@ -8,6 +8,7 @@ import androidx.navigation.Navigation
 import androidx.navigation.testing.TestNavHostController
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.material.button.MaterialButton
+import com.google.android.material.progressindicator.CircularProgressIndicator
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.identity.IdentityVerificationSheetContract
@@ -188,6 +189,11 @@ internal class ConsentFragmentTest {
 
                 binding.agree.findViewById<MaterialButton>(R.id.button).callOnClick()
 
+                assertThat(binding.agree.findViewById<MaterialButton>(R.id.button).isEnabled).isFalse()
+                assertThat(binding.agree.findViewById<CircularProgressIndicator>(R.id.indicator).visibility).isEqualTo(
+                    View.VISIBLE
+                )
+                assertThat(binding.decline.isEnabled).isFalse()
                 assertThat(navController.currentDestination?.id)
                     .isEqualTo(R.id.docSelectionFragment)
             }
@@ -222,6 +228,11 @@ internal class ConsentFragmentTest {
                 setUpSuccessVerificationPage()
                 binding.decline.findViewById<MaterialButton>(R.id.button).callOnClick()
 
+                assertThat(binding.decline.findViewById<MaterialButton>(R.id.button).isEnabled).isFalse()
+                assertThat(binding.decline.findViewById<CircularProgressIndicator>(R.id.indicator).visibility).isEqualTo(
+                    View.VISIBLE
+                )
+                assertThat(binding.agree.isEnabled).isFalse()
                 requireNotNull(navController.backStack.last().arguments).let { arguments ->
                     assertThat(arguments[ErrorFragment.ARG_ERROR_TITLE])
                         .isEqualTo(ERROR_TITLE)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Not only blocking click, but also disable the button

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Identity SDK

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![disableButtonBefore](https://user-images.githubusercontent.com/79880926/159093470-50d4867f-a336-43de-8aff-a04eba25631e.gif) |  ![disableButtonAfter](https://user-images.githubusercontent.com/79880926/159093480-ce66eb57-3b36-4da8-988d-3ded818705d3.gif)|

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
