### PR TITLE
change default cursor color away from material primary

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/PaymentsTheme.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/PaymentsTheme.kt
@@ -36,6 +36,7 @@ data class PaymentsColors(
     val componentDivider: Color,
     val onPrimary: Color,
     val textSecondary: Color,
+    val textCursor: Color,
     val placeholderText: Color,
     val onBackground: Color,
     val appBarIcon: Color,
@@ -63,6 +64,7 @@ object PaymentsThemeConfig {
         componentDivider = Color(0x33787880),
         onPrimary = Color.Black,
         textSecondary = Color(0x99000000),
+        textCursor = Color.Black,
         placeholderText = Color(0x993C3C43),
         onBackground = Color.Black,
         appBarIcon = Color(0x99000000),
@@ -77,6 +79,7 @@ object PaymentsThemeConfig {
         componentDivider = Color(0xFF787880),
         onPrimary = Color.White,
         textSecondary = Color(0x99FFFFFF),
+        textCursor = Color.White,
         placeholderText = Color(0x61FFFFFF),
         onBackground = Color.White,
         appBarIcon = Color.White,
@@ -90,6 +93,7 @@ data class PaymentsComposeColors(
     val colorComponentBorder: Color,
     val colorComponentDivider: Color,
     val colorTextSecondary: Color,
+    val colorTextCursor: Color,
     val placeholderText: Color,
     val material: Colors
 )
@@ -111,6 +115,7 @@ fun PaymentsThemeConfig.toComposeColors(): PaymentsComposeColors {
         colorComponentBorder = colors.componentBorder,
         colorComponentDivider = colors.componentDivider,
         colorTextSecondary = colors.textSecondary,
+        colorTextCursor = colors.textCursor,
         placeholderText = colors.placeholderText,
 
         material = lightColors(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
@@ -60,7 +60,8 @@ internal fun TextField(
         backgroundColor = PaymentsTheme.colors.colorComponentBackground,
         focusedIndicatorColor = Color.Transparent,
         disabledIndicatorColor = Color.Transparent,
-        unfocusedIndicatorColor = Color.Transparent
+        unfocusedIndicatorColor = Color.Transparent,
+        cursorColor = PaymentsTheme.colors.colorTextCursor
     )
 
     TextField(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This changes the default cursor color away from MaterialTheme.colorPrimary to our own color. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
* JJ asked me to change to this color. 
* Dogfooding

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
|![oldCursorLight](https://user-images.githubusercontent.com/89166418/159367764-dd1ce2b7-ef82-4c0b-932e-28f86dade5e9.png)|![newCursorLight](https://user-images.githubusercontent.com/89166418/159367760-33d0c0ed-6d5b-42b4-9de8-f31aa56e8822.png)|
|![oldCursorDark](https://user-images.githubusercontent.com/89166418/159367762-9d39bebb-608d-409b-a9a6-39bdb2fe5163.png)|![newCursorDark](https://user-images.githubusercontent.com/89166418/159367758-bb7097ef-f9c1-46ff-8e00-ac5e376b6fa9.png)|