### PR TITLE
[Identity] Cache downloaded model file

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
@@ -7,6 +7,7 @@ import com.stripe.android.camera.AppSettingsOpenable
 import com.stripe.android.camera.CameraPermissionEnsureable
 import com.stripe.android.identity.IdentityVerificationSheetContract
 import com.stripe.android.identity.VerificationFlowFinishable
+import com.stripe.android.identity.networking.DefaultIDDetectorFetcher
 import com.stripe.android.identity.networking.DefaultIdentityRepository
 import com.stripe.android.identity.utils.DefaultIdentityIO
 import com.stripe.android.identity.utils.IdentityIO
@@ -29,7 +30,7 @@ internal class IdentityFragmentFactory(
 ) : FragmentFactory() {
     private val identityIO: IdentityIO = DefaultIdentityIO(context)
     private val identityRepository =
-        DefaultIdentityRepository(context = context, identityIO = identityIO)
+        DefaultIdentityRepository(identityIO = identityIO)
     private val identityScanViewModelFactory =
         IdentityScanViewModel.IdentityScanViewModelFactory(
             identityRepository,
@@ -51,7 +52,8 @@ internal class IdentityFragmentFactory(
 
     internal val identityViewModelFactory = IdentityViewModel.IdentityViewModelFactory(
         verificationArgs,
-        identityRepository
+        identityRepository,
+        DefaultIDDetectorFetcher(identityRepository, identityIO)
     )
 
     override fun instantiate(classLoader: ClassLoader, className: String): Fragment {

--- a/identity/src/main/java/com/stripe/android/identity/networking/DefaultIDDetectorFetcher.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/DefaultIDDetectorFetcher.kt
@@ -1,0 +1,21 @@
+package com.stripe.android.identity.networking
+
+import com.stripe.android.identity.utils.IdentityIO
+import java.io.File
+
+internal class DefaultIDDetectorFetcher(
+    private val identityRepository: IdentityRepository,
+    private val identityIO: IdentityIO
+) :
+    IDDetectorFetcher {
+    override suspend fun fetchIDDetector(modelUrl: String): File {
+        // Use the filename as a look up key
+        identityIO.createTFLiteFile(modelUrl).let { tfliteFile ->
+            return if (tfliteFile.exists()) {
+                tfliteFile
+            } else {
+                identityRepository.downloadModel(modelUrl)
+            }
+        }
+    }
+}

--- a/identity/src/main/java/com/stripe/android/identity/networking/DefaultIdentityRepository.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/DefaultIdentityRepository.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.identity.networking
 
-import android.content.Context
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.exception.APIException
@@ -29,7 +28,6 @@ import kotlinx.serialization.json.Json
 import java.io.File
 
 internal class DefaultIdentityRepository(
-    private val context: Context,
     private val stripeNetworkClient: StripeNetworkClient = DefaultStripeNetworkClient(),
     private val identityIO: IdentityIO
 ) : IdentityRepository {
@@ -101,7 +99,7 @@ internal class DefaultIdentityRepository(
     override suspend fun downloadModel(modelUrl: String) = runCatching {
         stripeNetworkClient.executeRequestForFile(
             IdentityModelDownloadRequest(modelUrl),
-            identityIO.createTFLiteFile()
+            identityIO.createTFLiteFile(modelUrl)
         )
     }.fold(
         onSuccess = { response ->

--- a/identity/src/main/java/com/stripe/android/identity/networking/IDDetectorFetcher.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/IDDetectorFetcher.kt
@@ -1,0 +1,12 @@
+package com.stripe.android.identity.networking
+
+import java.io.File
+
+/**
+ * A class to fetch the model file for IDDetector either from local cache or from web.
+ *
+ * TODO(ccen): Merge it with [Fetcher] from stripecardscan
+ */
+internal interface IDDetectorFetcher {
+    suspend fun fetchIDDetector(modelUrl: String): File
+}

--- a/identity/src/main/java/com/stripe/android/identity/utils/DefaultIdentityIO.kt
+++ b/identity/src/main/java/com/stripe/android/identity/utils/DefaultIdentityIO.kt
@@ -135,10 +135,10 @@ internal class DefaultIdentityIO(private val context: Context) : IdentityIO {
         )
     }
 
-    override fun createTFLiteFile(): File {
+    override fun createTFLiteFile(modelUrl: String): File {
         return File(
-            context.filesDir,
-            generateTFLiteFileName()
+            context.cacheDir,
+            generateTFLiteFileNameWithGitHash(modelUrl)
         )
     }
 
@@ -154,6 +154,10 @@ internal class DefaultIdentityIO(private val context: Context) : IdentityIO {
     private fun generateJpgFileName() =
         "JPEG_" + SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
 
-    private fun generateTFLiteFileName() =
-        "TFLITE_${(SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date()))}.tflite"
+    // Find the githash part of the model URL and general a tflite file name.
+    // Example of modelUrl: https://b.stripecdn.com/gelato/assets/50e98374a70b71b2ee7ec8c3060f187ee1d833bd/assets/id_detectors/tflite/2022-02-23/model.tflite
+    // TODO(ccen): Add name and versioning of the model, calculate MD5 and build a more descriptive caching machanism.
+    private fun generateTFLiteFileNameWithGitHash(modelUrl: String): String {
+        return "${modelUrl.split('/')[5]}.tflite"
+    }
 }

--- a/identity/src/main/java/com/stripe/android/identity/utils/IdentityIO.kt
+++ b/identity/src/main/java/com/stripe/android/identity/utils/IdentityIO.kt
@@ -64,5 +64,5 @@ internal interface IdentityIO {
     /**
      * Create a file for tflite model.
      */
-    fun createTFLiteFile(): File
+    fun createTFLiteFile(modelUrl: String): File
 }

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.viewModelScope
 import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.identity.IdentityVerificationSheetContract
+import com.stripe.android.identity.networking.IDDetectorFetcher
 import com.stripe.android.identity.networking.IdentityRepository
 import com.stripe.android.identity.networking.Resource
 import com.stripe.android.identity.networking.Status
@@ -25,7 +26,8 @@ import java.io.File
  */
 internal class IdentityViewModel(
     internal val args: IdentityVerificationSheetContract.Args,
-    private val identityRepository: IdentityRepository
+    private val identityRepository: IdentityRepository,
+    private val idDetectorFetcher: IDDetectorFetcher
 ) : ViewModel() {
 
     /**
@@ -100,7 +102,7 @@ internal class IdentityViewModel(
         viewModelScope.launch {
             runCatching {
                 _idDetectorModelFile.postValue(Resource.loading())
-                identityRepository.downloadModel(modelUrl)
+                idDetectorFetcher.fetchIDDetector(modelUrl)
             }.fold(
                 onSuccess = {
                     _idDetectorModelFile.postValue(Resource.success(it))
@@ -151,10 +153,11 @@ internal class IdentityViewModel(
     internal class IdentityViewModelFactory(
         private val args: IdentityVerificationSheetContract.Args,
         private val identityRepository: IdentityRepository,
+        private val idDetectorFetcher: IDDetectorFetcher
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return IdentityViewModel(args, identityRepository) as T
+            return IdentityViewModel(args, identityRepository, idDetectorFetcher) as T
         }
     }
 

--- a/identity/src/test/java/com/stripe/android/identity/networking/DefaultIdentityRepositoryTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/networking/DefaultIdentityRepositoryTest.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.identity.networking
 
-import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.exception.APIException
@@ -40,11 +39,10 @@ import kotlin.test.assertFailsWith
 @RunWith(RobolectricTestRunner::class)
 class DefaultIdentityRepositoryTest {
     private val mockIO = mock<IdentityIO>().also {
-        whenever(it.createTFLiteFile()).thenReturn(mock())
+        whenever(it.createTFLiteFile(any())).thenReturn(mock())
     }
     private val mockStripeNetworkClient: StripeNetworkClient = mock()
     private val identityRepository = DefaultIdentityRepository(
-        ApplicationProvider.getApplicationContext(),
         mockStripeNetworkClient,
         mockIO
     )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Create a simple caching mechanism to use the githash as a key to save the model files, download new ones if the file wasn't downloaded earlier.

Later when versioning is introduced to the model file, migrate with the `Fetcher` utils in stripecardscan.


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Don't redownoad model files.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
