### PR TITLE
[Identity] Correct action bar behavior

### DIFF
--- a/identity/api/identity.api
+++ b/identity/api/identity.api
@@ -184,6 +184,7 @@ public final class com/stripe/android/identity/databinding/GetLocalImageFragment
 
 public final class com/stripe/android/identity/databinding/IdentityActivityBinding : androidx/viewbinding/ViewBinding {
 	public final field identityNavHost Landroidx/fragment/app/FragmentContainerView;
+	public final field topAppBar Lcom/google/android/material/appbar/MaterialToolbar;
 	public static fun bind (Landroid/view/View;)Lcom/stripe/android/identity/databinding/IdentityActivityBinding;
 	public synthetic fun getRoot ()Landroid/view/View;
 	public fun getRoot ()Landroidx/constraintlayout/widget/ConstraintLayout;

--- a/identity/res/layout/identity_activity.xml
+++ b/identity/res/layout/identity_activity.xml
@@ -1,10 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".navigation.NavHostActivity">
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/top_app_bar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        android:layout_width="0dp"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintBottom_toTopOf="@id/identity_nav_host"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/identity_nav_host"
@@ -14,6 +22,6 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@id/top_app_bar" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/identity/res/navigation/identity_nav_graph.xml
+++ b/identity/res/navigation/identity_nav_graph.xml
@@ -24,7 +24,6 @@
     <fragment
         android:id="@+id/consentFragment"
         android:name="com.stripe.android.identity.navigation.ConsentFragment"
-        android:label="consent_fragment"
         tools:layout="@layout/consent_fragment">
         <action
             android:id="@+id/action_consentFragment_to_docSelectionFragment"
@@ -33,40 +32,30 @@
     <fragment
         android:id="@+id/IDScanFragment"
         android:name="com.stripe.android.identity.navigation.IDScanFragment"
-        android:label="id_scan_fragment"
-        tools:layout="@layout/id_scan_fragment">
-    </fragment>
+        tools:layout="@layout/id_scan_fragment" />
     <fragment
         android:id="@+id/passportScanFragment"
         android:name="com.stripe.android.identity.navigation.PassportScanFragment"
-        android:label="passport_scan_fragment"
-        tools:layout="@layout/passport_scan_fragment">
-    </fragment>
+        tools:layout="@layout/passport_scan_fragment" />
     <fragment
         android:id="@+id/driverLicenseScanFragment"
         android:name="com.stripe.android.identity.navigation.DriverLicenseScanFragment"
-        android:label="driver_license_scan_fragment"
-        tools:layout="@layout/driver_license_scan_fragment">
-    </fragment>
+        tools:layout="@layout/driver_license_scan_fragment" />
     <fragment
         android:id="@+id/IDUploadFragment"
         android:name="com.stripe.android.identity.navigation.IDUploadFragment"
-        android:label="id_upload_fragment"
-        tools:layout="@layout/id_upload_fragment"/>
+        tools:layout="@layout/id_upload_fragment" />
     <fragment
         android:id="@+id/passportUploadFragment"
         android:name="com.stripe.android.identity.navigation.PassportUploadFragment"
-        android:label="passport_upload_fragment"
-        tools:layout="@layout/passport_upload_fragment"/>
+        tools:layout="@layout/passport_upload_fragment" />
     <fragment
         android:id="@+id/driverLicenseUploadFragment"
         android:name="com.stripe.android.identity.navigation.DriverLicenseUploadFragment"
-        android:label="driver_license_upload_fragment"
-        tools:layout="@layout/driver_license_upload_fragment"/>
+        tools:layout="@layout/driver_license_upload_fragment" />
     <fragment
         android:id="@+id/cameraPermissionDeniedFragment"
         android:name="com.stripe.android.identity.navigation.CameraPermissionDeniedFragment"
-        android:label="camera_permission_denied_fragment"
         tools:layout="@layout/camera_permission_denied_fragment">
         <argument
             android:name="scanType"
@@ -87,17 +76,14 @@
     <fragment
         android:id="@+id/cameraErrorFragment"
         android:name="com.stripe.android.identity.navigation.CameraErrorFragment"
-        android:label="camera_error_fragment"
         tools:layout="@layout/camera_error_fragment" />
     <fragment
         android:id="@+id/confirmationFragment"
         android:name="com.stripe.android.identity.navigation.ConfirmationFragment"
-        android:label="confirmation_fragment"
         tools:layout="@layout/confirmation_fragment" />
     <fragment
         android:id="@+id/docSelectionFragment"
         android:name="com.stripe.android.identity.navigation.DocSelectionFragment"
-        android:label="doc_selection_fragment"
         tools:layout="@layout/doc_selection_fragment">
         <action
             android:id="@+id/action_docSelectionFragment_to_passportScanFragment"
@@ -120,8 +106,7 @@
     </fragment>
     <fragment
         android:id="@+id/errorFragment"
-        android:name="com.stripe.android.identity.navigation.ErrorFragment"
-        android:label="ErrorFragment">
+        android:name="com.stripe.android.identity.navigation.ErrorFragment">
         <argument
             android:name="errorTitle"
             android:defaultValue=""

--- a/identity/src/main/AndroidManifest.xml
+++ b/identity/src/main/AndroidManifest.xml
@@ -7,10 +7,10 @@
     <application>
         <activity
             android:name=".IdentityActivity"
+            android:theme="@style/Theme.MaterialComponents.DayNight.NoActionBar"
             android:screenOrientation="portrait"
             android:configChanges="orientation|keyboardHidden"
             android:exported="false" />
-
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
@@ -7,8 +7,10 @@ import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.lifecycle.ViewModelProvider
+import androidx.navigation.NavController
 import androidx.navigation.findNavController
 import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.ui.setupActionBarWithNavController
 import com.stripe.android.camera.CameraPermissionCheckingActivity
 import com.stripe.android.identity.IdentityVerificationSheet.VerificationResult
 import com.stripe.android.identity.databinding.IdentityActivityBinding
@@ -39,6 +41,8 @@ internal class IdentityActivity : CameraPermissionCheckingActivity(), Verificati
         )
     }
 
+    private lateinit var navController: NavController
+
     @VisibleForTesting
     internal val viewModelFactory: ViewModelProvider.Factory by lazy {
         identityFragmentFactory.identityViewModelFactory
@@ -51,11 +55,17 @@ internal class IdentityActivity : CameraPermissionCheckingActivity(), Verificati
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
 
+        setSupportActionBar(binding.topAppBar)
+
         supportFragmentManager.fragmentFactory = identityFragmentFactory
 
-        val navHostFragment =
-            supportFragmentManager.findFragmentById(R.id.identity_nav_host) as NavHostFragment
-        navHostFragment.navController.setGraph(R.navigation.identity_nav_graph)
+        navController =
+            (supportFragmentManager.findFragmentById(R.id.identity_nav_host) as NavHostFragment).navController
+        navController.setGraph(R.navigation.identity_nav_graph)
+        navController.addOnDestinationChangedListener { _, _, _ ->
+            title = "" // clear title on each screen
+        }
+        setupActionBarWithNavController(navController)
 
         identityViewModel.retrieveAndBufferVerificationPage()
     }
@@ -68,6 +78,10 @@ internal class IdentityActivity : CameraPermissionCheckingActivity(), Verificati
                 navController.navigateUp()
             }
         }
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        return navController.navigateUp() || super.onSupportNavigateUp()
     }
 
     override fun finishWithResult(result: VerificationResult) {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update the action bar behavior per design
* No title on each fragment
* Any fragments other than `ConsentFragment` would have a up button to previous fragment

Fortunately the logic is handled natively by navigation component.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Identity SDK UI final touch


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![withTitle](https://user-images.githubusercontent.com/79880926/159389333-f4bb098b-0762-474f-9218-843368708670.gif) | ![noTitle](https://user-images.githubusercontent.com/79880926/159389311-9dbb369e-3637-4268-89a0-c5ed419d867e.gif) |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
