### PR TITLE
Fix intermittent crash

### DIFF
--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanActivity.kt
@@ -140,8 +140,6 @@ internal class CardScanActivity : ScanActivity(), SimpleScanStateful<CardScanSta
             override suspend fun onResult(
                 result: MainLoopAggregator.FinalResult,
             ) {
-                super.onResult(result)
-
                 launch(Dispatchers.Main) {
                     changeScanState(CardScanState.Correct)
                     cameraAdapter.unbindFromLifecycle(this@CardScanActivity)

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanFlow.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanFlow.kt
@@ -97,17 +97,9 @@ internal abstract class CardScanFlow(
         }
     }.let { }
 
-    override suspend fun onResult(result: MainLoopAggregator.FinalResult) {
-        stopFlow()
-    }
-
     override fun cancelFlow() {
         canceled = true
         mainLoopAggregator?.run { cancel() }
-        stopFlow()
-    }
-
-    private fun stopFlow() {
         mainLoopAggregator = null
 
         mainLoop?.unsubscribe()

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanFragment.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanFragment.kt
@@ -121,8 +121,6 @@ class CardScanFragment : ScanFragment(), SimpleScanStateful<CardScanState> {
             override suspend fun onResult(
                 result: MainLoopAggregator.FinalResult,
             ) {
-                super.onResult(result)
-
                 launch(Dispatchers.Main) {
                     changeScanState(CardScanState.Correct)
                     cameraAdapter.unbindFromLifecycle(requireActivity())
@@ -161,7 +159,7 @@ class CardScanFragment : ScanFragment(), SimpleScanStateful<CardScanState> {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         viewBinding = FragmentCardscanBinding.inflate(inflater, container, false)
 
         setupViewFinderConstraints()
@@ -298,7 +296,6 @@ class CardScanFragment : ScanFragment(), SimpleScanStateful<CardScanState> {
             appDetails = AppDetails.fromContext(requireActivity()),
             scanStatistics = ScanStatistics.fromStats()
         )
-        scanFlow.cancelFlow()
         super.closeScanner()
     }
 }


### PR DESCRIPTION
# Summary
Fix the intermittent crash on OCR-only cardscan flows by stopping the stopFlow() function running twice. Also prevents mainLoopAggregator being set to null before running cancel() on it.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
