### PR TITLE
Add ability to verify with microdeposit

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -5063,6 +5063,14 @@ public final class com/stripe/android/payments/bankaccount/domain/CreateLinkAcco
 	public static fun newInstance (Lcom/stripe/android/networking/StripeRepository;)Lcom/stripe/android/payments/bankaccount/domain/CreateLinkAccountSession;
 }
 
+public final class com/stripe/android/payments/bankaccount/domain/VerifyWithMicrodeposit_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/payments/bankaccount/domain/VerifyWithMicrodeposit_Factory;
+	public fun get ()Lcom/stripe/android/payments/bankaccount/domain/VerifyWithMicrodeposit;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Lcom/stripe/android/networking/StripeRepository;)Lcom/stripe/android/payments/bankaccount/domain/VerifyWithMicrodeposit;
+}
+
 public final class com/stripe/android/payments/bankaccount/navigation/CollectBankAccountResponse : com/stripe/android/core/model/StripeModel {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -3314,6 +3314,7 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Companion 
 	public final fun createPayPal ()Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun createPayPal (Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static synthetic fun createPayPal$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static synthetic fun createUSBankAccount$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun createWeChatPay ()Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun createWeChatPay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun createWeChatPay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;

--- a/payments-core/src/main/java/com/stripe/android/Stripe.kt
+++ b/payments-core/src/main/java/com/stripe/android/Stripe.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import androidx.activity.ComponentActivity
+import androidx.annotation.RestrictTo
 import androidx.annotation.Size
 import androidx.annotation.UiThread
 import androidx.annotation.WorkerThread
@@ -1637,6 +1638,138 @@ class Stripe internal constructor(
         executeAsync(callback) {
             stripeRepository.createRadarSession(
                 ApiRequest.Options(
+                    apiKey = publishableKey,
+                    stripeAccount = stripeAccountId
+                )
+            )
+        }
+    }
+
+    /**
+     * Verify a customer's bank account with micro-deposits
+     *
+     * This function should only be called when the PaymentIntent is in the `requires_action` state
+     * and `NextActionType` is VerifyWithMicrodeposits.
+     *
+     * See the [Verify bank account with micro-despoits](https://stripe.com/docs/payments/ach-debit/accept-a-payment#web-verify-with-microdeposits) docs for more details.
+     *
+     * @param clientSecret The client secret of the PaymentIntent
+     * @param firstAmount The amount, in cents of USD, equal to the value of the first micro-deposit
+     * sent to the bank account
+     * @param secondAmount The amount, in cents of USD, equal to the value of the second micro-deposit
+     * sent to the bank account
+     * @param callback a [ApiResultCallback] to receive the result or error
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun verifyPaymentIntentWithMicrodeposits(
+        clientSecret: String,
+        firstAmount: Int,
+        secondAmount: Int,
+        callback: ApiResultCallback<PaymentIntent>
+    ) {
+        executeAsync(callback) {
+            stripeRepository.verifyPaymentIntentWithMicrodeposits(
+                clientSecret = clientSecret,
+                firstAmount = firstAmount,
+                secondAmount = secondAmount,
+                requestOptions = ApiRequest.Options(
+                    apiKey = publishableKey,
+                    stripeAccount = stripeAccountId
+                )
+            )
+        }
+    }
+
+    /**
+     * Verify a customer's bank account with micro-deposits
+     *
+     * This function should only be called when the PaymentIntent is in the `requires_action` state
+     * and `NextActionType` is VerifyWithMicrodeposits.
+     *
+     * See the [Verify bank account with micro-despoits](https://stripe.com/docs/payments/ach-debit/accept-a-payment#web-verify-with-microdeposits) docs for more details.
+     *
+     * @param clientSecret The client secret of the PaymentIntent
+     * @param descriptorCode A unique, 6-digit descriptor code that starts with SM that was sent as
+     * statement descriptor to the bank account
+     * @param callback a [ApiResultCallback] to receive the result or error
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun verifyPaymentIntentWithMicrodeposits(
+        clientSecret: String,
+        descriptorCode: String,
+        callback: ApiResultCallback<PaymentIntent>
+    ) {
+        executeAsync(callback) {
+            stripeRepository.verifyPaymentIntentWithMicrodeposits(
+                clientSecret = clientSecret,
+                descriptorCode = descriptorCode,
+                requestOptions = ApiRequest.Options(
+                    apiKey = publishableKey,
+                    stripeAccount = stripeAccountId
+                )
+            )
+        }
+    }
+
+    /**
+     * Verify a customer's bank account with micro-deposits
+     *
+     * This function should only be called when the SetupIntent is in the `requires_action` state
+     * and `NextActionType` is VerifyWithMicrodeposits.
+     *
+     * See the [Verify bank account with micro-despoits](https://stripe.com/docs/payments/ach-debit/accept-a-payment#web-verify-with-microdeposits) docs for more details.
+     *
+     * @param clientSecret The client secret of the SetupIntent
+     * @param firstAmount The amount, in cents of USD, equal to the value of the first micro-deposit
+     * sent to the bank account
+     * @param secondAmount The amount, in cents of USD, equal to the value of the second micro-deposit
+     * sent to the bank account
+     * @param callback a [ApiResultCallback] to receive the result or error
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun verifySetupIntentWithMicrodeposits(
+        clientSecret: String,
+        firstAmount: Int,
+        secondAmount: Int,
+        callback: ApiResultCallback<SetupIntent>
+    ) {
+        executeAsync(callback) {
+            stripeRepository.verifySetupIntentWithMicrodeposits(
+                clientSecret = clientSecret,
+                firstAmount = firstAmount,
+                secondAmount = secondAmount,
+                requestOptions = ApiRequest.Options(
+                    apiKey = publishableKey,
+                    stripeAccount = stripeAccountId
+                )
+            )
+        }
+    }
+
+    /**
+     * Verify a customer's bank account with micro-deposits
+     *
+     * This function should only be called when the SetupIntent is in the `requires_action` state
+     * and `NextActionType` is VerifyWithMicrodeposits.
+     *
+     * See the [Verify bank account with micro-despoits](https://stripe.com/docs/payments/ach-debit/accept-a-payment#web-verify-with-microdeposits) docs for more details.
+     *
+     * @param clientSecret The client secret of the SetupIntent
+     * @param descriptorCode A unique, 6-digit descriptor code that starts with SM that was sent as
+     * statement descriptor to the bank account
+     * @param callback a [ApiResultCallback] to receive the result or error
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun verifySetupIntentWithMicrodeposits(
+        clientSecret: String,
+        descriptorCode: String,
+        callback: ApiResultCallback<SetupIntent>
+    ) {
+        executeAsync(callback) {
+            stripeRepository.verifySetupIntentWithMicrodeposits(
+                clientSecret = clientSecret,
+                descriptorCode = descriptorCode,
+                requestOptions = ApiRequest.Options(
                     apiKey = publishableKey,
                     stripeAccount = stripeAccountId
                 )

--- a/payments-core/src/main/java/com/stripe/android/StripeKtx.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripeKtx.kt
@@ -1,6 +1,7 @@
 package com.stripe.android
 
 import android.content.Intent
+import androidx.annotation.RestrictTo
 import androidx.annotation.Size
 import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.exception.APIException
@@ -793,3 +794,175 @@ internal inline fun <reified ApiObject : StripeModel> runApiRequest(
         }
         block()
     }.getOrElse { throw StripeException.create(it) }
+
+/**
+ * Suspend function to verify a customer's bank account with micro-deposits
+ *
+ * This function should only be called when the PaymentIntent is in the `requires_action` state
+ * and `NextActionType` is VerifyWithMicrodeposits.
+ *
+ * See the [Verify bank account with micro-despoits](https://stripe.com/docs/payments/ach-debit/accept-a-payment#web-verify-with-microdeposits) docs for more details.
+ *
+ * @param clientSecret The client secret of the PaymentIntent
+ * @param firstAmount The amount, in cents of USD, equal to the value of the first micro-deposit
+ * sent to the bank account
+ * @param secondAmount The amount, in cents of USD, equal to the value of the second micro-deposit
+ * sent to the bank account
+ * @param callback a [ApiResultCallback] to receive the result or error
+ *
+ * @return a [PaymentIntent] object
+ *
+ * @throws AuthenticationException failure to properly authenticate yourself (check your key)
+ * @throws InvalidRequestException your request has invalid parameters
+ * @throws APIConnectionException failure to connect to Stripe's API
+ * @throws APIException any other type of problem (for instance, a temporary issue with Stripe's servers)
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Throws(
+    AuthenticationException::class,
+    InvalidRequestException::class,
+    APIConnectionException::class,
+    APIException::class
+)
+suspend fun Stripe.verifyPaymentIntentWithMicrodeposits(
+    clientSecret: String,
+    firstAmount: Int,
+    secondAmount: Int
+): PaymentIntent = runApiRequest {
+    stripeRepository.verifyPaymentIntentWithMicrodeposits(
+        clientSecret = clientSecret,
+        firstAmount = firstAmount,
+        secondAmount = secondAmount,
+        requestOptions = ApiRequest.Options(
+            apiKey = publishableKey,
+            stripeAccount = stripeAccountId,
+        )
+    )
+}
+
+/**
+ * Suspend function to verify a customer's bank account with micro-deposits
+ *
+ * This function should only be called when the PaymentIntent is in the `requires_action` state
+ * and `NextActionType` is VerifyWithMicrodeposits.
+ *
+ * See the [Verify bank account with micro-despoits](https://stripe.com/docs/payments/ach-debit/accept-a-payment#web-verify-with-microdeposits) docs for more details.
+ *
+ * @param clientSecret The client secret of the PaymentIntent
+ * @param descriptorCode A unique, 6-digit descriptor code that starts with SM that was sent as
+ * statement descriptor to the bank account
+ * @param callback a [ApiResultCallback] to receive the result or error
+ *
+ * @return a [PaymentIntent] object
+ *
+ * @throws AuthenticationException failure to properly authenticate yourself (check your key)
+ * @throws InvalidRequestException your request has invalid parameters
+ * @throws APIConnectionException failure to connect to Stripe's API
+ * @throws APIException any other type of problem (for instance, a temporary issue with Stripe's servers)
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Throws(
+    AuthenticationException::class,
+    InvalidRequestException::class,
+    APIConnectionException::class,
+    APIException::class
+)
+suspend fun Stripe.verifyPaymentIntentWithMicrodeposits(
+    clientSecret: String,
+    descriptorCode: String
+): PaymentIntent = runApiRequest {
+    stripeRepository.verifyPaymentIntentWithMicrodeposits(
+        clientSecret = clientSecret,
+        descriptorCode = descriptorCode,
+        requestOptions = ApiRequest.Options(
+            apiKey = publishableKey,
+            stripeAccount = stripeAccountId
+        )
+    )
+}
+
+/**
+ * Suspend function to verify a customer's bank account with micro-deposits
+ *
+ * This function should only be called when the SetupIntent is in the `requires_action` state
+ * and `NextActionType` is VerifyWithMicrodeposits.
+ *
+ * See the [Verify bank account with micro-despoits](https://stripe.com/docs/payments/ach-debit/accept-a-payment#web-verify-with-microdeposits) docs for more details.
+ *
+ * @param clientSecret The client secret of the SetupIntent
+ * @param firstAmount The amount, in cents of USD, equal to the value of the first micro-deposit
+ * sent to the bank account
+ * @param secondAmount The amount, in cents of USD, equal to the value of the second micro-deposit
+ * sent to the bank account
+ * @param callback a [ApiResultCallback] to receive the result or error
+ *
+ * @return a [SetupIntent] object
+ *
+ * @throws AuthenticationException failure to properly authenticate yourself (check your key)
+ * @throws InvalidRequestException your request has invalid parameters
+ * @throws APIConnectionException failure to connect to Stripe's API
+ * @throws APIException any other type of problem (for instance, a temporary issue with Stripe's servers)
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Throws(
+    AuthenticationException::class,
+    InvalidRequestException::class,
+    APIConnectionException::class,
+    APIException::class
+)
+suspend fun Stripe.verifySetupIntentWithMicrodeposits(
+    clientSecret: String,
+    firstAmount: Int,
+    secondAmount: Int
+): SetupIntent = runApiRequest {
+    stripeRepository.verifySetupIntentWithMicrodeposits(
+        clientSecret = clientSecret,
+        firstAmount = firstAmount,
+        secondAmount = secondAmount,
+        requestOptions = ApiRequest.Options(
+            apiKey = publishableKey,
+            stripeAccount = stripeAccountId
+        )
+    )
+}
+
+/**
+ * Suspend function to verify a customer's bank account with micro-deposits
+ *
+ * This function should only be called when the SetupIntent is in the `requires_action` state
+ * and `NextActionType` is VerifyWithMicrodeposits.
+ *
+ * See the [Verify bank account with micro-despoits](https://stripe.com/docs/payments/ach-debit/accept-a-payment#web-verify-with-microdeposits) docs for more details.
+ *
+ * @param clientSecret The client secret of the SetupIntent
+ * @param descriptorCode A unique, 6-digit descriptor code that starts with SM that was sent as
+ * statement descriptor to the bank account
+ * @param callback a [ApiResultCallback] to receive the result or error
+ *
+ * @return a [SetupIntent] object
+ *
+ * @throws AuthenticationException failure to properly authenticate yourself (check your key)
+ * @throws InvalidRequestException your request has invalid parameters
+ * @throws APIConnectionException failure to connect to Stripe's API
+ * @throws APIException any other type of problem (for instance, a temporary issue with Stripe's servers)
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Throws(
+    AuthenticationException::class,
+    InvalidRequestException::class,
+    APIConnectionException::class,
+    APIException::class
+)
+suspend fun Stripe.verifySetupIntentWithMicrodeposits(
+    clientSecret: String,
+    descriptorCode: String
+): SetupIntent = runApiRequest {
+    stripeRepository.verifySetupIntentWithMicrodeposits(
+        clientSecret = clientSecret,
+        descriptorCode = descriptorCode,
+        requestOptions = ApiRequest.Options(
+            apiKey = publishableKey,
+            stripeAccount = stripeAccountId
+        )
+    )
+}

--- a/payments-core/src/main/java/com/stripe/android/model/MicrodepositType.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/MicrodepositType.kt
@@ -1,6 +1,9 @@
 package com.stripe.android.model
 
-internal enum class MicrodepositType(val value: String) {
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+enum class MicrodepositType(val value: String) {
     // Two non-unique micro-deposits to the customer's bank account
     AMOUNTS("amounts"),
     // A single micro-deposit sent to the customer's bank account with a unique descriptor code

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -839,7 +839,8 @@ data class PaymentMethodCreateParams internal constructor(
             )
         }
 
-        internal fun createUSBankAccount(
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        fun createUSBankAccount(
             billingDetails: PaymentMethod.BillingDetails? = null,
             metadata: Map<String, String>? = null
         ): PaymentMethodCreateParams {

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodOptionsParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodOptionsParams.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model
 
 import android.os.Parcelable
+import androidx.annotation.RestrictTo
 import kotlinx.parcelize.Parcelize
 
 sealed class PaymentMethodOptionsParams(
@@ -90,8 +91,9 @@ sealed class PaymentMethodOptionsParams(
         }
     }
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
-    internal data class USBankAccount(
+    data class USBankAccount(
         var setupFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage? = null
     ) : PaymentMethodOptionsParams(PaymentMethod.Type.USBankAccount) {
         override fun createTypeParams(): List<Pair<String, Any?>> {

--- a/payments-core/src/main/java/com/stripe/android/model/StripeIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/StripeIntent.kt
@@ -253,8 +253,9 @@ sealed interface StripeIntent : StripeModel {
         @Parcelize
         data class WeChatPayRedirect(val weChat: WeChat) : NextActionData()
 
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         @Parcelize
-        internal data class VerifyWithMicrodeposits(
+        data class VerifyWithMicrodeposits(
             val arrivalDate: Long,
             val hostedVerificationUrl: String,
             val microdepositType: MicrodepositType

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1441,6 +1441,100 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
     }
 
     /**
+     * Verifies the PaymentIntent with microdeposits amounts
+     */
+    override suspend fun verifyPaymentIntentWithMicrodeposits(
+        clientSecret: String,
+        firstAmount: Int,
+        secondAmount: Int,
+        requestOptions: ApiRequest.Options
+    ): PaymentIntent? {
+        return fetchStripeModel(
+            apiRequestFactory.createPost(
+                getVerifyMicrodepositsOnPaymentIntentUrl(PaymentIntent.ClientSecret(clientSecret).paymentIntentId),
+                requestOptions,
+                mapOf(
+                    "client_secret" to clientSecret,
+                    "amounts" to listOf(firstAmount, secondAmount)
+                )
+            ),
+            PaymentIntentJsonParser()
+        ) {
+            // no-op
+        }
+    }
+
+    /**
+     * Verifies the PaymentIntent with microdeposits descriptor code
+     */
+    override suspend fun verifyPaymentIntentWithMicrodeposits(
+        clientSecret: String,
+        descriptorCode: String,
+        requestOptions: ApiRequest.Options
+    ): PaymentIntent? {
+        return fetchStripeModel(
+            apiRequestFactory.createPost(
+                getVerifyMicrodepositsOnPaymentIntentUrl(PaymentIntent.ClientSecret(clientSecret).paymentIntentId),
+                requestOptions,
+                mapOf(
+                    "client_secret" to clientSecret,
+                    "descriptor_code" to descriptorCode
+                )
+            ),
+            PaymentIntentJsonParser()
+        ) {
+            // no-op
+        }
+    }
+
+    /**
+     * Verifies the SetupIntent with microdeposits amounts
+     */
+    override suspend fun verifySetupIntentWithMicrodeposits(
+        clientSecret: String,
+        firstAmount: Int,
+        secondAmount: Int,
+        requestOptions: ApiRequest.Options
+    ): SetupIntent? {
+        return fetchStripeModel(
+            apiRequestFactory.createPost(
+                getVerifyMicrodepositsOnSetupIntentUrl(SetupIntent.ClientSecret(clientSecret).setupIntentId),
+                requestOptions,
+                mapOf(
+                    "client_secret" to clientSecret,
+                    "amounts" to listOf(firstAmount, secondAmount)
+                )
+            ),
+            SetupIntentJsonParser()
+        ) {
+            // no-op
+        }
+    }
+
+    /**
+     * Verifies the SetupIntent with microdeposits descriptor code
+     */
+    override suspend fun verifySetupIntentWithMicrodeposits(
+        clientSecret: String,
+        descriptorCode: String,
+        requestOptions: ApiRequest.Options
+    ): SetupIntent? {
+        return fetchStripeModel(
+            apiRequestFactory.createPost(
+                getVerifyMicrodepositsOnSetupIntentUrl(SetupIntent.ClientSecret(clientSecret).setupIntentId),
+                requestOptions,
+                mapOf(
+                    "client_secret" to clientSecret,
+                    "descriptor_code" to descriptorCode
+                )
+            ),
+            SetupIntentJsonParser()
+        ) {
+            // no-op
+        }
+    }
+
+    /**
      * @return `https://api.stripe.com/v1/payment_methods/:id/detach`
      */
     @VisibleForTesting
@@ -1926,6 +2020,34 @@ internal class StripeApiRepository @JvmOverloads internal constructor(
                 "setup_intents/%s/link_account_sessions/%s/attach",
                 setupIntentId,
                 linkAccountSessionId
+            )
+        }
+
+        /**
+         * @return `https://api.stripe.com/v1/payment_intents/:clientSecret/verify_microdeposits`
+         */
+        @VisibleForTesting
+        @JvmSynthetic
+        internal fun getVerifyMicrodepositsOnPaymentIntentUrl(
+            clientSecret: String
+        ): String {
+            return getApiUrl(
+                "payment_intents/%s/verify_microdeposits",
+                clientSecret
+            )
+        }
+
+        /**
+         * @return `https://api.stripe.com/v1/setup_intents/:clientSecret/verify_microdeposits`
+         */
+        @VisibleForTesting
+        @JvmSynthetic
+        internal fun getVerifyMicrodepositsOnSetupIntentUrl(
+            clientSecret: String
+        ): String {
+            return getApiUrl(
+                "setup_intents/%s/verify_microdeposits",
+                clientSecret
             )
         }
 

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -468,4 +468,34 @@ abstract class StripeRepository {
         linkAccountSessionId: String,
         requestOptions: ApiRequest.Options
     ): SetupIntent?
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    abstract suspend fun verifyPaymentIntentWithMicrodeposits(
+        clientSecret: String,
+        firstAmount: Int,
+        secondAmount: Int,
+        requestOptions: ApiRequest.Options
+    ): PaymentIntent?
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    abstract suspend fun verifyPaymentIntentWithMicrodeposits(
+        clientSecret: String,
+        descriptorCode: String,
+        requestOptions: ApiRequest.Options
+    ): PaymentIntent?
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    abstract suspend fun verifySetupIntentWithMicrodeposits(
+        clientSecret: String,
+        firstAmount: Int,
+        secondAmount: Int,
+        requestOptions: ApiRequest.Options
+    ): SetupIntent?
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    abstract suspend fun verifySetupIntentWithMicrodeposits(
+        clientSecret: String,
+        descriptorCode: String,
+        requestOptions: ApiRequest.Options
+    ): SetupIntent?
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/domain/VerifyWithMicrodeposit.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/domain/VerifyWithMicrodeposit.kt
@@ -1,0 +1,87 @@
+package com.stripe.android.payments.bankaccount.domain
+
+import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.SetupIntent
+import com.stripe.android.networking.StripeRepository
+import javax.inject.Inject
+
+internal class VerifyWithMicrodeposit @Inject constructor(
+    private val stripeRepository: StripeRepository
+) {
+    /**
+     * Verifies a PaymentIntent given a microdeposit,
+     * using [firstAmount], [secondAmount] and the intent [clientSecret].
+     *
+     * @return [PaymentIntent].
+     */
+    suspend fun forPaymentIntent(
+        publishableKey: String,
+        clientSecret: String,
+        firstAmount: Int,
+        secondAmount: Int,
+    ): Result<PaymentIntent> = kotlin.runCatching {
+        stripeRepository.verifyPaymentIntentWithMicrodeposits(
+            clientSecret = clientSecret,
+            firstAmount = firstAmount,
+            secondAmount = secondAmount,
+            requestOptions = ApiRequest.Options(publishableKey)
+        )
+    }.mapCatching { it ?: throw InternalError("Error verifying PaymentIntent with microdeposits") }
+
+    /**
+     * Verifies a PaymentIntent given a microdeposit,
+     * using [descriptorCode] and the intent [clientSecret].
+     *
+     * @return [PaymentIntent].
+     */
+    suspend fun forPaymentIntent(
+        publishableKey: String,
+        clientSecret: String,
+        descriptorCode: String,
+    ): Result<PaymentIntent> = kotlin.runCatching {
+        stripeRepository.verifyPaymentIntentWithMicrodeposits(
+            clientSecret = clientSecret,
+            descriptorCode = descriptorCode,
+            requestOptions = ApiRequest.Options(publishableKey)
+        )
+    }.mapCatching { it ?: throw InternalError("Error verifying PaymentIntent with microdeposits") }
+
+    /**
+     * Verifies a SetupIntent given a microdeposit,
+     * using [firstAmount], [secondAmount] and the intent [clientSecret].
+     *
+     * @return [SetupIntent].
+     */
+    suspend fun forSetupIntent(
+        publishableKey: String,
+        clientSecret: String,
+        firstAmount: Int,
+        secondAmount: Int,
+    ): Result<SetupIntent> = kotlin.runCatching {
+        stripeRepository.verifySetupIntentWithMicrodeposits(
+            clientSecret = clientSecret,
+            firstAmount = firstAmount,
+            secondAmount = secondAmount,
+            requestOptions = ApiRequest.Options(publishableKey)
+        )
+    }.mapCatching { it ?: throw InternalError("Error verifying SetupIntent with microdeposits") }
+
+    /**
+     * Verifies a PaymentIntent given a microdeposit,
+     * using [descriptorCode] and the intent [clientSecret].
+     *
+     * @return [PaymentIntent].
+     */
+    suspend fun forSetupIntent(
+        publishableKey: String,
+        clientSecret: String,
+        descriptorCode: String,
+    ): Result<SetupIntent> = kotlin.runCatching {
+        stripeRepository.verifySetupIntentWithMicrodeposits(
+            clientSecret = clientSecret,
+            descriptorCode = descriptorCode,
+            requestOptions = ApiRequest.Options(publishableKey)
+        )
+    }.mapCatching { it ?: throw InternalError("Error verifying SetupIntent with microdeposits") }
+}

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
@@ -1412,4 +1412,39 @@ internal object PaymentIntentFixtures {
             }
         """.trimIndent()
     )
+
+    val PI_WITH_US_BANK_ACCOUNT_VERIFY_COMPLETED_JSON = JSONObject(
+        """
+            {
+                "id": "pi_3KbV27Lu5o3P18Zp1e7NOonG",
+                "object": "payment_intent",
+                "client_secret": "pi_3KbV27Lu5o3P18Zp1e7NOonG_secret_9PqgvdhyLNub0UvzjFf9bQKqd",
+                "last_payment_error": null,
+                "livemode": false,
+                "next_action": null,
+                "status": "processing",
+                "amount": 6099,
+                "automatic_payment_methods": null,
+                "canceled_at": null,
+                "cancellation_reason": null,
+                "capture_method": "automatic",
+                "confirmation_method": "automatic",
+                "created": 1646853531,
+                "currency": "usd",
+                "description": "Example PaymentIntent",
+                "payment_method": "pm_1KbV27Lu5o3P18ZpAEIGorq8",
+                "payment_method_options": { },
+                "payment_method_types": [
+                    "us_bank_account"
+                ],
+                "processing": null,
+                "receipt_email": null,
+                "setup_future_usage": "off_session",
+                "shipping": null,
+                "source": null
+            }
+        """.trimIndent()
+    )
+
+    val PI_WITH_US_BANK_ACCOUNT_VERIFY_COMPLETED = PARSER.parse(PI_WITH_US_BANK_ACCOUNT_VERIFY_COMPLETED_JSON)!!
 }

--- a/payments-core/src/test/java/com/stripe/android/model/SetupIntentFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/SetupIntentFixtures.kt
@@ -414,4 +414,39 @@ internal object SetupIntentFixtures {
     val SI_NEXT_ACTION_VERIFY_WITH_MICRODEPOSITS = requireNotNull(
         PARSER.parse(SI_NEXT_ACTION_VERIFY_WITH_MICRODEPOSITS_JSON)
     )
+
+    val SI_WITH_US_BANK_ACCOUNT_VERIFY_COMPLETED_JSON = JSONObject(
+        """
+            {
+                "id": "seti_3KbV27Lu5o3P18Zp1e7NOonG",
+                "object": "setup_intent",
+                "client_secret": "seti_3KbV27Lu5o3P18Zp1e7NOonG_secret_9PqgvdhyLNub0UvzjFf9bQKqd",
+                "last_payment_error": null,
+                "livemode": false,
+                "next_action": null,
+                "status": "processing",
+                "amount": 6099,
+                "automatic_payment_methods": null,
+                "canceled_at": null,
+                "cancellation_reason": null,
+                "capture_method": "automatic",
+                "confirmation_method": "automatic",
+                "created": 1646853531,
+                "currency": "usd",
+                "description": "Example SetupIntent",
+                "payment_method": "pm_1KbV27Lu5o3P18ZpAEIGorq8",
+                "payment_method_options": { },
+                "payment_method_types": [
+                    "us_bank_account"
+                ],
+                "processing": null,
+                "receipt_email": null,
+                "setup_future_usage": "off_session",
+                "shipping": null,
+                "source": null
+            }
+        """.trimIndent()
+    )
+
+    val SI_WITH_US_BANK_ACCOUNT_VERIFY_COMPLETED = PARSER.parse(SI_WITH_US_BANK_ACCOUNT_VERIFY_COMPLETED_JSON)!!
 }

--- a/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
@@ -366,4 +366,38 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
     ): BankConnectionsLinkedAccountSession? {
         return null
     }
+
+    override suspend fun verifyPaymentIntentWithMicrodeposits(
+        clientSecret: String,
+        firstAmount: Int,
+        secondAmount: Int,
+        requestOptions: ApiRequest.Options
+    ): PaymentIntent? {
+        return null
+    }
+
+    override suspend fun verifyPaymentIntentWithMicrodeposits(
+        clientSecret: String,
+        descriptorCode: String,
+        requestOptions: ApiRequest.Options
+    ): PaymentIntent? {
+        return null
+    }
+
+    override suspend fun verifySetupIntentWithMicrodeposits(
+        clientSecret: String,
+        firstAmount: Int,
+        secondAmount: Int,
+        requestOptions: ApiRequest.Options
+    ): SetupIntent? {
+        return null
+    }
+
+    override suspend fun verifySetupIntentWithMicrodeposits(
+        clientSecret: String,
+        descriptorCode: String,
+        requestOptions: ApiRequest.Options
+    ): SetupIntent? {
+        return null
+    }
 }

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -30,12 +30,14 @@ import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.ConsumerFixtures
 import com.stripe.android.model.CreateLinkAccountSessionParams
 import com.stripe.android.model.ListPaymentMethodsParams
+import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodPreferenceFixtures
+import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.SourceFixtures
 import com.stripe.android.model.SourceParams
@@ -1965,6 +1967,148 @@ internal class StripeApiRepositoryTest {
                     assertEquals(customerName, this["name"])
                 }
             }
+        }
+    }
+
+    @Test
+    fun `verifyPaymentIntentWithMicrodeposits() with amounts sends all parameters`() = runTest {
+        val stripeResponse = StripeResponse(
+            200,
+            PaymentIntentFixtures.PI_WITH_US_BANK_ACCOUNT_VERIFY_COMPLETED_JSON.toString(),
+            emptyMap()
+        )
+        whenever(stripeNetworkClient.executeRequest(any<ApiRequest>()))
+            .thenReturn(stripeResponse)
+
+        val clientSecret = PaymentIntentFixtures.PI_WITH_US_BANK_ACCOUNT_VERIFY_COMPLETED.clientSecret!!
+        create().verifyPaymentIntentWithMicrodeposits(
+            clientSecret = clientSecret,
+            firstAmount = 12,
+            secondAmount = 34,
+            DEFAULT_OPTIONS
+        )
+
+        verify(stripeNetworkClient).executeRequest(apiRequestArgumentCaptor.capture())
+
+        val request = apiRequestArgumentCaptor.firstValue
+        val params = requireNotNull(request.params)
+
+        assertEquals(
+            "https://api.stripe.com/v1/payment_intents/" +
+                PaymentIntent.ClientSecret(clientSecret).paymentIntentId +
+                "/verify_microdeposits",
+            request.baseUrl
+        )
+
+        with(params) {
+            assertEquals(clientSecret, this["client_secret"])
+            assertEquals(listOf(12, 34), this["amounts"])
+        }
+    }
+
+    @Test
+    fun `verifyPaymentIntentWithMicrodeposits() with descriptorCode sends all parameters`() = runTest {
+        val stripeResponse = StripeResponse(
+            200,
+            PaymentIntentFixtures.PI_WITH_US_BANK_ACCOUNT_VERIFY_COMPLETED_JSON.toString(),
+            emptyMap()
+        )
+        whenever(stripeNetworkClient.executeRequest(any<ApiRequest>()))
+            .thenReturn(stripeResponse)
+
+        val clientSecret = PaymentIntentFixtures.PI_WITH_US_BANK_ACCOUNT_VERIFY_COMPLETED.clientSecret!!
+        create().verifyPaymentIntentWithMicrodeposits(
+            clientSecret = clientSecret,
+            descriptorCode = "some_description",
+            DEFAULT_OPTIONS
+        )
+
+        verify(stripeNetworkClient).executeRequest(apiRequestArgumentCaptor.capture())
+
+        val request = apiRequestArgumentCaptor.firstValue
+        val params = requireNotNull(request.params)
+
+        assertEquals(
+            "https://api.stripe.com/v1/payment_intents/" +
+                PaymentIntent.ClientSecret(clientSecret).paymentIntentId +
+                "/verify_microdeposits",
+            request.baseUrl
+        )
+
+        with(params) {
+            assertEquals(clientSecret, this["client_secret"])
+            assertEquals("some_description", this["descriptor_code"])
+        }
+    }
+
+    @Test
+    fun `verifySetupIntentWithMicrodeposits() with amounts sends all parameters`() = runTest {
+        val stripeResponse = StripeResponse(
+            200,
+            SetupIntentFixtures.SI_WITH_US_BANK_ACCOUNT_VERIFY_COMPLETED_JSON.toString(),
+            emptyMap()
+        )
+        whenever(stripeNetworkClient.executeRequest(any<ApiRequest>()))
+            .thenReturn(stripeResponse)
+
+        val clientSecret = SetupIntentFixtures.SI_WITH_US_BANK_ACCOUNT_VERIFY_COMPLETED.clientSecret!!
+        create().verifySetupIntentWithMicrodeposits(
+            clientSecret = clientSecret,
+            firstAmount = 12,
+            secondAmount = 34,
+            DEFAULT_OPTIONS
+        )
+
+        verify(stripeNetworkClient).executeRequest(apiRequestArgumentCaptor.capture())
+
+        val request = apiRequestArgumentCaptor.firstValue
+        val params = requireNotNull(request.params)
+
+        assertEquals(
+            "https://api.stripe.com/v1/setup_intents/" +
+                SetupIntent.ClientSecret(clientSecret).setupIntentId +
+                "/verify_microdeposits",
+            request.baseUrl
+        )
+
+        with(params) {
+            assertEquals(clientSecret, this["client_secret"])
+            assertEquals(listOf(12, 34), this["amounts"])
+        }
+    }
+
+    @Test
+    fun `verifySetupIntentWithMicrodeposits() with descriptorCode sends all parameters`() = runTest {
+        val stripeResponse = StripeResponse(
+            200,
+            SetupIntentFixtures.SI_WITH_US_BANK_ACCOUNT_VERIFY_COMPLETED_JSON.toString(),
+            emptyMap()
+        )
+        whenever(stripeNetworkClient.executeRequest(any<ApiRequest>()))
+            .thenReturn(stripeResponse)
+
+        val clientSecret = SetupIntentFixtures.SI_WITH_US_BANK_ACCOUNT_VERIFY_COMPLETED.clientSecret!!
+        create().verifySetupIntentWithMicrodeposits(
+            clientSecret = clientSecret,
+            descriptorCode = "some_description",
+            DEFAULT_OPTIONS
+        )
+
+        verify(stripeNetworkClient).executeRequest(apiRequestArgumentCaptor.capture())
+
+        val request = apiRequestArgumentCaptor.firstValue
+        val params = requireNotNull(request.params)
+
+        assertEquals(
+            "https://api.stripe.com/v1/setup_intents/" +
+                SetupIntent.ClientSecret(clientSecret).setupIntentId +
+                "/verify_microdeposits",
+            request.baseUrl
+        )
+
+        with(params) {
+            assertEquals(clientSecret, this["client_secret"])
+            assertEquals("some_description", this["descriptor_code"])
         }
     }
 

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/domain/VerifyWithMicrodepositTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/domain/VerifyWithMicrodepositTest.kt
@@ -1,0 +1,285 @@
+package com.stripe.android.payments.bankaccount.domain
+
+import com.google.common.truth.Truth
+import com.stripe.android.core.exception.APIException
+import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.SetupIntent
+import com.stripe.android.networking.StripeRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+class VerifyWithMicrodepositTest {
+
+    private val stripeRepository = mock<StripeRepository>()
+    private val verifyWithMicrodeposit = VerifyWithMicrodeposit(stripeRepository)
+
+    @Test
+    fun `forPaymentIntent - given repository succeeds, verified with amounts and paymentIntent returned`() {
+        runTest {
+            // Given
+            val publishableKey = "publishable_key"
+            val clientSecret = "pi_1234_secret_5678"
+            val paymentIntent = mock<PaymentIntent> {
+                on { this.clientSecret } doReturn clientSecret
+            }
+            givenVerifyPaymentIntentReturns { paymentIntent }
+
+            // When
+            val result: Result<PaymentIntent> = verifyWithMicrodeposit.forPaymentIntent(
+                publishableKey,
+                clientSecret,
+                12,
+                34
+            )
+
+            // Then
+            verify(stripeRepository).verifyPaymentIntentWithMicrodeposits(
+                clientSecret = clientSecret,
+                firstAmount = 12,
+                secondAmount = 34,
+                requestOptions = ApiRequest.Options(publishableKey)
+            )
+            Truth.assertThat((result)).isEqualTo(Result.success(paymentIntent))
+        }
+    }
+
+    @Test
+    fun `forPaymentIntent - given repository succeeds, verified with decriptorCode and paymentIntent returned`() {
+        runTest {
+            // Given
+            val publishableKey = "publishable_key"
+            val clientSecret = "pi_1234_secret_5678"
+            val paymentIntent = mock<PaymentIntent> {
+                on { this.clientSecret } doReturn clientSecret
+            }
+            givenVerifyPaymentIntentReturns { paymentIntent }
+
+            // When
+            val result: Result<PaymentIntent> = verifyWithMicrodeposit.forPaymentIntent(
+                publishableKey,
+                clientSecret,
+                "code"
+            )
+
+            // Then
+            verify(stripeRepository).verifyPaymentIntentWithMicrodeposits(
+                clientSecret = clientSecret,
+                descriptorCode = "code",
+                requestOptions = ApiRequest.Options(publishableKey)
+            )
+            Truth.assertThat((result)).isEqualTo(Result.success(paymentIntent))
+        }
+    }
+
+    @Test
+    fun `forPaymentIntent - given repository returns null, results in internal error failure`() {
+        runTest {
+            // Given
+            val publishableKey = "publishable_key"
+            val clientSecret = "pi_1234_secret_5678"
+            givenVerifyPaymentIntentReturns { null }
+
+            // When
+            val result: Result<PaymentIntent> = verifyWithMicrodeposit.forPaymentIntent(
+                publishableKey,
+                clientSecret,
+                12,
+                34
+            )
+
+            // Then
+            verify(stripeRepository).verifyPaymentIntentWithMicrodeposits(
+                clientSecret = clientSecret,
+                firstAmount = 12,
+                secondAmount = 34,
+                requestOptions = ApiRequest.Options(publishableKey)
+            )
+            Truth.assertThat(result.exceptionOrNull()!!).isInstanceOf(InternalError::class.java)
+        }
+    }
+
+    @Test
+    fun `forPaymentIntent - given repository throws exception, results in internal error failure`() {
+        runTest {
+            // Given
+            val publishableKey = "publishable_key"
+            val clientSecret = "pi_1234_secret_5678"
+            val expectedException = APIException()
+            givenVerifyPaymentIntentReturns { throw expectedException }
+
+            // When
+            val result: Result<PaymentIntent> = verifyWithMicrodeposit.forPaymentIntent(
+                publishableKey,
+                clientSecret,
+                12,
+                34
+            )
+
+            // Then
+            verify(stripeRepository).verifyPaymentIntentWithMicrodeposits(
+                clientSecret = clientSecret,
+                firstAmount = 12,
+                secondAmount = 34,
+                requestOptions = ApiRequest.Options(publishableKey)
+            )
+            Truth.assertThat(result.exceptionOrNull()!!).isEqualTo(expectedException)
+        }
+    }
+
+    @Test
+    fun `forSetupIntent - given repository succeeds, verified with amounts and paymentIntent returned`() {
+        runTest {
+            // Given
+            val publishableKey = "publishable_key"
+            val clientSecret = "pi_1234_secret_5678"
+            val setupIntent = mock<SetupIntent> {
+                on { this.clientSecret } doReturn clientSecret
+            }
+            givenVerifySetupIntentReturns { setupIntent }
+
+            // When
+            val result: Result<SetupIntent> = verifyWithMicrodeposit.forSetupIntent(
+                publishableKey,
+                clientSecret,
+                12,
+                34
+            )
+
+            // Then
+            verify(stripeRepository).verifySetupIntentWithMicrodeposits(
+                clientSecret = clientSecret,
+                firstAmount = 12,
+                secondAmount = 34,
+                requestOptions = ApiRequest.Options(publishableKey)
+            )
+            Truth.assertThat((result)).isEqualTo(Result.success(setupIntent))
+        }
+    }
+
+    @Test
+    fun `forSetupIntent - given repository succeeds, verified with decriptorCode and paymentIntent returned`() {
+        runTest {
+            // Given
+            val publishableKey = "publishable_key"
+            val clientSecret = "pi_1234_secret_5678"
+            val setupIntent = mock<SetupIntent> {
+                on { this.clientSecret } doReturn clientSecret
+            }
+            givenVerifySetupIntentReturns { setupIntent }
+
+            // When
+            val result: Result<SetupIntent> = verifyWithMicrodeposit.forSetupIntent(
+                publishableKey,
+                clientSecret,
+                "code"
+            )
+
+            // Then
+            verify(stripeRepository).verifySetupIntentWithMicrodeposits(
+                clientSecret = clientSecret,
+                descriptorCode = "code",
+                requestOptions = ApiRequest.Options(publishableKey)
+            )
+            Truth.assertThat((result)).isEqualTo(Result.success(setupIntent))
+        }
+    }
+
+    @Test
+    fun `forSetupIntent - given repository returns null, results in internal error failure`() {
+        runTest {
+            // Given
+            val publishableKey = "publishable_key"
+            val clientSecret = "pi_1234_secret_5678"
+            givenVerifySetupIntentReturns { null }
+
+            // When
+            val result: Result<SetupIntent> = verifyWithMicrodeposit.forSetupIntent(
+                publishableKey,
+                clientSecret,
+                12,
+                34
+            )
+
+            // Then
+            verify(stripeRepository).verifySetupIntentWithMicrodeposits(
+                clientSecret = clientSecret,
+                firstAmount = 12,
+                secondAmount = 34,
+                requestOptions = ApiRequest.Options(publishableKey)
+            )
+            Truth.assertThat(result.exceptionOrNull()!!).isInstanceOf(InternalError::class.java)
+        }
+    }
+
+    @Test
+    fun `forSetupIntent - given repository throws exception, results in internal error failure`() {
+        runTest {
+            // Given
+            val publishableKey = "publishable_key"
+            val clientSecret = "pi_1234_secret_5678"
+            val expectedException = APIException()
+            givenVerifySetupIntentReturns { throw expectedException }
+
+            // When
+            val result: Result<SetupIntent> = verifyWithMicrodeposit.forSetupIntent(
+                publishableKey,
+                clientSecret,
+                12,
+                34
+            )
+
+            // Then
+            verify(stripeRepository).verifySetupIntentWithMicrodeposits(
+                clientSecret = clientSecret,
+                firstAmount = 12,
+                secondAmount = 34,
+                requestOptions = ApiRequest.Options(publishableKey)
+            )
+            Truth.assertThat(result.exceptionOrNull()!!).isEqualTo(expectedException)
+        }
+    }
+
+    private suspend fun givenVerifyPaymentIntentReturns(paymentIntent: () -> PaymentIntent?) {
+        whenever(
+            stripeRepository.verifyPaymentIntentWithMicrodeposits(
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        ).thenAnswer { paymentIntent() }
+        whenever(
+            stripeRepository.verifyPaymentIntentWithMicrodeposits(
+                any(),
+                any(),
+                any()
+            )
+        ).thenAnswer { paymentIntent() }
+    }
+
+    private suspend fun givenVerifySetupIntentReturns(setupIntent: () -> SetupIntent?) {
+        whenever(
+            stripeRepository.verifySetupIntentWithMicrodeposits(
+                any(),
+                any(),
+                any(),
+                any()
+            )
+        ).thenAnswer { setupIntent() }
+        whenever(
+            stripeRepository.verifySetupIntentWithMicrodeposits(
+                any(),
+                any(),
+                any()
+            )
+        ).thenAnswer { setupIntent() }
+    }
+}

--- a/stripe-test-e2e/src/test/java/com/stripe/android/test/e2e/CoroutineTestRule.kt
+++ b/stripe-test-e2e/src/test/java/com/stripe/android/test/e2e/CoroutineTestRule.kt
@@ -1,0 +1,27 @@
+package com.stripe.android.test.e2e
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@ExperimentalCoroutinesApi
+class CoroutineTestRule(
+    private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(TestCoroutineScheduler())
+) : TestWatcher() {
+
+    override fun starting(description: Description?) {
+        super.starting(description)
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description?) {
+        super.finished(description)
+        Dispatchers.resetMain()
+    }
+}

--- a/stripe-test-e2e/src/test/java/com/stripe/android/test/e2e/EndToEndTest.kt
+++ b/stripe-test-e2e/src/test/java/com/stripe/android/test/e2e/EndToEndTest.kt
@@ -4,20 +4,36 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiResultCallback
 import com.stripe.android.Stripe
+import com.stripe.android.StripeApiBeta
+import com.stripe.android.core.ApiVersion
+import com.stripe.android.core.exception.InvalidRequestException
 import com.stripe.android.model.CardParams
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
+import com.stripe.android.model.MandateDataParams
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.PaymentMethodOptionsParams
+import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.runner.RunWith
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
 import kotlin.test.Test
 
 @ExperimentalCoroutinesApi
 @RunWith(AndroidJUnit4::class)
 internal class EndToEndTest {
+    @get:Rule
+    var coroutinesTestRule = CoroutineTestRule()
+
     private val context = ApplicationProvider.getApplicationContext<Context>()
 
     private val settings: Settings by lazy {
@@ -47,7 +63,7 @@ internal class EndToEndTest {
                 ConfirmPaymentIntentParams
                     .createWithPaymentMethodCreateParams(
                         clientSecret = newPaymentIntent.clientSecret,
-                        paymentMethodCreateParams = PAYMENT_METHOD_CREATE_PARAMS
+                        paymentMethodCreateParams = CARD_PAYMENT_METHOD_CREATE_PARAMS
                     )
                     .withShouldUseStripeSdk(true)
             )
@@ -95,7 +111,7 @@ internal class EndToEndTest {
                 ConfirmPaymentIntentParams
                     .createWithPaymentMethodCreateParams(
                         clientSecret = newPaymentIntent.secret,
-                        paymentMethodCreateParams = PAYMENT_METHOD_CREATE_PARAMS
+                        paymentMethodCreateParams = CARD_PAYMENT_METHOD_CREATE_PARAMS
                     )
                     .withShouldUseStripeSdk(true)
             )
@@ -128,7 +144,7 @@ internal class EndToEndTest {
                 ConfirmSetupIntentParams
                     .create(
                         clientSecret = newPaymentIntent.secret,
-                        paymentMethodCreateParams = PAYMENT_METHOD_CREATE_PARAMS
+                        paymentMethodCreateParams = CARD_PAYMENT_METHOD_CREATE_PARAMS
                     )
                     .withShouldUseStripeSdk(true)
             )
@@ -138,13 +154,349 @@ internal class EndToEndTest {
             .isEqualTo(StripeIntent.Status.Succeeded)
     }
 
+    @Test
+    fun `test us_bank_account payment intent flow with amounts`() = runTest {
+        val stripe = Stripe(context, settings.publishableKey, betas = setOf(StripeApiBeta.USBankAccount))
+
+        // Create a PaymentIntent on the backend
+        val newPaymentIntent = service.createPaymentIntent(
+            Request.CreatePaymentIntentParams(
+                createParams = Request.CreateParams(
+                    paymentMethodTypes = listOf("us_bank_account")
+                ),
+                version = "${ApiVersion.API_VERSION_CODE};us_bank_account_beta=v2"
+            )
+        )
+
+        // Confirm the PaymentIntent with customers details collected from merchant app
+        val confirmedPaymentIntent = requireNotNull(
+            stripe.confirmPaymentIntentSynchronous(
+                ConfirmPaymentIntentParams
+                    .createWithPaymentMethodCreateParams(
+                        paymentMethodCreateParams = US_BANK_ACCOUNT_PAYMENT_METHOD_CREATE_PARAMS,
+                        clientSecret = newPaymentIntent.secret,
+                        paymentMethodOptions = PaymentMethodOptionsParams.USBankAccount(
+                            setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
+                        ),
+                        mandateData = MandateDataParams(MandateDataParams.Type.Online.DEFAULT)
+                    )
+            )
+        )
+
+        assertThat(confirmedPaymentIntent.amount)
+            .isEqualTo(100)
+        assertThat(confirmedPaymentIntent.currency)
+            .isEqualTo("usd")
+        assertThat(requireNotNull(confirmedPaymentIntent.status))
+            .isEqualTo(StripeIntent.Status.RequiresAction)
+        assertThat(requireNotNull(confirmedPaymentIntent.nextActionData))
+            .isInstanceOf(StripeIntent.NextActionData.VerifyWithMicrodeposits::class.java)
+        assertThat(requireNotNull(confirmedPaymentIntent.nextActionType))
+            .isEqualTo(StripeIntent.NextActionType.VerifyWithMicrodeposits)
+
+        // Verify the bank account
+        val verifiedPaymentIntent = suspendCoroutine<PaymentIntent> {
+            stripe.verifyPaymentIntentWithMicrodeposits(
+                clientSecret = confirmedPaymentIntent.clientSecret!!,
+                firstAmount = 32,
+                secondAmount = 45,
+                callback = object : ApiResultCallback<PaymentIntent> {
+                    override fun onSuccess(result: PaymentIntent) {
+                        it.resume(result)
+                    }
+
+                    override fun onError(e: Exception) {
+                        it.resumeWithException(e)
+                    }
+                }
+            )
+        }
+
+        assertThat(verifiedPaymentIntent.status)
+            .isEqualTo(StripeIntent.Status.Processing)
+    }
+
+    @Test(expected = InvalidRequestException::class)
+    fun `test us_bank_account payment intent flow with amounts fails`() = runTest {
+        val stripe = Stripe(context, settings.publishableKey, betas = setOf(StripeApiBeta.USBankAccount))
+
+        // Create a PaymentIntent on the backend
+        val newPaymentIntent = service.createPaymentIntent(
+            Request.CreatePaymentIntentParams(
+                createParams = Request.CreateParams(
+                    paymentMethodTypes = listOf("us_bank_account")
+                ),
+                version = "${ApiVersion.API_VERSION_CODE};us_bank_account_beta=v2"
+            )
+        )
+
+        // Confirm the PaymentIntent with customers details collected from merchant app
+        val confirmedPaymentIntent = requireNotNull(
+            stripe.confirmPaymentIntentSynchronous(
+                ConfirmPaymentIntentParams
+                    .createWithPaymentMethodCreateParams(
+                        paymentMethodCreateParams = US_BANK_ACCOUNT_PAYMENT_METHOD_CREATE_PARAMS,
+                        clientSecret = newPaymentIntent.secret,
+                        paymentMethodOptions = PaymentMethodOptionsParams.USBankAccount(
+                            setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
+                        ),
+                        mandateData = MandateDataParams(MandateDataParams.Type.Online.DEFAULT)
+                    )
+            )
+        )
+
+        // Verify the bank account with invalid request
+        suspendCoroutine<PaymentIntent> {
+            stripe.verifyPaymentIntentWithMicrodeposits(
+                clientSecret = confirmedPaymentIntent.clientSecret!!,
+                firstAmount = 10,
+                secondAmount = 11,
+                callback = object : ApiResultCallback<PaymentIntent> {
+                    override fun onSuccess(result: PaymentIntent) {
+                        it.resume(result)
+                    }
+
+                    override fun onError(e: Exception) {
+                        it.resumeWithException(e)
+                    }
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `test us_bank_account payment intent flow with desciptor code`() = runTest {
+        val stripe = Stripe(context, settings.publishableKey, betas = setOf(StripeApiBeta.USBankAccount))
+
+        // Create a PaymentIntent on the backend
+        val newPaymentIntent = service.createPaymentIntent(
+            Request.CreatePaymentIntentParams(
+                createParams = Request.CreateParams(
+                    paymentMethodTypes = listOf("us_bank_account")
+                ),
+                version = "${ApiVersion.API_VERSION_CODE};us_bank_account_beta=v2"
+            )
+        )
+
+        // Confirm the PaymentIntent with customers details collected from merchant app
+        val confirmedPaymentIntent = requireNotNull(
+            stripe.confirmPaymentIntentSynchronous(
+                ConfirmPaymentIntentParams
+                    .createWithPaymentMethodCreateParams(
+                        paymentMethodCreateParams = US_BANK_ACCOUNT_PAYMENT_METHOD_CREATE_PARAMS,
+                        clientSecret = newPaymentIntent.secret,
+                        paymentMethodOptions = PaymentMethodOptionsParams.USBankAccount(
+                            setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
+                        ),
+                        mandateData = MandateDataParams(MandateDataParams.Type.Online.DEFAULT)
+                    )
+            )
+        )
+
+        assertThat(confirmedPaymentIntent.amount)
+            .isEqualTo(100)
+        assertThat(confirmedPaymentIntent.currency)
+            .isEqualTo("usd")
+        assertThat(requireNotNull(confirmedPaymentIntent.status))
+            .isEqualTo(StripeIntent.Status.RequiresAction)
+        assertThat(requireNotNull(confirmedPaymentIntent.nextActionData))
+            .isInstanceOf(StripeIntent.NextActionData.VerifyWithMicrodeposits::class.java)
+        assertThat(requireNotNull(confirmedPaymentIntent.nextActionType))
+            .isEqualTo(StripeIntent.NextActionType.VerifyWithMicrodeposits)
+
+        // Verify the bank account
+        val verifiedPaymentIntent = suspendCoroutine<PaymentIntent> {
+            stripe.verifyPaymentIntentWithMicrodeposits(
+                clientSecret = confirmedPaymentIntent.clientSecret!!,
+                descriptorCode = "SM11AA",
+                callback = object : ApiResultCallback<PaymentIntent> {
+                    override fun onSuccess(result: PaymentIntent) {
+                        it.resume(result)
+                    }
+
+                    override fun onError(e: Exception) {
+                        it.resumeWithException(e)
+                    }
+                }
+            )
+        }
+
+        assertThat(verifiedPaymentIntent.status)
+            .isEqualTo(StripeIntent.Status.Processing)
+    }
+
+    @Test
+    fun `test us_bank_account setup intent flow with amounts`() = runTest {
+        val stripe = Stripe(context, settings.publishableKey, betas = setOf(StripeApiBeta.USBankAccount))
+
+        // Create a SetupIntent on the backend
+        val newPaymentIntent = service.createSetupIntent(
+            Request.CreateSetupIntentParams(
+                createParams = Request.CreateParams(
+                    paymentMethodTypes = listOf("us_bank_account")
+                ),
+                version = "${ApiVersion.API_VERSION_CODE};us_bank_account_beta=v2"
+            )
+        )
+
+        // Confirm the SetupIntent with customers details collected from merchant app
+        val confirmedSetupIntent = requireNotNull(
+            stripe.confirmSetupIntentSynchronous(
+                ConfirmSetupIntentParams
+                    .create(
+                        paymentMethodCreateParams = US_BANK_ACCOUNT_PAYMENT_METHOD_CREATE_PARAMS,
+                        clientSecret = newPaymentIntent.secret,
+                        mandateData = MandateDataParams(MandateDataParams.Type.Online.DEFAULT)
+                    )
+            )
+        )
+
+        assertThat(requireNotNull(confirmedSetupIntent.status))
+            .isEqualTo(StripeIntent.Status.RequiresAction)
+        assertThat(requireNotNull(confirmedSetupIntent.nextActionData))
+            .isInstanceOf(StripeIntent.NextActionData.VerifyWithMicrodeposits::class.java)
+        assertThat(requireNotNull(confirmedSetupIntent.nextActionType))
+            .isEqualTo(StripeIntent.NextActionType.VerifyWithMicrodeposits)
+
+        // Verify the bank account
+        val verifiedSetupIntent = suspendCoroutine<SetupIntent> {
+            stripe.verifySetupIntentWithMicrodeposits(
+                clientSecret = confirmedSetupIntent.clientSecret!!,
+                firstAmount = 32,
+                secondAmount = 45,
+                callback = object : ApiResultCallback<SetupIntent> {
+                    override fun onSuccess(result: SetupIntent) {
+                        it.resume(result)
+                    }
+
+                    override fun onError(e: Exception) {
+                        it.resumeWithException(e)
+                    }
+                }
+            )
+        }
+        assertThat(verifiedSetupIntent.status)
+            .isEqualTo(StripeIntent.Status.Succeeded)
+    }
+
+    @Test(expected = InvalidRequestException::class)
+    fun `test us_bank_account setup intent flow with amounts fails`() = runTest {
+        val stripe = Stripe(context, settings.publishableKey, betas = setOf(StripeApiBeta.USBankAccount))
+
+        // Create a SetupIntent on the backend
+        val newPaymentIntent = service.createSetupIntent(
+            Request.CreateSetupIntentParams(
+                createParams = Request.CreateParams(
+                    paymentMethodTypes = listOf("us_bank_account")
+                ),
+                version = "${ApiVersion.API_VERSION_CODE};us_bank_account_beta=v2"
+            )
+        )
+
+        // Confirm the SetupIntent with customers details collected from merchant app
+        val confirmedSetupIntent = requireNotNull(
+            stripe.confirmSetupIntentSynchronous(
+                ConfirmSetupIntentParams
+                    .create(
+                        paymentMethodCreateParams = US_BANK_ACCOUNT_PAYMENT_METHOD_CREATE_PARAMS,
+                        clientSecret = newPaymentIntent.secret,
+                        mandateData = MandateDataParams(MandateDataParams.Type.Online.DEFAULT)
+                    )
+            )
+        )
+
+        // Verify the bank account
+        suspendCoroutine<SetupIntent> {
+            stripe.verifySetupIntentWithMicrodeposits(
+                clientSecret = confirmedSetupIntent.clientSecret!!,
+                firstAmount = 10,
+                secondAmount = 11,
+                callback = object : ApiResultCallback<SetupIntent> {
+                    override fun onSuccess(result: SetupIntent) {
+                        it.resume(result)
+                    }
+
+                    override fun onError(e: Exception) {
+                        it.resumeWithException(e)
+                    }
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `test us_bank_account setup intent flow with descriptor code`() = runTest {
+        val stripe = Stripe(context, settings.publishableKey, betas = setOf(StripeApiBeta.USBankAccount))
+
+        // Create a SetupIntent on the backend
+        val newPaymentIntent = service.createSetupIntent(
+            Request.CreateSetupIntentParams(
+                createParams = Request.CreateParams(
+                    paymentMethodTypes = listOf("us_bank_account")
+                ),
+                version = "${ApiVersion.API_VERSION_CODE};us_bank_account_beta=v2"
+            )
+        )
+
+        // Confirm the SetupIntent with customers details collected from merchant app
+        val confirmedSetupIntent = requireNotNull(
+            stripe.confirmSetupIntentSynchronous(
+                ConfirmSetupIntentParams
+                    .create(
+                        paymentMethodCreateParams = US_BANK_ACCOUNT_PAYMENT_METHOD_CREATE_PARAMS,
+                        clientSecret = newPaymentIntent.secret,
+                        mandateData = MandateDataParams(MandateDataParams.Type.Online.DEFAULT)
+                    )
+            )
+        )
+
+        assertThat(requireNotNull(confirmedSetupIntent.status))
+            .isEqualTo(StripeIntent.Status.RequiresAction)
+        assertThat(requireNotNull(confirmedSetupIntent.nextActionData))
+            .isInstanceOf(StripeIntent.NextActionData.VerifyWithMicrodeposits::class.java)
+        assertThat(requireNotNull(confirmedSetupIntent.nextActionType))
+            .isEqualTo(StripeIntent.NextActionType.VerifyWithMicrodeposits)
+
+        // Verify the bank account
+        val verifiedSetupIntent = suspendCoroutine<SetupIntent> {
+            stripe.verifySetupIntentWithMicrodeposits(
+                clientSecret = confirmedSetupIntent.clientSecret!!,
+                descriptorCode = "SM11AA",
+                callback = object : ApiResultCallback<SetupIntent> {
+                    override fun onSuccess(result: SetupIntent) {
+                        it.resume(result)
+                    }
+
+                    override fun onError(e: Exception) {
+                        it.resumeWithException(e)
+                    }
+                }
+            )
+        }
+        assertThat(verifiedSetupIntent.status)
+            .isEqualTo(StripeIntent.Status.Succeeded)
+    }
+
     private companion object {
-        val PAYMENT_METHOD_CREATE_PARAMS = PaymentMethodCreateParams.createCard(
+        val CARD_PAYMENT_METHOD_CREATE_PARAMS = PaymentMethodCreateParams.createCard(
             CardParams(
                 number = "4242424242424242",
                 expMonth = 1,
                 expYear = 2025,
                 cvc = "123"
+            )
+        )
+
+        val US_BANK_ACCOUNT_PAYMENT_METHOD_CREATE_PARAMS = PaymentMethodCreateParams.create(
+            usBankAccount = PaymentMethodCreateParams.USBankAccount(
+                accountNumber = "000123456789",
+                routingNumber = "110000000",
+                accountType = PaymentMethod.USBankAccount.USBankAccountType.CHECKING,
+                accountHolderType = PaymentMethod.USBankAccount.USBankAccountHolderType.INDIVIDUAL
+            ),
+            billingDetails = PaymentMethod.BillingDetails(
+                name = "Jane Doe",
+                email = "jane+test_email@doe.com"
             )
         )
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Adds new public APIs to advance PaymentIntents and SetupIntents that are in `requires_action` with `next_action.type` == `verify_with_microdeposits` via entering two amounts or a descriptor code

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

ACHv2

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
