### PR TITLE
Fix json parsing for networks

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentMethodJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/PaymentMethodJsonParser.kt
@@ -263,12 +263,12 @@ class PaymentMethodJsonParser : ModelJsonParser<PaymentMethod> {
                 fingerprint = StripeJsonUtils.optString(json, FIELD_FINGERPRINT),
                 last4 = StripeJsonUtils.optString(json, FIELD_LAST4),
                 linkedAccount = StripeJsonUtils.optString(json, FIELD_LINKED_ACCOUNT),
-                networks = PaymentMethod.USBankAccount.USBankNetworks(
+                networks = if (json.has(FIELD_NETWORKS)) PaymentMethod.USBankAccount.USBankNetworks(
                     StripeJsonUtils.optString(json.optJSONObject(FIELD_NETWORKS), FIELD_NETWORKS_PREFERRED),
                     StripeJsonUtils.jsonArrayToList(
                         json.optJSONObject(FIELD_NETWORKS)?.getJSONArray(FIELD_NETWORKS_SUPPORTED)
                     ).orEmpty().map { it.toString() }
-                ),
+                ) else null,
                 routingNumber = StripeJsonUtils.optString(json, FIELD_ROUTING_NUMBER),
             )
         }

--- a/payments-core/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
@@ -123,10 +123,7 @@ internal class PaymentMethodEndToEndTest {
                 fingerprint = "FFDMA0xfhBjWSZLu",
                 last4 = "6789",
                 linkedAccount = null,
-                networks = PaymentMethod.USBankAccount.USBankNetworks(
-                    preferred = "ach",
-                    supported = listOf("ach", "us_domestic_wire")
-                ),
+                networks = null,
                 routingNumber = "110000000"
             )
         )


### PR DESCRIPTION
# Summary
Fix an issue with json parsing for us_bank_account payment method type networks.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified
