### PR TITLE
Adds `ConfirmIntentParams#create` entry for already attached payment methods.

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -1912,6 +1912,7 @@ public final class com/stripe/android/model/ConfirmPaymentIntentParams : com/str
 	public static final fun create (Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public static final fun create (Ljava/lang/String;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public static final fun create (Ljava/lang/String;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public static final fun create (Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Type;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public static final fun createAlipay (Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public static final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public static final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
@@ -1970,6 +1971,7 @@ public final class com/stripe/android/model/ConfirmPaymentIntentParams$Companion
 	public final fun create (Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public final fun create (Ljava/lang/String;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public final fun create (Ljava/lang/String;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
+	public final fun create (Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Type;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public static synthetic fun create$default (Lcom/stripe/android/model/ConfirmPaymentIntentParams$Companion;Ljava/lang/String;Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;ILjava/lang/Object;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public final fun createAlipay (Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
 	public final fun createWithPaymentMethodCreateParams (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmPaymentIntentParams;
@@ -2037,6 +2039,7 @@ public final class com/stripe/android/model/ConfirmSetupIntentParams : com/strip
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public static final fun create (Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Type;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public static final fun create (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
@@ -2063,6 +2066,7 @@ public final class com/stripe/android/model/ConfirmSetupIntentParams$Companion {
 	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
+	public final fun create (Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Type;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun create (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun create (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;)Lcom/stripe/android/model/ConfirmSetupIntentParams;
 	public final fun create (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/MandateDataParams;Ljava/lang/String;)Lcom/stripe/android/model/ConfirmSetupIntentParams;

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
@@ -321,6 +321,28 @@ data class ConfirmPaymentIntentParams internal constructor(
         private const val PARAM_SOURCE_ID = "source"
 
         /**
+         * Create the parameters necessary for confirming a [PaymentIntent] based on its [clientSecret]
+         * and [paymentMethodType]
+         *
+         * Use this initializer for PaymentIntents that already have a PaymentMethod attached.
+         *
+         * @param clientSecret client secret from the PaymentIntent that is to be confirmed
+         * @param paymentMethodType the known type of the PaymentIntent's attached PaymentMethod
+         */
+        @JvmStatic
+        fun create(
+            clientSecret: String,
+            paymentMethodType: PaymentMethod.Type
+        ): ConfirmPaymentIntentParams {
+            return ConfirmPaymentIntentParams(
+                clientSecret = clientSecret,
+                // infers default [MandateDataParams] based on the attached [paymentMethodType]
+                mandateData = MandateDataParams(MandateDataParams.Type.Online.DEFAULT)
+                    .takeIf { paymentMethodType.requiresMandate }
+            )
+        }
+
+        /**
          * Create a [ConfirmPaymentIntentParams] without a payment method.
          */
         @JvmOverloads

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
@@ -105,6 +105,29 @@ data class ConfirmSetupIntentParams internal constructor(
         }
 
     companion object {
+
+        /**
+         * Create the parameters necessary for confirming a [SetupIntent] based on its [clientSecret]
+         * and [paymentMethodType]
+         *
+         * Use this initializer for SetupIntents that already have a PaymentMethod attached.
+         *
+         * @param clientSecret client secret from the PaymentIntent that is to be confirmed
+         * @param paymentMethodType the known type of the SetupIntent's attached PaymentMethod
+         */
+        @JvmStatic
+        fun create(
+            clientSecret: String,
+            paymentMethodType: PaymentMethod.Type
+        ): ConfirmSetupIntentParams {
+            return ConfirmSetupIntentParams(
+                clientSecret = clientSecret,
+                // infers default [MandateDataParams] based on the attached [paymentMethodType]
+                mandateData = MandateDataParams(MandateDataParams.Type.Online.DEFAULT)
+                    .takeIf { paymentMethodType.requiresMandate }
+            )
+        }
+
         /**
          * Create the parameters necessary for confirming a SetupIntent, without specifying a payment method
          * to attach to the SetupIntent. Only use this if a payment method has already been attached

--- a/payments-core/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.kt
@@ -492,6 +492,44 @@ class ConfirmPaymentIntentParamsTest {
             )
     }
 
+    @Test
+    fun create_withAttachedPaymentMethodRequiringMandate_shouldIncludeDefaultMandateParams() {
+        val params = ConfirmPaymentIntentParams
+            .create(CLIENT_SECRET, PaymentMethod.Type.USBankAccount)
+            .toParamMap()
+
+        assertThat(params)
+            .isEqualTo(
+                mapOf(
+                    "client_secret" to CLIENT_SECRET,
+                    "use_stripe_sdk" to false,
+                    "mandate_data" to mapOf(
+                        "customer_acceptance" to mapOf(
+                            "type" to "online",
+                            "online" to mapOf(
+                                "infer_from_client" to true
+                            )
+                        )
+                    ),
+                )
+            )
+    }
+
+    @Test
+    fun create_withAttachedPaymentMethodNotRequiringMandate_shouldNotIncludeMandateParams() {
+        val params = ConfirmPaymentIntentParams
+            .create(CLIENT_SECRET, PaymentMethod.Type.Affirm)
+            .toParamMap()
+
+        assertThat(params)
+            .isEqualTo(
+                mapOf(
+                    "client_secret" to CLIENT_SECRET,
+                    "use_stripe_sdk" to false,
+                )
+            )
+    }
+
     private companion object {
         private const val CLIENT_SECRET = "pi_1CkiBMLENEVhOs7YMtUehLau_secret_s4O8SDh7s6spSmHDw1VaYPGZA"
 

--- a/payments-core/src/test/java/com/stripe/android/model/ConfirmSetupIntentParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ConfirmSetupIntentParamsTest.kt
@@ -176,6 +176,44 @@ class ConfirmSetupIntentParamsTest {
         )
     }
 
+    @Test
+    fun create_withAttachedPaymentMethodRequiringMandate_shouldIncludeDefaultMandateParams() {
+        val params = ConfirmSetupIntentParams
+            .create(CLIENT_SECRET, PaymentMethod.Type.USBankAccount)
+            .toParamMap()
+
+        assertThat(params)
+            .isEqualTo(
+                mapOf(
+                    "client_secret" to CLIENT_SECRET,
+                    "use_stripe_sdk" to false,
+                    "mandate_data" to mapOf(
+                        "customer_acceptance" to mapOf(
+                            "type" to "online",
+                            "online" to mapOf(
+                                "infer_from_client" to true
+                            )
+                        )
+                    ),
+                )
+            )
+    }
+
+    @Test
+    fun create_withAttachedPaymentMethodNotRequiringMandate_shouldNotIncludeMandateParams() {
+        val params = ConfirmSetupIntentParams
+            .create(CLIENT_SECRET, PaymentMethod.Type.Affirm)
+            .toParamMap()
+
+        assertThat(params)
+            .isEqualTo(
+                mapOf(
+                    "client_secret" to CLIENT_SECRET,
+                    "use_stripe_sdk" to false,
+                )
+            )
+    }
+
     private companion object {
         private const val CLIENT_SECRET = "seti_1CkiBMLENEVhOs7YMtUehLau_secret_sw1VaYPGZA"
     }


### PR DESCRIPTION
# Summary
- **Problem**: Since after collectBankAccountForPayment/Setup the Intent already has a PaymentMethod attached, the confirm params do not include `payment_method_data`, which means the SDK does not know what type of PaymentMethod is associated with this confirmation. This is an issue because we need to internally set the mandate_data field only for specific payment method types (including us_bank_account). This causes calls to confirm to fail.
- **Solution**: Add a new `create` function to `ConfirmPaymentIntentParams` and `ConfirmSetupIntentParams` specifically for Intents that already have a PaymentMethod attached that can indicate the PM type.

# Motivation
Find more context on the [API review](https://paper.dropbox.com/doc/2022-03-23-Payments-Connections-v2-Mobile-API-Review--BeVpEGcXEgkrQx6E1c9ijsgQAg-sjVrNSBLsVi84vCLURh48#:h2=Solution-to-3).

# Testing
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified
