### PR TITLE
use getLanguageTag for locale

### DIFF
--- a/stripe-core/src/main/java/com/stripe/android/core/networking/RequestHeadersFactory.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/RequestHeadersFactory.kt
@@ -47,8 +47,8 @@ sealed class RequestHeadersFactory {
 
         private val languageTag: String?
             get() {
-                return locale.toString().replace("_", "-")
-                    .takeIf { it.isNotBlank() }
+                return locale.toLanguageTag()
+                    .takeIf { it.isNotBlank() && it != UNDETERMINED_LANGUAGE }
             }
 
         override val userAgent: String
@@ -164,5 +164,7 @@ sealed class RequestHeadersFactory {
         ) = "Stripe/v1 $sdkVersion"
 
         val CHARSET: String = Charsets.UTF_8.name()
+
+        const val UNDETERMINED_LANGUAGE = "und"
     }
 }

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/RequestHeadersFactoriesTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/RequestHeadersFactoriesTest.kt
@@ -97,6 +97,21 @@ class RequestHeadersFactoriesTest {
             .isEqualTo("{name=MyAwesomePlugin, version=1.2.34, url=https://myawesomeplugin.info, partner_id=pp_partner_1234}")
     }
 
+    @Test
+    fun headers_withChineseSimplified_hasProperLanguageTag() {
+        val stripeAccount = "acct_123abc"
+        val headers = createBasePaymentApiHeaders(
+            locale = Locale.SIMPLIFIED_CHINESE,
+            options = ApiRequest.Options(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, stripeAccount)
+        )
+
+        assertThat(headers[HEADER_AUTHORIZATION])
+            .isEqualTo("Bearer ${ApiKeyFixtures.FAKE_PUBLISHABLE_KEY}")
+        assertThat(headers[HEADER_STRIPE_VERSION]).isEqualTo(ApiVersion.get().code)
+        assertThat(headers[HEADER_STRIPE_ACCOUNT]).isEqualTo(stripeAccount)
+        assertThat(headers[HEADER_ACCEPT_LANGUAGE]).isEqualTo("zh-CN")
+    }
+
     private fun createBasePaymentApiHeaders(
         locale: Locale = Locale.getDefault(),
         options: ApiRequest.Options = OPTIONS,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Use `getLanguageTag` instead of `toString` for the locale sent as request headers, as suggested by the [API doc](https://developer.android.com/reference/java/util/Locale#toString()).
This would make backend correctly parsing the language field.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Correct API requests

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
