### PR TITLE
[Identity][CardScan] Move callback from present to creation

### DIFF
--- a/identity-example/src/main/java/com/stripe/android/identity/example/MainActivity.kt
+++ b/identity-example/src/main/java/com/stripe/android/identity/example/MainActivity.kt
@@ -51,7 +51,13 @@ abstract class MainActivity : AppCompatActivity() {
                     // brandLogo = Uri.parse("https://path/to/a/logo.jpg")
                     brandLogo = logoUri
                 )
-            )
+            ) {
+                Snackbar.make(
+                    binding.root,
+                    "Verification result: $it",
+                    Snackbar.LENGTH_SHORT
+                ).show()
+            }
 
         binding.startVerification.setOnClickListener {
             binding.startVerification.isEnabled = false
@@ -100,9 +106,7 @@ abstract class MainActivity : AppCompatActivity() {
                                     identityVerificationSheet.present(
                                         verificationSessionId = it.verificationSessionId,
                                         ephemeralKeySecret = it.ephemeralKeySecret
-                                    ) { verificationResult ->
-                                        showSnackBar("Verification result: $verificationResult")
-                                    }
+                                    )
                                 }
                             } catch (t: Throwable) {
                                 showSnackBar("Fail to decode")

--- a/identity/api/identity.api
+++ b/identity/api/identity.api
@@ -35,7 +35,7 @@ public final class com/stripe/android/identity/IdentityVerificationSheet$Configu
 }
 
 public abstract interface class com/stripe/android/identity/IdentityVerificationSheet$IdentityVerificationCallback {
-	public abstract fun onVerificationResult (Lcom/stripe/android/identity/IdentityVerificationSheet$VerificationFlowResult;)V
+	public abstract fun onVerificationFlowResult (Lcom/stripe/android/identity/IdentityVerificationSheet$VerificationFlowResult;)V
 }
 
 public abstract class com/stripe/android/identity/IdentityVerificationSheet$VerificationFlowResult : android/os/Parcelable {

--- a/identity/api/identity.api
+++ b/identity/api/identity.api
@@ -15,12 +15,12 @@ public final class com/stripe/android/identity/IdentityActivity$inlined$sam$i$an
 
 public abstract interface class com/stripe/android/identity/IdentityVerificationSheet {
 	public static final field Companion Lcom/stripe/android/identity/IdentityVerificationSheet$Companion;
-	public abstract fun present (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun present (Ljava/lang/String;Ljava/lang/String;)V
 }
 
 public final class com/stripe/android/identity/IdentityVerificationSheet$Companion {
-	public final fun create (Landroidx/activity/ComponentActivity;Lcom/stripe/android/identity/IdentityVerificationSheet$Configuration;)Lcom/stripe/android/identity/IdentityVerificationSheet;
-	public final fun create (Landroidx/fragment/app/Fragment;Lcom/stripe/android/identity/IdentityVerificationSheet$Configuration;)Lcom/stripe/android/identity/IdentityVerificationSheet;
+	public final fun create (Landroidx/activity/ComponentActivity;Lcom/stripe/android/identity/IdentityVerificationSheet$Configuration;Lcom/stripe/android/identity/IdentityVerificationSheet$IdentityVerificationCallback;)Lcom/stripe/android/identity/IdentityVerificationSheet;
+	public final fun create (Landroidx/fragment/app/Fragment;Lcom/stripe/android/identity/IdentityVerificationSheet$Configuration;Lcom/stripe/android/identity/IdentityVerificationSheet$IdentityVerificationCallback;)Lcom/stripe/android/identity/IdentityVerificationSheet;
 }
 
 public final class com/stripe/android/identity/IdentityVerificationSheet$Configuration {
@@ -32,6 +32,10 @@ public final class com/stripe/android/identity/IdentityVerificationSheet$Configu
 	public final fun getBrandLogo ()Landroid/net/Uri;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/stripe/android/identity/IdentityVerificationSheet$IdentityVerificationCallback {
+	public abstract fun onVerificationResult (Lcom/stripe/android/identity/IdentityVerificationSheet$VerificationResult;)V
 }
 
 public abstract class com/stripe/android/identity/IdentityVerificationSheet$VerificationResult : android/os/Parcelable {

--- a/identity/api/identity.api
+++ b/identity/api/identity.api
@@ -35,28 +35,28 @@ public final class com/stripe/android/identity/IdentityVerificationSheet$Configu
 }
 
 public abstract interface class com/stripe/android/identity/IdentityVerificationSheet$IdentityVerificationCallback {
-	public abstract fun onVerificationResult (Lcom/stripe/android/identity/IdentityVerificationSheet$VerificationResult;)V
+	public abstract fun onVerificationResult (Lcom/stripe/android/identity/IdentityVerificationSheet$VerificationFlowResult;)V
 }
 
-public abstract class com/stripe/android/identity/IdentityVerificationSheet$VerificationResult : android/os/Parcelable {
+public abstract class com/stripe/android/identity/IdentityVerificationSheet$VerificationFlowResult : android/os/Parcelable {
 	public final synthetic fun toBundle ()Landroid/os/Bundle;
 }
 
-public final class com/stripe/android/identity/IdentityVerificationSheet$VerificationResult$Canceled : com/stripe/android/identity/IdentityVerificationSheet$VerificationResult {
+public final class com/stripe/android/identity/IdentityVerificationSheet$VerificationFlowResult$Canceled : com/stripe/android/identity/IdentityVerificationSheet$VerificationFlowResult {
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public static final field INSTANCE Lcom/stripe/android/identity/IdentityVerificationSheet$VerificationResult$Canceled;
+	public static final field INSTANCE Lcom/stripe/android/identity/IdentityVerificationSheet$VerificationFlowResult$Canceled;
 	public fun describeContents ()I
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public final class com/stripe/android/identity/IdentityVerificationSheet$VerificationResult$Completed : com/stripe/android/identity/IdentityVerificationSheet$VerificationResult {
+public final class com/stripe/android/identity/IdentityVerificationSheet$VerificationFlowResult$Completed : com/stripe/android/identity/IdentityVerificationSheet$VerificationFlowResult {
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public static final field INSTANCE Lcom/stripe/android/identity/IdentityVerificationSheet$VerificationResult$Completed;
+	public static final field INSTANCE Lcom/stripe/android/identity/IdentityVerificationSheet$VerificationFlowResult$Completed;
 	public fun describeContents ()I
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public final class com/stripe/android/identity/IdentityVerificationSheet$VerificationResult$Failed : com/stripe/android/identity/IdentityVerificationSheet$VerificationResult {
+public final class com/stripe/android/identity/IdentityVerificationSheet$VerificationFlowResult$Failed : com/stripe/android/identity/IdentityVerificationSheet$VerificationFlowResult {
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> (Ljava/lang/Throwable;)V
 	public fun describeContents ()I

--- a/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
@@ -14,7 +14,7 @@ import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupWithNavController
 import com.stripe.android.camera.CameraPermissionCheckingActivity
-import com.stripe.android.identity.IdentityVerificationSheet.VerificationResult
+import com.stripe.android.identity.IdentityVerificationSheet.VerificationFlowResult
 import com.stripe.android.identity.databinding.IdentityActivityBinding
 import com.stripe.android.identity.navigation.ErrorFragment
 import com.stripe.android.identity.navigation.IdentityFragmentFactory
@@ -120,7 +120,7 @@ internal class IdentityActivity : CameraPermissionCheckingActivity(), Verificati
         )
     }
 
-    override fun finishWithResult(result: VerificationResult) {
+    override fun finishWithResult(result: VerificationFlowResult) {
         setResult(
             Activity.RESULT_OK,
             Intent().putExtras(result.toBundle())

--- a/identity/src/main/java/com/stripe/android/identity/IdentityVerificationSheet.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityVerificationSheet.kt
@@ -65,7 +65,8 @@ interface IdentityVerificationSheet {
          * Creates a [IdentityVerificationSheet] instance with [ComponentActivity].
          *
          * This API registers an [ActivityResultLauncher] into the
-         * [ComponentActivity], it must be called before the [ComponentActivity]
+         * [ComponentActivity] and notifies its result to [identityVerificationCallback], it must
+         * be called before the [ComponentActivity]
          * is created (in the onCreate method).
          */
         fun create(
@@ -78,8 +79,9 @@ interface IdentityVerificationSheet {
         /**
          * Creates a [IdentityVerificationSheet] instance with [Fragment].
          *
-         * This API registers an [ActivityResultLauncher] into the [Fragment], it must be called
-         * before the [Fragment] is created (in the onCreate method).
+         * This API registers an [ActivityResultLauncher] into the [Fragment] and notifies its
+         * result to [identityVerificationCallback], it must be called before the [Fragment] is
+         * created (in the onCreate method).
          */
         fun create(
             from: Fragment,

--- a/identity/src/main/java/com/stripe/android/identity/IdentityVerificationSheet.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityVerificationSheet.kt
@@ -43,7 +43,7 @@ interface IdentityVerificationSheet {
 
             fun fromIntent(intent: Intent?): VerificationFlowResult {
                 return intent?.getParcelableExtra(EXTRA)
-                    ?: Failed(IllegalStateException("Failed to get VerificationResult from Intent"))
+                    ?: Failed(IllegalStateException("Failed to get VerificationFlowResult from Intent"))
             }
         }
     }
@@ -60,7 +60,7 @@ interface IdentityVerificationSheet {
      * Callback to notify when identity verification finishes and a result is available.
      */
     fun interface IdentityVerificationCallback {
-        fun onVerificationResult(result: VerificationFlowResult)
+        fun onVerificationFlowResult(result: VerificationFlowResult)
     }
 
     companion object {

--- a/identity/src/main/java/com/stripe/android/identity/IdentityVerificationSheet.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityVerificationSheet.kt
@@ -56,6 +56,9 @@ interface IdentityVerificationSheet {
         ephemeralKeySecret: String
     )
 
+    /**
+     * Callback to notify when identity verification finishes and a result is available.
+     */
     fun interface IdentityVerificationCallback {
         fun onVerificationResult(result: VerificationResult)
     }

--- a/identity/src/main/java/com/stripe/android/identity/IdentityVerificationSheet.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityVerificationSheet.kt
@@ -25,15 +25,15 @@ interface IdentityVerificationSheet {
     /**
      * Result of verification.
      */
-    sealed class VerificationResult : Parcelable {
+    sealed class VerificationFlowResult : Parcelable {
         @Parcelize
-        object Completed : VerificationResult()
+        object Completed : VerificationFlowResult()
 
         @Parcelize
-        object Canceled : VerificationResult()
+        object Canceled : VerificationFlowResult()
 
         @Parcelize
-        class Failed(val throwable: Throwable) : VerificationResult()
+        class Failed(val throwable: Throwable) : VerificationFlowResult()
 
         @JvmSynthetic
         fun toBundle() = bundleOf(EXTRA to this)
@@ -41,7 +41,7 @@ interface IdentityVerificationSheet {
         internal companion object {
             private const val EXTRA = "extra_args"
 
-            fun fromIntent(intent: Intent?): VerificationResult {
+            fun fromIntent(intent: Intent?): VerificationFlowResult {
                 return intent?.getParcelableExtra(EXTRA)
                     ?: Failed(IllegalStateException("Failed to get VerificationResult from Intent"))
             }
@@ -60,7 +60,7 @@ interface IdentityVerificationSheet {
      * Callback to notify when identity verification finishes and a result is available.
      */
     fun interface IdentityVerificationCallback {
-        fun onVerificationResult(result: VerificationResult)
+        fun onVerificationResult(result: VerificationFlowResult)
     }
 
     companion object {

--- a/identity/src/main/java/com/stripe/android/identity/IdentityVerificationSheet.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityVerificationSheet.kt
@@ -56,6 +56,10 @@ interface IdentityVerificationSheet {
         ephemeralKeySecret: String
     )
 
+    fun interface IdentityVerificationCallback {
+        fun onVerificationResult(result: VerificationResult)
+    }
+
     companion object {
         /**
          * Creates a [IdentityVerificationSheet] instance with [ComponentActivity].
@@ -67,9 +71,9 @@ interface IdentityVerificationSheet {
         fun create(
             from: ComponentActivity,
             configuration: Configuration,
-            onFinished: (verificationResult: VerificationResult) -> Unit
+            identityVerificationCallback: IdentityVerificationCallback
         ): IdentityVerificationSheet =
-            StripeIdentityVerificationSheet(from, configuration, onFinished)
+            StripeIdentityVerificationSheet(from, configuration, identityVerificationCallback)
 
         /**
          * Creates a [IdentityVerificationSheet] instance with [Fragment].
@@ -80,8 +84,8 @@ interface IdentityVerificationSheet {
         fun create(
             from: Fragment,
             configuration: Configuration,
-            onFinished: (verificationResult: VerificationResult) -> Unit
+            identityVerificationCallback: IdentityVerificationCallback
         ): IdentityVerificationSheet =
-            StripeIdentityVerificationSheet(from, configuration, onFinished)
+            StripeIdentityVerificationSheet(from, configuration, identityVerificationCallback)
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/IdentityVerificationSheet.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityVerificationSheet.kt
@@ -53,8 +53,7 @@ interface IdentityVerificationSheet {
      */
     fun present(
         verificationSessionId: String,
-        ephemeralKeySecret: String,
-        onFinished: (verificationResult: VerificationResult) -> Unit
+        ephemeralKeySecret: String
     )
 
     companion object {
@@ -68,7 +67,9 @@ interface IdentityVerificationSheet {
         fun create(
             from: ComponentActivity,
             configuration: Configuration,
-        ): IdentityVerificationSheet = StripeIdentityVerificationSheet(from, configuration)
+            onFinished: (verificationResult: VerificationResult) -> Unit
+        ): IdentityVerificationSheet =
+            StripeIdentityVerificationSheet(from, configuration, onFinished)
 
         /**
          * Creates a [IdentityVerificationSheet] instance with [Fragment].
@@ -79,6 +80,8 @@ interface IdentityVerificationSheet {
         fun create(
             from: Fragment,
             configuration: Configuration,
-        ): IdentityVerificationSheet = StripeIdentityVerificationSheet(from, configuration)
+            onFinished: (verificationResult: VerificationResult) -> Unit
+        ): IdentityVerificationSheet =
+            StripeIdentityVerificationSheet(from, configuration, onFinished)
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/IdentityVerificationSheetContract.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityVerificationSheetContract.kt
@@ -9,7 +9,7 @@ import androidx.core.os.bundleOf
 import kotlinx.parcelize.Parcelize
 
 internal class IdentityVerificationSheetContract :
-    ActivityResultContract<IdentityVerificationSheetContract.Args, IdentityVerificationSheet.VerificationResult>() {
+    ActivityResultContract<IdentityVerificationSheetContract.Args, IdentityVerificationSheet.VerificationFlowResult>() {
 
     @Parcelize
     internal data class Args(
@@ -38,7 +38,7 @@ internal class IdentityVerificationSheetContract :
     override fun parseResult(
         resultCode: Int,
         intent: Intent?
-    ): IdentityVerificationSheet.VerificationResult {
-        return IdentityVerificationSheet.VerificationResult.fromIntent(intent)
+    ): IdentityVerificationSheet.VerificationFlowResult {
+        return IdentityVerificationSheet.VerificationFlowResult.fromIntent(intent)
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/StripeIdentityVerificationSheet.kt
+++ b/identity/src/main/java/com/stripe/android/identity/StripeIdentityVerificationSheet.kt
@@ -8,25 +8,25 @@ import androidx.fragment.app.Fragment
 internal class StripeIdentityVerificationSheet private constructor(
     activityResultCaller: ActivityResultCaller,
     private val configuration: IdentityVerificationSheet.Configuration,
-    onFinished: (verificationResult: IdentityVerificationSheet.VerificationResult) -> Unit
+    identityVerificationCallback: IdentityVerificationSheet.IdentityVerificationCallback
 ) : IdentityVerificationSheet {
 
     constructor(
         from: ComponentActivity,
         configuration: IdentityVerificationSheet.Configuration,
-        onFinished: (verificationResult: IdentityVerificationSheet.VerificationResult) -> Unit
-    ) : this(from as ActivityResultCaller, configuration, onFinished)
+        identityVerificationCallback: IdentityVerificationSheet.IdentityVerificationCallback
+    ) : this(from as ActivityResultCaller, configuration, identityVerificationCallback)
 
     constructor(
         from: Fragment,
         configuration: IdentityVerificationSheet.Configuration,
-        onFinished: (verificationResult: IdentityVerificationSheet.VerificationResult) -> Unit
-    ) : this(from as ActivityResultCaller, configuration, onFinished)
+        identityVerificationCallback: IdentityVerificationSheet.IdentityVerificationCallback
+    ) : this(from as ActivityResultCaller, configuration, identityVerificationCallback)
 
     private val activityResultLauncher: ActivityResultLauncher<IdentityVerificationSheetContract.Args> =
         activityResultCaller.registerForActivityResult(
             IdentityVerificationSheetContract(),
-            onFinished
+            identityVerificationCallback::onVerificationResult
         )
 
     override fun present(

--- a/identity/src/main/java/com/stripe/android/identity/StripeIdentityVerificationSheet.kt
+++ b/identity/src/main/java/com/stripe/android/identity/StripeIdentityVerificationSheet.kt
@@ -26,7 +26,7 @@ internal class StripeIdentityVerificationSheet private constructor(
     private val activityResultLauncher: ActivityResultLauncher<IdentityVerificationSheetContract.Args> =
         activityResultCaller.registerForActivityResult(
             IdentityVerificationSheetContract(),
-            identityVerificationCallback::onVerificationResult
+            identityVerificationCallback::onVerificationFlowResult
         )
 
     override fun present(

--- a/identity/src/main/java/com/stripe/android/identity/StripeIdentityVerificationSheet.kt
+++ b/identity/src/main/java/com/stripe/android/identity/StripeIdentityVerificationSheet.kt
@@ -7,34 +7,32 @@ import androidx.fragment.app.Fragment
 
 internal class StripeIdentityVerificationSheet private constructor(
     activityResultCaller: ActivityResultCaller,
-    private val configuration: IdentityVerificationSheet.Configuration
+    private val configuration: IdentityVerificationSheet.Configuration,
+    onFinished: (verificationResult: IdentityVerificationSheet.VerificationResult) -> Unit
 ) : IdentityVerificationSheet {
 
     constructor(
         from: ComponentActivity,
-        configuration: IdentityVerificationSheet.Configuration
-    ) : this(from as ActivityResultCaller, configuration)
+        configuration: IdentityVerificationSheet.Configuration,
+        onFinished: (verificationResult: IdentityVerificationSheet.VerificationResult) -> Unit
+    ) : this(from as ActivityResultCaller, configuration, onFinished)
 
     constructor(
         from: Fragment,
-        configuration: IdentityVerificationSheet.Configuration
-    ) : this(from as ActivityResultCaller, configuration)
+        configuration: IdentityVerificationSheet.Configuration,
+        onFinished: (verificationResult: IdentityVerificationSheet.VerificationResult) -> Unit
+    ) : this(from as ActivityResultCaller, configuration, onFinished)
 
     private val activityResultLauncher: ActivityResultLauncher<IdentityVerificationSheetContract.Args> =
         activityResultCaller.registerForActivityResult(
             IdentityVerificationSheetContract(),
-            ::onResult
+            onFinished
         )
-
-    private var onFinished: ((verificationResult: IdentityVerificationSheet.VerificationResult) -> Unit)? =
-        null
 
     override fun present(
         verificationSessionId: String,
         ephemeralKeySecret: String,
-        onFinished: (verificationResult: IdentityVerificationSheet.VerificationResult) -> Unit
     ) {
-        this.onFinished = onFinished
         activityResultLauncher.launch(
             IdentityVerificationSheetContract.Args(
                 verificationSessionId,
@@ -42,11 +40,5 @@ internal class StripeIdentityVerificationSheet private constructor(
                 configuration.brandLogo
             )
         )
-    }
-
-    private fun onResult(verificationResult: IdentityVerificationSheet.VerificationResult) {
-        onFinished?.let {
-            it(verificationResult)
-        }
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/VerificationFlowFinishable.kt
+++ b/identity/src/main/java/com/stripe/android/identity/VerificationFlowFinishable.kt
@@ -4,5 +4,5 @@ package com.stripe.android.identity
  * An interface to indicate this class is able to finish verification flow with result.
  */
 internal fun interface VerificationFlowFinishable {
-    fun finishWithResult(result: IdentityVerificationSheet.VerificationResult)
+    fun finishWithResult(result: IdentityVerificationSheet.VerificationFlowResult)
 }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/ConfirmationFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ConfirmationFragment.kt
@@ -37,7 +37,7 @@ internal class ConfirmationFragment(
         binding = ConfirmationFragmentBinding.inflate(inflater, container, false)
         binding.kontinue.setOnClickListener {
             verificationFlowFinishable.finishWithResult(
-                IdentityVerificationSheet.VerificationResult.Completed
+                IdentityVerificationSheet.VerificationFlowResult.Completed
             )
         }
         return binding.root

--- a/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
@@ -49,7 +49,7 @@ internal class ConsentFragment(
             object : OnBackPressedCallback(true) {
                 override fun handleOnBackPressed() {
                     verificationFlowFinishable.finishWithResult(
-                        IdentityVerificationSheet.VerificationResult.Canceled
+                        IdentityVerificationSheet.VerificationFlowResult.Canceled
                     )
                 }
             }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/ErrorFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ErrorFragment.kt
@@ -8,7 +8,7 @@ import androidx.core.os.bundleOf
 import androidx.navigation.NavController
 import androidx.navigation.fragment.findNavController
 import com.stripe.android.identity.IdentityVerificationSheet
-import com.stripe.android.identity.IdentityVerificationSheet.VerificationResult.Failed
+import com.stripe.android.identity.IdentityVerificationSheet.VerificationFlowResult.Failed
 import com.stripe.android.identity.R
 import com.stripe.android.identity.VerificationFlowFinishable
 import com.stripe.android.identity.networking.models.VerificationPageDataRequirementError
@@ -102,7 +102,7 @@ internal class ErrorFragment(
         /**
          * Navigate to error fragment with failed reason. This would be the final destination of
          * verification flow, clicking back button would end the follow with
-         * [IdentityVerificationSheet.VerificationResult.Failed] with [failedReason].
+         * [IdentityVerificationSheet.VerificationFlowResult.Failed] with [failedReason].
          */
         fun NavController.navigateToErrorFragmentWithFailedReason(
             context: Context,

--- a/identity/src/test/java/com/stripe/android/identity/navigation/ConfirmationFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/ConfirmationFragmentTest.kt
@@ -85,7 +85,7 @@ class ConfirmationFragmentTest {
             binding.kontinue.callOnClick()
 
             verify(mockVerificationFlowFinishable).finishWithResult(
-                eq(IdentityVerificationSheet.VerificationResult.Completed)
+                eq(IdentityVerificationSheet.VerificationFlowResult.Completed)
             )
         }
     }

--- a/identity/src/test/java/com/stripe/android/identity/navigation/ErrorFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/ErrorFragmentTest.kt
@@ -7,7 +7,7 @@ import androidx.navigation.Navigation
 import androidx.navigation.testing.TestNavHostController
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.identity.IdentityVerificationSheet.VerificationResult
+import com.stripe.android.identity.IdentityVerificationSheet.VerificationFlowResult
 import com.stripe.android.identity.R
 import com.stripe.android.identity.VerificationFlowFinishable
 import com.stripe.android.identity.databinding.BaseErrorFragmentBinding
@@ -92,7 +92,7 @@ class ErrorFragmentTest {
             assertThat(binding.bottomButton.text).isEqualTo(TEST_GO_BACK_BUTTON_TEXT)
 
             binding.bottomButton.callOnClick()
-            val resultCaptor = argumentCaptor<VerificationResult.Failed>()
+            val resultCaptor = argumentCaptor<VerificationFlowResult.Failed>()
             verify(mockVerificationFlowFinishable).finishWithResult(
                 resultCaptor.capture()
             )

--- a/stripecardscan-example/src/main/java/com/stripe/android/stripecardscan/example/CardImageVerificationDemoActivity.kt
+++ b/stripecardscan-example/src/main/java/com/stripe/android/stripecardscan/example/CardImageVerificationDemoActivity.kt
@@ -36,7 +36,11 @@ class CardImageVerificationDemoActivity : AppCompatActivity() {
         setContentView(viewBinding.root)
 
         val cardImageVerificationSheet =
-            CardImageVerificationSheet.create(this, settings.publishableKey)
+            CardImageVerificationSheet.create(
+                this,
+                settings.publishableKey,
+                cardImageVerificationResultCallback = this::onScanFinished
+            )
 
         viewBinding.generateCivIntent.setOnClickListener {
             Fuel.post("${settings.backendUrl}/card-set/checkout")
@@ -97,8 +101,7 @@ class CardImageVerificationDemoActivity : AppCompatActivity() {
         viewBinding.launchScanButton.setOnClickListener {
             cardImageVerificationSheet.present(
                 viewBinding.civIdText.text.toString(),
-                viewBinding.civSecretText.text.toString(),
-                this::onScanFinished,
+                viewBinding.civSecretText.text.toString()
             )
         }
     }

--- a/stripecardscan-example/src/main/java/com/stripe/android/stripecardscan/example/CardScanDemoActivity.kt
+++ b/stripecardscan-example/src/main/java/com/stripe/android/stripecardscan/example/CardScanDemoActivity.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.stripecardscan.example
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 import com.stripe.android.stripecardscan.cardscan.CardScanSheet
 import com.stripe.android.stripecardscan.cardscan.CardScanSheetResult
 import com.stripe.android.stripecardscan.example.databinding.ActivityCardScanDemoBinding
@@ -17,10 +17,10 @@ class CardScanDemoActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(viewBinding.root)
 
-        val cardScanSheet = CardScanSheet.create(this, settings.publishableKey)
+        val cardScanSheet = CardScanSheet.create(this, settings.publishableKey, ::onScanFinished)
 
         viewBinding.launchScanButton.setOnClickListener {
-            cardScanSheet.present(this::onScanFinished)
+            cardScanSheet.present()
         }
     }
 

--- a/stripecardscan-example/src/main/java/com/stripe/android/stripecardscan/example/CardScanFragmentDemoActivity.kt
+++ b/stripecardscan-example/src/main/java/com/stripe/android/stripecardscan/example/CardScanFragmentDemoActivity.kt
@@ -20,7 +20,7 @@ class CardScanFragmentDemoActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(viewBinding.root)
 
-        cardScanSheet = CardScanSheet.create(this, settings.publishableKey)
+        cardScanSheet = CardScanSheet.create(this, settings.publishableKey, ::onScanFinished)
 
         viewBinding.launchScanButton.setOnClickListener {
             attachCardScanFragment()

--- a/stripecardscan/api/stripecardscan.api
+++ b/stripecardscan/api/stripecardscan.api
@@ -9,24 +9,28 @@ public final class com/stripe/android/stripecardscan/cardimageverification/CardI
 	public static final field $stable I
 	public static final field Companion Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public static final fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
-	public static final fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
-	public static final fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration;Landroidx/activity/result/ActivityResultRegistry;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
-	public static final fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
-	public static final fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
-	public static final fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration;Landroidx/activity/result/ActivityResultRegistry;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
-	public final fun present (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public static final fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$CardImageVerificationResultCallback;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
+	public static final fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$CardImageVerificationResultCallback;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
+	public static final fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$CardImageVerificationResultCallback;Landroidx/activity/result/ActivityResultRegistry;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
+	public static final fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$CardImageVerificationResultCallback;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
+	public static final fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$CardImageVerificationResultCallback;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
+	public static final fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$CardImageVerificationResultCallback;Landroidx/activity/result/ActivityResultRegistry;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
+	public final fun present (Ljava/lang/String;Ljava/lang/String;)V
+}
+
+public abstract interface class com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$CardImageVerificationResultCallback {
+	public abstract fun onCardImageVerificationSheetResult (Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheetResult;)V
 }
 
 public final class com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Companion {
-	public final fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
-	public final fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
-	public final fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration;Landroidx/activity/result/ActivityResultRegistry;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
-	public final fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
-	public final fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
-	public final fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration;Landroidx/activity/result/ActivityResultRegistry;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
-	public static synthetic fun create$default (Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Companion;Landroidx/activity/ComponentActivity;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration;Landroidx/activity/result/ActivityResultRegistry;ILjava/lang/Object;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
-	public static synthetic fun create$default (Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Companion;Landroidx/fragment/app/Fragment;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration;Landroidx/activity/result/ActivityResultRegistry;ILjava/lang/Object;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
+	public final fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$CardImageVerificationResultCallback;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
+	public final fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$CardImageVerificationResultCallback;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
+	public final fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$CardImageVerificationResultCallback;Landroidx/activity/result/ActivityResultRegistry;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
+	public final fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$CardImageVerificationResultCallback;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
+	public final fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$CardImageVerificationResultCallback;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
+	public final fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$CardImageVerificationResultCallback;Landroidx/activity/result/ActivityResultRegistry;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
+	public static synthetic fun create$default (Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Companion;Landroidx/activity/ComponentActivity;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$CardImageVerificationResultCallback;Landroidx/activity/result/ActivityResultRegistry;ILjava/lang/Object;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
+	public static synthetic fun create$default (Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Companion;Landroidx/fragment/app/Fragment;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration;Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$CardImageVerificationResultCallback;Landroidx/activity/result/ActivityResultRegistry;ILjava/lang/Object;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet;
 }
 
 public final class com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration : android/os/Parcelable {
@@ -107,12 +111,14 @@ public final class com/stripe/android/stripecardscan/cardimageverification/CardI
 public final class com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheetResult$Completed : com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheetResult {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (Lcom/stripe/android/stripecardscan/payment/card/ScannedCard;)V
-	public final fun component1 ()Lcom/stripe/android/stripecardscan/payment/card/ScannedCard;
-	public final fun copy (Lcom/stripe/android/stripecardscan/payment/card/ScannedCard;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheetResult$Completed;
-	public static synthetic fun copy$default (Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheetResult$Completed;Lcom/stripe/android/stripecardscan/payment/card/ScannedCard;ILjava/lang/Object;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheetResult$Completed;
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/stripecardscan/payment/card/ScannedCard;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/stripe/android/stripecardscan/payment/card/ScannedCard;
+	public final fun copy (Ljava/lang/String;Lcom/stripe/android/stripecardscan/payment/card/ScannedCard;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheetResult$Completed;
+	public static synthetic fun copy$default (Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheetResult$Completed;Ljava/lang/String;Lcom/stripe/android/stripecardscan/payment/card/ScannedCard;ILjava/lang/Object;)Lcom/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheetResult$Completed;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCardImageVerificationIntentId ()Ljava/lang/String;
 	public final fun getScannedCard ()Lcom/stripe/android/stripecardscan/payment/card/ScannedCard;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -190,8 +196,8 @@ public final class com/stripe/android/stripecardscan/cardscan/CardScanSheet {
 	public static final field Companion Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun attachCardScanFragment (Landroidx/lifecycle/LifecycleOwner;Landroidx/fragment/app/FragmentManager;ILkotlin/jvm/functions/Function1;)V
-	public static final fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet$CardScanResultCallback;)Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet;
-	public static final fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet$CardScanResultCallback;)Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet;
+	public static final fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet$CardScanResultCallback;Landroidx/activity/result/ActivityResultRegistry;)Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet;
+	public static final fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet$CardScanResultCallback;Landroidx/activity/result/ActivityResultRegistry;)Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet;
 	public final fun present ()V
 }
 
@@ -200,8 +206,10 @@ public abstract interface class com/stripe/android/stripecardscan/cardscan/CardS
 }
 
 public final class com/stripe/android/stripecardscan/cardscan/CardScanSheet$Companion {
-	public final fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet$CardScanResultCallback;)Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet;
-	public final fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet$CardScanResultCallback;)Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet;
+	public final fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet$CardScanResultCallback;Landroidx/activity/result/ActivityResultRegistry;)Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet;
+	public final fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet$CardScanResultCallback;Landroidx/activity/result/ActivityResultRegistry;)Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet;
+	public static synthetic fun create$default (Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet$Companion;Landroidx/activity/ComponentActivity;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet$CardScanResultCallback;Landroidx/activity/result/ActivityResultRegistry;ILjava/lang/Object;)Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet;
+	public static synthetic fun create$default (Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet$Companion;Landroidx/fragment/app/Fragment;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet$CardScanResultCallback;Landroidx/activity/result/ActivityResultRegistry;ILjava/lang/Object;)Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet;
 	public final fun removeCardScanFragment (Landroidx/fragment/app/FragmentManager;)V
 }
 

--- a/stripecardscan/api/stripecardscan.api
+++ b/stripecardscan/api/stripecardscan.api
@@ -190,14 +190,18 @@ public final class com/stripe/android/stripecardscan/cardscan/CardScanSheet {
 	public static final field Companion Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun attachCardScanFragment (Landroidx/lifecycle/LifecycleOwner;Landroidx/fragment/app/FragmentManager;ILkotlin/jvm/functions/Function1;)V
-	public static final fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;)Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet;
-	public static final fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;)Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet;
-	public final fun present (Lkotlin/jvm/functions/Function1;)V
+	public static final fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet$CardScanResultCallback;)Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet;
+	public static final fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet$CardScanResultCallback;)Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet;
+	public final fun present ()V
+}
+
+public abstract interface class com/stripe/android/stripecardscan/cardscan/CardScanSheet$CardScanResultCallback {
+	public abstract fun onCardScanSheetResult (Lcom/stripe/android/stripecardscan/cardscan/CardScanSheetResult;)V
 }
 
 public final class com/stripe/android/stripecardscan/cardscan/CardScanSheet$Companion {
-	public final fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;)Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet;
-	public final fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;)Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet;
+	public final fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet$CardScanResultCallback;)Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet;
+	public final fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet$CardScanResultCallback;)Lcom/stripe/android/stripecardscan/cardscan/CardScanSheet;
 	public final fun removeCardScanFragment (Landroidx/fragment/app/FragmentManager;)V
 }
 

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationActivity.kt
@@ -147,6 +147,7 @@ internal open class CardImageVerificationActivity :
                     .putExtra(
                         INTENT_PARAM_RESULT,
                         CardImageVerificationSheetResult.Completed(
+                            params.cardImageVerificationIntentId,
                             ScannedCard(
                                 pan = pan
                             )

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet.kt
@@ -123,11 +123,12 @@ class CardImageVerificationSheet private constructor(
                     from.registerForActivityResult(
                         activityResultContract,
                         registry,
-                        cardImageVerificationResultCallback::onCardImageVerificationSheetResult)
+                        cardImageVerificationResultCallback::onCardImageVerificationSheetResult,
+                    )
                 } else {
                     from.registerForActivityResult(
                         activityResultContract,
-                        cardImageVerificationResultCallback::onCardImageVerificationSheetResult
+                        cardImageVerificationResultCallback::onCardImageVerificationSheetResult,
                     )
                 }
             }

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet.kt
@@ -26,6 +26,7 @@ sealed interface CardImageVerificationSheetResult : Parcelable {
 
     @Parcelize
     data class Completed(
+        val cardImageVerificationIntentId: String,
         val scannedCard: ScannedCard,
     ) : CardImageVerificationSheetResult
 
@@ -66,8 +67,15 @@ class CardImageVerificationSheet private constructor(
         }
     }
 
-    private var onFinished:
-        ((cardImageVerificationSheetResult: CardImageVerificationSheetResult) -> Unit)? = null
+    /**
+     * Callback to notify when scanning finishes and a result is available.
+     */
+    fun interface CardImageVerificationResultCallback {
+        fun onCardImageVerificationSheetResult(
+            cardImageVerificationSheetResult: CardImageVerificationSheetResult
+        )
+    }
+
     private lateinit var launcher: ActivityResultLauncher<CardImageVerificationSheetParams>
 
     companion object {
@@ -84,13 +92,14 @@ class CardImageVerificationSheet private constructor(
             from: ComponentActivity,
             stripePublishableKey: String,
             config: Configuration = Configuration(),
+            cardImageVerificationResultCallback: CardImageVerificationResultCallback,
             registry: ActivityResultRegistry = from.activityResultRegistry,
         ) =
             CardImageVerificationSheet(stripePublishableKey, config).apply {
                 launcher = from.registerForActivityResult(
                     activityResultContract,
                     registry,
-                    ::onResult,
+                    cardImageVerificationResultCallback::onCardImageVerificationSheetResult,
                 )
             }
 
@@ -106,13 +115,20 @@ class CardImageVerificationSheet private constructor(
             from: Fragment,
             stripePublishableKey: String,
             config: Configuration = Configuration(),
+            cardImageVerificationResultCallback: CardImageVerificationResultCallback,
             registry: ActivityResultRegistry? = null,
         ) =
             CardImageVerificationSheet(stripePublishableKey, config).apply {
                 launcher = if (registry != null) {
-                    from.registerForActivityResult(activityResultContract, registry, ::onResult)
+                    from.registerForActivityResult(
+                        activityResultContract,
+                        registry,
+                        cardImageVerificationResultCallback::onCardImageVerificationSheetResult)
                 } else {
-                    from.registerForActivityResult(activityResultContract, ::onResult)
+                    from.registerForActivityResult(
+                        activityResultContract,
+                        cardImageVerificationResultCallback::onCardImageVerificationSheetResult
+                    )
                 }
             }
 
@@ -152,9 +168,7 @@ class CardImageVerificationSheet private constructor(
     fun present(
         cardImageVerificationIntentId: String,
         cardImageVerificationIntentSecret: String,
-        onFinished: (cardImageVerificationSheetResult: CardImageVerificationSheetResult) -> Unit,
     ) {
-        this.onFinished = onFinished
         launcher.launch(
             CardImageVerificationSheetParams(
                 stripePublishableKey = stripePublishableKey,
@@ -163,12 +177,5 @@ class CardImageVerificationSheet private constructor(
                 cardImageVerificationIntentSecret = cardImageVerificationIntentSecret,
             )
         )
-    }
-
-    /**
-     * When a result is available from the activity, call [onFinished] if it's available.
-     */
-    private fun onResult(cardImageVerificationSheetResult: CardImageVerificationSheetResult) {
-        onFinished?.let { it(cardImageVerificationSheetResult) }
     }
 }

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanSheet.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanSheet.kt
@@ -82,7 +82,8 @@ class CardScanSheet private constructor(private val stripePublishableKey: String
          */
         @JvmStatic
         fun create(
-            from: Fragment, stripePublishableKey: String,
+            from: Fragment,
+            stripePublishableKey: String,
             cardScanSheetResultCallback: CardScanResultCallback
         ) =
             CardScanSheet(stripePublishableKey).apply {

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanSheet.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanSheet.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Parcelable
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.ActivityResultRegistry
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.annotation.IdRes
 import androidx.core.os.bundleOf
@@ -64,12 +65,14 @@ class CardScanSheet private constructor(private val stripePublishableKey: String
         fun create(
             from: ComponentActivity,
             stripePublishableKey: String,
-            cardScanSheetResultCallback: CardScanResultCallback
+            cardScanSheetResultCallback: CardScanResultCallback,
+            registry: ActivityResultRegistry = from.activityResultRegistry,
         ) =
             CardScanSheet(stripePublishableKey).apply {
                 launcher = from.registerForActivityResult(
                     activityResultContract,
-                    cardScanSheetResultCallback::onCardScanSheetResult
+                    registry,
+                    cardScanSheetResultCallback::onCardScanSheetResult,
                 )
             }
 
@@ -84,13 +87,22 @@ class CardScanSheet private constructor(private val stripePublishableKey: String
         fun create(
             from: Fragment,
             stripePublishableKey: String,
-            cardScanSheetResultCallback: CardScanResultCallback
+            cardScanSheetResultCallback: CardScanResultCallback,
+            registry: ActivityResultRegistry? = null,
         ) =
             CardScanSheet(stripePublishableKey).apply {
-                launcher = from.registerForActivityResult(
-                    activityResultContract,
-                    cardScanSheetResultCallback::onCardScanSheetResult
-                )
+                launcher = if (registry != null) {
+                    from.registerForActivityResult(
+                        activityResultContract,
+                        registry,
+                        cardScanSheetResultCallback::onCardScanSheetResult
+                    )
+                } else {
+                    from.registerForActivityResult(
+                        activityResultContract,
+                        cardScanSheetResultCallback::onCardScanSheetResult
+                    )
+                }
             }
 
         private fun createIntent(context: Context, input: CardScanSheetParams) =

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanSheet.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanSheet.kt
@@ -95,12 +95,12 @@ class CardScanSheet private constructor(private val stripePublishableKey: String
                     from.registerForActivityResult(
                         activityResultContract,
                         registry,
-                        cardScanSheetResultCallback::onCardScanSheetResult
+                        cardScanSheetResultCallback::onCardScanSheetResult,
                     )
                 } else {
                     from.registerForActivityResult(
                         activityResultContract,
-                        cardScanSheetResultCallback::onCardScanSheetResult
+                        cardScanSheetResultCallback::onCardScanSheetResult,
                     )
                 }
             }

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanSheet.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanSheet.kt
@@ -43,9 +43,11 @@ private const val CARD_SCAN_FRAGMENT_TAG = "CardScanFragmentTag"
 
 class CardScanSheet private constructor(private val stripePublishableKey: String) {
 
-    private var onFinished:
-        ((cardImageVerificationSheetResult: CardScanSheetResult) -> Unit)? = null
     private lateinit var launcher: ActivityResultLauncher<CardScanSheetParams>
+
+    fun interface CardScanResultCallback {
+        fun onCardScanSheetResult(cardScanSheetResult: CardScanSheetResult)
+    }
 
     companion object {
         /**
@@ -56,9 +58,16 @@ class CardScanSheet private constructor(private val stripePublishableKey: String
          * is created (in the onCreate method).
          */
         @JvmStatic
-        fun create(from: ComponentActivity, stripePublishableKey: String) =
+        fun create(
+            from: ComponentActivity,
+            stripePublishableKey: String,
+            cardScanSheetResultCallback: CardScanResultCallback
+        ) =
             CardScanSheet(stripePublishableKey).apply {
-                launcher = from.registerForActivityResult(activityResultContract, ::onResult)
+                launcher = from.registerForActivityResult(
+                    activityResultContract,
+                    cardScanSheetResultCallback::onCardScanSheetResult
+                )
             }
 
         /**
@@ -68,9 +77,15 @@ class CardScanSheet private constructor(private val stripePublishableKey: String
          * before the [Fragment] is created (in the onCreate method).
          */
         @JvmStatic
-        fun create(from: Fragment, stripePublishableKey: String) =
+        fun create(
+            from: Fragment, stripePublishableKey: String,
+            cardScanSheetResultCallback: CardScanResultCallback
+        ) =
             CardScanSheet(stripePublishableKey).apply {
-                launcher = from.registerForActivityResult(activityResultContract, ::onResult)
+                launcher = from.registerForActivityResult(
+                    activityResultContract,
+                    cardScanSheetResultCallback::onCardScanSheetResult
+                )
             }
 
         private fun createIntent(context: Context, input: CardScanSheetParams) =
@@ -118,22 +133,12 @@ class CardScanSheet private constructor(private val stripePublishableKey: String
      * The ID and Secret are created from this server-server request:
      * https://paper.dropbox.com/doc/Bouncer-Web-API-Review--BTOclListnApWjHdpv4DoaOuAg-Wy0HGlL0XfwAOz9hHuzS1#:h2=Creating-a-CardImageVerificati
      */
-    fun present(
-        onFinished: (cardScanSheetResult: CardScanSheetResult) -> Unit,
-    ) {
-        this.onFinished = onFinished
+    fun present() {
         launcher.launch(
             CardScanSheetParams(
                 stripePublishableKey = stripePublishableKey
             )
         )
-    }
-
-    /**
-     * When a result is available from the activity, call [onFinished] if it's available.
-     */
-    private fun onResult(cardScanSheetResult: CardScanSheetResult) {
-        onFinished?.let { it(cardScanSheetResult) }
     }
 
     /**

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanSheet.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanSheet.kt
@@ -45,6 +45,9 @@ class CardScanSheet private constructor(private val stripePublishableKey: String
 
     private lateinit var launcher: ActivityResultLauncher<CardScanSheetParams>
 
+    /**
+     * Callback to notify when scanning finishes and a result is available.
+     */
     fun interface CardScanResultCallback {
         fun onCardScanSheetResult(cardScanSheetResult: CardScanSheetResult)
     }

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanSheet.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanSheet.kt
@@ -54,8 +54,8 @@ class CardScanSheet private constructor(private val stripePublishableKey: String
          * Create a [CardScanSheet] instance with [ComponentActivity].
          *
          * This API registers an [ActivityResultLauncher] into the
-         * [ComponentActivity], it must be called before the [ComponentActivity]
-         * is created (in the onCreate method).
+         * [ComponentActivity] and notifies its result to [cardScanSheetResultCallback], it must be
+         * called before the [ComponentActivity] is created (in the onCreate method).
          */
         @JvmStatic
         fun create(
@@ -73,8 +73,9 @@ class CardScanSheet private constructor(private val stripePublishableKey: String
         /**
          * Create a [CardScanSheet] instance with [Fragment].
          *
-         * This API registers an [ActivityResultLauncher] into the [Fragment], it must be called
-         * before the [Fragment] is created (in the onCreate method).
+         * This API registers an [ActivityResultLauncher] into the [Fragment] and notifies its
+         * result to [cardScanSheetResultCallback], it must be called before the [Fragment] is
+         * created (in the onCreate method).
          */
         @JvmStatic
         fun create(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* The result callback needs to be registered during creation so that they gets re-registered when hosting activity is recreated.
* Please see [this](https://jira.corp.stripe.com/browse/IDPROD-3587) internal ticket for more details

* Note: this is a breaking API change and would require a major version bump

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Recovers Identity/CardScan's state when hosting activity is destroyed.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
