### PR TITLE
[ACH] Connects create LAS and attach usecases to VM

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -9,3 +9,7 @@ ext.buildLibs = [
 ext.configs = [
         androidLibrary: "${project.rootDir}/build-configuration/android-library.gradle",
 ]
+
+ext.testLibs = [
+        turbine: "app.cash.turbine:turbine:0.7.0"
+]

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -4971,6 +4971,30 @@ public final class com/stripe/android/payments/SetupIntentFlowResultProcessor_Fa
 	public static fun newInstance (Landroid/content/Context;Lkotlin/jvm/functions/Function0;Lcom/stripe/android/networking/StripeRepository;Lcom/stripe/android/core/Logger;Lkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/payments/SetupIntentFlowResultProcessor;
 }
 
+public abstract class com/stripe/android/payments/bankaccount/CollectBankAccountConfiguration : android/os/Parcelable {
+	public static final field $stable I
+}
+
+public final class com/stripe/android/payments/bankaccount/CollectBankAccountConfiguration$USBankAccount : com/stripe/android/payments/bankaccount/CollectBankAccountConfiguration, android/os/Parcelable {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/payments/bankaccount/CollectBankAccountConfiguration$USBankAccount;
+	public static synthetic fun copy$default (Lcom/stripe/android/payments/bankaccount/CollectBankAccountConfiguration$USBankAccount;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/payments/bankaccount/CollectBankAccountConfiguration$USBankAccount;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEmail ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public abstract interface class com/stripe/android/payments/bankaccount/CollectBankAccountLauncher {
+}
+
 public final class com/stripe/android/payments/bankaccount/di/CollectBankAccountModule_ProvidePublishableKeyFactory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;)V
 	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/payments/bankaccount/di/CollectBankAccountModule_ProvidePublishableKeyFactory;
@@ -5028,13 +5052,13 @@ public final class com/stripe/android/payments/bankaccount/domain/CreateLinkAcco
 public final class com/stripe/android/payments/bankaccount/navigation/CollectBankAccountResponse : com/stripe/android/core/model/StripeModel {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/payments/bankaccount/navigation/CollectBankAccountResponse;
-	public static synthetic fun copy$default (Lcom/stripe/android/payments/bankaccount/navigation/CollectBankAccountResponse;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/payments/bankaccount/navigation/CollectBankAccountResponse;
+	public fun <init> (Lcom/stripe/android/model/StripeIntent;)V
+	public final fun component1 ()Lcom/stripe/android/model/StripeIntent;
+	public final fun copy (Lcom/stripe/android/model/StripeIntent;)Lcom/stripe/android/payments/bankaccount/navigation/CollectBankAccountResponse;
+	public static synthetic fun copy$default (Lcom/stripe/android/payments/bankaccount/navigation/CollectBankAccountResponse;Lcom/stripe/android/model/StripeIntent;ILjava/lang/Object;)Lcom/stripe/android/payments/bankaccount/navigation/CollectBankAccountResponse;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getClientSecret ()Ljava/lang/String;
+	public final fun getIntent ()Lcom/stripe/android/model/StripeIntent;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
@@ -5083,11 +5107,11 @@ public final class com/stripe/android/payments/bankaccount/navigation/CollectBan
 }
 
 public final class com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel_Factory;
 	public fun get ()Lcom/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/payments/bankaccount/navigation/CollectBankAccountContract$Args;Lcom/stripe/android/payments/bankaccount/domain/CreateLinkAccountSession;Lcom/stripe/android/payments/bankaccount/domain/AttachLinkAccountSession;Lcom/stripe/android/core/Logger;)Lcom/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel;
+	public static fun newInstance (Lcom/stripe/android/payments/bankaccount/navigation/CollectBankAccountContract$Args;Lkotlinx/coroutines/flow/MutableSharedFlow;Lcom/stripe/android/payments/bankaccount/domain/CreateLinkAccountSession;Lcom/stripe/android/payments/bankaccount/domain/AttachLinkAccountSession;Lcom/stripe/android/core/Logger;)Lcom/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel;
 }
 
 public final class com/stripe/android/payments/core/ActivityResultLauncherHost$DefaultImpls {

--- a/payments-core/build.gradle
+++ b/payments-core/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     testImplementation "com.google.truth:truth:$truthVersion"
     testImplementation "androidx.arch.core:core-testing:$androidxArchCoreVersion"
     testImplementation "androidx.fragment:fragment-testing:$androidxFragmentVersion"
+    testImplementation testLibs.turbine
 
     androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
     androidTestImplementation "androidx.test:rules:$androidTestVersion"

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountLauncher.kt
@@ -1,0 +1,15 @@
+package com.stripe.android.payments.bankaccount
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+// TODO coming in a different PR.
+interface CollectBankAccountLauncher
+
+sealed class CollectBankAccountConfiguration : Parcelable {
+    @Parcelize
+    data class USBankAccount(
+        val name: String,
+        val email: String?
+    ) : Parcelable, CollectBankAccountConfiguration()
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/di/CollectBankAccountComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/di/CollectBankAccountComponent.kt
@@ -4,10 +4,12 @@ import android.app.Application
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.core.injection.LoggingModule
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountContract
+import com.stripe.android.payments.bankaccount.ui.CollectBankAccountViewEffect
 import com.stripe.android.payments.bankaccount.ui.CollectBankAccountViewModel
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import dagger.BindsInstance
 import dagger.Component
+import kotlinx.coroutines.flow.MutableSharedFlow
 import javax.inject.Singleton
 
 @Singleton
@@ -28,6 +30,9 @@ internal interface CollectBankAccountComponent {
     interface Builder {
         @BindsInstance
         fun application(application: Application): Builder
+
+        @BindsInstance
+        fun viewEffect(application: MutableSharedFlow<CollectBankAccountViewEffect>): Builder
 
         @BindsInstance
         fun configuration(configuration: CollectBankAccountContract.Args): Builder

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/domain/AttachLinkAccountSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/domain/AttachLinkAccountSession.kt
@@ -14,13 +14,13 @@ internal class AttachLinkAccountSession @Inject constructor(
      * Attaches a LinkedAccountSession to a given PaymentIntent,
      * using the [linkedAccountSessionId] and the intent [clientSecret].
      *
-     * @return whether the operation succeeded or not.
+     * @return [PaymentIntent] with attached linkedAccount.
      */
     suspend fun forPaymentIntent(
         publishableKey: String,
         linkedAccountSessionId: String,
         clientSecret: String,
-    ): Result<Unit> = kotlin.runCatching {
+    ): Result<PaymentIntent> = kotlin.runCatching {
         stripeRepository.attachLinkAccountSessionToPaymentIntent(
             linkAccountSessionId = linkedAccountSessionId,
             clientSecret = clientSecret,
@@ -33,13 +33,13 @@ internal class AttachLinkAccountSession @Inject constructor(
      * Attaches a LinkedAccountSession to a given PaymentIntent,
      * using the [linkedAccountSessionId] and the intent [clientSecret].
      *
-     * @return whether the operation succeeded or not.
+     * @return [SetupIntent] with attached linkedAccount.
      */
     suspend fun forSetupIntent(
         publishableKey: String,
         linkedAccountSessionId: String,
         clientSecret: String,
-    ): Result<Unit> = kotlin.runCatching {
+    ): Result<SetupIntent> = kotlin.runCatching {
         stripeRepository.attachLinkAccountSessionToSetupIntent(
             linkAccountSessionId = linkedAccountSessionId,
             clientSecret = clientSecret,

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/navigation/CollectBankAccountContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/navigation/CollectBankAccountContract.kt
@@ -7,6 +7,7 @@ import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.annotation.VisibleForTesting
 import androidx.core.os.bundleOf
+import com.stripe.android.payments.bankaccount.CollectBankAccountConfiguration
 import com.stripe.android.payments.bankaccount.ui.CollectBankAccountActivity
 import kotlinx.parcelize.Parcelize
 
@@ -34,6 +35,7 @@ internal class CollectBankAccountContract :
     sealed class Args(
         open val publishableKey: String,
         open val clientSecret: String,
+        open val configuration: CollectBankAccountConfiguration,
     ) : Parcelable {
         fun toBundle() = bundleOf(EXTRA_ARGS to this)
 
@@ -41,13 +43,15 @@ internal class CollectBankAccountContract :
         data class ForPaymentIntent internal constructor(
             override val publishableKey: String,
             override val clientSecret: String,
-        ) : Args(publishableKey, clientSecret)
+            override val configuration: CollectBankAccountConfiguration,
+        ) : Args(publishableKey, clientSecret, configuration)
 
         @Parcelize
         data class ForSetupIntent internal constructor(
             override val publishableKey: String,
             override val clientSecret: String,
-        ) : Args(publishableKey, clientSecret)
+            override val configuration: CollectBankAccountConfiguration,
+        ) : Args(publishableKey, clientSecret, configuration)
 
         companion object {
             fun fromIntent(intent: Intent): Args? {

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/navigation/CollectBankAccountResult.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/navigation/CollectBankAccountResult.kt
@@ -2,6 +2,7 @@ package com.stripe.android.payments.bankaccount.navigation
 
 import android.os.Parcelable
 import com.stripe.android.core.model.StripeModel
+import com.stripe.android.model.StripeIntent
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -25,5 +26,5 @@ sealed class CollectBankAccountResult : Parcelable {
 
 @Parcelize
 data class CollectBankAccountResponse(
-    val clientSecret: String
+    val intent: StripeIntent
 ) : StripeModel

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountActivity.kt
@@ -1,11 +1,15 @@
 package com.stripe.android.payments.bankaccount.ui
 
+import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountContract
+import com.stripe.android.payments.bankaccount.ui.CollectBankAccountViewEffect.FinishWithResult
+import com.stripe.android.payments.bankaccount.ui.CollectBankAccountViewEffect.OpenConnectionsFlow
 
 /**
  * No-UI activity that will handle collect bank account logic.
@@ -29,8 +33,27 @@ internal class CollectBankAccountActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         lifecycleScope.launchWhenStarted {
-            // TODO(carlosmuvi) observe and handle view effects.
-            viewModel.viewEffect.collect {}
+            viewModel.viewEffect.collect { viewEffect ->
+                when (viewEffect) {
+                    is OpenConnectionsFlow -> viewEffect.launch()
+                    is FinishWithResult -> viewEffect.launch()
+                }
+            }
         }
+    }
+
+    private fun OpenConnectionsFlow.launch() {
+        // TODO@carlosmuvi open connections flow and wait for result instead.
+        viewModel.onConnectionsResult("resulting_linked_account_session")
+    }
+
+    private fun FinishWithResult.launch() {
+        setResult(
+            Activity.RESULT_OK,
+            Intent().putExtras(
+                CollectBankAccountContract.Result(result).toBundle()
+            )
+        )
+        finish()
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel.kt
@@ -96,17 +96,14 @@ internal class CollectBankAccountViewModel @Inject constructor(
                     publishableKey = args.publishableKey,
                     clientSecret = args.clientSecret,
                     linkedAccountSessionId = linkedAccountSessionId
-                ).mapCatching {
-                    Completed(CollectBankAccountResponse(it))
-                }
+                )
                 is ForSetupIntent -> attachLinkAccountSession.forSetupIntent(
                     publishableKey = args.publishableKey,
                     clientSecret = args.clientSecret,
                     linkedAccountSessionId = linkedAccountSessionId
-                ).mapCatching {
-                    Completed(CollectBankAccountResponse(it))
-                }
+                )
             }
+                .mapCatching { Completed(CollectBankAccountResponse(it)) }
                 .onSuccess { result: Completed ->
                     logger.debug("Bank account session attached to  intent!!")
                     finishWithResult(result)

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel.kt
@@ -8,24 +8,33 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.savedstate.SavedStateRegistryOwner
 import com.stripe.android.core.Logger
+import com.stripe.android.payments.bankaccount.CollectBankAccountConfiguration
 import com.stripe.android.payments.bankaccount.di.DaggerCollectBankAccountComponent
 import com.stripe.android.payments.bankaccount.domain.AttachLinkAccountSession
 import com.stripe.android.payments.bankaccount.domain.CreateLinkAccountSession
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountContract
+import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountContract.Args.ForPaymentIntent
+import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountContract.Args.ForSetupIntent
+import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResponse
+import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResult
+import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResult.Completed
+import com.stripe.android.payments.bankaccount.ui.CollectBankAccountViewEffect.OpenConnectionsFlow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-@Suppress("UnusedPrivateMember")
+@Suppress("ConstructorParameterNaming")
 internal class CollectBankAccountViewModel @Inject constructor(
+    // bound instances
     private val args: CollectBankAccountContract.Args,
+    private val _viewEffect: MutableSharedFlow<CollectBankAccountViewEffect>,
+    // injected instances
     private val createLinkAccountSession: CreateLinkAccountSession,
     private val attachLinkAccountSession: AttachLinkAccountSession,
     private val logger: Logger
 ) : ViewModel() {
 
-    private val _viewEffect = MutableSharedFlow<CollectBankAccountViewEffect>()
     val viewEffect: SharedFlow<CollectBankAccountViewEffect> = _viewEffect
 
     init {
@@ -35,7 +44,80 @@ internal class CollectBankAccountViewModel @Inject constructor(
     }
 
     private suspend fun createLinkAccountSession() {
-        // TODO@Carlos call createLinkAccountSession
+        when (val configuration = args.configuration) {
+            is CollectBankAccountConfiguration.USBankAccount -> when (args) {
+                is ForPaymentIntent -> createLinkAccountSession.forPaymentIntent(
+                    publishableKey = args.publishableKey,
+                    clientSecret = args.clientSecret,
+                    customerName = configuration.name,
+                    customerEmail = configuration.email
+                )
+                is ForSetupIntent -> createLinkAccountSession.forSetupIntent(
+                    publishableKey = args.publishableKey,
+                    clientSecret = args.clientSecret,
+                    customerName = configuration.name,
+                    customerEmail = configuration.email
+                )
+            }
+                .mapCatching { requireNotNull(it.clientSecret) }
+                .onSuccess { linkedAccountSessionSecret: String ->
+                    logger.debug("Bank account session created! $linkedAccountSessionSecret.")
+                    _viewEffect.emit(
+                        OpenConnectionsFlow(
+                            linkedAccountSessionClientSecret = linkedAccountSessionSecret,
+                            publishableKey = args.publishableKey
+                        )
+                    )
+                }
+                .onFailure { finishWithError(it) }
+        }
+    }
+
+    fun onConnectionsResult(linkedAccountSessionId: String) {
+        // viewModelScope.launch {
+        //     when (result) {
+        //         is Canceled -> finishWithResult(CollectBankAccountResult.Cancelled)
+        //         is Failed -> finishWithError(result.error)
+        //         is Completed -> attachLinkAccountSessionToIntent(result.linkAccountSession.id)
+        //     }
+        // }
+        // TODO handle connections flow result and attach linkAccountSessionId when succeeded.
+        attachLinkAccountSessionToIntent(linkedAccountSessionId)
+    }
+
+    private suspend fun finishWithResult(result: CollectBankAccountResult) {
+        _viewEffect.emit(CollectBankAccountViewEffect.FinishWithResult(result))
+    }
+
+    private fun attachLinkAccountSessionToIntent(linkedAccountSessionId: String) {
+        viewModelScope.launch {
+            when (args) {
+                is ForPaymentIntent -> attachLinkAccountSession.forPaymentIntent(
+                    publishableKey = args.publishableKey,
+                    clientSecret = args.clientSecret,
+                    linkedAccountSessionId = linkedAccountSessionId
+                ).mapCatching {
+                    Completed(CollectBankAccountResponse(it))
+                }
+                is ForSetupIntent -> attachLinkAccountSession.forSetupIntent(
+                    publishableKey = args.publishableKey,
+                    clientSecret = args.clientSecret,
+                    linkedAccountSessionId = linkedAccountSessionId
+                ).mapCatching {
+                    Completed(CollectBankAccountResponse(it))
+                }
+            }
+                .onSuccess { result: Completed ->
+                    logger.debug("Bank account session attached to  intent!!")
+                    finishWithResult(result)
+                }
+                .onFailure { finishWithError(it) }
+        }
+    }
+
+    private suspend fun finishWithError(throwable: Throwable) {
+        logger.error("Error", Exception(throwable))
+        finishWithResult(CollectBankAccountResult.Failed(throwable))
     }
 
     class Factory(
@@ -46,13 +128,14 @@ internal class CollectBankAccountViewModel @Inject constructor(
     ) : AbstractSavedStateViewModelFactory(owner, defaultArgs) {
 
         @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel?> create(
+        override fun <T : ViewModel> create(
             key: String,
             modelClass: Class<T>,
             savedStateHandle: SavedStateHandle
         ): T {
             return DaggerCollectBankAccountComponent.builder()
                 .application(applicationSupplier())
+                .viewEffect(MutableSharedFlow())
                 .configuration(argsSupplier()).build()
                 .viewModel as T
         }

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/domain/AttachLinkAccountSessionTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/domain/AttachLinkAccountSessionTest.kt
@@ -35,7 +35,7 @@ class AttachLinkAccountSessionTest {
             givenAttachPaymentIntentReturns { paymentIntent }
 
             // When
-            val result: Result<Unit> = attachLinkAccountSession.forPaymentIntent(
+            val result: Result<PaymentIntent> = attachLinkAccountSession.forPaymentIntent(
                 publishableKey,
                 linkedAccountSessionId,
                 clientSecret
@@ -48,7 +48,7 @@ class AttachLinkAccountSessionTest {
                 linkAccountSessionId = linkedAccountSessionId,
                 requestOptions = ApiRequest.Options(publishableKey)
             )
-            assertThat((result)).isEqualTo(Result.success(Unit))
+            assertThat((result)).isEqualTo(Result.success(paymentIntent))
         }
     }
 
@@ -62,7 +62,7 @@ class AttachLinkAccountSessionTest {
             givenAttachPaymentIntentReturns { null }
 
             // When
-            val result: Result<Unit> = attachLinkAccountSession.forPaymentIntent(
+            val result: Result<PaymentIntent> = attachLinkAccountSession.forPaymentIntent(
                 publishableKey,
                 linkedAccountSessionId,
                 clientSecret
@@ -90,7 +90,7 @@ class AttachLinkAccountSessionTest {
             givenAttachPaymentIntentReturns { throw expectedException }
 
             // When
-            val result: Result<Unit> = attachLinkAccountSession.forPaymentIntent(
+            val result: Result<PaymentIntent> = attachLinkAccountSession.forPaymentIntent(
                 publishableKey,
                 linkedAccountSessionId,
                 clientSecret
@@ -118,7 +118,7 @@ class AttachLinkAccountSessionTest {
             givenAttachPaymentIntentReturns { paymentIntent }
 
             // When
-            val result: Result<Unit> = attachLinkAccountSession.forPaymentIntent(
+            val result: Result<PaymentIntent> = attachLinkAccountSession.forPaymentIntent(
                 publishableKey,
                 linkedAccountSessionId,
                 clientSecret
@@ -136,13 +136,13 @@ class AttachLinkAccountSessionTest {
             val publishableKey = "publishable_key"
             val linkedAccountSessionId = "session_id"
             val clientSecret = "seti_1234_secret_5678"
-            val resultSetupIntent = mock<SetupIntent> {
+            val setupIntent = mock<SetupIntent> {
                 on { this.clientSecret } doReturn clientSecret
             }
-            givenAttachSetupIntentReturns { resultSetupIntent }
+            givenAttachSetupIntentReturns { setupIntent }
 
             // When
-            val result: Result<Unit> = attachLinkAccountSession.forSetupIntent(
+            val result: Result<SetupIntent> = attachLinkAccountSession.forSetupIntent(
                 publishableKey,
                 linkedAccountSessionId,
                 clientSecret
@@ -155,7 +155,7 @@ class AttachLinkAccountSessionTest {
                 linkAccountSessionId = linkedAccountSessionId,
                 requestOptions = ApiRequest.Options(publishableKey)
             )
-            assertThat((result)).isEqualTo(Result.success(Unit))
+            assertThat((result)).isEqualTo(Result.success(setupIntent))
         }
     }
 
@@ -169,7 +169,7 @@ class AttachLinkAccountSessionTest {
             givenAttachSetupIntentReturns { null }
 
             // When
-            val setupIntent: Result<Unit> = attachLinkAccountSession.forSetupIntent(
+            val setupIntent: Result<SetupIntent> = attachLinkAccountSession.forSetupIntent(
                 publishableKey,
                 linkedAccountSessionId,
                 clientSecret
@@ -197,7 +197,7 @@ class AttachLinkAccountSessionTest {
             givenAttachSetupIntentReturns { throw expectedException }
 
             // When
-            val setupIntent: Result<Unit> = attachLinkAccountSession.forSetupIntent(
+            val setupIntent: Result<SetupIntent> = attachLinkAccountSession.forSetupIntent(
                 publishableKey,
                 linkedAccountSessionId,
                 clientSecret
@@ -225,7 +225,7 @@ class AttachLinkAccountSessionTest {
             givenAttachSetupIntentReturns { resultSetupIntent }
 
             // When
-            val setupIntent: Result<Unit> = attachLinkAccountSession.forSetupIntent(
+            val setupIntent: Result<SetupIntent> = attachLinkAccountSession.forSetupIntent(
                 publishableKey,
                 linkedAccountSessionId,
                 clientSecret

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
@@ -64,7 +64,6 @@ class CollectBankAccountViewModelTest {
         }
     }
 
-
     @Test
     fun `init - when createLinkAccountSession succeeds for SI, opens connection flow`() = runTest {
         val viewEffect = MutableSharedFlow<CollectBankAccountViewEffect>()

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
@@ -1,0 +1,165 @@
+package com.stripe.android.payments.bankaccount.ui
+
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.Logger
+import com.stripe.android.model.BankConnectionsLinkedAccountSession
+import com.stripe.android.payments.bankaccount.CollectBankAccountConfiguration
+import com.stripe.android.payments.bankaccount.domain.AttachLinkAccountSession
+import com.stripe.android.payments.bankaccount.domain.CreateLinkAccountSession
+import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountContract
+import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountContract.Args.ForPaymentIntent
+import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountContract.Args.ForSetupIntent
+import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResult.Failed
+import com.stripe.android.payments.bankaccount.ui.CollectBankAccountViewEffect.FinishWithResult
+import com.stripe.android.payments.bankaccount.ui.CollectBankAccountViewEffect.OpenConnectionsFlow
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.stub
+import org.robolectric.RobolectricTestRunner
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class CollectBankAccountViewModelTest {
+
+    private val createLinkAccountSession: CreateLinkAccountSession = mock()
+    private val attachLinkAccountSession: AttachLinkAccountSession = mock()
+
+    private val publishableKey = "publishable_key"
+    private val clientSecret = "client_secret"
+    private val name = "name"
+    private val email = "email"
+    private val linkedAccountSession = BankConnectionsLinkedAccountSession(
+        clientSecret = "las_client_secret",
+        id = "las_id"
+    )
+
+    @Test
+    fun `init - when createLinkAccountSession succeeds for PI, opens connection flow`() = runTest {
+        val viewEffect = MutableSharedFlow<CollectBankAccountViewEffect>()
+        viewEffect.test {
+            // Given
+            givenCreateAccountSessionForPaymentIntentReturns(Result.success(linkedAccountSession))
+
+            // When
+            buildViewModel(viewEffect, paymentIntentConfiguration())
+
+            // Then
+            assertThat(awaitItem()).isEqualTo(
+                OpenConnectionsFlow(
+                    publishableKey,
+                    linkedAccountSession.clientSecret!!
+                )
+            )
+        }
+    }
+
+
+    @Test
+    fun `init - when createLinkAccountSession succeeds for SI, opens connection flow`() = runTest {
+        val viewEffect = MutableSharedFlow<CollectBankAccountViewEffect>()
+        viewEffect.test {
+            // Given
+            givenCreateAccountSessionForSetupIntentReturns(Result.success(linkedAccountSession))
+
+            // When
+            buildViewModel(viewEffect, setupIntentConfiguration())
+
+            // Then
+            assertThat(awaitItem()).isEqualTo(
+                OpenConnectionsFlow(
+                    publishableKey,
+                    linkedAccountSession.clientSecret!!
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `init - when createLinkAccountSession fails, opens connection flow`() = runTest {
+        val viewEffect = MutableSharedFlow<CollectBankAccountViewEffect>()
+        viewEffect.test {
+            // Given
+            val expectedException = Exception("Random error")
+            givenCreateAccountSessionForPaymentIntentReturns(Result.failure(expectedException))
+
+            // When
+            buildViewModel(viewEffect, paymentIntentConfiguration())
+
+            // Then
+            assertThat(awaitItem()).isEqualTo(
+                FinishWithResult(
+                    Failed(expectedException)
+                )
+            )
+        }
+    }
+
+    private fun givenCreateAccountSessionForPaymentIntentReturns(
+        result: Result<BankConnectionsLinkedAccountSession>
+    ) {
+        createLinkAccountSession.stub {
+            onBlocking {
+                forPaymentIntent(
+                    publishableKey = publishableKey,
+                    clientSecret = clientSecret,
+                    customerName = name,
+                    customerEmail = email
+                )
+            }.doReturn(result)
+        }
+    }
+
+    private fun givenCreateAccountSessionForSetupIntentReturns(
+        result: Result<BankConnectionsLinkedAccountSession>
+    ) {
+        createLinkAccountSession.stub {
+            onBlocking {
+                forSetupIntent(
+                    publishableKey = publishableKey,
+                    clientSecret = clientSecret,
+                    customerName = name,
+                    customerEmail = email
+                )
+            }.doReturn(result)
+        }
+    }
+
+    private fun buildViewModel(
+        viewEffect: MutableSharedFlow<CollectBankAccountViewEffect>,
+        configuration: CollectBankAccountContract.Args
+    ) = CollectBankAccountViewModel(
+        args = configuration,
+        createLinkAccountSession = createLinkAccountSession,
+        attachLinkAccountSession = attachLinkAccountSession,
+        logger = Logger.noop(),
+        _viewEffect = viewEffect
+    )
+
+    private fun paymentIntentConfiguration(): ForPaymentIntent {
+        return ForPaymentIntent(
+            publishableKey = publishableKey,
+            clientSecret = clientSecret,
+            configuration = CollectBankAccountConfiguration.USBankAccount(
+                name,
+                email
+            )
+        )
+    }
+
+    private fun setupIntentConfiguration(): ForSetupIntent {
+        return ForSetupIntent(
+            publishableKey = publishableKey,
+            clientSecret = clientSecret,
+            configuration = CollectBankAccountConfiguration.USBankAccount(
+                name,
+                email
+            )
+        )
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
@@ -116,6 +116,7 @@ class CollectBankAccountViewModelTest {
             // When
             val viewModel = buildViewModel(viewEffect, paymentIntentConfiguration())
             viewModel.onConnectionsResult(linkedAccountSessionId)
+
             // Then
             assertThat(expectMostRecentItem()).isEqualTo(
                 FinishWithResult(
@@ -137,6 +138,7 @@ class CollectBankAccountViewModelTest {
             // When
             val viewModel = buildViewModel(viewEffect, setupIntentConfiguration())
             viewModel.onConnectionsResult(linkedAccountSessionId)
+
             // Then
             assertThat(expectMostRecentItem()).isEqualTo(
                 FinishWithResult(
@@ -158,6 +160,7 @@ class CollectBankAccountViewModelTest {
             // When
             val viewModel = buildViewModel(viewEffect, setupIntentConfiguration())
             viewModel.onConnectionsResult(linkedAccountSessionId)
+
             // Then
             assertThat(expectMostRecentItem()).isEqualTo(
                 FinishWithResult(


### PR DESCRIPTION
# Summary
- Creates link account session when viewmodel initializes
- attaches link account session to PI / SI when the connection flow succeeds (untestable manually yet)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified
