### PR TITLE
[Identity] Use applicationID as the file provider authoritiy

### DIFF
--- a/identity/api/identity.api
+++ b/identity/api/identity.api
@@ -5,6 +5,14 @@ public final class com/stripe/android/identity/BuildConfig {
 	public fun <init> ()V
 }
 
+public final class com/stripe/android/identity/IdentityActivity$inlined$sam$i$androidx_navigation_ui_AppBarConfiguration_OnNavigateUpListener$0 : androidx/navigation/ui/AppBarConfiguration$OnNavigateUpListener, kotlin/jvm/internal/FunctionAdapter {
+	public fun <init> (Lkotlin/jvm/functions/Function0;)V
+	public final fun equals (Ljava/lang/Object;)Z
+	public final fun getFunctionDelegate ()Lkotlin/Function;
+	public final fun hashCode ()I
+	public final synthetic fun onNavigateUp ()Z
+}
+
 public abstract interface class com/stripe/android/identity/IdentityVerificationSheet {
 	public static final field Companion Lcom/stripe/android/identity/IdentityVerificationSheet$Companion;
 	public abstract fun present (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
@@ -166,6 +174,7 @@ public final class com/stripe/android/identity/databinding/GetLocalImageDialogBi
 
 public final class com/stripe/android/identity/databinding/IdentityActivityBinding : androidx/viewbinding/ViewBinding {
 	public final field identityNavHost Landroidx/fragment/app/FragmentContainerView;
+	public final field topAppBar Lcom/google/android/material/appbar/MaterialToolbar;
 	public static fun bind (Landroid/view/View;)Lcom/stripe/android/identity/databinding/IdentityActivityBinding;
 	public synthetic fun getRoot ()Landroid/view/View;
 	public fun getRoot ()Landroidx/constraintlayout/widget/ConstraintLayout;

--- a/identity/api/identity.api
+++ b/identity/api/identity.api
@@ -166,7 +166,6 @@ public final class com/stripe/android/identity/databinding/GetLocalImageDialogBi
 
 public final class com/stripe/android/identity/databinding/IdentityActivityBinding : androidx/viewbinding/ViewBinding {
 	public final field identityNavHost Landroidx/fragment/app/FragmentContainerView;
-	public final field topAppBar Lcom/google/android/material/appbar/MaterialToolbar;
 	public static fun bind (Landroid/view/View;)Lcom/stripe/android/identity/databinding/IdentityActivityBinding;
 	public synthetic fun getRoot ()Landroid/view/View;
 	public fun getRoot ()Landroidx/constraintlayout/widget/ConstraintLayout;

--- a/identity/res/layout/identity_activity.xml
+++ b/identity/res/layout/identity_activity.xml
@@ -4,6 +4,16 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/top_app_bar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        android:layout_width="0dp"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintBottom_toTopOf="@id/identity_nav_host"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/identity_nav_host"
         android:name="androidx.navigation.fragment.NavHostFragment"
@@ -12,5 +22,6 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@id/top_app_bar" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/identity/res/layout/identity_activity.xml
+++ b/identity/res/layout/identity_activity.xml
@@ -4,16 +4,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <com.google.android.material.appbar.MaterialToolbar
-        android:id="@+id/top_app_bar"
-        style="@style/Widget.MaterialComponents.Toolbar.Primary"
-        android:layout_width="0dp"
-        android:layout_height="?attr/actionBarSize"
-        app:layout_constraintBottom_toTopOf="@id/identity_nav_host"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/identity_nav_host"
         android:name="androidx.navigation.fragment.NavHostFragment"
@@ -22,6 +12,5 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/top_app_bar" />
-
+        app:layout_constraintTop_toTopOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/identity/src/main/AndroidManifest.xml
+++ b/identity/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
 
         <provider
             android:name="androidx.core.content.FileProvider"
-            android:authorities="com.stripe.android.identity.fileprovider"
+            android:authorities="${applicationId}.fileprovider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data

--- a/identity/src/main/AndroidManifest.xml
+++ b/identity/src/main/AndroidManifest.xml
@@ -7,7 +7,6 @@
     <application>
         <activity
             android:name=".IdentityActivity"
-            android:theme="@style/Theme.MaterialComponents.DayNight.NoActionBar"
             android:screenOrientation="portrait"
             android:configChanges="orientation|keyboardHidden"
             android:exported="false" />

--- a/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
@@ -3,17 +3,20 @@ package com.stripe.android.identity
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.NavController
-import androidx.navigation.findNavController
+import androidx.navigation.NavDestination
 import androidx.navigation.fragment.NavHostFragment
-import androidx.navigation.ui.setupActionBarWithNavController
+import androidx.navigation.ui.AppBarConfiguration
+import androidx.navigation.ui.setupWithNavController
 import com.stripe.android.camera.CameraPermissionCheckingActivity
 import com.stripe.android.identity.IdentityVerificationSheet.VerificationResult
 import com.stripe.android.identity.databinding.IdentityActivityBinding
+import com.stripe.android.identity.navigation.ErrorFragment
 import com.stripe.android.identity.navigation.IdentityFragmentFactory
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 
@@ -51,34 +54,70 @@ internal class IdentityActivity : CameraPermissionCheckingActivity(), Verificati
     @VisibleForTesting
     internal val identityViewModel: IdentityViewModel by viewModels { viewModelFactory }
 
+    private val onBackPressedCallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            navController.navigateUp()
+        }
+    }
+
+    private fun isConsentFragment(destination: NavDestination) =
+        destination.id == R.id.consentFragment
+
+    private fun isErrorFragmentWithFinalDestination(
+        destination: NavDestination,
+        args: Bundle?
+    ) = destination.id == R.id.errorFragment &&
+        args?.containsKey(ErrorFragment.ARG_FAILED_REASON) == true
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
         supportFragmentManager.fragmentFactory = identityFragmentFactory
-
-        navController =
-            (supportFragmentManager.findFragmentById(R.id.identity_nav_host) as NavHostFragment).navController
-        navController.setGraph(R.navigation.identity_nav_graph)
-        navController.addOnDestinationChangedListener { _, _, _ ->
-            title = "" // clear title on each screen
-        }
-        setupActionBarWithNavController(navController)
-
+        setUpNavigationController()
         identityViewModel.retrieveAndBufferVerificationPage()
     }
 
-    override fun onBackPressed() {
-        findNavController(R.id.identity_nav_host).let { navController ->
-            if (navController.currentDestination?.id == R.id.consentFragment) {
-                finishWithResult(VerificationResult.Canceled)
-            } else {
-                navController.navigateUp()
-            }
-        }
-    }
+    private fun setUpNavigationController() {
+        // hide supportActionBar and use the customized ToolBar to configure NavController.
+        // supportActionBar is unreliable as it might be null if host app uses a NoActionBar theme.
+        supportActionBar?.hide()
 
-    override fun onSupportNavigateUp(): Boolean {
-        return navController.navigateUp() || super.onSupportNavigateUp()
+        navController =
+            (supportFragmentManager.findFragmentById(R.id.identity_nav_host) as NavHostFragment).navController
+
+        navController.setGraph(R.navigation.identity_nav_graph)
+
+        onBackPressedDispatcher.addCallback(onBackPressedCallback)
+        navController.addOnDestinationChangedListener { _, destination, args ->
+            // By default clicking back is the same as clicking navigate up.
+            // When currently destination is ConsentFragment or ErrorFragment, the back press
+            // behavior will be handled in the Fragment itself.
+            onBackPressedCallback.isEnabled =
+                !isConsentFragment(destination) &&
+                !isErrorFragmentWithFinalDestination(destination, args)
+        }
+        binding.topAppBar.setupWithNavController(
+            navController,
+            AppBarConfiguration(
+                // navController.navigateUp() won't work on the two fragments because -
+                //  consentFragment - it's the very first fragment of the navigation graph
+                //  errorFragment - it's sometimes triggered by an error that needs to terminate
+                //    verification flow(e.g incorrect network response). navigateUp would re-trigger
+                //    the same error and let navController re-navigate to the errorFragment,
+                //    creating a endless loop.
+                //
+                // Since we can't override the behavior of navController.navigateUp(), when
+                // navigationDestination is on these two fragment, disable the up button to
+                // prevent navController.navigateUp() being called.
+                //
+                // Note: system back button can be still pressed on these two fragments, they have
+                // corresponding logic to end verification flow in different ways.
+                topLevelDestinationIds = setOf(
+                    R.id.consentFragment,
+                    R.id.errorFragment
+                )
+            )
+        )
     }
 
     override fun finishWithResult(result: VerificationResult) {

--- a/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
@@ -63,7 +63,7 @@ internal class IdentityActivity : CameraPermissionCheckingActivity(), Verificati
     private fun isConsentFragment(destination: NavDestination) =
         destination.id == R.id.consentFragment
 
-    private fun isErrorFragmentWithFinalDestination(
+    private fun isErrorFragmentWithFailedReason(
         destination: NavDestination,
         args: Bundle?
     ) = destination.id == R.id.errorFragment &&
@@ -94,7 +94,7 @@ internal class IdentityActivity : CameraPermissionCheckingActivity(), Verificati
             // behavior will be handled in the Fragment itself.
             onBackPressedCallback.isEnabled =
                 !isConsentFragment(destination) &&
-                !isErrorFragmentWithFinalDestination(destination, args)
+                !isErrorFragmentWithFailedReason(destination, args)
         }
         binding.topAppBar.setupWithNavController(
             navController,

--- a/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
@@ -54,9 +54,6 @@ internal class IdentityActivity : CameraPermissionCheckingActivity(), Verificati
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
-
-        setSupportActionBar(binding.topAppBar)
-
         supportFragmentManager.fragmentFactory = identityFragmentFactory
 
         navController =

--- a/identity/src/main/java/com/stripe/android/identity/navigation/ErrorFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ErrorFragment.kt
@@ -2,18 +2,23 @@ package com.stripe.android.identity.navigation
 
 import android.content.Context
 import android.view.View
+import androidx.activity.OnBackPressedCallback
 import androidx.annotation.IdRes
 import androidx.core.os.bundleOf
 import androidx.navigation.NavController
 import androidx.navigation.fragment.findNavController
+import com.stripe.android.identity.IdentityVerificationSheet
+import com.stripe.android.identity.IdentityVerificationSheet.VerificationResult.Failed
 import com.stripe.android.identity.R
+import com.stripe.android.identity.VerificationFlowFinishable
 import com.stripe.android.identity.networking.models.VerificationPageDataRequirementError
 
 /**
  * Fragment to show generic error.
  */
-internal class ErrorFragment : BaseErrorFragment() {
-
+internal class ErrorFragment(
+    private val verificationFlowFinishable: VerificationFlowFinishable
+) : BaseErrorFragment() {
     override fun onCustomizingViews() {
         val args = requireNotNull(arguments)
         title.text = args[ARG_ERROR_TITLE] as String
@@ -21,14 +26,36 @@ internal class ErrorFragment : BaseErrorFragment() {
         message2.visibility = View.GONE
 
         topButton.visibility = View.GONE
-        if (args.getInt(ARG_GO_BACK_BUTTON_DESTINATION) == UNSET_DESTINATION) {
+
+        if (args.getInt(ARG_GO_BACK_BUTTON_DESTINATION) == UNSET_DESTINATION &&
+            !args.containsKey(ARG_FAILED_REASON)
+        ) {
             bottomButton.visibility = View.GONE
         } else {
             bottomButton.text = args[ARG_GO_BACK_BUTTON_TEXT] as String
             bottomButton.visibility = View.VISIBLE
-            bottomButton.setOnClickListener {
-                // Can only go back to consent page at the moment
-                findNavController().navigate(args[ARG_GO_BACK_BUTTON_DESTINATION] as Int)
+
+            // If this is final destination, clicking bottom button and pressBack would end flow
+            (args.getSerializable(ARG_FAILED_REASON) as? Throwable)?.let { failedReason ->
+                bottomButton.setOnClickListener {
+                    verificationFlowFinishable.finishWithResult(
+                        Failed(failedReason)
+                    )
+                }
+                requireActivity().onBackPressedDispatcher.addCallback(
+                    this,
+                    object : OnBackPressedCallback(true) {
+                        override fun handleOnBackPressed() {
+                            verificationFlowFinishable.finishWithResult(
+                                Failed(failedReason)
+                            )
+                        }
+                    }
+                )
+            } ?: run {
+                bottomButton.setOnClickListener {
+                    findNavController().navigate(args[ARG_GO_BACK_BUTTON_DESTINATION] as Int)
+                }
             }
         }
     }
@@ -40,6 +67,7 @@ internal class ErrorFragment : BaseErrorFragment() {
         // if set, shows go_back button, clicking it would navigate to the destination.
         const val ARG_GO_BACK_BUTTON_TEXT = "goBackButtonText"
         const val ARG_GO_BACK_BUTTON_DESTINATION = "goBackButtonDestination"
+        const val ARG_FAILED_REASON = "failedReason"
         private const val UNSET_DESTINATION = 0
 
         fun NavController.navigateToErrorFragmentWithRequirementErrorAndDestination(
@@ -66,7 +94,27 @@ internal class ErrorFragment : BaseErrorFragment() {
                     ARG_ERROR_TITLE to context.getString(R.string.error),
                     ARG_ERROR_CONTENT to context.getString(R.string.unexpected_error_try_again),
                     ARG_GO_BACK_BUTTON_DESTINATION to R.id.action_errorFragment_to_consentFragment,
+                    ARG_GO_BACK_BUTTON_TEXT to context.getString(R.string.go_back)
+                )
+            )
+        }
+
+        /**
+         * Navigate to error fragment with failed reason. This would be the final destination of
+         * verification flow, clicking back button would end the follow with
+         * [IdentityVerificationSheet.VerificationResult.Failed] with [failedReason].
+         */
+        fun NavController.navigateToErrorFragmentWithFailedReason(
+            context: Context,
+            failedReason: Throwable
+        ) {
+            navigate(
+                R.id.action_global_errorFragment,
+                bundleOf(
+                    ARG_ERROR_TITLE to context.getString(R.string.error),
+                    ARG_ERROR_CONTENT to context.getString(R.string.unexpected_error_try_again),
                     ARG_GO_BACK_BUTTON_TEXT to context.getString(R.string.go_back),
+                    ARG_FAILED_REASON to failedReason
                 )
             )
         }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
@@ -76,7 +76,8 @@ internal class IdentityFragmentFactory(
                 identityViewModelFactory
             )
             ConsentFragment::class.java.name -> ConsentFragment(
-                identityViewModelFactory
+                identityViewModelFactory,
+                verificationFlowFinishable
             )
             DocSelectionFragment::class.java.name -> DocSelectionFragment(
                 identityViewModelFactory,
@@ -84,6 +85,9 @@ internal class IdentityFragmentFactory(
             )
             ConfirmationFragment::class.java.name -> ConfirmationFragment(
                 identityViewModelFactory,
+                verificationFlowFinishable
+            )
+            ErrorFragment::class.java.name -> ErrorFragment(
                 verificationFlowFinishable
             )
             else -> super.instantiate(classLoader, className)

--- a/identity/src/main/java/com/stripe/android/identity/utils/navigationUtils.kt
+++ b/identity/src/main/java/com/stripe/android/identity/utils/navigationUtils.kt
@@ -8,6 +8,7 @@ import androidx.navigation.fragment.findNavController
 import com.stripe.android.identity.R
 import com.stripe.android.identity.navigation.ErrorFragment
 import com.stripe.android.identity.navigation.ErrorFragment.Companion.navigateToErrorFragmentWithDefaultValues
+import com.stripe.android.identity.navigation.ErrorFragment.Companion.navigateToErrorFragmentWithFailedReason
 import com.stripe.android.identity.navigation.ErrorFragment.Companion.navigateToErrorFragmentWithRequirementErrorAndDestination
 import com.stripe.android.identity.networking.models.ClearDataParam
 import com.stripe.android.identity.networking.models.CollectedDataParam
@@ -104,6 +105,13 @@ private fun Fragment.navigateToRequirementErrorFragment(
  */
 internal fun Fragment.navigateToDefaultErrorFragment() {
     findNavController().navigateToErrorFragmentWithDefaultValues(requireContext())
+}
+
+/**
+ * Navigate to [ErrorFragment] as final destination.
+ */
+internal fun Fragment.navigateToErrorFragmentWithFailedReason(failedReason: Throwable) {
+    findNavController().navigateToErrorFragmentWithFailedReason(requireContext(), failedReason)
 }
 
 /**

--- a/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
@@ -272,7 +272,7 @@ internal class ConsentFragmentTest {
     ) = launchFragmentInContainer(
         themeResId = R.style.Theme_MaterialComponents
     ) {
-        ConsentFragment(viewModelFactoryFor(mockIdentityViewModel))
+        ConsentFragment(viewModelFactoryFor(mockIdentityViewModel), mock())
     }.onFragment {
         val navController = TestNavHostController(
             ApplicationProvider.getApplicationContext()

--- a/identity/src/test/java/com/stripe/android/identity/navigation/ErrorFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/ErrorFragmentTest.kt
@@ -7,14 +7,21 @@ import androidx.navigation.Navigation
 import androidx.navigation.testing.TestNavHostController
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.identity.IdentityVerificationSheet.VerificationResult
 import com.stripe.android.identity.R
+import com.stripe.android.identity.VerificationFlowFinishable
 import com.stripe.android.identity.databinding.BaseErrorFragmentBinding
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class ErrorFragmentTest {
+
+    private val mockVerificationFlowFinishable = mock<VerificationFlowFinishable>()
 
     @Test
     fun `title and content are set correctly`() {
@@ -27,7 +34,7 @@ class ErrorFragmentTest {
     }
 
     @Test
-    fun `go back button is hidden correctly when not set`() {
+    fun `bottom button is hidden correctly when not set`() {
         launchErrorFragment().onFragment {
             val binding = BaseErrorFragmentBinding.bind(it.requireView())
 
@@ -37,7 +44,7 @@ class ErrorFragmentTest {
     }
 
     @Test
-    fun `go back button is set correctly when set`() {
+    fun `bottom button is set correctly when set`() {
         launchErrorFragment(R.id.action_errorFragment_to_consentFragment).onFragment {
             val navController = TestNavHostController(
                 ApplicationProvider.getApplicationContext()
@@ -63,6 +70,36 @@ class ErrorFragmentTest {
         }
     }
 
+    @Test
+    fun `clicking bottom button finishes the flow when failed reason is set`() {
+        val mockFailedReason = mock<Throwable>()
+        launchErrorFragmentWithFailedReason(mockFailedReason).onFragment {
+            val navController = TestNavHostController(
+                ApplicationProvider.getApplicationContext()
+            )
+            navController.setGraph(
+                R.navigation.identity_nav_graph
+            )
+            navController.setCurrentDestination(R.id.errorFragment)
+            Navigation.setViewNavController(
+                it.requireView(),
+                navController
+            )
+            val binding = BaseErrorFragmentBinding.bind(it.requireView())
+
+            assertThat(binding.topButton.visibility).isEqualTo(View.GONE)
+            assertThat(binding.bottomButton.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.bottomButton.text).isEqualTo(TEST_GO_BACK_BUTTON_TEXT)
+
+            binding.bottomButton.callOnClick()
+            val resultCaptor = argumentCaptor<VerificationResult.Failed>()
+            verify(mockVerificationFlowFinishable).finishWithResult(
+                resultCaptor.capture()
+            )
+            assertThat(resultCaptor.firstValue.throwable).isSameInstanceAs(mockFailedReason)
+        }
+    }
+
     private fun launchErrorFragment(
         navigationDestination: Int? = null
     ) = launchFragmentInContainer(
@@ -77,7 +114,21 @@ class ErrorFragmentTest {
         },
         themeResId = R.style.Theme_MaterialComponents
     ) {
-        ErrorFragment()
+        ErrorFragment(mock())
+    }
+
+    private fun launchErrorFragmentWithFailedReason(
+        throwable: Throwable
+    ) = launchFragmentInContainer(
+        bundleOf(
+            ErrorFragment.ARG_ERROR_TITLE to TEST_ERROR_TITLE,
+            ErrorFragment.ARG_ERROR_CONTENT to TEST_ERROR_CONTENT,
+            ErrorFragment.ARG_GO_BACK_BUTTON_TEXT to TEST_GO_BACK_BUTTON_TEXT,
+            ErrorFragment.ARG_FAILED_REASON to throwable
+        ),
+        themeResId = R.style.Theme_MaterialComponents
+    ) {
+        ErrorFragment(mockVerificationFlowFinishable)
     }
 
     private companion object {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Using the host app's applicationID would allow host apps with different flavor not conflicting with each other

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Supporting multi flavor of host app

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
