### PR TITLE
change $ to € in paymentsheet example app

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/activity/BasePaymentSheetActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/activity/BasePaymentSheetActivity.kt
@@ -122,17 +122,17 @@ fun Receipt(
                 Column(
                     Modifier.fillMaxWidth(1f)
                 ) {
-                    ProductRow(HOT_DOG_EMOJI, R.string.hot_dog, "$0.99")
-                    ProductRow(SALAD_EMOJI, R.string.salad, "$8.00")
+                    ProductRow(HOT_DOG_EMOJI, R.string.hot_dog, "€0.99")
+                    ProductRow(SALAD_EMOJI, R.string.salad, "€8.00")
                 }
             }
             Column(
                 Modifier.fillMaxWidth(1f).padding(vertical = PADDING)
             ) {
-                ReceiptRow(stringResource(R.string.subtotal), "$8.99")
-                ReceiptRow(stringResource(R.string.sales_tax), "$0.74")
+                ReceiptRow(stringResource(R.string.subtotal), "€8.99")
+                ReceiptRow(stringResource(R.string.sales_tax), "€0.74")
                 TotalLine(Modifier.align(Alignment.CenterHorizontally))
-                ReceiptRow(stringResource(R.string.total), "$9.73")
+                ReceiptRow(stringResource(R.string.total), "€9.73")
                 bottomContent()
             }
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Noticed our payment sheet example was using Euros but the example store front UI was using USD.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
|![dollars](https://user-images.githubusercontent.com/89166418/160456229-53dd7fab-74dc-447e-b949-264ebac062fb.png)|![euros](https://user-images.githubusercontent.com/89166418/160456207-90939484-3f50-4d9a-afcc-073d636d1a3d.png)|

