### PR TITLE
fix corner radius of payment selectors not being themed

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionUI.kt
@@ -65,6 +65,7 @@ fun SectionCard(
         // TODO(skyler-stripe): this will change when we add shadow configurations.
         elevation = if (isSelected) 1.5.dp else 0.dp,
         backgroundColor = PaymentsTheme.colors.colorComponentBackground,
+        shape = PaymentsTheme.shapes.material.medium,
         modifier = modifier
     ) {
         content()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* SectionUI now looks at `PaymentsTheme` for corner radius. Previously it was looking at `MaterialTheme`. We didn't notice until this value became changeable with the new API. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
* Project Wardrobe dog fooding.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
|![borderBefore](https://user-images.githubusercontent.com/89166418/160503818-1875d1d0-c2a7-4dab-8bd0-ac2e5bfffc9c.png)|![borderAfter](https://user-images.githubusercontent.com/89166418/160503828-b3919c7a-dc95-4b0f-a0ba-b178030f31d8.png)|

Tested using 20dp to exaggerate the change. The default value has no appearance changes. 
