### PR TITLE
Fix cardscan touch target

### DIFF
--- a/stripecardscan/res/layout/fragment_cardscan.xml
+++ b/stripecardscan/res/layout/fragment_cardscan.xml
@@ -49,8 +49,7 @@
         android:src="@drawable/stripe_paymentsheet_close_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="20dp"
-        android:layout_marginStart="20dp"
+        android:padding="20dp"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toStartOf="@id/view_finder_window"/>


### PR DESCRIPTION
# Summary
Make the touch target for the close button on the CardScanFragment bigger 