### PR TITLE
[Identity] update fileprovider authority

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/utils/DefaultIdentityIO.kt
+++ b/identity/src/main/java/com/stripe/android/identity/utils/DefaultIdentityIO.kt
@@ -32,7 +32,7 @@ internal class DefaultIdentityIO(private val context: Context) : IdentityIO {
             return ContentUriResult(
                 FileProvider.getUriForFile(
                     context,
-                    "com.stripe.android.identity.fileprovider",
+                    "${context.packageName}.fileprovider",
                     file
                 ),
                 file.absolutePath


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
The fileprovider authority is updated with applicatID in manifest, need to match the same by using `context.package` here

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
