### PR TITLE
Adds Connections SDK

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,9 @@
 /identity/ @ccen-stripe @awush-stripe
 /identity-example/ @ccen-stripe @awush-stripe
 
+# connections sdk
+/connections/ @carlosmuvi-stripe
+
 # shared modules
 /stripe-core/ @ccen-stripe
 /payments-ui-core/ @brnunes-stripe @michelleb-stripe @skyler-stripe @jameswoo-stripe

--- a/connections/api/connections.api
+++ b/connections/api/connections.api
@@ -1,0 +1,887 @@
+public final class com/stripe/android/connections/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public final class com/stripe/android/connections/ConnectionsSheet {
+	public fun <init> (Landroidx/activity/ComponentActivity;Lcom/stripe/android/connections/ConnectionsSheetResultCallback;)V
+	public fun <init> (Landroidx/fragment/app/Fragment;Lcom/stripe/android/connections/ConnectionsSheetResultCallback;)V
+	public final fun present (Lcom/stripe/android/connections/ConnectionsSheet$Configuration;)V
+}
+
+public final class com/stripe/android/connections/ConnectionsSheet$Configuration : android/os/Parcelable {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/connections/ConnectionsSheet$Configuration;
+	public static synthetic fun copy$default (Lcom/stripe/android/connections/ConnectionsSheet$Configuration;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/connections/ConnectionsSheet$Configuration;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLinkAccountSessionClientSecret ()Ljava/lang/String;
+	public final fun getPublishableKey ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/connections/ConnectionsSheetRedirectActivity : androidx/appcompat/app/AppCompatActivity {
+	public fun <init> ()V
+}
+
+public abstract class com/stripe/android/connections/ConnectionsSheetResult : android/os/Parcelable {
+}
+
+public final class com/stripe/android/connections/ConnectionsSheetResult$Canceled : com/stripe/android/connections/ConnectionsSheetResult {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field INSTANCE Lcom/stripe/android/connections/ConnectionsSheetResult$Canceled;
+	public fun describeContents ()I
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/connections/ConnectionsSheetResult$Completed : com/stripe/android/connections/ConnectionsSheetResult {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Lcom/stripe/android/connections/model/LinkAccountSession;)V
+	public final fun component1 ()Lcom/stripe/android/connections/model/LinkAccountSession;
+	public final fun copy (Lcom/stripe/android/connections/model/LinkAccountSession;)Lcom/stripe/android/connections/ConnectionsSheetResult$Completed;
+	public static synthetic fun copy$default (Lcom/stripe/android/connections/ConnectionsSheetResult$Completed;Lcom/stripe/android/connections/model/LinkAccountSession;ILjava/lang/Object;)Lcom/stripe/android/connections/ConnectionsSheetResult$Completed;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLinkAccountSession ()Lcom/stripe/android/connections/model/LinkAccountSession;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/connections/ConnectionsSheetResult$Failed : com/stripe/android/connections/ConnectionsSheetResult {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/Throwable;)V
+	public final fun component1 ()Ljava/lang/Throwable;
+	public final fun copy (Ljava/lang/Throwable;)Lcom/stripe/android/connections/ConnectionsSheetResult$Failed;
+	public static synthetic fun copy$default (Lcom/stripe/android/connections/ConnectionsSheetResult$Failed;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/stripe/android/connections/ConnectionsSheetResult$Failed;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getError ()Ljava/lang/Throwable;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public abstract interface class com/stripe/android/connections/ConnectionsSheetResultCallback {
+	public abstract fun onConnectionsSheetResult (Lcom/stripe/android/connections/ConnectionsSheetResult;)V
+}
+
+public final class com/stripe/android/connections/ConnectionsSheetViewModel_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/connections/ConnectionsSheetViewModel_Factory;
+	public fun get ()Lcom/stripe/android/connections/ConnectionsSheetViewModel;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Ljava/lang/String;Lcom/stripe/android/connections/ConnectionsSheetContract$Args;Lcom/stripe/android/connections/domain/GenerateLinkAccountSessionManifest;Lcom/stripe/android/connections/domain/FetchLinkAccountSession;Lcom/stripe/android/connections/analytics/ConnectionsEventReporter;)Lcom/stripe/android/connections/ConnectionsSheetViewModel;
+}
+
+public final class com/stripe/android/connections/analytics/DefaultConnectionsEventReporter_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/connections/analytics/DefaultConnectionsEventReporter_Factory;
+	public fun get ()Lcom/stripe/android/connections/analytics/DefaultConnectionsEventReporter;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Lcom/stripe/android/core/networking/AnalyticsRequestExecutor;Lcom/stripe/android/core/networking/AnalyticsRequestFactory;Lkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/connections/analytics/DefaultConnectionsEventReporter;
+}
+
+public final class com/stripe/android/connections/databinding/ActivityConnectionsSheetBinding : androidx/viewbinding/ViewBinding {
+	public final field spinner Lcom/google/android/material/progressindicator/CircularProgressIndicator;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/connections/databinding/ActivityConnectionsSheetBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroidx/constraintlayout/widget/ConstraintLayout;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/connections/databinding/ActivityConnectionsSheetBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/connections/databinding/ActivityConnectionsSheetBinding;
+}
+
+public final class com/stripe/android/connections/di/ConnectionsSheetConfigurationModule_ProvidesApplicationIdFactory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/connections/di/ConnectionsSheetConfigurationModule_ProvidesApplicationIdFactory;
+	public synthetic fun get ()Ljava/lang/Object;
+	public fun get ()Ljava/lang/String;
+	public static fun providesApplicationId (Landroid/app/Application;)Ljava/lang/String;
+}
+
+public final class com/stripe/android/connections/di/ConnectionsSheetConfigurationModule_ProvidesConfigurationFactory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/connections/di/ConnectionsSheetConfigurationModule_ProvidesConfigurationFactory;
+	public fun get ()Lcom/stripe/android/connections/ConnectionsSheet$Configuration;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun providesConfiguration (Lcom/stripe/android/connections/ConnectionsSheetContract$Args;)Lcom/stripe/android/connections/ConnectionsSheet$Configuration;
+}
+
+public final class com/stripe/android/connections/di/ConnectionsSheetConfigurationModule_ProvidesEnableLoggingFactory : dagger/internal/Factory {
+	public fun <init> ()V
+	public static fun create ()Lcom/stripe/android/connections/di/ConnectionsSheetConfigurationModule_ProvidesEnableLoggingFactory;
+	public fun get ()Ljava/lang/Boolean;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun providesEnableLogging ()Z
+}
+
+public final class com/stripe/android/connections/di/ConnectionsSheetConfigurationModule_ProvidesPublishableKeyFactory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/connections/di/ConnectionsSheetConfigurationModule_ProvidesPublishableKeyFactory;
+	public synthetic fun get ()Ljava/lang/Object;
+	public fun get ()Ljava/lang/String;
+	public static fun providesPublishableKey (Lcom/stripe/android/connections/ConnectionsSheet$Configuration;)Ljava/lang/String;
+}
+
+public final class com/stripe/android/connections/di/ConnectionsSheetModule_ProvideAnalyticsRequestFactory$connections_releaseFactory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/connections/di/ConnectionsSheetModule_ProvideAnalyticsRequestFactory$connections_releaseFactory;
+	public fun get ()Lcom/stripe/android/core/networking/AnalyticsRequestFactory;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideAnalyticsRequestFactory$connections_release (Landroid/app/Application;Ljava/lang/String;)Lcom/stripe/android/core/networking/AnalyticsRequestFactory;
+}
+
+public final class com/stripe/android/connections/di/ConnectionsSheetModule_ProvideConnectionsRepositoryFactory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/connections/di/ConnectionsSheetModule_ProvideConnectionsRepositoryFactory;
+	public fun get ()Lcom/stripe/android/connections/repository/ConnectionsRepository;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideConnectionsRepository (Lcom/stripe/android/connections/repository/ConnectionsApiRepository;)Lcom/stripe/android/connections/repository/ConnectionsRepository;
+}
+
+public final class com/stripe/android/connections/di/ConnectionsSheetModule_ProvideEventReporterFactory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/connections/di/ConnectionsSheetModule_ProvideEventReporterFactory;
+	public fun get ()Lcom/stripe/android/connections/analytics/ConnectionsEventReporter;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideEventReporter (Lcom/stripe/android/connections/analytics/DefaultConnectionsEventReporter;)Lcom/stripe/android/connections/analytics/ConnectionsEventReporter;
+}
+
+public final class com/stripe/android/connections/di/ConnectionsSheetModule_ProvideLocaleFactory : dagger/internal/Factory {
+	public fun <init> ()V
+	public static fun create ()Lcom/stripe/android/connections/di/ConnectionsSheetModule_ProvideLocaleFactory;
+	public synthetic fun get ()Ljava/lang/Object;
+	public fun get ()Ljava/util/Locale;
+	public static fun provideLocale ()Ljava/util/Locale;
+}
+
+public final class com/stripe/android/connections/di/ConnectionsSheetModule_ProvideStripeNetworkClientFactory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/connections/di/ConnectionsSheetModule_ProvideStripeNetworkClientFactory;
+	public fun get ()Lcom/stripe/android/core/networking/StripeNetworkClient;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideStripeNetworkClient (Lkotlin/coroutines/CoroutineContext;Lcom/stripe/android/core/Logger;)Lcom/stripe/android/core/networking/StripeNetworkClient;
+}
+
+public final class com/stripe/android/connections/di/ConnectionsSheetModule_ProvidesAnalyticsRequestExecutor$connections_releaseFactory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/connections/di/ConnectionsSheetModule_ProvidesAnalyticsRequestExecutor$connections_releaseFactory;
+	public fun get ()Lcom/stripe/android/core/networking/AnalyticsRequestExecutor;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun providesAnalyticsRequestExecutor$connections_release (Lcom/stripe/android/core/networking/DefaultAnalyticsRequestExecutor;)Lcom/stripe/android/core/networking/AnalyticsRequestExecutor;
+}
+
+public final class com/stripe/android/connections/di/DaggerConnectionsSheetComponent : com/stripe/android/connections/di/ConnectionsSheetComponent {
+	public static fun builder ()Lcom/stripe/android/connections/di/ConnectionsSheetComponent$Builder;
+	public fun getViewModel ()Lcom/stripe/android/connections/ConnectionsSheetViewModel;
+	public fun inject (Lcom/stripe/android/connections/ConnectionsSheetViewModel$Factory;)V
+}
+
+public final class com/stripe/android/connections/domain/FetchLinkAccountSession_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/connections/domain/FetchLinkAccountSession_Factory;
+	public fun get ()Lcom/stripe/android/connections/domain/FetchLinkAccountSession;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Lcom/stripe/android/connections/repository/ConnectionsRepository;)Lcom/stripe/android/connections/domain/FetchLinkAccountSession;
+}
+
+public final class com/stripe/android/connections/domain/GenerateLinkAccountSessionManifest_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/connections/domain/GenerateLinkAccountSessionManifest_Factory;
+	public fun get ()Lcom/stripe/android/connections/domain/GenerateLinkAccountSessionManifest;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Lcom/stripe/android/connections/repository/ConnectionsRepository;)Lcom/stripe/android/connections/domain/GenerateLinkAccountSessionManifest;
+}
+
+public final class com/stripe/android/connections/model/AccountHolder : android/os/Parcelable, com/stripe/android/core/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/connections/model/AccountHolder$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILcom/stripe/android/connections/model/AccountHolder$Type;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/stripe/android/connections/model/AccountHolder$Type;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/stripe/android/connections/model/AccountHolder$Type;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/stripe/android/connections/model/AccountHolder$Type;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Lcom/stripe/android/connections/model/AccountHolder$Type;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/connections/model/AccountHolder;
+	public static synthetic fun copy$default (Lcom/stripe/android/connections/model/AccountHolder;Lcom/stripe/android/connections/model/AccountHolder$Type;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/connections/model/AccountHolder;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccount ()Ljava/lang/String;
+	public final fun getCustomer ()Ljava/lang/String;
+	public final fun getType ()Lcom/stripe/android/connections/model/AccountHolder$Type;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/stripe/android/connections/model/AccountHolder;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/connections/model/AccountHolder$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/connections/model/AccountHolder$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/connections/model/AccountHolder;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/connections/model/AccountHolder;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/AccountHolder$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/AccountHolder$Type : java/lang/Enum {
+	public static final field ACCOUNT Lcom/stripe/android/connections/model/AccountHolder$Type;
+	public static final field CUSTOMER Lcom/stripe/android/connections/model/AccountHolder$Type;
+	public static final field Companion Lcom/stripe/android/connections/model/AccountHolder$Type$Companion;
+	public static final field UNKNOWN Lcom/stripe/android/connections/model/AccountHolder$Type;
+	public final fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/connections/model/AccountHolder$Type;
+	public static fun values ()[Lcom/stripe/android/connections/model/AccountHolder$Type;
+}
+
+public final class com/stripe/android/connections/model/AccountHolder$Type$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/connections/model/AccountHolder$Type$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/connections/model/AccountHolder$Type;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/connections/model/AccountHolder$Type;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/AccountHolder$Type$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/Balance : android/os/Parcelable, com/stripe/android/core/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/connections/model/Balance$Companion;
+	public synthetic fun <init> (IILjava/util/Map;Lcom/stripe/android/connections/model/Balance$Type;Lcom/stripe/android/connections/model/CashBalance;Lcom/stripe/android/connections/model/CreditBalance;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (ILjava/util/Map;Lcom/stripe/android/connections/model/Balance$Type;Lcom/stripe/android/connections/model/CashBalance;Lcom/stripe/android/connections/model/CreditBalance;)V
+	public synthetic fun <init> (ILjava/util/Map;Lcom/stripe/android/connections/model/Balance$Type;Lcom/stripe/android/connections/model/CashBalance;Lcom/stripe/android/connections/model/CreditBalance;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Lcom/stripe/android/connections/model/Balance$Type;
+	public final fun component4 ()Lcom/stripe/android/connections/model/CashBalance;
+	public final fun component5 ()Lcom/stripe/android/connections/model/CreditBalance;
+	public final fun copy (ILjava/util/Map;Lcom/stripe/android/connections/model/Balance$Type;Lcom/stripe/android/connections/model/CashBalance;Lcom/stripe/android/connections/model/CreditBalance;)Lcom/stripe/android/connections/model/Balance;
+	public static synthetic fun copy$default (Lcom/stripe/android/connections/model/Balance;ILjava/util/Map;Lcom/stripe/android/connections/model/Balance$Type;Lcom/stripe/android/connections/model/CashBalance;Lcom/stripe/android/connections/model/CreditBalance;ILjava/lang/Object;)Lcom/stripe/android/connections/model/Balance;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAsOf ()I
+	public final fun getCash ()Lcom/stripe/android/connections/model/CashBalance;
+	public final fun getCredit ()Lcom/stripe/android/connections/model/CreditBalance;
+	public final fun getCurrent ()Ljava/util/Map;
+	public final fun getType ()Lcom/stripe/android/connections/model/Balance$Type;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/stripe/android/connections/model/Balance;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/connections/model/Balance$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/connections/model/Balance$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/connections/model/Balance;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/connections/model/Balance;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/Balance$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/Balance$Type : java/lang/Enum {
+	public static final field CASH Lcom/stripe/android/connections/model/Balance$Type;
+	public static final field CREDIT Lcom/stripe/android/connections/model/Balance$Type;
+	public static final field Companion Lcom/stripe/android/connections/model/Balance$Type$Companion;
+	public static final field UNKNOWN Lcom/stripe/android/connections/model/Balance$Type;
+	public final fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/connections/model/Balance$Type;
+	public static fun values ()[Lcom/stripe/android/connections/model/Balance$Type;
+}
+
+public final class com/stripe/android/connections/model/Balance$Type$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/connections/model/Balance$Type$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/connections/model/Balance$Type;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/connections/model/Balance$Type;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/Balance$Type$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/BalanceRefresh : android/os/Parcelable, com/stripe/android/core/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/connections/model/BalanceRefresh$Companion;
+	public synthetic fun <init> (ILcom/stripe/android/connections/model/BalanceRefresh$BalanceRefreshStatus;ILkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/stripe/android/connections/model/BalanceRefresh$BalanceRefreshStatus;I)V
+	public synthetic fun <init> (Lcom/stripe/android/connections/model/BalanceRefresh$BalanceRefreshStatus;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/stripe/android/connections/model/BalanceRefresh$BalanceRefreshStatus;
+	public final fun component2 ()I
+	public final fun copy (Lcom/stripe/android/connections/model/BalanceRefresh$BalanceRefreshStatus;I)Lcom/stripe/android/connections/model/BalanceRefresh;
+	public static synthetic fun copy$default (Lcom/stripe/android/connections/model/BalanceRefresh;Lcom/stripe/android/connections/model/BalanceRefresh$BalanceRefreshStatus;IILjava/lang/Object;)Lcom/stripe/android/connections/model/BalanceRefresh;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLastAttemptedAt ()I
+	public final fun getStatus ()Lcom/stripe/android/connections/model/BalanceRefresh$BalanceRefreshStatus;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/stripe/android/connections/model/BalanceRefresh;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/connections/model/BalanceRefresh$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/connections/model/BalanceRefresh$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/connections/model/BalanceRefresh;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/connections/model/BalanceRefresh;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/BalanceRefresh$BalanceRefreshStatus : java/lang/Enum {
+	public static final field Companion Lcom/stripe/android/connections/model/BalanceRefresh$BalanceRefreshStatus$Companion;
+	public static final field FAILED Lcom/stripe/android/connections/model/BalanceRefresh$BalanceRefreshStatus;
+	public static final field PENDING Lcom/stripe/android/connections/model/BalanceRefresh$BalanceRefreshStatus;
+	public static final field SUCCEEDED Lcom/stripe/android/connections/model/BalanceRefresh$BalanceRefreshStatus;
+	public static final field UNKNOWN Lcom/stripe/android/connections/model/BalanceRefresh$BalanceRefreshStatus;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/connections/model/BalanceRefresh$BalanceRefreshStatus;
+	public static fun values ()[Lcom/stripe/android/connections/model/BalanceRefresh$BalanceRefreshStatus;
+}
+
+public final class com/stripe/android/connections/model/BalanceRefresh$BalanceRefreshStatus$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/connections/model/BalanceRefresh$BalanceRefreshStatus$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/connections/model/BalanceRefresh$BalanceRefreshStatus;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/connections/model/BalanceRefresh$BalanceRefreshStatus;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/BalanceRefresh$BalanceRefreshStatus$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/BalanceRefresh$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/CashBalance : android/os/Parcelable, com/stripe/android/core/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/connections/model/CashBalance$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/util/Map;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/Map;)Lcom/stripe/android/connections/model/CashBalance;
+	public static synthetic fun copy$default (Lcom/stripe/android/connections/model/CashBalance;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/connections/model/CashBalance;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAvailable ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/stripe/android/connections/model/CashBalance;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/connections/model/CashBalance$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/connections/model/CashBalance$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/connections/model/CashBalance;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/connections/model/CashBalance;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/CashBalance$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/CreditBalance : android/os/Parcelable, com/stripe/android/core/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/connections/model/CreditBalance$Companion;
+	public fun <init> ()V
+	public synthetic fun <init> (ILjava/util/Map;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/Map;)Lcom/stripe/android/connections/model/CreditBalance;
+	public static synthetic fun copy$default (Lcom/stripe/android/connections/model/CreditBalance;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/connections/model/CreditBalance;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUsed ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/stripe/android/connections/model/CreditBalance;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/connections/model/CreditBalance$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/connections/model/CreditBalance$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/connections/model/CreditBalance;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/connections/model/CreditBalance;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/CreditBalance$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/LinkAccountSession : android/os/Parcelable, com/stripe/android/core/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/connections/model/LinkAccountSession$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Lcom/stripe/android/connections/model/LinkedAccountList;ZLcom/stripe/android/connections/model/LinkedAccount;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lcom/stripe/android/connections/model/LinkedAccountList;
+	public final fun component4 ()Z
+	public final fun component5 ()Lcom/stripe/android/connections/model/LinkedAccount;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/connections/model/LinkedAccountList;ZLcom/stripe/android/connections/model/LinkedAccount;Ljava/lang/String;)Lcom/stripe/android/connections/model/LinkAccountSession;
+	public static synthetic fun copy$default (Lcom/stripe/android/connections/model/LinkAccountSession;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/connections/model/LinkedAccountList;ZLcom/stripe/android/connections/model/LinkedAccount;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/connections/model/LinkAccountSession;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClientSecret ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLinkedAccounts ()Lcom/stripe/android/connections/model/LinkedAccountList;
+	public final fun getLivemode ()Z
+	public final fun getPaymentAccount ()Lcom/stripe/android/connections/model/LinkedAccount;
+	public final fun getReturnUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/stripe/android/connections/model/LinkAccountSession;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/connections/model/LinkAccountSession$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/connections/model/LinkAccountSession$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/connections/model/LinkAccountSession;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/connections/model/LinkAccountSession;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/LinkAccountSession$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/LinkAccountSessionManifest {
+	public static final field Companion Lcom/stripe/android/connections/model/LinkAccountSessionManifest$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/connections/model/LinkAccountSessionManifest;
+	public static synthetic fun copy$default (Lcom/stripe/android/connections/model/LinkAccountSessionManifest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/connections/model/LinkAccountSessionManifest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCancelUrl ()Ljava/lang/String;
+	public final fun getHostedAuthUrl ()Ljava/lang/String;
+	public final fun getSuccessUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/stripe/android/connections/model/LinkAccountSessionManifest;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+}
+
+public final class com/stripe/android/connections/model/LinkAccountSessionManifest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/connections/model/LinkAccountSessionManifest$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/connections/model/LinkAccountSessionManifest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/connections/model/LinkAccountSessionManifest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/LinkAccountSessionManifest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/LinkedAccount : android/os/Parcelable, com/stripe/android/core/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/connections/model/LinkedAccount$Companion;
+	public synthetic fun <init> (ILcom/stripe/android/connections/model/LinkedAccount$Category;ILjava/lang/String;Ljava/lang/String;ZLcom/stripe/android/connections/model/LinkedAccount$Status;Lcom/stripe/android/connections/model/LinkedAccount$Subcategory;Ljava/util/List;Lcom/stripe/android/connections/model/AccountHolder;Lcom/stripe/android/connections/model/Balance;Lcom/stripe/android/connections/model/BalanceRefresh;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/connections/model/OwnershipRefresh;Ljava/util/List;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Lcom/stripe/android/connections/model/LinkedAccount$Category;ILjava/lang/String;Ljava/lang/String;ZLcom/stripe/android/connections/model/LinkedAccount$Status;Lcom/stripe/android/connections/model/LinkedAccount$Subcategory;Ljava/util/List;Lcom/stripe/android/connections/model/AccountHolder;Lcom/stripe/android/connections/model/Balance;Lcom/stripe/android/connections/model/BalanceRefresh;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/connections/model/OwnershipRefresh;Ljava/util/List;)V
+	public synthetic fun <init> (Lcom/stripe/android/connections/model/LinkedAccount$Category;ILjava/lang/String;Ljava/lang/String;ZLcom/stripe/android/connections/model/LinkedAccount$Status;Lcom/stripe/android/connections/model/LinkedAccount$Subcategory;Ljava/util/List;Lcom/stripe/android/connections/model/AccountHolder;Lcom/stripe/android/connections/model/Balance;Lcom/stripe/android/connections/model/BalanceRefresh;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/connections/model/OwnershipRefresh;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/stripe/android/connections/model/LinkedAccount$Category;
+	public final fun component10 ()Lcom/stripe/android/connections/model/Balance;
+	public final fun component11 ()Lcom/stripe/android/connections/model/BalanceRefresh;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Lcom/stripe/android/connections/model/OwnershipRefresh;
+	public final fun component16 ()Ljava/util/List;
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Z
+	public final fun component6 ()Lcom/stripe/android/connections/model/LinkedAccount$Status;
+	public final fun component7 ()Lcom/stripe/android/connections/model/LinkedAccount$Subcategory;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Lcom/stripe/android/connections/model/AccountHolder;
+	public final fun copy (Lcom/stripe/android/connections/model/LinkedAccount$Category;ILjava/lang/String;Ljava/lang/String;ZLcom/stripe/android/connections/model/LinkedAccount$Status;Lcom/stripe/android/connections/model/LinkedAccount$Subcategory;Ljava/util/List;Lcom/stripe/android/connections/model/AccountHolder;Lcom/stripe/android/connections/model/Balance;Lcom/stripe/android/connections/model/BalanceRefresh;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/connections/model/OwnershipRefresh;Ljava/util/List;)Lcom/stripe/android/connections/model/LinkedAccount;
+	public static synthetic fun copy$default (Lcom/stripe/android/connections/model/LinkedAccount;Lcom/stripe/android/connections/model/LinkedAccount$Category;ILjava/lang/String;Ljava/lang/String;ZLcom/stripe/android/connections/model/LinkedAccount$Status;Lcom/stripe/android/connections/model/LinkedAccount$Subcategory;Ljava/util/List;Lcom/stripe/android/connections/model/AccountHolder;Lcom/stripe/android/connections/model/Balance;Lcom/stripe/android/connections/model/BalanceRefresh;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/connections/model/OwnershipRefresh;Ljava/util/List;ILjava/lang/Object;)Lcom/stripe/android/connections/model/LinkedAccount;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccountholder ()Lcom/stripe/android/connections/model/AccountHolder;
+	public final fun getBalance ()Lcom/stripe/android/connections/model/Balance;
+	public final fun getBalanceRefresh ()Lcom/stripe/android/connections/model/BalanceRefresh;
+	public final fun getCategory ()Lcom/stripe/android/connections/model/LinkedAccount$Category;
+	public final fun getCreated ()I
+	public final fun getDisplayName ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getInstitutionName ()Ljava/lang/String;
+	public final fun getLast4 ()Ljava/lang/String;
+	public final fun getLivemode ()Z
+	public final fun getOwnership ()Ljava/lang/String;
+	public final fun getOwnershipRefresh ()Lcom/stripe/android/connections/model/OwnershipRefresh;
+	public final fun getPermissions ()Ljava/util/List;
+	public final fun getStatus ()Lcom/stripe/android/connections/model/LinkedAccount$Status;
+	public final fun getSubcategory ()Lcom/stripe/android/connections/model/LinkedAccount$Subcategory;
+	public final fun getSupportedPaymentMethodTypes ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/stripe/android/connections/model/LinkedAccount;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/connections/model/LinkedAccount$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/connections/model/LinkedAccount$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/connections/model/LinkedAccount;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/connections/model/LinkedAccount;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/LinkedAccount$Category : java/lang/Enum {
+	public static final field CASH Lcom/stripe/android/connections/model/LinkedAccount$Category;
+	public static final field CREDIT Lcom/stripe/android/connections/model/LinkedAccount$Category;
+	public static final field Companion Lcom/stripe/android/connections/model/LinkedAccount$Category$Companion;
+	public static final field INVESTMENT Lcom/stripe/android/connections/model/LinkedAccount$Category;
+	public static final field OTHER Lcom/stripe/android/connections/model/LinkedAccount$Category;
+	public static final field UNKNOWN Lcom/stripe/android/connections/model/LinkedAccount$Category;
+	public final fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/connections/model/LinkedAccount$Category;
+	public static fun values ()[Lcom/stripe/android/connections/model/LinkedAccount$Category;
+}
+
+public final class com/stripe/android/connections/model/LinkedAccount$Category$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/connections/model/LinkedAccount$Category$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/connections/model/LinkedAccount$Category;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/connections/model/LinkedAccount$Category;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/LinkedAccount$Category$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/LinkedAccount$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/LinkedAccount$Permissions : java/lang/Enum {
+	public static final field BALANCES Lcom/stripe/android/connections/model/LinkedAccount$Permissions;
+	public static final field Companion Lcom/stripe/android/connections/model/LinkedAccount$Permissions$Companion;
+	public static final field IDENTITY Lcom/stripe/android/connections/model/LinkedAccount$Permissions;
+	public static final field OWNERSHIP Lcom/stripe/android/connections/model/LinkedAccount$Permissions;
+	public static final field PAYMENT_METHOD Lcom/stripe/android/connections/model/LinkedAccount$Permissions;
+	public static final field TRANSACTIONS Lcom/stripe/android/connections/model/LinkedAccount$Permissions;
+	public static final field UNKNOWN Lcom/stripe/android/connections/model/LinkedAccount$Permissions;
+	public final fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/connections/model/LinkedAccount$Permissions;
+	public static fun values ()[Lcom/stripe/android/connections/model/LinkedAccount$Permissions;
+}
+
+public final class com/stripe/android/connections/model/LinkedAccount$Permissions$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/connections/model/LinkedAccount$Permissions$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/connections/model/LinkedAccount$Permissions;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/connections/model/LinkedAccount$Permissions;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/LinkedAccount$Permissions$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/LinkedAccount$Status : java/lang/Enum {
+	public static final field ACTIVE Lcom/stripe/android/connections/model/LinkedAccount$Status;
+	public static final field Companion Lcom/stripe/android/connections/model/LinkedAccount$Status$Companion;
+	public static final field DISCONNECTED Lcom/stripe/android/connections/model/LinkedAccount$Status;
+	public static final field INACTIVE Lcom/stripe/android/connections/model/LinkedAccount$Status;
+	public static final field UNKNOWN Lcom/stripe/android/connections/model/LinkedAccount$Status;
+	public final fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/connections/model/LinkedAccount$Status;
+	public static fun values ()[Lcom/stripe/android/connections/model/LinkedAccount$Status;
+}
+
+public final class com/stripe/android/connections/model/LinkedAccount$Status$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/connections/model/LinkedAccount$Status$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/connections/model/LinkedAccount$Status;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/connections/model/LinkedAccount$Status;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/LinkedAccount$Status$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/LinkedAccount$Subcategory : java/lang/Enum {
+	public static final field CHECKING Lcom/stripe/android/connections/model/LinkedAccount$Subcategory;
+	public static final field CREDIT_CARD Lcom/stripe/android/connections/model/LinkedAccount$Subcategory;
+	public static final field Companion Lcom/stripe/android/connections/model/LinkedAccount$Subcategory$Companion;
+	public static final field LINE_OF_CREDIT Lcom/stripe/android/connections/model/LinkedAccount$Subcategory;
+	public static final field MORTGAGE Lcom/stripe/android/connections/model/LinkedAccount$Subcategory;
+	public static final field OTHER Lcom/stripe/android/connections/model/LinkedAccount$Subcategory;
+	public static final field SAVINGS Lcom/stripe/android/connections/model/LinkedAccount$Subcategory;
+	public static final field UNKNOWN Lcom/stripe/android/connections/model/LinkedAccount$Subcategory;
+	public final fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/connections/model/LinkedAccount$Subcategory;
+	public static fun values ()[Lcom/stripe/android/connections/model/LinkedAccount$Subcategory;
+}
+
+public final class com/stripe/android/connections/model/LinkedAccount$Subcategory$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/connections/model/LinkedAccount$Subcategory$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/connections/model/LinkedAccount$Subcategory;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/connections/model/LinkedAccount$Subcategory;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/LinkedAccount$Subcategory$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/LinkedAccount$SupportedPaymentMethodTypes : java/lang/Enum {
+	public static final field Companion Lcom/stripe/android/connections/model/LinkedAccount$SupportedPaymentMethodTypes$Companion;
+	public static final field LINK Lcom/stripe/android/connections/model/LinkedAccount$SupportedPaymentMethodTypes;
+	public static final field UNKNOWN Lcom/stripe/android/connections/model/LinkedAccount$SupportedPaymentMethodTypes;
+	public static final field US_BANK_ACCOUNT Lcom/stripe/android/connections/model/LinkedAccount$SupportedPaymentMethodTypes;
+	public final fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/connections/model/LinkedAccount$SupportedPaymentMethodTypes;
+	public static fun values ()[Lcom/stripe/android/connections/model/LinkedAccount$SupportedPaymentMethodTypes;
+}
+
+public final class com/stripe/android/connections/model/LinkedAccount$SupportedPaymentMethodTypes$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/connections/model/LinkedAccount$SupportedPaymentMethodTypes$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/connections/model/LinkedAccount$SupportedPaymentMethodTypes;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/connections/model/LinkedAccount$SupportedPaymentMethodTypes;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/LinkedAccount$SupportedPaymentMethodTypes$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/LinkedAccountList : android/os/Parcelable, com/stripe/android/core/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/connections/model/LinkedAccountList$Companion;
+	public synthetic fun <init> (ILjava/util/List;ZLjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/util/List;ZLjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/util/List;ZLjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Z
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/util/List;ZLjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;)Lcom/stripe/android/connections/model/LinkedAccountList;
+	public static synthetic fun copy$default (Lcom/stripe/android/connections/model/LinkedAccountList;Ljava/util/List;ZLjava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/stripe/android/connections/model/LinkedAccountList;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCount ()Ljava/lang/Integer;
+	public final fun getHasMore ()Z
+	public final fun getLinkedAccounts ()Ljava/util/List;
+	public final fun getTotalCount ()Ljava/lang/Integer;
+	public final fun getUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/stripe/android/connections/model/LinkedAccountList;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/connections/model/LinkedAccountList$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/connections/model/LinkedAccountList$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/connections/model/LinkedAccountList;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/connections/model/LinkedAccountList;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/LinkedAccountList$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/ListLinkedAccountParams : android/os/Parcelable {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/connections/model/ListLinkedAccountParams;
+	public static synthetic fun copy$default (Lcom/stripe/android/connections/model/ListLinkedAccountParams;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/connections/model/ListLinkedAccountParams;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/stripe/android/connections/model/ListLinkedAccountParams;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/connections/model/ListLinkedAccountParams$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/connections/model/ListLinkedAccountParams$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/connections/model/ListLinkedAccountParams;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/connections/model/ListLinkedAccountParams;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/OwnershipRefresh : android/os/Parcelable, com/stripe/android/core/model/StripeModel {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/connections/model/OwnershipRefresh$Companion;
+	public synthetic fun <init> (IILcom/stripe/android/connections/model/OwnershipRefresh$Status;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
+	public fun <init> (ILcom/stripe/android/connections/model/OwnershipRefresh$Status;)V
+	public synthetic fun <init> (ILcom/stripe/android/connections/model/OwnershipRefresh$Status;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Lcom/stripe/android/connections/model/OwnershipRefresh$Status;
+	public final fun copy (ILcom/stripe/android/connections/model/OwnershipRefresh$Status;)Lcom/stripe/android/connections/model/OwnershipRefresh;
+	public static synthetic fun copy$default (Lcom/stripe/android/connections/model/OwnershipRefresh;ILcom/stripe/android/connections/model/OwnershipRefresh$Status;ILjava/lang/Object;)Lcom/stripe/android/connections/model/OwnershipRefresh;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLastAttemptedAt ()I
+	public final fun getStatus ()Lcom/stripe/android/connections/model/OwnershipRefresh$Status;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun write$Self (Lcom/stripe/android/connections/model/OwnershipRefresh;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/connections/model/OwnershipRefresh$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/connections/model/OwnershipRefresh$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/connections/model/OwnershipRefresh;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/connections/model/OwnershipRefresh;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/OwnershipRefresh$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/OwnershipRefresh$Status : java/lang/Enum {
+	public static final field Companion Lcom/stripe/android/connections/model/OwnershipRefresh$Status$Companion;
+	public static final field FAILED Lcom/stripe/android/connections/model/OwnershipRefresh$Status;
+	public static final field PENDING Lcom/stripe/android/connections/model/OwnershipRefresh$Status;
+	public static final field SUCCEEDED Lcom/stripe/android/connections/model/OwnershipRefresh$Status;
+	public static final field UNKNOWN Lcom/stripe/android/connections/model/OwnershipRefresh$Status;
+	public final fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/connections/model/OwnershipRefresh$Status;
+	public static fun values ()[Lcom/stripe/android/connections/model/OwnershipRefresh$Status;
+}
+
+public final class com/stripe/android/connections/model/OwnershipRefresh$Status$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/connections/model/OwnershipRefresh$Status$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/connections/model/OwnershipRefresh$Status;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/connections/model/OwnershipRefresh$Status;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/model/OwnershipRefresh$Status$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/connections/repository/ConnectionsApiRepository_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/connections/repository/ConnectionsApiRepository_Factory;
+	public fun get ()Lcom/stripe/android/connections/repository/ConnectionsApiRepository;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Ljava/lang/String;Lcom/stripe/android/core/networking/StripeNetworkClient;)Lcom/stripe/android/connections/repository/ConnectionsApiRepository;
+}
+

--- a/connections/build.gradle
+++ b/connections/build.gradle
@@ -1,0 +1,69 @@
+apply from: configs.androidLibrary
+
+apply plugin: 'kotlin-kapt'
+apply plugin: 'checkstyle'
+apply plugin: 'org.jetbrains.kotlin.plugin.parcelize'
+apply plugin: 'kotlinx-serialization'
+
+android {
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
+}
+
+dependencies {
+    api project(":stripe-core")
+
+    implementation "androidx.activity:activity-ktx:$androidxActivityVersion"
+    implementation "androidx.annotation:annotation:$androidxAnnotationVersion"
+    implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"
+    implementation "androidx.browser:browser:$androidxBrowserVersion"
+    implementation "androidx.constraintlayout:constraintlayout:$androidxConstraintlayoutVersion"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$androidxLifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:$androidxLifecycleVersion"
+    implementation "com.google.android.material:material:$materialVersion"
+    implementation "com.google.dagger:dagger:$daggerVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinSerializationVersion"
+
+    kapt "com.google.dagger:dagger-compiler:$daggerVersion"
+
+    testImplementation 'app.cash.turbine:turbine:0.7.0'
+    testImplementation "androidx.arch.core:core-testing:$androidxArchCoreVersion"
+    testImplementation "androidx.test.ext:junit-ktx:$androidTestJunitVersion"
+    testImplementation "androidx.test:core:$androidTestVersion"
+    testImplementation "com.google.truth:truth:$truthVersion"
+    testImplementation "junit:junit:$junitVersion"
+    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlinVersion"
+    testImplementation "org.jetbrains.kotlin:kotlin-test-annotations-common:$kotlinVersion"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinCoroutinesVersion"
+    testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
+    testImplementation "org.mockito:mockito-inline:$mockitoCoreVersion"
+    testImplementation "org.robolectric:robolectric:$robolectricVersion"
+
+    androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"
+    androidTestImplementation "androidx.test:rules:$androidTestVersion"
+    androidTestImplementation "androidx.test:runner:$androidTestVersion"
+    androidTestUtil "androidx.test:orchestrator:$androidTestVersion"
+
+    ktlint "com.pinterest:ktlint:$ktlintVersion"
+}
+
+android {
+    buildFeatures {
+        viewBinding true
+    }
+}
+
+
+//ext {
+//    artifactId = "connections"
+//    artifactName = "connections"
+//    artifactDescrption = "The connections module of Stripe Payment Android SDK"
+//}
+//
+//apply from: "${rootDir}/deploy/deploy.gradle"

--- a/connections/proguard-rules.txt
+++ b/connections/proguard-rules.txt
@@ -1,0 +1,6 @@
+-keep class com.stripe.android.** { *; }
+-dontwarn com.stripe.android.view.**
+
+-keepclassmembernames class kotlinx.** {
+    volatile <fields>;
+}

--- a/connections/res/layout/activity_connections_sheet.xml
+++ b/connections/res/layout/activity_connections_sheet.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.progressindicator.CircularProgressIndicator
+        android:id="@+id/spinner"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        app:indicatorColor="@color/stripe_toolbar_color_default"
+        app:indicatorSize="@dimen/stripe_connectionssheet_loading_indicator_size"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:trackThickness="@dimen/stripe_connectionssheet_loading_indicator_stroke_width" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/connections/res/values/colors.xml
+++ b/connections/res/values/colors.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="stripe_accent_color_default">#ff2296f3</color>
+    <color name="stripe_control_normal_color_default">#ff90A4AE</color>
+    <color name="stripe_toolbar_color_default">#ff3f51b5</color>
+    <color name="stripe_toolbar_color_default_dark">#ff324090</color>
+    <color name="stripe_title_text_color">@android:color/white</color>
+    <color name="stripe_text_color_secondary">@android:color/secondary_text_light</color>
+</resources>

--- a/connections/res/values/dimens.xml
+++ b/connections/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="stripe_connectionssheet_loading_indicator_size">24dp</dimen>
+    <dimen name="stripe_connectionssheet_loading_indicator_stroke_width">2dp</dimen>
+</resources>

--- a/connections/res/values/themes.xml
+++ b/connections/res/values/themes.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="StripeBaseTheme" parent="@style/Theme.AppCompat.DayNight.NoActionBar">
+        <item name="colorAccent">@color/stripe_accent_color_default</item>
+        <item name="colorControlNormal">@color/stripe_control_normal_color_default</item>
+        <item name="colorPrimary">@color/stripe_toolbar_color_default</item>
+        <item name="colorPrimaryDark">@color/stripe_toolbar_color_default_dark</item>
+        <item name="titleTextColor">@color/stripe_title_text_color</item>
+        <item name="android:textColorSecondary">@color/stripe_text_color_secondary</item>
+    </style>
+
+    <style name="StripeDefaultTheme" parent="StripeBaseTheme" />
+</resources>

--- a/connections/src/main/AndroidManifest.xml
+++ b/connections/src/main/AndroidManifest.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.stripe.android.connections">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application>
+        <activity
+            android:name=".ConnectionsSheetRedirectActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <!-- Accepts success and cancel URIs that begin with "stripe-auth://link-accounts” -->
+                <data
+                    android:host="link-accounts"
+                    android:scheme="stripe-auth"
+                    android:path="/${applicationId}/success" />
+                <data
+                    android:host="link-accounts"
+                    android:scheme="stripe-auth"
+                    android:path="/${applicationId}/cancel" />
+            </intent-filter>
+        </activity>
+        <activity
+            android:name=".ConnectionsSheetActivity"
+            android:exported="false"
+            android:theme="@style/StripeDefaultTheme" />
+    </application>
+
+</manifest>

--- a/connections/src/main/java/com/stripe/android/connections/ConnectionsSheet.kt
+++ b/connections/src/main/java/com/stripe/android/connections/ConnectionsSheet.kt
@@ -1,0 +1,65 @@
+package com.stripe.android.connections
+
+import android.os.Parcelable
+import androidx.activity.ComponentActivity
+import androidx.fragment.app.Fragment
+import kotlinx.parcelize.Parcelize
+
+/**
+ * A drop in class to present the Link Account Session Auth Flow.
+ *
+ * This *must* be called unconditionally, as part of initialization path,
+ * typically as a field initializer of an Activity or Fragment.
+ */
+class ConnectionsSheet internal constructor(
+    private val connectionsSheetLauncher: ConnectionsSheetLauncher
+) {
+    /**
+     * Constructor to be used when launching the connections sheet from an Activity.
+     *
+     * @param activity  the Activity that is presenting the connections sheet.
+     * @param callback  called with the result of the connections session after the connections sheet is dismissed.
+     */
+    constructor(
+        activity: ComponentActivity,
+        callback: ConnectionsSheetResultCallback
+    ) : this(
+        DefaultConnectionsSheetLauncher(activity, callback)
+    )
+
+    /**
+     * Constructor to be used when launching the payment sheet from a Fragment.
+     *
+     * @param fragment the Fragment that is presenting the payment sheet.
+     * @param callback called with the result of the payment after the payment sheet is dismissed.
+     */
+    constructor(
+        fragment: Fragment,
+        callback: ConnectionsSheetResultCallback
+    ) : this(
+        DefaultConnectionsSheetLauncher(fragment, callback)
+    )
+
+    /**
+     * Configuration for a Connections Sheet
+     *
+     * @param linkAccountSessionClientSecret the client secret for the Link Account Session
+     * @param publishableKey the Stripe publishable key
+     */
+    @Parcelize
+    data class Configuration(
+        val linkAccountSessionClientSecret: String,
+        val publishableKey: String,
+    ) : Parcelable
+
+    /**
+     * Present the connections sheet.
+     *
+     * @param configuration the connections sheet configuration
+     */
+    fun present(
+        configuration: Configuration
+    ) {
+        connectionsSheetLauncher.present(configuration)
+    }
+}

--- a/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetActivity.kt
+++ b/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetActivity.kt
@@ -1,0 +1,124 @@
+package com.stripe.android.connections
+
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
+import androidx.activity.viewModels
+import androidx.annotation.VisibleForTesting
+import androidx.appcompat.app.AppCompatActivity
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
+import com.stripe.android.connections.ConnectionsSheetViewEffect.FinishWithResult
+import com.stripe.android.connections.ConnectionsSheetViewEffect.OpenAuthFlowWithUrl
+import com.stripe.android.connections.databinding.ActivityConnectionsSheetBinding
+import java.security.InvalidParameterException
+
+internal class ConnectionsSheetActivity : AppCompatActivity() {
+
+    private val startForResult = registerForActivityResult(StartActivityForResult()) {
+        viewModel.onActivityResult()
+    }
+
+    @VisibleForTesting
+    internal val viewBinding by lazy {
+        ActivityConnectionsSheetBinding.inflate(layoutInflater)
+    }
+
+    @VisibleForTesting
+    internal var viewModelFactory: ViewModelProvider.Factory =
+        ConnectionsSheetViewModel.Factory(
+            { application },
+            { requireNotNull(starterArgs) },
+            this,
+            intent?.extras
+        )
+
+    private val viewModel: ConnectionsSheetViewModel by viewModels { viewModelFactory }
+
+    private val starterArgs: ConnectionsSheetContract.Args? by lazy {
+        ConnectionsSheetContract.Args.fromIntent(intent)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(viewBinding.root)
+
+        val starterArgs = this.starterArgs
+        if (starterArgs == null) {
+            finishWithResult(
+                ConnectionsSheetResult.Failed(
+                    IllegalArgumentException("ConnectionsSheet started without arguments.")
+                )
+            )
+            return
+        } else {
+            try {
+                starterArgs.validate()
+            } catch (e: InvalidParameterException) {
+                finishWithResult(ConnectionsSheetResult.Failed(e))
+                return
+            }
+        }
+
+        setupObservers()
+        if (savedInstanceState != null) viewModel.onActivityRecreated()
+    }
+
+    private fun setupObservers() {
+        lifecycleScope.launchWhenStarted {
+            viewModel.state.collect {
+                // process state updates here.
+            }
+        }
+        lifecycleScope.launchWhenStarted {
+            viewModel.viewEffect.collect { viewEffect ->
+                when (viewEffect) {
+                    is OpenAuthFlowWithUrl -> viewEffect.launch()
+                    is FinishWithResult -> finishWithResult(viewEffect.result)
+                }
+            }
+        }
+    }
+
+    private fun OpenAuthFlowWithUrl.launch() {
+        startForResult.launch(
+            CustomTabsIntent.Builder()
+                .setShareState(CustomTabsIntent.SHARE_STATE_OFF)
+                .build()
+                .also { it.intent.data = Uri.parse(this.url) }
+                .intent
+        )
+    }
+
+    override fun onResume() {
+        super.onResume()
+        viewModel.onResume()
+    }
+
+    /**
+     * Handles new intents in the form of the redirect from the custom tab hosted auth flow
+     */
+    public override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        viewModel.handleOnNewIntent(intent)
+    }
+
+    /**
+     * If the back button is pressed during the manifest fetch or link account session fetch
+     * return canceled result
+     */
+    override fun onBackPressed() {
+        finishWithResult(ConnectionsSheetResult.Canceled)
+    }
+
+    private fun finishWithResult(result: ConnectionsSheetResult) {
+        setResult(
+            Activity.RESULT_OK,
+            Intent().putExtras(ConnectionsSheetContract.Result(result).toBundle())
+        )
+        finish()
+    }
+}

--- a/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetContract.kt
+++ b/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetContract.kt
@@ -1,0 +1,73 @@
+package com.stripe.android.connections
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.os.Parcelable
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.core.os.bundleOf
+import kotlinx.parcelize.Parcelize
+import java.security.InvalidParameterException
+
+internal class ConnectionsSheetContract :
+    ActivityResultContract<ConnectionsSheetContract.Args, ConnectionsSheetResult>() {
+
+    override fun createIntent(
+        context: Context,
+        input: Args
+    ): Intent {
+        return Intent(context, ConnectionsSheetActivity::class.java).putExtra(EXTRA_ARGS, input)
+    }
+
+    override fun parseResult(
+        resultCode: Int,
+        intent: Intent?
+    ): ConnectionsSheetResult {
+        val connectionsResult =
+            intent?.getParcelableExtra<Result>(EXTRA_RESULT)?.connectionsSheetResult
+        return connectionsResult ?: ConnectionsSheetResult.Failed(
+            IllegalArgumentException("Failed to retrieve a ConnectionsSheetResult.")
+        )
+    }
+
+    @Parcelize
+    data class Args constructor(
+        val configuration: ConnectionsSheet.Configuration,
+    ) : Parcelable {
+
+        fun validate() {
+            if (configuration.linkAccountSessionClientSecret.isBlank()) {
+                throw InvalidParameterException(
+                    "The link account session client secret cannot be an empty string."
+                )
+            }
+            if (configuration.publishableKey.isBlank()) {
+                throw InvalidParameterException(
+                    "The publishable key cannot be an empty string."
+                )
+            }
+        }
+
+        companion object {
+            internal fun fromIntent(intent: Intent): Args? {
+                return intent.getParcelableExtra(EXTRA_ARGS)
+            }
+        }
+    }
+
+    @Parcelize
+    data class Result(
+        val connectionsSheetResult: ConnectionsSheetResult
+    ) : Parcelable {
+        fun toBundle(): Bundle {
+            return bundleOf(EXTRA_RESULT to this)
+        }
+    }
+
+    companion object {
+        const val EXTRA_ARGS =
+            "com.stripe.android.connections.ConnectionsSheetContract.extra_args"
+        private const val EXTRA_RESULT =
+            "com.stripe.android.connections.ConnectionsSheetContract.extra_result"
+    }
+}

--- a/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetLauncher.kt
+++ b/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetLauncher.kt
@@ -1,0 +1,5 @@
+package com.stripe.android.connections
+
+internal interface ConnectionsSheetLauncher {
+    fun present(configuration: ConnectionsSheet.Configuration)
+}

--- a/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetRedirectActivity.kt
+++ b/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetRedirectActivity.kt
@@ -1,0 +1,25 @@
+package com.stripe.android.connections
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+
+/**
+ * This Activity handles redirects from the ChromeCustomTab hosting the AuthFlow.
+ * It'll process the result url in [Intent.getData] and pass them back to the opening activity,
+ * [ConnectionsSheetActivity].
+ */
+class ConnectionsSheetRedirectActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        /**
+         * Used together, FLAG_ACTIVITY_SINGLE_TOP and FLAG_ACTIVITY_CLEAR_TOP
+         * clear everything on the stack above the opening activity, including CCT.
+         */
+        Intent(this, ConnectionsSheetActivity::class.java)
+            .setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+            .also { it.data = intent.data }
+            .let { startActivity(it) }
+        finish()
+    }
+}

--- a/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetResult.kt
+++ b/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetResult.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.connections
+
+import android.os.Parcelable
+import com.stripe.android.connections.model.LinkAccountSession
+import kotlinx.parcelize.Parcelize
+
+/**
+ * The result of an attempt to complete a connections session
+ */
+sealed class ConnectionsSheetResult : Parcelable {
+    /**
+     * The customer completed the connections session.
+     * @param linkAccountSession The link account session connected
+     */
+    @Parcelize
+    data class Completed(
+        val linkAccountSession: LinkAccountSession
+    ) : ConnectionsSheetResult()
+
+    /**
+     * The customer canceled the connections session attempt.
+     */
+    @Parcelize
+    object Canceled : ConnectionsSheetResult()
+
+    /**
+     * The connections session attempt failed.
+     * @param error The error encountered by the customer.
+     */
+    @Parcelize
+    data class Failed(
+        val error: Throwable
+    ) : ConnectionsSheetResult()
+}

--- a/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetResultCallback.kt
+++ b/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetResultCallback.kt
@@ -1,0 +1,8 @@
+package com.stripe.android.connections
+
+/**
+ * Callback that is invoked when a [ConnectionsSheetResult] is available.
+ */
+fun interface ConnectionsSheetResultCallback {
+    fun onConnectionsSheetResult(connectionsSheetResult: ConnectionsSheetResult)
+}

--- a/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetState.kt
+++ b/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetState.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.connections
+
+import com.stripe.android.connections.model.LinkAccountSessionManifest
+
+/**
+ *  Class containing all of the data needed to represent the screen.
+ */
+internal data class ConnectionsSheetState(
+    val activityRecreated: Boolean = false,
+    val manifest: LinkAccountSessionManifest? = null,
+    val authFlowActive: Boolean = false
+)
+
+/**
+ *  Class containing all side effects intended to be run by the view.
+ *
+ *  Mostly one-off actions to be executed by the view will be instances of ViewEffect.
+ */
+internal sealed class ConnectionsSheetViewEffect {
+
+    /**
+     * Open the AuthFlow.
+     */
+    data class OpenAuthFlowWithUrl(
+        val url: String
+    ) : ConnectionsSheetViewEffect()
+
+    /**
+     * Finish [ConnectionsSheetActivity] with a given [ConnectionsSheetResult]
+     */
+    data class FinishWithResult(
+        val result: ConnectionsSheetResult
+    ) : ConnectionsSheetViewEffect()
+}

--- a/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetViewModel.kt
+++ b/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetViewModel.kt
@@ -1,0 +1,215 @@
+package com.stripe.android.connections
+
+import android.app.Application
+import android.content.Intent
+import android.os.Bundle
+import androidx.lifecycle.AbstractSavedStateViewModelFactory
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.savedstate.SavedStateRegistryOwner
+import com.stripe.android.connections.ConnectionsSheetViewEffect.FinishWithResult
+import com.stripe.android.connections.ConnectionsSheetViewEffect.OpenAuthFlowWithUrl
+import com.stripe.android.connections.analytics.ConnectionsEventReporter
+import com.stripe.android.connections.di.APPLICATION_ID
+import com.stripe.android.connections.di.DaggerConnectionsSheetComponent
+import com.stripe.android.connections.domain.FetchLinkAccountSession
+import com.stripe.android.connections.domain.GenerateLinkAccountSessionManifest
+import com.stripe.android.connections.model.LinkAccountSession
+import com.stripe.android.connections.model.LinkAccountSessionManifest
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Named
+
+internal class ConnectionsSheetViewModel @Inject constructor(
+    @Named(APPLICATION_ID) private val applicationId: String,
+    private val starterArgs: ConnectionsSheetContract.Args,
+    private val generateLinkAccountSessionManifest: GenerateLinkAccountSessionManifest,
+    private val fetchLinkAccountSession: FetchLinkAccountSession,
+    private val eventReporter: ConnectionsEventReporter
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(ConnectionsSheetState())
+    internal val state: StateFlow<ConnectionsSheetState> = _state
+    private val _viewEffect = MutableSharedFlow<ConnectionsSheetViewEffect>()
+    internal val viewEffect: SharedFlow<ConnectionsSheetViewEffect> = _viewEffect
+
+    init {
+        eventReporter.onPresented(starterArgs.configuration)
+        fetchManifest()
+    }
+
+    /**
+     * Fetches the [LinkAccountSessionManifest] from the Stripe API to get the hosted auth flow URL
+     * as well as the success and cancel callback URLs to verify.
+     */
+    private fun fetchManifest() {
+        viewModelScope.launch {
+            kotlin.runCatching {
+                generateLinkAccountSessionManifest(
+                    clientSecret = starterArgs.configuration.linkAccountSessionClientSecret,
+                    applicationId = applicationId
+                )
+            }.onFailure {
+                onFatal(it)
+            }.onSuccess {
+                openAuthFlow(it)
+            }
+        }
+    }
+
+    /**
+     * Builds the ChromeCustomTab intent to launch the hosted auth flow and launches it.
+     *
+     * @param manifest the manifest containing the hosted auth flow URL to launch
+     *
+     */
+    private suspend fun openAuthFlow(manifest: LinkAccountSessionManifest) {
+        // stores manifest in state for future references.
+        _state.emit(
+            state.value.copy(
+                manifest = manifest,
+                authFlowActive = true
+            )
+        )
+        _viewEffect.emit(OpenAuthFlowWithUrl(manifest.hostedAuthUrl))
+    }
+
+    /**
+     * Activity recreation changes the lifecycle order:
+     *
+     * - If config change happens while in web flow: onResume -> onNewIntent -> activityResult
+     * - If no config change happens: onActivityResult -> onNewIntent -> onResume
+     *
+     * (note [handleOnNewIntent] will just get called if user completed the web flow and clicked
+     * the deeplink that redirects back to the app)
+     *
+     * We need to rely on a post-onNewIntent lifecycle callback to figure if the user completed
+     * or cancelled the web flow. [ConnectionsSheetState.activityRecreated] will be used to
+     * figure which lifecycle callback happens after onNewIntent.
+     *
+     * @see onResume (we rely on this on regular flows)
+     * @see onActivityResult (we rely on this on config changes)
+     */
+    internal fun onActivityRecreated() {
+        _state.update { it.copy(activityRecreated = true) }
+    }
+
+    /**
+     *  If activity resumes and we did not receive a callback from the custom tabs,
+     *  then the user hit the back button or closed the custom tabs UI, so return result as
+     *  canceled.
+     */
+    internal fun onResume() {
+        if (_state.value.authFlowActive && _state.value.activityRecreated.not()) {
+            viewModelScope.launch {
+                _viewEffect.emit(FinishWithResult(ConnectionsSheetResult.Canceled))
+            }
+        }
+    }
+
+    /**
+     * If activity receives result and we did not receive a callback from the custom tabs,
+     * if activity got recreated and the auth flow is still active then the user hit
+     * the back button or closed the custom tabs UI, so return result as canceled.
+     */
+    internal fun onActivityResult() {
+        if (_state.value.authFlowActive && _state.value.activityRecreated) {
+            viewModelScope.launch {
+                _viewEffect.emit(FinishWithResult(ConnectionsSheetResult.Canceled))
+            }
+        }
+    }
+
+    /**
+     * On successfully completing the hosted auth flow and receiving the success callback intent,
+     * fetch the updated [LinkAccountSession] model from the API and return that via the
+     * [ConnectionsSheetResult] and [ConnectionsSheetResultCallback]
+     */
+    private fun fetchLinkAccountSession() {
+        viewModelScope.launch {
+            kotlin.runCatching {
+                fetchLinkAccountSession(starterArgs.configuration.linkAccountSessionClientSecret)
+            }.onSuccess {
+                val result = ConnectionsSheetResult.Completed(it)
+                eventReporter.onResult(starterArgs.configuration, result)
+                _viewEffect.emit(FinishWithResult(result))
+            }.onFailure {
+                onFatal(it)
+            }
+        }
+    }
+
+    /**
+     * If an error occurs during the connections sheet auth flow, return that error via the
+     * [ConnectionsSheetResultCallback] and [ConnectionsSheetResult.Failed].
+     *
+     * @param throwable the error encountered during the connections sheet auth flow
+     */
+    private suspend fun onFatal(throwable: Throwable) {
+        val result = ConnectionsSheetResult.Failed(throwable)
+        eventReporter.onResult(starterArgs.configuration, result)
+        _viewEffect.emit(FinishWithResult(result))
+    }
+
+    /**
+     * If a user cancels the hosted auth flow either by closing the custom tab with the back button
+     * or clicking a cancel link within the hosted auth flow and the activity received the canceled
+     * URL callback, notify the [ConnectionsSheetResultCallback] of [ConnectionsSheetResult.Canceled]
+     */
+    private suspend fun onUserCancel() {
+        val result = ConnectionsSheetResult.Canceled
+        eventReporter.onResult(starterArgs.configuration, result)
+        _viewEffect.emit(FinishWithResult(result))
+    }
+
+    /**
+     * The hosted auth flow will redirect to a URL scheme stripe-auth://link-accounts which will be
+     * handled by the [ConnectionsSheetActivity] per the intent filter in the Android manifest and
+     * with the launch mode for the activity being `singleTask` it will trigger a new intent for the
+     * activity which this method will receive
+     *
+     * @param intent the new intent with the redirect URL in the intent data
+     */
+    internal fun handleOnNewIntent(intent: Intent?) {
+        _state.update { it.copy(authFlowActive = false) }
+        viewModelScope.launch {
+            val manifest = _state.value.manifest
+            when (intent?.data.toString()) {
+                manifest?.successUrl -> fetchLinkAccountSession()
+                manifest?.cancelUrl -> onUserCancel()
+                else -> onFatal(Exception("Error processing ConnectionsSheet intent"))
+            }
+        }
+    }
+
+    class Factory(
+        private val applicationSupplier: () -> Application,
+        private val starterArgsSupplier: () -> ConnectionsSheetContract.Args,
+        owner: SavedStateRegistryOwner,
+        defaultArgs: Bundle? = null
+    ) : AbstractSavedStateViewModelFactory(owner, defaultArgs) {
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(
+            key: String,
+            modelClass: Class<T>,
+            savedStateHandle: SavedStateHandle
+        ): T {
+            return DaggerConnectionsSheetComponent
+                .builder()
+                .application(applicationSupplier())
+                .configuration(starterArgsSupplier())
+                .build().viewModel as T
+        }
+    }
+
+    internal companion object {
+        internal const val MAX_ACCOUNTS = 100
+    }
+}

--- a/connections/src/main/java/com/stripe/android/connections/DefaultConnectionsSheetLauncher.kt
+++ b/connections/src/main/java/com/stripe/android/connections/DefaultConnectionsSheetLauncher.kt
@@ -1,0 +1,40 @@
+package com.stripe.android.connections
+
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultLauncher
+import androidx.fragment.app.Fragment
+
+internal class DefaultConnectionsSheetLauncher(
+    private val activityResultLauncher: ActivityResultLauncher<ConnectionsSheetContract.Args>
+) : ConnectionsSheetLauncher {
+
+    constructor(
+        activity: ComponentActivity,
+        callback: ConnectionsSheetResultCallback
+    ) : this(
+        activity.registerForActivityResult(
+            ConnectionsSheetContract()
+        ) {
+            callback.onConnectionsSheetResult(it)
+        }
+    )
+
+    constructor(
+        fragment: Fragment,
+        callback: ConnectionsSheetResultCallback
+    ) : this(
+        fragment.registerForActivityResult(
+            ConnectionsSheetContract()
+        ) {
+            callback.onConnectionsSheetResult(it)
+        }
+    )
+
+    override fun present(configuration: ConnectionsSheet.Configuration) {
+        activityResultLauncher.launch(
+            ConnectionsSheetContract.Args(
+                configuration,
+            )
+        )
+    }
+}

--- a/connections/src/main/java/com/stripe/android/connections/analytics/ConnectionsAnalyticsEvent.kt
+++ b/connections/src/main/java/com/stripe/android/connections/analytics/ConnectionsAnalyticsEvent.kt
@@ -1,0 +1,27 @@
+package com.stripe.android.connections.analytics
+
+import com.stripe.android.core.networking.AnalyticsEvent
+
+internal data class ConnectionsAnalyticsEvent(
+    val eventCode: Code,
+    val additionalParams: Map<String, String> = emptyMap()
+) : AnalyticsEvent {
+
+    override val eventName: String = eventCode.toString()
+
+    enum class Code(internal val code: String) {
+
+        // Connections Sheet Events
+        SheetPresented("sheet.presented"),
+        SheetClosed("sheet.closed"),
+        SheetFailed("sheet.failed");
+
+        override fun toString(): String {
+            return "$PREFIX.$code"
+        }
+
+        private companion object {
+            private const val PREFIX = "stripe_android.connections"
+        }
+    }
+}

--- a/connections/src/main/java/com/stripe/android/connections/analytics/ConnectionsEventReporter.kt
+++ b/connections/src/main/java/com/stripe/android/connections/analytics/ConnectionsEventReporter.kt
@@ -1,0 +1,22 @@
+package com.stripe.android.connections.analytics
+
+import com.stripe.android.connections.ConnectionsSheet
+import com.stripe.android.connections.ConnectionsSheetResult
+
+/**
+ * Contract for connections related analytic events that will be tracked.
+ *
+ * Implementation will encapsulate the firing event logic.
+ *
+ * @see [ConnectionsAnalyticsEvent].
+ *
+ */
+internal interface ConnectionsEventReporter {
+
+    fun onPresented(configuration: ConnectionsSheet.Configuration)
+
+    fun onResult(
+        configuration: ConnectionsSheet.Configuration,
+        connectionsSheetResult: ConnectionsSheetResult
+    )
+}

--- a/connections/src/main/java/com/stripe/android/connections/analytics/DefaultConnectionsEventReporter.kt
+++ b/connections/src/main/java/com/stripe/android/connections/analytics/DefaultConnectionsEventReporter.kt
@@ -1,0 +1,77 @@
+package com.stripe.android.connections.analytics
+
+import com.stripe.android.connections.ConnectionsSheet
+import com.stripe.android.connections.ConnectionsSheetResult
+import com.stripe.android.core.injection.IOContext
+import com.stripe.android.core.networking.AnalyticsRequestExecutor
+import com.stripe.android.core.networking.AnalyticsRequestFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import kotlin.coroutines.CoroutineContext
+
+internal class DefaultConnectionsEventReporter @Inject constructor(
+    private val analyticsRequestExecutor: AnalyticsRequestExecutor,
+    private val analyticsRequestFactory: AnalyticsRequestFactory,
+    @IOContext private val workContext: CoroutineContext
+) : ConnectionsEventReporter {
+
+    override fun onPresented(configuration: ConnectionsSheet.Configuration) {
+        fireEvent(
+            ConnectionsAnalyticsEvent(
+                ConnectionsAnalyticsEvent.Code.SheetPresented,
+                mapOf(PARAM_CLIENT_SECRET to configuration.linkAccountSessionClientSecret)
+            )
+        )
+    }
+
+    override fun onResult(
+        configuration: ConnectionsSheet.Configuration,
+        connectionsSheetResult: ConnectionsSheetResult
+    ) {
+        val event = when (connectionsSheetResult) {
+            is ConnectionsSheetResult.Completed ->
+                ConnectionsAnalyticsEvent(
+                    ConnectionsAnalyticsEvent.Code.SheetClosed,
+                    mapOf(
+                        PARAM_CLIENT_SECRET to configuration.linkAccountSessionClientSecret,
+                        PARAM_SESSION_RESULT to "completed"
+                    )
+                )
+            is ConnectionsSheetResult.Canceled ->
+                ConnectionsAnalyticsEvent(
+                    ConnectionsAnalyticsEvent.Code.SheetClosed,
+                    mapOf(
+                        PARAM_CLIENT_SECRET to configuration.linkAccountSessionClientSecret,
+                        PARAM_SESSION_RESULT to "cancelled"
+                    )
+                )
+            is ConnectionsSheetResult.Failed ->
+                ConnectionsAnalyticsEvent(
+                    ConnectionsAnalyticsEvent.Code.SheetFailed,
+                    mapOf(
+                        PARAM_CLIENT_SECRET to configuration.linkAccountSessionClientSecret,
+                        PARAM_SESSION_RESULT to "failure"
+                    )
+                )
+        }
+
+        fireEvent(event)
+    }
+
+    private fun fireEvent(event: ConnectionsAnalyticsEvent) {
+        CoroutineScope(workContext).launch {
+            analyticsRequestExecutor.executeAsync(
+                analyticsRequestFactory.createRequest(
+                    event = event,
+                    additionalParams = event.additionalParams
+                )
+            )
+        }
+    }
+
+    internal companion object {
+        const val PARAM_CLIENT_SECRET = "las_client_secret"
+        const val PARAM_SESSION_RESULT = "session_result"
+    }
+}

--- a/connections/src/main/java/com/stripe/android/connections/di/ConnectionsSheetComponent.kt
+++ b/connections/src/main/java/com/stripe/android/connections/di/ConnectionsSheetComponent.kt
@@ -1,0 +1,35 @@
+package com.stripe.android.connections.di
+
+import android.app.Application
+import com.stripe.android.connections.ConnectionsSheetContract
+import com.stripe.android.connections.ConnectionsSheetViewModel
+import com.stripe.android.core.injection.CoroutineContextModule
+import com.stripe.android.core.injection.LoggingModule
+import dagger.BindsInstance
+import dagger.Component
+import javax.inject.Singleton
+
+@Singleton
+@Component(
+    modules = [
+        ConnectionsSheetModule::class,
+        CoroutineContextModule::class,
+        LoggingModule::class
+    ]
+)
+internal interface ConnectionsSheetComponent {
+    val viewModel: ConnectionsSheetViewModel
+
+    fun inject(factory: ConnectionsSheetViewModel.Factory)
+
+    @Component.Builder
+    interface Builder {
+        @BindsInstance
+        fun application(application: Application): Builder
+
+        @BindsInstance
+        fun configuration(configuration: ConnectionsSheetContract.Args): Builder
+
+        fun build(): ConnectionsSheetComponent
+    }
+}

--- a/connections/src/main/java/com/stripe/android/connections/di/ConnectionsSheetConfigurationModule.kt
+++ b/connections/src/main/java/com/stripe/android/connections/di/ConnectionsSheetConfigurationModule.kt
@@ -1,0 +1,40 @@
+package com.stripe.android.connections.di
+
+import android.app.Application
+import com.stripe.android.connections.BuildConfig
+import com.stripe.android.connections.ConnectionsSheet
+import com.stripe.android.connections.ConnectionsSheetContract
+import com.stripe.android.core.injection.ENABLE_LOGGING
+import dagger.Module
+import dagger.Provides
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Module
+internal object ConnectionsSheetConfigurationModule {
+
+    @Provides
+    @Singleton
+    fun providesConfiguration(
+        args: ConnectionsSheetContract.Args
+    ): ConnectionsSheet.Configuration = args.configuration
+
+    @Provides
+    @Named(PUBLISHABLE_KEY)
+    @Singleton
+    fun providesPublishableKey(
+        configuration: ConnectionsSheet.Configuration
+    ): String = configuration.publishableKey
+
+    @Provides
+    @Named(ENABLE_LOGGING)
+    @Singleton
+    fun providesEnableLogging(): Boolean = BuildConfig.DEBUG
+
+    @Provides
+    @Singleton
+    @Named(APPLICATION_ID)
+    fun providesApplicationId(
+        application: Application
+    ): String = application.packageName
+}

--- a/connections/src/main/java/com/stripe/android/connections/di/ConnectionsSheetModule.kt
+++ b/connections/src/main/java/com/stripe/android/connections/di/ConnectionsSheetModule.kt
@@ -1,0 +1,72 @@
+package com.stripe.android.connections.di
+
+import android.app.Application
+import androidx.core.os.LocaleListCompat
+import com.stripe.android.connections.analytics.ConnectionsEventReporter
+import com.stripe.android.connections.analytics.DefaultConnectionsEventReporter
+import com.stripe.android.connections.repository.ConnectionsApiRepository
+import com.stripe.android.connections.repository.ConnectionsRepository
+import com.stripe.android.core.Logger
+import com.stripe.android.core.injection.IOContext
+import com.stripe.android.core.networking.AnalyticsRequestExecutor
+import com.stripe.android.core.networking.AnalyticsRequestFactory
+import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
+import com.stripe.android.core.networking.DefaultStripeNetworkClient
+import com.stripe.android.core.networking.StripeNetworkClient
+import dagger.Module
+import dagger.Provides
+import java.util.Locale
+import javax.inject.Named
+import javax.inject.Singleton
+import kotlin.coroutines.CoroutineContext
+
+@Module(
+    includes = [ConnectionsSheetConfigurationModule::class]
+)
+internal object ConnectionsSheetModule {
+
+    @Provides
+    @Singleton
+    fun provideStripeNetworkClient(
+        @IOContext context: CoroutineContext,
+        logger: Logger
+    ): StripeNetworkClient = DefaultStripeNetworkClient(
+        workContext = context,
+        logger = logger
+    )
+
+    @Provides
+    @Singleton
+    fun provideConnectionsRepository(
+        repository: ConnectionsApiRepository
+    ): ConnectionsRepository = repository
+
+    @Provides
+    @Singleton
+    fun provideLocale(): Locale? =
+        LocaleListCompat.getAdjustedDefault().takeUnless { it.isEmpty }?.get(0)
+
+    @Provides
+    @Singleton
+    fun provideEventReporter(
+        defaultConnectionsEventReporter: DefaultConnectionsEventReporter
+    ): ConnectionsEventReporter = defaultConnectionsEventReporter
+
+    @Provides
+    @Singleton
+    internal fun providesAnalyticsRequestExecutor(
+        executor: DefaultAnalyticsRequestExecutor
+    ): AnalyticsRequestExecutor = executor
+
+    @Provides
+    @Singleton
+    internal fun provideAnalyticsRequestFactory(
+        application: Application,
+        @Named(PUBLISHABLE_KEY) publishableKey: String,
+    ): AnalyticsRequestFactory = AnalyticsRequestFactory(
+        packageManager = application.packageManager,
+        packageName = application.packageName.orEmpty(),
+        packageInfo = application.packageManager.getPackageInfo(application.packageName, 0),
+        publishableKeyProvider = { publishableKey }
+    )
+}

--- a/connections/src/main/java/com/stripe/android/connections/di/NamedConstants.kt
+++ b/connections/src/main/java/com/stripe/android/connections/di/NamedConstants.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.connections.di
+
+/**
+ * Name for user's publishable key
+ */
+internal const val PUBLISHABLE_KEY = "publishableKey"
+
+/**
+ * Host's applicationId.
+ */
+internal const val APPLICATION_ID = "applicationId"

--- a/connections/src/main/java/com/stripe/android/connections/domain/FetchLinkAccountSession.kt
+++ b/connections/src/main/java/com/stripe/android/connections/domain/FetchLinkAccountSession.kt
@@ -1,0 +1,55 @@
+package com.stripe.android.connections.domain
+
+import com.stripe.android.connections.ConnectionsSheetViewModel
+import com.stripe.android.connections.model.LinkAccountSession
+import com.stripe.android.connections.model.LinkedAccount
+import com.stripe.android.connections.model.LinkedAccountList
+import com.stripe.android.connections.model.ListLinkedAccountParams
+import com.stripe.android.connections.repository.ConnectionsRepository
+import javax.inject.Inject
+
+internal class FetchLinkAccountSession @Inject constructor(
+    private val connectionsRepository: ConnectionsRepository
+) {
+
+    /**
+     * Fetches the link account session with all linked accounts via pagination
+     *
+     * @param clientSecret the link account session client secret
+     *
+     * @return LinkAccountSession with all linked accounts
+     */
+    suspend operator fun invoke(clientSecret: String): LinkAccountSession {
+        val linkAccountSession = connectionsRepository.getLinkAccountSession(clientSecret)
+        if (linkAccountSession.linkedAccounts.hasMore) {
+            val accounts = mutableListOf<LinkedAccount>()
+            accounts.addAll(linkAccountSession.linkedAccounts.linkedAccounts)
+
+            var nextLinkedAccountList = connectionsRepository.getLinkedAccounts(
+                ListLinkedAccountParams(clientSecret, accounts.last().id)
+            )
+            accounts.addAll(nextLinkedAccountList.linkedAccounts)
+
+            while (nextLinkedAccountList.hasMore && accounts.size < ConnectionsSheetViewModel.MAX_ACCOUNTS) {
+                nextLinkedAccountList = connectionsRepository.getLinkedAccounts(
+                    ListLinkedAccountParams(clientSecret, accounts.last().id)
+                )
+                accounts.addAll(nextLinkedAccountList.linkedAccounts)
+            }
+
+            return LinkAccountSession(
+                id = linkAccountSession.id,
+                clientSecret = linkAccountSession.clientSecret,
+                linkedAccounts = LinkedAccountList(
+                    linkedAccounts = accounts,
+                    hasMore = nextLinkedAccountList.hasMore,
+                    url = nextLinkedAccountList.url,
+                    count = accounts.size,
+                    totalCount = nextLinkedAccountList.totalCount
+                ),
+                livemode = linkAccountSession.livemode
+            )
+        }
+        return linkAccountSession
+    }
+}

--- a/connections/src/main/java/com/stripe/android/connections/domain/GenerateLinkAccountSessionManifest.kt
+++ b/connections/src/main/java/com/stripe/android/connections/domain/GenerateLinkAccountSessionManifest.kt
@@ -1,0 +1,24 @@
+package com.stripe.android.connections.domain
+
+import com.stripe.android.connections.model.LinkAccountSessionManifest
+import com.stripe.android.connections.repository.ConnectionsRepository
+import javax.inject.Inject
+
+/**
+ * Fetches the [LinkAccountSessionManifest] from the Stripe API to get the hosted auth flow URL
+ * as well as the success and cancel callback URLs to verify.
+ */
+internal class GenerateLinkAccountSessionManifest @Inject constructor(
+    private val connectionsRepository: ConnectionsRepository,
+) {
+
+    suspend operator fun invoke(
+        clientSecret: String,
+        applicationId: String
+    ): LinkAccountSessionManifest {
+        return connectionsRepository.generateLinkAccountSessionManifest(
+            clientSecret = clientSecret,
+            applicationId = applicationId
+        )
+    }
+}

--- a/connections/src/main/java/com/stripe/android/connections/exception/AuthenticationException.kt
+++ b/connections/src/main/java/com/stripe/android/connections/exception/AuthenticationException.kt
@@ -1,0 +1,19 @@
+package com.stripe.android.connections.exception
+
+import com.stripe.android.core.StripeError
+import com.stripe.android.core.exception.StripeException
+import java.net.HttpURLConnection
+
+/**
+ * No valid API key provided.
+ *
+ * [Errors](https://stripe.com/docs/api/errors)
+ */
+internal class AuthenticationException internal constructor(
+    stripeError: StripeError,
+    requestId: String? = null
+) : StripeException(
+    stripeError,
+    requestId,
+    HttpURLConnection.HTTP_UNAUTHORIZED
+)

--- a/connections/src/main/java/com/stripe/android/connections/exception/PermissionException.kt
+++ b/connections/src/main/java/com/stripe/android/connections/exception/PermissionException.kt
@@ -1,0 +1,18 @@
+package com.stripe.android.connections.exception
+
+import com.stripe.android.core.StripeError
+import com.stripe.android.core.exception.StripeException
+import java.net.HttpURLConnection
+
+/**
+ * A type of [AuthenticationException] resulting from incorrect permissions
+ * to perform the requested action.
+ */
+internal class PermissionException(
+    stripeError: StripeError,
+    requestId: String? = null
+) : StripeException(
+    stripeError,
+    requestId,
+    HttpURLConnection.HTTP_FORBIDDEN
+)

--- a/connections/src/main/java/com/stripe/android/connections/exception/RateLimitException.kt
+++ b/connections/src/main/java/com/stripe/android/connections/exception/RateLimitException.kt
@@ -1,0 +1,21 @@
+package com.stripe.android.connections.exception
+
+import com.stripe.android.core.StripeError
+import com.stripe.android.core.exception.StripeException
+import com.stripe.android.core.networking.HTTP_TOO_MANY_REQUESTS
+
+/**
+ * An [Exception] indicating that too many requests have hit the API too quickly.
+ */
+internal class RateLimitException(
+    stripeError: StripeError? = null,
+    requestId: String? = null,
+    message: String? = stripeError?.message,
+    cause: Throwable? = null
+) : StripeException(
+    stripeError,
+    requestId,
+    HTTP_TOO_MANY_REQUESTS,
+    cause,
+    message
+)

--- a/connections/src/main/java/com/stripe/android/connections/model/AccountHolder.kt
+++ b/connections/src/main/java/com/stripe/android/connections/model/AccountHolder.kt
@@ -1,0 +1,43 @@
+package com.stripe.android.connections.model
+
+import android.os.Parcelable
+import com.stripe.android.core.model.StripeModel
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ *
+ *
+ * @param type
+ * @param account
+ * @param customer ID of the Customer this LinkedAccount belongs to. Present if and only if `type` is `customer`.
+ */
+@Parcelize
+@Serializable
+@Suppress("unused")
+data class AccountHolder(
+
+    @SerialName("type")
+    val type: Type = Type.UNKNOWN,
+
+    @SerialName("account")
+    val account: String? = null,
+
+    /* ID of the Customer this LinkedAccount belongs to. Present if and only if `type` is `customer`. */
+    @SerialName("customer")
+    val customer: String? = null
+
+) : StripeModel, Parcelable {
+
+    @Serializable
+    enum class Type(val value: String) {
+        @SerialName("account")
+        ACCOUNT("account"),
+
+        @SerialName("customer")
+        CUSTOMER("customer"),
+
+        UNKNOWN("unknown");
+    }
+}

--- a/connections/src/main/java/com/stripe/android/connections/model/Balance.kt
+++ b/connections/src/main/java/com/stripe/android/connections/model/Balance.kt
@@ -1,0 +1,63 @@
+package com.stripe.android.connections.model
+
+import android.os.Parcelable
+import com.stripe.android.core.model.StripeModel
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ *
+ *
+ * @param asOf The time that the external institution calculated this balance.
+ * Measured in seconds since the Unix epoch.
+ * @param current The balances owed to (or by) the account holder.
+ * Each key is a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html),
+ * in lowercase. Each value is a integer amount.
+ * A positive amount indicates money owed to the account holder.
+ * A negative amount indicates money owed by the account holder.
+ * @param type
+ * @param cash
+ * @param credit
+ */
+@Parcelize
+@Serializable
+@Suppress("unused")
+data class Balance(
+
+    /* The time that the external institution calculated this balance.
+     Measured in seconds since the Unix epoch. */
+    @SerialName("as_of")
+    val asOf: Int,
+
+    /* The balances owed to (or by) the account holder.
+     Each key is a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html),
+     in lowercase. Each value is a integer amount.
+     A positive amount indicates money owed to the account holder.
+     A negative amount indicates money owed by the account holder.
+    */
+    @SerialName("current")
+    val current: Map<String, Int>,
+
+    @SerialName("type")
+    val type: Type = Type.UNKNOWN,
+
+    @SerialName("cash")
+    val cash: CashBalance? = null,
+
+    @SerialName("credit")
+    val credit: CreditBalance? = null
+
+) : StripeModel, Parcelable {
+
+    @Serializable
+    enum class Type(val value: String) {
+        @SerialName("cash")
+        CASH("cash"),
+
+        @SerialName("credit")
+        CREDIT("credit"),
+
+        UNKNOWN("unknown");
+    }
+}

--- a/connections/src/main/java/com/stripe/android/connections/model/BalanceRefresh.kt
+++ b/connections/src/main/java/com/stripe/android/connections/model/BalanceRefresh.kt
@@ -1,0 +1,30 @@
+package com.stripe.android.connections.model
+
+import android.os.Parcelable
+import com.stripe.android.core.model.StripeModel
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Parcelize
+@Serializable
+@Suppress("unused")
+data class BalanceRefresh(
+    @SerialName("status") val status: BalanceRefreshStatus? = BalanceRefreshStatus.UNKNOWN,
+    @SerialName("last_attempted_at") val lastAttemptedAt: Int
+) : StripeModel, Parcelable {
+
+    @Serializable
+    enum class BalanceRefreshStatus(internal val code: String) {
+        @SerialName("failed")
+        FAILED("failed"),
+
+        @SerialName("pending")
+        PENDING("pending"),
+
+        @SerialName("succeeded")
+        SUCCEEDED("succeeded"),
+
+        UNKNOWN("unknown");
+    }
+}

--- a/connections/src/main/java/com/stripe/android/connections/model/CashBalance.kt
+++ b/connections/src/main/java/com/stripe/android/connections/model/CashBalance.kt
@@ -1,0 +1,24 @@
+package com.stripe.android.connections.model
+
+import android.os.Parcelable
+import com.stripe.android.core.model.StripeModel
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ *
+ *
+ * @param available The funds available to the account holder. Typically this is the current balance less any holds.
+ * Each key is a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
+ * Each value is a integer amount.
+ * A positive amount indicates money owed to the account holder.
+ * A negative amount indicates money owed by the account holder.
+ */
+@Serializable
+@Parcelize
+data class CashBalance(
+    @SerialName("available")
+    val available: Map<String, Int>? = null
+
+) : StripeModel, Parcelable

--- a/connections/src/main/java/com/stripe/android/connections/model/CreditBalance.kt
+++ b/connections/src/main/java/com/stripe/android/connections/model/CreditBalance.kt
@@ -1,0 +1,24 @@
+package com.stripe.android.connections.model
+
+import android.os.Parcelable
+import com.stripe.android.core.model.StripeModel
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ *
+ *
+ * @param used The credit that has been used by the account holder.
+ * Each key is a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
+ * Each value is a integer amount.
+ * A positive amount indicates money owed to the account holder.
+ * A negative amount indicates money owed by the account holder.
+ */
+@Serializable
+@Parcelize
+data class CreditBalance(
+    @SerialName("used")
+    val used: Map<String, Int>? = null
+
+) : StripeModel, Parcelable

--- a/connections/src/main/java/com/stripe/android/connections/model/LinkAccountSession.kt
+++ b/connections/src/main/java/com/stripe/android/connections/model/LinkAccountSession.kt
@@ -1,0 +1,39 @@
+package com.stripe.android.connections.model
+
+import android.os.Parcelable
+import com.stripe.android.core.model.StripeModel
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ *
+ *
+ * @param clientSecret
+ * @param id
+ * @param linkedAccounts
+ * @param livemode
+ * @param paymentAccount
+ * @param returnUrl
+ */
+@Parcelize
+@Serializable
+data class LinkAccountSession internal constructor(
+    @SerialName("client_secret")
+    val clientSecret: String,
+
+    @SerialName("id")
+    val id: String,
+
+    @SerialName("linked_accounts")
+    val linkedAccounts: LinkedAccountList,
+
+    @SerialName("livemode")
+    val livemode: Boolean,
+
+    @SerialName("payment_account")
+    val paymentAccount: LinkedAccount? = null,
+
+    @SerialName("return_url")
+    val returnUrl: String? = null
+) : StripeModel, Parcelable

--- a/connections/src/main/java/com/stripe/android/connections/model/LinkAccountSessionManifest.kt
+++ b/connections/src/main/java/com/stripe/android/connections/model/LinkAccountSessionManifest.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.connections.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class LinkAccountSessionManifest(
+    @SerialName("hosted_auth_url") val hostedAuthUrl: String,
+    @SerialName("success_url") val successUrl: String,
+    @SerialName("cancel_url") val cancelUrl: String
+)

--- a/connections/src/main/java/com/stripe/android/connections/model/LinkedAccount.kt
+++ b/connections/src/main/java/com/stripe/android/connections/model/LinkedAccount.kt
@@ -1,0 +1,222 @@
+package com.stripe.android.connections.model
+
+import android.os.Parcelable
+import com.stripe.android.core.model.StripeModel
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * A Linked Account represents an account that exists outside of Stripe,
+ * to which you have been granted some degree of access.
+ *
+ * @param category
+ * @param created Time at which the object was created. Measured in seconds since the Unix epoch.
+ * @param id Unique identifier for the object.
+ * @param institutionName The name of the institution that holds this account.
+ * @param livemode Has the value `true` if the object exists in live mode or the value `false` if
+ * the object exists in test mode.
+ * @param status The status of the link to the account.
+ * @param subcategory If `category` is `cash`, one of:   - `checking`  - `savings`  - `other`
+ * If `category` is `credit`, one of:   - `mortgage`  - `line_of_credit`  - `credit_card`  - `other`
+ * If `category` is `investment` or `other`, this will be `other`.
+ * @param supportedPaymentMethodTypes
+ * The [PaymentMethod type](https://stripe.com/docs/api/payment_methods/object#payment_method_object-type)(s)
+ * that can be created from this LinkedAccount.
+ * @param accountholder
+ * @param balance The most recent information about the account's balance.
+ * @param balanceRefresh The state of the most recent attempt to refresh the account balance.
+ * @param displayName A human-readable name that has been assigned to this account,
+ * either by the account holder or by the institution.
+ * @param last4 The last 4 digits of the account number. If present, this will be 4 numeric characters.
+ * @param ownership The most recent information about the account's owners.
+ * @param ownershipRefresh The state of the most recent attempt to refresh the account owners.
+ * @param permissions The list of permissions granted by this account.
+ */
+@Serializable
+@Parcelize
+@Suppress("unused")
+data class LinkedAccount(
+
+    @SerialName("category")
+    val category: Category = Category.UNKNOWN,
+
+    /* Time at which the object was created. Measured in seconds since the Unix epoch. */
+    @SerialName("created")
+    val created: Int,
+
+    /* Unique identifier for the object. */
+    @SerialName("id")
+    val id: String,
+
+    /* The name of the institution that holds this account. */
+    @SerialName("institution_name")
+    val institutionName: String,
+
+    /* Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode. */
+    @SerialName("livemode")
+    val livemode: Boolean,
+
+    /* The status of the link to the account. */
+    @SerialName("status")
+    val status: Status = Status.UNKNOWN,
+
+    /* If `category` is `cash`, one of:   - `checking`  - `savings`  - `other`
+       If `category` is `credit`, one of:   - `mortgage`  - `line_of_credit`  - `credit_card`  - `other`
+       If `category` is `investment` or `other`, this will be `other`.
+    */
+    @SerialName("subcategory")
+    val subcategory: Subcategory = Subcategory.UNKNOWN,
+
+    /* The [PaymentMethod type](https://stripe.com/docs/api/payment_methods/object#payment_method_object-type)(s)
+     that can be created from this LinkedAccount. */
+    @SerialName("supported_payment_method_types")
+    val supportedPaymentMethodTypes: List<SupportedPaymentMethodTypes>,
+
+    @SerialName("accountholder")
+    val accountholder: AccountHolder? = null,
+
+    /* The most recent information about the account's balance. */
+    @SerialName("balance")
+    val balance: Balance? = null,
+
+    /* The state of the most recent attempt to refresh the account balance. */
+    @SerialName("balance_refresh")
+    val balanceRefresh: BalanceRefresh? = null,
+
+    /* A human-readable name that has been assigned to this account,
+    either by the account holder or by the institution. */
+    @SerialName("display_name")
+    val displayName: String? = null,
+
+    /* The last 4 digits of the account number. If present, this will be 4 numeric characters. */
+    @SerialName("last4")
+    val last4: String? = null,
+
+    /* The most recent information about the account's owners. */
+    @SerialName("ownership")
+    val ownership: String? = null,
+
+    /* The state of the most recent attempt to refresh the account owners. */
+    @SerialName("ownership_refresh")
+    val ownershipRefresh: OwnershipRefresh? = null,
+
+    /* The list of permissions granted by this account. */
+    @SerialName("permissions")
+    val permissions: List<Permissions>? = null
+
+) : StripeModel, Parcelable {
+
+    /**
+     *
+     *
+     * Values: cash,credit,investment,other
+     */
+    @Serializable
+    enum class Category(val value: String) {
+        @SerialName("cash")
+        CASH("cash"),
+
+        @SerialName("credit")
+        CREDIT("credit"),
+
+        @SerialName("investment")
+        INVESTMENT("investment"),
+
+        @SerialName("other")
+        OTHER("other"),
+
+        UNKNOWN("unknown");
+    }
+
+    /**
+     * The status of the link to the account.
+     *
+     * Values: active,disconnected,inactive
+     */
+    @Serializable
+    enum class Status(val value: String) {
+        @SerialName("active")
+        ACTIVE("active"),
+
+        @SerialName("disconnected")
+        DISCONNECTED("disconnected"),
+
+        @SerialName("inactive")
+        INACTIVE("inactive"),
+
+        UNKNOWN("unknown");
+    }
+
+    /**
+     * If `category` is `cash`, one of:   - `checking`  - `savings`  - `other`
+     * If `category` is `credit`, one of:   - `mortgage`  - `line_of_credit`  - `credit_card`  - `other`
+     * If `category` is `investment` or `other`, this will be `other`.
+     *
+     * Values: checking,creditCard,lineOfCredit,mortgage,other,savings
+     */
+    @Serializable
+    enum class Subcategory(val value: String) {
+        @SerialName("checking")
+        CHECKING("checking"),
+
+        @SerialName("credit_card")
+        CREDIT_CARD("credit_card"),
+
+        @SerialName("line_of_credit")
+        LINE_OF_CREDIT("line_of_credit"),
+
+        @SerialName("mortgage")
+        MORTGAGE("mortgage"),
+
+        @SerialName("other")
+        OTHER("other"),
+
+        @SerialName("savings")
+        SAVINGS("savings"),
+
+        UNKNOWN("unknown");
+    }
+
+    /**
+     * The [PaymentMethod type](https://stripe.com/docs/api/payment_methods/object#payment_method_object-type)(s)
+     * that can be created from this LinkedAccount.
+     *
+     * Values: link,usBankAccount
+     */
+    @Serializable
+    enum class SupportedPaymentMethodTypes(val value: String) {
+        @SerialName("link")
+        LINK("link"),
+
+        @SerialName("us_bank_account")
+        US_BANK_ACCOUNT("us_bank_account"),
+
+        UNKNOWN("unknown");
+    }
+
+    /**
+     * The list of permissions granted by this account.
+     *
+     * Values: balances,identity,ownership,paymentMethod,transactions
+     */
+    @Serializable
+    enum class Permissions(val value: String) {
+        @SerialName("balances")
+        BALANCES("balances"),
+
+        @SerialName("identity")
+        IDENTITY("identity"),
+
+        @SerialName("ownership")
+        OWNERSHIP("ownership"),
+
+        @SerialName("payment_method")
+        PAYMENT_METHOD("payment_method"),
+
+        @SerialName("transactions")
+        TRANSACTIONS("transactions"),
+
+        UNKNOWN("unknown");
+    }
+}

--- a/connections/src/main/java/com/stripe/android/connections/model/LinkedAccountList.kt
+++ b/connections/src/main/java/com/stripe/android/connections/model/LinkedAccountList.kt
@@ -1,0 +1,37 @@
+package com.stripe.android.connections.model
+
+import android.os.Parcelable
+import com.stripe.android.core.model.StripeModel
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ *
+ *
+ * @param `data`
+ * @param hasMore True if this list has another page of items after this one that can be fetched.
+ * @param url The URL where this list can be accessed.
+ * @param count
+ * @param totalCount
+ */
+@Parcelize
+@Serializable
+data class LinkedAccountList(
+    @SerialName("data")
+    val linkedAccounts: List<LinkedAccount>,
+
+    /* True if this list has another page of items after this one that can be fetched. */
+    @SerialName("has_more")
+    val hasMore: Boolean,
+
+    /* The URL where this list can be accessed. */
+    @SerialName("url")
+    val url: String,
+
+    @SerialName("count")
+    val count: Int? = null,
+
+    @SerialName("total_count")
+    val totalCount: Int? = null
+) : StripeModel, Parcelable

--- a/connections/src/main/java/com/stripe/android/connections/model/ListLinkedAccountParams.kt
+++ b/connections/src/main/java/com/stripe/android/connections/model/ListLinkedAccountParams.kt
@@ -1,0 +1,29 @@
+package com.stripe.android.connections.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Parcelize
+@Serializable
+data class ListLinkedAccountParams(
+    @SerialName("client_secret") private val clientSecret: String,
+    @SerialName("starting_after") private val startingAfterAccountId: String?,
+) : Parcelable {
+    fun toParamMap(): Map<String, Any> {
+        return listOf(
+            PARAM_CLIENT_SECRET to clientSecret,
+            PARAM_STARTING_AFTER to startingAfterAccountId
+        ).fold(emptyMap()) { acc, (key, value) ->
+            acc.plus(
+                value?.let { mapOf(key to it) }.orEmpty()
+            )
+        }
+    }
+
+    private companion object {
+        private const val PARAM_CLIENT_SECRET = "client_secret"
+        private const val PARAM_STARTING_AFTER = "starting_after"
+    }
+}

--- a/connections/src/main/java/com/stripe/android/connections/model/OwnershipRefresh.kt
+++ b/connections/src/main/java/com/stripe/android/connections/model/OwnershipRefresh.kt
@@ -1,0 +1,43 @@
+package com.stripe.android.connections.model
+
+import android.os.Parcelable
+import com.stripe.android.core.model.StripeModel
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ *
+ * @param lastAttemptedAt The time at which the last refresh attempt was initiated.
+ * Measured in seconds since the Unix epoch.
+ * @param status
+ */
+
+@Serializable
+@Parcelize
+@Suppress("unused")
+data class OwnershipRefresh(
+
+    /* The time at which the last refresh attempt was initiated. Measured in seconds since the Unix epoch. */
+    @SerialName("last_attempted_at")
+    val lastAttemptedAt: Int,
+
+    @SerialName("status")
+    val status: Status = Status.UNKNOWN
+
+) : Parcelable, StripeModel {
+
+    @Serializable
+    enum class Status(val value: String) {
+        @SerialName("failed")
+        FAILED("failed"),
+
+        @SerialName("pending")
+        PENDING("pending"),
+
+        @SerialName("succeeded")
+        SUCCEEDED("succeeded"),
+
+        UNKNOWN("unknown");
+    }
+}

--- a/connections/src/main/java/com/stripe/android/connections/repository/ConnectionsApiRepository.kt
+++ b/connections/src/main/java/com/stripe/android/connections/repository/ConnectionsApiRepository.kt
@@ -1,0 +1,163 @@
+package com.stripe.android.connections.repository
+
+import androidx.annotation.VisibleForTesting
+import com.stripe.android.connections.di.PUBLISHABLE_KEY
+import com.stripe.android.connections.exception.AuthenticationException
+import com.stripe.android.connections.exception.PermissionException
+import com.stripe.android.connections.exception.RateLimitException
+import com.stripe.android.connections.model.LinkAccountSession
+import com.stripe.android.connections.model.LinkAccountSessionManifest
+import com.stripe.android.connections.model.LinkedAccountList
+import com.stripe.android.connections.model.ListLinkedAccountParams
+import com.stripe.android.core.exception.APIConnectionException
+import com.stripe.android.core.exception.APIException
+import com.stripe.android.core.exception.InvalidRequestException
+import com.stripe.android.core.model.parsers.StripeErrorJsonParser
+import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.core.networking.HTTP_TOO_MANY_REQUESTS
+import com.stripe.android.core.networking.StripeNetworkClient
+import com.stripe.android.core.networking.StripeRequest
+import com.stripe.android.core.networking.StripeResponse
+import com.stripe.android.core.networking.responseJson
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
+import java.lang.Exception
+import java.net.HttpURLConnection
+import javax.inject.Inject
+import javax.inject.Named
+
+internal class ConnectionsApiRepository @Inject constructor(
+    @Named(PUBLISHABLE_KEY) publishableKey: String,
+    private val stripeNetworkClient: StripeNetworkClient,
+) : ConnectionsRepository {
+
+    @VisibleForTesting
+    internal val json: Json = Json {
+        coerceInputValues = true
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = true
+    }
+
+    private val apiRequestFactory = ApiRequest.Factory()
+    private val options = ApiRequest.Options(
+        apiKey = publishableKey
+    )
+
+    override suspend fun getLinkedAccounts(
+        listLinkedAccountParams: ListLinkedAccountParams
+    ): LinkedAccountList {
+        val connectionsRequest = apiRequestFactory.createGet(
+            url = listAccountsUrl,
+            options = options,
+            params = listLinkedAccountParams.toParamMap()
+        )
+        return executeRequest(connectionsRequest, LinkedAccountList.serializer())
+    }
+
+    override suspend fun getLinkAccountSession(
+        clientSecret: String
+    ): LinkAccountSession {
+        val connectionsRequest = apiRequestFactory.createGet(
+            url = sessionReceiptUrl,
+            options = options,
+            params = mapOf(
+                PARAMS_CLIENT_SECRET to clientSecret
+            ),
+        )
+        return executeRequest(connectionsRequest, LinkAccountSession.serializer())
+    }
+
+    override suspend fun generateLinkAccountSessionManifest(
+        clientSecret: String,
+        applicationId: String
+    ): LinkAccountSessionManifest {
+        val connectionsRequest = apiRequestFactory.createPost(
+            url = generateHostedUrl,
+            options = options,
+            params = mapOf(
+                PARAMS_CLIENT_SECRET to clientSecret,
+                PARAMS_APPLICATION_ID to applicationId
+            ),
+        )
+        return executeRequest(connectionsRequest, LinkAccountSessionManifest.serializer())
+    }
+
+    private suspend fun <Response> executeRequest(
+        request: StripeRequest,
+        responseSerializer: KSerializer<Response>
+    ): Response = runCatching {
+        stripeNetworkClient.executeRequest(
+            request
+        )
+    }.fold(
+        onSuccess = { response ->
+            if (response.isError) {
+                throw handleApiError(response)
+            } else {
+                json.decodeFromString(
+                    responseSerializer,
+                    requireNotNull(response.body)
+                )
+            }
+        },
+        onFailure = {
+            throw APIConnectionException(
+                "Failed to execute $request",
+                cause = it
+            )
+        }
+    )
+
+    @Throws(
+        InvalidRequestException::class,
+        AuthenticationException::class,
+        APIException::class
+    )
+    private fun handleApiError(response: StripeResponse<String>): Exception {
+        val requestId = response.requestId?.value
+        val responseCode = response.code
+        val stripeError = StripeErrorJsonParser().parse(response.responseJson())
+        throw when (responseCode) {
+            HttpURLConnection.HTTP_BAD_REQUEST,
+            HttpURLConnection.HTTP_NOT_FOUND -> InvalidRequestException(
+                stripeError,
+                requestId,
+                responseCode
+            )
+            HttpURLConnection.HTTP_UNAUTHORIZED -> AuthenticationException(stripeError, requestId)
+            HttpURLConnection.HTTP_FORBIDDEN -> PermissionException(stripeError, requestId)
+            HTTP_TOO_MANY_REQUESTS -> RateLimitException(stripeError, requestId)
+            else -> APIException(stripeError, requestId, responseCode)
+        }
+    }
+
+    internal companion object {
+        private const val API_HOST = "https://api.stripe.com"
+
+        internal const val PARAMS_CLIENT_SECRET = "client_secret"
+        internal const val PARAMS_APPLICATION_ID = "application_id"
+
+        /**
+         * @return `https://api.stripe.com/v1/link_account_sessions/list_accounts`
+         */
+        internal val listAccountsUrl: String
+            @JvmSynthetic
+            get() = getApiUrl("list_accounts")
+
+        /**
+         * @return `https://api.stripe.com/v1/link_account_sessions/generate_hosted_url`
+         */
+        internal val generateHostedUrl: String
+            @JvmSynthetic
+            get() = getApiUrl("generate_hosted_url")
+
+        internal val sessionReceiptUrl: String
+            @JvmSynthetic
+            get() = getApiUrl("session_receipt")
+
+        private fun getApiUrl(path: String): String {
+            return "$API_HOST/v1/link_account_sessions/$path"
+        }
+    }
+}

--- a/connections/src/main/java/com/stripe/android/connections/repository/ConnectionsRepository.kt
+++ b/connections/src/main/java/com/stripe/android/connections/repository/ConnectionsRepository.kt
@@ -1,0 +1,43 @@
+package com.stripe.android.connections.repository
+
+import com.stripe.android.connections.exception.AuthenticationException
+import com.stripe.android.connections.model.LinkAccountSession
+import com.stripe.android.connections.model.LinkAccountSessionManifest
+import com.stripe.android.connections.model.LinkedAccountList
+import com.stripe.android.connections.model.ListLinkedAccountParams
+import com.stripe.android.core.exception.APIConnectionException
+import com.stripe.android.core.exception.APIException
+import com.stripe.android.core.exception.InvalidRequestException
+
+internal interface ConnectionsRepository {
+    @Throws(
+        AuthenticationException::class,
+        InvalidRequestException::class,
+        APIConnectionException::class,
+        APIException::class
+    )
+    suspend fun getLinkedAccounts(
+        listLinkedAccountParams: ListLinkedAccountParams
+    ): LinkedAccountList
+
+    @Throws(
+        AuthenticationException::class,
+        InvalidRequestException::class,
+        APIConnectionException::class,
+        APIException::class
+    )
+    suspend fun getLinkAccountSession(
+        clientSecret: String
+    ): LinkAccountSession
+
+    @Throws(
+        AuthenticationException::class,
+        InvalidRequestException::class,
+        APIConnectionException::class,
+        APIException::class
+    )
+    suspend fun generateLinkAccountSessionManifest(
+        clientSecret: String,
+        applicationId: String
+    ): LinkAccountSessionManifest
+}

--- a/connections/src/test/java/com/stripe/android/connections/ApiKeyFixtures.kt
+++ b/connections/src/test/java/com/stripe/android/connections/ApiKeyFixtures.kt
@@ -1,0 +1,13 @@
+package com.stripe.android.connections
+
+import com.stripe.android.connections.model.LinkAccountSessionManifest
+
+internal object ApiKeyFixtures {
+    const val DEFAULT_PUBLISHABLE_KEY = "pk_test_vOo1umqsYxSrP5UXfOeL3ecm"
+    const val DEFAULT_LINK_ACCOUNT_SESSION_SECRET = "las_client_secret_asdf1234"
+
+    const val HOSTED_AUTH_URL = "https://stripe.com/auth/flow/start"
+    const val SUCCESS_URL = "stripe-auth://link-accounts/success"
+    const val CANCEL_URL = "stripe-auth://link-accounts/cancel"
+    val MANIFEST = LinkAccountSessionManifest(HOSTED_AUTH_URL, SUCCESS_URL, CANCEL_URL)
+}

--- a/connections/src/test/java/com/stripe/android/connections/ConnectionsSheetActivityTest.kt
+++ b/connections/src/test/java/com/stripe/android/connections/ConnectionsSheetActivityTest.kt
@@ -1,0 +1,156 @@
+package com.stripe.android.connections
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.browser.customtabs.CustomTabsIntent.SHARE_STATE_OFF
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.connections.utils.InjectableActivityScenario
+import com.stripe.android.connections.utils.TestUtils.viewModelFactoryFor
+import com.stripe.android.connections.utils.injectableActivityScenario
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(RobolectricTestRunner::class)
+@ExperimentalCoroutinesApi
+class ConnectionsSheetActivityTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val contract = ConnectionsSheetContract()
+    private val configuration = ConnectionsSheet.Configuration(
+        ApiKeyFixtures.DEFAULT_LINK_ACCOUNT_SESSION_SECRET,
+        ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
+    )
+    private val args = ConnectionsSheetContract.Args(configuration)
+    private val intent = contract.createIntent(context, args)
+    private val viewModel = createViewModel()
+
+    private fun createViewModel(): ConnectionsSheetViewModel = runBlocking {
+        ConnectionsSheetViewModel(
+            applicationId = "com.example.test",
+            starterArgs = args,
+            generateLinkAccountSessionManifest = mock(),
+            fetchLinkAccountSession = mock(),
+            eventReporter = mock()
+        )
+    }
+
+    private fun activityScenario(
+        viewModel: ConnectionsSheetViewModel = this.viewModel
+    ): InjectableActivityScenario<ConnectionsSheetActivity> {
+        return injectableActivityScenario {
+            injectActivity {
+                viewModelFactory = viewModelFactoryFor(viewModel)
+            }
+        }
+    }
+
+    @Test
+    fun `onCreate() with no args returns Failed result`() {
+        val scenario = activityScenario()
+        val intent = Intent(context, ConnectionsSheetActivity::class.java)
+        scenario.launch(intent)
+        assertThat(
+            contract.parseResult(
+                scenario.getResult().resultCode,
+                scenario.getResult().resultData
+            )
+        ).isInstanceOf(
+            ConnectionsSheetResult.Failed::class.java
+        )
+    }
+
+    @Test
+    fun `onCreate() with invalid args returns Failed result`() {
+        val scenario = activityScenario()
+        val configuration = ConnectionsSheet.Configuration("", "")
+        val args = ConnectionsSheetContract.Args(configuration)
+        val intent = contract.createIntent(context, args)
+        scenario.launch(intent)
+        assertThat(
+            contract.parseResult(
+                scenario.getResult().resultCode,
+                scenario.getResult().resultData
+            )
+        ).isInstanceOf(
+            ConnectionsSheetResult.Failed::class.java
+        )
+    }
+
+    @Test
+    fun `viewEffect - OpenAuthFlowWithUrl opens Chrome Custom Tab intent`() {
+        val chromeCustomTabUrl = "www.authflow.com"
+        val viewEffects = MutableSharedFlow<ConnectionsSheetViewEffect>()
+        val mockViewModel = mock<ConnectionsSheetViewModel> {
+            on { viewEffect } doReturn viewEffects
+        }
+        activityScenario(mockViewModel).launch(intent).suspendOnActivity {
+            viewEffects.emit(ConnectionsSheetViewEffect.OpenAuthFlowWithUrl(chromeCustomTabUrl))
+            val intent: Intent = shadowOf(it).nextStartedActivity
+            assertThat(intent.getIntExtra(CustomTabsIntent.EXTRA_SHARE_STATE, 0)).isEqualTo(
+                SHARE_STATE_OFF
+            )
+        }
+    }
+
+    @Test
+    fun `onNewIntent() calls view model handleOnNewIntent()`() {
+        val mockViewModel = mock<ConnectionsSheetViewModel>()
+        val scenario = activityScenario(mockViewModel)
+        scenario.launch(intent).suspendOnActivity {
+            val newIntent = Intent(Intent.ACTION_VIEW)
+            newIntent.data = Uri.parse(ApiKeyFixtures.SUCCESS_URL)
+            it.onNewIntent(newIntent)
+            val argument: ArgumentCaptor<Intent> = ArgumentCaptor.forClass(Intent::class.java)
+            verify(mockViewModel).handleOnNewIntent(argument.capture())
+            assertThat(argument.value.data.toString()).isEqualTo(ApiKeyFixtures.SUCCESS_URL)
+        }
+    }
+
+    @Test
+    fun `onBackPressed() cancels connection sheet`() {
+        val mockViewModel = mock<ConnectionsSheetViewModel> {
+            on { state } doReturn MutableStateFlow(ConnectionsSheetState(authFlowActive = true))
+        }
+        val scenario = activityScenario(mockViewModel)
+        scenario.launch(intent).suspendOnActivity {
+            it.onBackPressed()
+        }
+        assertThat(
+            contract.parseResult(
+                scenario.getResult().resultCode,
+                scenario.getResult().resultData
+            )
+        ).isInstanceOf(
+            ConnectionsSheetResult.Canceled::class.java
+        )
+    }
+
+    /**
+     * When [InjectableActivityScenario.onActivity] triggers,
+     * runs the given block within the provided [TestScope].
+     */
+    private fun InjectableActivityScenario<ConnectionsSheetActivity>.suspendOnActivity(
+        block: suspend TestScope.(ConnectionsSheetActivity) -> Unit
+    ) {
+        this.onActivity {
+            runTest {
+                block(this, it)
+            }
+        }
+    }
+}

--- a/connections/src/test/java/com/stripe/android/connections/ConnectionsSheetContractTest.kt
+++ b/connections/src/test/java/com/stripe/android/connections/ConnectionsSheetContractTest.kt
@@ -1,0 +1,57 @@
+package com.stripe.android.connections
+
+import android.content.Intent
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.security.InvalidParameterException
+import kotlin.test.assertFailsWith
+
+@RunWith(RobolectricTestRunner::class)
+class ConnectionsSheetContractTest {
+
+    @Test
+    fun `parseResult() with missing data should return failed result`() {
+        assertThat(ConnectionsSheetContract().parseResult(0, Intent()))
+            .isInstanceOf(ConnectionsSheetResult.Failed::class.java)
+    }
+
+    @Test
+    fun `validate() valid args`() {
+        val configuration = ConnectionsSheet.Configuration(
+            ApiKeyFixtures.DEFAULT_LINK_ACCOUNT_SESSION_SECRET,
+            ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
+        )
+        val args = ConnectionsSheetContract.Args(configuration)
+        args.validate()
+    }
+
+    @Test
+    fun `validate() missing link account session client secret`() {
+        val configuration = ConnectionsSheet.Configuration(
+            " ",
+            ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
+        )
+        val args = ConnectionsSheetContract.Args(configuration)
+        assertFailsWith<InvalidParameterException>(
+            "The link account session client secret cannot be an empty string."
+        ) {
+            args.validate()
+        }
+    }
+
+    @Test
+    fun `validate() missing publishable key`() {
+        val configuration = ConnectionsSheet.Configuration(
+            ApiKeyFixtures.DEFAULT_LINK_ACCOUNT_SESSION_SECRET,
+            " "
+        )
+        val args = ConnectionsSheetContract.Args(configuration)
+        assertFailsWith<InvalidParameterException>(
+            "The publishable key cannot be an empty string."
+        ) {
+            args.validate()
+        }
+    }
+}

--- a/connections/src/test/java/com/stripe/android/connections/ConnectionsSheetTest.kt
+++ b/connections/src/test/java/com/stripe/android/connections/ConnectionsSheetTest.kt
@@ -1,0 +1,20 @@
+package com.stripe.android.connections
+
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class ConnectionsSheetTest {
+    private val connectionsSheetLauncher = mock<ConnectionsSheetLauncher>()
+    private val configuration = ConnectionsSheet.Configuration(
+        ApiKeyFixtures.DEFAULT_LINK_ACCOUNT_SESSION_SECRET,
+        ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
+    )
+    private val connectionsSheet = ConnectionsSheet(connectionsSheetLauncher)
+
+    @Test
+    fun `present() should launch the connection sheet with the given configuration`() {
+        connectionsSheet.present(configuration)
+        verify(connectionsSheetLauncher).present(configuration)
+    }
+}

--- a/connections/src/test/java/com/stripe/android/connections/ConnectionsSheetViewModelTest.kt
+++ b/connections/src/test/java/com/stripe/android/connections/ConnectionsSheetViewModelTest.kt
@@ -1,0 +1,271 @@
+package com.stripe.android.connections
+
+import android.content.Intent
+import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.connections.ConnectionsSheetResult.Completed
+import com.stripe.android.connections.ConnectionsSheetViewEffect.FinishWithResult
+import com.stripe.android.connections.analytics.ConnectionsEventReporter
+import com.stripe.android.connections.domain.FetchLinkAccountSession
+import com.stripe.android.connections.domain.GenerateLinkAccountSessionManifest
+import com.stripe.android.connections.model.LinkAccountSession
+import com.stripe.android.connections.model.LinkAccountSessionManifest
+import com.stripe.android.connections.model.LinkedAccountFixtures
+import com.stripe.android.connections.model.LinkedAccountList
+import com.stripe.android.core.exception.APIException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+@RunWith(AndroidJUnit4::class)
+class ConnectionsSheetViewModelTest {
+
+    private val eventReporter = mock<ConnectionsEventReporter>()
+    private val configuration = ConnectionsSheet.Configuration(
+        ApiKeyFixtures.DEFAULT_LINK_ACCOUNT_SESSION_SECRET,
+        ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
+    )
+    private val manifest = LinkAccountSessionManifest(
+        ApiKeyFixtures.HOSTED_AUTH_URL,
+        ApiKeyFixtures.SUCCESS_URL,
+        ApiKeyFixtures.CANCEL_URL
+    )
+    private val fetchLinkAccountSession = mock<FetchLinkAccountSession>()
+    private val generateLinkAccountSessionManifest = mock<GenerateLinkAccountSessionManifest>()
+
+    @Test
+    fun `init - eventReporter fires onPresented`() {
+        createViewModel(configuration)
+        verify(eventReporter)
+            .onPresented(configuration)
+    }
+
+    @Test
+    fun `handleOnNewIntent - wrong intent should fire analytics event and set fail result`() {
+        runTest {
+            // Given
+            val viewModel = createViewModel(configuration)
+
+            // When
+            viewModel.handleOnNewIntent(Intent("error_url"))
+
+            // Then
+            verify(eventReporter)
+                .onResult(eq(configuration), any<ConnectionsSheetResult.Failed>())
+        }
+    }
+
+    @Test
+    fun `handleOnNewIntent - intent with cancel url should fire analytics event and set cancel result`() {
+        runTest {
+            // Given
+            whenever(generateLinkAccountSessionManifest(any(), any())).thenReturn(manifest)
+            val viewModel = createViewModel(configuration)
+            val cancelIntent = cancelIntent()
+
+            // When
+            // end auth flow
+            viewModel.handleOnNewIntent(cancelIntent)
+
+            // Then
+            verify(eventReporter)
+                .onResult(configuration, ConnectionsSheetResult.Canceled)
+        }
+    }
+
+    @Test
+    fun `handleOnNewIntent - when intent with cancel URL received, then finish with Result#Cancel`() =
+        runTest {
+            // Given
+            whenever(generateLinkAccountSessionManifest(any(), any())).thenReturn(manifest)
+            val viewModel = createViewModel(configuration)
+            viewModel.viewEffect.test {
+                // When
+                // end auth flow
+                viewModel.handleOnNewIntent(cancelIntent())
+
+                // Then
+                assertThat(viewModel.state.value.authFlowActive).isFalse()
+                assertThat(FinishWithResult(ConnectionsSheetResult.Canceled)).isEqualTo(awaitItem())
+            }
+        }
+
+    @Test
+    fun `handleOnNewIntent - when intent with unknown received, then finish with Result#Failed`() =
+        runTest {
+            val viewModel = createViewModel(configuration)
+            viewModel.viewEffect.test {
+                // Given
+                val errorIntent = Intent()
+
+                // When
+                // end auth flow
+                viewModel.handleOnNewIntent(errorIntent)
+
+                // Then
+                assertThat(viewModel.state.value.authFlowActive).isFalse()
+                val viewEffect = awaitItem() as FinishWithResult
+                assertThat(viewEffect.result).isInstanceOf(ConnectionsSheetResult.Failed::class.java)
+            }
+        }
+
+    @Test
+    fun `handleOnNewIntent - when intent with success, then finish with Result#Success`() =
+        runTest {
+            // Given
+            val expectedLinkAccountSession = linkAccountSession()
+            whenever(generateLinkAccountSessionManifest(any(), any())).thenReturn(manifest)
+            whenever(fetchLinkAccountSession(any())).thenReturn(expectedLinkAccountSession)
+
+            val viewModel = createViewModel(configuration)
+            viewModel.viewEffect.test {
+
+                // When
+                // end auth flow
+                viewModel.handleOnNewIntent(successIntent())
+
+                // Then
+                assertThat(viewModel.state.value.authFlowActive).isFalse()
+                assertThat(awaitItem()).isEqualTo(
+                    FinishWithResult(result = Completed(expectedLinkAccountSession))
+                )
+            }
+        }
+
+    @Test
+    fun `handleOnNewIntent - with success URL but fails fetching session, redirect with error response`() =
+        runTest {
+            // Given
+            val apiException = APIException()
+            whenever(generateLinkAccountSessionManifest(any(), any())).thenReturn(manifest)
+            whenever(fetchLinkAccountSession.invoke(any())).thenAnswer { throw apiException }
+            val viewModel = createViewModel(configuration)
+            viewModel.viewEffect.test {
+                // When
+                // end auth flow
+                viewModel.handleOnNewIntent(successIntent())
+
+                // Then
+                assertThat(viewModel.state.value.authFlowActive).isFalse()
+                assertThat(awaitItem()).isEqualTo(
+                    FinishWithResult(ConnectionsSheetResult.Failed(apiException))
+                )
+            }
+        }
+
+    @Test
+    fun `handleOnNewIntent - when error fetching account session, then finish with Result#Failed`() =
+        runTest {
+            // Given
+            whenever(generateLinkAccountSessionManifest(any(), any())).thenReturn(manifest)
+            whenever(fetchLinkAccountSession(any())).thenAnswer { throw APIException() }
+            val viewModel = createViewModel(configuration)
+            viewModel.viewEffect.test {
+                // When
+                // end auth flow
+                viewModel.handleOnNewIntent(successIntent())
+
+                // Then
+                assertThat(viewModel.state.value.authFlowActive).isFalse()
+                assertThat(awaitItem()).isEqualTo(
+                    FinishWithResult(ConnectionsSheetResult.Failed(APIException()))
+                )
+            }
+        }
+
+    @Test
+    fun `onResume - when flow is still active and no config changes, finish with Result#Cancelled`() {
+        runTest {
+            // Given
+            val viewModel = createViewModel(configuration)
+            viewModel.viewEffect.test {
+                // When
+                // end auth flow (activity resumed without new intent received)
+                viewModel.onResume()
+
+                // Then
+                assertThat(viewModel.state.value.authFlowActive).isTrue()
+                assertThat(awaitItem()).isEqualTo(FinishWithResult(ConnectionsSheetResult.Canceled))
+            }
+        }
+    }
+
+    @Test
+    fun `onActivityResult - when flow is still active and config changed, finish with Result#Cancelled`() {
+        runTest {
+            // Given
+            val viewModel = createViewModel(configuration)
+            viewModel.viewEffect.test {
+                // When
+                // configuration changes, changing lifecycle flow.
+                viewModel.onActivityRecreated()
+                // auth flow ends (activity received result without new intent received)
+                viewModel.onActivityResult()
+
+                // Then
+                assertThat(viewModel.state.value.authFlowActive).isTrue()
+                assertThat(awaitItem()).isEqualTo(FinishWithResult(ConnectionsSheetResult.Canceled))
+            }
+        }
+    }
+
+    @Test
+    fun `init - when repository returns manifest, manifest fetched and stored in state`() {
+        runTest {
+            // Given
+            whenever(generateLinkAccountSessionManifest(any(), any())).thenReturn(manifest)
+
+            // When
+            val viewModel = createViewModel(configuration)
+
+            // Then
+            assertThat(viewModel.state.value.manifest).isEqualTo(manifest)
+        }
+    }
+
+    private fun successIntent(): Intent = Intent().apply {
+        data = Uri.parse(ApiKeyFixtures.SUCCESS_URL)
+    }
+
+    private fun cancelIntent() = Intent().also {
+        it.data = Uri.parse(ApiKeyFixtures.CANCEL_URL)
+    }
+
+    private fun linkAccountSession() = LinkAccountSession(
+        id = "las_no_more",
+        clientSecret = configuration.linkAccountSessionClientSecret,
+        livemode = true,
+        linkedAccounts = LinkedAccountList(
+            hasMore = false,
+            count = 2,
+            url = "url",
+            totalCount = 2,
+            linkedAccounts = listOf(
+                LinkedAccountFixtures.CREDIT_CARD,
+                LinkedAccountFixtures.CHECKING_ACCOUNT
+            ),
+        )
+    )
+
+    private fun createViewModel(
+        configuration: ConnectionsSheet.Configuration
+    ): ConnectionsSheetViewModel {
+        val args = ConnectionsSheetContract.Args(configuration)
+        return ConnectionsSheetViewModel(
+            applicationId = "com.example.app",
+            starterArgs = args,
+            generateLinkAccountSessionManifest = generateLinkAccountSessionManifest,
+            fetchLinkAccountSession = fetchLinkAccountSession,
+            eventReporter = eventReporter
+        )
+    }
+}

--- a/connections/src/test/java/com/stripe/android/connections/analytics/DefaultConnectionsEventReportTest.kt
+++ b/connections/src/test/java/com/stripe/android/connections/analytics/DefaultConnectionsEventReportTest.kt
@@ -1,0 +1,104 @@
+package com.stripe.android.connections.analytics
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import com.stripe.android.connections.ApiKeyFixtures
+import com.stripe.android.connections.ConnectionsSheet
+import com.stripe.android.connections.ConnectionsSheetResult
+import com.stripe.android.connections.model.LinkAccountSession
+import com.stripe.android.connections.model.LinkedAccountList
+import com.stripe.android.core.networking.AnalyticsRequestExecutor
+import com.stripe.android.core.networking.AnalyticsRequestFactory
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.argWhere
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.robolectric.RobolectricTestRunner
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class DefaultConnectionsEventReportTest {
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private val application = ApplicationProvider.getApplicationContext<Application>()
+    private val analyticsRequestExecutor = mock<AnalyticsRequestExecutor>()
+    private val analyticsRequestFactory = AnalyticsRequestFactory(
+        packageManager = application.packageManager,
+        packageName = application.packageName.orEmpty(),
+        packageInfo = application.packageManager.getPackageInfo(application.packageName, 0),
+        publishableKeyProvider = { ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY }
+    )
+
+    private val eventReporter = DefaultConnectionsEventReporter(
+        analyticsRequestExecutor,
+        analyticsRequestFactory,
+        testDispatcher
+    )
+
+    private val configuration = ConnectionsSheet.Configuration(
+        ApiKeyFixtures.DEFAULT_LINK_ACCOUNT_SESSION_SECRET,
+        ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
+    )
+
+    private val linkAccountSession = LinkAccountSession(
+        "las_1234567890",
+        ApiKeyFixtures.DEFAULT_LINK_ACCOUNT_SESSION_SECRET,
+        LinkedAccountList(
+            linkedAccounts = emptyList(),
+            hasMore = false,
+            url = "url",
+            count = 0
+        ),
+        true
+    )
+
+    @Test
+    fun `onPresented() should fire analytics request with expected event value`() {
+        eventReporter.onPresented(configuration)
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == "stripe_android.connections.sheet.presented" &&
+                    req.params["las_client_secret"] == ApiKeyFixtures.DEFAULT_LINK_ACCOUNT_SESSION_SECRET
+            }
+        )
+    }
+
+    @Test
+    fun `onResult() should fire analytics request with expected event value for success`() {
+        eventReporter.onResult(configuration, ConnectionsSheetResult.Completed(linkAccountSession))
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == "stripe_android.connections.sheet.closed" &&
+                    req.params["session_result"] == "completed" &&
+                    req.params["las_client_secret"] == ApiKeyFixtures.DEFAULT_LINK_ACCOUNT_SESSION_SECRET
+            }
+        )
+    }
+
+    @Test
+    fun `onResult() should fire analytics request with expected event value for cancelled`() {
+        eventReporter.onResult(configuration, ConnectionsSheetResult.Canceled)
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == "stripe_android.connections.sheet.closed" &&
+                    req.params["session_result"] == "cancelled" &&
+                    req.params["las_client_secret"] == ApiKeyFixtures.DEFAULT_LINK_ACCOUNT_SESSION_SECRET
+            }
+        )
+    }
+
+    @Test
+    fun `onResult() should fire analytics request with expected event value for failure`() {
+        eventReporter.onResult(configuration, ConnectionsSheetResult.Failed(Exception()))
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == "stripe_android.connections.sheet.failed" &&
+                    req.params["session_result"] == "failure" &&
+                    req.params["las_client_secret"] == ApiKeyFixtures.DEFAULT_LINK_ACCOUNT_SESSION_SECRET
+            }
+        )
+    }
+}

--- a/connections/src/test/java/com/stripe/android/connections/domain/FetchLinkAccountSessionTest.kt
+++ b/connections/src/test/java/com/stripe/android/connections/domain/FetchLinkAccountSessionTest.kt
@@ -1,0 +1,105 @@
+package com.stripe.android.connections.domain
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.connections.ApiKeyFixtures
+import com.stripe.android.connections.linkAccountSessionWithMoreAccounts
+import com.stripe.android.connections.linkAccountSessionWithNoMoreAccounts
+import com.stripe.android.connections.model.LinkAccountSession
+import com.stripe.android.connections.model.LinkedAccountList
+import com.stripe.android.connections.moreLinkedAccountList
+import com.stripe.android.connections.networking.FakeConnectionsRepository
+import com.stripe.android.core.exception.APIException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertFailsWith
+
+@ExperimentalCoroutinesApi
+@RunWith(AndroidJUnit4::class)
+class FetchLinkAccountSessionTest {
+
+    private val repository = FakeConnectionsRepository(ApiKeyFixtures.MANIFEST)
+    private val getLinkAccountSession = FetchLinkAccountSession(repository)
+
+    @Test
+    fun `invoke - when session with no more accounts, should return unmodified session`() =
+        runTest {
+            // Given
+            val clientSecret = "clientSecret"
+            repository.getLinkAccountSessionResultProvider =
+                { linkAccountSessionWithNoMoreAccounts }
+
+            // When
+            val result: LinkAccountSession = getLinkAccountSession(clientSecret)
+
+            // Then
+            assertThat(result).isEqualTo(linkAccountSessionWithNoMoreAccounts)
+        }
+
+    @Test
+    fun `invoke - when session with more accounts, should return combined linked account list`() =
+        runTest {
+            // Given
+            val clientSecret = "clientSecret"
+            repository.getLinkAccountSessionResultProvider = { linkAccountSessionWithMoreAccounts }
+            repository.getLinkedAccountsResultProvider = { moreLinkedAccountList }
+
+            // When
+            val result: LinkAccountSession = getLinkAccountSession(clientSecret)
+
+            // Then
+            val combinedAccounts = listOf(
+                // Original account list with hasMore == true
+                linkAccountSessionWithMoreAccounts.linkedAccounts.linkedAccounts,
+                // Next and last linked accounts page.
+                moreLinkedAccountList.linkedAccounts
+            ).flatten()
+
+            assertThat(result).isEqualTo(
+                linkAccountSessionWithMoreAccounts.copy(
+                    linkedAccounts = LinkedAccountList(
+                        linkedAccounts = combinedAccounts,
+                        hasMore = false,
+                        count = combinedAccounts.size,
+                        totalCount = combinedAccounts.size,
+                        url = moreLinkedAccountList.url
+                    )
+                )
+            )
+        }
+
+    @Test
+    fun `invoke - when failure fetching more accounts, should return exception`() = runTest {
+        // Given
+        assertFailsWith<APIException> {
+            val clientSecret = "clientSecret"
+            repository.getLinkAccountSessionResultProvider =
+                { linkAccountSessionWithMoreAccounts }
+            repository.getLinkedAccountsResultProvider = { throw APIException() }
+
+            // When
+            val result: LinkAccountSession = getLinkAccountSession(clientSecret)
+
+            // Then
+            val combinedAccounts = listOf(
+                // Original account list with hasMore == true
+                linkAccountSessionWithMoreAccounts.linkedAccounts.linkedAccounts,
+                // Next and last linked accounts page.
+                moreLinkedAccountList.linkedAccounts
+            ).flatten()
+
+            assertThat(result).isEqualTo(
+                linkAccountSessionWithMoreAccounts.copy(
+                    linkedAccounts = LinkedAccountList(
+                        linkedAccounts = combinedAccounts,
+                        hasMore = false,
+                        totalCount = combinedAccounts.size,
+                        url = "url"
+                    )
+                )
+            )
+        }
+    }
+}

--- a/connections/src/test/java/com/stripe/android/connections/model/LinkedAccountFixtures.kt
+++ b/connections/src/test/java/com/stripe/android/connections/model/LinkedAccountFixtures.kt
@@ -1,0 +1,51 @@
+package com.stripe.android.connections.model
+
+internal object LinkedAccountFixtures {
+
+    val CREDIT_CARD = LinkedAccount(
+        id = "la_1KMEuEClCIKljWvsfeLEm28K",
+        displayName = "My Credit Card",
+        institutionName = "My Bank",
+        last4 = "3456",
+        category = LinkedAccount.Category.CREDIT,
+        created = 1643216618,
+        livemode = true,
+        permissions = listOf(LinkedAccount.Permissions.PAYMENT_METHOD),
+        status = LinkedAccount.Status.ACTIVE,
+        subcategory = LinkedAccount.Subcategory.CREDIT_CARD,
+        supportedPaymentMethodTypes = emptyList()
+    )
+
+    val CHECKING_ACCOUNT = LinkedAccount(
+        id = "la_1KMGIuClCIKljWvsLzbigpVh",
+        displayName = "My Checking",
+        institutionName = "My Bank",
+        last4 = "3456",
+        category = LinkedAccount.Category.CASH,
+        created = 1643221992,
+        livemode = true,
+        permissions = listOf(LinkedAccount.Permissions.PAYMENT_METHOD),
+        status = LinkedAccount.Status.ACTIVE,
+        subcategory = LinkedAccount.Subcategory.CHECKING,
+        supportedPaymentMethodTypes = listOf(
+            LinkedAccount.SupportedPaymentMethodTypes.US_BANK_ACCOUNT,
+            LinkedAccount.SupportedPaymentMethodTypes.LINK
+        ),
+    )
+
+    val SAVINGS_ACCOUNT = LinkedAccount(
+        id = "la_1KMGIuClCIKljWvsN3k8bH3B",
+        displayName = "My Savings",
+        institutionName = "My Bank",
+        last4 = "6789",
+        category = LinkedAccount.Category.CASH,
+        created = 1643221992,
+        livemode = true,
+        permissions = listOf(LinkedAccount.Permissions.PAYMENT_METHOD),
+        status = LinkedAccount.Status.ACTIVE,
+        subcategory = LinkedAccount.Subcategory.SAVINGS,
+        supportedPaymentMethodTypes = listOf(
+            LinkedAccount.SupportedPaymentMethodTypes.US_BANK_ACCOUNT,
+        ),
+    )
+}

--- a/connections/src/test/java/com/stripe/android/connections/networking/FakeConnectionsRepository.kt
+++ b/connections/src/test/java/com/stripe/android/connections/networking/FakeConnectionsRepository.kt
@@ -1,0 +1,31 @@
+package com.stripe.android.connections.networking
+
+import com.stripe.android.connections.linkAccountSessionWithNoMoreAccounts
+import com.stripe.android.connections.model.LinkAccountSession
+import com.stripe.android.connections.model.LinkAccountSessionManifest
+import com.stripe.android.connections.model.LinkedAccountList
+import com.stripe.android.connections.model.ListLinkedAccountParams
+import com.stripe.android.connections.moreLinkedAccountList
+import com.stripe.android.connections.repository.ConnectionsRepository
+
+internal class FakeConnectionsRepository(
+    private val manifest: LinkAccountSessionManifest,
+) : ConnectionsRepository {
+
+    var getLinkAccountSessionResultProvider: () -> LinkAccountSession =
+        { linkAccountSessionWithNoMoreAccounts }
+    var getLinkedAccountsResultProvider: () -> LinkedAccountList = { moreLinkedAccountList }
+
+    override suspend fun getLinkedAccounts(
+        listLinkedAccountParams: ListLinkedAccountParams
+    ): LinkedAccountList = getLinkedAccountsResultProvider()
+
+    override suspend fun getLinkAccountSession(
+        clientSecret: String
+    ): LinkAccountSession = getLinkAccountSessionResultProvider()
+
+    override suspend fun generateLinkAccountSessionManifest(
+        clientSecret: String,
+        applicationId: String
+    ): LinkAccountSessionManifest = manifest
+}

--- a/connections/src/test/java/com/stripe/android/connections/testmodels.kt
+++ b/connections/src/test/java/com/stripe/android/connections/testmodels.kt
@@ -1,0 +1,44 @@
+package com.stripe.android.connections
+
+import com.stripe.android.connections.model.LinkAccountSession
+import com.stripe.android.connections.model.LinkedAccountFixtures
+import com.stripe.android.connections.model.LinkedAccountList
+
+val linkAccountSessionWithNoMoreAccounts = LinkAccountSession(
+    id = "las_no_more",
+    clientSecret = ApiKeyFixtures.DEFAULT_LINK_ACCOUNT_SESSION_SECRET,
+    linkedAccounts = LinkedAccountList(
+        listOf(
+            LinkedAccountFixtures.CREDIT_CARD,
+            LinkedAccountFixtures.CHECKING_ACCOUNT
+        ),
+        false,
+        "url",
+        2
+    ),
+    livemode = true
+)
+
+val linkAccountSessionWithMoreAccounts = LinkAccountSession(
+    id = "las_has_more",
+    clientSecret = ApiKeyFixtures.DEFAULT_LINK_ACCOUNT_SESSION_SECRET,
+    linkedAccounts = LinkedAccountList(
+        linkedAccounts = listOf(
+            LinkedAccountFixtures.CREDIT_CARD,
+            LinkedAccountFixtures.CHECKING_ACCOUNT
+        ),
+        hasMore = true,
+        url = "url",
+        count = 2,
+        totalCount = 3
+    ),
+    livemode = true
+)
+
+val moreLinkedAccountList = LinkedAccountList(
+    linkedAccounts = listOf(LinkedAccountFixtures.SAVINGS_ACCOUNT),
+    hasMore = false,
+    url = "url",
+    count = 1,
+    totalCount = 3
+)

--- a/connections/src/test/java/com/stripe/android/connections/utils/InjectableActivityScenario.kt
+++ b/connections/src/test/java/com/stripe/android/connections/utils/InjectableActivityScenario.kt
@@ -1,0 +1,155 @@
+package com.stripe.android.connections.utils
+
+import android.app.Activity
+import android.app.Instrumentation
+import android.content.Context
+import android.content.Intent
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentManager
+import androidx.test.core.app.ActivityScenario
+import androidx.test.runner.lifecycle.ActivityLifecycleCallback
+import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry
+import androidx.test.runner.lifecycle.Stage
+import java.io.Closeable
+
+/**
+ * Creates an [InjectableActivityScenario] that uses the supplied injections.
+ *
+ * ```
+ * injectableActivityScenario<MyActivity> {
+ *   injectActivity { // this: MyActivity
+ *     dependency1 = myMockDependency1
+ *     dependency2 = myMockDependency2
+ *   }
+ *   injectFragment<MyFragment> { // this: MyFragment
+ *     dependency1 = myMockDependency1
+ *   }
+ * }
+ * ```
+ */
+inline fun <reified T : Activity> injectableActivityScenario(injector: InjectableActivityScenario<T>.() -> Unit) =
+    InjectableActivityScenario(T::class.java).apply {
+        this.injector()
+    }
+
+/**
+ * InjectableActivityScenario is an extension and wrapper of [ActivityScenario] which allows you to easily inject
+ * any [Activity]s and [Fragment]s that need to be loaded from the launch Activity.
+ *
+ * Based on https://gist.github.com/rharter/5939bb73207aeb6f24c8522ecf4c9d72
+ *
+ * ```
+ * val activityScenario = InjectableActivityScenario(MyActivity::class.java)
+ * activityScenario.injectActivity { // this: MyActivity
+ *   dependency1 = myMockDependency1
+ *   dependency2 = myMockDependency2
+ * }
+ * activityScenario.injectFragment(MyFragment::class.java) { // this: MyFragment
+ *   dependency1 = myMockDependency1
+ * }
+ * ```
+ */
+class InjectableActivityScenario<T : Activity>(private val activityClass: Class<T>) : AutoCloseable,
+    Closeable {
+
+    private var delegate: ActivityScenario<T>? = null
+
+    private val activityInjectors = mutableListOf<ActivityInjector<out Activity>>()
+    private val fragmentInjectors = mutableListOf<FragmentInjector<out Fragment>>()
+
+    fun launch(startIntent: Intent? = null): InjectableActivityScenario<T> {
+        ActivityLifecycleMonitorRegistry.getInstance()
+            .addLifecycleCallback(activityLifecycleObserver)
+        delegate = if (startIntent != null) {
+            ActivityScenario.launch(startIntent)
+        } else {
+            ActivityScenario.launch(activityClass)
+        }
+        return this
+    }
+
+    override fun close() {
+        delegate?.close()
+        ActivityLifecycleMonitorRegistry.getInstance()
+            .removeLifecycleCallback(activityLifecycleObserver)
+    }
+
+    fun onActivity(action: (T) -> Unit): InjectableActivityScenario<T> {
+        val d = delegate ?: throw IllegalStateException(
+            "Cannot run onActivity since the activity hasn't been launched."
+        )
+        d.onActivity(action)
+        return this
+    }
+
+    fun getResult(): Instrumentation.ActivityResult =
+        delegate?.result ?: throw IllegalStateException(
+            "Cannot get result since activity hasn't been launched."
+        )
+
+    /**
+     * Injects the target Activity using the supplied [injector].
+     *
+     */
+    fun injectActivity(injector: T.() -> Unit) {
+        activityInjectors.add(ActivityInjector(activityClass, injector))
+    }
+
+    private class ActivityInjector<A : Activity>(
+        private val activityClass: Class<A>,
+        private val injector: A.() -> Unit
+    ) {
+        fun inject(activity: Activity?): Boolean {
+            if (activityClass.isInstance(activity)) {
+                activityClass.cast(activity)!!.injector()
+                return true
+            }
+            return false
+        }
+    }
+
+    private class FragmentInjector<F : Fragment>(
+        private val fragmentClass: Class<F>,
+        private val injection: F.() -> Unit
+    ) {
+        fun inject(fragment: Fragment?): Boolean {
+            if (fragmentClass.isInstance(fragment)) {
+                fragmentClass.cast(fragment)!!.injection()
+                return true
+            }
+            return false
+        }
+    }
+
+    private val fragmentCallbacks = object : FragmentManager.FragmentLifecycleCallbacks() {
+        override fun onFragmentPreAttached(fm: FragmentManager, f: Fragment, context: Context) {
+            fragmentInjectors.forEach {
+                if (it.inject(f)) return
+            }
+        }
+    }
+
+    private val activityLifecycleObserver = object : ActivityLifecycleCallback {
+        override fun onActivityLifecycleChanged(activity: Activity?, stage: Stage?) {
+            when (stage) {
+                Stage.PRE_ON_CREATE -> {
+                    if (activity is FragmentActivity) {
+                        activity.supportFragmentManager
+                            .registerFragmentLifecycleCallbacks(fragmentCallbacks, true)
+                    }
+                    activityInjectors.forEach { if (it.inject(activity)) return }
+                }
+                Stage.DESTROYED -> {
+                    if (activity is FragmentActivity) {
+                        activity.supportFragmentManager
+                            .unregisterFragmentLifecycleCallbacks(fragmentCallbacks)
+                    }
+                }
+                else -> {
+                    // no op
+                }
+            }
+        }
+    }
+}

--- a/connections/src/test/java/com/stripe/android/connections/utils/InjectableActivityScenario.kt
+++ b/connections/src/test/java/com/stripe/android/connections/utils/InjectableActivityScenario.kt
@@ -50,8 +50,9 @@ inline fun <reified T : Activity> injectableActivityScenario(injector: Injectabl
  * }
  * ```
  */
-class InjectableActivityScenario<T : Activity>(private val activityClass: Class<T>) : AutoCloseable,
-    Closeable {
+class InjectableActivityScenario<T : Activity>(
+    private val activityClass: Class<T>
+) : AutoCloseable, Closeable {
 
     private var delegate: ActivityScenario<T>? = null
 

--- a/connections/src/test/java/com/stripe/android/connections/utils/TestUtils.kt
+++ b/connections/src/test/java/com/stripe/android/connections/utils/TestUtils.kt
@@ -1,0 +1,14 @@
+package com.stripe.android.connections.utils
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+
+@Suppress("UNCHECKED_CAST")
+internal object TestUtils {
+    @Suppress("UNCHECKED_CAST")
+    fun viewModelFactoryFor(viewModel: ViewModel) = object : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return viewModel as T
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 enableFeaturePreview("VERSION_CATALOGS")
 
 include ':camera-core'
+include ':connections'
 include ':example'
 include ':identity'
 include ':identity-example'


### PR DESCRIPTION
## Summary

**Just looking for a quick 👀 , code here has already been reviewed**

- Adds the `:connections` module to `master`.
- Pulled just the :connections module from the [integration branch](https://github.com/stripe/stripe-android/pull/4702) to unlock ACH work.

**NOTE**: All the code here has been already reviewed when merging into the integration branch mentioned above.

## Broader context

- [Mobile API Review](https://paper.dropbox.com/doc/2022-02-22-Connections-Android-SDK-Mobile-API-Review--BemDrFik0AqCIFFfjbmwQ0sVAg-IM83NCZBxeiQNNXNQfyfq)
- [Tech spec](https://paper.dropbox.com/doc/Connections-Android-SDK-Tech-spec--BeneUKKomplFjk4OdxdasiyJAQ-gNKCqt8vOLZwpD5QzT3eK)

## Motivation

Unlock ACH work.

## Testing

Connections SDK has been tested and has test coverage.