### PR TITLE
Adds soft linking to collect bank account launcher.

### DIFF
--- a/payments-core/build.gradle
+++ b/payments-core/build.gradle
@@ -6,6 +6,7 @@ apply plugin: 'org.jetbrains.kotlin.plugin.parcelize'
 
 dependencies {
     api project(":stripe-core")
+    compileOnly project(':connections')
 
     implementation "androidx.annotation:annotation:$androidxAnnotationVersion"
     implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"
@@ -36,6 +37,7 @@ dependencies {
     javadocDeps "androidx.appcompat:appcompat:$androidxAppcompatVersion"
     javadocDeps "com.google.android.material:material:$materialVersion"
 
+    testImplementation project(':connections')
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
     testImplementation "org.robolectric:robolectric:$robolectricVersion"

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.savedstate.SavedStateRegistryOwner
+import com.stripe.android.connections.ConnectionsSheetResult
 import com.stripe.android.core.Logger
 import com.stripe.android.payments.bankaccount.CollectBankAccountConfiguration
 import com.stripe.android.payments.bankaccount.di.DaggerCollectBankAccountComponent
@@ -17,6 +18,7 @@ import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountCont
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountContract.Args.ForSetupIntent
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResponse
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResult
+import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResult.Cancelled
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResult.Completed
 import com.stripe.android.payments.bankaccount.ui.CollectBankAccountViewEffect.OpenConnectionsFlow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -73,16 +75,17 @@ internal class CollectBankAccountViewModel @Inject constructor(
         }
     }
 
-    fun onConnectionsResult(linkedAccountSessionId: String) {
-        // viewModelScope.launch {
-        //     when (result) {
-        //         is Canceled -> finishWithResult(CollectBankAccountResult.Cancelled)
-        //         is Failed -> finishWithError(result.error)
-        //         is Completed -> attachLinkAccountSessionToIntent(result.linkAccountSession.id)
-        //     }
-        // }
-        // TODO handle connections flow result and attach linkAccountSessionId when succeeded.
-        attachLinkAccountSessionToIntent(linkedAccountSessionId)
+    fun onConnectionsResult(result: ConnectionsSheetResult) {
+        viewModelScope.launch {
+            when (result) {
+                is ConnectionsSheetResult.Canceled ->
+                    finishWithResult(Cancelled)
+                is ConnectionsSheetResult.Failed ->
+                    finishWithError(result.error)
+                is ConnectionsSheetResult.Completed ->
+                    attachLinkAccountSessionToIntent(result.linkAccountSession.id)
+            }
+        }
     }
 
     private suspend fun finishWithResult(result: CollectBankAccountResult) {

--- a/payments-core/src/main/java/com/stripe/android/payments/connections/ConnectionsPaymentsProxy.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/connections/ConnectionsPaymentsProxy.kt
@@ -1,0 +1,78 @@
+package com.stripe.android.payments.connections
+
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import com.stripe.android.BuildConfig
+import com.stripe.android.connections.ConnectionsSheet
+import com.stripe.android.connections.ConnectionsSheetResult
+import com.stripe.android.payments.connections.reflection.DefaultIsConnectionsAvailable
+import com.stripe.android.payments.connections.reflection.IsConnectionsAvailable
+
+/**
+ * Proxy to access connections code safely in payments.
+ *
+ */
+internal interface ConnectionsPaymentsProxy {
+    fun present(
+        linkAccountSessionClientSecret: String,
+        publishableKey: String
+    )
+
+    companion object {
+        fun create(
+            fragment: Fragment,
+            onComplete: (ConnectionsSheetResult) -> Unit,
+            provider: () -> ConnectionsPaymentsProxy = {
+                DefaultConnectionsPaymentsProxy(ConnectionsSheet(fragment, onComplete))
+            },
+            isConnectionsAvailable: IsConnectionsAvailable = DefaultIsConnectionsAvailable()
+        ): ConnectionsPaymentsProxy {
+            return if (isConnectionsAvailable()) {
+                provider()
+            } else {
+                UnsupportedConnectionsPaymentsProxy()
+            }
+        }
+
+        fun create(
+            activity: AppCompatActivity,
+            onComplete: (ConnectionsSheetResult) -> Unit,
+            provider: () -> ConnectionsPaymentsProxy = {
+                DefaultConnectionsPaymentsProxy(ConnectionsSheet(activity, onComplete))
+            },
+            isConnectionsAvailable: IsConnectionsAvailable = DefaultIsConnectionsAvailable()
+        ): ConnectionsPaymentsProxy {
+            return if (isConnectionsAvailable()) {
+                provider()
+            } else {
+                UnsupportedConnectionsPaymentsProxy()
+            }
+        }
+    }
+}
+
+internal class DefaultConnectionsPaymentsProxy(
+    private val connectionsSheet: ConnectionsSheet
+) : ConnectionsPaymentsProxy {
+    override fun present(
+        linkAccountSessionClientSecret: String,
+        publishableKey: String
+    ) {
+        connectionsSheet.present(
+            ConnectionsSheet.Configuration(
+                linkAccountSessionClientSecret,
+                publishableKey
+            )
+        )
+    }
+}
+
+internal class UnsupportedConnectionsPaymentsProxy : ConnectionsPaymentsProxy {
+    override fun present(linkAccountSessionClientSecret: String, publishableKey: String) {
+        if (BuildConfig.DEBUG) {
+            throw IllegalStateException(
+                "Missing connections dependency, please add it to your apps build.gradle"
+            )
+        }
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/connections/IsConnectionsAvailable.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/connections/IsConnectionsAvailable.kt
@@ -1,0 +1,16 @@
+package com.stripe.android.payments.connections.reflection
+
+internal interface IsConnectionsAvailable {
+    operator fun invoke(): Boolean
+}
+
+internal class DefaultIsConnectionsAvailable : IsConnectionsAvailable {
+    override fun invoke(): Boolean {
+        return try {
+            Class.forName("com.stripe.android.connections.ConnectionsSheet")
+            true
+        } catch (_: Exception) {
+            false
+        }
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
@@ -2,6 +2,8 @@ package com.stripe.android.payments.bankaccount.ui
 
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.connections.ConnectionsSheetResult
+import com.stripe.android.connections.model.LinkAccountSession
 import com.stripe.android.core.Logger
 import com.stripe.android.model.BankConnectionsLinkedAccountSession
 import com.stripe.android.model.PaymentIntent
@@ -39,10 +41,16 @@ class CollectBankAccountViewModelTest {
     private val name = "name"
     private val email = "email"
     private val linkedAccountSessionId = "las_id"
+    private val linkedAccountSessionClientSecret = "las_client_secret"
     private val linkedAccountSession = BankConnectionsLinkedAccountSession(
-        clientSecret = "las_client_secret",
+        clientSecret = linkedAccountSessionClientSecret,
         id = linkedAccountSessionId
     )
+
+    private val connectionsLinkAccountSession = mock<LinkAccountSession> {
+        on { this.clientSecret } doReturn "client_secret"
+        on { this.id } doReturn linkedAccountSessionId
+    }
 
     @Test
     fun `init - when createLinkAccountSession succeeds for PI, opens connection flow`() = runTest {
@@ -115,7 +123,10 @@ class CollectBankAccountViewModelTest {
 
             // When
             val viewModel = buildViewModel(viewEffect, paymentIntentConfiguration())
-            viewModel.onConnectionsResult(linkedAccountSessionId)
+
+            viewModel.onConnectionsResult(
+                ConnectionsSheetResult.Completed(connectionsLinkAccountSession)
+            )
 
             // Then
             assertThat(expectMostRecentItem()).isEqualTo(
@@ -137,7 +148,9 @@ class CollectBankAccountViewModelTest {
 
             // When
             val viewModel = buildViewModel(viewEffect, setupIntentConfiguration())
-            viewModel.onConnectionsResult(linkedAccountSessionId)
+            viewModel.onConnectionsResult(
+                ConnectionsSheetResult.Completed(connectionsLinkAccountSession)
+            )
 
             // Then
             assertThat(expectMostRecentItem()).isEqualTo(
@@ -159,7 +172,9 @@ class CollectBankAccountViewModelTest {
 
             // When
             val viewModel = buildViewModel(viewEffect, setupIntentConfiguration())
-            viewModel.onConnectionsResult(linkedAccountSessionId)
+            viewModel.onConnectionsResult(
+                ConnectionsSheetResult.Completed(connectionsLinkAccountSession)
+            )
 
             // Then
             assertThat(expectMostRecentItem()).isEqualTo(

--- a/payments-core/src/test/java/com/stripe/android/payments/connections/ConnectionsPaymentsProxyTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/connections/ConnectionsPaymentsProxyTest.kt
@@ -1,0 +1,92 @@
+package com.stripe.android.payments.connections
+
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import com.stripe.android.connections.ConnectionsSheet
+import com.stripe.android.payments.connections.reflection.IsConnectionsAvailable
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class ConnectionsPaymentsProxyTest {
+    companion object {
+        private const val CONNECTIONS_SHEET_CANONICAL_NAME =
+            "com.stripe.android.connections.ConnectionsSheet"
+    }
+
+    private val mockIsConnectionsAvailable: IsConnectionsAvailable = mock()
+    private val mockFragment: Fragment = mock()
+    private val mockActivity: AppCompatActivity = mock()
+
+    private class FakeProxy : ConnectionsPaymentsProxy {
+        override fun present(linkAccountSessionClientSecret: String, publishableKey: String) {
+            // noop
+        }
+    }
+
+    @Test
+    fun `connections SDK availability returns null when connections module is not loaded`() {
+        whenever(mockIsConnectionsAvailable()).thenAnswer { false }
+
+        assertTrue(
+            ConnectionsPaymentsProxy.create(
+                fragment = mockFragment,
+                onComplete = {},
+                isConnectionsAvailable = mockIsConnectionsAvailable
+            ) is UnsupportedConnectionsPaymentsProxy
+        )
+        assertTrue(
+            ConnectionsPaymentsProxy.create(
+                activity = mockActivity,
+                onComplete = {},
+                isConnectionsAvailable = mockIsConnectionsAvailable
+            ) is UnsupportedConnectionsPaymentsProxy
+        )
+    }
+
+    @Test
+    fun `connections SDK availability returns sdk when connections module is loaded`() {
+        assertTrue(
+            ConnectionsPaymentsProxy.create(
+                fragment = mockFragment,
+                onComplete = {},
+                provider = { FakeProxy() }
+            ) is FakeProxy
+        )
+        assertTrue(
+            ConnectionsPaymentsProxy.create(
+                activity = mockActivity,
+                onComplete = {},
+                provider = { FakeProxy() }
+            ) is FakeProxy
+        )
+    }
+
+    @Test
+    fun `calling present on UnsupportedConnectionsPaymentsProxy throws an exception`() {
+        whenever(mockIsConnectionsAvailable()).thenAnswer { false }
+
+        assertFailsWith<IllegalStateException> {
+            ConnectionsPaymentsProxy.create(
+                fragment = mockFragment,
+                onComplete = {},
+                isConnectionsAvailable = mockIsConnectionsAvailable
+            ).present("", "")
+        }
+        assertFailsWith<IllegalStateException> {
+            ConnectionsPaymentsProxy.create(
+                activity = mockActivity,
+                onComplete = {},
+                isConnectionsAvailable = mockIsConnectionsAvailable
+            ).present("", "")
+        }
+    }
+
+    @Test
+    fun `ensure ConnectionsSheet exists`() {
+        assertEquals(CONNECTIONS_SHEET_CANONICAL_NAME, ConnectionsSheet::class.qualifiedName)
+    }
+}


### PR DESCRIPTION
# Summary
- Adds `ConnectionsPaymentsProxy` (already reviewed)
- Links it to the CollectBankAccountLauncher flow.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [ ] Manually verified
