### PR TITLE
fix padding issue with large corner radii in primary button

### DIFF
--- a/paymentsheet/res/values/dimens.xml
+++ b/paymentsheet/res/values/dimens.xml
@@ -9,7 +9,7 @@
     <dimen name="stripe_paymentsheet_outer_spacing_horizontal">20dp</dimen>
     <dimen name="stripe_paymentsheet_button_container_spacing">10dp</dimen>
     <dimen name="stripe_paymentsheet_button_container_spacing_bottom">34dp</dimen>
-    <dimen name="stripe_paymentsheet_primary_button_corner_radius">4dp</dimen>
+    <dimen name="stripe_paymentsheet_primary_button_padding">4dp</dimen>
     <dimen name="stripe_paymentsheet_primary_button_icon_size">20dp</dimen>
     <dimen name="stripe_paymentsheet_primary_button_icon_padding">8dp</dimen>
     <dimen name="stripe_paymentsheet_max_primary_button_height">54dp</dimen>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
@@ -79,7 +79,11 @@ internal class PrimaryButton @JvmOverloads constructor(
         shape.color = tintList
 
         background = shape
-        setPadding(cornerRadius.toInt())
+        setPadding(
+            resources.getDimensionPixelSize(
+                R.dimen.stripe_paymentsheet_primary_button_padding
+            )
+        )
     }
 
     private fun getTextAttributeValue(attrs: AttributeSet?): CharSequence? {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Before allowing the corner radius to change via public api it was safe to have button padding == corner radius. Now that is no longer the case.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Wardrobe API dogfooding.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before (using 20.dp radius)  | After (using 20.dp radius) |
| ------------- | ------------- |
|![buttonbefore](https://user-images.githubusercontent.com/89166418/160911432-c7075d59-190b-4111-85c1-31369db2b508.png)|![buttonafter](https://user-images.githubusercontent.com/89166418/160911431-1112364d-9ca0-4355-a32b-9bfb818cc95b.png)|

