### PR TITLE
Rename onPrimary to onComponent, onBackground to onSurface, textSecondary to subtitle, and componentBackground to component

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/PaymentsTheme.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/PaymentsTheme.kt
@@ -32,11 +32,11 @@ data class PaymentsColors(
     val componentBackground: Color,
     val componentBorder: Color,
     val componentDivider: Color,
-    val onPrimary: Color,
+    val onComponent: Color,
     val textSecondary: Color,
     val textCursor: Color,
     val placeholderText: Color,
-    val onBackground: Color,
+    val onSurface: Color,
     val appBarIcon: Color,
     val error: Color,
 )
@@ -129,11 +129,11 @@ object PaymentsThemeConfig {
         componentBackground = Color.White,
         componentBorder = Color(0x33787880),
         componentDivider = Color(0x33787880),
-        onPrimary = Color.Black,
+        onComponent = Color.Black,
         textSecondary = Color(0x99000000),
         textCursor = Color.Black,
         placeholderText = Color(0x993C3C43),
-        onBackground = Color.Black,
+        onSurface = Color.Black,
         appBarIcon = Color(0x99000000),
         error = Color.Red,
     )
@@ -144,11 +144,11 @@ object PaymentsThemeConfig {
         componentBackground = Color.DarkGray,
         componentBorder = Color(0xFF787880),
         componentDivider = Color(0xFF787880),
-        onPrimary = Color.White,
+        onComponent = Color.White,
         textSecondary = Color(0x99FFFFFF),
         textCursor = Color.White,
         placeholderText = Color(0x61FFFFFF),
-        onBackground = Color.White,
+        onSurface = Color.White,
         appBarIcon = Color.White,
         error = Color.Red,
     )
@@ -162,6 +162,7 @@ data class PaymentsComposeColors(
     val colorTextSecondary: Color,
     val colorTextCursor: Color,
     val placeholderText: Color,
+    val onComponent: Color,
     val material: Colors
 )
 
@@ -181,15 +182,15 @@ fun PaymentsThemeConfig.toComposeColors(): PaymentsComposeColors {
         colorComponentBackground = colors.componentBackground,
         colorComponentBorder = colors.componentBorder,
         colorComponentDivider = colors.componentDivider,
+        onComponent = colors.onComponent,
         colorTextSecondary = colors.textSecondary,
         colorTextCursor = colors.textCursor,
         placeholderText = colors.placeholderText,
 
         material = lightColors(
             primary = colors.primary,
-            onPrimary = colors.onPrimary,
             surface = colors.surface,
-            onBackground = colors.onBackground,
+            onSurface = colors.onSurface,
             error = colors.error,
         )
     )

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/PaymentsTheme.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/PaymentsTheme.kt
@@ -29,11 +29,11 @@ import androidx.compose.ui.unit.sp
 data class PaymentsColors(
     val primary: Color,
     val surface: Color,
-    val componentBackground: Color,
+    val component: Color,
     val componentBorder: Color,
     val componentDivider: Color,
     val onComponent: Color,
-    val textSecondary: Color,
+    val subtitle: Color,
     val textCursor: Color,
     val placeholderText: Color,
     val onSurface: Color,
@@ -126,11 +126,11 @@ object PaymentsThemeConfig {
     private val colorsLight = PaymentsColors(
         primary = Color(0xFF007AFF),
         surface = Color.White,
-        componentBackground = Color.White,
+        component = Color.White,
         componentBorder = Color(0x33787880),
         componentDivider = Color(0x33787880),
         onComponent = Color.Black,
-        textSecondary = Color(0x99000000),
+        subtitle = Color(0x99000000),
         textCursor = Color.Black,
         placeholderText = Color(0x993C3C43),
         onSurface = Color.Black,
@@ -141,11 +141,11 @@ object PaymentsThemeConfig {
     private val colorsDark = PaymentsColors(
         primary = Color(0xFF0074D4),
         surface = Color(0xff2e2e2e),
-        componentBackground = Color.DarkGray,
+        component = Color.DarkGray,
         componentBorder = Color(0xFF787880),
         componentDivider = Color(0xFF787880),
         onComponent = Color.White,
-        textSecondary = Color(0x99FFFFFF),
+        subtitle = Color(0x99FFFFFF),
         textCursor = Color.White,
         placeholderText = Color(0x61FFFFFF),
         onSurface = Color.White,
@@ -156,10 +156,10 @@ object PaymentsThemeConfig {
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class PaymentsComposeColors(
-    val colorComponentBackground: Color,
+    val component: Color,
     val colorComponentBorder: Color,
     val colorComponentDivider: Color,
-    val colorTextSecondary: Color,
+    val subtitle: Color,
     val colorTextCursor: Color,
     val placeholderText: Color,
     val onComponent: Color,
@@ -179,11 +179,11 @@ data class PaymentsComposeShapes(
 fun PaymentsThemeConfig.toComposeColors(): PaymentsComposeColors {
     val colors = colors(isSystemInDarkTheme())
     return PaymentsComposeColors(
-        colorComponentBackground = colors.componentBackground,
+        component = colors.component,
         colorComponentBorder = colors.componentBorder,
         colorComponentDivider = colors.componentDivider,
         onComponent = colors.onComponent,
-        colorTextSecondary = colors.textSecondary,
+        subtitle = colors.subtitle,
         colorTextCursor = colors.textCursor,
         placeholderText = colors.placeholderText,
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayElementUI.kt
@@ -41,7 +41,7 @@ fun AfterpayClearpayElementUI(
             element.getLabel(context.resources),
             Modifier
                 .padding(end = 4.dp),
-            color = PaymentsTheme.colors.colorTextSecondary
+            color = PaymentsTheme.colors.subtitle
         )
         Image(
             painter = painterResource(R.drawable.stripe_ic_afterpay_clearpay_logo),
@@ -68,7 +68,7 @@ fun AfterpayClearpayElementUI(
                 text = "ⓘ",
                 modifier = Modifier.padding(0.dp),
                 style = TextStyle(fontWeight = FontWeight.Bold),
-                color = PaymentsTheme.colors.colorTextSecondary
+                color = PaymentsTheme.colors.subtitle
             )
         }
     }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBecsDebitMandateElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBecsDebitMandateElementUI.kt
@@ -27,7 +27,7 @@ fun AuBecsDebitMandateElementUI(
 
     val annotatedText = buildAnnotatedString {
         val nonLinkTextStyle = SpanStyle(
-            color = PaymentsTheme.colors.colorTextSecondary,
+            color = PaymentsTheme.colors.subtitle,
             fontSize = PaymentsTheme.typography.body2.fontSize,
             letterSpacing = PaymentsTheme.typography.body2.letterSpacing,
         )
@@ -44,7 +44,7 @@ fun AuBecsDebitMandateElementUI(
         )
         withStyle(
             style = SpanStyle(
-                color = PaymentsTheme.colors.colorTextSecondary,
+                color = PaymentsTheme.colors.subtitle,
                 fontWeight = FontWeight.Bold,
                 fontSize = PaymentsTheme.typography.body2.fontSize,
                 letterSpacing = PaymentsTheme.typography.body2.letterSpacing,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownFieldUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownFieldUI.kt
@@ -42,7 +42,7 @@ internal fun DropDown(
     var expanded by remember { mutableStateOf(false) }
     val interactionSource = remember { MutableInteractionSource() }
     val currentTextColor = if (enabled) {
-        PaymentsTheme.colors.material.onBackground
+        PaymentsTheme.colors.onComponent
     } else {
         TextFieldDefaults
             .textFieldColors()

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownFieldUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownFieldUI.kt
@@ -53,7 +53,7 @@ internal fun DropDown(
     Box(
         modifier = Modifier
             .wrapContentSize(Alignment.TopStart)
-            .background(PaymentsTheme.colors.colorComponentBackground)
+            .background(PaymentsTheme.colors.component)
     ) {
         // Click handling happens on the box, so that it is a single accessible item
         Box(
@@ -95,7 +95,7 @@ internal fun DropDown(
         DropdownMenu(
             expanded = expanded,
             onDismissRequest = { expanded = false },
-            modifier = Modifier.background(color = PaymentsTheme.colors.colorComponentBackground)
+            modifier = Modifier.background(color = PaymentsTheme.colors.component)
         ) {
             items.forEachIndexed { index, displayValue ->
                 DropdownMenuItem(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/H4Text.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/H4Text.kt
@@ -14,7 +14,7 @@ fun H4Text(
 ) {
     Text(
         text = text,
-        color = PaymentsTheme.colors.material.onPrimary,
+        color = PaymentsTheme.colors.material.onSurface,
         style = PaymentsTheme.typography.h4,
         modifier = modifier
     )

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/H6Text.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/H6Text.kt
@@ -14,7 +14,7 @@ fun H6Text(
 ) {
     Text(
         text = text,
-        color = PaymentsTheme.colors.colorTextSecondary,
+        color = PaymentsTheme.colors.subtitle,
         style = PaymentsTheme.typography.h6,
         modifier = modifier
     )

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/HtmlText.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/HtmlText.kt
@@ -86,7 +86,7 @@ internal fun HtmlText(
         modifier = modifier
             .padding(vertical = 8.dp)
             .semantics(mergeDescendants = true) {}, // makes it a separate accessibile item,
-        color = PaymentsTheme.colors.colorTextSecondary,
+        color = PaymentsTheme.colors.subtitle,
         onClick = {
             annotatedText
                 .getStringAnnotations(LINK_TAG, it, it)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateTextUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateTextUI.kt
@@ -18,7 +18,7 @@ fun MandateTextUI(
     Text(
         text = stringResource(element.stringResId, element.merchantName ?: ""),
         style = PaymentsTheme.typography.body2,
-        color = PaymentsTheme.colors.colorTextSecondary,
+        color = PaymentsTheme.colors.subtitle,
         modifier = Modifier
             .padding(vertical = 8.dp)
             .semantics(mergeDescendants = true) {}, // makes it a separate accessibile item

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionUI.kt
@@ -64,7 +64,7 @@ fun SectionCard(
         border = PaymentsTheme.getBorderStroke(isSelected),
         // TODO(skyler-stripe): this will change when we add shadow configurations.
         elevation = if (isSelected) 1.5.dp else 0.dp,
-        backgroundColor = PaymentsTheme.colors.colorComponentBackground,
+        backgroundColor = PaymentsTheme.colors.component,
         shape = PaymentsTheme.shapes.material.medium,
         modifier = modifier
     ) {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
@@ -56,7 +56,7 @@ internal fun TextField(
         unfocusedLabelColor = PaymentsTheme.colors.placeholderText,
         focusedLabelColor = PaymentsTheme.colors.placeholderText,
         placeholderColor = PaymentsTheme.colors.placeholderText,
-        backgroundColor = PaymentsTheme.colors.colorComponentBackground,
+        backgroundColor = PaymentsTheme.colors.component,
         focusedIndicatorColor = Color.Transparent,
         disabledIndicatorColor = Color.Transparent,
         unfocusedIndicatorColor = Color.Transparent,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
@@ -51,7 +51,7 @@ internal fun TextField(
         textColor = if (shouldShowError) {
             PaymentsTheme.colors.material.error
         } else {
-            PaymentsTheme.colors.material.onBackground
+            PaymentsTheme.colors.onComponent
         },
         unfocusedLabelColor = PaymentsTheme.colors.placeholderText,
         focusedLabelColor = PaymentsTheme.colors.placeholderText,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentMethodsUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentMethodsUI.kt
@@ -145,7 +145,7 @@ internal fun PaymentMethodUI(
     ) {
         Column {
             val color = if (isSelected) PaymentsTheme.colors.material.primary
-            else PaymentsTheme.colors.material.onBackground
+            else PaymentsTheme.colors.onComponent
 
             val colorFilter = if (tintOnSelected) ColorFilter.tint(color) else null
             Image(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
@@ -589,7 +589,7 @@ internal fun PaymentOptionUi(
 
         LpmSelectorText(
             text = labelText,
-            textColor = PaymentsTheme.colors.material.onPrimary,
+            textColor = PaymentsTheme.colors.material.onSurface,
             isEnabled = isEnabled,
             modifier = Modifier
                 .constrainAs(label) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormUI.kt
@@ -91,7 +91,7 @@ internal fun FormInternal(
                 modifier = Modifier.size(
                     dimensionResource(R.dimen.stripe_paymentsheet_loading_indicator_size)
                 ),
-                color = PaymentsTheme.colors.colorTextSecondary,
+                color = PaymentsTheme.colors.subtitle,
                 strokeWidth = dimensionResource(
                     R.dimen.stripe_paymentsheet_loading_indicator_stroke_width
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/GooglePayDivider.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/GooglePayDivider.kt
@@ -54,7 +54,7 @@ internal class GooglePayDivider @JvmOverloads constructor(
             Text(
                 text = text,
                 style = PaymentsTheme.typography.body1,
-                color = PaymentsTheme.colors.colorTextSecondary
+                color = PaymentsTheme.colors.subtitle
             )
         }
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* `onPrimary` doesn't make sense at current usage. I replaced it with `onComponent` so that it's clear it's a color that goes over our components. 
* `onBackground` is technically incorrect as a sheet uses a surface, so I changed my usage to `onSurface`
* `textSecondary` maps better to the word `subtitle` which is used in material a lot
* `componentBackground` renamed to just `component` to follow our established pattern.
* As a result a few fields were wrong and are now fixed.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
These will be public variables soon and I think it makes sense to rename them now so other changes can be made on top of this. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified


# Screenshots (using Green to demonstrate)
| onComponent | onComponent |
| ------------- | ------------- |
|![onComponent1](https://user-images.githubusercontent.com/89166418/160926462-920ffb50-e34f-4f03-9190-3df13e61ab56.png)|![onComponent2](https://user-images.githubusercontent.com/89166418/160926466-5a0d9e5a-2e80-4175-8d97-b22544295d13.png)|

| onSurface | onSurface |
| ------------- | ------------- |
|![onSuface2](https://user-images.githubusercontent.com/89166418/160926467-1cd183d9-ef86-4cd6-b9b1-d19b536c194a.png)|![onSurface1](https://user-images.githubusercontent.com/89166418/160926469-8f0cc41e-85af-4673-baa0-af11b09d8b62.png)|


