### PR TITLE
BaseSheet should follow theme for background color

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -305,13 +305,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
             viewBinding.buyButton.isEnabled = isEnabled
             viewBinding.googlePayButton.isEnabled = isEnabled
         }
-
-        viewBinding.bottomSheet.setBackgroundColor(
-            PaymentsThemeConfig.colors(isDark).surface.toArgb()
-        )
-        viewBinding.toolbar.setBackgroundColor(
-            PaymentsThemeConfig.colors(isDark).surface.toArgb()
-        )
     }
 
     override fun setActivityResult(result: PaymentSheetResult) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -116,6 +116,14 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
             testModeIndicator.visibility = if (isLiveMode) View.GONE else View.VISIBLE
         }
 
+        val isDark = baseContext.isSystemDarkTheme()
+        bottomSheet.setBackgroundColor(
+            PaymentsThemeConfig.colors(isDark).surface.toArgb()
+        )
+        toolbar.setBackgroundColor(
+            PaymentsThemeConfig.colors(isDark).surface.toArgb()
+        )
+
         setSheetWidthForTablets()
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Our base sheet activity should be reading in surface color from our config and setting it. This was causing our theme to not be applied to all sheets.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Theme api. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
Note: Magenta used for demonstration only. The default is still white. 
| Before  | After |
| ------------- | ------------- |
|![before](https://user-images.githubusercontent.com/89166418/160938330-5a990343-38fb-4efb-bd86-05410d8e35ad.png)|![after](https://user-images.githubusercontent.com/89166418/160938326-0eadc660-07fb-4ae2-b209-689f18bf3f7b.png)|


