### PR TITLE
Relocate network exceptions to :stripe-core.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/PaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/PaymentController.kt
@@ -10,7 +10,7 @@ import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.exception.InvalidRequestException
 import com.stripe.android.core.networking.ApiRequest
-import com.stripe.android.exception.AuthenticationException
+import com.stripe.android.core.exception.AuthenticationException
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.PaymentIntent

--- a/payments-core/src/main/java/com/stripe/android/Stripe.kt
+++ b/payments-core/src/main/java/com/stripe/android/Stripe.kt
@@ -19,7 +19,7 @@ import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.model.StripeModel
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.version.StripeSdkVersion
-import com.stripe.android.exception.AuthenticationException
+import com.stripe.android.core.exception.AuthenticationException
 import com.stripe.android.exception.CardException
 import com.stripe.android.model.AccountParams
 import com.stripe.android.model.BankAccount

--- a/payments-core/src/main/java/com/stripe/android/StripeKtx.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripeKtx.kt
@@ -8,7 +8,7 @@ import com.stripe.android.core.exception.InvalidRequestException
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.model.StripeModel
 import com.stripe.android.core.networking.ApiRequest
-import com.stripe.android.exception.AuthenticationException
+import com.stripe.android.core.exception.AuthenticationException
 import com.stripe.android.exception.CardException
 import com.stripe.android.model.AccountParams
 import com.stripe.android.model.BankAccountTokenParams

--- a/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -16,7 +16,7 @@ import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
 import com.stripe.android.core.networking.RetryDelaySupplier
-import com.stripe.android.exception.AuthenticationException
+import com.stripe.android.core.exception.AuthenticationException
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams

--- a/payments-core/src/main/java/com/stripe/android/exception/MaxRetryReachedException.kt
+++ b/payments-core/src/main/java/com/stripe/android/exception/MaxRetryReachedException.kt
@@ -1,9 +1,0 @@
-package com.stripe.android.exception
-
-import com.stripe.android.core.exception.StripeException
-
-/**
- * An [Exception] that represents max retry is reached when making a request.
- */
-internal class MaxRetryReachedException(message: String? = null) :
-    StripeException(message = message)

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -32,10 +32,10 @@ import com.stripe.android.core.networking.StripeNetworkClient
 import com.stripe.android.core.networking.StripeResponse
 import com.stripe.android.core.networking.responseJson
 import com.stripe.android.core.version.StripeSdkVersion
-import com.stripe.android.exception.AuthenticationException
+import com.stripe.android.core.exception.AuthenticationException
 import com.stripe.android.exception.CardException
-import com.stripe.android.exception.PermissionException
-import com.stripe.android.exception.RateLimitException
+import com.stripe.android.core.exception.PermissionException
+import com.stripe.android.core.exception.RateLimitException
 import com.stripe.android.model.BankConnectionsLinkedAccountSession
 import com.stripe.android.model.BankStatuses
 import com.stripe.android.model.CardMetadata

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -7,7 +7,7 @@ import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.exception.InvalidRequestException
 import com.stripe.android.core.networking.ApiRequest
-import com.stripe.android.exception.AuthenticationException
+import com.stripe.android.core.exception.AuthenticationException
 import com.stripe.android.exception.CardException
 import com.stripe.android.model.BankConnectionsLinkedAccountSession
 import com.stripe.android.model.BankStatuses

--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
@@ -12,7 +12,7 @@ import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.RetryDelaySupplier
-import com.stripe.android.exception.MaxRetryReachedException
+import com.stripe.android.core.exception.MaxRetryReachedException
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent

--- a/payments-core/src/test/java/com/stripe/android/PaymentRelayStarterTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentRelayStarterTest.kt
@@ -5,7 +5,7 @@ import androidx.activity.ComponentActivity
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.exception.InvalidRequestException
-import com.stripe.android.exception.PermissionException
+import com.stripe.android.core.exception.PermissionException
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.SourceFixtures

--- a/payments-core/src/test/java/com/stripe/android/StripeKtxTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripeKtxTest.kt
@@ -5,7 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.exception.InvalidRequestException
 import com.stripe.android.core.model.StripeModel
 import com.stripe.android.core.networking.ApiRequest
-import com.stripe.android.exception.AuthenticationException
+import com.stripe.android.core.exception.AuthenticationException
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.Source

--- a/payments-core/src/test/java/com/stripe/android/StripeTest.java
+++ b/payments-core/src/test/java/com/stripe/android/StripeTest.java
@@ -9,7 +9,7 @@ import com.stripe.android.core.networking.AnalyticsRequest;
 import com.stripe.android.core.networking.AnalyticsRequestExecutor;
 import com.stripe.android.core.networking.DefaultStripeNetworkClient;
 import com.stripe.android.core.version.StripeSdkVersion;
-import com.stripe.android.exception.AuthenticationException;
+import com.stripe.android.core.exception.AuthenticationException;
 import com.stripe.android.exception.CardException;
 import com.stripe.android.core.exception.InvalidRequestException;
 import com.stripe.android.core.exception.StripeException;

--- a/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
@@ -7,7 +7,7 @@ import com.stripe.android.PaymentIntentResult
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.core.Logger
 import com.stripe.android.core.networking.ApiRequest
-import com.stripe.android.exception.MaxRetryReachedException
+import com.stripe.android.core.exception.MaxRetryReachedException
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.networking.StripeRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/payments-core/src/test/java/com/stripe/android/view/PaymentRelayActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/PaymentRelayActivityTest.kt
@@ -7,7 +7,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentRelayContract
 import com.stripe.android.PaymentRelayStarter
 import com.stripe.android.StripeErrorFixtures
-import com.stripe.android.exception.PermissionException
+import com.stripe.android.core.exception.PermissionException
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.payments.PaymentFlowResult
 import org.junit.Test

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/AuthenticationException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/AuthenticationException.kt
@@ -1,7 +1,7 @@
-package com.stripe.android.exception
+package com.stripe.android.core.exception
 
+import androidx.annotation.RestrictTo
 import com.stripe.android.core.StripeError
-import com.stripe.android.core.exception.StripeException
 import java.net.HttpURLConnection
 
 /**
@@ -9,7 +9,7 @@ import java.net.HttpURLConnection
  *
  * [Errors](https://stripe.com/docs/api/errors)
  */
-class AuthenticationException internal constructor(
+class AuthenticationException @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) constructor(
     stripeError: StripeError,
     requestId: String? = null
 ) : StripeException(

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/MaxRetryReachedException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/MaxRetryReachedException.kt
@@ -1,0 +1,10 @@
+package com.stripe.android.core.exception
+
+import androidx.annotation.RestrictTo
+
+/**
+ * An [Exception] that represents max retry is reached when making a request.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class MaxRetryReachedException(message: String? = null) :
+    StripeException(message = message)

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/PermissionException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/PermissionException.kt
@@ -1,7 +1,6 @@
-package com.stripe.android.exception
+package com.stripe.android.core.exception
 
 import com.stripe.android.core.StripeError
-import com.stripe.android.core.exception.StripeException
 import java.net.HttpURLConnection
 
 /**

--- a/stripe-core/src/main/java/com/stripe/android/core/exception/RateLimitException.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/exception/RateLimitException.kt
@@ -1,7 +1,6 @@
-package com.stripe.android.exception
+package com.stripe.android.core.exception
 
 import com.stripe.android.core.StripeError
-import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.networking.HTTP_TOO_MANY_REQUESTS
 
 /**


### PR DESCRIPTION
# Summary
- Moves common network exceptions to stripe-core from payments. 

# Motivation
- Allow other SDKs to use the same network exceptions.

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Changed] Relocated common nework exceptions from `com.stripe.android.exception` to `com.stripe.android.core.exception`:
      - AuthenticationException
      - PermissionException
      - RateLimitException 
-->
