### PR TITLE
checkbox colors should follow payments theme rather than material theme

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SaveForFutureUseElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SaveForFutureUseElementUI.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material.Checkbox
+import androidx.compose.material.CheckboxDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -18,6 +19,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
+import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.R
 
 @Composable
@@ -39,6 +41,11 @@ fun SaveForFutureUseElementUI(
         }
     )
 
+    val checkboxColors = CheckboxDefaults.colors(
+        checkedColor = PaymentsTheme.colors.material.primary,
+        uncheckedColor = PaymentsTheme.colors.subtitle,
+        checkmarkColor = PaymentsTheme.colors.material.surface
+    )
     Row(
         modifier = Modifier
             .padding(vertical = 2.dp)
@@ -60,7 +67,8 @@ fun SaveForFutureUseElementUI(
         Checkbox(
             checked = checked,
             onCheckedChange = null, // needs to be null for accessibility on row click to work
-            enabled = enabled
+            enabled = enabled,
+            colors = checkboxColors
         )
         label?.let {
             H6Text(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Check box UI now follows Payments Theme.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
It's currently following material theme and is wrong. Not sure when it regressed. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
|![checkboxBeforeLight](https://user-images.githubusercontent.com/89166418/161129066-2c8789b1-7e13-4909-be20-1bc29cb43c88.png)|![checkboxAfterLight](https://user-images.githubusercontent.com/89166418/161129063-e1deaee8-7454-4df3-b041-ac8dfc9cde3b.png)|
|![checkboxBeforeDark](https://user-images.githubusercontent.com/89166418/161129064-c0ea5232-588f-43bc-9819-40b746dbcdcc.png)|![checkboxAfterDark](https://user-images.githubusercontent.com/89166418/161129058-e7db3852-b966-489d-9d08-39c4ab50870b.png)|





