### PR TITLE
[Identity] Parse body text for single doc type

### DIFF
--- a/identity/api/identity.api
+++ b/identity/api/identity.api
@@ -79,7 +79,6 @@ public final class com/stripe/android/identity/databinding/BaseErrorFragmentBind
 }
 
 public final class com/stripe/android/identity/databinding/ConfirmationFragmentBinding : androidx/viewbinding/ViewBinding {
-	public final field clockLogo Landroid/widget/ImageView;
 	public final field contentText Landroid/widget/TextView;
 	public final field kontinue Landroid/widget/Button;
 	public final field titleText Landroid/widget/TextView;
@@ -168,7 +167,6 @@ public final class com/stripe/android/identity/databinding/FrontBackUploadFragme
 public final class com/stripe/android/identity/databinding/GetLocalImageDialogBinding : androidx/viewbinding/ViewBinding {
 	public final field chooseFile Lcom/google/android/material/button/MaterialButton;
 	public final field takePhoto Lcom/google/android/material/button/MaterialButton;
-	public final field title Lcom/google/android/material/textview/MaterialTextView;
 	public static fun bind (Landroid/view/View;)Lcom/stripe/android/identity/databinding/GetLocalImageDialogBinding;
 	public synthetic fun getRoot ()Landroid/view/View;
 	public fun getRoot ()Landroid/widget/LinearLayout;

--- a/identity/res/layout/confirmation_fragment.xml
+++ b/identity/res/layout/confirmation_fragment.xml
@@ -20,19 +20,6 @@
             android:layout_height="wrap_content"
             tools:context=".navigation.ConsentFragment">
 
-
-            <ImageView
-                android:id="@+id/clock_logo"
-                android:src="@drawable/ic_clock_16"
-                android:layout_width="32dp"
-                android:layout_height="32dp"
-                android:padding="5dp"
-                android:background="?android:colorPrimary"
-                android:contentDescription="@string/description_clock"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:tint="@android:color/white" />
-
             <TextView
                 android:id="@+id/title_text"
                 android:layout_width="0dp"
@@ -40,11 +27,12 @@
                 android:layout_marginTop="@dimen/item_vertical_margin"
                 android:textSize="@dimen/consent_title_text_size"
                 android:textStyle="bold"
-                android:layout_marginBottom="42dp"
+                android:paddingBottom="24dp"
                 app:layout_constraintBottom_toTopOf="@id/content_text"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/clock_logo" />
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="Verification pending" />
 
             <TextView
                 android:id="@+id/content_text"
@@ -54,7 +42,8 @@
                 android:lineSpacingExtra="2sp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/title_text" />
+                app:layout_constraintTop_toBottomOf="@+id/title_text"
+                tools:text="Thank you for providing your information" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>

--- a/identity/res/layout/doc_selection_fragment.xml
+++ b/identity/res/layout/doc_selection_fragment.xml
@@ -18,19 +18,14 @@
         android:textSize="@dimen/doc_selection_title_text_size"
         android:textStyle="bold"
         android:layout_marginTop="58dp"
-        android:layout_marginBottom="32dp" />
+        android:layout_marginBottom="32dp"
+        tools:text="Which form of identification do you want to use?"/>
 
     <LinearLayout
         android:id="@+id/multi_selection_content"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical">
-
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_marginBottom="@dimen/item_vertical_margin"
-            android:background="?android:attr/listDivider" />
 
         <RelativeLayout
             android:id="@+id/dl_container"

--- a/identity/res/layout/front_back_upload_fragment.xml
+++ b/identity/res/layout/front_back_upload_fragment.xml
@@ -25,7 +25,7 @@
                 android:id="@+id/title_text"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:gravity="center_horizontal"
+                android:gravity="start"
                 android:layout_marginTop="@dimen/item_vertical_margin"
                 android:textSize="@dimen/upload_title_text_size"
                 android:text="@string/file_upload"
@@ -37,23 +37,15 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/file_upload_content_id"
-                android:gravity="center"
-                android:layout_marginBottom="@dimen/item_vertical_margin"
+                android:gravity="start"
+                android:layout_marginBottom="32dp"
                 tools:text="@string/file_upload_content_id" />
 
-
-            <View
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:layout_marginBottom="@dimen/item_vertical_margin"
-                android:background="?android:attr/listDivider" />
 
             <RelativeLayout
                 android:layout_width="match_parent"
                 android:layout_height="48dp"
-                android:layout_marginBottom="@dimen/item_vertical_margin"
-                android:layout_marginStart="@dimen/item_horizontal_margin"
-                android:layout_marginEnd="@dimen/item_horizontal_margin">
+                android:layout_marginBottom="@dimen/item_vertical_margin">
 
                 <TextView
                     android:id="@+id/label_front"
@@ -104,9 +96,7 @@
             <RelativeLayout
                 android:layout_width="match_parent"
                 android:layout_height="48dp"
-                android:layout_marginBottom="@dimen/item_vertical_margin"
-                android:layout_marginStart="@dimen/item_horizontal_margin"
-                android:layout_marginEnd="@dimen/item_horizontal_margin">
+                android:layout_marginBottom="@dimen/item_vertical_margin">
 
                 <TextView
                     android:id="@+id/label_back"
@@ -147,12 +137,6 @@
                     android:contentDescription="@string/back_of_id_selected"
                     app:tint="?android:colorPrimary" />
             </RelativeLayout>
-
-            <View
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:layout_marginBottom="@dimen/item_vertical_margin"
-                android:background="?android:attr/listDivider" />
 
         </LinearLayout>
     </ScrollView>

--- a/identity/res/layout/get_local_image_dialog.xml
+++ b/identity/res/layout/get_local_image_dialog.xml
@@ -2,17 +2,11 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="600dp"
     android:layout_height="wrap_content"
-    android:layout_margin="16dp"
+    android:layout_marginTop="16dp"
+    android:layout_marginBottom="16dp"
+    android:layout_marginStart="24dp"
+    android:layout_marginEnd="24dp"
     android:orientation="vertical">
-
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/title"
-        android:textStyle="bold"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:textSize="16sp"
-        android:textColor="?android:textColorPrimary"
-        android:layout_marginBottom="12dp" />
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/take_photo"

--- a/identity/res/layout/identity_camera_scan_fragment.xml
+++ b/identity/res/layout/identity_camera_scan_fragment.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_marginStart="@dimen/page_horizontal_margin"
     android:layout_marginEnd="@dimen/page_horizontal_margin"
     android:layout_marginTop="@dimen/page_vertical_margin"
@@ -15,7 +16,7 @@
 
         <TextView
             android:id="@+id/header_title"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:textStyle="bold"
             android:textSize="@dimen/scan_title_text_size"
@@ -23,17 +24,19 @@
             app:layout_constraintBottom_toTopOf="@id/message"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Front of driver's license" />
 
         <TextView
             android:id="@+id/message"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/page_vertical_margin"
             app:layout_constraintBottom_toTopOf="@id/camera_view_card"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/header_title" />
+            app:layout_constraintTop_toBottomOf="@id/header_title"
+            tools:text="Position your driver's license in the center of the frame" />
 
         <com.google.android.material.card.MaterialCardView
             android:id="@+id/camera_view_card"

--- a/identity/res/layout/passport_upload_fragment.xml
+++ b/identity/res/layout/passport_upload_fragment.xml
@@ -25,7 +25,7 @@
                 android:id="@+id/title_text"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:gravity="center_horizontal"
+                android:gravity="start"
                 android:layout_marginTop="@dimen/item_vertical_margin"
                 android:textSize="@dimen/upload_title_text_size"
                 android:text="@string/file_upload"
@@ -37,23 +37,15 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/file_upload_content_passport"
-                android:gravity="center"
-                android:layout_marginBottom="@dimen/item_vertical_margin"
+                android:gravity="start"
+                android:layout_marginBottom="32dp"
                 tools:text="@string/file_upload_content_passport" />
 
-
-            <View
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:layout_marginBottom="@dimen/item_vertical_margin"
-                android:background="?android:attr/listDivider" />
 
             <RelativeLayout
                 android:layout_width="match_parent"
                 android:layout_height="48dp"
-                android:layout_marginBottom="@dimen/item_vertical_margin"
-                android:layout_marginStart="@dimen/item_horizontal_margin"
-                android:layout_marginEnd="@dimen/item_horizontal_margin">
+                android:layout_marginBottom="@dimen/item_vertical_margin">
 
                 <TextView
                     android:id="@+id/label"
@@ -94,14 +86,6 @@
                     android:contentDescription="@string/passport_selected"
                     app:tint="?android:colorPrimary" />
             </RelativeLayout>
-
-
-            <View
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:layout_marginBottom="@dimen/item_vertical_margin"
-                android:background="?android:attr/listDivider" />
-
         </LinearLayout>
     </ScrollView>
 

--- a/identity/res/navigation/identity_nav_graph.xml
+++ b/identity/res/navigation/identity_nav_graph.xml
@@ -20,7 +20,7 @@
     <action
         android:id="@+id/action_global_couldNotCaptureFragment"
         app:destination="@id/couldNotCaptureFragment" />
-    
+
     <fragment
         android:id="@+id/consentFragment"
         android:name="com.stripe.android.identity.navigation.ConsentFragment"
@@ -130,8 +130,7 @@
     </fragment>
     <fragment
         android:id="@+id/couldNotCaptureFragment"
-        android:name="com.stripe.android.identity.navigation.CouldNotCaptureFragment"
-        android:label="CouldNotCaptureFragment">
+        android:name="com.stripe.android.identity.navigation.CouldNotCaptureFragment">
         <argument
             android:name="scanType"
             app:argType="com.stripe.android.identity.states.IdentityScanState$ScanType" />

--- a/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
@@ -66,7 +66,7 @@ internal class DocSelectionFragment(
                             toggleSingleSelectionUI(
                                 documentSelect.idDocumentTypeAllowlist.entries.first().key,
                                 documentSelect.buttonText,
-                                documentSelect.idDocumentTypeAllowlist.entries.first().value,
+                                documentSelect.body,
                             )
                         }
                     }
@@ -142,7 +142,7 @@ internal class DocSelectionFragment(
     /**
      * Toggle UI to show single selection type.
      */
-    private fun toggleSingleSelectionUI(allowedType: String, buttonText: String, bodyText: String) {
+    private fun toggleSingleSelectionUI(allowedType: String, buttonText: String, bodyText: String?) {
         binding.multiSelectionContent.visibility = View.GONE
         binding.singleSelectionContent.visibility = View.VISIBLE
         binding.singleSelectionContinue.setText(buttonText)

--- a/identity/src/main/java/com/stripe/android/identity/navigation/DriverLicenseScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/DriverLicenseScanFragment.kt
@@ -62,9 +62,11 @@ internal class DriverLicenseScanFragment(
             is IdentityScanState.Initial -> {
                 when (identityScanViewModel.targetScanType) {
                     DL_FRONT -> {
+                        headerTitle.text = requireContext().getText(R.string.front_of_dl)
                         messageView.text = requireContext().getText(R.string.position_dl_front)
                     }
                     DL_BACK -> {
+                        headerTitle.text = requireContext().getText(R.string.back_of_dl)
                         messageView.text = requireContext().getText(R.string.position_dl_back)
                     }
                     else -> {
@@ -78,9 +80,11 @@ internal class DriverLicenseScanFragment(
             is IdentityScanState.Unsatisfied -> {
                 when (identityScanViewModel.targetScanType) {
                     DL_FRONT -> {
+                        headerTitle.text = requireContext().getText(R.string.front_of_dl)
                         messageView.text = requireContext().getText(R.string.position_dl_front)
                     }
                     DL_BACK -> {
+                        headerTitle.text = requireContext().getText(R.string.back_of_dl)
                         messageView.text = requireContext().getText(R.string.position_dl_back)
                     }
                     else -> {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/DriverLicenseScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/DriverLicenseScanFragment.kt
@@ -6,7 +6,6 @@ import android.view.View
 import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.identity.R
 import com.stripe.android.identity.networking.models.IdDocumentParam
-import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.states.IdentityScanState.ScanType.DL_BACK
 import com.stripe.android.identity.states.IdentityScanState.ScanType.DL_FRONT
 
@@ -56,46 +55,23 @@ internal class DriverLicenseScanFragment(
         }
     }
 
-    override fun updateUI(identityScanState: IdentityScanState) {
-        super.updateUI(identityScanState)
-        when (identityScanState) {
-            is IdentityScanState.Initial -> {
-                when (identityScanViewModel.targetScanType) {
-                    DL_FRONT -> {
-                        headerTitle.text = requireContext().getText(R.string.front_of_dl)
-                        messageView.text = requireContext().getText(R.string.position_dl_front)
-                    }
-                    DL_BACK -> {
-                        headerTitle.text = requireContext().getText(R.string.back_of_dl)
-                        messageView.text = requireContext().getText(R.string.position_dl_back)
-                    }
-                    else -> {
-                        Log.e(
-                            TAG,
-                            "Incorrect target scan type: ${identityScanViewModel.targetScanType}"
-                        )
-                    }
-                }
+    override fun resetUI() {
+        super.resetUI()
+        when (identityScanViewModel.targetScanType) {
+            DL_FRONT -> {
+                headerTitle.text = requireContext().getText(R.string.front_of_dl)
+                messageView.text = requireContext().getText(R.string.position_dl_front)
             }
-            is IdentityScanState.Unsatisfied -> {
-                when (identityScanViewModel.targetScanType) {
-                    DL_FRONT -> {
-                        headerTitle.text = requireContext().getText(R.string.front_of_dl)
-                        messageView.text = requireContext().getText(R.string.position_dl_front)
-                    }
-                    DL_BACK -> {
-                        headerTitle.text = requireContext().getText(R.string.back_of_dl)
-                        messageView.text = requireContext().getText(R.string.position_dl_back)
-                    }
-                    else -> {
-                        Log.e(
-                            TAG,
-                            "Incorrect target scan type: ${identityScanViewModel.targetScanType}"
-                        )
-                    }
-                }
+            DL_BACK -> {
+                headerTitle.text = requireContext().getText(R.string.back_of_dl)
+                messageView.text = requireContext().getText(R.string.position_dl_back)
             }
-            else -> {} // no-op
+            else -> {
+                Log.e(
+                    TAG,
+                    "Incorrect target scan type: ${identityScanViewModel.targetScanType}"
+                )
+            }
         }
     }
 

--- a/identity/src/main/java/com/stripe/android/identity/navigation/FrontBackUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/FrontBackUploadFragment.kt
@@ -7,7 +7,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
-import android.widget.TextView
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatDialog
 import androidx.fragment.app.Fragment
@@ -226,8 +225,7 @@ internal abstract class FrontBackUploadFragment(
         scanType: IdentityScanState.ScanType
     ) = AppCompatDialog(requireContext()).also { dialog ->
         dialog.setContentView(R.layout.get_local_image_dialog)
-        dialog.findViewById<TextView>(R.id.title)?.text = getTitleFromScanType(scanType)
-
+        dialog.setTitle(getTitleFromScanType(scanType))
         if (shouldShowCamera) {
             dialog.findViewById<Button>(R.id.take_photo)?.setOnClickListener {
                 if (scanType == frontScanType) {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IDScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IDScanFragment.kt
@@ -62,9 +62,11 @@ internal class IDScanFragment(
             is IdentityScanState.Initial -> {
                 when (identityScanViewModel.targetScanType) {
                     ID_FRONT -> {
+                        headerTitle.text = requireContext().getText(R.string.front_of_id)
                         messageView.text = requireContext().getText(R.string.position_id_front)
                     }
                     ID_BACK -> {
+                        headerTitle.text = requireContext().getText(R.string.back_of_id)
                         messageView.text = requireContext().getText(R.string.position_id_back)
                     }
                     else -> {
@@ -78,9 +80,11 @@ internal class IDScanFragment(
             is IdentityScanState.Unsatisfied -> {
                 when (identityScanViewModel.targetScanType) {
                     ID_FRONT -> {
+                        headerTitle.text = requireContext().getText(R.string.front_of_id)
                         messageView.text = requireContext().getText(R.string.position_id_front)
                     }
                     ID_BACK -> {
+                        headerTitle.text = requireContext().getText(R.string.back_of_id)
                         messageView.text = requireContext().getText(R.string.position_id_back)
                     }
                     else -> {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IDScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IDScanFragment.kt
@@ -6,7 +6,6 @@ import android.view.View
 import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.identity.R
 import com.stripe.android.identity.networking.models.IdDocumentParam
-import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.states.IdentityScanState.ScanType.ID_BACK
 import com.stripe.android.identity.states.IdentityScanState.ScanType.ID_FRONT
 
@@ -56,46 +55,23 @@ internal class IDScanFragment(
         }
     }
 
-    override fun updateUI(identityScanState: IdentityScanState) {
-        super.updateUI(identityScanState)
-        when (identityScanState) {
-            is IdentityScanState.Initial -> {
-                when (identityScanViewModel.targetScanType) {
-                    ID_FRONT -> {
-                        headerTitle.text = requireContext().getText(R.string.front_of_id)
-                        messageView.text = requireContext().getText(R.string.position_id_front)
-                    }
-                    ID_BACK -> {
-                        headerTitle.text = requireContext().getText(R.string.back_of_id)
-                        messageView.text = requireContext().getText(R.string.position_id_back)
-                    }
-                    else -> {
-                        Log.e(
-                            TAG,
-                            "Incorrect target scan type: ${identityScanViewModel.targetScanType}"
-                        )
-                    }
-                }
+    override fun resetUI() {
+        super.resetUI()
+        when (identityScanViewModel.targetScanType) {
+            ID_FRONT -> {
+                headerTitle.text = requireContext().getText(R.string.front_of_id)
+                messageView.text = requireContext().getText(R.string.position_id_front)
             }
-            is IdentityScanState.Unsatisfied -> {
-                when (identityScanViewModel.targetScanType) {
-                    ID_FRONT -> {
-                        headerTitle.text = requireContext().getText(R.string.front_of_id)
-                        messageView.text = requireContext().getText(R.string.position_id_front)
-                    }
-                    ID_BACK -> {
-                        headerTitle.text = requireContext().getText(R.string.back_of_id)
-                        messageView.text = requireContext().getText(R.string.position_id_back)
-                    }
-                    else -> {
-                        Log.e(
-                            TAG,
-                            "Incorrect target scan type: ${identityScanViewModel.targetScanType}"
-                        )
-                    }
-                }
+            ID_BACK -> {
+                headerTitle.text = requireContext().getText(R.string.back_of_id)
+                messageView.text = requireContext().getText(R.string.position_id_back)
             }
-            else -> {} // no-op
+            else -> {
+                Log.e(
+                    TAG,
+                    "Incorrect target scan type: ${identityScanViewModel.targetScanType}"
+                )
+            }
         }
     }
 

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
@@ -79,6 +79,8 @@ internal abstract class IdentityCameraScanFragment(
         binding = IdentityCameraScanFragmentBinding.inflate(inflater, container, false)
         cameraView = binding.cameraView
 
+        cameraView.viewFinderWindowView.setBackgroundResource(R.drawable.viewfinder_background)
+
         headerTitle = binding.headerTitle
         messageView = binding.message
 
@@ -164,25 +166,15 @@ internal abstract class IdentityCameraScanFragment(
     protected open fun updateUI(identityScanState: IdentityScanState) {
         when (identityScanState) {
             is IdentityScanState.Initial -> {
-                cameraView.viewFinderBackgroundView.visibility = View.VISIBLE
-                cameraView.viewFinderWindowView.visibility = View.VISIBLE
-                cameraView.viewFinderBorderView.visibility = View.VISIBLE
-                continueButton.isEnabled = false
-                checkMarkView.visibility = View.GONE
-                cameraView.viewFinderWindowView.setBackgroundResource(R.drawable.viewfinder_background)
-                cameraView.viewFinderBorderView.startAnimation(R.drawable.viewfinder_border_initial)
+                resetUI()
             }
             is IdentityScanState.Found -> {
                 messageView.text = requireContext().getText(R.string.hold_still)
-                cameraView.viewFinderWindowView.setBackgroundResource(R.drawable.viewfinder_background)
                 cameraView.viewFinderBorderView.startAnimationIfNotRunning(R.drawable.viewfinder_border_found)
             }
-            is IdentityScanState.Unsatisfied -> {
-                cameraView.viewFinderWindowView.setBackgroundResource(R.drawable.viewfinder_background)
-            }
+            is IdentityScanState.Unsatisfied -> {} // no-op
             is IdentityScanState.Satisfied -> {
                 messageView.text = requireContext().getText(R.string.scanned)
-                cameraView.viewFinderWindowView.setBackgroundResource(R.drawable.viewfinder_background)
             }
             is IdentityScanState.Finished -> {
                 cameraView.viewFinderBackgroundView.visibility = View.INVISIBLE
@@ -199,11 +191,21 @@ internal abstract class IdentityCameraScanFragment(
         }
     }
 
+    protected open fun resetUI() {
+        cameraView.viewFinderBackgroundView.visibility = View.VISIBLE
+        cameraView.viewFinderWindowView.visibility = View.VISIBLE
+        cameraView.viewFinderBorderView.visibility = View.VISIBLE
+        continueButton.isEnabled = false
+        checkMarkView.visibility = View.GONE
+        cameraView.viewFinderBorderView.startAnimation(R.drawable.viewfinder_border_initial)
+    }
+
     /**
      * Start scanning for the required scan type.
      */
     protected fun startScanning(scanType: IdentityScanState.ScanType) {
         identityScanViewModel.targetScanType = scanType
+        resetUI()
         cameraAdapter.bindToLifecycle(this)
         identityScanViewModel.scanState = null
         identityScanViewModel.scanStatePrevious = null

--- a/identity/src/main/java/com/stripe/android/identity/navigation/PassportScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/PassportScanFragment.kt
@@ -30,17 +30,10 @@ internal class PassportScanFragment(
         startScanning(IdentityScanState.ScanType.PASSPORT)
     }
 
-    override fun updateUI(identityScanState: IdentityScanState) {
-        super.updateUI(identityScanState)
-        when (identityScanState) {
-            is IdentityScanState.Initial -> {
-                messageView.text = requireContext().getText(R.string.position_passport)
-            }
-            is IdentityScanState.Unsatisfied -> {
-                messageView.text = requireContext().getText(R.string.position_passport)
-            }
-            else -> {} // no-op
-        }
+    override fun resetUI() {
+        super.resetUI()
+        headerTitle.text = requireContext().getText(R.string.passport)
+        messageView.text = requireContext().getText(R.string.position_passport)
     }
 
     internal companion object {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/PassportUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/PassportUploadFragment.kt
@@ -7,7 +7,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
-import android.widget.TextView
 import androidx.appcompat.app.AppCompatDialog
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -95,8 +94,7 @@ internal class PassportUploadFragment(
 
     private fun buildDialog() = AppCompatDialog(requireContext()).also { dialog ->
         dialog.setContentView(R.layout.get_local_image_dialog)
-        dialog.findViewById<TextView>(R.id.title)?.text =
-            getString(R.string.upload_dialog_title_passport)
+        dialog.setTitle(getString(R.string.upload_dialog_title_passport))
 
         if (shouldShowCamera) {
             dialog.findViewById<Button>(R.id.take_photo)?.setOnClickListener {

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageStaticContentDocumentSelectPage.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageStaticContentDocumentSelectPage.kt
@@ -11,5 +11,8 @@ internal data class VerificationPageStaticContentDocumentSelectPage(
     @SerialName("id_document_type_allowlist")
     val idDocumentTypeAllowlist: Map<String, String>,
     @SerialName("title")
-    val title: String
+    val title: String,
+    @SerialName("body")
+    val body: String?
+
 )

--- a/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
@@ -128,7 +128,7 @@ internal class DocSelectionFragmentTest {
     fun `Passport single choice UI is correctly bound`() {
         verifySingleChoiceUI(
             DOC_SELECT_SINGLE_CHOICE_PASSPORT,
-            PASSPORT_BODY_TEXT
+            PASSPORT_SINGLE_BODY_TEXT
         )
     }
 
@@ -136,7 +136,7 @@ internal class DocSelectionFragmentTest {
     fun `ID single choice UI is correctly bound`() {
         verifySingleChoiceUI(
             DOC_SELECT_SINGLE_CHOICE_ID,
-            ID_BODY_TEXT
+            ID_SINGLE_BODY_TEXT
         )
     }
 
@@ -144,7 +144,7 @@ internal class DocSelectionFragmentTest {
     fun `Driver license single choice UI is correctly bound`() {
         verifySingleChoiceUI(
             DOC_SELECT_SINGLE_CHOICE_DL,
-            DRIVING_LICENSE_BODY_TEXT
+            DRIVING_LICENSE_SINGLE_BODY_TEXT
         )
     }
 
@@ -300,7 +300,7 @@ internal class DocSelectionFragmentTest {
 
             assertThat(
                 requireNotNull(navController.backStack.last().arguments)
-                [ARG_SCAN_TYPE]
+                    [ARG_SCAN_TYPE]
             ).isEqualTo(IdDocumentParam.Type.DRIVINGLICENSE)
 
             assertThat(navController.currentDestination?.id)
@@ -411,6 +411,9 @@ internal class DocSelectionFragmentTest {
         const val PASSPORT_BODY_TEXT = "Passport body"
         const val ID_BODY_TEXT = "ID body"
         const val DRIVING_LICENSE_BODY_TEXT = "Driver's license body"
+        const val PASSPORT_SINGLE_BODY_TEXT = "Passport single selection body"
+        const val ID_SINGLE_BODY_TEXT = "ID single selection body"
+        const val DRIVING_LICENSE_SINGLE_BODY_TEXT = "Driver's license single selection body"
 
         val DOC_SELECT_MULTI_CHOICE = VerificationPageStaticContentDocumentSelectPage(
             title = DOCUMENT_SELECT_TITLE,
@@ -419,7 +422,8 @@ internal class DocSelectionFragmentTest {
                 ID_CARD_KEY to ID_BUTTON_TEXT,
                 DRIVING_LICENSE_KEY to DRIVING_LICENSE_BUTTON_TEXT
             ),
-            buttonText = DOCUMENT_SELECT_BUTTON_TEXT
+            buttonText = DOCUMENT_SELECT_BUTTON_TEXT,
+            body = null
         )
 
         val DOC_SELECT_SINGLE_CHOICE_PASSPORT = VerificationPageStaticContentDocumentSelectPage(
@@ -427,7 +431,8 @@ internal class DocSelectionFragmentTest {
             idDocumentTypeAllowlist = mapOf(
                 PASSPORT_KEY to PASSPORT_BODY_TEXT,
             ),
-            buttonText = DOCUMENT_SELECT_BUTTON_TEXT
+            buttonText = DOCUMENT_SELECT_BUTTON_TEXT,
+            body = PASSPORT_SINGLE_BODY_TEXT
         )
 
         val DOC_SELECT_SINGLE_CHOICE_ID = VerificationPageStaticContentDocumentSelectPage(
@@ -435,7 +440,8 @@ internal class DocSelectionFragmentTest {
             idDocumentTypeAllowlist = mapOf(
                 ID_CARD_KEY to ID_BODY_TEXT,
             ),
-            buttonText = DOCUMENT_SELECT_BUTTON_TEXT
+            buttonText = DOCUMENT_SELECT_BUTTON_TEXT,
+            body = ID_SINGLE_BODY_TEXT
         )
 
         val DOC_SELECT_SINGLE_CHOICE_DL = VerificationPageStaticContentDocumentSelectPage(
@@ -443,13 +449,15 @@ internal class DocSelectionFragmentTest {
             idDocumentTypeAllowlist = mapOf(
                 DRIVING_LICENSE_KEY to DRIVING_LICENSE_BODY_TEXT
             ),
-            buttonText = DOCUMENT_SELECT_BUTTON_TEXT
+            buttonText = DOCUMENT_SELECT_BUTTON_TEXT,
+            body = DRIVING_LICENSE_SINGLE_BODY_TEXT
         )
 
         val DOC_SELECT_ZERO_CHOICE = VerificationPageStaticContentDocumentSelectPage(
             title = DOCUMENT_SELECT_TITLE,
             idDocumentTypeAllowlist = emptyMap(),
-            buttonText = DOCUMENT_SELECT_BUTTON_TEXT
+            buttonText = DOCUMENT_SELECT_BUTTON_TEXT,
+            body = null
         )
 
         val MISSING_BACK_VERIFICATION_PAGE_DATA = VerificationPageData(

--- a/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
@@ -300,7 +300,7 @@ internal class DocSelectionFragmentTest {
 
             assertThat(
                 requireNotNull(navController.backStack.last().arguments)
-                    [ARG_SCAN_TYPE]
+                [ARG_SCAN_TYPE]
             ).isEqualTo(IdDocumentParam.Type.DRIVINGLICENSE)
 
             assertThat(navController.currentDestination?.id)

--- a/identity/src/test/java/com/stripe/android/identity/navigation/DriverLicenseScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/DriverLicenseScanFragmentTest.kt
@@ -305,6 +305,9 @@ internal class DriverLicenseScanFragmentTest {
                 .isEqualTo(View.VISIBLE)
             assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
             assertThat(binding.kontinue.isEnabled).isFalse()
+            assertThat(binding.headerTitle.text).isEqualTo(
+                context.getText(R.string.front_of_dl)
+            )
             assertThat(binding.message.text).isEqualTo(
                 context.getText(R.string.position_dl_front)
             )
@@ -323,6 +326,9 @@ internal class DriverLicenseScanFragmentTest {
                 .isEqualTo(View.VISIBLE)
             assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
             assertThat(binding.kontinue.isEnabled).isFalse()
+            assertThat(binding.headerTitle.text).isEqualTo(
+                context.getText(R.string.back_of_dl)
+            )
             assertThat(binding.message.text).isEqualTo(
                 context.getText(R.string.position_dl_back)
             )

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IDScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IDScanFragmentTest.kt
@@ -294,6 +294,9 @@ internal class IDScanFragmentTest {
             assertThat(binding.cameraView.viewFinderBorderView.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
             assertThat(binding.kontinue.isEnabled).isFalse()
+            assertThat(binding.headerTitle.text).isEqualTo(
+                context.getText(R.string.front_of_id)
+            )
             assertThat(binding.message.text).isEqualTo(
                 context.getText(R.string.position_id_front)
             )
@@ -309,6 +312,9 @@ internal class IDScanFragmentTest {
             assertThat(binding.cameraView.viewFinderBorderView.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.checkMarkView.visibility).isEqualTo(View.GONE)
             assertThat(binding.kontinue.isEnabled).isFalse()
+            assertThat(binding.headerTitle.text).isEqualTo(
+                context.getText(R.string.back_of_id)
+            )
             assertThat(binding.message.text).isEqualTo(
                 context.getText(R.string.position_id_back)
             )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Read a different field when only one type of document type is allowed

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Identity SDK

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![singleDocBefore](https://user-images.githubusercontent.com/79880926/161153578-1b9378a0-3bb6-4aaa-a835-37e605f8db1e.png)  | ![singleDocAfter](https://user-images.githubusercontent.com/79880926/161153572-68448b3f-e0ac-4641-9acf-62047f365111.png)  |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
