### PR TITLE
Unifies view effects in state.

### DIFF
--- a/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetActivity.kt
+++ b/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetActivity.kt
@@ -69,18 +69,18 @@ internal class ConnectionsSheetActivity : AppCompatActivity() {
 
     private fun setupObservers() {
         lifecycleScope.launchWhenStarted {
-            viewModel.state.collect {
-                // process state updates here.
+            viewModel.state.collect { state ->
+                state.viewEffects.firstOrNull()?.launch()
             }
         }
-        lifecycleScope.launchWhenStarted {
-            viewModel.viewEffect.collect { viewEffect ->
-                when (viewEffect) {
-                    is OpenAuthFlowWithUrl -> viewEffect.launch()
-                    is FinishWithResult -> finishWithResult(viewEffect.result)
-                }
-            }
+    }
+
+    private fun ConnectionsSheetViewEffect.launch() {
+        when (this) {
+            is OpenAuthFlowWithUrl -> launch()
+            is FinishWithResult -> finishWithResult(result)
         }
+        viewModel.markAsLaunched(this)
     }
 
     private fun OpenAuthFlowWithUrl.launch() {

--- a/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetState.kt
+++ b/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetState.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.connections
 
 import com.stripe.android.connections.model.LinkAccountSessionManifest
+import java.util.UUID
 
 /**
  *  Class containing all of the data needed to represent the screen.
@@ -8,15 +9,26 @@ import com.stripe.android.connections.model.LinkAccountSessionManifest
 internal data class ConnectionsSheetState(
     val activityRecreated: Boolean = false,
     val manifest: LinkAccountSessionManifest? = null,
-    val authFlowActive: Boolean = false
-)
+    val authFlowActive: Boolean = false,
+    val viewEffects: List<ConnectionsSheetViewEffect> = emptyList()
+) {
+    operator fun plus(viewEffect: ConnectionsSheetViewEffect): ConnectionsSheetState {
+        return copy(viewEffects = viewEffects + viewEffect)
+    }
+
+    operator fun minus(viewEffect: ConnectionsSheetViewEffect): ConnectionsSheetState {
+        return copy(viewEffects = viewEffects.filterNot { it.id == viewEffect.id })
+    }
+}
 
 /**
  *  Class containing all side effects intended to be run by the view.
  *
  *  Mostly one-off actions to be executed by the view will be instances of ViewEffect.
  */
-internal sealed class ConnectionsSheetViewEffect {
+internal sealed class ConnectionsSheetViewEffect(
+    val id: Long = UUID.randomUUID().mostSignificantBits,
+) {
 
     /**
      * Open the AuthFlow.

--- a/connections/src/test/java/com/stripe/android/connections/ConnectionsSheetActivityTest.kt
+++ b/connections/src/test/java/com/stripe/android/connections/ConnectionsSheetActivityTest.kt
@@ -7,11 +7,11 @@ import androidx.browser.customtabs.CustomTabsIntent
 import androidx.browser.customtabs.CustomTabsIntent.SHARE_STATE_OFF
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.connections.ConnectionsSheetViewEffect.OpenAuthFlowWithUrl
 import com.stripe.android.connections.utils.InjectableActivityScenario
 import com.stripe.android.connections.utils.TestUtils.viewModelFactoryFor
 import com.stripe.android.connections.utils.injectableActivityScenario
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestScope
@@ -94,12 +94,12 @@ class ConnectionsSheetActivityTest {
     @Test
     fun `viewEffect - OpenAuthFlowWithUrl opens Chrome Custom Tab intent`() {
         val chromeCustomTabUrl = "www.authflow.com"
-        val viewEffects = MutableSharedFlow<ConnectionsSheetViewEffect>()
+        val states = MutableStateFlow<ConnectionsSheetState>(ConnectionsSheetState())
         val mockViewModel = mock<ConnectionsSheetViewModel> {
-            on { viewEffect } doReturn viewEffects
+            on { state } doReturn states
         }
         activityScenario(mockViewModel).launch(intent).suspendOnActivity {
-            viewEffects.emit(ConnectionsSheetViewEffect.OpenAuthFlowWithUrl(chromeCustomTabUrl))
+            states.emit(states.value + OpenAuthFlowWithUrl(chromeCustomTabUrl))
             val intent: Intent = shadowOf(it).nextStartedActivity
             assertThat(intent.getIntExtra(CustomTabsIntent.EXTRA_SHARE_STATE, 0)).isEqualTo(
                 SHARE_STATE_OFF

--- a/connections/src/test/java/com/stripe/android/connections/ConnectionsSheetViewModelTest.kt
+++ b/connections/src/test/java/com/stripe/android/connections/ConnectionsSheetViewModelTest.kt
@@ -7,6 +7,7 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.connections.ConnectionsSheetResult.Completed
 import com.stripe.android.connections.ConnectionsSheetViewEffect.FinishWithResult
+import com.stripe.android.connections.ConnectionsSheetViewEffect.OpenAuthFlowWithUrl
 import com.stripe.android.connections.analytics.ConnectionsEventReporter
 import com.stripe.android.connections.domain.FetchLinkAccountSession
 import com.stripe.android.connections.domain.GenerateLinkAccountSessionManifest
@@ -41,6 +42,22 @@ class ConnectionsSheetViewModelTest {
     )
     private val fetchLinkAccountSession = mock<FetchLinkAccountSession>()
     private val generateLinkAccountSessionManifest = mock<GenerateLinkAccountSessionManifest>()
+
+    @Test
+    fun `init - when fetch manifest succeeds, emits OpenAuthFlow with retrieved url`() = runTest {
+        // Given
+        val expectedLinkAccountSession = linkAccountSession()
+        whenever(generateLinkAccountSessionManifest(any(), any())).thenReturn(manifest)
+        whenever(fetchLinkAccountSession(any())).thenReturn(expectedLinkAccountSession)
+
+        // When
+        createViewModel(configuration).state.test {
+
+            // Then
+            assertThat(expectMostRecentItem().viewEffects.last())
+                .isEqualTo(OpenAuthFlowWithUrl(manifest.hostedAuthUrl))
+        }
+    }
 
     @Test
     fun `init - eventReporter fires onPresented`() {


### PR DESCRIPTION
# Summary
- Removes separated sharedFlow and adds view effects list in state.
- Since since viewEffects are now part of a state flow, we can test emissions that happen during viewModel#init. Added a test covering viewModel initialization to prove it.

# Motivation
- Follow Unidirectional Data Flow as stated in the android architecture guidelines. 
- Recommended reading - https://developer.android.com/jetpack/guide/ui-layer/events#consuming-trigger-updates

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified
