### PR TITLE
[Identity] When requireLiveCapture is true, disable choose photo

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/navigation/CameraPermissionDeniedFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/CameraPermissionDeniedFragment.kt
@@ -27,7 +27,8 @@ internal class CameraPermissionDeniedFragment(
         topButton.setOnClickListener {
             navigateToUploadFragment(
                 identityScanType.toUploadDestinationId(),
-                false
+                shouldShowTakePhoto = false,
+                shouldShowChoosePhoto = true
             )
         }
 

--- a/identity/src/main/java/com/stripe/android/identity/navigation/CouldNotCaptureFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/CouldNotCaptureFragment.kt
@@ -14,8 +14,11 @@ import com.stripe.android.identity.utils.navigateToUploadFragment
 internal class CouldNotCaptureFragment : BaseErrorFragment() {
 
     override fun onCustomizingViews() {
-        val scanType =
-            requireNotNull(arguments)[ARG_COULD_NOT_CAPTURE_SCAN_TYPE] as IdentityScanState.ScanType
+        val args = requireNotNull(arguments) {
+            "Argument to CouldNotCaptureFragment is null"
+        }
+        val scanType = args[ARG_COULD_NOT_CAPTURE_SCAN_TYPE] as IdentityScanState.ScanType
+        val requireLiveCapture = args[ARG_REQUIRE_LIVE_CAPTURE] as Boolean
 
         title.text = getString(R.string.could_not_capture_title)
         message1.text = getString(R.string.could_not_capture_body1)
@@ -25,7 +28,8 @@ internal class CouldNotCaptureFragment : BaseErrorFragment() {
         topButton.setOnClickListener {
             navigateToUploadFragment(
                 scanType.toUploadDestinationId(),
-                true
+                shouldShowTakePhoto = true,
+                shouldShowChoosePhoto = !requireLiveCapture
             )
         }
 
@@ -42,6 +46,7 @@ internal class CouldNotCaptureFragment : BaseErrorFragment() {
 
     internal companion object {
         const val ARG_COULD_NOT_CAPTURE_SCAN_TYPE = "scanType"
+        const val ARG_REQUIRE_LIVE_CAPTURE = "requireLiveCapture"
 
         @IdRes
         private fun IdentityScanState.ScanType.toUploadDestinationId() =

--- a/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
@@ -229,7 +229,11 @@ internal class DocSelectionFragment(
                     Log.e(TAG, "Can't access camera and client has required live capture.")
                     navigateToDefaultErrorFragment()
                 } else {
-                    navigateToUploadFragment(type.toUploadDestinationId(), true)
+                    navigateToUploadFragment(
+                        type.toUploadDestinationId(),
+                        shouldShowTakePhoto = true,
+                        shouldShowChoosePhoto = true
+                    )
                 }
             },
             onFailure = {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityUploadFragment.kt
@@ -23,6 +23,7 @@ import com.stripe.android.identity.networking.models.DocumentUploadParam
 import com.stripe.android.identity.networking.models.IdDocumentParam
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentDocumentCapturePage
 import com.stripe.android.identity.states.IdentityScanState
+import com.stripe.android.identity.utils.ARG_SHOULD_SHOW_CHOOSE_PHOTO
 import com.stripe.android.identity.utils.ARG_SHOULD_SHOW_TAKE_PHOTO
 import com.stripe.android.identity.utils.navigateToDefaultErrorFragment
 import com.stripe.android.identity.utils.postVerificationPageDataAndMaybeSubmit
@@ -65,6 +66,8 @@ internal abstract class IdentityUploadFragment(
 
     private var shouldShowTakePhoto: Boolean = false
 
+    private var shouldShowChoosePhoto: Boolean = false
+
     private val identityUploadViewModel: IdentityUploadViewModel by viewModels { identityUploadViewModelFactory }
 
     protected val identityViewModel: IdentityViewModel by activityViewModels { identityViewModelFactory }
@@ -83,6 +86,7 @@ internal abstract class IdentityUploadFragment(
             "Argument to FrontBackUploadFragment is null"
         }
         shouldShowTakePhoto = args[ARG_SHOULD_SHOW_TAKE_PHOTO] as Boolean
+        shouldShowChoosePhoto = args[ARG_SHOULD_SHOW_CHOOSE_PHOTO] as Boolean
 
         binding = IdentityUploadFragmentBinding.inflate(layoutInflater, container, false)
         binding.titleText.text = getString(titleRes)
@@ -280,25 +284,29 @@ internal abstract class IdentityUploadFragment(
             requireNotNull(dialog.findViewById(R.id.take_photo)).visibility = View.GONE
         }
 
-        dialog.findViewById<Button>(R.id.choose_file)?.setOnClickListener {
-            if (scanType == frontScanType) {
-                identityUploadViewModel.chooseImageFront {
-                    uploadResult(
-                        uri = it,
-                        uploadMethod = DocumentUploadParam.UploadMethod.FILEUPLOAD,
-                        isFront = true
-                    )
+        if (shouldShowChoosePhoto) {
+            dialog.findViewById<Button>(R.id.choose_file)?.setOnClickListener {
+                if (scanType == frontScanType) {
+                    identityUploadViewModel.chooseImageFront {
+                        uploadResult(
+                            uri = it,
+                            uploadMethod = DocumentUploadParam.UploadMethod.FILEUPLOAD,
+                            isFront = true
+                        )
+                    }
+                } else if (scanType == backScanType) {
+                    identityUploadViewModel.chooseImageBack {
+                        uploadResult(
+                            uri = it,
+                            uploadMethod = DocumentUploadParam.UploadMethod.FILEUPLOAD,
+                            isFront = false
+                        )
+                    }
                 }
-            } else if (scanType == backScanType) {
-                identityUploadViewModel.chooseImageBack {
-                    uploadResult(
-                        uri = it,
-                        uploadMethod = DocumentUploadParam.UploadMethod.FILEUPLOAD,
-                        isFront = false
-                    )
-                }
+                dialog.dismiss()
             }
-            dialog.dismiss()
+        } else {
+            requireNotNull(dialog.findViewById(R.id.choose_file)).visibility = View.GONE
         }
     }
 

--- a/identity/src/main/java/com/stripe/android/identity/utils/navigationUtils.kt
+++ b/identity/src/main/java/com/stripe/android/identity/utils/navigationUtils.kt
@@ -119,12 +119,14 @@ internal fun Fragment.navigateToErrorFragmentWithFailedReason(failedReason: Thro
  */
 internal fun Fragment.navigateToUploadFragment(
     @IdRes destinationId: Int,
-    shouldShowTakePhoto: Boolean
+    shouldShowTakePhoto: Boolean,
+    shouldShowChoosePhoto: Boolean
 ) {
     findNavController().navigate(
         destinationId,
         bundleOf(
-            ARG_SHOULD_SHOW_TAKE_PHOTO to shouldShowTakePhoto
+            ARG_SHOULD_SHOW_TAKE_PHOTO to shouldShowTakePhoto,
+            ARG_SHOULD_SHOW_CHOOSE_PHOTO to shouldShowChoosePhoto
         )
     )
 }
@@ -133,5 +135,10 @@ internal fun Fragment.navigateToUploadFragment(
  * Argument to indicate if take photo option should be shown when picking an image.
  */
 internal const val ARG_SHOULD_SHOW_TAKE_PHOTO = "shouldShowTakePhoto"
+
+/**
+ * Argument to indicate if choose photo option should be shown when picking an image.
+ */
+internal const val ARG_SHOULD_SHOW_CHOOSE_PHOTO = "shouldShowChoosePhoto"
 
 private const val TAG = "NAVIGATION_UTIL"

--- a/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
@@ -300,7 +300,7 @@ internal class DocSelectionFragmentTest {
 
             assertThat(
                 requireNotNull(navController.backStack.last().arguments)
-                [ARG_SCAN_TYPE]
+                    [ARG_SCAN_TYPE]
             ).isEqualTo(IdDocumentParam.Type.DRIVINGLICENSE)
 
             assertThat(navController.currentDestination?.id)

--- a/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
@@ -300,7 +300,7 @@ internal class DocSelectionFragmentTest {
 
             assertThat(
                 requireNotNull(navController.backStack.last().arguments)
-                    [ARG_SCAN_TYPE]
+                [ARG_SCAN_TYPE]
             ).isEqualTo(IdDocumentParam.Type.DRIVINGLICENSE)
 
             assertThat(navController.currentDestination?.id)

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IdentityCameraScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IdentityCameraScanFragmentTest.kt
@@ -31,7 +31,9 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
 import org.junit.runner.RunWith
+import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.same
 import org.mockito.kotlin.verify
@@ -166,6 +168,14 @@ class IdentityCameraScanFragmentTest {
                     whenever(it.identityState).thenReturn(mock<IdentityScanState.TimeOut>())
                 }
             )
+
+            val successCaptor: KArgumentCaptor<(VerificationPage) -> Unit> = argumentCaptor()
+            verify(mockIdentityViewModel).observeForVerificationPage(
+                any(),
+                successCaptor.capture(),
+                any()
+            )
+            successCaptor.firstValue(SUCCESS_VERIFICATION_PAGE)
 
             verify(mockScanFlow).resetFlow()
             assertThat(testFragment.cameraAdapter.isBoundToLifecycle()).isFalse()

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IdentityUploadFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IdentityUploadFragmentTest.kt
@@ -30,6 +30,7 @@ import com.stripe.android.identity.networking.models.IdDocumentParam
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentDocumentCapturePage
 import com.stripe.android.identity.states.IdentityScanState
+import com.stripe.android.identity.utils.ARG_SHOULD_SHOW_CHOOSE_PHOTO
 import com.stripe.android.identity.utils.ARG_SHOULD_SHOW_TAKE_PHOTO
 import com.stripe.android.identity.utils.PairMediatorLiveData
 import com.stripe.android.identity.viewModelFactoryFor
@@ -108,7 +109,7 @@ class IdentityUploadFragmentTest {
     }
 
     @Test
-    fun `when shouldShowCamera is true UI is correct`() {
+    fun `when shouldShowTakePhoto is true UI is correct`() {
         launchFragment(shouldShowTakePhoto = true) { binding, _, _ ->
             binding.selectFront.callOnClick()
             val dialog = ShadowDialog.getLatestDialog()
@@ -124,7 +125,7 @@ class IdentityUploadFragmentTest {
     }
 
     @Test
-    fun `when shouldShowCamera is false UI is correct`() {
+    fun `when shouldShowTakePhoto is false UI is correct`() {
         launchFragment(shouldShowTakePhoto = false) { binding, _, _ ->
             binding.selectFront.callOnClick()
             val dialog = ShadowDialog.getLatestDialog()
@@ -136,6 +137,38 @@ class IdentityUploadFragmentTest {
             // assert dialog content
             assertThat(dialog.findViewById<Button>(R.id.choose_file).visibility).isEqualTo(View.VISIBLE)
             assertThat(dialog.findViewById<Button>(R.id.take_photo).visibility).isEqualTo(View.GONE)
+        }
+    }
+
+    @Test
+    fun `when shouldShowChoosePhoto is true UI is correct`() {
+        launchFragment(shouldShowChoosePhoto = true) { binding, _, _ ->
+            binding.selectFront.callOnClick()
+            val dialog = ShadowDialog.getLatestDialog()
+
+            // dialog shows up
+            assertThat(dialog.isShowing).isTrue()
+            assertThat(dialog).isInstanceOf(AppCompatDialog::class.java)
+
+            // assert dialog content
+            assertThat(dialog.findViewById<Button>(R.id.choose_file).visibility).isEqualTo(View.VISIBLE)
+            assertThat(dialog.findViewById<Button>(R.id.take_photo).visibility).isEqualTo(View.VISIBLE)
+        }
+    }
+
+    @Test
+    fun `when shouldShowChoosePhoto is false UI is correct`() {
+        launchFragment(shouldShowChoosePhoto = false) { binding, _, _ ->
+            binding.selectFront.callOnClick()
+            val dialog = ShadowDialog.getLatestDialog()
+
+            // dialog shows up
+            assertThat(dialog.isShowing).isTrue()
+            assertThat(dialog).isInstanceOf(AppCompatDialog::class.java)
+
+            // assert dialog content
+            assertThat(dialog.findViewById<Button>(R.id.choose_file).visibility).isEqualTo(View.GONE)
+            assertThat(dialog.findViewById<Button>(R.id.take_photo).visibility).isEqualTo(View.VISIBLE)
         }
     }
 
@@ -432,6 +465,7 @@ class IdentityUploadFragmentTest {
 
     private fun launchFragment(
         shouldShowTakePhoto: Boolean = true,
+        shouldShowChoosePhoto: Boolean = true,
         testBlock: (
             binding: IdentityUploadFragmentBinding,
             navController: TestNavHostController,
@@ -439,7 +473,8 @@ class IdentityUploadFragmentTest {
         ) -> Unit
     ) = launchFragmentInContainer(
         fragmentArgs = bundleOf(
-            ARG_SHOULD_SHOW_TAKE_PHOTO to shouldShowTakePhoto
+            ARG_SHOULD_SHOW_TAKE_PHOTO to shouldShowTakePhoto,
+            ARG_SHOULD_SHOW_CHOOSE_PHOTO to shouldShowChoosePhoto
         ),
         themeResId = R.style.Theme_MaterialComponents
     ) {

--- a/identity/src/test/java/com/stripe/android/identity/navigation/PassportUploadFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/PassportUploadFragmentTest.kt
@@ -28,6 +28,7 @@ import com.stripe.android.identity.networking.models.DocumentUploadParam.UploadM
 import com.stripe.android.identity.networking.models.IdDocumentParam
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentDocumentCapturePage
+import com.stripe.android.identity.utils.ARG_SHOULD_SHOW_CHOOSE_PHOTO
 import com.stripe.android.identity.utils.ARG_SHOULD_SHOW_TAKE_PHOTO
 import com.stripe.android.identity.viewModelFactoryFor
 import com.stripe.android.identity.viewmodel.IdentityUploadViewModel
@@ -264,7 +265,8 @@ class PassportUploadFragmentTest {
         ) -> Unit
     ) = launchFragmentInContainer(
         fragmentArgs = bundleOf(
-            ARG_SHOULD_SHOW_TAKE_PHOTO to shouldShowTakePhoto
+            ARG_SHOULD_SHOW_TAKE_PHOTO to shouldShowTakePhoto,
+            ARG_SHOULD_SHOW_CHOOSE_PHOTO to true
         ),
         themeResId = R.style.Theme_MaterialComponents
     ) {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Don't allow uploading from local file when "requireLiveCapture" is true

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Identity SDK

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
