### PR TITLE
Add verify with microdeposit to example app

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/ManualUSBankAccountPaymentMethodActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/ManualUSBankAccountPaymentMethodActivity.kt
@@ -23,32 +23,87 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.lifecycleScope
+import com.stripe.android.ApiResultCallback
+import com.stripe.android.StripeApiBeta
+import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.SetupIntent
+import com.stripe.android.model.StripeIntent
+import com.stripe.example.StripeFactory
 import com.stripe.example.theme.DefaultExampleTheme
+import kotlinx.coroutines.flow.MutableStateFlow
 
 /**
  * This example is currently work in progress. Do not use it as a reference.
  *
- * In order for this example to work, perform the following:
- * 1. Update ApiVersion.kt manually:
- *    const val API_VERSION_CODE: String = "2020-08-27;us_bank_account_beta=v2"
- * 2. Uncomment ManualUSBankAccountPaymentMethodActivity in LauncherActivity.kt
+ * In order for this example to work uncomment ManualUSBankAccountPaymentMethodActivity
+ * in LauncherActivity.kt
  */
 class ManualUSBankAccountPaymentMethodActivity : StripeIntentActivity() {
+    private val stripe by lazy {
+        StripeFactory(this, betas = setOf(StripeApiBeta.USBankAccount)).create()
+    }
+
+    private var paymentIntentSecret: String? = null
+    private var setupIntentSecret: String? = null
+
+    private val verifyCallback = object : ApiResultCallback<StripeIntent> {
+        override fun onSuccess(result: StripeIntent) {
+            viewModel.inProgress.value = false
+            viewModel.status.value += "Account verified with \n\n$result\n"
+        }
+
+        override fun onError(e: Exception) {
+            error(
+                "Can't verify ${if (paymentIntentSecret != null) "Payment" else "Setup"}Intent, $e"
+            )
+        }
+    }
+
+    private val screenState = MutableStateFlow<ScreenState>(ScreenState.CustomerCollectionScreen)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContent {
-            DefaultExampleTheme {
-                USBankAccountScreen()
+        lifecycleScope.launchWhenStarted {
+            screenState.collect {
+                when (it) {
+                    is ScreenState.CustomerCollectionScreen -> {
+                        setContent { DefaultExampleTheme { CollectBankScreen() } }
+                    }
+                    is ScreenState.VerificationNeededScreen -> {
+                        viewModel.inProgress.value = false
+                        viewModel.status.value = ""
+                        setContent { DefaultExampleTheme { VerificationNeededScreen() } }
+                    }
+                    is ScreenState.VerifyWithMicrodepositsScreen -> {
+                        viewModel.inProgress.value = false
+                        viewModel.status.value = ""
+                        setContent { DefaultExampleTheme { VerifyWithMicrodepositScreen() } }
+                    }
+                    is ScreenState.Error -> {
+                        viewModel.inProgress.value = false
+                        viewModel.status.value += it.message
+                    }
+                }
             }
         }
     }
 
+    override fun onConfirmSuccess() {
+        super.onConfirmSuccess()
+
+        // onConfirmSuccess gets called when we use PaymentLauncher to perform confirmation
+        // In this case we want to go to the next screen state
+        next()
+    }
+
     @Composable
-    private fun USBankAccountScreen() {
+    private fun CollectBankScreen() {
         val inProgress by viewModel.inProgress.observeAsState(false)
         val status by viewModel.status.observeAsState("")
         val scrollState = rememberScrollState()
@@ -63,9 +118,7 @@ class ManualUSBankAccountPaymentMethodActivity : StripeIntentActivity() {
         val isSaveForFutureUsage = remember { mutableStateOf(false) }
 
         if (inProgress) {
-            LinearProgressIndicator(
-                modifier = Modifier.fillMaxWidth(),
-            )
+            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
         }
         if (status.isNotEmpty()) {
             Text(text = status)
@@ -81,9 +134,7 @@ class ManualUSBankAccountPaymentMethodActivity : StripeIntentActivity() {
                     label = { Text("Name") },
                     value = name.value,
                     maxLines = 1,
-                    onValueChange = {
-                        name.value = it
-                    }
+                    onValueChange = { name.value = it }
                 )
                 OutlinedTextField(
                     modifier = Modifier.fillMaxWidth(),
@@ -93,9 +144,7 @@ class ManualUSBankAccountPaymentMethodActivity : StripeIntentActivity() {
                     keyboardOptions = KeyboardOptions(
                         keyboardType = KeyboardType.Email
                     ),
-                    onValueChange = {
-                        email.value = it
-                    }
+                    onValueChange = { email.value = it }
                 )
                 OutlinedTextField(
                     modifier = Modifier.fillMaxWidth(),
@@ -105,9 +154,7 @@ class ManualUSBankAccountPaymentMethodActivity : StripeIntentActivity() {
                     keyboardOptions = KeyboardOptions(
                         keyboardType = KeyboardType.Number
                     ),
-                    onValueChange = {
-                        accountNumber.value = it
-                    }
+                    onValueChange = { accountNumber.value = it }
                 )
                 OutlinedTextField(
                     modifier = Modifier.fillMaxWidth(),
@@ -117,9 +164,7 @@ class ManualUSBankAccountPaymentMethodActivity : StripeIntentActivity() {
                     keyboardOptions = KeyboardOptions(
                         keyboardType = KeyboardType.Number
                     ),
-                    onValueChange = {
-                        routingNumber.value = it
-                    }
+                    onValueChange = { routingNumber.value = it }
                 )
                 Column(modifier = Modifier.padding(top = 10.dp)) {
                     Text(text = "Account type")
@@ -185,9 +230,7 @@ class ManualUSBankAccountPaymentMethodActivity : StripeIntentActivity() {
                 ) {
                     Switch(
                         checked = isSaveForFutureUsage.value,
-                        onCheckedChange = {
-                            isSaveForFutureUsage.value = it
-                        }
+                        onCheckedChange = { isSaveForFutureUsage.value = it }
                     )
                     Text(
                         text = "Save for future usage",
@@ -197,7 +240,7 @@ class ManualUSBankAccountPaymentMethodActivity : StripeIntentActivity() {
                 Button(
                     modifier = Modifier.fillMaxWidth(),
                     onClick = {
-                        val params = PaymentMethodCreateParams.create(
+                        val paymentMethodCreateParams = PaymentMethodCreateParams.create(
                             PaymentMethodCreateParams.USBankAccount(
                                 accountNumber = accountNumber.value,
                                 routingNumber = routingNumber.value,
@@ -218,14 +261,22 @@ class ManualUSBankAccountPaymentMethodActivity : StripeIntentActivity() {
                             )
                         )
                         if (isSaveForFutureUsage.value) {
-                            createAndConfirmSetupIntent("us", params)
+                            createAndConfirmSetupIntent(
+                                "us",
+                                paymentMethodCreateParams
+                            ) { secret ->
+                                setupIntentSecret = secret
+                            }
                         } else {
-                            createAndConfirmPaymentIntent("us", params)
+                            createAndConfirmPaymentIntent(
+                                "us",
+                                paymentMethodCreateParams
+                            ) { secret ->
+                                paymentIntentSecret = secret
+                            }
                         }
                     }
-                ) {
-                    Text(text = "Pay with US Bank Account")
-                }
+                ) { Text(text = "Pay with US Bank Account") }
                 Text(
                     text =
                     "By clicking Pay with US Bank Account, you authorize Non-Card Payment" +
@@ -249,9 +300,218 @@ class ManualUSBankAccountPaymentMethodActivity : StripeIntentActivity() {
         }
     }
 
-    override fun onConfirmSuccess() {
-        super.onConfirmSuccess()
-        viewModel.status.value += "Payment successfully initiated. Will fulfill " +
-            "after microdeposit verification"
+    @Composable
+    private fun VerificationNeededScreen() {
+        val status by viewModel.status.observeAsState("")
+        val scrollState = rememberScrollState()
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(10.dp)
+                .verticalScroll(scrollState)
+        ) {
+            Text(
+                text = "${if (paymentIntentSecret != null) "Payment" else "Setup"}Intent " +
+                    "awaiting verification.\n\nStripe will send a descriptor code microdeposit " +
+                    "and may fall back to an amount microdeposit. These deposits take 1-2 " +
+                    "business days to appear on the customer's online statement.\n\nIf you " +
+                    "supplied a billing email, Stripe notifies your customer via this email when " +
+                    "the deposits are expected to arrive.\n\nOnce the customer is ready to " +
+                    "verify their account, you can manually collect the descriptor code or " +
+                    "amounts to verify their account with this SDK."
+            )
+            Button(
+                modifier = Modifier.fillMaxWidth(),
+                content = { Text(text = "Continue to verification") },
+                onClick = { next() }
+            )
+            Text(
+                text = status,
+                modifier = Modifier.fillMaxWidth().padding(8.dp)
+            )
+        }
+    }
+
+    @Composable
+    private fun VerifyWithMicrodepositScreen() {
+        val inProgress by viewModel.inProgress.observeAsState(false)
+        val status by viewModel.status.observeAsState("")
+        val scrollState = rememberScrollState()
+        val descriptorCode = remember { mutableStateOf("") }
+        val firstAmount = remember { mutableStateOf("") }
+        val secondAmount = remember { mutableStateOf("") }
+
+        if (inProgress) {
+            LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+        }
+        if (status.isNotEmpty()) {
+            Text(text = status)
+        } else {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(10.dp)
+                    .verticalScroll(scrollState)
+            ) {
+                Text(text = "Enter verification details from your bank account.")
+                OutlinedTextField(
+                    modifier = Modifier.fillMaxWidth(),
+                    label = { Text("Descriptor code") },
+                    value = descriptorCode.value,
+                    onValueChange = { descriptorCode.value = it }
+                )
+                Text(
+                    text = "--- OR ---",
+                    modifier = Modifier.fillMaxWidth().padding(8.dp),
+                    textAlign = TextAlign.Center
+                )
+                OutlinedTextField(
+                    modifier = Modifier.fillMaxWidth(),
+                    label = { Text("First amount") },
+                    value = firstAmount.value,
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Number
+                    ),
+                    onValueChange = { firstAmount.value = it }
+                )
+                OutlinedTextField(
+                    modifier = Modifier.fillMaxWidth(),
+                    label = { Text("Second amount") },
+                    value = secondAmount.value,
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Number
+                    ),
+                    onValueChange = { secondAmount.value = it }
+                )
+                Button(
+                    modifier = Modifier.fillMaxWidth(),
+                    content = { Text(text = "Verify") },
+                    onClick = {
+                        verifyWithMicrodeposits(
+                            descriptorCode = descriptorCode.value,
+                            firstAmount = firstAmount.value.toInt(),
+                            secondAmount = secondAmount.value.toInt()
+                        )
+                    }
+                )
+                Text(
+                    text = status,
+                    modifier = Modifier.fillMaxWidth().padding(8.dp)
+                )
+            }
+        }
+    }
+
+    private fun verifyWithMicrodeposits(
+        descriptorCode: String,
+        firstAmount: Int,
+        secondAmount: Int
+    ) {
+        if (paymentIntentSecret != null) {
+            verifyPaymentIntent(paymentIntentSecret!!, descriptorCode, firstAmount, secondAmount)
+        } else {
+            verifySetupIntent(setupIntentSecret!!, descriptorCode, firstAmount, secondAmount)
+        }
+    }
+
+    private fun verifyPaymentIntent(
+        clientSecret: String,
+        descriptorCode: String,
+        firstAmount: Int,
+        secondAmount: Int
+    ) {
+        viewModel.inProgress.value = true
+        viewModel.status.value += "Retreiving PaymentIntent...\n"
+        stripe.retrievePaymentIntent(
+            clientSecret,
+            callback = object : ApiResultCallback<PaymentIntent> {
+                override fun onSuccess(result: PaymentIntent) {
+                    if (descriptorCode.isNotEmpty()) {
+                        viewModel.status.value += "Verifying PaymentIntent with descriptorCode...\n"
+                        stripe.verifyPaymentIntentWithMicrodeposits(
+                            clientSecret = clientSecret,
+                            descriptorCode = descriptorCode,
+                            callback = verifyCallback
+                        )
+                    } else {
+                        viewModel.status.value += "Verifying PaymentIntent with amounts...\n"
+                        stripe.verifyPaymentIntentWithMicrodeposits(
+                            clientSecret = clientSecret,
+                            firstAmount = firstAmount,
+                            secondAmount = secondAmount,
+                            callback = verifyCallback
+                        )
+                    }
+                }
+                override fun onError(e: Exception) {
+                    error("Could not retrieve PaymentIntent, $e\n")
+                }
+            }
+        )
+    }
+
+    private fun verifySetupIntent(
+        clientSecret: String,
+        descriptorCode: String,
+        firstAmount: Int,
+        secondAmount: Int
+    ) {
+        viewModel.inProgress.value = true
+        viewModel.status.value += "Retreiving SetupIntent...\n"
+        stripe.retrieveSetupIntent(
+            clientSecret,
+            callback = object : ApiResultCallback<SetupIntent> {
+                override fun onSuccess(result: SetupIntent) {
+                    if (descriptorCode.isNotEmpty()) {
+                        viewModel.status.value += "Verifying SetupIntent with descriptorCode...\n"
+                        stripe.verifySetupIntentWithMicrodeposits(
+                            clientSecret = clientSecret,
+                            descriptorCode = descriptorCode,
+                            callback = verifyCallback
+                        )
+                    } else {
+                        viewModel.status.value += "Verifying SetupIntent with amounts...\n"
+                        stripe.verifySetupIntentWithMicrodeposits(
+                            clientSecret = clientSecret,
+                            firstAmount = firstAmount,
+                            secondAmount = secondAmount,
+                            callback = verifyCallback
+                        )
+                    }
+                }
+                override fun onError(e: Exception) {
+                    error("Could not retrieve SetupIntent, $e\n")
+                }
+            }
+        )
+    }
+
+    private fun next() {
+        val current = screenState.value
+        screenState.tryEmit(
+            when (current) {
+                is ScreenState.CustomerCollectionScreen ->
+                    ScreenState.VerificationNeededScreen
+                is ScreenState.VerificationNeededScreen ->
+                    ScreenState.VerifyWithMicrodepositsScreen
+                ScreenState.VerifyWithMicrodepositsScreen ->
+                    ScreenState.VerifyWithMicrodepositsScreen
+                is ScreenState.Error -> ScreenState.Error(current.message)
+            }
+        )
+    }
+
+    private fun error(message: String) {
+        screenState.tryEmit(
+            ScreenState.Error(message)
+        )
+    }
+
+    private sealed class ScreenState {
+        object CustomerCollectionScreen : ScreenState()
+        object VerificationNeededScreen : ScreenState()
+        object VerifyWithMicrodepositsScreen : ScreenState()
+        data class Error(val message: String) : ScreenState()
     }
 }


### PR DESCRIPTION
# Summary

Add verify with microdeposits to the example us_bank_account bindings activity.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

To showcase how you can manually collect, verify, and process a payment with us_bank_account

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

https://user-images.githubusercontent.com/99316447/161322978-021d92ef-5fc0-4047-b588-2e357b926c88.mov

