### PR TITLE
[Identity] Reserve 3 lines for scanning message view

### DIFF
--- a/identity/res/layout/identity_camera_scan_fragment.xml
+++ b/identity/res/layout/identity_camera_scan_fragment.xml
@@ -30,6 +30,7 @@
         <TextView
             android:id="@+id/message"
             android:layout_width="0dp"
+            android:lines="3"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/page_vertical_margin"
             app:layout_constraintBottom_toTopOf="@id/camera_view_card"

--- a/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
@@ -300,7 +300,7 @@ internal class DocSelectionFragmentTest {
 
             assertThat(
                 requireNotNull(navController.backStack.last().arguments)
-                [ARG_SCAN_TYPE]
+                    [ARG_SCAN_TYPE]
             ).isEqualTo(IdDocumentParam.Type.DRIVINGLICENSE)
 
             assertThat(navController.currentDestination?.id)

--- a/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
@@ -300,7 +300,7 @@ internal class DocSelectionFragmentTest {
 
             assertThat(
                 requireNotNull(navController.backStack.last().arguments)
-                    [ARG_SCAN_TYPE]
+                [ARG_SCAN_TYPE]
             ).isEqualTo(IdDocumentParam.Type.DRIVINGLICENSE)
 
             assertThat(navController.currentDestination?.id)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This prevent the viewfinder being pushed down on lower DPI settings

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
UI tweak

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![lineBefore](https://user-images.githubusercontent.com/79880926/161333695-d5416aa1-3a13-4801-b164-79705398fd43.png)  | ![lineAfter](https://user-images.githubusercontent.com/79880926/161333518-1a04c728-c1a0-43a3-a4d1-a7d5bbd9a64a.png) |




# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
