### PR TITLE
Various component divider fixes

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressElementUI.kt
@@ -17,7 +17,12 @@ internal fun AddressElementUI(
     lastTextFieldIdentifier: IdentifierSpec?
 ) {
     val fields by controller.fieldsFlowable.collectAsState(null)
-    fields?.let { fieldList ->
+
+    // The last rendered field is not always the last field in the list.
+    // So we need to pre filter so we know when to stop drawing dividers.
+    fields?.filter {
+        (hiddenIdentifiers?.contains(it.identifier) == false)
+    }?.let { fieldList ->
         Column {
             fieldList.forEachIndexed { index, field ->
                 SectionFieldElementUI(
@@ -26,11 +31,9 @@ internal fun AddressElementUI(
                     hiddenIdentifiers = hiddenIdentifiers,
                     lastTextFieldIdentifier = lastTextFieldIdentifier
                 )
-                if ((hiddenIdentifiers?.contains(field.identifier) == false) &&
-                    (index != fieldList.size - 1)
-                ) {
+                if (index != fieldList.lastIndex) {
                     Divider(
-                        color = PaymentsTheme.colors.colorComponentBorder,
+                        color = PaymentsTheme.colors.colorComponentDivider,
                         thickness = PaymentsTheme.shapes.borderStrokeWidth,
                         modifier = Modifier.padding(
                             horizontal = PaymentsTheme.shapes.borderStrokeWidth

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElementUI.kt
@@ -20,12 +20,14 @@ internal fun CardDetailsElementUI(
             hiddenIdentifiers = hiddenIdentifiers,
             lastTextFieldIdentifier = lastTextFieldIdentifier
         )
-        Divider(
-            color = PaymentsTheme.colors.colorComponentBorder,
-            thickness = PaymentsTheme.shapes.borderStrokeWidth,
-            modifier = Modifier.padding(
-                horizontal = PaymentsTheme.shapes.borderStrokeWidth
+        if (index != controller.fields.lastIndex) {
+            Divider(
+                color = PaymentsTheme.colors.colorComponentDivider,
+                thickness = PaymentsTheme.shapes.borderStrokeWidth,
+                modifier = Modifier.padding(
+                    horizontal = PaymentsTheme.shapes.borderStrokeWidth
+                )
             )
-        )
+        }
     }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/RowElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/RowElementUI.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.ui.core.elements
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -55,7 +54,7 @@ internal fun RowElementUI(
                         )
                 )
 
-                if (!hiddenIdentifiers.contains(field.identifier) && index != (fields.size - 1)) {
+                if (!hiddenIdentifiers.contains(field.identifier) && index != fields.lastIndex) {
                     Divider(
                         modifier = Modifier
                             .constrainAs(dividerRefs[index]) {
@@ -67,8 +66,8 @@ internal fun RowElementUI(
                             .padding(
                                 horizontal = PaymentsTheme.shapes.borderStrokeWidth
                             )
-                            .width(PaymentsTheme.shapes.borderStrokeWidth)
-                            .background(PaymentsTheme.colors.colorComponentBorder)
+                            .width(PaymentsTheme.shapes.borderStrokeWidth),
+                        color = PaymentsTheme.colors.colorComponentDivider
                     )
                 }
             }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionElementUI.kt
@@ -39,9 +39,9 @@ fun SectionElementUI(
                     hiddenIdentifiers = hiddenIdentifiers,
                     lastTextFieldIdentifier = lastTextFieldIdentifier
                 )
-                if (index != element.fields.size - 1) {
+                if (index != element.fields.lastIndex) {
                     Divider(
-                        color = PaymentsTheme.colors.colorComponentBorder,
+                        color = PaymentsTheme.colors.colorComponentDivider,
                         thickness = PaymentsTheme.shapes.borderStrokeWidth,
                         modifier = Modifier.padding(
                             horizontal = PaymentsTheme.shapes.borderStrokeWidth


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* We were accidentally drawing dividers on to the bottom of components. This made them look extra thick. See screenshots
* We were not coloring dividers the right color. Now they follow the correct theme color.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
* general polish
* Styling api.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
## Note the border at the bottom of expiry date/CVC and under zip code.
| Before  | After |
| ------------- | ------------- |
| ![thickBordersMaster](https://user-images.githubusercontent.com/89166418/161350577-7ae5f2c9-f1d9-427f-a7c2-728002372c2c.png)|![thickBordersBranch](https://user-images.githubusercontent.com/89166418/161350575-0bb9381f-adb7-4d5a-ab3e-004be5f42d46.png)|

## Note: using green to demonstrate. 
| Before  | After |
| ------------- | ------------- |
|![sepaMaster](https://user-images.githubusercontent.com/89166418/161350741-cc8c4473-d8de-45e9-8c8d-fb6bdad7b928.png)|![sepaBranch](https://user-images.githubusercontent.com/89166418/161350737-32645a4e-4150-4a96-823b-fa711a7901bb.png)|

