### PR TITLE
[Identity] navigate to camera permission when requireLiveCapture is true

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/navigation/CameraPermissionDeniedFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/CameraPermissionDeniedFragment.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.identity.navigation
 
+import android.view.View
 import androidx.annotation.IdRes
 import androidx.navigation.fragment.findNavController
 import com.stripe.android.camera.AppSettingsOpenable
@@ -14,22 +15,24 @@ internal class CameraPermissionDeniedFragment(
     private val appSettingsOpenable: AppSettingsOpenable
 ) : BaseErrorFragment() {
     override fun onCustomizingViews() {
-        val args = requireNotNull(arguments)
-
-        val identityScanType = args[ARG_SCAN_TYPE] as CollectedDataParam.Type
 
         title.text = getString(R.string.camera_permission)
         message1.text = getString(R.string.grant_camera_permission_text)
-        message2.text =
-            getString(R.string.upload_file_text, identityScanType.getDisplayName())
 
-        topButton.text = getString(R.string.file_upload)
-        topButton.setOnClickListener {
-            navigateToUploadFragment(
-                identityScanType.toUploadDestinationId(),
-                shouldShowTakePhoto = false,
-                shouldShowChoosePhoto = true
-            )
+        (arguments?.get(ARG_SCAN_TYPE) as? CollectedDataParam.Type)?.let { identityScanType ->
+            message2.text =
+                getString(R.string.upload_file_text, identityScanType.getDisplayName())
+            topButton.text = getString(R.string.file_upload)
+            topButton.setOnClickListener {
+                navigateToUploadFragment(
+                    identityScanType.toUploadDestinationId(),
+                    shouldShowTakePhoto = false,
+                    shouldShowChoosePhoto = true
+                )
+            }
+        } ?: run {
+            message2.visibility = View.GONE
+            topButton.visibility = View.GONE
         }
 
         bottomButton.text = getString(R.string.app_settings)

--- a/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
@@ -246,19 +246,18 @@ internal class DocSelectionFragment(
         identityViewModel.observeForVerificationPage(
             viewLifecycleOwner,
             onSuccess = { verificationPage ->
-                if (verificationPage.documentCapture.requireLiveCapture) {
-                    Log.e(TAG, "Can't access camera and client has required live capture.")
-                    navigateToDefaultErrorFragment()
-                } else {
-                    findNavController().navigate(
-                        R.id.action_camera_permission_denied,
+                findNavController().navigate(
+                    R.id.action_camera_permission_denied,
+                    if (verificationPage.documentCapture.requireLiveCapture)
+                        null
+                    else
                         bundleOf(
                             CameraPermissionDeniedFragment.ARG_SCAN_TYPE to type
                         )
-                    )
-                }
+                )
             },
             onFailure = {
+                Log.e(TAG, "failed to observeForVerificationPage: $it")
                 navigateToDefaultErrorFragment()
             }
         )

--- a/identity/src/test/java/com/stripe/android/identity/navigation/CameraPermissionDeniedFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/CameraPermissionDeniedFragmentTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.identity.navigation
 
+import android.view.View
 import androidx.annotation.IdRes
 import androidx.annotation.StringRes
 import androidx.core.os.bundleOf
@@ -49,6 +50,15 @@ class CameraPermissionDeniedFragmentTest {
             R.id.passportUploadFragment,
             R.string.passport
         )
+    }
+
+    @Test
+    fun `when scan type is not set message2 is hidden and top button is hidden`() {
+        launchCameraPermissionDeniedFragment().onFragment {
+            val binding = BaseErrorFragmentBinding.bind(it.requireView())
+            assertThat(binding.message2.visibility).isEqualTo(View.GONE)
+            assertThat(binding.topButton.visibility).isEqualTo(View.GONE)
+        }
     }
 
     @Test
@@ -113,11 +123,13 @@ class CameraPermissionDeniedFragmentTest {
     }
 
     private fun launchCameraPermissionDeniedFragment(
-        type: CollectedDataParam.Type
+        type: CollectedDataParam.Type? = null
     ) = launchFragmentInContainer(
-        bundleOf(
-            ARG_SCAN_TYPE to type
-        ),
+        type?.let {
+            bundleOf(
+                ARG_SCAN_TYPE to type
+            )
+        },
         themeResId = R.style.Theme_MaterialComponents
     ) {
         CameraPermissionDeniedFragment(mockAppSettingsOpenable)

--- a/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
@@ -309,7 +309,7 @@ internal class DocSelectionFragmentTest {
     }
 
     @Test
-    fun `when camera permission is denied, clicking continue navigates to ErrorFragment when requireLiveCapture is true`() {
+    fun `when camera permission is denied, clicking continue navigates to CameraPermissionDeniedFragment when requireLiveCapture is true`() {
         launchDocSelectionFragment { binding, navController, _ ->
             whenever(verificationPage.documentSelect).thenReturn(
                 DOC_SELECT_SINGLE_CHOICE_DL
@@ -344,7 +344,9 @@ internal class DocSelectionFragmentTest {
             setUpSuccessVerificationPage(2)
 
             assertThat(navController.currentDestination?.id)
-                .isEqualTo(R.id.errorFragment)
+                .isEqualTo(R.id.cameraPermissionDeniedFragment)
+
+            assertThat(requireNotNull(navController.backStack.last().arguments).isEmpty).isTrue()
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
When "requireLiveCapture" is true and camera permission was denied, instead of navigating to errorFragment, navigates to CameraPermissionFragment with file upload options turned off, only allowing going to app settings to grant camera permission.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Smoother flow

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
