### PR TITLE
Apply deploy Gradle plugin to connections.

### DIFF
--- a/connections/build.gradle
+++ b/connections/build.gradle
@@ -60,10 +60,10 @@ android {
 }
 
 
-//ext {
-//    artifactId = "connections"
-//    artifactName = "connections"
-//    artifactDescrption = "The connections module of Stripe Payment Android SDK"
-//}
-//
-//apply from: "${rootDir}/deploy/deploy.gradle"
+ext {
+    artifactId = "connections"
+    artifactName = "connections"
+    artifactDescrption = "The connections module of Stripe Payment Android SDK"
+}
+
+apply from: "${rootDir}/deploy/deploy.gradle"


### PR DESCRIPTION
# Summary
- Apply `deploy.gradle` plugin to connections. 
- This will make `com.stripe.connections` available on maven when running an android SDK release.