### PR TITLE
[BANKCON-3866] make LinkedAccountSession#paymentAccount and BankAccount stripe-internal

### DIFF
--- a/connections/api/connections.api
+++ b/connections/api/connections.api
@@ -403,30 +403,6 @@ public final class com/stripe/android/connections/model/BalanceRefresh$Companion
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/stripe/android/connections/model/BankAccount : com/stripe/android/connections/model/PaymentAccount {
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public static final field Companion Lcom/stripe/android/connections/model/BankAccount$Companion;
-	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/connections/model/BankAccount;
-	public static synthetic fun copy$default (Lcom/stripe/android/connections/model/BankAccount;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/connections/model/BankAccount;
-	public fun describeContents ()I
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBankName ()Ljava/lang/String;
-	public final fun getId ()Ljava/lang/String;
-	public final fun getLast4 ()Ljava/lang/String;
-	public final fun getRoutingNumber ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lcom/stripe/android/connections/model/BankAccount;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
-	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
 public final class com/stripe/android/connections/model/BankAccount$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lcom/stripe/android/connections/model/BankAccount$$serializer;
 	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
@@ -531,7 +507,6 @@ public final class com/stripe/android/connections/model/LinkAccountSession : and
 	public final fun getId ()Ljava/lang/String;
 	public final fun getLinkedAccounts ()Lcom/stripe/android/connections/model/LinkedAccountList;
 	public final fun getLivemode ()Z
-	public final fun getPaymentAccount ()Lcom/stripe/android/connections/model/PaymentAccount;
 	public final fun getReturnUrl ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/connections/src/main/java/com/stripe/android/connections/model/BankAccount.kt
+++ b/connections/src/main/java/com/stripe/android/connections/model/BankAccount.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.connections.model
 
+import androidx.annotation.RestrictTo
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Required
 import kotlinx.serialization.SerialName
@@ -7,7 +8,8 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 @Parcelize
-internal data class BankAccount(
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class BankAccount(
 
     @SerialName(value = "id") @Required val id: String,
 

--- a/connections/src/main/java/com/stripe/android/connections/model/BankAccount.kt
+++ b/connections/src/main/java/com/stripe/android/connections/model/BankAccount.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 @Parcelize
-data class BankAccount(
+internal data class BankAccount(
 
     @SerialName(value = "id") @Required val id: String,
 

--- a/connections/src/main/java/com/stripe/android/connections/model/LinkAccountSession.kt
+++ b/connections/src/main/java/com/stripe/android/connections/model/LinkAccountSession.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.connections.model
 
 import android.os.Parcelable
+import androidx.annotation.RestrictTo
 import com.stripe.android.connections.model.serializer.PaymentAccountSerializer
 import com.stripe.android.core.model.StripeModel
 import kotlinx.parcelize.Parcelize
@@ -33,7 +34,8 @@ data class LinkAccountSession internal constructor(
     val livemode: Boolean,
 
     @SerialName("payment_account")
-    internal val paymentAccount: PaymentAccount? = null,
+    @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    val paymentAccount: PaymentAccount? = null,
 
     @SerialName("return_url")
     val returnUrl: String? = null

--- a/connections/src/main/java/com/stripe/android/connections/model/LinkAccountSession.kt
+++ b/connections/src/main/java/com/stripe/android/connections/model/LinkAccountSession.kt
@@ -33,7 +33,7 @@ data class LinkAccountSession internal constructor(
     val livemode: Boolean,
 
     @SerialName("payment_account")
-    val paymentAccount: PaymentAccount? = null,
+    internal val paymentAccount: PaymentAccount? = null,
 
     @SerialName("return_url")
     val returnUrl: String? = null


### PR DESCRIPTION
# Summary
- PaymentAccount enum type and field in LinkedAccountSession: available for ACH, not available publicly on the Connections SDK
- BankAccount subtype: available for ACH, not available publicly on the Connections SDK
- LinkedAccount subtype: already available for everyone