### PR TITLE
[FIXED] Multi-step now shows the last 4 of the card number instead of 'card'.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # CHANGELOG
+
+## x.x.x - xxxx-xx-xx
+
+### PaymentSheet
+* [FIXED] [4840](https://github.com/stripe/stripe-android/pull/4840) Multi-step now shows the last 4 of the card number instead of 'card'.
+
 ## 20.0.0 - 2022-04-04
 This release patches on a crash on PaymentLauncher, updates the package name of some public classes,
 changes the public API for CardImageVerificationSheet and releases Identity SDK.

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -83,6 +83,22 @@ public final class com/stripe/android/ui/core/elements/H4TextKt {
 public final class com/stripe/android/ui/core/elements/H6TextKt {
 }
 
+public final class com/stripe/android/ui/core/elements/IdentifierSpec$CardBrand : com/stripe/android/ui/core/elements/IdentifierSpec {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/IdentifierSpec$CardBrand;
+	public fun describeContents ()I
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/ui/core/elements/IdentifierSpec$CardNumber : com/stripe/android/ui/core/elements/IdentifierSpec {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/IdentifierSpec$CardNumber;
+	public fun describeContents ()I
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
 public final class com/stripe/android/ui/core/elements/IdentifierSpec$City : com/stripe/android/ui/core/elements/IdentifierSpec {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
@@ -8,7 +8,7 @@ internal class CardDetailsController constructor(context: Context) : SectionFiel
 
     val label: Int? = null
     val numberElement = CardNumberElement(
-        IdentifierSpec.Generic("number"),
+        IdentifierSpec.CardNumber,
         CardNumberController(CardNumberConfig(), context)
     )
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.ui.core.elements
 
 import android.content.Context
+import com.stripe.android.ui.core.forms.FormFieldEntry
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
@@ -33,8 +34,9 @@ internal class CardDetailsElement(
     override fun getFormFieldValueFlow() = combine(
         controller.numberElement.controller.formFieldValue,
         controller.cvcElement.controller.formFieldValue,
-        controller.expirationDateElement.controller.formFieldValue
-    ) { number, cvc, expirationDate ->
+        controller.expirationDateElement.controller.formFieldValue,
+        controller.numberElement.controller.cardBrandFlow,
+    ) { number, cvc, expirationDate, brand ->
         var month = -1
         var year = -1
         expirationDate.value?.let { date ->
@@ -48,6 +50,7 @@ internal class CardDetailsElement(
         listOf(
             controller.numberElement.identifier to number,
             controller.cvcElement.identifier to cvc,
+            IdentifierSpec.CardBrand to FormFieldEntry(brand.code, true),
             IdentifierSpec.Generic("exp_month") to expirationDate.copy(
                 value = month.toString()
             ),

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IdentifierSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IdentifierSpec.kt
@@ -18,6 +18,12 @@ sealed class IdentifierSpec(val value: String) : Parcelable {
     object Name : IdentifierSpec("name")
 
     @Parcelize
+    object CardBrand : IdentifierSpec("card_brand_code")
+
+    @Parcelize
+    object CardNumber : IdentifierSpec("number")
+
+    @Parcelize
     object Email : IdentifierSpec("email")
 
     @Parcelize

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.asFlow
 import androidx.lifecycle.lifecycleScope
 import com.stripe.android.core.injection.InjectorKey
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.databinding.FragmentPaymentsheetAddPaymentMethodBinding
 import com.stripe.android.paymentsheet.forms.FormFieldValues
@@ -34,6 +35,7 @@ import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.PaymentsThemeConfig
 import com.stripe.android.ui.core.elements.H4Text
+import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.ui.core.isSystemDarkTheme
 import com.stripe.android.ui.core.shouldUseDarkDynamicColor
 import kotlinx.coroutines.launch
@@ -237,12 +239,23 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
         ) = formFieldValues?.let {
             transformToPaymentMethodCreateParams.transform(formFieldValues, paramKey)
                 ?.run {
-                    PaymentSelection.New.GenericPaymentMethod(
-                        selectedPaymentMethodResources.displayNameResource,
-                        selectedPaymentMethodResources.iconResource,
-                        this,
-                        customerRequestedSave = formFieldValues.userRequestedReuse
-                    )
+                    if (this.typeCode == "card") {
+                        PaymentSelection.New.Card(
+                            paymentMethodCreateParams = this,
+                            brand = CardBrand.fromCode(
+                                formFieldValues.fieldValuePairs[IdentifierSpec.CardBrand]?.value
+                            ),
+                            customerRequestedSave = formFieldValues.userRequestedReuse
+
+                        )
+                    } else {
+                        PaymentSelection.New.GenericPaymentMethod(
+                            selectedPaymentMethodResources.displayNameResource,
+                            selectedPaymentMethodResources.iconResource,
+                            this,
+                            customerRequestedSave = formFieldValues.userRequestedReuse
+                        )
+                    }
                 }
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
@@ -217,7 +217,7 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
             )
             replace(
                 R.id.payment_method_fragment_container,
-                fragmentForPaymentMethod(paymentMethod),
+                ComposeFormDataCollectionFragment::class.java,
                 args
             )
         }
@@ -227,10 +227,6 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
         childFragmentManager.findFragmentById(R.id.payment_method_fragment_container)
 
     companion object {
-
-        private fun fragmentForPaymentMethod(paymentMethod: SupportedPaymentMethod) =
-            ComposeFormDataCollectionFragment::class.java
-
         private val transformToPaymentMethodCreateParams = TransformToPaymentMethodCreateParams()
 
         @VisibleForTesting

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormUI.kt
@@ -67,7 +67,7 @@ internal fun FormInternal(
 
     ) {
         elements?.let {
-            it.forEachIndexed { index, element ->
+            it.forEachIndexed { _, element ->
                 if (!hiddenIdentifiers.contains(element.identifier)) {
                     when (element) {
                         is SectionElement -> SectionElementUI(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
@@ -30,7 +30,7 @@ internal class PaymentOptionFactory(
                     drawableResourceId = selection.brand.getCardBrandIcon(),
                     label = createCardLabel(
                         resources,
-                        selection.paymentMethodCreateParams.card?.getLast4()
+                        selection.last4
                     )
                 )
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -32,7 +32,11 @@ internal sealed class PaymentSelection : Parcelable {
             override val paymentMethodCreateParams: PaymentMethodCreateParams,
             val brand: CardBrand,
             override val customerRequestedSave: CustomerRequestedSave
-        ) : New()
+        ) : New() {
+            val last4: String = ((paymentMethodCreateParams.toParamMap()["card"] as? Map<*, *>)!!
+                ["number"] as String)
+                .takeLast(4)
+        }
 
         @Parcelize
         data class GenericPaymentMethod(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -33,8 +33,10 @@ internal sealed class PaymentSelection : Parcelable {
             val brand: CardBrand,
             override val customerRequestedSave: CustomerRequestedSave
         ) : New() {
-            val last4: String = ((paymentMethodCreateParams.toParamMap()["card"] as? Map<*, *>)!!
-                ["number"] as String)
+            val last4: String = (
+                (paymentMethodCreateParams.toParamMap()["card"] as? Map<*, *>)!!
+                ["number"] as String
+                )
                 .takeLast(4)
         }
 


### PR DESCRIPTION
# Summary
[FIXED] Multi-step now shows the last 4 of the card number instead of 'card'.

# Motivation
This is a regression that happened when moving to jetpack compose.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
[FIXED] Multi-step now shows the last 4 of the card number instead of 'card'.
