### PR TITLE
Saves persistable fields on SavedStateHandle and restores them on process recreation

### DIFF
--- a/connections/api/connections.api
+++ b/connections/api/connections.api
@@ -74,11 +74,11 @@ public abstract interface class com/stripe/android/connections/ConnectionsSheetR
 }
 
 public final class com/stripe/android/connections/ConnectionsSheetViewModel_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/connections/ConnectionsSheetViewModel_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/connections/ConnectionsSheetViewModel_Factory;
 	public fun get ()Lcom/stripe/android/connections/ConnectionsSheetViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Ljava/lang/String;Lcom/stripe/android/connections/ConnectionsSheetContract$Args;Lcom/stripe/android/connections/domain/GenerateLinkAccountSessionManifest;Lcom/stripe/android/connections/domain/FetchLinkAccountSession;Lcom/stripe/android/connections/analytics/ConnectionsEventReporter;)Lcom/stripe/android/connections/ConnectionsSheetViewModel;
+	public static fun newInstance (Ljava/lang/String;Lcom/stripe/android/connections/ConnectionsSheetContract$Args;Lcom/stripe/android/connections/domain/GenerateLinkAccountSessionManifest;Lcom/stripe/android/connections/domain/FetchLinkAccountSession;Landroidx/lifecycle/SavedStateHandle;Lcom/stripe/android/connections/analytics/ConnectionsEventReporter;)Lcom/stripe/android/connections/ConnectionsSheetViewModel;
 }
 
 public final class com/stripe/android/connections/analytics/DefaultConnectionsEventReporter_Factory : dagger/internal/Factory {
@@ -552,40 +552,6 @@ public final class com/stripe/android/connections/model/LinkAccountSession$$seri
 }
 
 public final class com/stripe/android/connections/model/LinkAccountSession$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
-public final class com/stripe/android/connections/model/LinkAccountSessionManifest {
-	public static final field Companion Lcom/stripe/android/connections/model/LinkAccountSessionManifest$Companion;
-	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/connections/model/LinkAccountSessionManifest;
-	public static synthetic fun copy$default (Lcom/stripe/android/connections/model/LinkAccountSessionManifest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/connections/model/LinkAccountSessionManifest;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getCancelUrl ()Ljava/lang/String;
-	public final fun getHostedAuthUrl ()Ljava/lang/String;
-	public final fun getSuccessUrl ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-	public static final fun write$Self (Lcom/stripe/android/connections/model/LinkAccountSessionManifest;Lkotlinx/serialization/encoding/CompositeEncoder;Lkotlinx/serialization/descriptors/SerialDescriptor;)V
-}
-
-public final class com/stripe/android/connections/model/LinkAccountSessionManifest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field INSTANCE Lcom/stripe/android/connections/model/LinkAccountSessionManifest$$serializer;
-	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/connections/model/LinkAccountSessionManifest;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/connections/model/LinkAccountSessionManifest;)V
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
-}
-
-public final class com/stripe/android/connections/model/LinkAccountSessionManifest$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetState.kt
+++ b/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetState.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.connections
 
+import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.connections.model.LinkAccountSessionManifest
 
 /**
@@ -9,7 +10,29 @@ internal data class ConnectionsSheetState(
     val activityRecreated: Boolean = false,
     val manifest: LinkAccountSessionManifest? = null,
     val authFlowActive: Boolean = false
-)
+) {
+
+    /**
+     * Restores existing persisted fields into the current [ConnectionsSheetState]
+     */
+    internal fun from(savedStateHandle: SavedStateHandle): ConnectionsSheetState {
+        return copy(
+            manifest = savedStateHandle.get(KEY_MANIFEST)
+        )
+    }
+
+    /**
+     * Saves the persistable fields of this state that changed to the given [SavedStateHandle]
+     */
+    internal fun to(savedStateHandle: SavedStateHandle, previousValue: ConnectionsSheetState) {
+        if (previousValue.manifest != manifest) savedStateHandle.set(KEY_MANIFEST, manifest)
+    }
+
+    companion object {
+        private const val KEY_MANIFEST = "key_manifest"
+    }
+}
+
 
 /**
  *  Class containing all side effects intended to be run by the view.

--- a/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetState.kt
+++ b/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetState.kt
@@ -17,7 +17,8 @@ internal data class ConnectionsSheetState(
      */
     internal fun from(savedStateHandle: SavedStateHandle): ConnectionsSheetState {
         return copy(
-            manifest = savedStateHandle.get(KEY_MANIFEST)
+            manifest = savedStateHandle.get(KEY_MANIFEST) ?: manifest,
+            authFlowActive = savedStateHandle.get(KEY_AUTHFLOW_ACTIVE) ?: authFlowActive,
         )
     }
 
@@ -25,11 +26,15 @@ internal data class ConnectionsSheetState(
      * Saves the persistable fields of this state that changed to the given [SavedStateHandle]
      */
     internal fun to(savedStateHandle: SavedStateHandle, previousValue: ConnectionsSheetState) {
-        if (previousValue.manifest != manifest) savedStateHandle.set(KEY_MANIFEST, manifest)
+        if (previousValue.manifest != manifest)
+            savedStateHandle.set(KEY_MANIFEST, manifest)
+        if (previousValue.authFlowActive != authFlowActive)
+            savedStateHandle.set(KEY_AUTHFLOW_ACTIVE, authFlowActive)
     }
 
     companion object {
         private const val KEY_MANIFEST = "key_manifest"
+        private const val KEY_AUTHFLOW_ACTIVE = "key_authflow_active"
     }
 }
 

--- a/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetState.kt
+++ b/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetState.kt
@@ -33,7 +33,6 @@ internal data class ConnectionsSheetState(
     }
 }
 
-
 /**
  *  Class containing all side effects intended to be run by the view.
  *

--- a/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetViewModel.kt
+++ b/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetViewModel.kt
@@ -231,4 +231,3 @@ internal class ConnectionsSheetViewModel @Inject constructor(
         internal const val MAX_ACCOUNTS = 100
     }
 }
-

--- a/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetViewModel.kt
+++ b/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetViewModel.kt
@@ -183,7 +183,7 @@ internal class ConnectionsSheetViewModel @Inject constructor(
      * @param intent the new intent with the redirect URL in the intent data
      */
     internal fun handleOnNewIntent(intent: Intent?) {
-        _state.update { it.copy(authFlowActive = false) }
+        _state.updateAndPersist { it.copy(authFlowActive = false) }
         viewModelScope.launch {
             val manifest = _state.value.manifest
             when (intent?.data.toString()) {

--- a/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetViewModel.kt
+++ b/connections/src/main/java/com/stripe/android/connections/ConnectionsSheetViewModel.kt
@@ -31,17 +31,23 @@ internal class ConnectionsSheetViewModel @Inject constructor(
     private val starterArgs: ConnectionsSheetContract.Args,
     private val generateLinkAccountSessionManifest: GenerateLinkAccountSessionManifest,
     private val fetchLinkAccountSession: FetchLinkAccountSession,
+    private val savedStateHandle: SavedStateHandle,
     private val eventReporter: ConnectionsEventReporter
 ) : ViewModel() {
 
-    private val _state = MutableStateFlow(ConnectionsSheetState())
+    // on process recreation - restore saved fields from [SavedStateHandle].
+    private val _state = MutableStateFlow(ConnectionsSheetState().from(savedStateHandle))
     internal val state: StateFlow<ConnectionsSheetState> = _state
+
     private val _viewEffect = MutableSharedFlow<ConnectionsSheetViewEffect>()
     internal val viewEffect: SharedFlow<ConnectionsSheetViewEffect> = _viewEffect
 
     init {
         eventReporter.onPresented(starterArgs.configuration)
-        fetchManifest()
+        // avoid re-fetching manifest if already exists (this will happen on process recreations)
+        if (state.value.manifest == null) {
+            fetchManifest()
+        }
     }
 
     /**
@@ -71,12 +77,12 @@ internal class ConnectionsSheetViewModel @Inject constructor(
      */
     private suspend fun openAuthFlow(manifest: LinkAccountSessionManifest) {
         // stores manifest in state for future references.
-        _state.emit(
-            state.value.copy(
+        _state.updateAndPersist {
+            it.copy(
                 manifest = manifest,
                 authFlowActive = true
             )
-        )
+        }
         _viewEffect.emit(OpenAuthFlowWithUrl(manifest.hostedAuthUrl))
     }
 
@@ -97,7 +103,7 @@ internal class ConnectionsSheetViewModel @Inject constructor(
      * @see onActivityResult (we rely on this on config changes)
      */
     internal fun onActivityRecreated() {
-        _state.update { it.copy(activityRecreated = true) }
+        _state.updateAndPersist { it.copy(activityRecreated = true) }
     }
 
     /**
@@ -188,6 +194,17 @@ internal class ConnectionsSheetViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Updates state AND saves persistable fields into [SavedStateHandle]
+     */
+    private inline fun MutableStateFlow<ConnectionsSheetState>.updateAndPersist(
+        function: (ConnectionsSheetState) -> ConnectionsSheetState
+    ) {
+        val previousValue = value
+        update(function)
+        value.to(savedStateHandle, previousValue)
+    }
+
     class Factory(
         private val applicationSupplier: () -> Application,
         private val starterArgsSupplier: () -> ConnectionsSheetContract.Args,
@@ -204,6 +221,7 @@ internal class ConnectionsSheetViewModel @Inject constructor(
             return DaggerConnectionsSheetComponent
                 .builder()
                 .application(applicationSupplier())
+                .savedStateHandle(savedStateHandle)
                 .configuration(starterArgsSupplier())
                 .build().viewModel as T
         }
@@ -213,3 +231,4 @@ internal class ConnectionsSheetViewModel @Inject constructor(
         internal const val MAX_ACCOUNTS = 100
     }
 }
+

--- a/connections/src/main/java/com/stripe/android/connections/di/ConnectionsSheetComponent.kt
+++ b/connections/src/main/java/com/stripe/android/connections/di/ConnectionsSheetComponent.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.connections.di
 
 import android.app.Application
+import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.connections.ConnectionsSheetContract
 import com.stripe.android.connections.ConnectionsSheetViewModel
 import com.stripe.android.core.injection.CoroutineContextModule
@@ -26,6 +27,9 @@ internal interface ConnectionsSheetComponent {
     interface Builder {
         @BindsInstance
         fun application(application: Application): Builder
+
+        @BindsInstance
+        fun savedStateHandle(savedStateHandle: SavedStateHandle): Builder
 
         @BindsInstance
         fun configuration(configuration: ConnectionsSheetContract.Args): Builder

--- a/connections/src/main/java/com/stripe/android/connections/model/LinkAccountSessionManifest.kt
+++ b/connections/src/main/java/com/stripe/android/connections/model/LinkAccountSessionManifest.kt
@@ -1,11 +1,14 @@
 package com.stripe.android.connections.model
 
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class LinkAccountSessionManifest(
+@Parcelize
+internal data class LinkAccountSessionManifest(
     @SerialName("hosted_auth_url") val hostedAuthUrl: String,
     @SerialName("success_url") val successUrl: String,
     @SerialName("cancel_url") val cancelUrl: String
-)
+) : Parcelable

--- a/connections/src/test/java/com/stripe/android/connections/ConnectionsSheetActivityTest.kt
+++ b/connections/src/test/java/com/stripe/android/connections/ConnectionsSheetActivityTest.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.browser.customtabs.CustomTabsIntent.SHARE_STATE_OFF
+import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.connections.utils.InjectableActivityScenario
@@ -43,6 +44,7 @@ class ConnectionsSheetActivityTest {
         ConnectionsSheetViewModel(
             applicationId = "com.example.test",
             starterArgs = args,
+            savedStateHandle = SavedStateHandle(),
             generateLinkAccountSessionManifest = mock(),
             fetchLinkAccountSession = mock(),
             eventReporter = mock()

--- a/connections/src/test/java/com/stripe/android/connections/ConnectionsSheetViewModelTest.kt
+++ b/connections/src/test/java/com/stripe/android/connections/ConnectionsSheetViewModelTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.connections
 
 import android.content.Intent
 import android.net.Uri
+import androidx.lifecycle.SavedStateHandle
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
@@ -23,6 +24,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
 @ExperimentalCoroutinesApi
@@ -47,6 +49,29 @@ class ConnectionsSheetViewModelTest {
         createViewModel(configuration)
         verify(eventReporter)
             .onPresented(configuration)
+    }
+
+    @Test
+    fun `init - if manifest not restored from SavedStateHandle, fetchManifest triggered`() =
+        runTest {
+            createViewModel(
+                configuration = configuration,
+                savedStateHandle = SavedStateHandle()
+            )
+
+            verify(generateLinkAccountSessionManifest).invoke(any(), any())
+        }
+
+    @Test
+    fun `init - if manifest restored from SavedStateHandle, fetchManifest not triggered`() {
+        runTest {
+            createViewModel(
+                configuration = configuration,
+                savedStateHandle = SavedStateHandle().also { it.set("key_manifest", manifest) }
+            )
+
+            verifyNoInteractions(generateLinkAccountSessionManifest)
+        }
     }
 
     @Test
@@ -257,12 +282,14 @@ class ConnectionsSheetViewModelTest {
     )
 
     private fun createViewModel(
-        configuration: ConnectionsSheet.Configuration
+        configuration: ConnectionsSheet.Configuration,
+        savedStateHandle: SavedStateHandle = SavedStateHandle()
     ): ConnectionsSheetViewModel {
         val args = ConnectionsSheetContract.Args(configuration)
         return ConnectionsSheetViewModel(
             applicationId = "com.example.app",
             starterArgs = args,
+            savedStateHandle = savedStateHandle,
             generateLinkAccountSessionManifest = generateLinkAccountSessionManifest,
             fetchLinkAccountSession = fetchLinkAccountSession,
             eventReporter = eventReporter


### PR DESCRIPTION
# Summary
- Issue: If the process of the app is killed while the user is on the `CustomTabsActivity` that host the auth flow, the viewModel dies. Then it gets restored and receives the `CustomTabsActivity` result via `onNewIntent`. At that point, the `manifest` we compare results against, stored in the state, is null, making the flow fail.
- Solution: persist relevant state properties onto `savedStateHandle`, and restore them on process recreation. Also avoids re-fetching manifest on process kills.

# Motivation

https://jira.corp.stripe.com/browse/BANKCON-3609

# Testing
- [X] Added tests
- [X] Modified tests
- [X] Manually verified: Set `don't keep activities on` and go through the connections flow to test this.

# Changelog
- [Fixed] AuthFlow on process recreation.

