### PR TITLE
[Identity] Use stateFlow to track upload status

### DIFF
--- a/identity/build.gradle
+++ b/identity/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 
     implementation "androidx.core:core-ktx:$androidxCoreVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:$androidxLifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$androidxLifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$androidxLifecycleVersion"
     implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"

--- a/identity/src/main/java/com/stripe/android/identity/navigation/DriverLicenseScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/DriverLicenseScanFragment.kt
@@ -35,7 +35,7 @@ internal class DriverLicenseScanFragment(
                     startScanning(DL_BACK)
                 }
                 DL_BACK -> {
-                    observeAndUploadForBothSides(CollectedDataParam.Type.DRIVINGLICENSE)
+                    collectUploadedStateAndUploadForBothSides(CollectedDataParam.Type.DRIVINGLICENSE)
                 }
                 else -> {
                     Log.e(

--- a/identity/src/main/java/com/stripe/android/identity/navigation/DriverLicenseUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/DriverLicenseUploadFragment.kt
@@ -1,7 +1,5 @@
 package com.stripe.android.identity.navigation
 
-import android.os.Bundle
-import android.view.View
 import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.identity.R
 import com.stripe.android.identity.states.IdentityScanState
@@ -21,11 +19,4 @@ internal class DriverLicenseUploadFragment(
     override var backCheckMarkContentDescription: Int? = R.string.back_of_dl_selected
     override val frontScanType = IdentityScanState.ScanType.DL_FRONT
     override var backScanType: IdentityScanState.ScanType? = IdentityScanState.ScanType.DL_BACK
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        observeForFrontUploaded()
-        observeForBackUploaded()
-        enableKontinueWhenBothUploaded()
-    }
 }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IDScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IDScanFragment.kt
@@ -35,7 +35,8 @@ internal class IDScanFragment(
                     startScanning(ID_BACK)
                 }
                 ID_BACK -> {
-                    observeAndUploadForBothSides(CollectedDataParam.Type.IDCARD)
+                    continueButton.toggleToLoading()
+                    collectUploadedStateAndUploadForBothSides(CollectedDataParam.Type.IDCARD)
                 }
                 else -> {
                     Log.e(

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IDUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IDUploadFragment.kt
@@ -1,7 +1,5 @@
 package com.stripe.android.identity.navigation
 
-import android.os.Bundle
-import android.view.View
 import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.identity.R
 import com.stripe.android.identity.states.IdentityScanState
@@ -21,11 +19,4 @@ internal class IDUploadFragment(
     override var backCheckMarkContentDescription: Int? = R.string.back_of_id_selected
     override val frontScanType = IdentityScanState.ScanType.ID_FRONT
     override var backScanType: IdentityScanState.ScanType? = IdentityScanState.ScanType.ID_BACK
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        observeForFrontUploaded()
-        observeForBackUploaded()
-        enableKontinueWhenBothUploaded()
-    }
 }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
@@ -13,8 +13,10 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import com.stripe.android.camera.Camera1Adapter
 import com.stripe.android.camera.DefaultCameraErrorListener
@@ -38,6 +40,7 @@ import com.stripe.android.identity.viewmodel.CameraViewModel
 import com.stripe.android.identity.viewmodel.IdentityScanViewModel
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 /**
@@ -93,6 +96,7 @@ internal abstract class IdentityCameraScanFragment(
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        identityViewModel.resetUploadedState()
         identityScanViewModel.displayStateChanged.observe(viewLifecycleOwner) { (newState, _) ->
             updateUI(newState)
         }
@@ -230,89 +234,56 @@ internal abstract class IdentityCameraScanFragment(
     }
 
     /**
-     * Observe for [IdentityViewModel.bothUploaded],
-     * try to [postVerificationPageDataAndMaybeSubmit] when success and navigates to error when fails.
+     * Collect the [IdentityViewModel.uploadState] and update UI accordingly.
+     *
+     * Try to [postVerificationPageDataAndMaybeSubmit] when all images are uploaded and navigates
+     * to error when error occurs.
      */
-    protected fun observeAndUploadForBothSides(type: CollectedDataParam.Type) =
-        identityViewModel.bothUploaded.observe(viewLifecycleOwner) {
-            when (it.status) {
-                Status.SUCCESS -> {
-                    it.data?.let { uploadedFiles ->
-                        lifecycleScope.launch {
-                            runCatching {
-                                postVerificationPageDataAndMaybeSubmit(
-                                    identityViewModel = identityViewModel,
-                                    collectedDataParam =
-                                    CollectedDataParam.createFromUploadedResultsForAutoCapture(
-                                        type = type,
-                                        frontHighResResult = uploadedFiles.first.first,
-                                        frontLowResResult = uploadedFiles.first.second,
-                                        backHighResResult = uploadedFiles.second.first,
-                                        backLowResResult = uploadedFiles.second.second,
-                                    ),
-                                    clearDataParam = ClearDataParam.UPLOAD_TO_CONFIRM,
-                                    shouldNotSubmit = { false }
-                                )
-                            }.onFailure { throwable ->
-                                Log.d(
-                                    TAG,
-                                    "fail to submit uploaded files: $throwable"
-                                )
-                                navigateToDefaultErrorFragment()
+    protected fun collectUploadedStateAndUploadForBothSides(type: CollectedDataParam.Type) =
+        lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                identityViewModel.uploadState.collectLatest {
+                    when {
+                        it.hasError() -> {
+                            Log.e(TAG, "Fail to upload files: ${it.getError()}")
+                            navigateToDefaultErrorFragment()
+                        }
+                        it.isAnyLoading() -> {
+                            continueButton.toggleToLoading()
+                        }
+                        it.isBothUploaded() -> {
+                            lifecycleScope.launch {
+                                runCatching {
+                                    postVerificationPageDataAndMaybeSubmit(
+                                        identityViewModel = identityViewModel,
+                                        collectedDataParam =
+                                        CollectedDataParam.createFromUploadedResultsForAutoCapture(
+                                            type = type,
+                                            frontHighResResult = requireNotNull(it.frontHighResResult.data),
+                                            frontLowResResult = requireNotNull(it.frontLowResResult.data),
+                                            backHighResResult = requireNotNull(it.backHighResResult.data),
+                                            backLowResResult = requireNotNull(it.backLowResResult.data)
+                                        ),
+                                        clearDataParam = ClearDataParam.UPLOAD_TO_CONFIRM,
+                                        shouldNotSubmit = { false }
+                                    )
+                                }.onFailure { throwable ->
+                                    Log.e(
+                                        TAG,
+                                        "fail to submit uploaded files: $throwable"
+                                    )
+                                    navigateToDefaultErrorFragment()
+                                }
                             }
                         }
-                    }
-                }
-                Status.ERROR -> {
-                    Log.e(TAG, "Fail to upload files: ${it.throwable}")
-                    navigateToDefaultErrorFragment()
-                }
-                Status.LOADING -> {
-                    continueButton.toggleToLoading()
-                }
-            }
-        }
-
-    /**
-     * Observe for [IdentityViewModel.frontUploaded],
-     * try to [postVerificationPageDataAndMaybeSubmit] when success and navigates to error when fails.
-     */
-    protected fun observeAndUploadForFrontSide(type: CollectedDataParam.Type) =
-        identityViewModel.frontUploaded.observe(viewLifecycleOwner) {
-            when (it.status) {
-                Status.SUCCESS -> {
-                    it.data?.let { uploadedFiles ->
-                        val frontHighResResult = uploadedFiles.first
-                        val frontLowResResult = uploadedFiles.second
-                        lifecycleScope.launch {
-                            runCatching {
-                                postVerificationPageDataAndMaybeSubmit(
-                                    identityViewModel = identityViewModel,
-                                    collectedDataParam =
-                                    CollectedDataParam.createFromUploadedResultsForAutoCapture(
-                                        type,
-                                        frontHighResResult,
-                                        frontLowResResult
-                                    ),
-                                    clearDataParam = ClearDataParam.UPLOAD_TO_CONFIRM,
-                                    shouldNotSubmit = { false }
-                                )
-                            }.onFailure { throwable ->
-                                Log.d(
-                                    PassportScanFragment.TAG,
-                                    "fail to submit uploaded files: $throwable"
-                                )
-                                navigateToDefaultErrorFragment()
-                            }
+                        else -> {
+                            Log.e(
+                                TAG,
+                                "observeAndUploadForBothSides reaches unexpected upload state: $it"
+                            )
+                            navigateToDefaultErrorFragment()
                         }
                     }
-                }
-                Status.ERROR -> {
-                    Log.e(PassportScanFragment.TAG, "Fail to upload files: ${it.throwable}")
-                    navigateToDefaultErrorFragment()
-                }
-                Status.LOADING -> {
-                    continueButton.toggleToLoading()
                 }
             }
         }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityUploadFragment.kt
@@ -12,22 +12,27 @@ import androidx.appcompat.app.AppCompatDialog
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.NavArgument
+import androidx.navigation.fragment.findNavController
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.IdentityUploadFragmentBinding
-import com.stripe.android.identity.networking.Status
 import com.stripe.android.identity.networking.models.ClearDataParam
 import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.networking.models.DocumentUploadParam
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentDocumentCapturePage
 import com.stripe.android.identity.states.IdentityScanState
+import com.stripe.android.identity.utils.ARG_IS_NAVIGATED_UP_TO
 import com.stripe.android.identity.utils.ARG_SHOULD_SHOW_CHOOSE_PHOTO
 import com.stripe.android.identity.utils.ARG_SHOULD_SHOW_TAKE_PHOTO
 import com.stripe.android.identity.utils.navigateToDefaultErrorFragment
 import com.stripe.android.identity.utils.postVerificationPageDataAndMaybeSubmit
 import com.stripe.android.identity.viewmodel.IdentityUploadViewModel
 import com.stripe.android.identity.viewmodel.IdentityViewModel
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 /**
@@ -76,6 +81,36 @@ internal abstract class IdentityUploadFragment(
         identityUploadViewModel.registerActivityResultCaller(this)
     }
 
+    /**
+     * Check how this fragment is navigated from and reset uploaded state when needed.
+     *
+     * The upload state should only be kept when scanning fails and user is redirected to this
+     * fragment through CouldNotCaptureFragment, in which case it's possible that the front is
+     * already scanned and uploaded, and this fragment should correctly updating the front uploaded UI.
+     *
+     * For all other cases the upload state should be reset in order to reupload both front and back.
+     */
+    private fun maybeResetUploadedState() {
+        val isFromNavigateUp: Boolean = findNavController().currentDestination?.arguments?.get(
+            ARG_IS_NAVIGATED_UP_TO
+        )?.defaultValue as? Boolean == true
+
+        val isPreviousEntryCouldNotCapture =
+            findNavController().previousBackStackEntry?.destination?.id == R.id.couldNotCaptureFragment
+
+        if (isFromNavigateUp || !isPreviousEntryCouldNotCapture) {
+            identityViewModel.resetUploadedState()
+        }
+
+        // flip the argument to indicate it's no longer navigated through back pressed
+        findNavController().currentDestination?.addArgument(
+            ARG_IS_NAVIGATED_UP_TO,
+            NavArgument.Builder()
+                .setDefaultValue(false)
+                .build()
+        )
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -118,6 +153,12 @@ internal abstract class IdentityUploadFragment(
         return binding.root
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        maybeResetUploadedState()
+        collectUploadedStateAndUpdateUI()
+    }
+
     private fun checkBackFields(
         nonNullBlock: (String, String, IdentityScanState.ScanType) -> Unit,
         nullBlock: () -> Unit
@@ -145,85 +186,25 @@ internal abstract class IdentityUploadFragment(
             }
         }
 
-    protected fun observeForFrontUploaded() {
-        identityViewModel.frontHighResUploaded.observe(viewLifecycleOwner) {
-            when (it.status) {
-                Status.SUCCESS -> {
-                    showFrontDone(it.data)
-                }
-                Status.ERROR -> {
-                    Log.e(TAG, "error uploading front image: $it")
-                    navigateToDefaultErrorFragment()
-                }
-                Status.LOADING -> {
-                    showFrontUploading()
-                }
-            }
-        }
-    }
-
-    protected fun observeForBackUploaded() {
-        identityViewModel.backHighResUploaded.observe(viewLifecycleOwner) {
-            when (it.status) {
-                Status.SUCCESS -> {
-                    showBackDone()
-                }
-                Status.ERROR -> {
-                    Log.e(TAG, "error uploading front image: $it")
-                    navigateToDefaultErrorFragment()
-                }
-                Status.LOADING -> {
-                    showBackUploading()
-                }
-            }
-        }
-    }
-
-    protected fun enableKontinueWhenBothUploaded() {
-        identityViewModel.highResUploaded.observe(viewLifecycleOwner) { frontBackPair ->
-            when (frontBackPair.status) {
-                Status.SUCCESS -> {
-                    binding.kontinue.isEnabled = true
-                    binding.kontinue.setOnClickListener {
-                        binding.kontinue.toggleToLoading()
-                        lifecycleScope.launch {
-                            runCatching {
-                                requireNotNull(frontBackPair.data)
-                                val front = frontBackPair.data.first
-                                val back = frontBackPair.data.second
-
-                                postVerificationPageDataAndMaybeSubmit(
-                                    identityViewModel = identityViewModel,
-                                    collectedDataParam = CollectedDataParam(
-                                        idDocumentFront = DocumentUploadParam(
-                                            highResImage = requireNotNull(front.uploadedStripeFile.id) {
-                                                "front uploaded file id is null"
-                                            },
-                                            uploadMethod = front.uploadMethod
-                                        ),
-                                        idDocumentBack = DocumentUploadParam(
-                                            highResImage = requireNotNull(back.uploadedStripeFile.id) {
-                                                "back uploaded file id is null"
-                                            },
-                                            uploadMethod = back.uploadMethod
-                                        ),
-                                        idDocumentType = frontScanType.toType()
-                                    ),
-                                    clearDataParam = ClearDataParam.UPLOAD_TO_CONFIRM,
-                                    shouldNotSubmit = { false }
-                                )
-                            }.onFailure {
-                                Log.d(TAG, "fail to submit uploaded files: $it")
-                                navigateToDefaultErrorFragment()
-                            }
+    private fun collectUploadedStateAndUpdateUI() {
+        lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                identityViewModel.uploadState.collectLatest { latestState ->
+                    if (latestState.hasError()) {
+                        Log.e(TAG, "Fail to upload files: ${latestState.getError()}")
+                        navigateToDefaultErrorFragment()
+                    } else {
+                        if (latestState.isFrontHighResUploaded()) {
+                            showFrontDone(latestState)
+                        }
+                        if (latestState.isBackHighResUploaded()) {
+                            showBackDone()
+                        }
+                        if (latestState.isHighResUploaded()) {
+                            showBothDone(latestState)
                         }
                     }
                 }
-                Status.ERROR -> {
-                    Log.d(TAG, "highResUploaded posts an Error: $frontBackPair")
-                    navigateToDefaultErrorFragment()
-                }
-                Status.LOADING -> {} // no-op
             }
         }
     }
@@ -326,6 +307,11 @@ internal abstract class IdentityUploadFragment(
         uploadMethod: DocumentUploadParam.UploadMethod,
         isFront: Boolean
     ) {
+        if (isFront) {
+            showFrontUploading()
+        } else {
+            showBackUploading()
+        }
         observeForDocCapturePage { docCapturePage ->
             identityViewModel.uploadManualResult(
                 uri = uri,
@@ -342,7 +328,7 @@ internal abstract class IdentityUploadFragment(
         binding.finishedCheckMarkFront.visibility = View.GONE
     }
 
-    protected open fun showFrontDone(frontResult: IdentityViewModel.UploadedResult?) {
+    protected open fun showFrontDone(latestState: IdentityViewModel.UploadState) {
         binding.selectFront.visibility = View.GONE
         binding.progressCircularFront.visibility = View.GONE
         binding.finishedCheckMarkFront.visibility = View.VISIBLE
@@ -358,6 +344,44 @@ internal abstract class IdentityUploadFragment(
         binding.selectBack.visibility = View.GONE
         binding.progressCircularBack.visibility = View.GONE
         binding.finishedCheckMarkBack.visibility = View.VISIBLE
+    }
+
+    private fun showBothDone(latestState: IdentityViewModel.UploadState) {
+        binding.kontinue.isEnabled = true
+        binding.kontinue.setOnClickListener {
+            binding.kontinue.toggleToLoading()
+            lifecycleScope.launch {
+                runCatching {
+                    val front =
+                        requireNotNull(latestState.frontHighResResult.data)
+                    val back =
+                        requireNotNull(latestState.backHighResResult.data)
+                    postVerificationPageDataAndMaybeSubmit(
+                        identityViewModel = identityViewModel,
+                        collectedDataParam = CollectedDataParam(
+                            idDocumentFront = DocumentUploadParam(
+                                highResImage = requireNotNull(front.uploadedStripeFile.id) {
+                                    "front uploaded file id is null"
+                                },
+                                uploadMethod = front.uploadMethod
+                            ),
+                            idDocumentBack = DocumentUploadParam(
+                                highResImage = requireNotNull(back.uploadedStripeFile.id) {
+                                    "back uploaded file id is null"
+                                },
+                                uploadMethod = back.uploadMethod
+                            ),
+                            idDocumentType = frontScanType.toType()
+                        ),
+                        clearDataParam = ClearDataParam.UPLOAD_TO_CONFIRM,
+                        shouldNotSubmit = { false }
+                    )
+                }.onFailure {
+                    Log.d(TAG, "fail to submit uploaded files: $it")
+                    navigateToDefaultErrorFragment()
+                }
+            }
+        }
     }
 
     companion object {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/PassportScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/PassportScanFragment.kt
@@ -1,11 +1,21 @@
 package com.stripe.android.identity.navigation
 
 import android.os.Bundle
+import android.util.Log
 import android.view.View
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.stripe.android.identity.R
+import com.stripe.android.identity.networking.models.ClearDataParam
 import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.states.IdentityScanState
+import com.stripe.android.identity.utils.navigateToDefaultErrorFragment
+import com.stripe.android.identity.utils.postVerificationPageDataAndMaybeSubmit
+import com.stripe.android.identity.viewmodel.IdentityViewModel
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 
 /**
  * Fragment to scan passport.
@@ -22,9 +32,62 @@ internal class PassportScanFragment(
         headerTitle.text = requireContext().getText(R.string.passport)
         messageView.text = requireContext().getText(R.string.position_passport)
         continueButton.setOnClickListener {
-            observeAndUploadForFrontSide(CollectedDataParam.Type.PASSPORT)
+            continueButton.toggleToLoading()
+            collectUploadedStateAndUploadForFrontSide()
         }
     }
+
+    /**
+     * Collect the [IdentityViewModel.uploadState] and upload when frontHighRes and frontLowRes
+     * are uploaded.
+     *
+     * Try to [postVerificationPageDataAndMaybeSubmit] when success and navigates to error when fails.
+     */
+    private fun collectUploadedStateAndUploadForFrontSide() =
+        lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                identityViewModel.uploadState.collectLatest {
+                    when {
+                        it.hasError() -> {
+                            navigateToDefaultErrorFragment()
+                        }
+                        it.isFrontLoading() -> {
+                            continueButton.toggleToLoading()
+                        }
+                        it.isFrontUploaded() -> {
+                            lifecycleScope.launch {
+                                runCatching {
+                                    postVerificationPageDataAndMaybeSubmit(
+                                        identityViewModel = identityViewModel,
+                                        collectedDataParam =
+                                        CollectedDataParam.createFromUploadedResultsForAutoCapture(
+                                            type = CollectedDataParam.Type.PASSPORT,
+                                            frontHighResResult = requireNotNull(it.frontHighResResult.data),
+                                            frontLowResResult = requireNotNull(it.frontLowResResult.data)
+                                        ),
+                                        clearDataParam = ClearDataParam.UPLOAD_TO_CONFIRM,
+                                        shouldNotSubmit = { false }
+                                    )
+                                }.onFailure { throwable ->
+                                    Log.e(
+                                        TAG,
+                                        "fail to submit uploaded files: $throwable"
+                                    )
+                                    navigateToDefaultErrorFragment()
+                                }
+                            }
+                        }
+                        else -> {
+                            Log.d(
+                                TAG,
+                                "observeAndUploadForFrontSide reaches unexpected upload state: $it"
+                            )
+                            navigateToDefaultErrorFragment()
+                        }
+                    }
+                }
+            }
+        }
 
     override fun onCameraReady() {
         startScanning(IdentityScanState.ScanType.PASSPORT)

--- a/identity/src/main/java/com/stripe/android/identity/navigation/PassportUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/PassportUploadFragment.kt
@@ -1,8 +1,6 @@
 package com.stripe.android.identity.navigation
 
-import android.os.Bundle
 import android.util.Log
-import android.view.View
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import com.stripe.android.identity.R
@@ -18,7 +16,7 @@ import kotlinx.coroutines.launch
 /**
  * Fragment to upload passport.
  */
-internal class PassportUploadFragment(
+internal open class PassportUploadFragment(
     identityUploadViewModelFactory: ViewModelProvider.Factory,
     identityViewModelFactory: ViewModelProvider.Factory
 ) : IdentityUploadFragment(identityUploadViewModelFactory, identityViewModelFactory) {
@@ -28,23 +26,14 @@ internal class PassportUploadFragment(
     override val frontCheckMarkContentDescription = R.string.passport_selected
     override val frontScanType = IdentityScanState.ScanType.PASSPORT
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        observeForFrontUploaded()
-    }
-
-    override fun showFrontDone(frontResult: IdentityViewModel.UploadedResult?) {
-        super.showFrontDone(frontResult)
-        enableKontinueWhenFrontUploaded(frontResult)
-    }
-
-    private fun enableKontinueWhenFrontUploaded(frontResult: IdentityViewModel.UploadedResult?) {
+    override fun showFrontDone(latestState: IdentityViewModel.UploadState) {
+        super.showFrontDone(latestState)
         binding.kontinue.isEnabled = true
         binding.kontinue.setOnClickListener {
             binding.kontinue.toggleToLoading()
             lifecycleScope.launch {
                 runCatching {
-                    requireNotNull(frontResult)
+                    val frontResult = requireNotNull(latestState.frontHighResResult.data)
                     postVerificationPageDataAndMaybeSubmit(
                         identityViewModel = identityViewModel,
                         collectedDataParam = CollectedDataParam(

--- a/identity/src/main/java/com/stripe/android/identity/utils/navigationUtils.kt
+++ b/identity/src/main/java/com/stripe/android/identity/utils/navigationUtils.kt
@@ -141,4 +141,9 @@ internal const val ARG_SHOULD_SHOW_TAKE_PHOTO = "shouldShowTakePhoto"
  */
 internal const val ARG_SHOULD_SHOW_CHOOSE_PHOTO = "shouldShowChoosePhoto"
 
+/**
+ * Navigation Argument to indicate if the current Fragment is reached through navigateUp.
+ */
+internal const val ARG_IS_NAVIGATED_UP_TO = "isNavigatedUpTo"
+
 private const val TAG = "NAVIGATION_UTIL"

--- a/identity/src/test/java/com/stripe/android/identity/navigation/DriverLicenseScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/DriverLicenseScanFragmentTest.kt
@@ -7,7 +7,6 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.core.os.bundleOf
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.lifecycle.MediatorLiveData
-import androidx.lifecycle.Observer
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.Navigation
 import androidx.navigation.testing.TestNavHostController
@@ -28,12 +27,13 @@ import com.stripe.android.identity.networking.models.DocumentUploadParam
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentDocumentCapturePage
 import com.stripe.android.identity.states.IdentityScanState
-import com.stripe.android.identity.utils.PairMediatorLiveData
 import com.stripe.android.identity.utils.SingleLiveEvent
 import com.stripe.android.identity.viewModelFactoryFor
 import com.stripe.android.identity.viewmodel.IdentityScanViewModel
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 import com.stripe.android.identity.viewmodel.IdentityViewModel.UploadedResult
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Rule
@@ -42,6 +42,7 @@ import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.same
@@ -58,12 +59,6 @@ internal class DriverLicenseScanFragmentTest {
 
     private val finalResultLiveData = SingleLiveEvent<IDDetectorAggregator.FinalResult>()
     private val displayStateChanged = SingleLiveEvent<Pair<IdentityScanState, IdentityScanState?>>()
-    private val mockBothUploaded: PairMediatorLiveData<Pair<UploadedResult, UploadedResult>> =
-        mock()
-    private val bothUploadedObserverCaptor =
-        argumentCaptor<Observer<Resource<Pair<
-                        Pair<UploadedResult, UploadedResult>, Pair<UploadedResult, UploadedResult>
-                        >>>>()
 
     private val mockScanFlow = mock<IdentityScanFlow>()
     private val mockIdentityScanViewModel = mock<IdentityScanViewModel>().also {
@@ -73,10 +68,29 @@ internal class DriverLicenseScanFragmentTest {
     }
 
     private val mockPageAndModel = MediatorLiveData<Resource<Pair<VerificationPage, File>>>()
-    private val mockIdentityViewModel = mock<IdentityViewModel>().also {
-        whenever(it.pageAndModel).thenReturn(mockPageAndModel)
-        whenever(it.bothUploaded).thenReturn(mockBothUploaded)
+
+    private val uploadState =
+        MutableStateFlow(IdentityViewModel.UploadState())
+
+    private val mockIdentityViewModel = mock<IdentityViewModel>() {
+        on { pageAndModel } doReturn mockPageAndModel
+        on { uploadState } doReturn uploadState
     }
+
+    private val errorUploadState = mock<IdentityViewModel.UploadState> {
+        on { hasError() } doReturn true
+    }
+
+    private val anyLoadingUploadState = mock<IdentityViewModel.UploadState> {
+        on { isAnyLoading() } doReturn true
+    }
+
+    private val bothUploadedUploadState = IdentityViewModel.UploadState(
+        frontHighResResult = Resource.success(FRONT_HIGH_RES_RESULT),
+        frontLowResResult = Resource.success(FRONT_LOW_RES_RESULT),
+        backHighResResult = Resource.success(BACK_HIGH_RES_RESULT),
+        backLowResResult = Resource.success(BACK_LOW_RES_RESULT)
+    )
 
     @Before
     fun simulateModelDownloaded() {
@@ -154,14 +168,9 @@ internal class DriverLicenseScanFragmentTest {
         simulateBothSidesScanned { _, _ ->
             runBlocking {
                 // mock bothUploaded success
-                bothUploadedObserverCaptor.firstValue.onChanged(
-                    Resource.success(
-                        Pair(
-                            Pair(FRONT_HIGH_RES_RESULT, FRONT_LOW_RES_RESULT),
-                            Pair(BACK_HIGH_RES_RESULT, BACK_LOW_RES_RESULT),
-                        )
-                    )
-                )
+                uploadState.update {
+                    bothUploadedUploadState
+                }
 
                 // verify navigation attempts
                 verify(mockIdentityViewModel).postVerificationPageData(
@@ -186,9 +195,9 @@ internal class DriverLicenseScanFragmentTest {
     fun `when both sides are scanned but files uploaded failed, clicking button navigate to error`() {
         simulateBothSidesScanned { navController, _ ->
             // mock bothUploaded error
-            bothUploadedObserverCaptor.firstValue.onChanged(
-                Resource.error()
-            )
+            uploadState.update {
+                errorUploadState
+            }
 
             assertThat(navController.currentDestination?.id)
                 .isEqualTo(R.id.errorFragment)
@@ -199,9 +208,9 @@ internal class DriverLicenseScanFragmentTest {
     fun `when both sides are scanned and files are being uploaded, clicking button toggles loading state`() {
         simulateBothSidesScanned { _, binding ->
             // mock bothUploaded loading
-            bothUploadedObserverCaptor.firstValue.onChanged(
-                Resource.loading()
-            )
+            uploadState.update {
+                anyLoadingUploadState
+            }
 
             assertThat(
                 binding.kontinue.findViewById<MaterialButton>(R.id.button).isEnabled
@@ -440,8 +449,6 @@ internal class DriverLicenseScanFragmentTest {
 
             // click continue, navigates
             binding.kontinue.findViewById<Button>(R.id.button).callOnClick()
-
-            verify(mockBothUploaded).observe(any(), bothUploadedObserverCaptor.capture())
 
             afterScannedBlock(navController, binding)
         }

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IdentityCameraScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IdentityCameraScanFragmentTest.kt
@@ -96,6 +96,13 @@ class IdentityCameraScanFragmentTest {
     }
 
     @Test
+    fun `when viewCreated uploadedState is reset`() {
+        launchTestFragment().onFragment {
+            verify(mockIdentityViewModel).resetUploadedState()
+        }
+    }
+
+    @Test
     fun `when page or model is not ready exception is thrown`() {
         launchTestFragment().onFragment {
             assertFailsWith<InvalidResponseException> {

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IdentityUploadFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IdentityUploadFragmentTest.kt
@@ -2,15 +2,17 @@ package com.stripe.android.identity.navigation
 
 import android.net.Uri
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import android.widget.Button
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatDialog
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.core.os.bundleOf
 import androidx.fragment.app.testing.launchFragmentInContainer
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModelProvider
+import androidx.navigation.NavArgument
 import androidx.navigation.Navigation
 import androidx.navigation.testing.TestNavHostController
 import androidx.test.core.app.ApplicationProvider
@@ -29,13 +31,15 @@ import com.stripe.android.identity.networking.models.DocumentUploadParam
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentDocumentCapturePage
 import com.stripe.android.identity.states.IdentityScanState
+import com.stripe.android.identity.utils.ARG_IS_NAVIGATED_UP_TO
 import com.stripe.android.identity.utils.ARG_SHOULD_SHOW_CHOOSE_PHOTO
 import com.stripe.android.identity.utils.ARG_SHOULD_SHOW_TAKE_PHOTO
-import com.stripe.android.identity.utils.PairMediatorLiveData
 import com.stripe.android.identity.viewModelFactoryFor
 import com.stripe.android.identity.viewmodel.IdentityUploadViewModel
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 import com.stripe.android.identity.viewmodel.IdentityViewModel.UploadedResult
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
@@ -44,9 +48,11 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.same
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
@@ -57,12 +63,16 @@ class IdentityUploadFragmentTest {
     @get:Rule
     var rule: TestRule = InstantTaskExecutorRule()
 
-    private val frontHighResUploaded = MutableLiveData<Resource<UploadedResult>>()
-    private val backHighResUploaded = MutableLiveData<Resource<UploadedResult>>()
-    private val highResUploaded = PairMediatorLiveData(frontHighResUploaded, backHighResUploaded)
     private val mockUri = mock<Uri>()
     private val verificationPage = mock<VerificationPage>().also {
         whenever(it.documentCapture).thenReturn(DOCUMENT_CAPTURE)
+    }
+
+    private val uploadState =
+        MutableStateFlow(IdentityViewModel.UploadState())
+
+    private val errorUploadState = mock<IdentityViewModel.UploadState> {
+        on { hasError() } doReturn true
     }
 
     private val mockIdentityViewModel = mock<IdentityViewModel>().also {
@@ -70,12 +80,19 @@ class IdentityUploadFragmentTest {
         whenever(it.observeForVerificationPage(any(), successCaptor.capture(), any())).then {
             successCaptor.firstValue(verificationPage)
         }
-        whenever(it.frontHighResUploaded).thenReturn(frontHighResUploaded)
-        whenever(it.backHighResUploaded).thenReturn(backHighResUploaded)
-        whenever(it.highResUploaded).thenReturn(highResUploaded)
+        whenever(it.uploadState).thenReturn(uploadState)
     }
 
     private val mockFrontBackUploadViewModel = mock<IdentityUploadViewModel>()
+
+    private val navController = TestNavHostController(
+        ApplicationProvider.getApplicationContext()
+    ).also {
+        it.setGraph(
+            R.navigation.identity_nav_graph
+        )
+        it.setCurrentDestination(R.id.IDUploadFragment)
+    }
 
     @Test
     fun `when initialized viewmodel registers activityResultCaller and UI is correct`() {
@@ -194,7 +211,9 @@ class IdentityUploadFragmentTest {
     @Test
     fun `verify front upload failure navigates to error fragment `() {
         launchFragment { _, navController, _ ->
-            frontHighResUploaded.postValue(Resource.error())
+            uploadState.update {
+                errorUploadState
+            }
 
             assertThat(navController.currentDestination?.id)
                 .isEqualTo(R.id.errorFragment)
@@ -204,7 +223,9 @@ class IdentityUploadFragmentTest {
     @Test
     fun `verify back upload failure navigates to error fragment `() {
         launchFragment { _, navController, _ ->
-            backHighResUploaded.postValue(Resource.error())
+            uploadState.update {
+                errorUploadState
+            }
 
             assertThat(navController.currentDestination?.id)
                 .isEqualTo(R.id.errorFragment)
@@ -214,24 +235,16 @@ class IdentityUploadFragmentTest {
     @Test
     fun `verify uploadFinished updates UI`() {
         launchFragment { binding, _, _ ->
-            frontHighResUploaded.postValue(
-                Resource.success(
-                    UploadedResult(
-                        uploadedStripeFile = StripeFile(id = FRONT_UPLOADED_ID),
-                        scores = null,
-                        uploadMethod = DocumentUploadParam.UploadMethod.FILEUPLOAD
+            uploadState.update {
+                IdentityViewModel.UploadState(
+                    frontHighResResult = Resource.success(
+                        FRONT_HIGH_RES_RESULT_FILEUPLOAD
+                    ),
+                    backHighResResult = Resource.success(
+                        BACK_HIGH_RES_RESULT_FILEUPLOAD
                     )
                 )
-            )
-            backHighResUploaded.postValue(
-                Resource.success(
-                    UploadedResult(
-                        uploadedStripeFile = StripeFile(id = BACK_UPLOADED_ID),
-                        scores = null,
-                        uploadMethod = DocumentUploadParam.UploadMethod.FILEUPLOAD
-                    )
-                )
-            )
+            }
 
             assertThat(binding.selectFront.visibility).isEqualTo(View.GONE)
             assertThat(binding.progressCircularFront.visibility).isEqualTo(View.GONE)
@@ -248,24 +261,16 @@ class IdentityUploadFragmentTest {
     fun `verify when kontinue is clicked and post succeeds navigates to confirmation`() {
         launchFragment { binding, navController, _ ->
             runBlocking {
-                frontHighResUploaded.postValue(
-                    Resource.success(
-                        UploadedResult(
-                            uploadedStripeFile = StripeFile(id = FRONT_UPLOADED_ID),
-                            scores = null,
-                            uploadMethod = DocumentUploadParam.UploadMethod.FILEUPLOAD
+                uploadState.update {
+                    IdentityViewModel.UploadState(
+                        frontHighResResult = Resource.success(
+                            FRONT_HIGH_RES_RESULT_FILEUPLOAD
+                        ),
+                        backHighResResult = Resource.success(
+                            BACK_HIGH_RES_RESULT_FILEUPLOAD
                         )
                     )
-                )
-                backHighResUploaded.postValue(
-                    Resource.success(
-                        UploadedResult(
-                            uploadedStripeFile = StripeFile(id = BACK_UPLOADED_ID),
-                            scores = null,
-                            uploadMethod = DocumentUploadParam.UploadMethod.FILEUPLOAD
-                        )
-                    )
-                )
+                }
 
                 val collectedDataParamCaptor: KArgumentCaptor<CollectedDataParam> = argumentCaptor()
                 val clearDataParamCaptor: KArgumentCaptor<ClearDataParam> = argumentCaptor()
@@ -307,15 +312,41 @@ class IdentityUploadFragmentTest {
     }
 
     @Test
-    fun `verify when kontinue is clicked and data is null navigates to error`() {
-        launchFragment { binding, navController, _ ->
-            // leave frontBackPair.data null
-            highResUploaded.postValue(Resource.success(mock()))
+    fun `when not navigatedUp and previous backstack entry is couldNotCapture don't reset uploadState`() {
+        navController.setCurrentDestination(R.id.couldNotCaptureFragment)
+        navController.navigate(R.id.IDUploadFragment)
+        launchFragment { _, _, _ ->
+            verify(mockIdentityViewModel, times(0)).resetUploadedState()
+        }
+    }
 
-            binding.kontinue.findViewById<MaterialButton>(R.id.button).callOnClick()
+    @Test
+    fun `when is navigateUp and previous backstack entry is couldNotCapture reset uploadState`() {
+        navController.setCurrentDestination(R.id.couldNotCaptureFragment)
+        navController.navigate(R.id.IDUploadFragment)
+        navController.navigate(R.id.confirmationFragment)
 
-            assertThat(navController.currentDestination?.id)
-                .isEqualTo(R.id.errorFragment)
+        // Simulate the behavior set in IdentityActivity.onBackPressedCallback
+        navController.previousBackStackEntry?.destination?.addArgument(
+            ARG_IS_NAVIGATED_UP_TO,
+            NavArgument.Builder()
+                .setDefaultValue(true)
+                .build()
+        )
+
+        navController.navigateUp()
+        launchFragment { _, _, _ ->
+            verify(mockIdentityViewModel).resetUploadedState()
+        }
+    }
+
+    @Test
+    fun `when previous backstack entry is not couldNotCapture reset uploadState`() {
+        navController.setCurrentDestination(R.id.confirmationFragment)
+        navController.navigate(R.id.IDUploadFragment)
+
+        launchFragment { _, _, _ ->
+            verify(mockIdentityViewModel).resetUploadedState()
         }
     }
 
@@ -391,21 +422,17 @@ class IdentityUploadFragmentTest {
                         same(fragment.requireContext()),
                         callbackCaptor.capture()
                     )
-                    frontHighResUploaded.postValue(Resource.loading())
                 } else if (scanType == IdentityScanState.ScanType.ID_BACK) {
                     verify(mockFrontBackUploadViewModel).takePhotoBack(
                         same(fragment.requireContext()),
                         callbackCaptor.capture()
                     )
-                    backHighResUploaded.postValue(Resource.loading())
                 }
             } else {
                 if (scanType == IdentityScanState.ScanType.ID_FRONT) {
                     verify(mockFrontBackUploadViewModel).chooseImageFront(callbackCaptor.capture())
-                    frontHighResUploaded.postValue(Resource.loading())
                 } else if (scanType == IdentityScanState.ScanType.ID_BACK) {
                     verify(mockFrontBackUploadViewModel).chooseImageBack(callbackCaptor.capture())
-                    backHighResUploaded.postValue(Resource.loading())
                 }
             }
 
@@ -445,13 +472,27 @@ class IdentityUploadFragmentTest {
 
             // mock file uploaded
             if (scanType == IdentityScanState.ScanType.ID_FRONT) {
-                frontHighResUploaded.postValue(Resource.success(mock()))
+                uploadState.update {
+                    IdentityViewModel.UploadState(
+                        frontHighResResult =
+                        Resource.success(
+                            if (isTakePhoto) FRONT_HIGH_RES_RESULT_MANUALCAPTURE else FRONT_HIGH_RES_RESULT_FILEUPLOAD
+                        )
+                    )
+                }
 
                 assertThat(binding.selectFront.visibility).isEqualTo(View.GONE)
                 assertThat(binding.progressCircularFront.visibility).isEqualTo(View.GONE)
                 assertThat(binding.finishedCheckMarkFront.visibility).isEqualTo(View.VISIBLE)
             } else if (scanType == IdentityScanState.ScanType.ID_BACK) {
-                backHighResUploaded.postValue(Resource.success(mock()))
+                uploadState.update {
+                    IdentityViewModel.UploadState(
+                        backHighResResult =
+                        Resource.success(
+                            if (isTakePhoto) BACK_HIGH_RES_RESULT_MANUALCAPTURE else BACK_HIGH_RES_RESULT_FILEUPLOAD
+                        )
+                    )
+                }
 
                 assertThat(binding.selectBack.visibility).isEqualTo(View.GONE)
                 assertThat(binding.progressCircularBack.visibility).isEqualTo(View.GONE)
@@ -477,26 +518,17 @@ class IdentityUploadFragmentTest {
     ) {
         TestFragment(
             viewModelFactoryFor(mockFrontBackUploadViewModel),
-            viewModelFactoryFor(mockIdentityViewModel)
-        )
-    }.onFragment {
-        val navController = TestNavHostController(
-            ApplicationProvider.getApplicationContext()
-        )
-        navController.setGraph(
-            R.navigation.identity_nav_graph
-        )
-        navController.setCurrentDestination(R.id.IDUploadFragment)
-        Navigation.setViewNavController(
-            it.requireView(),
+            viewModelFactoryFor(mockIdentityViewModel),
             navController
         )
+    }.onFragment {
         testBlock(IdentityUploadFragmentBinding.bind(it.requireView()), navController, it)
     }
 
     internal class TestFragment(
         identityUploadViewModelFactory: ViewModelProvider.Factory,
-        identityViewModelFactory: ViewModelProvider.Factory
+        identityViewModelFactory: ViewModelProvider.Factory,
+        val navController: TestNavHostController
     ) :
         IdentityUploadFragment(identityUploadViewModelFactory, identityViewModelFactory) {
         override val titleRes = R.string.file_upload
@@ -508,11 +540,17 @@ class IdentityUploadFragmentTest {
         override val frontScanType = IdentityScanState.ScanType.ID_FRONT
         override var backScanType: IdentityScanState.ScanType? = IdentityScanState.ScanType.ID_BACK
 
-        override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-            super.onViewCreated(view, savedInstanceState)
-            observeForFrontUploaded()
-            observeForBackUploaded()
-            enableKontinueWhenBothUploaded()
+        override fun onCreateView(
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?
+        ): View {
+            val view = super.onCreateView(inflater, container, savedInstanceState)
+            Navigation.setViewNavController(
+                view,
+                navController
+            )
+            return view
         }
     }
 
@@ -534,5 +572,29 @@ class IdentityUploadFragmentTest {
 
         const val FRONT_UPLOADED_ID = "id_front"
         const val BACK_UPLOADED_ID = "id_back"
+
+        val FRONT_HIGH_RES_RESULT_FILEUPLOAD = UploadedResult(
+            uploadedStripeFile = StripeFile(id = FRONT_UPLOADED_ID),
+            scores = null,
+            uploadMethod = DocumentUploadParam.UploadMethod.FILEUPLOAD
+        )
+
+        val BACK_HIGH_RES_RESULT_FILEUPLOAD = UploadedResult(
+            uploadedStripeFile = StripeFile(id = BACK_UPLOADED_ID),
+            scores = null,
+            uploadMethod = DocumentUploadParam.UploadMethod.FILEUPLOAD
+        )
+
+        val FRONT_HIGH_RES_RESULT_MANUALCAPTURE = UploadedResult(
+            uploadedStripeFile = StripeFile(id = FRONT_UPLOADED_ID),
+            scores = null,
+            uploadMethod = DocumentUploadParam.UploadMethod.MANUALCAPTURE
+        )
+
+        val BACK_HIGH_RES_RESULT_MANUALCAPTURE = UploadedResult(
+            uploadedStripeFile = StripeFile(id = BACK_UPLOADED_ID),
+            scores = null,
+            uploadMethod = DocumentUploadParam.UploadMethod.MANUALCAPTURE
+        )
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Replace the livedata to tracking upload status in `IdentityViewModel` with `MutableStateFlow` of `UploadState`
* The flow will only notify the latest value posted, as opposed to LiveData wich replays all values post to it
  * this would make sure that every time the flow is collected, all stale data is ignored. e.g navigate back to the upload fragment would clear the uploaded status before
* uploadedState should be reset in most cases but there is only one case we need to carry over the uploadedState - when user scans front of ID and cannot scan the back of id, then was brought to upload fragment, in this case we need to show front already uploaded - this is done in `IdentityUploadFragment.maybeResetUploadState`, where we checked if this fragment is reached through navigate() or navigateUp(), please see the method for details
# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Correct UI

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
