### PR TITLE
[Identity] set error backbutton destination

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
@@ -8,7 +8,6 @@ import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.lifecycle.ViewModelProvider
-import androidx.navigation.NavArgument
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import androidx.navigation.fragment.NavHostFragment
@@ -19,7 +18,7 @@ import com.stripe.android.identity.IdentityVerificationSheet.VerificationFlowRes
 import com.stripe.android.identity.databinding.IdentityActivityBinding
 import com.stripe.android.identity.navigation.ErrorFragment
 import com.stripe.android.identity.navigation.IdentityFragmentFactory
-import com.stripe.android.identity.utils.ARG_IS_NAVIGATED_UP_TO
+import com.stripe.android.identity.utils.navigateUpAndSetArgForUploadFragment
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 
 /**
@@ -57,21 +56,9 @@ internal class IdentityActivity : CameraPermissionCheckingActivity(), Verificati
     internal val identityViewModel: IdentityViewModel by viewModels { viewModelFactory }
 
     private val onBackPressedCallback = object : OnBackPressedCallback(true) {
-        private fun isBackingToUploadFragment() =
-            navController.previousBackStackEntry?.destination?.id == R.id.IDUploadFragment ||
-                navController.previousBackStackEntry?.destination?.id == R.id.passportUploadFragment ||
-                navController.previousBackStackEntry?.destination?.id == R.id.driverLicenseUploadFragment
 
         override fun handleOnBackPressed() {
-            if (isBackingToUploadFragment()) {
-                navController.previousBackStackEntry?.destination?.addArgument(
-                    ARG_IS_NAVIGATED_UP_TO,
-                    NavArgument.Builder()
-                        .setDefaultValue(true)
-                        .build()
-                )
-            }
-            navController.navigateUp()
+            navController.navigateUpAndSetArgForUploadFragment()
         }
     }
 
@@ -135,9 +122,9 @@ internal class IdentityActivity : CameraPermissionCheckingActivity(), Verificati
         )
 
         binding.topAppBar.setNavigationOnClickListener {
-            // Explicitly invoke the onBackPressedCallback, as clicking up button on app bar should
-            // have the same behavior as clicking device back button
-            onBackPressedCallback.handleOnBackPressed()
+            // clicking up button on app bar should have the same behavior as clicking device back
+            // button
+            navController.navigateUpAndSetArgForUploadFragment()
         }
     }
 

--- a/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
@@ -127,6 +127,7 @@ internal class ConsentFragment(
                 identityViewModel,
                 collectedDataParam,
                 ClearDataParam.CONSENT_TO_DOC_SELECT,
+                fromFragment = R.id.consentFragment,
                 shouldNotSubmit = { true },
                 notSubmitBlock = {
                     navigateToDocSelection()

--- a/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
@@ -186,6 +186,7 @@ internal class DocSelectionFragment(
                 identityViewModel = identityViewModel,
                 collectedDataParam = CollectedDataParam(idDocumentType = type),
                 clearDataParam = ClearDataParam.DOC_SELECT_TO_UPLOAD,
+                fromFragment = R.id.docSelectionFragment,
                 shouldNotSubmit = { true },
                 notSubmitBlock = {
                     cameraPermissionEnsureable.ensureCameraPermission(

--- a/identity/src/main/java/com/stripe/android/identity/navigation/DriverLicenseScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/DriverLicenseScanFragment.kt
@@ -19,6 +19,8 @@ internal class DriverLicenseScanFragment(
     identityCameraScanViewModelFactory,
     identityViewModelFactory
 ) {
+    override val fragmentId = R.id.driverLicenseScanFragment
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         if (shouldStartFromBack()) {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/DriverLicenseUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/DriverLicenseUploadFragment.kt
@@ -19,4 +19,5 @@ internal class DriverLicenseUploadFragment(
     override var backCheckMarkContentDescription: Int? = R.string.back_of_dl_selected
     override val frontScanType = IdentityScanState.ScanType.DL_FRONT
     override var backScanType: IdentityScanState.ScanType? = IdentityScanState.ScanType.DL_BACK
+    override val fragmentId = R.id.driverLicenseUploadFragment
 }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IDScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IDScanFragment.kt
@@ -19,6 +19,8 @@ internal class IDScanFragment(
     identityCameraScanViewModelFactory,
     identityViewModelFactory
 ) {
+    override val fragmentId = R.id.IDScanFragment
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         if (shouldStartFromBack()) {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IDUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IDUploadFragment.kt
@@ -19,4 +19,5 @@ internal class IDUploadFragment(
     override var backCheckMarkContentDescription: Int? = R.string.back_of_id_selected
     override val frontScanType = IdentityScanState.ScanType.ID_FRONT
     override var backScanType: IdentityScanState.ScanType? = IdentityScanState.ScanType.ID_BACK
+    override val fragmentId = R.id.IDUploadFragment
 }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
@@ -54,6 +55,9 @@ internal abstract class IdentityCameraScanFragment(
 ) : Fragment() {
     protected val identityScanViewModel: IdentityScanViewModel by viewModels { identityCameraScanViewModelFactory }
     protected val identityViewModel: IdentityViewModel by activityViewModels { identityViewModelFactory }
+
+    @get:IdRes
+    protected abstract val fragmentId: Int
 
     @VisibleForTesting
     internal lateinit var cameraAdapter: Camera1Adapter
@@ -264,6 +268,7 @@ internal abstract class IdentityCameraScanFragment(
                                             backHighResResult = requireNotNull(it.backHighResResult.data),
                                             backLowResResult = requireNotNull(it.backLowResResult.data)
                                         ),
+                                        fromFragment = fragmentId,
                                         clearDataParam = ClearDataParam.UPLOAD_TO_CONFIRM,
                                         shouldNotSubmit = { false }
                                     )

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityUploadFragment.kt
@@ -7,6 +7,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import androidx.annotation.IdRes
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatDialog
 import androidx.fragment.app.Fragment
@@ -61,6 +62,9 @@ internal abstract class IdentityUploadFragment(
 
     @get:StringRes
     open var backCheckMarkContentDescription: Int? = null
+
+    @get:IdRes
+    abstract val fragmentId: Int
 
     abstract val frontScanType: IdentityScanState.ScanType
 
@@ -356,9 +360,8 @@ internal abstract class IdentityUploadFragment(
                         requireNotNull(latestState.frontHighResResult.data)
                     val back =
                         requireNotNull(latestState.backHighResResult.data)
-                    postVerificationPageDataAndMaybeSubmit(
-                        identityViewModel = identityViewModel,
-                        collectedDataParam = CollectedDataParam(
+                    trySubmit(
+                        CollectedDataParam(
                             idDocumentFront = DocumentUploadParam(
                                 highResImage = requireNotNull(front.uploadedStripeFile.id) {
                                     "front uploaded file id is null"
@@ -372,9 +375,7 @@ internal abstract class IdentityUploadFragment(
                                 uploadMethod = back.uploadMethod
                             ),
                             idDocumentType = frontScanType.toType()
-                        ),
-                        clearDataParam = ClearDataParam.UPLOAD_TO_CONFIRM,
-                        shouldNotSubmit = { false }
+                        )
                     )
                 }.onFailure {
                     Log.d(TAG, "fail to submit uploaded files: $it")
@@ -382,6 +383,16 @@ internal abstract class IdentityUploadFragment(
                 }
             }
         }
+    }
+
+    protected suspend fun trySubmit(collectedDataParam: CollectedDataParam) {
+        postVerificationPageDataAndMaybeSubmit(
+            identityViewModel = identityViewModel,
+            collectedDataParam = collectedDataParam,
+            clearDataParam = ClearDataParam.UPLOAD_TO_CONFIRM,
+            fromFragment = fragmentId,
+            shouldNotSubmit = { false }
+        )
     }
 
     companion object {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/PassportScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/PassportScanFragment.kt
@@ -27,6 +27,8 @@ internal class PassportScanFragment(
     identityCameraScanViewModelFactory,
     identityViewModelFactory
 ) {
+    override val fragmentId = R.id.passportScanFragment
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         headerTitle.text = requireContext().getText(R.string.passport)
@@ -66,6 +68,7 @@ internal class PassportScanFragment(
                                             frontLowResResult = requireNotNull(it.frontLowResResult.data)
                                         ),
                                         clearDataParam = ClearDataParam.UPLOAD_TO_CONFIRM,
+                                        fromFragment = R.id.passportScanFragment,
                                         shouldNotSubmit = { false }
                                     )
                                 }.onFailure { throwable ->

--- a/identity/src/main/java/com/stripe/android/identity/navigation/PassportUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/PassportUploadFragment.kt
@@ -4,12 +4,10 @@ import android.util.Log
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import com.stripe.android.identity.R
-import com.stripe.android.identity.networking.models.ClearDataParam
 import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.networking.models.DocumentUploadParam
 import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.utils.navigateToDefaultErrorFragment
-import com.stripe.android.identity.utils.postVerificationPageDataAndMaybeSubmit
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 import kotlinx.coroutines.launch
 
@@ -25,6 +23,7 @@ internal open class PassportUploadFragment(
     override val frontTextRes = R.string.passport
     override val frontCheckMarkContentDescription = R.string.passport_selected
     override val frontScanType = IdentityScanState.ScanType.PASSPORT
+    override val fragmentId = R.id.passportUploadFragment
 
     override fun showFrontDone(latestState: IdentityViewModel.UploadState) {
         super.showFrontDone(latestState)
@@ -34,9 +33,8 @@ internal open class PassportUploadFragment(
             lifecycleScope.launch {
                 runCatching {
                     val frontResult = requireNotNull(latestState.frontHighResResult.data)
-                    postVerificationPageDataAndMaybeSubmit(
-                        identityViewModel = identityViewModel,
-                        collectedDataParam = CollectedDataParam(
+                    trySubmit(
+                        CollectedDataParam(
                             idDocumentFront = DocumentUploadParam(
                                 highResImage = requireNotNull(frontResult.uploadedStripeFile.id) {
                                     "front uploaded file id is null"
@@ -44,9 +42,7 @@ internal open class PassportUploadFragment(
                                 uploadMethod = frontResult.uploadMethod
                             ),
                             idDocumentType = CollectedDataParam.Type.PASSPORT
-                        ),
-                        clearDataParam = ClearDataParam.UPLOAD_TO_CONFIRM,
-                        shouldNotSubmit = { false }
+                        )
                     )
                 }.onFailure {
                     Log.d(TAG, "fail to submit uploaded files: $it")

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageDataRequirementError.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageDataRequirementError.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.identity.networking.models
 
+import androidx.annotation.IdRes
+import com.stripe.android.identity.R
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -29,5 +31,35 @@ internal data class VerificationPageDataRequirementError(
 
         @SerialName("id_document_type")
         IDDOCUMENTTYPE;
+
+        internal companion object {
+            private val SCAN_UPLOAD_FRAGMENT_ID_SET = setOf(
+                R.id.driverLicenseUploadFragment,
+                R.id.IDUploadFragment,
+                R.id.passportUploadFragment,
+                R.id.driverLicenseScanFragment,
+                R.id.IDScanFragment,
+                R.id.passportScanFragment
+            )
+
+            /**
+             * Checks whether the Requirement matches the Fragment the error occurred from.
+             */
+            fun Requirement.matchesFromFragment(@IdRes fromFragment: Int) =
+                when (this) {
+                    BIOMETRICCONSENT -> {
+                        fromFragment == R.id.consentFragment
+                    }
+                    IDDOCUMENTBACK -> {
+                        SCAN_UPLOAD_FRAGMENT_ID_SET.contains(fromFragment)
+                    }
+                    IDDOCUMENTFRONT -> {
+                        SCAN_UPLOAD_FRAGMENT_ID_SET.contains(fromFragment)
+                    }
+                    IDDOCUMENTTYPE -> {
+                        fromFragment == R.id.docSelectionFragment
+                    }
+                }
+        }
     }
 }

--- a/identity/src/test/java/com/stripe/android/identity/TestFixtures.kt
+++ b/identity/src/test/java/com/stripe/android/identity/TestFixtures.kt
@@ -3,7 +3,6 @@ package com.stripe.android.identity
 import com.stripe.android.identity.networking.VERIFICATION_PAGE_JSON_STRING
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPageData
-import com.stripe.android.identity.networking.models.VerificationPageDataRequirementError
 import com.stripe.android.identity.networking.models.VerificationPageDataRequirements
 import kotlinx.serialization.json.Json
 
@@ -29,23 +28,6 @@ internal val CORRECT_WITH_SUBMITTED_SUCCESS_VERIFICATION_PAGE_DATA = Verificatio
     ),
     status = VerificationPageData.Status.VERIFIED,
     submitted = true
-)
-
-internal val ERROR_VERIFICATION_PAGE_DATA = VerificationPageData(
-    id = "id",
-    objectType = "type",
-    requirements = VerificationPageDataRequirements(
-        errors = listOf(
-            VerificationPageDataRequirementError(
-                body = ERROR_BODY,
-                backButtonText = ERROR_BUTTON_TEXT,
-                requirement = VerificationPageDataRequirementError.Requirement.BIOMETRICCONSENT,
-                title = ERROR_TITLE
-            )
-        )
-    ),
-    status = VerificationPageData.Status.VERIFIED,
-    submitted = false
 )
 
 internal val json: Json = Json {

--- a/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
@@ -295,7 +295,7 @@ internal class ConsentFragmentTest {
                     assertThat(arguments[ErrorFragment.ARG_ERROR_CONTENT])
                         .isEqualTo(ERROR_BODY)
                     assertThat(arguments[ErrorFragment.ARG_GO_BACK_BUTTON_DESTINATION])
-                        .isEqualTo(R.id.action_errorFragment_to_consentFragment)
+                        .isEqualTo(R.id.consentFragment)
                     assertThat(arguments[ErrorFragment.ARG_GO_BACK_BUTTON_TEXT])
                         .isEqualTo(ERROR_BUTTON_TEXT)
                 }

--- a/identity/src/test/java/com/stripe/android/identity/navigation/ErrorFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/ErrorFragmentTest.kt
@@ -45,7 +45,7 @@ class ErrorFragmentTest {
 
     @Test
     fun `bottom button is set correctly when set`() {
-        launchErrorFragment(R.id.action_errorFragment_to_consentFragment).onFragment {
+        launchErrorFragment(ErrorFragment.UNEXPECTED_DESTINATION).onFragment {
             val navController = TestNavHostController(
                 ApplicationProvider.getApplicationContext()
             )

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IdentityCameraScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IdentityCameraScanFragmentTest.kt
@@ -74,6 +74,7 @@ class IdentityCameraScanFragmentTest {
     ) : IdentityCameraScanFragment(
         identityScanViewModelFactory, identityViewModelFactory
     ) {
+        override val fragmentId = R.id.IDScanFragment
         var currentState: IdentityScanState? = null
         var onCameraReadyIsCalled = false
 

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IdentityUploadFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IdentityUploadFragmentTest.kt
@@ -539,6 +539,7 @@ class IdentityUploadFragmentTest {
         override var backCheckMarkContentDescription: Int? = R.string.back_of_id_selected
         override val frontScanType = IdentityScanState.ScanType.ID_FRONT
         override var backScanType: IdentityScanState.ScanType? = IdentityScanState.ScanType.ID_BACK
+        override val fragmentId = R.id.IDUploadFragment
 
         override fun onCreateView(
             inflater: LayoutInflater,

--- a/identity/src/test/java/com/stripe/android/identity/utils/NavigationUtilsTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/utils/NavigationUtilsTest.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.IdRes
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.navigation.Navigation
@@ -16,9 +17,11 @@ import com.stripe.android.identity.CORRECT_WITH_SUBMITTED_SUCCESS_VERIFICATION_P
 import com.stripe.android.identity.ERROR_BODY
 import com.stripe.android.identity.ERROR_BUTTON_TEXT
 import com.stripe.android.identity.ERROR_TITLE
-import com.stripe.android.identity.ERROR_VERIFICATION_PAGE_DATA
 import com.stripe.android.identity.R
 import com.stripe.android.identity.navigation.ErrorFragment
+import com.stripe.android.identity.networking.models.VerificationPageData
+import com.stripe.android.identity.networking.models.VerificationPageDataRequirementError
+import com.stripe.android.identity.networking.models.VerificationPageDataRequirements
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
@@ -32,36 +35,173 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 internal class NavigationUtilsTest {
     @Test
-    fun `postVerificationPageDataAndMaybeSubmit navigates to error fragment when has error`() {
-        runBlocking {
-            val mockIdentityViewModel = mock<IdentityViewModel>().also {
-                whenever(it.postVerificationPageData(any(), any())).thenReturn(
-                    ERROR_VERIFICATION_PAGE_DATA
-                )
-            }
+    fun `postVerificationPageDataAndMaybeSubmit from consent navigates to error fragment when has BIOMETRICCONSENT error `() {
+        testPostVerificationPageDataAndMaybeSubmitWithError(
+            ERROR_VERIFICATION_PAGE_DATA_BIOMETRICCONSENT,
+            R.id.consentFragment,
+            R.id.consentFragment
+        )
+    }
 
-            launchFragment { navController, fragment ->
-                fragment.postVerificationPageDataAndMaybeSubmit(
-                    mockIdentityViewModel,
-                    mock(),
-                    mock(),
-                    { true },
-                    {}
-                )
+    @Test
+    fun `postVerificationPageDataAndMaybeSubmit from passportUpload navigates to error fragment when has IDDOCUMENT error`() {
+        testPostVerificationPageDataAndMaybeSubmitWithError(
+            ERROR_VERIFICATION_PAGE_DATA_IDDOCUMENTFRONT,
+            R.id.passportUploadFragment,
+            R.id.passportUploadFragment
+        )
 
-                requireNotNull(navController.backStack.last().arguments).let { arguments ->
-                    assertThat(arguments[ErrorFragment.ARG_ERROR_TITLE])
-                        .isEqualTo(ERROR_TITLE)
-                    assertThat(arguments[ErrorFragment.ARG_ERROR_CONTENT])
-                        .isEqualTo(ERROR_BODY)
-                    assertThat(arguments[ErrorFragment.ARG_GO_BACK_BUTTON_DESTINATION])
-                        .isEqualTo(R.id.action_errorFragment_to_consentFragment)
-                    assertThat(arguments[ErrorFragment.ARG_GO_BACK_BUTTON_TEXT])
-                        .isEqualTo(ERROR_BUTTON_TEXT)
-                }
-                assertThat(navController.currentDestination?.id)
-                    .isEqualTo(R.id.errorFragment)
+        testPostVerificationPageDataAndMaybeSubmitWithError(
+            ERROR_VERIFICATION_PAGE_DATA_IDDOCUMENTBACK,
+            R.id.passportUploadFragment,
+            R.id.passportUploadFragment
+        )
+    }
+
+    @Test
+    fun `postVerificationPageDataAndMaybeSubmit from idUpload navigates to error fragment when has IDDOCUMENT error`() {
+        testPostVerificationPageDataAndMaybeSubmitWithError(
+            ERROR_VERIFICATION_PAGE_DATA_IDDOCUMENTFRONT,
+            R.id.IDUploadFragment,
+            R.id.IDUploadFragment
+        )
+
+        testPostVerificationPageDataAndMaybeSubmitWithError(
+            ERROR_VERIFICATION_PAGE_DATA_IDDOCUMENTBACK,
+            R.id.IDUploadFragment,
+            R.id.IDUploadFragment
+        )
+    }
+
+    @Test
+    fun `postVerificationPageDataAndMaybeSubmit from driverLicenseUpload navigates to error fragment when has IDDOCUMENT error`() {
+        testPostVerificationPageDataAndMaybeSubmitWithError(
+            ERROR_VERIFICATION_PAGE_DATA_IDDOCUMENTFRONT,
+            R.id.driverLicenseUploadFragment,
+            R.id.driverLicenseUploadFragment
+        )
+
+        testPostVerificationPageDataAndMaybeSubmitWithError(
+            ERROR_VERIFICATION_PAGE_DATA_IDDOCUMENTBACK,
+            R.id.driverLicenseUploadFragment,
+            R.id.driverLicenseUploadFragment
+        )
+    }
+
+    @Test
+    fun `postVerificationPageDataAndMaybeSubmit from passportScan navigates to error fragment when has IDDOCUMENT error`() {
+        testPostVerificationPageDataAndMaybeSubmitWithError(
+            ERROR_VERIFICATION_PAGE_DATA_IDDOCUMENTFRONT,
+            R.id.passportScanFragment,
+            R.id.passportScanFragment
+        )
+
+        testPostVerificationPageDataAndMaybeSubmitWithError(
+            ERROR_VERIFICATION_PAGE_DATA_IDDOCUMENTBACK,
+            R.id.passportScanFragment,
+            R.id.passportScanFragment
+        )
+    }
+
+    @Test
+    fun `postVerificationPageDataAndMaybeSubmit from idScan navigates to error fragment when has IDDOCUMENT error`() {
+        testPostVerificationPageDataAndMaybeSubmitWithError(
+            ERROR_VERIFICATION_PAGE_DATA_IDDOCUMENTFRONT,
+            R.id.IDScanFragment,
+            R.id.IDScanFragment
+        )
+
+        testPostVerificationPageDataAndMaybeSubmitWithError(
+            ERROR_VERIFICATION_PAGE_DATA_IDDOCUMENTBACK,
+            R.id.IDScanFragment,
+            R.id.IDScanFragment
+        )
+    }
+
+    @Test
+    fun `postVerificationPageDataAndMaybeSubmit from driverLicenseScan navigates to error fragment when has IDDOCUMENT error`() {
+        testPostVerificationPageDataAndMaybeSubmitWithError(
+            ERROR_VERIFICATION_PAGE_DATA_IDDOCUMENTFRONT,
+            R.id.driverLicenseScanFragment,
+            R.id.driverLicenseScanFragment
+        )
+
+        testPostVerificationPageDataAndMaybeSubmitWithError(
+            ERROR_VERIFICATION_PAGE_DATA_IDDOCUMENTBACK,
+            R.id.driverLicenseScanFragment,
+            R.id.driverLicenseScanFragment
+        )
+    }
+
+    @Test
+    fun `postVerificationPageDataAndMaybeSubmit from docSelection navigates to error fragment when has IDDOCUMENTTYPE error`() {
+        testPostVerificationPageDataAndMaybeSubmitWithError(
+            ERROR_VERIFICATION_PAGE_DATA_IDDOCUMENTTYPE,
+            R.id.docSelectionFragment,
+            R.id.docSelectionFragment
+        )
+    }
+
+    @Test
+    fun `postVerificationPageDataAndMaybeSubmit navigates to error fragment with default destination when error type doesn't match`() {
+        // only uploadFragment and scanFragment could possible have IDDOCUMENTFRONT or IDDOCUMENTBACK errors,
+        // all other fragments should return with default destination when error returns with this type.
+
+        testPostVerificationPageDataAndMaybeSubmitWithError(
+            ERROR_VERIFICATION_PAGE_DATA_IDDOCUMENTFRONT,
+            R.id.consentFragment,
+            ErrorFragment.UNEXPECTED_DESTINATION
+        )
+        testPostVerificationPageDataAndMaybeSubmitWithError(
+            ERROR_VERIFICATION_PAGE_DATA_IDDOCUMENTBACK,
+            R.id.consentFragment,
+            ErrorFragment.UNEXPECTED_DESTINATION
+        )
+        testPostVerificationPageDataAndMaybeSubmitWithError(
+            ERROR_VERIFICATION_PAGE_DATA_IDDOCUMENTFRONT,
+            R.id.docSelectionFragment,
+            ErrorFragment.UNEXPECTED_DESTINATION
+        )
+        testPostVerificationPageDataAndMaybeSubmitWithError(
+            ERROR_VERIFICATION_PAGE_DATA_IDDOCUMENTBACK,
+            R.id.docSelectionFragment,
+            ErrorFragment.UNEXPECTED_DESTINATION
+        )
+    }
+
+    private fun testPostVerificationPageDataAndMaybeSubmitWithError(
+        errorResponse: VerificationPageData,
+        @IdRes fromFragment: Int,
+        @IdRes backButtonDestination: Int
+    ) = runBlocking {
+        val mockIdentityViewModel = mock<IdentityViewModel>().also {
+            whenever(it.postVerificationPageData(any(), any())).thenReturn(
+                errorResponse
+            )
+        }
+
+        launchFragment { navController, fragment ->
+            fragment.postVerificationPageDataAndMaybeSubmit(
+                mockIdentityViewModel,
+                mock(),
+                mock(),
+                fromFragment,
+                { true },
+                {}
+            )
+
+            requireNotNull(navController.backStack.last().arguments).let { arguments ->
+                assertThat(arguments[ErrorFragment.ARG_ERROR_TITLE])
+                    .isEqualTo(ERROR_TITLE)
+                assertThat(arguments[ErrorFragment.ARG_ERROR_CONTENT])
+                    .isEqualTo(ERROR_BODY)
+                assertThat(arguments[ErrorFragment.ARG_GO_BACK_BUTTON_DESTINATION])
+                    .isEqualTo(backButtonDestination)
+                assertThat(arguments[ErrorFragment.ARG_GO_BACK_BUTTON_TEXT])
+                    .isEqualTo(ERROR_BUTTON_TEXT)
             }
+            assertThat(navController.currentDestination?.id)
+                .isEqualTo(R.id.errorFragment)
         }
     }
 
@@ -79,6 +219,7 @@ internal class NavigationUtilsTest {
                     mockIdentityViewModel,
                     mock(),
                     mock(),
+                    R.id.consentFragment,
                     { true },
                     {}
                 )
@@ -104,6 +245,7 @@ internal class NavigationUtilsTest {
                     mockIdentityViewModel,
                     mock(),
                     mock(),
+                    R.id.consentFragment,
                     { true },
                     {
                         blockExecuted = true
@@ -132,6 +274,7 @@ internal class NavigationUtilsTest {
                     mockIdentityViewModel,
                     mock(),
                     mock(),
+                    R.id.consentFragment,
                     { false },
                     {}
                 )
@@ -150,7 +293,7 @@ internal class NavigationUtilsTest {
                 )
 
                 whenever(it.postVerificationPageSubmit()).thenReturn(
-                    ERROR_VERIFICATION_PAGE_DATA
+                    ERROR_VERIFICATION_PAGE_DATA_BIOMETRICCONSENT
                 )
             }
 
@@ -159,6 +302,7 @@ internal class NavigationUtilsTest {
                     mockIdentityViewModel,
                     mock(),
                     mock(),
+                    R.id.consentFragment,
                     { false },
                     {}
                 )
@@ -169,7 +313,7 @@ internal class NavigationUtilsTest {
                     assertThat(arguments[ErrorFragment.ARG_ERROR_CONTENT])
                         .isEqualTo(ERROR_BODY)
                     assertThat(arguments[ErrorFragment.ARG_GO_BACK_BUTTON_DESTINATION])
-                        .isEqualTo(R.id.action_errorFragment_to_consentFragment)
+                        .isEqualTo(R.id.consentFragment)
                     assertThat(arguments[ErrorFragment.ARG_GO_BACK_BUTTON_TEXT])
                         .isEqualTo(ERROR_BUTTON_TEXT)
                 }
@@ -197,6 +341,7 @@ internal class NavigationUtilsTest {
                     mockIdentityViewModel,
                     mock(),
                     mock(),
+                    R.id.consentFragment,
                     { false },
                     {}
                 )
@@ -225,6 +370,7 @@ internal class NavigationUtilsTest {
                     mockIdentityViewModel,
                     mock(),
                     mock(),
+                    R.id.consentFragment,
                     { false },
                     {}
                 )
@@ -253,6 +399,7 @@ internal class NavigationUtilsTest {
                     mockIdentityViewModel,
                     mock(),
                     mock(),
+                    R.id.consentFragment,
                     { false },
                     {}
                 )
@@ -287,5 +434,75 @@ internal class NavigationUtilsTest {
             container: ViewGroup?,
             savedInstanceState: Bundle?
         ) = View(context)
+    }
+
+    internal companion object {
+        internal val ERROR_VERIFICATION_PAGE_DATA_BIOMETRICCONSENT = VerificationPageData(
+            id = "id",
+            objectType = "type",
+            requirements = VerificationPageDataRequirements(
+                errors = listOf(
+                    VerificationPageDataRequirementError(
+                        body = ERROR_BODY,
+                        backButtonText = ERROR_BUTTON_TEXT,
+                        requirement = VerificationPageDataRequirementError.Requirement.BIOMETRICCONSENT,
+                        title = ERROR_TITLE
+                    )
+                )
+            ),
+            status = VerificationPageData.Status.VERIFIED,
+            submitted = false
+        )
+
+        internal val ERROR_VERIFICATION_PAGE_DATA_IDDOCUMENTBACK = VerificationPageData(
+            id = "id",
+            objectType = "type",
+            requirements = VerificationPageDataRequirements(
+                errors = listOf(
+                    VerificationPageDataRequirementError(
+                        body = ERROR_BODY,
+                        backButtonText = ERROR_BUTTON_TEXT,
+                        requirement = VerificationPageDataRequirementError.Requirement.IDDOCUMENTBACK,
+                        title = ERROR_TITLE
+                    )
+                )
+            ),
+            status = VerificationPageData.Status.VERIFIED,
+            submitted = false
+        )
+
+        internal val ERROR_VERIFICATION_PAGE_DATA_IDDOCUMENTFRONT = VerificationPageData(
+            id = "id",
+            objectType = "type",
+            requirements = VerificationPageDataRequirements(
+                errors = listOf(
+                    VerificationPageDataRequirementError(
+                        body = ERROR_BODY,
+                        backButtonText = ERROR_BUTTON_TEXT,
+                        requirement = VerificationPageDataRequirementError.Requirement.IDDOCUMENTFRONT,
+                        title = ERROR_TITLE
+                    )
+                )
+            ),
+            status = VerificationPageData.Status.VERIFIED,
+            submitted = false
+        )
+
+        internal val ERROR_VERIFICATION_PAGE_DATA_IDDOCUMENTTYPE = VerificationPageData(
+            id = "id",
+            objectType = "type",
+            requirements = VerificationPageDataRequirements(
+                errors = listOf(
+                    VerificationPageDataRequirementError(
+                        body = ERROR_BODY,
+                        backButtonText = ERROR_BUTTON_TEXT,
+                        requirement = VerificationPageDataRequirementError.Requirement.IDDOCUMENTTYPE,
+                        title = ERROR_TITLE
+                    )
+                )
+            ),
+            status = VerificationPageData.Status.VERIFIED,
+            submitted = false
+        )
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Instead of always going back to consent page, Parse `VerificationPageDataRequirementError.requirement` and determine the corresponding error page's back button destination.

* We just need to verify if the error requirement responsed does match our current Fragment, if it doesn't match then always fallback to navigating to `ConsentFragment`, please see [ErrorFragment.UNEXPECTED_DESTINATION] for detailed explanation.
* Note we can't use NavController.navigate() to the destination, as that would lose the arguments passed to the fragment. Instead, to preserve the params, keep calling `navigateUp()` until this fragment is reached, please see `NavController.navigateUpAndSetArgForUploadFragment` in `navigationUtils.kt` for details.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Correct back button destination

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
