### PR TITLE
[PaymentSheet] Modify the form to PaymentMethodCreateParams mapping.

### DIFF
--- a/link/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
@@ -139,7 +139,7 @@ private fun EmailCollectionSection(
         SectionElementUI(
             enabled = signUpState != SignUpState.VerifyingEmail,
             element = SectionElement(
-                identifier = IdentifierSpec.Generic("email"),
+                identifier = IdentifierSpec.Email,
                 fields = listOf(emailElement),
                 controller = SectionController(
                     null,

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -176,14 +176,6 @@ public final class com/stripe/android/ui/core/elements/IdentifierSpec$PostalCode
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
-public final class com/stripe/android/ui/core/elements/IdentifierSpec$PreFilledParameterMap : com/stripe/android/ui/core/elements/IdentifierSpec {
-	public static final field $stable I
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/IdentifierSpec$PreFilledParameterMap;
-	public fun describeContents ()I
-	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
 public final class com/stripe/android/ui/core/elements/IdentifierSpec$SaveForFutureUse : com/stripe/android/ui/core/elements/IdentifierSpec {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
@@ -232,67 +224,54 @@ public final class com/stripe/android/ui/core/elements/menu/CheckboxKt {
 
 public final class com/stripe/android/ui/core/forms/AffirmSpecKt {
 	public static final fun getAffirmForm ()Lcom/stripe/android/ui/core/elements/LayoutSpec;
-	public static final fun getAffirmParamKey ()Ljava/util/Map;
 }
 
 public final class com/stripe/android/ui/core/forms/AfterpayClearpaySpecKt {
 	public static final fun getAfterpayClearpayForm ()Lcom/stripe/android/ui/core/elements/LayoutSpec;
-	public static final fun getAfterpayClearpayParamKey ()Ljava/util/Map;
 }
 
 public final class com/stripe/android/ui/core/forms/AuBecsDebitSpecKt {
 	public static final fun getAuBecsDebitForm ()Lcom/stripe/android/ui/core/elements/LayoutSpec;
-	public static final fun getAuBecsDebitParamKey ()Ljava/util/Map;
 }
 
 public final class com/stripe/android/ui/core/forms/BancontactSpecKt {
 	public static final fun getBancontactForm ()Lcom/stripe/android/ui/core/elements/LayoutSpec;
-	public static final fun getBancontactParamKey ()Ljava/util/Map;
 }
 
 public final class com/stripe/android/ui/core/forms/CardSpecKt {
 	public static final fun getCardForm ()Lcom/stripe/android/ui/core/elements/LayoutSpec;
-	public static final fun getCardParamKey ()Ljava/util/Map;
 }
 
 public final class com/stripe/android/ui/core/forms/EpsSpecKt {
 	public static final fun getEpsForm ()Lcom/stripe/android/ui/core/elements/LayoutSpec;
-	public static final fun getEpsParamKey ()Ljava/util/Map;
 }
 
 public final class com/stripe/android/ui/core/forms/GiropaySpecKt {
 	public static final fun getGiropayForm ()Lcom/stripe/android/ui/core/elements/LayoutSpec;
-	public static final fun getGiropayParamKey ()Ljava/util/Map;
 }
 
 public final class com/stripe/android/ui/core/forms/IdealSpecKt {
 	public static final fun getIdealForm ()Lcom/stripe/android/ui/core/elements/LayoutSpec;
-	public static final fun getIdealParamKey ()Ljava/util/Map;
 }
 
 public final class com/stripe/android/ui/core/forms/KlarnaSpecKt {
 	public static final fun getKlarnaForm ()Lcom/stripe/android/ui/core/elements/LayoutSpec;
-	public static final fun getKlarnaParamKey ()Ljava/util/Map;
 }
 
 public final class com/stripe/android/ui/core/forms/P24SpecKt {
 	public static final fun getP24Form ()Lcom/stripe/android/ui/core/elements/LayoutSpec;
-	public static final fun getP24ParamKey ()Ljava/util/Map;
 }
 
 public final class com/stripe/android/ui/core/forms/PaypalSpecKt {
 	public static final fun getPaypalForm ()Lcom/stripe/android/ui/core/elements/LayoutSpec;
-	public static final fun getPaypalParamKey ()Ljava/util/Map;
 }
 
 public final class com/stripe/android/ui/core/forms/SepaDebitSpecKt {
 	public static final fun getSepaDebitForm ()Lcom/stripe/android/ui/core/elements/LayoutSpec;
-	public static final fun getSepaDebitParamKey ()Ljava/util/Map;
 }
 
 public final class com/stripe/android/ui/core/forms/SofortSpecKt {
 	public static final fun getSofortForm ()Lcom/stripe/android/ui/core/elements/LayoutSpec;
-	public static final fun getSofortParamKey ()Ljava/util/Map;
 }
 
 public final class com/stripe/android/ui/core/forms/TransformSpecToElements {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbElement.kt
@@ -17,7 +17,7 @@ class BsbElement(
         get() = identifierSpec
 
     internal val textElement: SimpleTextElement = SimpleTextElement(
-        identifier = IdentifierSpec.Generic("bsb_number"),
+        identifier = IdentifierSpec.Generic("au_becs_debit[bsb_number]"),
         SimpleTextFieldController(BsbConfig(banks))
     )
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbSpec.kt
@@ -8,7 +8,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 data class BsbSpec(
-    override val identifier: IdentifierSpec = IdentifierSpec.Generic("bsb_number")
+    override val identifier: IdentifierSpec = IdentifierSpec.Generic("au_becs_debit[bsb_number]")
 ) : FormItemSpec(), RequiredItemSpec, Parcelable {
     fun transform(): BsbElement =
         BsbElement(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
@@ -13,7 +13,7 @@ internal class CardDetailsController constructor(context: Context) : SectionFiel
     )
 
     val cvcElement = CvcElement(
-        IdentifierSpec.Generic("cvc"),
+        IdentifierSpec.Generic("card[cvc]"),
         CvcController(CvcConfig(), numberElement.controller.cardBrandFlow)
     )
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
@@ -51,10 +51,10 @@ internal class CardDetailsElement(
             controller.numberElement.identifier to number,
             controller.cvcElement.identifier to cvc,
             IdentifierSpec.CardBrand to FormFieldEntry(brand.code, true),
-            IdentifierSpec.Generic("exp_month") to expirationDate.copy(
+            IdentifierSpec.Generic("card[exp_month]") to expirationDate.copy(
                 value = month.toString()
             ),
-            IdentifierSpec.Generic("exp_year") to expirationDate.copy(
+            IdentifierSpec.Generic("card[exp_year]") to expirationDate.copy(
                 value = year.toString()
             )
         )

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IbanSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IbanSpec.kt
@@ -5,7 +5,7 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
-object IbanSpec : SectionFieldSpec(IdentifierSpec.Generic("iban")) {
+object IbanSpec : SectionFieldSpec(IdentifierSpec.Generic("sepa_debit[iban]")) {
     fun transform(): SectionFieldElement =
         IbanElement(
             this.identifier,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IdentifierSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IdentifierSpec.kt
@@ -15,42 +15,39 @@ sealed class IdentifierSpec(val value: String) : Parcelable {
 
     // Needed to pre-populate forms
     @Parcelize
-    object Name : IdentifierSpec("name")
+    object Name : IdentifierSpec("billing_details[name]")
 
     @Parcelize
-    object CardBrand : IdentifierSpec("card_brand_code")
+    object CardBrand : IdentifierSpec("card[brand]")
 
     @Parcelize
-    object CardNumber : IdentifierSpec("number")
+    object CardNumber : IdentifierSpec("card[number]")
 
     @Parcelize
-    object Email : IdentifierSpec("email")
+    object Email : IdentifierSpec("billing_details[email]")
 
     @Parcelize
-    object Phone : IdentifierSpec("phone")
+    object Phone : IdentifierSpec("billing_details[phone]")
 
     @Parcelize
-    object Line1 : IdentifierSpec("line1")
+    object Line1 : IdentifierSpec("billing_details[address][line1]")
 
     @Parcelize
-    object Line2 : IdentifierSpec("line2")
+    object Line2 : IdentifierSpec("billing_details[address][line2]")
 
     @Parcelize
-    object City : IdentifierSpec("city")
+    object City : IdentifierSpec("billing_details[address][city]")
 
     @Parcelize
-    object PostalCode : IdentifierSpec("postal_code")
+    object PostalCode : IdentifierSpec("billing_details[address][postal_code]")
 
     @Parcelize
-    object State : IdentifierSpec("state")
+    object State : IdentifierSpec("billing_details[address][state]")
 
     @Parcelize
-    object Country : IdentifierSpec("country")
+    object Country : IdentifierSpec("billing_details[address][country]")
 
     // Unique extracting functionality
     @Parcelize
     object SaveForFutureUse : IdentifierSpec("save_for_future_use")
-
-    @Parcelize
-    object PreFilledParameterMap : IdentifierSpec("save_for_future_use")
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/AffirmSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/AffirmSpec.kt
@@ -5,11 +5,6 @@ import com.stripe.android.ui.core.elements.AffirmTextSpec
 import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.ui.core.elements.LayoutSpec
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-val AffirmParamKey: MutableMap<String, Any?> = mutableMapOf(
-    "type" to "affirm"
-)
-
 internal val affirmHeader = AffirmTextSpec(
     IdentifierSpec.Generic("affirm_header")
 )

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/AfterpayClearpaySpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/AfterpayClearpaySpec.kt
@@ -9,14 +9,7 @@ import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.ui.core.elements.LayoutSpec
 import com.stripe.android.ui.core.elements.SectionSpec
 import com.stripe.android.ui.core.elements.SimpleTextSpec
-import com.stripe.android.ui.core.elements.billingParams
 import com.stripe.android.ui.core.elements.supportedBillingCountries
-
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-val AfterpayClearpayParamKey: MutableMap<String, Any?> = mutableMapOf(
-    "type" to "afterpay_clearpay",
-    "billing_details" to billingParams
-)
 
 internal val afterpayClearpayHeader = AfterpayClearpayTextSpec(
     IdentifierSpec.Generic("afterpay_clearpay_header")

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/AuBecsDebitSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/AuBecsDebitSpec.kt
@@ -12,19 +12,6 @@ import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.ui.core.elements.LayoutSpec
 import com.stripe.android.ui.core.elements.SectionSpec
 import com.stripe.android.ui.core.elements.SimpleTextSpec
-import com.stripe.android.ui.core.elements.billingParams
-
-internal val AuBecsDebitParams: MutableMap<String, Any?> = mutableMapOf(
-    "bsb_number" to null,
-    "account_number" to null
-)
-
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-val AuBecsDebitParamKey: MutableMap<String, Any?> = mutableMapOf(
-    "type" to "au_becs_debit",
-    "au_becs_debit" to AuBecsDebitParams,
-    "billing_details" to billingParams
-)
 
 internal val auBecsDebitNameSection = SectionSpec(
     IdentifierSpec.Generic("name_section"),
@@ -44,7 +31,7 @@ internal val auBecsDebitEmailSection = SectionSpec(
 internal val auBecsBsbNumberSection = BsbSpec()
 
 internal val auBecsDebitAccountNumberSection = SectionSpec(
-    IdentifierSpec.Generic("account_number"),
+    IdentifierSpec.Generic("au_becs_debit[account_number]"),
     AuBankAccountNumberSpec
 )
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/BancontactSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/BancontactSpec.kt
@@ -9,13 +9,6 @@ import com.stripe.android.ui.core.elements.MandateTextSpec
 import com.stripe.android.ui.core.elements.SaveForFutureUseSpec
 import com.stripe.android.ui.core.elements.SectionSpec
 import com.stripe.android.ui.core.elements.SimpleTextSpec
-import com.stripe.android.ui.core.elements.billingParams
-
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-val BancontactParamKey: MutableMap<String, Any?> = mutableMapOf(
-    "type" to "bancontact",
-    "billing_details" to billingParams
-)
 
 internal val bancontactNameSection = SectionSpec(
     IdentifierSpec.Generic("name_section"),

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/CardSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/CardSpec.kt
@@ -8,22 +8,7 @@ import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.ui.core.elements.LayoutSpec
 import com.stripe.android.ui.core.elements.SaveForFutureUseSpec
 import com.stripe.android.ui.core.elements.SectionSpec
-import com.stripe.android.ui.core.elements.billingParams
 import com.stripe.android.ui.core.elements.supportedBillingCountries
-
-internal val cardParams: MutableMap<String, Any?> = mutableMapOf(
-    "number" to null,
-    "exp_month" to null,
-    "exp_year" to null,
-    "cvc" to null,
-)
-
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-val CardParamKey: MutableMap<String, Any?> = mutableMapOf(
-    "type" to "card",
-    "billing_details" to billingParams,
-    "card" to cardParams
-)
 
 internal val creditDetailsSection = SectionSpec(
     IdentifierSpec.Generic("credit_details_section"),

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/EpsSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/EpsSpec.kt
@@ -8,18 +8,6 @@ import com.stripe.android.ui.core.elements.LayoutSpec
 import com.stripe.android.ui.core.elements.SectionSpec
 import com.stripe.android.ui.core.elements.SimpleTextSpec
 import com.stripe.android.ui.core.elements.SupportedBankType
-import com.stripe.android.ui.core.elements.billingParams
-
-internal val epsParams: MutableMap<String, Any?> = mutableMapOf(
-    "bank" to null,
-)
-
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-val EpsParamKey: MutableMap<String, Any?> = mutableMapOf(
-    "type" to "eps",
-    "billing_details" to billingParams,
-    "eps" to epsParams
-)
 
 internal val epsNameSection = SectionSpec(
     IdentifierSpec.Generic("name_section"),
@@ -29,7 +17,7 @@ internal val epsBankSection =
     SectionSpec(
         IdentifierSpec.Generic("bank_section"),
         BankDropdownSpec(
-            IdentifierSpec.Generic("bank"),
+            IdentifierSpec.Generic("eps[bank]"),
             R.string.eps_bank,
             SupportedBankType.Eps
         )

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/GiropaySpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/GiropaySpec.kt
@@ -5,13 +5,6 @@ import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.ui.core.elements.LayoutSpec
 import com.stripe.android.ui.core.elements.SectionSpec
 import com.stripe.android.ui.core.elements.SimpleTextSpec
-import com.stripe.android.ui.core.elements.billingParams
-
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-val GiropayParamKey: MutableMap<String, Any?> = mutableMapOf(
-    "type" to "giropay",
-    "billing_details" to billingParams,
-)
 
 internal val giropayNameSection = SectionSpec(
     IdentifierSpec.Generic("name_section"),

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/IdealSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/IdealSpec.kt
@@ -11,18 +11,6 @@ import com.stripe.android.ui.core.elements.SaveForFutureUseSpec
 import com.stripe.android.ui.core.elements.SectionSpec
 import com.stripe.android.ui.core.elements.SimpleTextSpec
 import com.stripe.android.ui.core.elements.SupportedBankType
-import com.stripe.android.ui.core.elements.billingParams
-
-internal val idealParams: MutableMap<String, Any?> = mutableMapOf(
-    "bank" to null,
-)
-
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-val IdealParamKey: MutableMap<String, Any?> = mutableMapOf(
-    "type" to "ideal",
-    "billing_details" to billingParams,
-    "ideal" to idealParams
-)
 
 internal val idealNameSection = SectionSpec(
     IdentifierSpec.Generic("name_section"),
@@ -32,7 +20,7 @@ internal val idealEmailSection = SectionSpec(IdentifierSpec.Email, EmailSpec)
 internal val idealBankSection = SectionSpec(
     IdentifierSpec.Generic("bank_section"),
     BankDropdownSpec(
-        IdentifierSpec.Generic("bank"),
+        IdentifierSpec.Generic("ideal[bank]"),
         R.string.ideal_bank,
         SupportedBankType.Ideal
     )

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/KlarnaSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/KlarnaSpec.kt
@@ -8,13 +8,6 @@ import com.stripe.android.ui.core.elements.KlarnaHelper
 import com.stripe.android.ui.core.elements.LayoutSpec
 import com.stripe.android.ui.core.elements.SectionSpec
 import com.stripe.android.ui.core.elements.StaticTextSpec
-import com.stripe.android.ui.core.elements.billingParams
-
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-val KlarnaParamKey: MutableMap<String, Any?> = mutableMapOf(
-    "type" to "klarna",
-    "billing_details" to billingParams
-)
 
 internal val klarnaHeader = StaticTextSpec(
     identifier = IdentifierSpec.Generic("klarna_header"),

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/P24Spec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/P24Spec.kt
@@ -9,18 +9,6 @@ import com.stripe.android.ui.core.elements.LayoutSpec
 import com.stripe.android.ui.core.elements.SectionSpec
 import com.stripe.android.ui.core.elements.SimpleTextSpec
 import com.stripe.android.ui.core.elements.SupportedBankType
-import com.stripe.android.ui.core.elements.billingParams
-
-internal val p24Params: MutableMap<String, Any?> = mutableMapOf(
-    "bank" to null,
-)
-
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-val P24ParamKey: MutableMap<String, Any?> = mutableMapOf(
-    "type" to "p24",
-    "billing_details" to billingParams,
-    "p24" to p24Params
-)
 
 internal val p24NameSection = SectionSpec(
     IdentifierSpec.Generic("name_section"),
@@ -34,7 +22,7 @@ internal val p24BankSection =
     SectionSpec(
         IdentifierSpec.Generic("bank_section"),
         BankDropdownSpec(
-            IdentifierSpec.Generic("bank"),
+            IdentifierSpec.Generic("p24[bank]"),
             R.string.p24_bank,
             SupportedBankType.P24
         )

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/PaypalSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/PaypalSpec.kt
@@ -4,9 +4,4 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.ui.core.elements.LayoutSpec
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-val PaypalParamKey: MutableMap<String, Any?> = mutableMapOf(
-    "type" to "paypal",
-)
-
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 val PaypalForm = LayoutSpec.create()

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/SepaDebitSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/SepaDebitSpec.kt
@@ -11,19 +11,7 @@ import com.stripe.android.ui.core.elements.MandateTextSpec
 import com.stripe.android.ui.core.elements.SaveForFutureUseSpec
 import com.stripe.android.ui.core.elements.SectionSpec
 import com.stripe.android.ui.core.elements.SimpleTextSpec
-import com.stripe.android.ui.core.elements.billingParams
 import com.stripe.android.ui.core.elements.supportedBillingCountries
-
-internal val sepaDebitParams: MutableMap<String, Any?> = mutableMapOf(
-    "iban" to null
-)
-
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-val SepaDebitParamKey: MutableMap<String, Any?> = mutableMapOf(
-    "type" to "sepa_debit",
-    "billing_details" to billingParams,
-    "sepa_debit" to sepaDebitParams
-)
 
 internal val sepaDebitNameSection = SectionSpec(
     IdentifierSpec.Generic("name_section"),

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/SofortSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/SofortSpec.kt
@@ -10,18 +10,6 @@ import com.stripe.android.ui.core.elements.MandateTextSpec
 import com.stripe.android.ui.core.elements.SaveForFutureUseSpec
 import com.stripe.android.ui.core.elements.SectionSpec
 import com.stripe.android.ui.core.elements.SimpleTextSpec
-import com.stripe.android.ui.core.elements.billingParams
-
-internal val sofortParams: MutableMap<String, Any?> = mutableMapOf(
-    "country" to null,
-)
-
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-val SofortParamKey: MutableMap<String, Any?> = mutableMapOf(
-    "type" to "sofort",
-    "billing_details" to billingParams,
-    "sofort" to sofortParams
-)
 
 internal val sofortNameSection = SectionSpec(
     IdentifierSpec.Generic("name_section"),

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressControllerTest.kt
@@ -27,7 +27,7 @@ class AddressControllerTest {
                 emailController
             ),
             IbanElement(
-                IdentifierSpec.Generic("iban"),
+                IdentifierSpec.Generic("sepa_debit[iban]"),
                 ibanController
             )
         )

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressElementTest.kt
@@ -39,7 +39,7 @@ class AddressElementTest {
             "JP",
             listOf(
                 IbanElement(
-                    IdentifierSpec.Generic("iban"),
+                    IdentifierSpec.Generic("sepa_debit[iban]"),
                     SimpleTextFieldController(IbanConfig())
                 )
             )
@@ -131,7 +131,7 @@ class AddressElementTest {
         ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
         firstForFieldValues = formFieldValueFlow.first()
-        assertThat(firstForFieldValues.toMap()[IdentifierSpec.Generic("iban")])
+        assertThat(firstForFieldValues.toMap()[IdentifierSpec.Generic("sepa_debit[iban]")])
             .isEqualTo(
                 FormFieldEntry("DE89370400440532013000", true)
             )

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardBillingAddressElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardBillingAddressElementTest.kt
@@ -39,7 +39,7 @@ internal class CardBillingAddressElementTest {
             "JP",
             listOf(
                 IbanElement(
-                    IdentifierSpec.Generic("iban"),
+                    IdentifierSpec.Generic("sepa_debit[iban]"),
                     SimpleTextFieldController(IbanConfig())
                 )
             )

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsElementTest.kt
@@ -39,10 +39,10 @@ class CardDetailsElementTest {
 
         Truth.assertThat(flowValues[flowValues.size - 1]).isEqualTo(
             listOf(
-                IdentifierSpec.Generic("number") to FormFieldEntry("4242424242424242", true),
-                IdentifierSpec.Generic("cvc") to FormFieldEntry("321", true),
-                IdentifierSpec.Generic("exp_month") to FormFieldEntry("1", true),
-                IdentifierSpec.Generic("exp_year") to FormFieldEntry("30", true),
+                IdentifierSpec.Generic("card[number]") to FormFieldEntry("4242424242424242", true),
+                IdentifierSpec.Generic("card[cvc]") to FormFieldEntry("321", true),
+                IdentifierSpec.Generic("card[exp_month]") to FormFieldEntry("1", true),
+                IdentifierSpec.Generic("card[exp_year]") to FormFieldEntry("30", true),
             )
         )
     }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/TransformSpecToElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/TransformSpecToElementTest.kt
@@ -244,7 +244,7 @@ internal class TransformSpecToElementTest {
 
     companion object {
         val IDEAL_BANK_CONFIG = BankDropdownSpec(
-            IdentifierSpec.Generic("bank"),
+            IdentifierSpec.Generic("ideal[bank]"),
             R.string.ideal_bank,
             SupportedBankType.Ideal
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormFieldValues.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormFieldValues.kt
@@ -7,7 +7,7 @@ import com.stripe.android.ui.core.forms.FormFieldEntry
 /**
  * The identifier here comes from the form element (section, static text, etc)
  */
-internal class FormFieldValues(
+internal data class FormFieldValues(
     val fieldValuePairs: Map<IdentifierSpec, FormFieldEntry> = mapOf(),
     val showsMandate: Boolean,
     val userRequestedReuse: PaymentSelection.CustomerRequestedSave

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethod.kt
@@ -16,8 +16,6 @@ import com.stripe.android.paymentsheet.forms.AfterpayClearpayRequirement
 import com.stripe.android.paymentsheet.forms.AuBecsDebitRequirement
 import com.stripe.android.paymentsheet.forms.BancontactRequirement
 import com.stripe.android.paymentsheet.forms.CardRequirement
-import com.stripe.android.ui.core.forms.CardForm
-import com.stripe.android.ui.core.forms.CardParamKey
 import com.stripe.android.paymentsheet.forms.Delayed
 import com.stripe.android.paymentsheet.forms.EpsRequirement
 import com.stripe.android.paymentsheet.forms.GiropayRequirement
@@ -34,29 +32,18 @@ import com.stripe.android.paymentsheet.forms.SofortRequirement
 import com.stripe.android.ui.core.elements.LayoutFormDescriptor
 import com.stripe.android.ui.core.elements.LayoutSpec
 import com.stripe.android.ui.core.forms.AffirmForm
-import com.stripe.android.ui.core.forms.AffirmParamKey
 import com.stripe.android.ui.core.forms.AfterpayClearpayForm
-import com.stripe.android.ui.core.forms.AfterpayClearpayParamKey
-import com.stripe.android.ui.core.forms.BancontactForm
-import com.stripe.android.ui.core.forms.BancontactParamKey
-import com.stripe.android.ui.core.forms.EpsForm
-import com.stripe.android.ui.core.forms.EpsParamKey
-import com.stripe.android.ui.core.forms.GiropayForm
-import com.stripe.android.ui.core.forms.GiropayParamKey
-import com.stripe.android.ui.core.forms.IdealForm
-import com.stripe.android.ui.core.forms.IdealParamKey
-import com.stripe.android.ui.core.forms.KlarnaForm
-import com.stripe.android.ui.core.forms.KlarnaParamKey
-import com.stripe.android.ui.core.forms.P24Form
-import com.stripe.android.ui.core.forms.P24ParamKey
-import com.stripe.android.ui.core.forms.PaypalForm
-import com.stripe.android.ui.core.forms.PaypalParamKey
-import com.stripe.android.ui.core.forms.SepaDebitForm
-import com.stripe.android.ui.core.forms.SepaDebitParamKey
-import com.stripe.android.ui.core.forms.SofortForm
-import com.stripe.android.ui.core.forms.SofortParamKey
 import com.stripe.android.ui.core.forms.AuBecsDebitForm
-import com.stripe.android.ui.core.forms.AuBecsDebitParamKey
+import com.stripe.android.ui.core.forms.BancontactForm
+import com.stripe.android.ui.core.forms.CardForm
+import com.stripe.android.ui.core.forms.EpsForm
+import com.stripe.android.ui.core.forms.GiropayForm
+import com.stripe.android.ui.core.forms.IdealForm
+import com.stripe.android.ui.core.forms.KlarnaForm
+import com.stripe.android.ui.core.forms.P24Form
+import com.stripe.android.ui.core.forms.PaypalForm
+import com.stripe.android.ui.core.forms.SepaDebitForm
+import com.stripe.android.ui.core.forms.SofortForm
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -88,11 +75,6 @@ sealed class SupportedPaymentMethod(
     private val requirement: PaymentMethodRequirements,
 
     /**
-     * This is a map of the fields in payment_method_options.  See [this](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-payment_method_options) for details.
-     */
-    val paramKey: MutableMap<String, Any?>,
-
-    /**
      * This describes how the UI should look.
      */
     val formSpec: LayoutSpec,
@@ -104,7 +86,6 @@ sealed class SupportedPaymentMethod(
         R.string.stripe_paymentsheet_payment_method_card,
         R.drawable.stripe_ic_paymentsheet_pm_card,
         CardRequirement,
-        CardParamKey,
         CardForm
     )
 
@@ -115,7 +96,6 @@ sealed class SupportedPaymentMethod(
         R.string.stripe_paymentsheet_payment_method_bancontact,
         R.drawable.stripe_ic_paymentsheet_pm_bancontact,
         BancontactRequirement,
-        BancontactParamKey,
         BancontactForm
     )
 
@@ -126,7 +106,6 @@ sealed class SupportedPaymentMethod(
         R.string.stripe_paymentsheet_payment_method_sofort,
         R.drawable.stripe_ic_paymentsheet_pm_klarna,
         SofortRequirement,
-        SofortParamKey,
         SofortForm
     )
 
@@ -137,7 +116,6 @@ sealed class SupportedPaymentMethod(
         R.string.stripe_paymentsheet_payment_method_ideal,
         R.drawable.stripe_ic_paymentsheet_pm_ideal,
         IdealRequirement,
-        IdealParamKey,
         IdealForm
     )
 
@@ -148,7 +126,6 @@ sealed class SupportedPaymentMethod(
         R.string.stripe_paymentsheet_payment_method_sepa_debit,
         R.drawable.stripe_ic_paymentsheet_pm_sepa_debit,
         SepaDebitRequirement,
-        SepaDebitParamKey,
         SepaDebitForm
     )
 
@@ -159,7 +136,6 @@ sealed class SupportedPaymentMethod(
         R.string.stripe_paymentsheet_payment_method_eps,
         R.drawable.stripe_ic_paymentsheet_pm_eps,
         EpsRequirement,
-        EpsParamKey,
         EpsForm
     )
 
@@ -170,7 +146,6 @@ sealed class SupportedPaymentMethod(
         R.string.stripe_paymentsheet_payment_method_p24,
         R.drawable.stripe_ic_paymentsheet_pm_p24,
         P24Requirement,
-        P24ParamKey,
         P24Form
     )
 
@@ -181,7 +156,6 @@ sealed class SupportedPaymentMethod(
         R.string.stripe_paymentsheet_payment_method_giropay,
         R.drawable.stripe_ic_paymentsheet_pm_giropay,
         GiropayRequirement,
-        GiropayParamKey,
         GiropayForm
     )
 
@@ -192,7 +166,6 @@ sealed class SupportedPaymentMethod(
         R.string.stripe_paymentsheet_payment_method_afterpay_clearpay,
         R.drawable.stripe_ic_paymentsheet_pm_afterpay_clearpay,
         AfterpayClearpayRequirement,
-        AfterpayClearpayParamKey,
         AfterpayClearpayForm
     )
 
@@ -203,7 +176,6 @@ sealed class SupportedPaymentMethod(
         R.string.stripe_paymentsheet_payment_method_klarna,
         R.drawable.stripe_ic_paymentsheet_pm_klarna,
         KlarnaRequirement,
-        KlarnaParamKey,
         KlarnaForm
     )
 
@@ -214,7 +186,6 @@ sealed class SupportedPaymentMethod(
         R.string.stripe_paymentsheet_payment_method_paypal,
         R.drawable.stripe_ic_paymentsheet_pm_paypal,
         PaypalRequirement,
-        PaypalParamKey,
         PaypalForm
     )
 
@@ -225,7 +196,6 @@ sealed class SupportedPaymentMethod(
         R.string.stripe_paymentsheet_payment_method_affirm,
         R.drawable.stripe_ic_paymentsheet_pm_affirm,
         AffirmRequirement,
-        AffirmParamKey,
         AffirmForm
     )
 
@@ -236,7 +206,6 @@ sealed class SupportedPaymentMethod(
         R.string.stripe_paymentsheet_payment_method_au_becs_debit,
         R.drawable.stripe_ic_paymentsheet_pm_bank,
         AuBecsDebitRequirement,
-        AuBecsDebitParamKey,
         AuBecsDebitForm
     )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ComposeFormDataCollectionFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ComposeFormDataCollectionFragment.kt
@@ -29,13 +29,6 @@ internal class ComposeFormDataCollectionFragment : Fragment() {
         )
     }
 
-    val paramKeySpec by lazy {
-        requireNotNull(
-            requireArguments().getParcelable<FormFragmentArguments>(EXTRA_CONFIG)
-                ?.paymentMethod?.paramKey
-        )
-    }
-
     val formViewModel: FormViewModel by viewModels {
         FormViewModel.Factory(
             resource = resources,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddPaymentMethodFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddPaymentMethodFragmentTest.kt
@@ -518,15 +518,6 @@ internal class PaymentSheetAddPaymentMethodFragmentTest : PaymentSheetViewModelT
         val selection =
             BaseAddPaymentMethodFragment.transformToPaymentSelection(
                 formFieldValues,
-                mapOf(
-                    "type" to "card",
-                    "card" to mapOf(
-                        "number" to null,
-                        "exp_month" to null,
-                        "exp_year" to null,
-                        "cvc" to null,
-                    )
-                ),
                 SupportedPaymentMethod.Card
             )
         assertThat(selection?.customerRequestedSave).isEqualTo(
@@ -552,9 +543,6 @@ internal class PaymentSheetAddPaymentMethodFragmentTest : PaymentSheetViewModelT
         val selection =
             BaseAddPaymentMethodFragment.transformToPaymentSelection(
                 formFieldValues,
-                mapOf(
-                    "type" to "sofort"
-                ),
                 SupportedPaymentMethod.Sofort
             )
         assertThat(selection?.customerRequestedSave).isEqualTo(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/TransformToPaymentMethodCreateParamMapTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/TransformToPaymentMethodCreateParamMapTest.kt
@@ -1,8 +1,11 @@
 package com.stripe.android.paymentsheet.paymentdatacollection
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.paymentdatacollection.TransformToPaymentMethodCreateParams.Companion.addPath
+import com.stripe.android.paymentsheet.paymentdatacollection.TransformToPaymentMethodCreateParams.Companion.getKeys
 import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.ui.core.forms.FormFieldEntry
 import org.junit.Test
@@ -14,7 +17,7 @@ class TransformToPaymentMethodCreateParamMapTest {
             .transform(
                 FormFieldValues(
                     mapOf(
-                        IdentifierSpec.Generic("bank") to FormFieldEntry(
+                        IdentifierSpec.Generic("ideal[bank]") to FormFieldEntry(
                             "abn_amro",
                             true
                         )
@@ -22,19 +25,52 @@ class TransformToPaymentMethodCreateParamMapTest {
                     showsMandate = false,
                     userRequestedReuse = PaymentSelection.CustomerRequestedSave.RequestReuse
                 ),
-                mapOf(
-                    "type" to "ideal",
-                    "billing_details" to billingParams,
-                    "ideal" to mapOf("bank" to null)
-                ),
+                PaymentMethod.Type.Ideal,
             )
 
-        assertThat(paymentMethodParams?.toParamMap().toString().replace("\\s".toRegex(), ""))
+        assertThat(paymentMethodParams.toParamMap().toString().replace("\\s".toRegex(), ""))
             .isEqualTo(
                 """
-                    {type=ideal,billing_details={address={city=null,country=null,line1=null,line2=null,postal_code=null,state=null},name=null,email=null,phone=null},ideal={bank=abn_amro}}
+                    {type=ideal,ideal={bank=abn_amro}}
                 """.trimIndent()
             )
+    }
+
+    @Test
+    fun `test function`() {
+        val map: MutableMap<String, Any?> = mutableMapOf("type" to "card")
+        FormFieldValues(
+            mapOf(
+                IdentifierSpec.Name to FormFieldEntry(
+                    "joe",
+                    true
+                ),
+                IdentifierSpec.Email to FormFieldEntry(
+                    "joe@gmail.com",
+                    true
+                ),
+                IdentifierSpec.Generic("billing_details[address][country]") to FormFieldEntry(
+                    "US",
+                    true
+                ),
+            ),
+            showsMandate = false,
+            userRequestedReuse = PaymentSelection.CustomerRequestedSave.RequestReuse
+        ).fieldValuePairs.entries.forEach {
+            addPath(map, getKeys(it.key.value), it.value.value)
+        }
+        assertThat(map).isEqualTo(
+            mapOf(
+                "type" to "card",
+                "billing_details" to mapOf(
+                    "name" to "joe",
+                    "email" to "joe@gmail.com",
+                    "address" to mapOf(
+                        "country" to "US"
+                    )
+                )
+            )
+        )
     }
 
     @Test
@@ -51,61 +87,37 @@ class TransformToPaymentMethodCreateParamMapTest {
                             "joe@gmail.com",
                             true
                         ),
-                        IdentifierSpec.Generic("country") to FormFieldEntry(
+                        IdentifierSpec.Generic("billing_details[address][country]") to FormFieldEntry(
                             "US",
+                            true
+                        ),
+                        IdentifierSpec.Line1 to FormFieldEntry(
+                            "123 Main Street",
                             true
                         ),
                     ),
                     showsMandate = false,
                     userRequestedReuse = PaymentSelection.CustomerRequestedSave.RequestReuse
                 ),
-                mapOf(
-                    "type" to "sofort",
-                    "billing_details" to billingParams,
-                    "sofort" to mapOf("country" to null)
-                ),
+                PaymentMethod.Type.Sofort,
             )
 
         assertThat(
-            paymentMethodParams?.toParamMap().toString().replace("\\s".toRegex(), "")
+            paymentMethodParams.toParamMap().toString()
         ).isEqualTo(
-            """
-                {
-                  type=sofort,
-                  billing_details={
-                    address={
-                      city=null,
-                      country=US,
-                      line1=null,
-                      line2=null,
-                      postal_code=null,
-                      state=null
-                    },
-                    name=joe,
-                    email=joe@gmail.com,
-                    phone=null
-                  },
-                  sofort={country=US}
-                }
-            """.replace("\\s".toRegex(), "")
-        )
-    }
-
-    companion object {
-        val addressParams: MutableMap<String, Any?> = mutableMapOf(
-            "city" to null,
-            "country" to null,
-            "line1" to null,
-            "line2" to null,
-            "postal_code" to null,
-            "state" to null,
-        )
-
-        val billingParams: MutableMap<String, Any?> = mutableMapOf(
-            "address" to addressParams,
-            "name" to null,
-            "email" to null,
-            "phone" to null,
+            "{" +
+                "type=sofort, " +
+                "billing_details={" +
+                "name=joe, " +
+                "email=joe@gmail.com, " +
+                "address={country=US, " +
+                "line1=123 Main Street" +
+                "}" +
+                "}, " +
+                "sofort={" +
+                "country=US" +
+                "}" +
+                "}"
         )
     }
 }


### PR DESCRIPTION
# Summary
Change how mapping from field field values works.   The form field value identifier should be of the form key[key] = value, which maps to the payment method create params.

# Motivation
This is one iteration to getting closer to a shared specification.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified:  Added a log statement to print the PaymentMethodCreateParams in the BaseAddPaymentMethodFragment, and compared it before and after the change.

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
