### PR TITLE
Fix the failing CardDetailsElementUI.

### DIFF
--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsElementTest.kt
@@ -39,8 +39,9 @@ class CardDetailsElementTest {
 
         Truth.assertThat(flowValues[flowValues.size - 1]).isEqualTo(
             listOf(
-                IdentifierSpec.Generic("number") to FormFieldEntry("4242424242424242", true),
+                IdentifierSpec.CardNumber to FormFieldEntry("4242424242424242", true),
                 IdentifierSpec.Generic("cvc") to FormFieldEntry("321", true),
+                IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
                 IdentifierSpec.Generic("exp_month") to FormFieldEntry("1", true),
                 IdentifierSpec.Generic("exp_year") to FormFieldEntry("30", true),
             )


### PR DESCRIPTION
# Summary
A form field value for the brand was added, but not correctly updated in the unit test.
