### PR TITLE
[stripe-core] Change from `HttpsURLConnection` to `HttpURLConnection`

### DIFF
--- a/stripe-core/api/stripe-core.api
+++ b/stripe-core/api/stripe-core.api
@@ -275,14 +275,6 @@ public final class com/stripe/android/core/networking/RetryDelaySupplier_Factory
 	public static fun newInstance ()Lcom/stripe/android/core/networking/RetryDelaySupplier;
 }
 
-public abstract class com/stripe/android/core/networking/StripeConnection$AbstractConnection : com/stripe/android/core/networking/StripeConnection {
-	public static final field $stable I
-	public fun <init> (Ljavax/net/ssl/HttpsURLConnection;)V
-	public fun close ()V
-	public synthetic fun getResponse ()Lcom/stripe/android/core/networking/StripeResponse;
-	public synthetic fun getResponseCode ()I
-}
-
 public final class com/stripe/android/core/networking/StripeConnection$Default : com/stripe/android/core/networking/StripeConnection$AbstractConnection {
 	public static final field $stable I
 	public synthetic fun createBodyFromResponseStream (Ljava/io/InputStream;)Ljava/lang/Object;

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/ConnectionFactory.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/ConnectionFactory.kt
@@ -4,12 +4,12 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.core.exception.InvalidRequestException
 import java.io.File
 import java.io.IOException
+import java.net.HttpURLConnection
 import java.net.URL
 import java.util.concurrent.TimeUnit
-import javax.net.ssl.HttpsURLConnection
 
 /**
- * Factory to create [StripeConnection], which encapsulates an [HttpsURLConnection], triggers the
+ * Factory to create [StripeConnection], which encapsulates an [HttpURLConnection], triggers the
  * request and parses the response with different body type as [StripeResponse].
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -43,8 +43,8 @@ interface ConnectionFactory {
             )
         }
 
-        private fun openConnectionAndApplyFields(request: StripeRequest): HttpsURLConnection {
-            return (URL(request.url).openConnection() as HttpsURLConnection).apply {
+        private fun openConnectionAndApplyFields(request: StripeRequest): HttpURLConnection {
+            return (URL(request.url).openConnection() as HttpURLConnection).apply {
                 connectTimeout = CONNECT_TIMEOUT
                 readTimeout = READ_TIMEOUT
                 useCaches = false

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/StripeConnection.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/StripeConnection.kt
@@ -9,7 +9,6 @@ import java.io.InputStream
 import java.net.HttpURLConnection
 import java.nio.charset.StandardCharsets
 import java.util.Scanner
-import javax.net.ssl.HttpsURLConnection
 
 /**
  * A wrapper for accessing a [HttpURLConnection]. Implements [Closeable] to simplify closing related
@@ -21,8 +20,9 @@ interface StripeConnection<ResponseBodyType> : Closeable {
     val response: StripeResponse<ResponseBodyType>
     fun createBodyFromResponseStream(responseStream: InputStream?): ResponseBodyType?
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     abstract class AbstractConnection<ResponseBodyType>(
-        private val conn: HttpsURLConnection
+        private val conn: HttpURLConnection
     ) : StripeConnection<ResponseBodyType> {
         override val responseCode: Int
             @JvmSynthetic
@@ -67,7 +67,7 @@ interface StripeConnection<ResponseBodyType> : Closeable {
      * Default [StripeConnection] that converts the ResponseStream to a String.
      */
     class Default internal constructor(
-        conn: HttpsURLConnection
+        conn: HttpURLConnection
     ) : AbstractConnection<String>(conn = conn) {
 
         /**
@@ -95,7 +95,7 @@ interface StripeConnection<ResponseBodyType> : Closeable {
      * [StripeConnection] that writes the ResponseStream to a File.
      */
     class FileConnection internal constructor(
-        conn: HttpsURLConnection,
+        conn: HttpURLConnection,
         private val outputFile: File
     ) : AbstractConnection<File>(conn = conn) {
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Change the interface in the network stack from `HttpsURLConnection` to `HttpURLConnection`

* Note this change will not change the behavior of the networkstack, as `HttpURLConnection` is a super class of `HttpsURLConnection`, and all of our current URLs requested here are `https://` API requests, they will still create an instance of `HttpsURLConnection`.

* This change is needed when we need to access an "http://" link. e.g Identity needs to load such a url for client's logo image.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Support `http://`

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
