### PR TITLE
Prevent crash on null response intent

### DIFF
--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet.kt
@@ -137,8 +137,8 @@ class CardImageVerificationSheet private constructor(
             Intent(context, CardImageVerificationActivity::class.java)
                 .putExtra(INTENT_PARAM_REQUEST, input)
 
-        private fun parseResult(intent: Intent): CardImageVerificationSheetResult =
-            intent.getParcelableExtra(INTENT_PARAM_RESULT)
+        private fun parseResult(intent: Intent?): CardImageVerificationSheetResult =
+            intent?.getParcelableExtra(INTENT_PARAM_RESULT)
                 ?: CardImageVerificationSheetResult.Failed(
                     UnknownScanException("No data in the result intent")
                 )
@@ -155,7 +155,7 @@ class CardImageVerificationSheet private constructor(
             override fun parseResult(
                 resultCode: Int,
                 intent: Intent?,
-            ) = this@Companion.parseResult(requireNotNull(intent))
+            ) = this@Companion.parseResult(intent)
         }
     }
 

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanSheet.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanSheet.kt
@@ -109,8 +109,8 @@ class CardScanSheet private constructor(private val stripePublishableKey: String
             Intent(context, CardScanActivity::class.java)
                 .putExtra(INTENT_PARAM_REQUEST, input)
 
-        private fun parseResult(intent: Intent): CardScanSheetResult =
-            intent.getParcelableExtra(INTENT_PARAM_RESULT)
+        private fun parseResult(intent: Intent?): CardScanSheetResult =
+            intent?.getParcelableExtra(INTENT_PARAM_RESULT)
                 ?: CardScanSheetResult.Failed(
                     UnknownScanException("No data in the result intent")
                 )
@@ -139,7 +139,7 @@ class CardScanSheet private constructor(private val stripePublishableKey: String
             override fun parseResult(
                 resultCode: Int,
                 intent: Intent?,
-            ) = this@Companion.parseResult(requireNotNull(intent))
+            ) = this@Companion.parseResult(intent)
         }
     }
 


### PR DESCRIPTION
# Summary
If the response intent is null, we should fail gracefully instead of crash

# Motivation
https://github.com/getbouncer/cardscan-android/issues/506

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified