### PR TITLE
Fix us_bank_account examples

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/ConnectUSBankAccountActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/ConnectUSBankAccountActivity.kt
@@ -34,12 +34,15 @@ class ConnectUSBankAccountActivity : StripeIntentActivity() {
         launcher = CollectBankAccountLauncher.create(
             this
         ) { result: CollectBankAccountResult ->
+            viewModel.inProgress.postValue(false)
             when (result) {
                 is CollectBankAccountResult.Completed -> {
                     viewModel.status
                         .postValue(
                             "Attached bank account to paymentIntent." +
-                                " secret: ${result.response.intent.clientSecret}. Confirming..."
+                                " secret: ${result.response.intent.clientSecret}. Attempting to " +
+                                "confirm payment intent. You should have webhooks setup to check" +
+                                " the final state of this payment intent."
                         )
                     confirmPaymentIntent(
                         ConfirmPaymentIntentParams.create(

--- a/example/src/main/java/com/stripe/example/activity/ManualUSBankAccountPaymentMethodActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/ManualUSBankAccountPaymentMethodActivity.kt
@@ -55,7 +55,7 @@ class ManualUSBankAccountPaymentMethodActivity : StripeIntentActivity() {
     private val verifyCallback = object : ApiResultCallback<StripeIntent> {
         override fun onSuccess(result: StripeIntent) {
             viewModel.inProgress.value = false
-            viewModel.status.value += "Account verified with \n\n$result\n"
+            viewModel.status.value += "Attempted to verify with \n\n$result\n"
         }
 
         override fun onError(e: Exception) {
@@ -345,15 +345,15 @@ class ManualUSBankAccountPaymentMethodActivity : StripeIntentActivity() {
         if (inProgress) {
             LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
         }
-        if (status.isNotEmpty()) {
-            Text(text = status)
-        } else {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(10.dp)
-                    .verticalScroll(scrollState)
-            ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(10.dp)
+                .verticalScroll(scrollState)
+        ) {
+            if (status.isNotEmpty()) {
+                Text(text = status)
+            } else {
                 Text(text = "Enter verification details from your bank account.")
                 OutlinedTextField(
                     modifier = Modifier.fillMaxWidth(),
@@ -390,8 +390,8 @@ class ManualUSBankAccountPaymentMethodActivity : StripeIntentActivity() {
                     onClick = {
                         verifyWithMicrodeposits(
                             descriptorCode = descriptorCode.value,
-                            firstAmount = firstAmount.value.toInt(),
-                            secondAmount = secondAmount.value.toInt()
+                            firstAmount = firstAmount.value.toIntOrNull() ?: 0,
+                            secondAmount = secondAmount.value.toIntOrNull() ?: 0
                         )
                     }
                 )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

- Fix stuck in loading (progress indicator keeps animating)
- Add message for listening to webhooks for case when user selects a bank account which results in a payment intent error
- Fix a crash wish descriptor code

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
