### PR TITLE
Removes ConnectionsSheet constructors in favor of create static functions.

### DIFF
--- a/connections/api/connections.api
+++ b/connections/api/connections.api
@@ -6,9 +6,14 @@ public final class com/stripe/android/connections/BuildConfig {
 }
 
 public final class com/stripe/android/connections/ConnectionsSheet {
-	public fun <init> (Landroidx/activity/ComponentActivity;Lcom/stripe/android/connections/ConnectionsSheetResultCallback;)V
-	public fun <init> (Landroidx/fragment/app/Fragment;Lcom/stripe/android/connections/ConnectionsSheetResultCallback;)V
+	public static final field Companion Lcom/stripe/android/connections/ConnectionsSheet$Companion;
+	public synthetic fun <init> (Lcom/stripe/android/connections/ConnectionsSheetLauncher;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun present (Lcom/stripe/android/connections/ConnectionsSheet$Configuration;)V
+}
+
+public final class com/stripe/android/connections/ConnectionsSheet$Companion {
+	public final fun create (Landroidx/activity/ComponentActivity;Lcom/stripe/android/connections/ConnectionsSheetResultCallback;)Lcom/stripe/android/connections/ConnectionsSheet;
+	public final fun create (Landroidx/fragment/app/Fragment;Lcom/stripe/android/connections/ConnectionsSheetResultCallback;)Lcom/stripe/android/connections/ConnectionsSheet;
 }
 
 public final class com/stripe/android/connections/ConnectionsSheet$Configuration : android/os/Parcelable {

--- a/connections/src/main/java/com/stripe/android/connections/ConnectionsSheet.kt
+++ b/connections/src/main/java/com/stripe/android/connections/ConnectionsSheet.kt
@@ -11,35 +11,9 @@ import kotlinx.parcelize.Parcelize
  * This *must* be called unconditionally, as part of initialization path,
  * typically as a field initializer of an Activity or Fragment.
  */
-class ConnectionsSheet internal constructor(
+class ConnectionsSheet private constructor(
     private val connectionsSheetLauncher: ConnectionsSheetLauncher
 ) {
-    /**
-     * Constructor to be used when launching the connections sheet from an Activity.
-     *
-     * @param activity  the Activity that is presenting the connections sheet.
-     * @param callback  called with the result of the connections session after the connections sheet is dismissed.
-     */
-    constructor(
-        activity: ComponentActivity,
-        callback: ConnectionsSheetResultCallback
-    ) : this(
-        DefaultConnectionsSheetLauncher(activity, callback)
-    )
-
-    /**
-     * Constructor to be used when launching the payment sheet from a Fragment.
-     *
-     * @param fragment the Fragment that is presenting the payment sheet.
-     * @param callback called with the result of the payment after the payment sheet is dismissed.
-     */
-    constructor(
-        fragment: Fragment,
-        callback: ConnectionsSheetResultCallback
-    ) : this(
-        DefaultConnectionsSheetLauncher(fragment, callback)
-    )
-
     /**
      * Configuration for a Connections Sheet
      *
@@ -61,5 +35,37 @@ class ConnectionsSheet internal constructor(
         configuration: Configuration
     ) {
         connectionsSheetLauncher.present(configuration)
+    }
+
+    companion object {
+        /**
+         * Constructor to be used when launching the connections sheet from an Activity.
+         *
+         * @param activity  the Activity that is presenting the connections sheet.
+         * @param callback  called with the result of the connections session after the connections sheet is dismissed.
+         */
+        fun create(
+            activity: ComponentActivity,
+            callback: ConnectionsSheetResultCallback
+        ): ConnectionsSheet {
+            return ConnectionsSheet(
+                DefaultConnectionsSheetLauncher(activity, callback)
+            )
+        }
+
+        /**
+         * Constructor to be used when launching the payment sheet from a Fragment.
+         *
+         * @param fragment the Fragment that is presenting the payment sheet.
+         * @param callback called with the result of the payment after the payment sheet is dismissed.
+         */
+        fun create(
+            fragment: Fragment,
+            callback: ConnectionsSheetResultCallback
+        ): ConnectionsSheet {
+            return ConnectionsSheet(
+                DefaultConnectionsSheetLauncher(fragment, callback)
+            )
+        }
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/connections/ConnectionsPaymentsProxy.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/connections/ConnectionsPaymentsProxy.kt
@@ -23,7 +23,7 @@ internal interface ConnectionsPaymentsProxy {
             fragment: Fragment,
             onComplete: (ConnectionsSheetResult) -> Unit,
             provider: () -> ConnectionsPaymentsProxy = {
-                DefaultConnectionsPaymentsProxy(ConnectionsSheet(fragment, onComplete))
+                DefaultConnectionsPaymentsProxy(ConnectionsSheet.create(fragment, onComplete))
             },
             isConnectionsAvailable: IsConnectionsAvailable = DefaultIsConnectionsAvailable()
         ): ConnectionsPaymentsProxy {
@@ -38,7 +38,7 @@ internal interface ConnectionsPaymentsProxy {
             activity: AppCompatActivity,
             onComplete: (ConnectionsSheetResult) -> Unit,
             provider: () -> ConnectionsPaymentsProxy = {
-                DefaultConnectionsPaymentsProxy(ConnectionsSheet(activity, onComplete))
+                DefaultConnectionsPaymentsProxy(ConnectionsSheet.create(activity, onComplete))
             },
             isConnectionsAvailable: IsConnectionsAvailable = DefaultIsConnectionsAvailable()
         ): ConnectionsPaymentsProxy {


### PR DESCRIPTION
# Summary
- makes ConnectionsSheet constructor private.
- Exposes create functions in ConnectionsSheet companion object.

# Motivation
- Allow extension to further create modes on ConnectionsSheet

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
