### PR TITLE
add variables and centralize primary button ui

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/PaymentsTheme.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/PaymentsTheme.kt
@@ -10,6 +10,7 @@ import android.text.TextPaint
 import android.text.style.AbsoluteSizeSpan
 import android.text.style.ForegroundColorSpan
 import android.text.style.MetricAffectingSpan
+import androidx.annotation.ColorInt
 import androidx.annotation.FontRes
 import androidx.annotation.RestrictTo
 import androidx.compose.foundation.BorderStroke
@@ -77,6 +78,20 @@ data class PaymentsTypography(
 )
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class PrimaryButtonModifier(
+    val primaryLight: Color,
+    val onPrimaryLight: Color,
+    val primaryDark: Color,
+    val onPrimaryDark: Color,
+    val cornerRadius: Float,
+    val border: Color,
+    val borderStrokeWidth: Float,
+    @FontRes
+    val fontFamily: Int?,
+    val height: Float,
+)
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 object PaymentsThemeDefaults {
     fun colors(isDark: Boolean): PaymentsColors {
         return if (isDark) colorsDark else colorsLight
@@ -131,6 +146,18 @@ object PaymentsThemeDefaults {
         xLargeFontSize = 20.sp,
         fontFamily = null // We default to the default system font.
     )
+
+    val primaryButtonModifier = PrimaryButtonModifier(
+        primaryLight = colors(false).primary,
+        onPrimaryLight = Color.White,
+        primaryDark = colors(true).primary,
+        onPrimaryDark = Color.White,
+        cornerRadius = shapes.cornerRadius,
+        border = Color.Transparent,
+        borderStrokeWidth = 0.0F,
+        fontFamily = typography.fontFamily,
+        height = 40.0f
+    )
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -150,6 +177,13 @@ data class PaymentsComposeShapes(
     val borderStrokeWidth: Dp,
     val borderStrokeWidthSelected: Dp,
     val material: Shapes
+)
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class PrimaryButtonModifierCompose(
+    val onPrimary: Color,
+    val style: TextStyle,
+    val height: Dp,
 )
 
 @Composable
@@ -266,6 +300,24 @@ fun PaymentsTypography.toComposeTypography(): Typography {
 }
 
 @Composable
+@ReadOnlyComposable
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun PrimaryButtonModifier.toComposeModifier(isDark: Boolean): PrimaryButtonModifierCompose {
+    val baseStyle = PaymentsTheme.typography.h5
+    val textStyle = if (fontFamily != null) {
+        baseStyle.copy(fontFamily = FontFamily(Font(fontFamily)))
+    } else {
+        baseStyle
+    }
+
+    return PrimaryButtonModifierCompose(
+        onPrimary = if (isDark) onPrimaryDark else onPrimaryLight,
+        style = textStyle,
+        height = height.dp
+    )
+}
+
+@Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun PaymentsTheme(
     content: @Composable () -> Unit
@@ -314,6 +366,12 @@ object PaymentsTheme {
         @Composable
         @ReadOnlyComposable
         get() = typographyMutable.toComposeTypography()
+
+    var primaryButtonModifierMutable = PaymentsThemeDefaults.primaryButtonModifier
+    val primaryButtonModifier: PrimaryButtonModifierCompose
+        @Composable
+        @ReadOnlyComposable
+        get() = primaryButtonModifierMutable.toComposeModifier(isSystemInDarkTheme())
 
     @Composable
     @ReadOnlyComposable
@@ -393,4 +451,11 @@ fun Color.shouldUseDarkDynamicColor(): Boolean {
     } else {
         contrastRatioToBlack > contrastRatioToWhite
     }
+}
+
+@ColorInt
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun PrimaryButtonModifier.getPrimaryColor(context: Context): Int {
+    val isDark = context.isSystemDarkTheme()
+    return (if (isDark) primaryDark else primaryLight).toArgb()
 }

--- a/paymentsheet/res/layout/activity_payment_sheet.xml
+++ b/paymentsheet/res/layout/activity_payment_sheet.xml
@@ -126,7 +126,7 @@
                     android:animateLayoutChanges="true"
                     android:visibility="gone"
                     android:layout_width="match_parent"
-                    android:layout_height="@dimen/stripe_paymentsheet_max_primary_button_height"
+                    android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/stripe_paymentsheet_button_container_spacing"
                     android:layout_marginHorizontal="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
                     android:layout_marginBottom="@dimen/stripe_paymentsheet_button_container_spacing_bottom">
@@ -134,7 +134,7 @@
                     <com.stripe.android.paymentsheet.ui.PrimaryButton
                         android:id="@+id/buy_button"
                         android:layout_width="match_parent"
-                        android:layout_height="@dimen/stripe_paymentsheet_primary_button_height"
+                        android:layout_height="wrap_content"
                         android:text="@string/stripe_paymentsheet_pay_button_label"
                         android:layout_marginVertical="2dp" />
                 </FrameLayout>

--- a/paymentsheet/res/values/colors.xml
+++ b/paymentsheet/res/values/colors.xml
@@ -20,7 +20,6 @@
     <color name="stripe_paymentsheet_payment_method_label_text_disabled">#61000000</color>
     <color name="stripe_paymentsheet_primary_button_default_background">#0074D4</color>
     <color name="stripe_paymentsheet_primary_button_success_background">#24B47E</color>
-    <color name="stripe_paymentsheet_primary_button_text">@android:color/white</color>
     <color name="stripe_paymentsheet_primary_button_confirming_progress">#ffffff</color>
     <color name="stripe_paymentsheet_form_border">#33787880</color>
     <color name="stripe_paymentsheet_elements_background_default">

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -9,7 +9,6 @@ import android.widget.TextView
 import androidx.activity.viewModels
 import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.os.bundleOf
 import androidx.core.view.doOnNextLayout
@@ -24,8 +23,8 @@ import com.stripe.android.paymentsheet.databinding.ActivityPaymentOptionsBinding
 import com.stripe.android.paymentsheet.ui.AnimationConstants
 import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.PrimaryButton
-import com.stripe.android.ui.core.PaymentsThemeDefaults
-import com.stripe.android.ui.core.isSystemDarkTheme
+import com.stripe.android.ui.core.PaymentsTheme
+import com.stripe.android.ui.core.getPrimaryColor
 
 /**
  * An `Activity` for selecting a payment option.
@@ -131,12 +130,13 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
         viewBinding.continueButton.updateState(PrimaryButton.State.Ready)
 
         viewModel.config?.let {
-            viewBinding.continueButton.setDefaultBackGroundColor(
-                it.primaryButtonColor ?: ColorStateList.valueOf(
-                    PaymentsThemeDefaults.colors(baseContext.isSystemDarkTheme()).primary.toArgb()
-                )
+            val buttonColor = it.primaryButtonColor ?: ColorStateList.valueOf(
+                PaymentsTheme.primaryButtonModifierMutable.getPrimaryColor(baseContext)
             )
-            viewBinding.continueButton.setCornerRadius(PaymentsThemeDefaults.shapes.cornerRadius)
+            viewBinding.continueButton.setAppearanceConfiguration(
+                PaymentsTheme.primaryButtonModifierMutable,
+                buttonColor
+            )
         }
 
         addButton.setOnClickListener {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -10,7 +10,6 @@ import android.widget.TextView
 import androidx.activity.viewModels
 import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.os.bundleOf
@@ -30,7 +29,9 @@ import com.stripe.android.paymentsheet.model.SupportedPaymentMethod
 import com.stripe.android.paymentsheet.ui.AnimationConstants
 import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.GooglePayDividerUi
+import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.PaymentsThemeDefaults
+import com.stripe.android.ui.core.getPrimaryColor
 import com.stripe.android.ui.core.isSystemDarkTheme
 import com.stripe.android.ui.core.shouldUseDarkDynamicColor
 import kotlinx.coroutines.launch
@@ -263,12 +264,13 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
         viewModel.getButtonStateObservable(CheckoutIdentifier.SheetBottomBuy)
             .observe(this, buyButtonStateObserver)
 
-        viewBinding.buyButton.setDefaultBackGroundColor(
-            viewModel.config?.primaryButtonColor ?: ColorStateList.valueOf(
-                PaymentsThemeDefaults.colors(isSystemDarkTheme()).primary.toArgb()
-            )
+        val buttonColor = viewModel.config?.primaryButtonColor ?: ColorStateList.valueOf(
+            PaymentsTheme.primaryButtonModifierMutable.getPrimaryColor(baseContext)
         )
-        viewBinding.buyButton.setCornerRadius(PaymentsThemeDefaults.shapes.cornerRadius)
+        viewBinding.buyButton.setAppearanceConfiguration(
+            PaymentsTheme.primaryButtonModifierMutable,
+            buttonColor
+        )
 
         viewBinding.buyButton.setOnClickListener {
             clearErrorMessages()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
@@ -7,12 +7,15 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.FrameLayout
 import androidx.annotation.VisibleForTesting
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.core.content.withStyledAttributes
@@ -22,6 +25,7 @@ import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.databinding.PrimaryButtonBinding
 import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.PaymentsThemeDefaults
+import com.stripe.android.ui.core.PrimaryButtonModifier
 import com.stripe.android.ui.core.convertDpToPx
 
 /**
@@ -53,7 +57,13 @@ internal class PrimaryButton @JvmOverloads constructor(
 
     private val confirmedIcon = viewBinding.confirmedIcon
 
-    private var cornerRadius = context.convertDpToPx(PaymentsThemeDefaults.shapes.cornerRadius.dp)
+    private var cornerRadius = context.convertDpToPx(
+        PaymentsThemeDefaults.primaryButtonModifier.cornerRadius.dp
+    )
+    private var borderStrokeWidth = context.convertDpToPx(
+        PaymentsThemeDefaults.primaryButtonModifier.borderStrokeWidth.dp
+    )
+    private var borderStrokeColor = PaymentsThemeDefaults.primaryButtonModifier.border.toArgb()
 
     init {
         // This is only needed if the button is inside a fragment
@@ -68,13 +78,15 @@ internal class PrimaryButton @JvmOverloads constructor(
         isEnabled = false
     }
 
-    fun setDefaultBackGroundColor(tintList: ColorStateList?) {
+    fun setAppearanceConfiguration(
+        primaryButtonModifier: PrimaryButtonModifier,
+        tintList: ColorStateList?
+    ) {
+        cornerRadius = context.convertDpToPx(primaryButtonModifier.cornerRadius.dp)
+        borderStrokeWidth = context.convertDpToPx(primaryButtonModifier.borderStrokeWidth.dp)
+        borderStrokeColor = primaryButtonModifier.border.toArgb()
         backgroundTintList = tintList
         defaultTintList = tintList
-    }
-
-    fun setCornerRadius(radius: Float) {
-        cornerRadius = context.convertDpToPx(radius.dp)
     }
 
     override fun setBackgroundTintList(tintList: ColorStateList?) {
@@ -82,6 +94,7 @@ internal class PrimaryButton @JvmOverloads constructor(
         shape.shape = GradientDrawable.RECTANGLE
         shape.cornerRadius = cornerRadius
         shape.color = tintList
+        shape.setStroke(borderStrokeWidth.toInt(), borderStrokeColor)
 
         background = shape
         setPadding(
@@ -194,11 +207,18 @@ internal class PrimaryButton @JvmOverloads constructor(
 
 @Composable
 private fun LabelUI(label: String) {
-    Text(
-        text = label,
-        textAlign = TextAlign.Center,
-        color = colorResource(R.color.stripe_paymentsheet_primary_button_text),
-        style = PaymentsTheme.typography.h5,
-        modifier = Modifier.padding(start = 4.dp, end = 4.dp, top = 4.dp, bottom = 5.dp)
-    )
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .height(PaymentsTheme.primaryButtonModifier.height)
+    ) {
+        Text(
+            text = label,
+            textAlign = TextAlign.Center,
+            color = PaymentsTheme.primaryButtonModifier.onPrimary,
+            style = PaymentsTheme.primaryButtonModifier.style,
+            modifier = Modifier
+                .padding(start = 4.dp, end = 4.dp, top = 4.dp, bottom = 5.dp)
+        )
+    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PrimaryButtonTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PrimaryButtonTest.kt
@@ -10,6 +10,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.paymentsheet.ui.PrimaryButton
+import com.stripe.android.ui.core.PaymentsThemeDefaults
 import com.stripe.android.view.ActivityScenarioFactory
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -36,8 +37,7 @@ class PrimaryButtonTest {
 
     @Test
     fun `onFinishingState() should clear any tint and restore onReadyState()`() {
-        primaryButton.setDefaultBackGroundColor(ColorStateList.valueOf(Color.BLACK))
-
+        primaryButton.setAppearanceConfiguration(PaymentsThemeDefaults.primaryButtonModifier, ColorStateList.valueOf(Color.BLACK))
         primaryButton.updateState(
             PrimaryButton.State.FinishProcessing({})
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Make the primary button look at a `PaymentsTheme` object for config. 
* No end user facing changes in this, entirely a refactor. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
* Rather than using a constant `PaymentsThemeDefaults.primaryButtonModifier` we will eventually open up these variables so merchants can change them. `primaryButtonModifierMutable` will be changed to read in a merchant's config. This PR is laying groundwork for that API. 
* Not sure about these variable names, any suggestions now before the API review will be appreciated. I'd like the public ones to be the same as the internal ones added in this PR.
* https://paper.dropbox.com/doc/Appearance-customization-rules-proposal--Bfl0mHHe3WetpJH943KbRHHJAg-grM5ueSOYPiqHSNE7ZWpY

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
|![buttonbefore](https://user-images.githubusercontent.com/89166418/163292335-71554cf6-302c-4ac9-b582-7d07e3e69600.png)|![buttonafter](https://user-images.githubusercontent.com/89166418/163292333-2e0009ef-3b30-4a65-a445-623a4c023e02.png)|



