### PR TITLE
Release us_bank_account payment method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 ## x.x.x - xxxx-xx-xx
 
+### Payments (`com.stripe:stripe-android`)
+* [ADDED] [4874](https://github.com/stripe/stripe-android/pull/4874) `us_bank_account` PaymentMethod is now available for ACH Direct Debit payments, including APIs to collect customer bank information (requires Connections SDK) and verify microdeposits.
+
 ### PaymentSheet
 * [FIXED] [4861](https://github.com/stripe/stripe-android/pull/4861) Remove font resource to save space and default to system default
 * [CHANGED] [4855](https://github.com/stripe/stripe-android/pull/4855) Remove force portrait mode in PaymentLauncher.

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -31,6 +31,7 @@ def getAccountId() {
 
 dependencies {
     implementation project(':payments')
+    implementation project(':connections')
     implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"
     implementation "androidx.recyclerview:recyclerview:$androidxRecyclerviewVersion"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$androidxLifecycleVersion"

--- a/example/src/main/java/com/stripe/example/activity/ConnectUSBankAccountActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/ConnectUSBankAccountActivity.kt
@@ -12,11 +12,6 @@ import com.stripe.example.R
 import com.stripe.example.Settings
 import com.stripe.example.databinding.ConnectBankAccountExampleActivityBinding
 
-/**
- * This example is currently work in progress. Do not use it as a reference.
- *
- * In order for this example to work, uncomment ConnectUSBankAccountActivity in LauncherActivity.kt
- */
 class ConnectUSBankAccountActivity : StripeIntentActivity() {
 
     private val viewBinding: ConnectBankAccountExampleActivityBinding by lazy {

--- a/example/src/main/java/com/stripe/example/activity/LauncherActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/LauncherActivity.kt
@@ -137,14 +137,14 @@ class LauncherActivity : AppCompatActivity() {
                 activity.getString(R.string.compose_example),
                 ComposeExampleActivity::class.java
             ),
-//            Item(
-//                activity.getString(R.string.confirm_with_us_bank_account_entry_point),
-//                ConnectUSBankAccountActivity::class.java
-//            ),
-//            Item(
-//                activity.getString(R.string.manual_us_bank_account_example),
-//                ManualUSBankAccountPaymentMethodActivity::class.java
-//            ),
+            Item(
+                activity.getString(R.string.confirm_with_us_bank_account_entry_point),
+                ConnectUSBankAccountActivity::class.java
+            ),
+            Item(
+                activity.getString(R.string.manual_us_bank_account_example),
+                ManualUSBankAccountPaymentMethodActivity::class.java
+            ),
         )
 
         override fun onCreateViewHolder(viewGroup: ViewGroup, i: Int): ExamplesViewHolder {

--- a/example/src/main/java/com/stripe/example/activity/ManualUSBankAccountPaymentMethodActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/ManualUSBankAccountPaymentMethodActivity.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.lifecycleScope
 import com.stripe.android.ApiResultCallback
-import com.stripe.android.StripeApiBeta
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -38,15 +37,9 @@ import com.stripe.example.StripeFactory
 import com.stripe.example.theme.DefaultExampleTheme
 import kotlinx.coroutines.flow.MutableStateFlow
 
-/**
- * This example is currently work in progress. Do not use it as a reference.
- *
- * In order for this example to work uncomment ManualUSBankAccountPaymentMethodActivity
- * in LauncherActivity.kt
- */
 class ManualUSBankAccountPaymentMethodActivity : StripeIntentActivity() {
     private val stripe by lazy {
-        StripeFactory(this, betas = setOf(StripeApiBeta.USBankAccount)).create()
+        StripeFactory(this).create()
     }
 
     private var paymentIntentSecret: String? = null

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -768,6 +768,10 @@ public final class com/stripe/android/Stripe {
 	public static synthetic fun retrieveSourceSynchronous$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/Source;
 	public static final fun setAdvancedFraudSignalsEnabled (Z)V
 	public static final fun setAppInfo (Lcom/stripe/android/core/AppInfo;)V
+	public final fun verifyPaymentIntentWithMicrodeposits (Ljava/lang/String;IILcom/stripe/android/ApiResultCallback;)V
+	public final fun verifyPaymentIntentWithMicrodeposits (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
+	public final fun verifySetupIntentWithMicrodeposits (Ljava/lang/String;IILcom/stripe/android/ApiResultCallback;)V
+	public final fun verifySetupIntentWithMicrodeposits (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
 }
 
 public final class com/stripe/android/Stripe$Companion {
@@ -845,6 +849,10 @@ public final class com/stripe/android/StripeKtxKt {
 	public static synthetic fun retrieveSetupIntent$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun retrieveSource (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun retrieveSource$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun verifyPaymentIntentWithMicrodeposits (Lcom/stripe/android/Stripe;Ljava/lang/String;IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun verifyPaymentIntentWithMicrodeposits (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun verifySetupIntentWithMicrodeposits (Lcom/stripe/android/Stripe;Ljava/lang/String;IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun verifySetupIntentWithMicrodeposits (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class com/stripe/android/cards/CardAccountRangeRepository$Factory {
@@ -2512,6 +2520,7 @@ public final class com/stripe/android/model/PaymentMethod : com/stripe/android/c
 	public final field sofort Lcom/stripe/android/model/PaymentMethod$Sofort;
 	public final field type Lcom/stripe/android/model/PaymentMethod$Type;
 	public final field upi Lcom/stripe/android/model/PaymentMethod$Upi;
+	public final field usBankAccount Lcom/stripe/android/model/PaymentMethod$USBankAccount;
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Long;ZLcom/stripe/android/model/PaymentMethod$Type;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$Card;Lcom/stripe/android/model/PaymentMethod$CardPresent;Lcom/stripe/android/model/PaymentMethod$Fpx;Lcom/stripe/android/model/PaymentMethod$Ideal;Lcom/stripe/android/model/PaymentMethod$SepaDebit;Lcom/stripe/android/model/PaymentMethod$AuBecsDebit;Lcom/stripe/android/model/PaymentMethod$BacsDebit;Lcom/stripe/android/model/PaymentMethod$Sofort;Lcom/stripe/android/model/PaymentMethod$Upi;Lcom/stripe/android/model/PaymentMethod$Netbanking;Lcom/stripe/android/model/PaymentMethod$USBankAccount;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Lcom/stripe/android/model/PaymentMethod$Ideal;
@@ -2521,6 +2530,7 @@ public final class com/stripe/android/model/PaymentMethod : com/stripe/android/c
 	public final fun component14 ()Lcom/stripe/android/model/PaymentMethod$Sofort;
 	public final fun component15 ()Lcom/stripe/android/model/PaymentMethod$Upi;
 	public final fun component16 ()Lcom/stripe/android/model/PaymentMethod$Netbanking;
+	public final fun component17 ()Lcom/stripe/android/model/PaymentMethod$USBankAccount;
 	public final fun component2 ()Ljava/lang/Long;
 	public final fun component3 ()Z
 	public final fun component4 ()Lcom/stripe/android/model/PaymentMethod$Type;
@@ -2637,6 +2647,7 @@ public final class com/stripe/android/model/PaymentMethod$Builder : com/stripe/a
 	public final fun setSepaDebit (Lcom/stripe/android/model/PaymentMethod$SepaDebit;)Lcom/stripe/android/model/PaymentMethod$Builder;
 	public final fun setSofort (Lcom/stripe/android/model/PaymentMethod$Sofort;)Lcom/stripe/android/model/PaymentMethod$Builder;
 	public final fun setType (Lcom/stripe/android/model/PaymentMethod$Type;)Lcom/stripe/android/model/PaymentMethod$Builder;
+	public final fun setUSBankAccount (Lcom/stripe/android/model/PaymentMethod$USBankAccount;)Lcom/stripe/android/model/PaymentMethod$Builder;
 	public final fun setUpi (Lcom/stripe/android/model/PaymentMethod$Upi;)Lcom/stripe/android/model/PaymentMethod$Builder;
 }
 
@@ -2879,6 +2890,76 @@ public abstract class com/stripe/android/model/PaymentMethod$TypeData : com/stri
 	public abstract fun getType ()Lcom/stripe/android/model/PaymentMethod$Type;
 }
 
+public final class com/stripe/android/model/PaymentMethod$USBankAccount : com/stripe/android/model/PaymentMethod$TypeData {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public final field accountHolderType Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountHolderType;
+	public final field accountType Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountType;
+	public final field bankName Ljava/lang/String;
+	public final field fingerprint Ljava/lang/String;
+	public final field last4 Ljava/lang/String;
+	public final field linkedAccount Ljava/lang/String;
+	public final field networks Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankNetworks;
+	public final field routingNumber Ljava/lang/String;
+	public final fun component1 ()Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountHolderType;
+	public final fun component2 ()Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountType;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankNetworks;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun copy (Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountHolderType;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankNetworks;Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$USBankAccount;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$USBankAccount;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountHolderType;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountType;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankNetworks;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$USBankAccount;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getType ()Lcom/stripe/android/model/PaymentMethod$Type;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountHolderType : java/lang/Enum, com/stripe/android/core/model/StripeModel {
+	public static final field COMPANY Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountHolderType;
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field INDIVIDUAL Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountHolderType;
+	public static final field UNKNOWN Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountHolderType;
+	public fun describeContents ()I
+	public final fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountHolderType;
+	public static fun values ()[Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountHolderType;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountType : java/lang/Enum, com/stripe/android/core/model/StripeModel {
+	public static final field CHECKING Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountType;
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field SAVINGS Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountType;
+	public static final field UNKNOWN Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountType;
+	public fun describeContents ()I
+	public final fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountType;
+	public static fun values ()[Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountType;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/PaymentMethod$USBankAccount$USBankNetworks : com/stripe/android/core/model/StripeModel {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankNetworks;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankNetworks;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankNetworks;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPreferred ()Ljava/lang/String;
+	public final fun getSupported ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
 public final class com/stripe/android/model/PaymentMethod$Upi : com/stripe/android/model/PaymentMethod$TypeData {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
@@ -2934,6 +3015,9 @@ public final class com/stripe/android/model/PaymentMethodCreateParams : android/
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$USBankAccount;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$USBankAccount;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$USBankAccount;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
@@ -2967,6 +3051,9 @@ public final class com/stripe/android/model/PaymentMethodCreateParams : android/
 	public static final fun createP24 (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun createPayPal ()Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun createPayPal (Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createUSBankAccount ()Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createUSBankAccount (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createUSBankAccount (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun createWeChatPay ()Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun createWeChatPay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun createWeChatPay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
@@ -3075,6 +3162,9 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Companion 
 	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Sofort;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$USBankAccount;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$USBankAccount;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$USBankAccount;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun create (Lcom/stripe/android/model/PaymentMethodCreateParams$Upi;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
@@ -3131,6 +3221,9 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Companion 
 	public final fun createPayPal ()Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun createPayPal (Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static synthetic fun createPayPal$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createUSBankAccount ()Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createUSBankAccount (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createUSBankAccount (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static synthetic fun createUSBankAccount$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun createWeChatPay ()Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun createWeChatPay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
@@ -3232,6 +3325,20 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Sofort : a
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
+public final class com/stripe/android/model/PaymentMethodCreateParams$USBankAccount : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountType;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountHolderType;)V
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountType;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountHolderType;)Lcom/stripe/android/model/PaymentMethodCreateParams$USBankAccount;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodCreateParams$USBankAccount;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountType;Lcom/stripe/android/model/PaymentMethod$USBankAccount$USBankAccountHolderType;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams$USBankAccount;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toParamMap ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
 public final class com/stripe/android/model/PaymentMethodCreateParams$Upi : android/os/Parcelable, com/stripe/android/model/StripeParamsModel {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
@@ -3289,6 +3396,25 @@ public final class com/stripe/android/model/PaymentMethodOptionsParams$Card : co
 	public fun hashCode ()I
 	public final fun setCvc (Ljava/lang/String;)V
 	public final fun setNetwork (Ljava/lang/String;)V
+	public final fun setSetupFutureUsage (Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)V
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/PaymentMethodOptionsParams$USBankAccount : com/stripe/android/model/PaymentMethodOptionsParams {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field PARAM_SETUP_FUTURE_USAGE Ljava/lang/String;
+	public fun <init> ()V
+	public fun <init> (Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)V
+	public synthetic fun <init> (Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;
+	public final fun copy (Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)Lcom/stripe/android/model/PaymentMethodOptionsParams$USBankAccount;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PaymentMethodOptionsParams$USBankAccount;Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodOptionsParams$USBankAccount;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSetupFutureUsage ()Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;
+	public fun hashCode ()I
 	public final fun setSetupFutureUsage (Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)V
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
@@ -4411,12 +4537,32 @@ public final class com/stripe/android/model/StripeIntent$NextActionData$SdkData$
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
+public final class com/stripe/android/model/StripeIntent$NextActionData$VerifyWithMicrodeposits : com/stripe/android/model/StripeIntent$NextActionData {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (JLjava/lang/String;Lcom/stripe/android/model/MicrodepositType;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lcom/stripe/android/model/MicrodepositType;
+	public final fun copy (JLjava/lang/String;Lcom/stripe/android/model/MicrodepositType;)Lcom/stripe/android/model/StripeIntent$NextActionData$VerifyWithMicrodeposits;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/StripeIntent$NextActionData$VerifyWithMicrodeposits;JLjava/lang/String;Lcom/stripe/android/model/MicrodepositType;ILjava/lang/Object;)Lcom/stripe/android/model/StripeIntent$NextActionData$VerifyWithMicrodeposits;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArrivalDate ()J
+	public final fun getHostedVerificationUrl ()Ljava/lang/String;
+	public final fun getMicrodepositType ()Lcom/stripe/android/model/MicrodepositType;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
 public final class com/stripe/android/model/StripeIntent$NextActionType : java/lang/Enum {
 	public static final field AlipayRedirect Lcom/stripe/android/model/StripeIntent$NextActionType;
 	public static final field BlikAuthorize Lcom/stripe/android/model/StripeIntent$NextActionType;
 	public static final field DisplayOxxoDetails Lcom/stripe/android/model/StripeIntent$NextActionType;
 	public static final field RedirectToUrl Lcom/stripe/android/model/StripeIntent$NextActionType;
 	public static final field UseStripeSdk Lcom/stripe/android/model/StripeIntent$NextActionType;
+	public static final field VerifyWithMicrodeposits Lcom/stripe/android/model/StripeIntent$NextActionType;
 	public static final field WeChatPayRedirect Lcom/stripe/android/model/StripeIntent$NextActionType;
 	public final fun getCode ()Ljava/lang/String;
 	public fun toString ()Ljava/lang/String;

--- a/payments-core/src/main/java/com/stripe/android/Stripe.kt
+++ b/payments-core/src/main/java/com/stripe/android/Stripe.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import androidx.activity.ComponentActivity
-import androidx.annotation.RestrictTo
 import androidx.annotation.Size
 import androidx.annotation.UiThread
 import androidx.annotation.WorkerThread
@@ -215,7 +214,6 @@ class Stripe internal constructor(
      * @see <a href="https://pay.weixin.qq.com/index.php/public/wechatpay">WeChat Pay Documentation</a>
      *
      * WeChat Pay API is still in beta, create a [Stripe] instance with [StripeApiBeta.WeChatPayV1] to enable this API.
-     * US Bank Account API is still in beta, create a [Stripe] instance with [StripeApiBeta.USBankAccount] to enable this API.
      *
      * @param confirmPaymentIntentParams [ConfirmPaymentIntentParams] used to confirm the
      * [PaymentIntent]
@@ -1661,7 +1659,8 @@ class Stripe internal constructor(
      * sent to the bank account
      * @param callback a [ApiResultCallback] to receive the result or error
      */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @UiThread
+    @JvmOverloads
     fun verifyPaymentIntentWithMicrodeposits(
         clientSecret: String,
         firstAmount: Int,
@@ -1694,7 +1693,8 @@ class Stripe internal constructor(
      * statement descriptor to the bank account
      * @param callback a [ApiResultCallback] to receive the result or error
      */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @UiThread
+    @JvmOverloads
     fun verifyPaymentIntentWithMicrodeposits(
         clientSecret: String,
         descriptorCode: String,
@@ -1727,7 +1727,8 @@ class Stripe internal constructor(
      * sent to the bank account
      * @param callback a [ApiResultCallback] to receive the result or error
      */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @UiThread
+    @JvmOverloads
     fun verifySetupIntentWithMicrodeposits(
         clientSecret: String,
         firstAmount: Int,
@@ -1760,7 +1761,8 @@ class Stripe internal constructor(
      * statement descriptor to the bank account
      * @param callback a [ApiResultCallback] to receive the result or error
      */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @UiThread
+    @JvmOverloads
     fun verifySetupIntentWithMicrodeposits(
         clientSecret: String,
         descriptorCode: String,

--- a/payments-core/src/main/java/com/stripe/android/StripeApiBeta.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripeApiBeta.kt
@@ -1,11 +1,8 @@
 package com.stripe.android
 
-import androidx.annotation.RestrictTo
-
 /**
  * Enums of beta headers allowed to be override when initializing [Stripe].
  */
 enum class StripeApiBeta(val code: String) {
-    WeChatPayV1("wechat_pay_beta=v1"),
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) USBankAccount("us_bank_account_beta=v2");
+    WeChatPayV1("wechat_pay_beta=v1")
 }

--- a/payments-core/src/main/java/com/stripe/android/StripeKtx.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripeKtx.kt
@@ -1,7 +1,6 @@
 package com.stripe.android
 
 import android.content.Intent
-import androidx.annotation.RestrictTo
 import androidx.annotation.Size
 import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.exception.APIException
@@ -605,7 +604,6 @@ suspend fun Stripe.confirmSetupIntent(
  * @see <a href="https://pay.weixin.qq.com/index.php/public/wechatpay">WeChat Pay Documentation</a>
  *
  * WeChat Pay API is still in beta, create a [Stripe] instance with [StripeApiBeta.WeChatPayV1] to enable this API.
- * US Bank Account API is still in beta, create a [Stripe] instance with [StripeApiBeta.USBankAccount] to enable this API.
  *
  * @param confirmPaymentIntentParams [ConfirmPaymentIntentParams] used to confirm the
  * [PaymentIntent]
@@ -817,7 +815,6 @@ internal inline fun <reified ApiObject : StripeModel> runApiRequest(
  * @throws APIConnectionException failure to connect to Stripe's API
  * @throws APIException any other type of problem (for instance, a temporary issue with Stripe's servers)
  */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Throws(
     AuthenticationException::class,
     InvalidRequestException::class,
@@ -860,7 +857,6 @@ suspend fun Stripe.verifyPaymentIntentWithMicrodeposits(
  * @throws APIConnectionException failure to connect to Stripe's API
  * @throws APIException any other type of problem (for instance, a temporary issue with Stripe's servers)
  */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Throws(
     AuthenticationException::class,
     InvalidRequestException::class,
@@ -903,7 +899,6 @@ suspend fun Stripe.verifyPaymentIntentWithMicrodeposits(
  * @throws APIConnectionException failure to connect to Stripe's API
  * @throws APIException any other type of problem (for instance, a temporary issue with Stripe's servers)
  */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Throws(
     AuthenticationException::class,
     InvalidRequestException::class,
@@ -946,7 +941,6 @@ suspend fun Stripe.verifySetupIntentWithMicrodeposits(
  * @throws APIConnectionException failure to connect to Stripe's API
  * @throws APIException any other type of problem (for instance, a temporary issue with Stripe's servers)
  */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Throws(
     AuthenticationException::class,
     InvalidRequestException::class,

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -127,7 +127,12 @@ constructor(
 
     @JvmField val netbanking: Netbanking? = null,
 
-    internal val usBankAccount: USBankAccount? = null
+    /**
+     * If this is an `us_bank_account` PaymentMethod, this hash contains details about the bank account.
+     *
+     * [us_bank_account](https://stripe.com/docs/api/payment_methods/object#payment_method_object-us_bank_account)
+     */
+    @JvmField val usBankAccount: USBankAccount? = null
 ) : StripeModel {
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) // For paymentsheet
@@ -362,7 +367,7 @@ constructor(
         private var bacsDebit: BacsDebit? = null
         private var sofort: Sofort? = null
         private var netbanking: Netbanking? = null
-        internal var usBankAccount: USBankAccount? = null
+        private var usBankAccount: USBankAccount? = null
         private var upi: Upi? = null
 
         fun setId(id: String?): Builder = apply {
@@ -429,7 +434,7 @@ constructor(
             this.netbanking = netbanking
         }
 
-        internal fun setUSBankAccount(usBankAccount: USBankAccount?): Builder = apply {
+        fun setUSBankAccount(usBankAccount: USBankAccount?): Builder = apply {
             this.usBankAccount = usBankAccount
         }
 
@@ -864,7 +869,6 @@ constructor(
     }
 
     @Parcelize
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class USBankAccount internal constructor(
         /**
          * Account holder type
@@ -926,7 +930,6 @@ constructor(
         override val type: Type get() = Type.USBankAccount
 
         @Parcelize
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         enum class USBankAccountHolderType(val value: String) : StripeModel {
             UNKNOWN("unknown"),
             // Account belongs to an individual
@@ -936,7 +939,6 @@ constructor(
         }
 
         @Parcelize
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         enum class USBankAccountType(val value: String) : StripeModel {
             UNKNOWN("unknown"),
             // Bank account type is checking
@@ -946,7 +948,6 @@ constructor(
         }
 
         @Parcelize
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         data class USBankNetworks(
             val preferred: String?,
             val supported: List<String>

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -429,7 +429,6 @@ data class PaymentMethodCreateParams internal constructor(
     }
 
     @Parcelize
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class USBankAccount(
         internal var accountNumber: String,
         internal var routingNumber: String,
@@ -612,7 +611,6 @@ data class PaymentMethodCreateParams internal constructor(
 
         @JvmStatic
         @JvmOverloads
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         fun create(
             usBankAccount: USBankAccount,
             billingDetails: PaymentMethod.BillingDetails? = null,
@@ -839,7 +837,8 @@ data class PaymentMethodCreateParams internal constructor(
             )
         }
 
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @JvmStatic
+        @JvmOverloads
         fun createUSBankAccount(
             billingDetails: PaymentMethod.BillingDetails? = null,
             metadata: Map<String, String>? = null

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodOptionsParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodOptionsParams.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.model
 
 import android.os.Parcelable
-import androidx.annotation.RestrictTo
 import kotlinx.parcelize.Parcelize
 
 sealed class PaymentMethodOptionsParams(
@@ -91,7 +90,6 @@ sealed class PaymentMethodOptionsParams(
         }
     }
 
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
     data class USBankAccount(
         var setupFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage? = null

--- a/payments-core/src/main/java/com/stripe/android/model/StripeIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/StripeIntent.kt
@@ -78,7 +78,7 @@ sealed interface StripeIntent : StripeModel {
         AlipayRedirect("alipay_handle_redirect"),
         BlikAuthorize("blik_authorize"),
         WeChatPayRedirect("wechat_pay_redirect_to_android_app"),
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) VerifyWithMicrodeposits("verify_with_microdeposits");
+        VerifyWithMicrodeposits("verify_with_microdeposits");
 
         override fun toString(): String {
             return code
@@ -253,7 +253,6 @@ sealed interface StripeIntent : StripeModel {
         @Parcelize
         data class WeChatPayRedirect(val weChat: WeChat) : NextActionData()
 
-        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         @Parcelize
         data class VerifyWithMicrodeposits(
             val arrivalDate: Long,

--- a/payments-core/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
@@ -111,8 +111,7 @@ internal class PaymentMethodEndToEndTest {
         val paymentMethod =
             Stripe(
                 context,
-                ApiKeyFixtures.US_BANK_ACCOUNT_PUBLISHABLE_KEY,
-                betas = setOf(StripeApiBeta.USBankAccount)
+                ApiKeyFixtures.US_BANK_ACCOUNT_PUBLISHABLE_KEY
             ).createPaymentMethodSynchronous(params)
         assertThat(paymentMethod?.type).isEqualTo(PaymentMethod.Type.USBankAccount)
         assertThat(paymentMethod?.usBankAccount).isEqualTo(
@@ -137,8 +136,7 @@ internal class PaymentMethodEndToEndTest {
         val paymentMethod =
             Stripe(
                 context,
-                ApiKeyFixtures.US_BANK_ACCOUNT_PUBLISHABLE_KEY,
-                betas = setOf(StripeApiBeta.USBankAccount)
+                ApiKeyFixtures.US_BANK_ACCOUNT_PUBLISHABLE_KEY
             ).createPaymentMethodSynchronous(params)
         assertThat(paymentMethod?.type)
             .isEqualTo(PaymentMethod.Type.USBankAccount)
@@ -154,8 +152,7 @@ internal class PaymentMethodEndToEndTest {
         ) {
             Stripe(
                 context,
-                ApiKeyFixtures.US_BANK_ACCOUNT_PUBLISHABLE_KEY,
-                betas = setOf(StripeApiBeta.USBankAccount)
+                ApiKeyFixtures.US_BANK_ACCOUNT_PUBLISHABLE_KEY
             ).createPaymentMethodSynchronous(params)
         }
         assertThat(exception.message)

--- a/stripe-test-e2e/src/test/java/com/stripe/android/test/e2e/EndToEndTest.kt
+++ b/stripe-test-e2e/src/test/java/com/stripe/android/test/e2e/EndToEndTest.kt
@@ -6,8 +6,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiResultCallback
 import com.stripe.android.Stripe
-import com.stripe.android.StripeApiBeta
-import com.stripe.android.core.ApiVersion
 import com.stripe.android.core.exception.InvalidRequestException
 import com.stripe.android.model.CardParams
 import com.stripe.android.model.ConfirmPaymentIntentParams
@@ -156,15 +154,14 @@ internal class EndToEndTest {
 
     @Test
     fun `test us_bank_account payment intent flow with amounts`() = runTest {
-        val stripe = Stripe(context, settings.publishableKey, betas = setOf(StripeApiBeta.USBankAccount))
+        val stripe = Stripe(context, settings.publishableKey)
 
         // Create a PaymentIntent on the backend
         val newPaymentIntent = service.createPaymentIntent(
             Request.CreatePaymentIntentParams(
                 createParams = Request.CreateParams(
                     paymentMethodTypes = listOf("us_bank_account")
-                ),
-                version = "${ApiVersion.API_VERSION_CODE};us_bank_account_beta=v2"
+                )
             )
         )
 
@@ -218,15 +215,14 @@ internal class EndToEndTest {
 
     @Test(expected = InvalidRequestException::class)
     fun `test us_bank_account payment intent flow with amounts fails`() = runTest {
-        val stripe = Stripe(context, settings.publishableKey, betas = setOf(StripeApiBeta.USBankAccount))
+        val stripe = Stripe(context, settings.publishableKey)
 
         // Create a PaymentIntent on the backend
         val newPaymentIntent = service.createPaymentIntent(
             Request.CreatePaymentIntentParams(
                 createParams = Request.CreateParams(
                     paymentMethodTypes = listOf("us_bank_account")
-                ),
-                version = "${ApiVersion.API_VERSION_CODE};us_bank_account_beta=v2"
+                )
             )
         )
 
@@ -266,15 +262,14 @@ internal class EndToEndTest {
 
     @Test
     fun `test us_bank_account payment intent flow with desciptor code`() = runTest {
-        val stripe = Stripe(context, settings.publishableKey, betas = setOf(StripeApiBeta.USBankAccount))
+        val stripe = Stripe(context, settings.publishableKey)
 
         // Create a PaymentIntent on the backend
         val newPaymentIntent = service.createPaymentIntent(
             Request.CreatePaymentIntentParams(
                 createParams = Request.CreateParams(
                     paymentMethodTypes = listOf("us_bank_account")
-                ),
-                version = "${ApiVersion.API_VERSION_CODE};us_bank_account_beta=v2"
+                )
             )
         )
 
@@ -327,15 +322,14 @@ internal class EndToEndTest {
 
     @Test
     fun `test us_bank_account setup intent flow with amounts`() = runTest {
-        val stripe = Stripe(context, settings.publishableKey, betas = setOf(StripeApiBeta.USBankAccount))
+        val stripe = Stripe(context, settings.publishableKey)
 
         // Create a SetupIntent on the backend
         val newPaymentIntent = service.createSetupIntent(
             Request.CreateSetupIntentParams(
                 createParams = Request.CreateParams(
                     paymentMethodTypes = listOf("us_bank_account")
-                ),
-                version = "${ApiVersion.API_VERSION_CODE};us_bank_account_beta=v2"
+                )
             )
         )
 
@@ -381,15 +375,14 @@ internal class EndToEndTest {
 
     @Test(expected = InvalidRequestException::class)
     fun `test us_bank_account setup intent flow with amounts fails`() = runTest {
-        val stripe = Stripe(context, settings.publishableKey, betas = setOf(StripeApiBeta.USBankAccount))
+        val stripe = Stripe(context, settings.publishableKey)
 
         // Create a SetupIntent on the backend
         val newPaymentIntent = service.createSetupIntent(
             Request.CreateSetupIntentParams(
                 createParams = Request.CreateParams(
                     paymentMethodTypes = listOf("us_bank_account")
-                ),
-                version = "${ApiVersion.API_VERSION_CODE};us_bank_account_beta=v2"
+                )
             )
         )
 
@@ -426,15 +419,14 @@ internal class EndToEndTest {
 
     @Test
     fun `test us_bank_account setup intent flow with descriptor code`() = runTest {
-        val stripe = Stripe(context, settings.publishableKey, betas = setOf(StripeApiBeta.USBankAccount))
+        val stripe = Stripe(context, settings.publishableKey)
 
         // Create a SetupIntent on the backend
         val newPaymentIntent = service.createSetupIntent(
             Request.CreateSetupIntentParams(
                 createParams = Request.CreateParams(
                     paymentMethodTypes = listOf("us_bank_account")
-                ),
-                version = "${ApiVersion.API_VERSION_CODE};us_bank_account_beta=v2"
+                )
             )
         )
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Release us_bank_account payment method

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

- [Added] `us_bank_account` PaymentMethod is now available for ACH Direct Debit payments, including APIs to collect customer bank information (requires Connections SDK) and verify microdeposits.