### PR TITLE
fix postal code callback not firing when enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 ## x.x.x - xxxx-xx-xx
 
+### Payments
+* [FIXED] [4875](https://github.com/stripe/stripe-android/pull/4875) fix postal code callback not firing when enabled
+
 ### PaymentSheet
 * [FIXED] [4861](https://github.com/stripe/stripe-android/pull/4861) Remove font resource to save space and default to system default
 * [CHANGED] [4855](https://github.com/stripe/stripe-android/pull/4855) Remove force portrait mode in PaymentLauncher.

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -288,11 +288,17 @@ class CardInputWidget @JvmOverloads constructor(
             postalCodeTextInputLayout.visibility = View.VISIBLE
 
             cvcEditText.imeOptions = EditorInfo.IME_ACTION_NEXT
+
+            // First remove if it's already added, to make sure it's not added multiple times.
+            postalCodeEditText.removeTextChangedListener(cardValidTextWatcher)
+            postalCodeEditText.addTextChangedListener(cardValidTextWatcher)
         } else {
             postalCodeEditText.isEnabled = false
             postalCodeTextInputLayout.visibility = View.GONE
 
             cvcEditText.imeOptions = EditorInfo.IME_ACTION_DONE
+
+            postalCodeEditText.removeTextChangedListener(cardValidTextWatcher)
         }
         updatePostalRequired()
     }
@@ -333,16 +339,8 @@ class CardInputWidget @JvmOverloads constructor(
     private fun updatePostalRequired() {
         if (isPostalRequired()) {
             requiredFields.add(postalCodeEditText)
-            cardValidCallback?.let {
-                // First remove if it's already added, to make sure it's not added multiple times.
-                postalCodeEditText.removeTextChangedListener(cardValidTextWatcher)
-                postalCodeEditText.addTextChangedListener(cardValidTextWatcher)
-            }
         } else {
             requiredFields.remove(postalCodeEditText)
-            cardValidCallback?.let {
-                postalCodeEditText.removeTextChangedListener(cardValidTextWatcher)
-            }
         }
     }
 
@@ -756,7 +754,7 @@ class CardInputWidget @JvmOverloads constructor(
         }
 
         postalCodeEditText.setAfterTextChangedListener {
-            if (isPostalRequired() && postalCodeEditText.hasValidPostal()) {
+            if (postalCodeEditText.hasValidPostal()) {
                 cardInputListener?.onPostalCodeComplete()
             }
         }

--- a/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardInputWidget.kt
@@ -754,7 +754,7 @@ class CardInputWidget @JvmOverloads constructor(
         }
 
         postalCodeEditText.setAfterTextChangedListener {
-            if (postalCodeEditText.hasValidPostal()) {
+            if (postalCodeEditText.isEnabled && postalCodeEditText.hasValidPostal()) {
                 cardInputListener?.onPostalCodeComplete()
             }
         }

--- a/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -1370,6 +1370,7 @@ internal class CardInputWidgetTest {
         var currentIsValid = false
         var currentInvalidFields = emptySet<CardValidCallback.Fields>()
         cardInputWidget.postalCodeEnabled = true
+        cardInputWidget.postalCodeRequired = false
         cardInputWidget.setCardValidCallback { isValid, invalidFields ->
             currentIsValid = isValid
             currentInvalidFields = invalidFields
@@ -1647,6 +1648,19 @@ internal class CardInputWidgetTest {
         cardInputWidget.postalCodeRequired = false
         cardInputWidget.postalCodeRequired = true
         cardInputWidget.postalCodeEnabled = true
+        postalCodeEditText.setText("54321")
+
+        // Called only when the callback is set and when the text is set.
+        verify(callback, times(2)).onInputChanged(any(), any())
+    }
+
+    @Test
+    fun `Enabled but not required postal code should fire card valid callback when changed`() {
+        val callback = mock<CardValidCallback>()
+        cardInputWidget.setCardValidCallback(callback)
+
+        cardInputWidget.postalCodeEnabled = true
+        cardInputWidget.postalCodeRequired = false
         postalCodeEditText.setText("54321")
 
         // Called only when the callback is set and when the text is set.

--- a/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardInputWidgetTest.kt
@@ -1530,10 +1530,10 @@ internal class CardInputWidgetTest {
     }
 
     @Test
-    fun usZipCodeRequired_whenFalse_shouldNotCallOnPostalCodeComplete() {
+    fun usZipCodeRequired_whenFalse_shouldCallOnPostalCodeComplete() {
         cardInputWidget.usZipCodeRequired = false
         postalCodeEditText.setText(POSTAL_CODE_VALUE)
-        assertThat(cardInputListener.onPostalCodeCompleteCalls).isEqualTo(0)
+        assertThat(cardInputListener.onPostalCodeCompleteCalls).isEqualTo(1)
     }
 
     @Test
@@ -1626,7 +1626,7 @@ internal class CardInputWidgetTest {
     }
 
     @Test
-    fun `Removing postal code requirement removes CardValidCallback notifications for the field`() {
+    fun `Removing postal code requirement keeps CardValidCallback notifications for the field`() {
         val callback = mock<CardValidCallback>()
         cardInputWidget.postalCodeRequired = true
         cardInputWidget.setCardValidCallback(callback)
@@ -1634,7 +1634,7 @@ internal class CardInputWidgetTest {
 
         postalCodeEditText.setText("54321")
 
-        verify(callback, times(1)).onInputChanged(any(), any())
+        verify(callback, times(2)).onInputChanged(any(), any())
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
The postal code field in `CardInputWidget` was only firing when PostalCode is **required** but it should be fired when it is **enabled** too. In all situations an enabled postal code field should be firing the callback.


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
* https://jira.corp.stripe.com/browse/RUN_MOBILEAPP-810

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
* added