### PR TITLE
Refactor primary button theme based on feedback

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/PaymentsTheme.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/PaymentsTheme.kt
@@ -78,7 +78,7 @@ data class PaymentsTypography(
 )
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-data class PrimaryButtonTheme(
+data class PrimaryButtonStyle(
     val colorsLight: PrimaryButtonColors,
     val colorsDark: PrimaryButtonColors,
     val shape: PrimaryButtonShape,
@@ -160,7 +160,7 @@ object PaymentsThemeDefaults {
         fontFamily = null // We default to the default system font.
     )
 
-    val primaryButtonTheme = PrimaryButtonTheme(
+    val primaryButtonStyle = PrimaryButtonStyle(
         colorsLight = PrimaryButtonColors(
             background = colors(false).primary,
             onBackground = Color.White,
@@ -363,7 +363,7 @@ object PaymentsTheme {
         @ReadOnlyComposable
         get() = typographyMutable.toComposeTypography()
 
-    var primaryButtonMutable = PaymentsThemeDefaults.primaryButtonTheme
+    var primaryButtonStyle = PaymentsThemeDefaults.primaryButtonStyle
 
     @Composable
     @ReadOnlyComposable
@@ -447,21 +447,21 @@ fun Color.shouldUseDarkDynamicColor(): Boolean {
 
 @ColorInt
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-fun PrimaryButtonTheme.getBackgroundColor(context: Context): Int {
+fun PrimaryButtonStyle.getBackgroundColor(context: Context): Int {
     val isDark = context.isSystemDarkTheme()
     return (if (isDark) colorsLight else colorsDark).background.toArgb()
 }
 
 @ColorInt
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-fun PrimaryButtonTheme.getOnBackgroundColor(context: Context): Int {
+fun PrimaryButtonStyle.getOnBackgroundColor(context: Context): Int {
     val isDark = context.isSystemDarkTheme()
     return (if (isDark) colorsLight else colorsDark).onBackground.toArgb()
 }
 
 @ColorInt
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-fun PrimaryButtonTheme.getBorderStrokeColor(context: Context): Int {
+fun PrimaryButtonStyle.getBorderStrokeColor(context: Context): Int {
     val isDark = context.isSystemDarkTheme()
     return (if (isDark) colorsLight.borderStroke else colorsDark.borderStroke).toArgb()
 }
@@ -469,7 +469,7 @@ fun PrimaryButtonTheme.getBorderStrokeColor(context: Context): Int {
 @Composable
 @ReadOnlyComposable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-fun PrimaryButtonTheme.getComposeTextStyle(): TextStyle {
+fun PrimaryButtonStyle.getComposeTextStyle(): TextStyle {
     val baseStyle = PaymentsTheme.typography.h5.copy(
         color = (if (isSystemInDarkTheme()) colorsDark else colorsLight).onBackground,
     )

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/PaymentsTheme.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/PaymentsTheme.kt
@@ -78,17 +78,30 @@ data class PaymentsTypography(
 )
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-data class PrimaryButtonModifier(
-    val primaryLight: Color,
-    val onPrimaryLight: Color,
-    val primaryDark: Color,
-    val onPrimaryDark: Color,
+data class PrimaryButtonTheme(
+    val colorsLight: PrimaryButtonColors,
+    val colorsDark: PrimaryButtonColors,
+    val shape: PrimaryButtonShape,
+    val typography: PrimaryButtonTypography
+)
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class PrimaryButtonColors(
+    val background: Color,
+    val onBackground: Color,
+    val borderStroke: Color,
+)
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class PrimaryButtonShape(
     val cornerRadius: Float,
-    val border: Color,
     val borderStrokeWidth: Float,
+)
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class PrimaryButtonTypography(
     @FontRes
-    val fontFamily: Int?,
-    val height: Float,
+    val fontFamily: Int?
 )
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -147,16 +160,24 @@ object PaymentsThemeDefaults {
         fontFamily = null // We default to the default system font.
     )
 
-    val primaryButtonModifier = PrimaryButtonModifier(
-        primaryLight = colors(false).primary,
-        onPrimaryLight = Color.White,
-        primaryDark = colors(true).primary,
-        onPrimaryDark = Color.White,
-        cornerRadius = shapes.cornerRadius,
-        border = Color.Transparent,
-        borderStrokeWidth = 0.0F,
-        fontFamily = typography.fontFamily,
-        height = 40.0f
+    val primaryButtonTheme = PrimaryButtonTheme(
+        colorsLight = PrimaryButtonColors(
+            background = colors(false).primary,
+            onBackground = Color.White,
+            borderStroke = Color.Transparent
+        ),
+        colorsDark = PrimaryButtonColors(
+            background = colors(true).primary,
+            onBackground = Color.White,
+            borderStroke = Color.Transparent
+        ),
+        shape = PrimaryButtonShape(
+            cornerRadius = shapes.cornerRadius,
+            borderStrokeWidth = 0.0f,
+        ),
+        typography = PrimaryButtonTypography(
+            fontFamily = typography.fontFamily,
+        )
     )
 }
 
@@ -177,13 +198,6 @@ data class PaymentsComposeShapes(
     val borderStrokeWidth: Dp,
     val borderStrokeWidthSelected: Dp,
     val material: Shapes
-)
-
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-data class PrimaryButtonModifierCompose(
-    val onPrimary: Color,
-    val style: TextStyle,
-    val height: Dp,
 )
 
 @Composable
@@ -300,24 +314,6 @@ fun PaymentsTypography.toComposeTypography(): Typography {
 }
 
 @Composable
-@ReadOnlyComposable
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-fun PrimaryButtonModifier.toComposeModifier(isDark: Boolean): PrimaryButtonModifierCompose {
-    val baseStyle = PaymentsTheme.typography.h5
-    val textStyle = if (fontFamily != null) {
-        baseStyle.copy(fontFamily = FontFamily(Font(fontFamily)))
-    } else {
-        baseStyle
-    }
-
-    return PrimaryButtonModifierCompose(
-        onPrimary = if (isDark) onPrimaryDark else onPrimaryLight,
-        style = textStyle,
-        height = height.dp
-    )
-}
-
-@Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun PaymentsTheme(
     content: @Composable () -> Unit
@@ -367,11 +363,7 @@ object PaymentsTheme {
         @ReadOnlyComposable
         get() = typographyMutable.toComposeTypography()
 
-    var primaryButtonModifierMutable = PaymentsThemeDefaults.primaryButtonModifier
-    val primaryButtonModifier: PrimaryButtonModifierCompose
-        @Composable
-        @ReadOnlyComposable
-        get() = primaryButtonModifierMutable.toComposeModifier(isSystemInDarkTheme())
+    var primaryButtonMutable = PaymentsThemeDefaults.primaryButtonTheme
 
     @Composable
     @ReadOnlyComposable
@@ -455,7 +447,35 @@ fun Color.shouldUseDarkDynamicColor(): Boolean {
 
 @ColorInt
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-fun PrimaryButtonModifier.getPrimaryColor(context: Context): Int {
+fun PrimaryButtonTheme.getBackgroundColor(context: Context): Int {
     val isDark = context.isSystemDarkTheme()
-    return (if (isDark) primaryDark else primaryLight).toArgb()
+    return (if (isDark) colorsLight else colorsDark).background.toArgb()
+}
+
+@ColorInt
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun PrimaryButtonTheme.getOnBackgroundColor(context: Context): Int {
+    val isDark = context.isSystemDarkTheme()
+    return (if (isDark) colorsLight else colorsDark).onBackground.toArgb()
+}
+
+@ColorInt
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun PrimaryButtonTheme.getBorderStrokeColor(context: Context): Int {
+    val isDark = context.isSystemDarkTheme()
+    return (if (isDark) colorsLight.borderStroke else colorsDark.borderStroke).toArgb()
+}
+
+@Composable
+@ReadOnlyComposable
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun PrimaryButtonTheme.getComposeTextStyle(): TextStyle {
+    val baseStyle = PaymentsTheme.typography.h5.copy(
+        color = (if (isSystemInDarkTheme()) colorsDark else colorsLight).onBackground,
+    )
+    return if (typography.fontFamily != null) {
+        baseStyle.copy(fontFamily = FontFamily(Font(typography.fontFamily)))
+    } else {
+        baseStyle
+    }
 }

--- a/paymentsheet/res/layout/activity_payment_sheet.xml
+++ b/paymentsheet/res/layout/activity_payment_sheet.xml
@@ -126,7 +126,7 @@
                     android:animateLayoutChanges="true"
                     android:visibility="gone"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
+                    android:layout_height="@dimen/stripe_paymentsheet_max_primary_button_height"
                     android:layout_marginTop="@dimen/stripe_paymentsheet_button_container_spacing"
                     android:layout_marginHorizontal="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
                     android:layout_marginBottom="@dimen/stripe_paymentsheet_button_container_spacing_bottom">
@@ -134,7 +134,7 @@
                     <com.stripe.android.paymentsheet.ui.PrimaryButton
                         android:id="@+id/buy_button"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
+                        android:layout_height="@dimen/stripe_paymentsheet_primary_button_height"
                         android:text="@string/stripe_paymentsheet_pay_button_label"
                         android:layout_marginVertical="2dp" />
                 </FrameLayout>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -24,7 +24,7 @@ import com.stripe.android.paymentsheet.ui.AnimationConstants
 import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.ui.core.PaymentsTheme
-import com.stripe.android.ui.core.getPrimaryColor
+import com.stripe.android.ui.core.getBackgroundColor
 
 /**
  * An `Activity` for selecting a payment option.
@@ -131,10 +131,10 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
 
         viewModel.config?.let {
             val buttonColor = it.primaryButtonColor ?: ColorStateList.valueOf(
-                PaymentsTheme.primaryButtonModifierMutable.getPrimaryColor(baseContext)
+                PaymentsTheme.primaryButtonMutable.getBackgroundColor(baseContext)
             )
             viewBinding.continueButton.setAppearanceConfiguration(
-                PaymentsTheme.primaryButtonModifierMutable,
+                PaymentsTheme.primaryButtonMutable,
                 buttonColor
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -131,10 +131,10 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
 
         viewModel.config?.let {
             val buttonColor = it.primaryButtonColor ?: ColorStateList.valueOf(
-                PaymentsTheme.primaryButtonMutable.getBackgroundColor(baseContext)
+                PaymentsTheme.primaryButtonStyle.getBackgroundColor(baseContext)
             )
             viewBinding.continueButton.setAppearanceConfiguration(
-                PaymentsTheme.primaryButtonMutable,
+                PaymentsTheme.primaryButtonStyle,
                 buttonColor
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -265,10 +265,10 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
             .observe(this, buyButtonStateObserver)
 
         val buttonColor = viewModel.config?.primaryButtonColor ?: ColorStateList.valueOf(
-            PaymentsTheme.primaryButtonMutable.getBackgroundColor(baseContext)
+            PaymentsTheme.primaryButtonStyle.getBackgroundColor(baseContext)
         )
         viewBinding.buyButton.setAppearanceConfiguration(
-            PaymentsTheme.primaryButtonMutable,
+            PaymentsTheme.primaryButtonStyle,
             buttonColor
         )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -31,7 +31,7 @@ import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.GooglePayDividerUi
 import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.PaymentsThemeDefaults
-import com.stripe.android.ui.core.getPrimaryColor
+import com.stripe.android.ui.core.getBackgroundColor
 import com.stripe.android.ui.core.isSystemDarkTheme
 import com.stripe.android.ui.core.shouldUseDarkDynamicColor
 import kotlinx.coroutines.launch
@@ -265,10 +265,10 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
             .observe(this, buyButtonStateObserver)
 
         val buttonColor = viewModel.config?.primaryButtonColor ?: ColorStateList.valueOf(
-            PaymentsTheme.primaryButtonModifierMutable.getPrimaryColor(baseContext)
+            PaymentsTheme.primaryButtonMutable.getBackgroundColor(baseContext)
         )
         viewBinding.buyButton.setAppearanceConfiguration(
-            PaymentsTheme.primaryButtonModifierMutable,
+            PaymentsTheme.primaryButtonMutable,
             buttonColor
         )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
@@ -7,15 +7,11 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.FrameLayout
 import androidx.annotation.VisibleForTesting
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.core.content.withStyledAttributes
@@ -214,17 +210,11 @@ internal class PrimaryButton @JvmOverloads constructor(
 
 @Composable
 private fun LabelUI(label: String) {
-    Box(
-        contentAlignment = Alignment.Center,
+    Text(
+        text = label,
+        textAlign = TextAlign.Center,
+        style = PaymentsTheme.primaryButtonStyle.getComposeTextStyle(),
         modifier = Modifier
-            .height(dimensionResource(R.dimen.stripe_paymentsheet_primary_button_height))
-    ) {
-        Text(
-            text = label,
-            textAlign = TextAlign.Center,
-            style = PaymentsTheme.primaryButtonStyle.getComposeTextStyle(),
-            modifier = Modifier
-                .padding(horizontal = 4.dp)
-        )
-    }
+            .padding(start = 4.dp, end = 4.dp, top = 4.dp, bottom = 5.dp)
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
@@ -14,8 +14,8 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.core.content.withStyledAttributes
@@ -25,8 +25,11 @@ import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.databinding.PrimaryButtonBinding
 import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.PaymentsThemeDefaults
-import com.stripe.android.ui.core.PrimaryButtonModifier
+import com.stripe.android.ui.core.PrimaryButtonTheme
 import com.stripe.android.ui.core.convertDpToPx
+import com.stripe.android.ui.core.getBorderStrokeColor
+import com.stripe.android.ui.core.getComposeTextStyle
+import com.stripe.android.ui.core.getOnBackgroundColor
 
 /**
  * The primary call-to-action for a payment sheet screen.
@@ -58,12 +61,13 @@ internal class PrimaryButton @JvmOverloads constructor(
     private val confirmedIcon = viewBinding.confirmedIcon
 
     private var cornerRadius = context.convertDpToPx(
-        PaymentsThemeDefaults.primaryButtonModifier.cornerRadius.dp
+        PaymentsThemeDefaults.primaryButtonTheme.shape.cornerRadius.dp
     )
     private var borderStrokeWidth = context.convertDpToPx(
-        PaymentsThemeDefaults.primaryButtonModifier.borderStrokeWidth.dp
+        PaymentsThemeDefaults.primaryButtonTheme.shape.borderStrokeWidth.dp
     )
-    private var borderStrokeColor = PaymentsThemeDefaults.primaryButtonModifier.border.toArgb()
+    private var borderStrokeColor =
+        PaymentsThemeDefaults.primaryButtonTheme.getBorderStrokeColor(context)
 
     init {
         // This is only needed if the button is inside a fragment
@@ -79,12 +83,15 @@ internal class PrimaryButton @JvmOverloads constructor(
     }
 
     fun setAppearanceConfiguration(
-        primaryButtonModifier: PrimaryButtonModifier,
+        primaryButtonTheme: PrimaryButtonTheme,
         tintList: ColorStateList?
     ) {
-        cornerRadius = context.convertDpToPx(primaryButtonModifier.cornerRadius.dp)
-        borderStrokeWidth = context.convertDpToPx(primaryButtonModifier.borderStrokeWidth.dp)
-        borderStrokeColor = primaryButtonModifier.border.toArgb()
+        cornerRadius = context.convertDpToPx(primaryButtonTheme.shape.cornerRadius.dp)
+        borderStrokeWidth = context.convertDpToPx(primaryButtonTheme.shape.borderStrokeWidth.dp)
+        borderStrokeColor = primaryButtonTheme.getBorderStrokeColor(context)
+        viewBinding.lockIcon.imageTintList = ColorStateList.valueOf(
+            primaryButtonTheme.getOnBackgroundColor(context)
+        )
         backgroundTintList = tintList
         defaultTintList = tintList
     }
@@ -210,15 +217,14 @@ private fun LabelUI(label: String) {
     Box(
         contentAlignment = Alignment.Center,
         modifier = Modifier
-            .height(PaymentsTheme.primaryButtonModifier.height)
+            .height(dimensionResource(R.dimen.stripe_paymentsheet_primary_button_height))
     ) {
         Text(
             text = label,
             textAlign = TextAlign.Center,
-            color = PaymentsTheme.primaryButtonModifier.onPrimary,
-            style = PaymentsTheme.primaryButtonModifier.style,
+            style = PaymentsTheme.primaryButtonMutable.getComposeTextStyle(),
             modifier = Modifier
-                .padding(start = 4.dp, end = 4.dp, top = 4.dp, bottom = 5.dp)
+                .padding(horizontal = 4.dp)
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
@@ -25,7 +25,7 @@ import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.databinding.PrimaryButtonBinding
 import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.PaymentsThemeDefaults
-import com.stripe.android.ui.core.PrimaryButtonTheme
+import com.stripe.android.ui.core.PrimaryButtonStyle
 import com.stripe.android.ui.core.convertDpToPx
 import com.stripe.android.ui.core.getBorderStrokeColor
 import com.stripe.android.ui.core.getComposeTextStyle
@@ -61,13 +61,13 @@ internal class PrimaryButton @JvmOverloads constructor(
     private val confirmedIcon = viewBinding.confirmedIcon
 
     private var cornerRadius = context.convertDpToPx(
-        PaymentsThemeDefaults.primaryButtonTheme.shape.cornerRadius.dp
+        PaymentsThemeDefaults.primaryButtonStyle.shape.cornerRadius.dp
     )
     private var borderStrokeWidth = context.convertDpToPx(
-        PaymentsThemeDefaults.primaryButtonTheme.shape.borderStrokeWidth.dp
+        PaymentsThemeDefaults.primaryButtonStyle.shape.borderStrokeWidth.dp
     )
     private var borderStrokeColor =
-        PaymentsThemeDefaults.primaryButtonTheme.getBorderStrokeColor(context)
+        PaymentsThemeDefaults.primaryButtonStyle.getBorderStrokeColor(context)
 
     init {
         // This is only needed if the button is inside a fragment
@@ -83,14 +83,14 @@ internal class PrimaryButton @JvmOverloads constructor(
     }
 
     fun setAppearanceConfiguration(
-        primaryButtonTheme: PrimaryButtonTheme,
+        primaryButtonStyle: PrimaryButtonStyle,
         tintList: ColorStateList?
     ) {
-        cornerRadius = context.convertDpToPx(primaryButtonTheme.shape.cornerRadius.dp)
-        borderStrokeWidth = context.convertDpToPx(primaryButtonTheme.shape.borderStrokeWidth.dp)
-        borderStrokeColor = primaryButtonTheme.getBorderStrokeColor(context)
+        cornerRadius = context.convertDpToPx(primaryButtonStyle.shape.cornerRadius.dp)
+        borderStrokeWidth = context.convertDpToPx(primaryButtonStyle.shape.borderStrokeWidth.dp)
+        borderStrokeColor = primaryButtonStyle.getBorderStrokeColor(context)
         viewBinding.lockIcon.imageTintList = ColorStateList.valueOf(
-            primaryButtonTheme.getOnBackgroundColor(context)
+            primaryButtonStyle.getOnBackgroundColor(context)
         )
         backgroundTintList = tintList
         defaultTintList = tintList
@@ -222,7 +222,7 @@ private fun LabelUI(label: String) {
         Text(
             text = label,
             textAlign = TextAlign.Center,
-            style = PaymentsTheme.primaryButtonMutable.getComposeTextStyle(),
+            style = PaymentsTheme.primaryButtonStyle.getComposeTextStyle(),
             modifier = Modifier
                 .padding(horizontal = 4.dp)
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PrimaryButtonTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PrimaryButtonTest.kt
@@ -37,7 +37,7 @@ class PrimaryButtonTest {
 
     @Test
     fun `onFinishingState() should clear any tint and restore onReadyState()`() {
-        primaryButton.setAppearanceConfiguration(PaymentsThemeDefaults.primaryButtonModifier, ColorStateList.valueOf(Color.BLACK))
+        primaryButton.setAppearanceConfiguration(PaymentsThemeDefaults.primaryButtonTheme, ColorStateList.valueOf(Color.BLACK))
         primaryButton.updateState(
             PrimaryButton.State.FinishProcessing({})
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PrimaryButtonTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PrimaryButtonTest.kt
@@ -37,7 +37,7 @@ class PrimaryButtonTest {
 
     @Test
     fun `onFinishingState() should clear any tint and restore onReadyState()`() {
-        primaryButton.setAppearanceConfiguration(PaymentsThemeDefaults.primaryButtonTheme, ColorStateList.valueOf(Color.BLACK))
+        primaryButton.setAppearanceConfiguration(PaymentsThemeDefaults.primaryButtonStyle, ColorStateList.valueOf(Color.BLACK))
         primaryButton.updateState(
             PrimaryButton.State.FinishProcessing({})
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* No visual changes.
* Add color, shape, typography
* PrimaryButtonModifier -> PrimaryButtonTheme
* Removes height as a variable.
* Adds a light/dark mode color for border stroke.
* Realized the old height value of 48dp would look the same as long as I remove the extra padding.
* Refactors Primary Button theme object to match that of this doc: https://paper.dropbox.com/doc/2022-04-18-PaymentSheet-Primary-Button-Appearance-APIs-Mobile-API-Review--Bf4AkKLFuYvhAd6~iBQyXieYAg-vjjl5N5OxQ7ZAK8VEgkVD

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
* Will make it easier to parse our public api if the shape of the internal representation of the theme is the same. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

