### PR TITLE
Add credit card end to end tests.

### DIFF
--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -209,6 +209,7 @@ public final class com/stripe/android/ui/core/elements/MandateTextUIKt {
 }
 
 public final class com/stripe/android/ui/core/elements/SaveForFutureUseElementUIKt {
+	public static final field SAVE_FOR_FUTURE_CHECKBOX_TEST_TAG Ljava/lang/String;
 }
 
 public final class com/stripe/android/ui/core/elements/SectionElementUIKt {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingSpec.kt
@@ -1,10 +1,12 @@
 package com.stripe.android.ui.core.elements
 
+import androidx.annotation.RestrictTo
 import com.stripe.android.ui.core.address.AddressFieldElementRepository
 import kotlinx.parcelize.Parcelize
 
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 @Parcelize
-internal data class CardBillingSpec(
+data class CardBillingSpec(
     override val identifier: IdentifierSpec = IdentifierSpec.Generic("card_billing"),
     val countryCodes: Set<String>
 ) : SectionFieldSpec(identifier) {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSpec.kt
@@ -1,10 +1,12 @@
 package com.stripe.android.ui.core.elements
 
 import android.content.Context
+import androidx.annotation.RestrictTo
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-internal object CardDetailsSpec : SectionFieldSpec(IdentifierSpec.Generic("card_details")) {
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
+object CardDetailsSpec : SectionFieldSpec(IdentifierSpec.Generic("card_details")) {
     fun transform(context: Context): SectionFieldElement = CardDetailsElement(
         IdentifierSpec.Generic("credit_detail"), context
     )

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SaveForFutureUseElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SaveForFutureUseElementUI.kt
@@ -16,9 +16,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.unit.dp
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.menu.Checkbox
+
+const val SAVE_FOR_FUTURE_CHECKBOX_TEST_TAG = "SAVE_FOR_FUTURE_CHECKBOX_TEST_TAG"
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -43,6 +46,7 @@ fun SaveForFutureUseElementUI(
         modifier = Modifier
             .padding(vertical = 2.dp)
             .semantics {
+                testTag = SAVE_FOR_FUTURE_CHECKBOX_TEST_TAG
                 stateDescription = description
             }
             .toggleable(

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestFieldPopulation.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestFieldPopulation.kt
@@ -3,20 +3,19 @@ package com.stripe.android
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTextInput
-import androidx.test.espresso.IdlingPolicies
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.stripe.android.paymentsheet.model.SupportedPaymentMethod
 import com.stripe.android.test.core.Automatic
 import com.stripe.android.test.core.Billing
-import com.stripe.android.test.core.IntentType
 import com.stripe.android.test.core.Currency
 import com.stripe.android.test.core.Customer
 import com.stripe.android.test.core.DelayedPMs
+import com.stripe.android.test.core.MyScreenCaptureProcessor
 import com.stripe.android.test.core.GooglePayState
 import com.stripe.android.test.core.INDIVIDUAL_TEST_TIMEOUT_SECONDS
-import com.stripe.android.test.core.MyScreenCaptureProcessor
+import com.stripe.android.test.core.IntentType
 import com.stripe.android.test.core.PlaygroundTestDriver
 import com.stripe.android.test.core.Shipping
 import com.stripe.android.test.core.TestParameters
@@ -28,7 +27,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.Timeout
 import org.junit.runner.RunWith
-import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
 class TestFieldPopulation {
@@ -71,9 +69,49 @@ class TestFieldPopulation {
         authorizationAction = null,
     )
 
+    private val card = TestParameters(
+        paymentMethod = SupportedPaymentMethod.Card,
+        customer = Customer.New,
+        googlePayState = GooglePayState.On,
+        currency = Currency.EUR,
+        intentType = IntentType.Pay,
+        billing = Billing.On,
+        shipping = Shipping.Off,
+        delayed = DelayedPMs.On,
+        automatic = Automatic.Off,
+        saveCheckboxValue = false,
+        saveForFutureUseCheckboxVisible = true,
+        useBrowser = null,
+        authorizationAction = null
+    )
+
     @Ignore("Testing of dropdowns is not yet supported")
     fun testDropdowns() {
 
+    }
+
+    @Test
+    fun testCardDefaultAddress() {
+        testDriver.confirmNewOrGuestComplete(
+            card.copy(
+                billing = Billing.On,
+                authorizationAction = null,
+                saveForFutureUseCheckboxVisible = true,
+                saveCheckboxValue = true,
+            )
+        )
+    }
+
+    @Test
+    fun testCardNoDefaultAddress() {
+        testDriver.confirmNewOrGuestComplete(
+            card.copy(
+                billing = Billing.Off,
+                authorizationAction = null,
+                saveForFutureUseCheckboxVisible = true,
+                saveCheckboxValue = false,
+            )
+        )
     }
 
     @Test

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestHardCodedLpms.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestHardCodedLpms.kt
@@ -13,10 +13,10 @@ import com.stripe.android.test.core.Billing
 import com.stripe.android.test.core.Currency
 import com.stripe.android.test.core.Customer
 import com.stripe.android.test.core.DelayedPMs
+import com.stripe.android.test.core.MyScreenCaptureProcessor
 import com.stripe.android.test.core.GooglePayState
 import com.stripe.android.test.core.INDIVIDUAL_TEST_TIMEOUT_SECONDS
 import com.stripe.android.test.core.IntentType
-import com.stripe.android.test.core.MyScreenCaptureProcessor
 import com.stripe.android.test.core.PlaygroundTestDriver
 import com.stripe.android.test.core.Shipping
 import com.stripe.android.test.core.TestParameters
@@ -70,6 +70,17 @@ class TestHardCodedLpms {
         authorizationAction = AuthorizeAction.Authorize,
         takeScreenshotOnLpmLoad = true
     )
+
+    @Test
+    fun testCard() {
+        testDriver.confirmNewOrGuestComplete(
+            newUser.copy(
+                billing= Billing.On,
+                paymentMethod = SupportedPaymentMethod.Card,
+                authorizationAction = null
+            )
+        )
+    }
 
     @Test
     fun testBancontact() {

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/Selectors.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/Selectors.kt
@@ -2,6 +2,7 @@ package com.stripe.android.test.core.ui
 
 import android.content.pm.PackageManager
 import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.By
@@ -27,6 +28,7 @@ import com.stripe.android.test.core.HOOKS_PAGE_LOAD_TIMEOUT
 import com.stripe.android.test.core.IntentType
 import com.stripe.android.test.core.Shipping
 import com.stripe.android.test.core.TestParameters
+import com.stripe.android.ui.core.elements.SAVE_FOR_FUTURE_CHECKBOX_TEST_TAG
 
 /**
  * This contains the Android specific code such as for accessing UI elements, detecting
@@ -37,8 +39,9 @@ class Selectors(
     val composeTestRule: ComposeTestRule,
     testParameters: TestParameters
 ) {
-    val saveForFutureCheckbox =
-        EspressoLabelIdButton(R.string.stripe_paymentsheet_save_this_card_with_merchant_name)
+    val saveForFutureCheckbox = composeTestRule
+        .onNodeWithTag(SAVE_FOR_FUTURE_CHECKBOX_TEST_TAG)
+
     val customer = when (testParameters.customer) {
         Customer.Guest -> EspressoLabelIdButton(R.string.customer_guest)
         Customer.New -> EspressoLabelIdButton(R.string.customer_new)
@@ -234,6 +237,24 @@ class Selectors(
         "Or pay",
         substring = true,
         useUnmergedTree = true
+    )
+
+    fun getCardNumber() = composeTestRule.onNodeWithText(
+        InstrumentationRegistry.getInstrumentation().targetContext.resources.getString(
+            com.stripe.android.R.string.acc_label_card_number
+        )
+    )
+
+    fun getCardExpiration() = composeTestRule.onNodeWithText(
+        InstrumentationRegistry.getInstrumentation().targetContext.resources.getString(
+            R.string.stripe_paymentsheet_expiration_date_hint
+        )
+    )
+
+    fun getCardCvc() = composeTestRule.onNodeWithText(
+        InstrumentationRegistry.getInstrumentation().targetContext.resources.getString(
+            com.stripe.android.ui.core.R.string.cvc_number_hint
+        )
     )
 
     companion object {


### PR DESCRIPTION
# Summary
Add credit card end to end tests.  These tests will just verify we can populate the fields for a credit card that does not require any additional authorization.

# Motivation
Reduce the chances of regression.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

