### PR TITLE
[Not being merged to master] Add public api for primary button

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -111,7 +111,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Appearance$Build
 	public fun <init> ()V
 	public final fun colorsDark (Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;)Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance$Builder;
 	public final fun colorsLight (Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;)Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance$Builder;
-	public final fun primaryButtonModifier (Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButton;)Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance$Builder;
+	public final fun primaryButton (Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButton;)Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance$Builder;
 	public final fun shapes (Lcom/stripe/android/paymentsheet/PaymentSheet$Shapes;)Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance$Builder;
 	public final fun typography (Lcom/stripe/android/paymentsheet/PaymentSheet$Typography;)Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance$Builder;
 }
@@ -326,7 +326,9 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$GooglePayConfigu
 public final class com/stripe/android/paymentsheet/PaymentSheet$PrimaryButton : android/os/Parcelable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonShape;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonTypography;)V
+	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonShape;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonTypography;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;
 	public final fun component2 ()Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;
 	public final fun component3 ()Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonShape;
@@ -347,15 +349,16 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$PrimaryButton : 
 public final class com/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors : android/os/Parcelable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (III)V
-	public final fun component1 ()I
+	public static final field Companion Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors$Companion;
+	public fun <init> (Ljava/lang/Integer;II)V
+	public final fun component1 ()Ljava/lang/Integer;
 	public final fun component2 ()I
 	public final fun component3 ()I
-	public final fun copy (III)Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;IIIILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;
+	public final fun copy (Ljava/lang/Integer;II)Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;Ljava/lang/Integer;IIILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBackground ()I
+	public final fun getBackground ()Ljava/lang/Integer;
 	public final fun getBorder ()I
 	public final fun getOnBackground ()I
 	public fun hashCode ()I
@@ -363,18 +366,25 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonCol
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
+public final class com/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors$Companion {
+	public final fun getDefaultDark ()Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;
+	public final fun getDefaultLight ()Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;
+}
+
 public final class com/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonShape : android/os/Parcelable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (FF)V
-	public final fun component1 ()F
-	public final fun component2 ()F
-	public final fun copy (FF)Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonShape;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonShape;FFILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonShape;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Float;Ljava/lang/Float;)V
+	public synthetic fun <init> (Ljava/lang/Float;Ljava/lang/Float;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Float;
+	public final fun component2 ()Ljava/lang/Float;
+	public final fun copy (Ljava/lang/Float;Ljava/lang/Float;)Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonShape;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonShape;Ljava/lang/Float;Ljava/lang/Float;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonShape;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBorderStrokeWidthDp ()F
-	public final fun getCornerRadiusDp ()F
+	public final fun getBorderStrokeWidthDp ()Ljava/lang/Float;
+	public final fun getCornerRadiusDp ()Ljava/lang/Float;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
@@ -383,7 +393,9 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonSha
 public final class com/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonTypography : android/os/Parcelable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
 	public fun <init> (Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Integer;
 	public final fun copy (Ljava/lang/Integer;)Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonTypography;
 	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonTypography;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonTypography;

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -84,19 +84,21 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Appearance : and
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public fun <init> ()V
-	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;Lcom/stripe/android/paymentsheet/PaymentSheet$Shapes;Lcom/stripe/android/paymentsheet/PaymentSheet$Typography;)V
-	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;Lcom/stripe/android/paymentsheet/PaymentSheet$Shapes;Lcom/stripe/android/paymentsheet/PaymentSheet$Typography;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;Lcom/stripe/android/paymentsheet/PaymentSheet$Shapes;Lcom/stripe/android/paymentsheet/PaymentSheet$Typography;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButton;)V
+	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;Lcom/stripe/android/paymentsheet/PaymentSheet$Shapes;Lcom/stripe/android/paymentsheet/PaymentSheet$Typography;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButton;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;
 	public final fun component2 ()Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;
 	public final fun component3 ()Lcom/stripe/android/paymentsheet/PaymentSheet$Shapes;
 	public final fun component4 ()Lcom/stripe/android/paymentsheet/PaymentSheet$Typography;
-	public final fun copy (Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;Lcom/stripe/android/paymentsheet/PaymentSheet$Shapes;Lcom/stripe/android/paymentsheet/PaymentSheet$Typography;)Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;Lcom/stripe/android/paymentsheet/PaymentSheet$Shapes;Lcom/stripe/android/paymentsheet/PaymentSheet$Typography;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;
+	public final fun component5 ()Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButton;
+	public final fun copy (Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;Lcom/stripe/android/paymentsheet/PaymentSheet$Shapes;Lcom/stripe/android/paymentsheet/PaymentSheet$Typography;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButton;)Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;Lcom/stripe/android/paymentsheet/PaymentSheet$Shapes;Lcom/stripe/android/paymentsheet/PaymentSheet$Typography;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButton;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getColors (Z)Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;
 	public final fun getColorsDark ()Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;
 	public final fun getColorsLight ()Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;
+	public final fun getPrimaryButton ()Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButton;
 	public final fun getShapes ()Lcom/stripe/android/paymentsheet/PaymentSheet$Shapes;
 	public final fun getTypography ()Lcom/stripe/android/paymentsheet/PaymentSheet$Typography;
 	public fun hashCode ()I
@@ -109,6 +111,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Appearance$Build
 	public fun <init> ()V
 	public final fun colorsDark (Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;)Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance$Builder;
 	public final fun colorsLight (Lcom/stripe/android/paymentsheet/PaymentSheet$Colors;)Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance$Builder;
+	public final fun primaryButtonModifier (Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButton;)Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance$Builder;
 	public final fun shapes (Lcom/stripe/android/paymentsheet/PaymentSheet$Shapes;)Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance$Builder;
 	public final fun typography (Lcom/stripe/android/paymentsheet/PaymentSheet$Typography;)Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance$Builder;
 }
@@ -320,6 +323,78 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$GooglePayConfigu
 	public static fun values ()[Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;
 }
 
+public final class com/stripe/android/paymentsheet/PaymentSheet$PrimaryButton : android/os/Parcelable {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonShape;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonTypography;)V
+	public final fun component1 ()Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;
+	public final fun component2 ()Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;
+	public final fun component3 ()Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonShape;
+	public final fun component4 ()Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonTypography;
+	public final fun copy (Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonShape;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonTypography;)Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButton;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButton;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonShape;Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonTypography;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButton;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getColorsDark ()Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;
+	public final fun getColorsLight ()Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;
+	public final fun getShape ()Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonShape;
+	public final fun getTypography ()Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonTypography;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors : android/os/Parcelable {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (III)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun copy (III)Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;IIIILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonColors;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBackground ()I
+	public final fun getBorder ()I
+	public final fun getOnBackground ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonShape : android/os/Parcelable {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (FF)V
+	public final fun component1 ()F
+	public final fun component2 ()F
+	public final fun copy (FF)Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonShape;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonShape;FFILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonShape;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBorderStrokeWidthDp ()F
+	public final fun getCornerRadiusDp ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonTypography : android/os/Parcelable {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/Integer;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/Integer;)Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonTypography;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonTypography;Ljava/lang/Integer;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$PrimaryButtonTypography;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFontResId ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
 public final class com/stripe/android/paymentsheet/PaymentSheet$Shapes : android/os/Parcelable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
@@ -346,18 +421,18 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Typography : and
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/paymentsheet/PaymentSheet$Typography$Companion;
-	public fun <init> (FIIII)V
+	public fun <init> (FIIILjava/lang/Integer;)V
 	public final fun component1 ()F
 	public final fun component2 ()I
 	public final fun component3 ()I
 	public final fun component4 ()I
-	public final fun component5 ()I
-	public final fun copy (FIIII)Lcom/stripe/android/paymentsheet/PaymentSheet$Typography;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$Typography;FIIIIILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$Typography;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun copy (FIIILjava/lang/Integer;)Lcom/stripe/android/paymentsheet/PaymentSheet$Typography;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$Typography;FIIILjava/lang/Integer;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$Typography;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBoldWeight ()I
-	public final fun getFontResId ()I
+	public final fun getFontResId ()Ljava/lang/Integer;
 	public final fun getMediumWeight ()I
 	public final fun getNormalWeight ()I
 	public final fun getSizeScaleFactor ()F

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -192,6 +192,34 @@ class PaymentSheet internal constructor(
 
         // Describes the typography used for text.
         val typography: Typography = Typography.default,
+
+        // Describes appearance of the primary button (e.g., the "Pay" button) in PaymentSheet
+        val primaryButton: PrimaryButton = PrimaryButton(
+            colorsLight = PrimaryButtonColors(
+                background =
+                colorsLight.primary,
+                onBackground =
+                PaymentsThemeDefaults.primaryButtonStyle.colorsLight.onBackground.toArgb(),
+                border =
+                PaymentsThemeDefaults.primaryButtonStyle.colorsLight.border.toArgb()
+            ),
+            colorsDark = PrimaryButtonColors(
+                background =
+                colorsDark.primary,
+                onBackground =
+                PaymentsThemeDefaults.primaryButtonStyle.colorsDark.onBackground.toArgb(),
+                border =
+                PaymentsThemeDefaults.primaryButtonStyle.colorsDark.border.toArgb()
+            ),
+            shape = PrimaryButtonShape(
+                cornerRadiusDp = shapes.cornerRadiusDp,
+                borderStrokeWidthDp = shapes.borderStrokeWidthDp
+            ),
+            typography = PrimaryButtonTypography(
+                fontResId = typography.fontResId
+            )
+        )
+
     ) : Parcelable {
         fun getColors(isDark: Boolean): Colors {
             return if (isDark) colorsDark else colorsLight
@@ -202,11 +230,14 @@ class PaymentSheet internal constructor(
             private var colorsDark = Colors.defaultDark
             private var shapes = Shapes.default
             private var typography = Typography.default
+            private var primaryButton: PrimaryButton = Appearance().primaryButton
 
             fun colorsLight(colors: Colors) = apply { this.colorsLight = colors }
             fun colorsDark(colors: Colors) = apply { this.colorsDark = colors }
             fun shapes(shapes: Shapes) = apply { this.shapes = shapes }
             fun typography(typography: Typography) = apply { this.typography = typography }
+            fun primaryButtonModifier(primaryButton: PrimaryButton) =
+                apply { this.primaryButton = primaryButton }
         }
     }
 
@@ -332,6 +363,47 @@ class PaymentSheet internal constructor(
             )
         }
     }
+
+    @Parcelize
+    data class PrimaryButton(
+        // Describes the colors used while the system is in light mode
+        val colorsLight: PrimaryButtonColors,
+        // Describes the colors used while the system is in dark mode
+        val colorsDark: PrimaryButtonColors,
+        // Describes the shape of the primary button.
+        val shape: PrimaryButtonShape,
+        // Describes the typography of the primary button.
+        val typography: PrimaryButtonTypography
+    ) : Parcelable
+
+    @Parcelize
+    data class PrimaryButtonColors(
+        // The background color of the primary button
+        @ColorInt
+        val background: Int,
+        // The color appearing on the primary button
+        @ColorInt
+        val onBackground: Int,
+        // The border color of the primary button
+        @ColorInt
+        val border: Int,
+    ) : Parcelable
+
+    @Parcelize
+    data class PrimaryButtonShape(
+        // The corner radius of the primary button
+        val cornerRadiusDp: Float,
+        // The border width of the primary button
+        val borderStrokeWidthDp: Float
+    ) : Parcelable
+
+    @Parcelize
+    data class PrimaryButtonTypography(
+        // The font used in the primary button.
+        // Note: if 'null' the Appearance.Typography.fontResId is used.
+        @FontRes
+        val fontResId: Int?
+    ) : Parcelable
 
     @Parcelize
     data class Address(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -181,19 +181,29 @@ class PaymentSheet internal constructor(
 
     @Parcelize
     data class Appearance(
-        // Describes the colors used while the system is in light mode
+        /**
+         * Describes the colors used while the system is in light mode
+         */
         val colorsLight: Colors = Colors.defaultLight,
 
-        // Describes the colors used while the system is in dark mode
+        /**
+         * Describes the colors used while the system is in dark mode
+         */
         val colorsDark: Colors = Colors.defaultDark,
 
-        // Describes the appearance of shapes
+        /**
+         * Describes the appearance of shapes
+         */
         val shapes: Shapes = Shapes.default,
 
-        // Describes the typography used for text.
+        /**
+         * Describes the typography used for text.
+         */
         val typography: Typography = Typography.default,
 
-        // Describes appearance of the primary button (e.g., the "Pay" button) in PaymentSheet
+        /**
+         * Describes the appearance of the primary button (e.g., the "Pay" button)
+         */
         val primaryButton: PrimaryButton = PrimaryButton()
     ) : Parcelable {
         fun getColors(isDark: Boolean): Colors {
@@ -218,47 +228,70 @@ class PaymentSheet internal constructor(
 
     @Parcelize
     data class Colors(
-        // A primary color used throughout PaymentSheet
+        /**
+         * A primary color used throughout PaymentSheet
+         */
         @ColorInt
         val primary: Int,
 
-        // The color used for the surfaces (backgrounds) of PaymentSheet
+        /**
+         * The color used for the surfaces (backgrounds) of PaymentSheet
+         */
         @ColorInt
         val surface: Int,
 
-        // The color used for the background of inputs, tabs, and other components
+        /**
+         * The color used for the background of inputs, tabs, and other components
+         */
         @ColorInt
         val component: Int,
 
-        // The color used for borders of inputs, tabs, and other components
+        /**
+         * The color used for borders of inputs, tabs, and other components
+         */
         @ColorInt
         val componentBorder: Int,
 
-        // The color of the divider lines used inside inputs, tabs, and other components
+        /**
+         * The color of the divider lines used inside inputs, tabs, and other components
+         */
         @ColorInt
         val componentDivider: Int,
 
-        // The default color used for text and on other elements that live on components
+        /**
+         * The default color used for text and on other elements that live on components
+         */
         @ColorInt
         val onComponent: Int,
 
-        // The color used for items appearing over the background in Payment Sheet
+        /**
+         * The color used for items appearing over the background in Payment Sheet
+         */
         @ColorInt
         val onSurface: Int,
 
-        // The color used for text of secondary importance. For example, this color is used for the label above input fields
+        /**
+         * The color used for text of secondary importance.
+         * For example, this color is used for the label above input fields
+         */
         @ColorInt
         val subtitle: Int,
 
-        // The color used for input placeholder text
+        /**
+         * The color used for input placeholder text
+         */
         @ColorInt
         val placeholderText: Int,
 
-        // The color used for icons in PaymentSheet, such as the close or back icons
+        /**
+         * The color used for icons in PaymentSheet, such as the close or back icons
+         */
         @ColorInt
         val appBarIcon: Int,
 
-        // A color used to indicate errors or destructive actions in PaymentSheet
+        /**
+         * A color used to indicate errors or destructive actions in PaymentSheet
+         */
         @ColorInt
         val error: Int,
     ) : Parcelable {
@@ -295,10 +328,14 @@ class PaymentSheet internal constructor(
 
     @Parcelize
     data class Shapes(
-        // The corner radius used for tabs, inputs, buttons, and other components in PaymentSheet
+        /**
+         * The corner radius used for tabs, inputs, buttons, and other components in PaymentSheet
+         */
         val cornerRadiusDp: Float,
 
-        // The border used for inputs, tabs, and other components in PaymentSheet
+        /**
+         * The border used for inputs, tabs, and other components in PaymentSheet
+         */
         val borderStrokeWidthDp: Float,
     ) : Parcelable {
         companion object {
@@ -311,20 +348,30 @@ class PaymentSheet internal constructor(
 
     @Parcelize
     data class Typography(
-        // The scale factor for all fonts in PaymentSheet, the default value is 1.0.
-        // When this value increases fonts will increase in size and decrease when this value is lowered
+        /**
+         * The scale factor for all fonts in PaymentSheet, the default value is 1.0.
+         * When this value increases fonts will increase in size and decrease when this value is lowered
+         */
         val sizeScaleFactor: Float,
 
-        // Base weight for text
+        /**
+         * Base weight for text
+         */
         val normalWeight: Int,
 
-        // Medium weight for text
+        /**
+         * Medium weight for text
+         */
         val mediumWeight: Int,
 
-        // Bold weight for text
+        /**
+         * Bold weight for text
+         */
         val boldWeight: Int,
 
-        // The font used in text. This should be a resource ID value.
+        /**
+         * The font used in text. This should be a resource ID value.
+         */
         @FontRes
         val fontResId: Int?,
     ) : Parcelable {
@@ -341,26 +388,40 @@ class PaymentSheet internal constructor(
 
     @Parcelize
     data class PrimaryButton(
-        // Describes the colors used while the system is in light mode
+        /**
+         * Describes the colors used while the system is in light mode
+         */
         val colorsLight: PrimaryButtonColors = PrimaryButtonColors.defaultLight,
-        // Describes the colors used while the system is in dark mode
+        /**
+         * Describes the colors used while the system is in dark mode
+         */
         val colorsDark: PrimaryButtonColors = PrimaryButtonColors.defaultDark,
-        // Describes the shape of the primary button.
+        /**
+         * Describes the shape of the primary button.
+         */
         val shape: PrimaryButtonShape = PrimaryButtonShape(),
-        // Describes the typography of the primary button.
+        /**
+         * Describes the typography of the primary button.
+         */
         val typography: PrimaryButtonTypography = PrimaryButtonTypography()
     ) : Parcelable
 
     @Parcelize
     data class PrimaryButtonColors(
-        // The background color of the primary button
-        // Note: if 'null' the Appearance.Colors.primary is used.
+        /**
+         * The background color of the primary button
+         * Note: If 'null', Appearance.Colors.primary is used.
+         */
         @ColorInt
         val background: Int?,
-        // The color appearing on the primary button
+        /**
+         * The color of the text and icon in the primary button
+         */
         @ColorInt
         val onBackground: Int,
-        // The border color of the primary button
+        /**
+         * The border color of the primary button
+         */
         @ColorInt
         val border: Int,
     ) : Parcelable {
@@ -382,18 +443,24 @@ class PaymentSheet internal constructor(
 
     @Parcelize
     data class PrimaryButtonShape(
-        // The corner radius of the primary button
-        // Note: if 'null' the Appearance.Shapes.cornerRadiusDp is used.
+        /**
+         * The corner radius of the primary button
+         * Note: If 'null', Appearance.Shapes.cornerRadiusDp is used.
+         */
         val cornerRadiusDp: Float? = null,
-        // The border width of the primary button
-        // Note: if 'null' the Appearance.Shapes.borderStrokeWidthDp is used.
+        /**
+         * The border width of the primary button
+         * Note: If 'null', Appearance.Shapes.borderStrokeWidthDp is used.
+         */
         val borderStrokeWidthDp: Float? = null
     ) : Parcelable
 
     @Parcelize
     data class PrimaryButtonTypography(
-        // The font used in the primary button.
-        // Note: if 'null' the Appearance.Typography.fontResId is used.
+        /**
+         * The font used in the primary button.
+         * Note: If 'null', Appearance.Typography.fontResId is used.
+         */
         @FontRes
         val fontResId: Int? = null
     ) : Parcelable

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -194,32 +194,7 @@ class PaymentSheet internal constructor(
         val typography: Typography = Typography.default,
 
         // Describes appearance of the primary button (e.g., the "Pay" button) in PaymentSheet
-        val primaryButton: PrimaryButton = PrimaryButton(
-            colorsLight = PrimaryButtonColors(
-                background =
-                colorsLight.primary,
-                onBackground =
-                PaymentsThemeDefaults.primaryButtonStyle.colorsLight.onBackground.toArgb(),
-                border =
-                PaymentsThemeDefaults.primaryButtonStyle.colorsLight.border.toArgb()
-            ),
-            colorsDark = PrimaryButtonColors(
-                background =
-                colorsDark.primary,
-                onBackground =
-                PaymentsThemeDefaults.primaryButtonStyle.colorsDark.onBackground.toArgb(),
-                border =
-                PaymentsThemeDefaults.primaryButtonStyle.colorsDark.border.toArgb()
-            ),
-            shape = PrimaryButtonShape(
-                cornerRadiusDp = shapes.cornerRadiusDp,
-                borderStrokeWidthDp = shapes.borderStrokeWidthDp
-            ),
-            typography = PrimaryButtonTypography(
-                fontResId = typography.fontResId
-            )
-        )
-
+        val primaryButton: PrimaryButton = PrimaryButton()
     ) : Parcelable {
         fun getColors(isDark: Boolean): Colors {
             return if (isDark) colorsDark else colorsLight
@@ -230,13 +205,13 @@ class PaymentSheet internal constructor(
             private var colorsDark = Colors.defaultDark
             private var shapes = Shapes.default
             private var typography = Typography.default
-            private var primaryButton: PrimaryButton = Appearance().primaryButton
+            private var primaryButton: PrimaryButton = PrimaryButton()
 
             fun colorsLight(colors: Colors) = apply { this.colorsLight = colors }
             fun colorsDark(colors: Colors) = apply { this.colorsDark = colors }
             fun shapes(shapes: Shapes) = apply { this.shapes = shapes }
             fun typography(typography: Typography) = apply { this.typography = typography }
-            fun primaryButtonModifier(primaryButton: PrimaryButton) =
+            fun primaryButton(primaryButton: PrimaryButton) =
                 apply { this.primaryButton = primaryButton }
         }
     }
@@ -367,34 +342,52 @@ class PaymentSheet internal constructor(
     @Parcelize
     data class PrimaryButton(
         // Describes the colors used while the system is in light mode
-        val colorsLight: PrimaryButtonColors,
+        val colorsLight: PrimaryButtonColors = PrimaryButtonColors.defaultLight,
         // Describes the colors used while the system is in dark mode
-        val colorsDark: PrimaryButtonColors,
+        val colorsDark: PrimaryButtonColors = PrimaryButtonColors.defaultDark,
         // Describes the shape of the primary button.
-        val shape: PrimaryButtonShape,
+        val shape: PrimaryButtonShape = PrimaryButtonShape(),
         // Describes the typography of the primary button.
-        val typography: PrimaryButtonTypography
+        val typography: PrimaryButtonTypography = PrimaryButtonTypography()
     ) : Parcelable
 
     @Parcelize
     data class PrimaryButtonColors(
         // The background color of the primary button
+        // Note: if 'null' the Appearance.Colors.primary is used.
         @ColorInt
-        val background: Int,
+        val background: Int?,
         // The color appearing on the primary button
         @ColorInt
         val onBackground: Int,
         // The border color of the primary button
         @ColorInt
         val border: Int,
-    ) : Parcelable
+    ) : Parcelable {
+        companion object {
+            val defaultLight = PrimaryButtonColors(
+                background = null,
+                onBackground =
+                PaymentsThemeDefaults.primaryButtonStyle.colorsLight.onBackground.toArgb(),
+                border = PaymentsThemeDefaults.primaryButtonStyle.colorsLight.border.toArgb(),
+            )
+            val defaultDark = PrimaryButtonColors(
+                background = null,
+                onBackground =
+                PaymentsThemeDefaults.primaryButtonStyle.colorsDark.onBackground.toArgb(),
+                border = PaymentsThemeDefaults.primaryButtonStyle.colorsDark.border.toArgb(),
+            )
+        }
+    }
 
     @Parcelize
     data class PrimaryButtonShape(
         // The corner radius of the primary button
-        val cornerRadiusDp: Float,
+        // Note: if 'null' the Appearance.Shapes.cornerRadiusDp is used.
+        val cornerRadiusDp: Float? = null,
         // The border width of the primary button
-        val borderStrokeWidthDp: Float
+        // Note: if 'null' the Appearance.Shapes.borderStrokeWidthDp is used.
+        val borderStrokeWidthDp: Float? = null
     ) : Parcelable
 
     @Parcelize
@@ -402,7 +395,7 @@ class PaymentSheet internal constructor(
         // The font used in the primary button.
         // Note: if 'null' the Appearance.Typography.fontResId is used.
         @FontRes
-        val fontResId: Int?
+        val fontResId: Int? = null
     ) : Parcelable
 
     @Parcelize

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtx.kt
@@ -3,6 +3,9 @@ package com.stripe.android.paymentsheet
 import androidx.compose.ui.graphics.Color
 import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.PaymentsThemeDefaults
+import com.stripe.android.ui.core.PrimaryButtonColors
+import com.stripe.android.ui.core.PrimaryButtonShape
+import com.stripe.android.ui.core.PrimaryButtonTypography
 import java.security.InvalidParameterException
 
 internal fun PaymentSheet.Configuration.validate() {
@@ -69,5 +72,25 @@ internal fun PaymentSheet.Appearance.parseAppearance() {
         fontWeightMedium = typography.mediumWeight,
         fontWeightBold = typography.boldWeight,
         fontSizeMultiplier = typography.sizeScaleFactor
+    )
+
+    PaymentsTheme.primaryButtonStyle = PaymentsThemeDefaults.primaryButtonStyle.copy(
+        colorsLight = PrimaryButtonColors(
+            background = Color(primaryButton.colorsLight.background),
+            onBackground = Color(primaryButton.colorsLight.onBackground),
+            border = Color(primaryButton.colorsLight.border),
+        ),
+        colorsDark = PrimaryButtonColors(
+            background = Color(primaryButton.colorsDark.background),
+            onBackground = Color(primaryButton.colorsDark.onBackground),
+            border = Color(primaryButton.colorsDark.border),
+        ),
+        shape = PrimaryButtonShape(
+            cornerRadius = primaryButton.shape.cornerRadiusDp,
+            borderStrokeWidth = primaryButton.shape.borderStrokeWidthDp,
+        ),
+        typography = PrimaryButtonTypography(
+            fontFamily = primaryButton.typography.fontResId
+        )
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtx.kt
@@ -76,21 +76,22 @@ internal fun PaymentSheet.Appearance.parseAppearance() {
 
     PaymentsTheme.primaryButtonStyle = PaymentsThemeDefaults.primaryButtonStyle.copy(
         colorsLight = PrimaryButtonColors(
-            background = Color(primaryButton.colorsLight.background),
+            background = Color(primaryButton.colorsLight.background ?: colorsLight.primary),
             onBackground = Color(primaryButton.colorsLight.onBackground),
             border = Color(primaryButton.colorsLight.border),
         ),
         colorsDark = PrimaryButtonColors(
-            background = Color(primaryButton.colorsDark.background),
+            background = Color(primaryButton.colorsDark.background ?: colorsDark.primary),
             onBackground = Color(primaryButton.colorsDark.onBackground),
             border = Color(primaryButton.colorsDark.border),
         ),
         shape = PrimaryButtonShape(
-            cornerRadius = primaryButton.shape.cornerRadiusDp,
-            borderStrokeWidth = primaryButton.shape.borderStrokeWidthDp,
+            cornerRadius = primaryButton.shape.cornerRadiusDp ?: shapes.cornerRadiusDp,
+            borderStrokeWidth =
+            primaryButton.shape.borderStrokeWidthDp ?: shapes.borderStrokeWidthDp,
         ),
         typography = PrimaryButtonTypography(
-            fontFamily = primaryButton.typography.fontResId
+            fontFamily = primaryButton.typography.fontResId ?: typography.fontResId
         )
     )
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
**NOT BEING MERGED TO MASTER**
* Adds the rules api for primary button as described here: https://paper.dropbox.com/doc/2022-04-18-PaymentSheet-Primary-Button-Appearance-APIs-Mobile-API-Review--Bf9LmLV57JZ8iL4s5Jz3~1mkAg-vjjl5N5OxQ7ZAK8VEgkVD

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
* Adds more customization to payment sheet.
* Will be merged to private beta branch 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

* default looks the same
* just setting variables api will also set primary button
* setting primary button changes the button differently from variables api values
* original primaryButton api still works.

# Screenshots
```
// no primarybutton showing that it follows the base level.
val appearance = PaymentSheet.Appearance(
    colorsLight = PaymentSheet.Colors.defaultLight.copy(
        primary = Color.RED
    ),
    shapes = PaymentSheet.Shapes.default.copy(
        borderStrokeWidthDp = 5.0f,
        cornerRadiusDp = 20.0f
    ),
    typography = PaymentSheet.Typography.default.copy(
        fontResId = R.font.cursive
    )
)
```
![config1](https://user-images.githubusercontent.com/89166418/164120506-a509429e-c7bc-411b-af31-d9fae50c467d.png)

```
// simple background change
val appearance = PaymentSheet.Appearance(
    colorsLight = PaymentSheet.Colors.defaultLight.copy(
        primary = Color.RED
    ),
    primaryButton = PaymentSheet.PrimaryButton(
        colorsLight = PaymentSheet.PrimaryButtonColors.defaultLight.copy(
            background = Color.BLACK,
        )
    )
)
```
![config3](https://user-images.githubusercontent.com/89166418/164293856-6acc1e32-3008-4c03-8042-78ce49841938.png)

```
// primary button config that is different to show that it changes independently when set  
val appearance = PaymentSheet.Appearance(
    colorsLight = PaymentSheet.Colors.defaultLight.copy(
        primary = Color.RED
    ),
    shapes = PaymentSheet.Shapes.default.copy(
        cornerRadiusDp = 5.0f
    ),
    typography = PaymentSheet.Typography.default.copy(
        fontResId = null
    ),
    primaryButton = PaymentSheet.PrimaryButton(
        colorsLight = PaymentSheet.PrimaryButtonColors(
            background = Color.TRANSPARENT,
            onBackground = Color.BLACK,
            border = Color.BLACK,
        ),
        shape = PaymentSheet.PrimaryButtonShape(
            cornerRadiusDp = 0.0f,
        ),
        typography = PaymentSheet.PrimaryButtonTypography(
            fontResId = R.font.cursive
        )
    )
)
```

![config2](https://user-images.githubusercontent.com/89166418/164293116-dd681774-debc-4710-b3cb-3253d25efa6a.png)


