### PR TITLE
Add ability to hide primary button

### DIFF
--- a/paymentsheet/res/layout/activity_payment_options.xml
+++ b/paymentsheet/res/layout/activity_payment_options.xml
@@ -91,8 +91,7 @@
                     <com.stripe.android.paymentsheet.ui.PrimaryButton
                         android:id="@+id/continue_button"
                         android:layout_marginTop="@dimen/stripe_paymentsheet_button_container_spacing"
-                        android:layout_marginStart="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
-                        android:layout_marginEnd="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
+                        android:layout_marginHorizontal="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
                         android:layout_marginBottom="@dimen/stripe_paymentsheet_button_container_spacing_bottom"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -82,7 +82,7 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
             closeSheet(it)
         }
 
-        setupContinueButton(viewBinding.continueButton)
+        setupContinueButton()
 
         viewModel.transition.observe(this) { event ->
             event?.getContentIfNotHandled()?.let { transitionTarget ->
@@ -125,7 +125,11 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
         )
     }
 
-    private fun setupContinueButton(addButton: PrimaryButton) {
+    private fun setupContinueButton() {
+        viewModel.primaryButtonVisibility.observe(this) {
+            viewBinding.continueButton.isVisible = it
+        }
+
         viewBinding.continueButton.lockVisible = false
         viewBinding.continueButton.updateState(PrimaryButton.State.Ready)
 
@@ -139,12 +143,12 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
             )
         }
 
-        addButton.setOnClickListener {
+        viewBinding.continueButton.setOnClickListener {
             viewModel.onUserSelection()
         }
 
         viewModel.ctaEnabled.observe(this) { isEnabled ->
-            addButton.isEnabled = isEnabled
+            viewBinding.continueButton.isEnabled = isEnabled
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -251,6 +251,11 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
     }
 
     private fun setupBuyButton() {
+        viewModel.primaryButtonVisibility.observe(this) {
+            viewBinding.buttonContainer.isVisible = it
+            viewBinding.buyButton.isVisible = it
+        }
+
         if (viewModel.isProcessingPaymentIntent) {
             viewModel.amount.observe(this) {
                 viewBinding.buyButton.setLabel(requireNotNull(it).buildPayButtonLabel(resources))

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -208,6 +208,10 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
         }
     }.distinctUntilChanged()
 
+    private val _primaryButtonVisibility = MutableLiveData<Boolean>()
+    val primaryButtonVisibility: LiveData<Boolean>
+        get() = _primaryButtonVisibility
+
     init {
         TransitionFragmentResource.idlingResource?.increment()
         if (_savedSelection.value == null) {
@@ -374,6 +378,10 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
                 }
             }
         }
+    }
+
+    fun setPrimaryButtonVisibility(visible: Boolean) {
+        _primaryButtonVisibility.value = visible
     }
 
     protected fun setupLink(stripeIntent: StripeIntent) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -165,6 +165,28 @@ class PaymentOptionsActivityTest {
     }
 
     @Test
+    fun `toggles primary button visibility`() {
+        val scenario = activityScenario(viewModel)
+        scenario.launch(createIntent()).onActivity { activity ->
+            // wait for bottom sheet to animate in
+            idleLooper()
+
+            assertThat(activity.viewBinding.continueButton.isVisible)
+                .isTrue()
+
+            viewModel.setPrimaryButtonVisibility(false)
+
+            assertThat(activity.viewBinding.continueButton.isVisible)
+                .isFalse()
+
+            viewModel.setPrimaryButtonVisibility(true)
+
+            assertThat(activity.viewBinding.continueButton.isVisible)
+                .isTrue()
+        }
+    }
+
+    @Test
     fun `Verify Ready state updates the add button label`() {
         val scenario = activityScenario()
         scenario.launch(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -195,6 +195,28 @@ internal class PaymentSheetActivityTest {
     }
 
     @Test
+    fun `toggles primary button visibility`() {
+        val scenario = activityScenario(viewModel)
+        scenario.launch(intent).onActivity { activity ->
+            // wait for bottom sheet to animate in
+            idleLooper()
+
+            assertThat(activity.viewBinding.buttonContainer.isVisible)
+                .isTrue()
+
+            viewModel.setPrimaryButtonVisibility(false)
+
+            assertThat(activity.viewBinding.buttonContainer.isVisible)
+                .isFalse()
+
+            viewModel.setPrimaryButtonVisibility(true)
+
+            assertThat(activity.viewBinding.buttonContainer.isVisible)
+                .isTrue()
+        }
+    }
+
+    @Test
     fun `when back to Ready state should update PaymentSelection`() {
         val scenario = activityScenario()
         scenario.launch(intent).onActivity { activity ->


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add ability to hide the primary button on `PaymentSheetActivity` and `PaymentOptionsActivity`. This PR does not hide the primary button, just adds the ability to hide the primary button through the view model.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

us_bank_account will have its own primary button logic, so we want to construct its own primary button in the us_bank_account payment method form fragment.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/99316447/164320800-0134e17f-2645-415a-9603-6d3b62a4fd7c.png" height=400/> | <img src="https://user-images.githubusercontent.com/99316447/164320906-e1bb9830-8a87-490e-9ecd-8ace73e4998b.png" height=400/> |
| <img src="https://user-images.githubusercontent.com/99316447/164320988-c1d3c9be-a652-4d54-8c80-bb634c804eb0.png" height=400/> | <img src="https://user-images.githubusercontent.com/99316447/164320906-e1bb9830-8a87-490e-9ecd-8ace73e4998b.png" height=400/> |

Here is what the us_bank_account payment method form would look like with the button visibility transitions:

https://user-images.githubusercontent.com/99316447/164323144-9b4fe77d-72c3-4142-8bd7-d5fee2a1aa93.mov


