### PR TITLE
Add fragmentForPaymentMethod

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
@@ -178,11 +178,24 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
             )
             replace(
                 R.id.payment_method_fragment_container,
-                ComposeFormDataCollectionFragment::class.java,
+                fragmentForPaymentMethod(paymentMethod),
                 args
             )
         }
     }
+
+    private fun fragmentForPaymentMethod(paymentMethod: SupportedPaymentMethod) =
+        when (paymentMethod.type) {
+            // TODO(jameswoo-stripe): add us_bank_account payment method form fragment
+//            PaymentMethod.Type.USBankAccount -> {
+//                if (sheetViewModel is PaymentSheetViewModel) {
+//                    USBankAccountFormForPaymentSheetFragment::class.java
+//                } else {
+//                    USBankAccountFormForPaymentOptionsFragment::class.java
+//                }
+//            }
+            else -> ComposeFormDataCollectionFragment::class.java
+        }
 
     private fun getFragment() =
         childFragmentManager.findFragmentById(R.id.payment_method_fragment_container)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add `fragmentForPaymentMethod` that allows `BaseAddPaymentMethodFragment` to replace the payment method fragment based on payment method type

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Needed for us_bank_account payment method type. This payment method type is a one-off that has multiple steps involved and we will use a new fragment to handle this form.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
