### PR TITLE
Fix flaky payment sheet activity test

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -51,7 +51,6 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -196,7 +195,6 @@ internal class PaymentSheetActivityTest {
     }
 
     @Test
-    @Ignore("This test is flaky in CI")
     fun `when back to Ready state should update PaymentSelection`() {
         val scenario = activityScenario()
         scenario.launch(intent).onActivity { activity ->

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -220,25 +220,31 @@ internal class PaymentSheetActivityTest {
             }
             idleLooper()
 
-            assertThat(paymentSelections.size)
+            val nonNullPaymentSelections = {
+                paymentSelections.filterNotNull()
+            }
+
+            assertThat(nonNullPaymentSelections().size)
                 .isEqualTo(1)
-            assertThat(paymentSelections[0])
+            assertThat(nonNullPaymentSelections()[0])
                 .isEqualTo(initialSelection)
 
             activity.viewBinding.googlePayButton.callOnClick()
+            idleLooper()
 
             // Updates PaymentSelection to Google Pay
-            assertThat(paymentSelections.size)
+            assertThat(nonNullPaymentSelections().size)
                 .isEqualTo(2)
-            assertThat(paymentSelections[1])
+            assertThat(nonNullPaymentSelections()[1])
                 .isEqualTo(PaymentSelection.GooglePay)
 
             viewModel.onGooglePayResult(GooglePayPaymentMethodLauncher.Result.Canceled)
+            idleLooper()
 
             // Back to Ready state, should return to null PaymentSelection
-            assertThat(paymentSelections.size)
+            assertThat(nonNullPaymentSelections().size)
                 .isEqualTo(3)
-            assertThat(paymentSelections[0])
+            assertThat(nonNullPaymentSelections()[0])
                 .isEqualTo(initialSelection)
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/utils/TestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/TestUtils.kt
@@ -1,8 +1,13 @@
 package com.stripe.android.utils
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import org.robolectric.shadows.ShadowLooper.idleMainLooper
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 
 internal object TestUtils {
     @JvmStatic
@@ -13,5 +18,34 @@ internal object TestUtils {
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             return viewModel as T
         }
+    }
+
+    // Adapted from https://github.com/android/architecture-components-samples/blob/master/GithubBrowserSample/app/src/test-common/java/com/android/example/github/util/LiveDataTestUtil.kt#L32
+    fun <T> LiveData<T>.getOrAwaitValue(
+        time: Long = 2,
+        timeUnit: TimeUnit = TimeUnit.SECONDS,
+        afterObserve: () -> Unit = {}
+    ): T {
+        var data: T? = null
+        val latch = CountDownLatch(1)
+        val observer = object : Observer<T> {
+            override fun onChanged(o: T?) {
+                data = o
+                latch.countDown()
+                this@getOrAwaitValue.removeObserver(this)
+            }
+        }
+        this.observeForever(observer)
+
+        afterObserve.invoke()
+
+        // Don't wait indefinitely if the LiveData is not set.
+        if (!latch.await(time, timeUnit)) {
+            this.removeObserver(observer)
+            throw TimeoutException("LiveData value was never set.")
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        return data as T
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fix flaky PaymentSheetActivity test. The tests were failing because `paymentSelections` contained null `PaymentSelection` when transitioning between different fragments. To fix this, just filter the list to get non-null selections.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

CI failing inconsistently.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

