### PR TITLE
[Identity] Don't clear upload status when starting scanning back

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/navigation/DriverLicenseScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/DriverLicenseScanFragment.kt
@@ -37,6 +37,7 @@ internal class DriverLicenseScanFragment(
                     startScanning(DL_BACK)
                 }
                 DL_BACK -> {
+                    continueButton.toggleToLoading()
                     collectUploadedStateAndUploadForBothSides(CollectedDataParam.Type.DRIVINGLICENSE)
                 }
                 else -> {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
@@ -100,7 +100,9 @@ internal abstract class IdentityCameraScanFragment(
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        identityViewModel.resetUploadedState()
+        if (!shouldStartFromBack()) {
+            identityViewModel.resetUploadedState()
+        }
         identityScanViewModel.displayStateChanged.observe(viewLifecycleOwner) { (newState, _) ->
             updateUI(newState)
         }

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IdentityCameraScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IdentityCameraScanFragmentTest.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.core.os.bundleOf
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.MediatorLiveData
@@ -36,6 +37,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.same
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
@@ -202,13 +204,27 @@ class IdentityCameraScanFragmentTest {
         verify(mockScanFlow).cancelFlow()
     }
 
-    private fun launchTestFragment() = launchFragmentInContainer(
-        themeResId = R.style.Theme_MaterialComponents
-    ) {
-        TestFragment(
-            viewModelFactoryFor(mockIdentityScanViewModel),
-            viewModelFactoryFor(mockIdentityViewModel),
-            mockCameraView
-        )
+    @Test
+    fun `when shouldStartFromBack don't reset upload state`() {
+        launchTestFragment(shouldStartFromBack = true)
+        verify(mockIdentityViewModel, times(0)).resetUploadedState()
     }
+
+    @Test
+    fun `when not shouldStartFromBack reset upload state`() {
+        launchTestFragment(shouldStartFromBack = false)
+        verify(mockIdentityViewModel).resetUploadedState()
+    }
+
+    private fun launchTestFragment(shouldStartFromBack: Boolean = false) =
+        launchFragmentInContainer(
+            bundleOf(IdentityCameraScanFragment.ARG_SHOULD_START_FROM_BACK to shouldStartFromBack),
+            themeResId = R.style.Theme_MaterialComponents
+        ) {
+            TestFragment(
+                viewModelFactoryFor(mockIdentityScanViewModel),
+                viewModelFactoryFor(mockIdentityViewModel),
+                mockCameraView
+            )
+        }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Clearing upload status would remove the front upload status, if we start from back, the front upload status would get lost

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This would fix the following issue:
* user failed to scan the back of the ID card, gets redirected to CouldNotCaptureFragment 
* they click retry and get back to scan with `shouldStartFromBack == true`
* finished scanning back and click continue <- !front upload status is cleared
* gets stuck as the SDK waits both front and back to be upload, but front status will stuck in loading status as it's cleared.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
