### PR TITLE
Add support for us_bank_account saved payment methods

### DIFF
--- a/payments-core/res/drawable/stripe_ic_bank.xml
+++ b/payments-core/res/drawable/stripe_ic_bank.xml
@@ -1,16 +1,14 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="14dp"
-    android:height="14dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-    <path
-        android:fillColor="#515e80"
-        android:pathData="M9.51,2.29l7.21,4.61a0.6,0.6 0,0 1,-0.34 1.1H0.62a0.6,0.6 0,0 1,-0.34 -1.1l7.21,-4.61a1.89,1.89 0,0 1,2.02 0zM1.08,16.47l-0.83,2c-0.12,0.28 0,0.57 0.28,0.57h15.66c0.27,0 0.41,-0.29 0.29,-0.57l-0.84,-2A0.73,0.73 0,0 0,15 16H1.73a0.74,0.74 0,0 0,-0.65 0.47z"
-        android:strokeAlpha="0.4"
-        android:fillAlpha="0.4" />
-    <path
-        android:fillColor="#515e80"
-        android:pathData="M2,9h2.5v6L2,15zM12.5,9L15,9v6h-2.5zM7.25,9h2.5v6h-2.5z"
-        android:strokeAlpha="0.2"
-        android:fillAlpha="0.2" />
+    android:width="15dp"
+    android:height="15dp"
+    android:viewportWidth="15"
+    android:viewportHeight="15">
+  <path
+      android:pathData="M1.0475,5.4492C1.2021,5.717 1.4849,5.8647 1.7737,5.8594H13.2263C13.5151,5.8647 13.7979,5.717 13.9525,5.4492C14.179,5.0569 14.0446,4.5552 13.6522,4.3286C13.3907,4.1776 11.3399,3.0473 7.5,0.9375C3.6601,3.0473 1.6093,4.1776 1.3478,4.3286C0.9554,4.5552 0.821,5.0569 1.0475,5.4492Z"
+      android:fillColor="#000000"
+      android:fillAlpha="0.6"/>
+  <path
+      android:pathData="M9.9609,7.0898V12.4219H8.7305V7.0898H6.2695V12.4219H5.0391V7.0898H2.5781V12.4219H1.5939C1.2314,12.4219 0.9376,12.7157 0.9376,13.0781V14.0625H14.0624V13.0781C14.0624,12.7157 13.7685,12.4219 13.4061,12.4219H12.4219V7.0898H9.9609Z"
+      android:fillColor="#000000"
+      android:fillAlpha="0.6"/>
 </vector>

--- a/payments-core/res/drawable/stripe_ic_bank_becs.xml
+++ b/payments-core/res/drawable/stripe_ic_bank_becs.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="14dp"
+    android:height="14dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#515e80"
+        android:pathData="M9.51,2.29l7.21,4.61a0.6,0.6 0,0 1,-0.34 1.1H0.62a0.6,0.6 0,0 1,-0.34 -1.1l7.21,-4.61a1.89,1.89 0,0 1,2.02 0zM1.08,16.47l-0.83,2c-0.12,0.28 0,0.57 0.28,0.57h15.66c0.27,0 0.41,-0.29 0.29,-0.57l-0.84,-2A0.73,0.73 0,0 0,15 16H1.73a0.74,0.74 0,0 0,-0.65 0.47z"
+        android:strokeAlpha="0.4"
+        android:fillAlpha="0.4" />
+    <path
+        android:fillColor="#515e80"
+        android:pathData="M2,9h2.5v6L2,15zM12.5,9L15,9v6h-2.5zM7.25,9h2.5v6h-2.5z"
+        android:strokeAlpha="0.2"
+        android:fillAlpha="0.2" />
+</vector>

--- a/payments-core/res/layout/becs_debit_widget.xml
+++ b/payments-core/res/layout/becs_debit_widget.xml
@@ -92,7 +92,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:imeOptions="actionNext"
-                    android:drawableStart="@drawable/stripe_ic_bank" />
+                    android:drawableStart="@drawable/stripe_ic_bank_becs" />
             </com.google.android.material.textfield.TextInputLayout>
 
             <com.google.android.material.textfield.TextInputLayout

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -869,7 +869,9 @@ constructor(
     }
 
     @Parcelize
-    data class USBankAccount internal constructor(
+    data class USBankAccount
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    constructor(
         /**
          * Account holder type
          *

--- a/payments-core/src/main/java/com/stripe/android/view/BecsDebitBsbEditText.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/BecsDebitBsbEditText.kt
@@ -113,7 +113,7 @@ internal class BecsDebitBsbEditText @JvmOverloads constructor(
             if (isError) {
                 R.drawable.stripe_ic_bank_error
             } else {
-                R.drawable.stripe_ic_bank
+                R.drawable.stripe_ic_bank_becs
             },
             0,
             0,

--- a/payments-ui-core/res/values/totranslate.xml
+++ b/payments-ui-core/res/values/totranslate.xml
@@ -6,6 +6,9 @@
     <!-- Card details section title for card form entry -->
     <string name="card_information" tools:ignore="ExtraTranslation">Card information</string>
 
+    <!-- Mandate for us_bank_account when using saved payment method -->
+    <string name="us_bank_account_payment_sheet_saved_mandate">By continuing you agree to authorize payments pursuant to &lt;a href=\"https://stripe.com/ach-payments/authorization\">these terms&lt;/a>.</string>
+
     <!-- Scan card button -->
     <string name="scan_card" tools:ignore="ExtraTranslation">Scan card</string>
 </resources>

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -347,6 +347,7 @@ public final class com/stripe/android/paymentsheet/analytics/DefaultEventReporte
 public final class com/stripe/android/paymentsheet/databinding/ActivityPaymentOptionsBinding : androidx/viewbinding/ViewBinding {
 	public final field appbar Lcom/google/android/material/appbar/AppBarLayout;
 	public final field bottomSheet Landroid/widget/LinearLayout;
+	public final field bottomSpacer Landroid/view/View;
 	public final field continueButton Lcom/stripe/android/paymentsheet/ui/PrimaryButton;
 	public final field coordinator Landroidx/coordinatorlayout/widget/CoordinatorLayout;
 	public final field fragmentContainer Landroidx/fragment/app/FragmentContainerView;
@@ -367,6 +368,7 @@ public final class com/stripe/android/paymentsheet/databinding/ActivityPaymentOp
 public final class com/stripe/android/paymentsheet/databinding/ActivityPaymentSheetBinding : androidx/viewbinding/ViewBinding {
 	public final field appbar Lcom/google/android/material/appbar/AppBarLayout;
 	public final field bottomSheet Landroid/widget/LinearLayout;
+	public final field bottomSpacer Landroid/view/View;
 	public final field buttonContainer Landroid/widget/FrameLayout;
 	public final field buyButton Lcom/stripe/android/paymentsheet/ui/PrimaryButton;
 	public final field coordinator Landroidx/coordinatorlayout/widget/CoordinatorLayout;

--- a/paymentsheet/res/layout/activity_payment_options.xml
+++ b/paymentsheet/res/layout/activity_payment_options.xml
@@ -93,7 +93,6 @@
                         android:layout_marginTop="@dimen/stripe_paymentsheet_button_container_spacing"
                         android:layout_marginStart="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
                         android:layout_marginEnd="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
-                        android:layout_marginBottom="@dimen/stripe_paymentsheet_button_container_spacing_bottom"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:visibility="gone" />
@@ -106,8 +105,13 @@
                     android:layout_height="wrap_content"
                     android:visibility="gone"
                     android:layout_marginVertical="2dp"
-                    android:layout_marginHorizontal="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
-                    android:layout_marginBottom="@dimen/stripe_paymentsheet_button_container_spacing_bottom" />
+                    android:layout_marginHorizontal="@dimen/stripe_paymentsheet_outer_spacing_horizontal" />
+
+                <View
+                    android:id="@+id/bottom_spacer"
+                    android:visibility="gone"
+                    android:layout_width="wrap_content"
+                    android:layout_height="@dimen/stripe_paymentsheet_button_container_spacing_bottom" />
             </LinearLayout>
         </ScrollView>
     </LinearLayout>

--- a/paymentsheet/res/layout/activity_payment_sheet.xml
+++ b/paymentsheet/res/layout/activity_payment_sheet.xml
@@ -128,8 +128,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="@dimen/stripe_paymentsheet_max_primary_button_height"
                     android:layout_marginTop="@dimen/stripe_paymentsheet_button_container_spacing"
-                    android:layout_marginHorizontal="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
-                    android:layout_marginBottom="@dimen/stripe_paymentsheet_button_container_spacing_bottom">
+                    android:layout_marginHorizontal="@dimen/stripe_paymentsheet_outer_spacing_horizontal">
 
                     <com.stripe.android.paymentsheet.ui.PrimaryButton
                         android:id="@+id/buy_button"
@@ -137,6 +136,7 @@
                         android:layout_height="@dimen/stripe_paymentsheet_primary_button_height"
                         android:text="@string/stripe_paymentsheet_pay_button_label"
                         android:layout_marginVertical="2dp" />
+
                 </FrameLayout>
 
                 <androidx.compose.ui.platform.ComposeView
@@ -145,8 +145,13 @@
                     android:layout_height="wrap_content"
                     android:visibility="gone"
                     android:layout_marginVertical="2dp"
-                    android:layout_marginHorizontal="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
-                    android:layout_marginBottom="@dimen/stripe_paymentsheet_button_container_spacing_bottom" />
+                    android:layout_marginHorizontal="@dimen/stripe_paymentsheet_outer_spacing_horizontal" />
+
+                <View
+                    android:id="@+id/bottom_spacer"
+                    android:visibility="gone"
+                    android:layout_width="wrap_content"
+                    android:layout_height="@dimen/stripe_paymentsheet_button_container_spacing_bottom" />
             </LinearLayout>
         </ScrollView>
     </LinearLayout>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet
 import android.content.Intent
 import android.content.res.ColorStateList
 import android.os.Bundle
+import android.view.View
 import android.view.ViewGroup
 import android.widget.ScrollView
 import android.widget.TextView
@@ -67,6 +68,7 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
     override val messageView: TextView by lazy { viewBinding.message }
     override val notesView: ComposeView by lazy { viewBinding.notes }
     override val primaryButton: PrimaryButton by lazy { viewBinding.continueButton }
+    override val bottomSpacer: View by lazy { viewBinding.bottomSpacer }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -126,7 +128,8 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
             object : FragmentManager.FragmentLifecycleCallbacks() {
                 override fun onFragmentStarted(fm: FragmentManager, fragment: Fragment) {
                     viewBinding.continueButton.isVisible =
-                        fragment is PaymentOptionsAddPaymentMethodFragment
+                        fragment is PaymentOptionsAddPaymentMethodFragment ||
+                        viewModel.primaryButtonUIState.value?.visible == true
                 }
             },
             false

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet
 import android.annotation.SuppressLint
 import android.content.res.Resources
 import android.view.ViewGroup
+import androidx.annotation.DrawableRes
 import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -49,6 +50,7 @@ import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.SupportedPaymentMethod
 import com.stripe.android.paymentsheet.ui.LpmSelectorText
 import com.stripe.android.paymentsheet.ui.getLabel
+import com.stripe.android.paymentsheet.ui.getLabelIcon
 import com.stripe.android.paymentsheet.ui.getSavedPaymentMethodIcon
 import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.elements.SectionCard
@@ -304,6 +306,7 @@ internal class PaymentOptionsAdapter(
             position: Int
         ) {
             val savedPaymentMethod = item as Item.SavedPaymentMethod
+            val labelIcon = savedPaymentMethod.paymentMethod.getLabelIcon()
             val labelText = savedPaymentMethod.paymentMethod.getLabel(itemView.resources) ?: return
             val removeTitle = itemView.resources.getString(
                 R.string.stripe_paymentsheet_remove_pm,
@@ -322,6 +325,7 @@ internal class PaymentOptionsAdapter(
                     isSelected = isSelected,
                     isEnabled = isEnabled,
                     iconRes = savedPaymentMethod.paymentMethod.getSavedPaymentMethodIcon() ?: 0,
+                    labelIcon = labelIcon,
                     labelText = labelText,
                     removePmDialogTitle = removeTitle,
                     description = item.getDescription(itemView.resources),
@@ -478,6 +482,10 @@ internal class PaymentOptionsAdapter(
                     R.string.bank_account_ending_in,
                     paymentMethod.sepaDebit?.last4
                 )
+                PaymentMethod.Type.USBankAccount -> resources.getString(
+                    R.string.bank_account_ending_in,
+                    paymentMethod.usBankAccount?.last4
+                )
                 else -> ""
             }
 
@@ -511,6 +519,7 @@ internal fun PaymentOptionUi(
     isEditing: Boolean,
     isEnabled: Boolean,
     iconRes: Int,
+    @DrawableRes labelIcon: Int? = null,
     labelText: String = "",
     removePmDialogTitle: String = "",
     description: String,
@@ -623,6 +632,7 @@ internal fun PaymentOptionUi(
         }
 
         LpmSelectorText(
+            icon = labelIcon,
             text = labelText,
             textColor = PaymentsTheme.colors.material.onSurface,
             isEnabled = isEnabled,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -98,6 +98,8 @@ internal class PaymentOptionsViewModel @Inject constructor(
 
             when (paymentSelection) {
                 is PaymentSelection.Saved -> {
+                    // We don't want the USBankAccount selection to close the payment sheet right
+                    // away, the user needs to accept a mandate
                     if (paymentSelection.paymentMethod.type != PaymentMethod.Type.USBankAccount) {
                         processExistingPaymentMethod(
                             paymentSelection
@@ -124,7 +126,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
         when (selection) {
             is PaymentSelection.Saved -> {
                 if (selection.paymentMethod.type == PaymentMethod.Type.USBankAccount) {
-                    updateNotes(
+                    updateBelowButtonText(
                         getApplication<Application>().getString(
                             R.string.us_bank_account_payment_sheet_saved_mandate
                         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -16,6 +16,7 @@ import com.stripe.android.core.injection.InjectorKey
 import com.stripe.android.core.injection.injectWithFallback
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.injection.LinkPaymentLauncherFactory
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.injection.DaggerPaymentOptionsViewModelFactoryComponent
 import com.stripe.android.paymentsheet.injection.PaymentOptionsViewModelSubcomponent
@@ -113,7 +114,12 @@ internal class PaymentOptionsViewModel @Inject constructor(
 
     private fun processExistingCard(paymentSelection: PaymentSelection) {
         prefsRepository.savePaymentSelection(paymentSelection)
-        _paymentOptionResult.value = PaymentOptionResult.Succeeded(paymentSelection)
+        if (paymentSelection is PaymentSelection.Saved &&
+            paymentSelection.paymentMethod.type == PaymentMethod.Type.USBankAccount) {
+            _mandateText.value = R.string.us_bank_account_payment_sheet_saved_mandate
+        } else {
+            _paymentOptionResult.value = PaymentOptionResult.Succeeded(paymentSelection)
+        }
     }
 
     private fun processNewCard(paymentSelection: PaymentSelection) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -4,8 +4,8 @@ import android.app.Activity
 import android.content.Intent
 import android.content.res.ColorStateList
 import android.os.Bundle
+import android.view.View
 import android.view.ViewGroup
-import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.TextView
 import androidx.activity.viewModels
@@ -13,12 +13,9 @@ import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.compose.ui.text.style.TextAlign
 import androidx.core.os.bundleOf
 import androidx.core.view.doOnNextLayout
 import androidx.core.view.isVisible
-import androidx.core.view.updateLayoutParams
-import androidx.core.view.updateMargins
 import androidx.fragment.app.commit
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -36,7 +33,6 @@ import com.stripe.android.paymentsheet.ui.GooglePayDividerUi
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.PaymentsThemeDefaults
-import com.stripe.android.ui.core.elements.Html
 import com.stripe.android.ui.core.getBackgroundColor
 import com.stripe.android.ui.core.isSystemDarkTheme
 import com.stripe.android.ui.core.shouldUseDarkDynamicColor
@@ -79,6 +75,7 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
     override val messageView: TextView by lazy { viewBinding.message }
     override val notesView: ComposeView by lazy { viewBinding.notes }
     override val primaryButton: PrimaryButton by lazy { viewBinding.buyButton }
+    override val bottomSpacer: View by lazy { viewBinding.bottomSpacer }
 
     private val buttonContainer: ViewGroup by lazy { viewBinding.buttonContainer }
     private val topContainer by lazy { viewBinding.topContainer }
@@ -141,7 +138,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
 
         setupBuyButton()
         setupTopContainer()
-        setupNotes()
 
         linkButton.apply {
             onClick = viewModel::launchLink
@@ -288,6 +284,8 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
             clearErrorMessages()
             viewModel.checkout(CheckoutIdentifier.SheetBottomBuy)
         }
+
+        viewBinding.bottomSpacer.isVisible = true
     }
 
     private fun setupTopContainer() {
@@ -314,34 +312,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
             linkButton.isVisible = viewModel.isLinkEnabled.value == true
             googlePayButton.isVisible = viewModel.isGooglePayReady.value == true
             topContainer.isVisible = visible
-        }
-    }
-
-    private fun setupNotes() {
-        viewModel.mandateText.observe(this) { stringRes ->
-            val showNotes = stringRes != null
-            stringRes?.let {
-                viewBinding.notes.setContent {
-                    Html(
-                        html = getString(stringRes),
-                        imageGetter = mapOf(),
-                        color = PaymentsTheme.colors.subtitle,
-                        style = PaymentsTheme.typography.body1.copy(textAlign = TextAlign.Center)
-                    )
-                }
-            }
-            viewBinding.notes.isVisible = showNotes
-            viewBinding.buttonContainer.updateLayoutParams {
-                (this as? LinearLayout.LayoutParams)?.updateMargins(
-                    bottom = if (showNotes) {
-                        0
-                    } else {
-                        resources.getDimensionPixelSize(
-                            R.dimen.stripe_paymentsheet_button_container_spacing_bottom
-                        )
-                    }
-                )
-            }
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.content.res.ColorStateList
 import android.os.Bundle
 import android.view.ViewGroup
+import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.TextView
 import androidx.activity.viewModels
@@ -12,9 +13,12 @@ import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.text.style.TextAlign
 import androidx.core.os.bundleOf
 import androidx.core.view.doOnNextLayout
 import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updateMargins
 import androidx.fragment.app.commit
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -32,6 +36,7 @@ import com.stripe.android.paymentsheet.ui.GooglePayDividerUi
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.PaymentsThemeDefaults
+import com.stripe.android.ui.core.elements.Html
 import com.stripe.android.ui.core.getBackgroundColor
 import com.stripe.android.ui.core.isSystemDarkTheme
 import com.stripe.android.ui.core.shouldUseDarkDynamicColor
@@ -136,6 +141,7 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
 
         setupBuyButton()
         setupTopContainer()
+        setupNotes()
 
         linkButton.apply {
             onClick = viewModel::launchLink
@@ -308,6 +314,34 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
             linkButton.isVisible = viewModel.isLinkEnabled.value == true
             googlePayButton.isVisible = viewModel.isGooglePayReady.value == true
             topContainer.isVisible = visible
+        }
+    }
+
+    private fun setupNotes() {
+        viewModel.mandateText.observe(this) { stringRes ->
+            val showNotes = stringRes != null
+            stringRes?.let {
+                viewBinding.notes.setContent {
+                    Html(
+                        html = getString(stringRes),
+                        imageGetter = mapOf(),
+                        color = PaymentsTheme.colors.subtitle,
+                        style = PaymentsTheme.typography.body1.copy(textAlign = TextAlign.Center)
+                    )
+                }
+            }
+            viewBinding.notes.isVisible = showNotes
+            viewBinding.buttonContainer.updateLayoutParams {
+                (this as? LinearLayout.LayoutParams)?.updateMargins(
+                    bottom = if (showNotes) {
+                        0
+                    } else {
+                        resources.getDimensionPixelSize(
+                            R.dimen.stripe_paymentsheet_button_container_spacing_bottom
+                        )
+                    }
+                )
+            }
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -32,6 +32,7 @@ import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.paymentlauncher.PaymentLauncher
 import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
@@ -351,6 +352,25 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             },
             onFailure = ::onFatal
         )
+    }
+
+    override fun updateSelection(selection: PaymentSelection?) {
+        super.updateSelection(selection)
+
+        when (selection) {
+            is PaymentSelection.Saved -> {
+                if (selection.paymentMethod.type == PaymentMethod.Type.USBankAccount) {
+                    updateNotes(
+                        getApplication<Application>().getString(
+                            R.string.us_bank_account_payment_sheet_saved_mandate
+                        )
+                    )
+                }
+            }
+            else -> {
+                // no-op
+            }
+        }
     }
 
     override fun registerFromActivity(activityResultCaller: ActivityResultCaller) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -360,7 +360,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         when (selection) {
             is PaymentSelection.Saved -> {
                 if (selection.paymentMethod.type == PaymentMethod.Type.USBankAccount) {
-                    updateNotes(
+                    updateBelowButtonText(
                         getApplication<Application>().getString(
                             R.string.us_bank_account_payment_sheet_saved_mandate
                         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -11,7 +11,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.WindowInsets
 import android.view.WindowMetrics
-import android.widget.FrameLayout
 import android.widget.ScrollView
 import android.widget.TextView
 import androidx.annotation.DrawableRes
@@ -28,8 +27,6 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.core.view.isVisible
-import androidx.core.view.updateLayoutParams
-import androidx.core.view.updateMargins
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -66,6 +63,7 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
     abstract val testModeIndicator: TextView
     abstract val notesView: ComposeView
     abstract val primaryButton: PrimaryButton
+    abstract val bottomSpacer: View
 
     abstract fun setActivityResult(result: ResultType)
 
@@ -217,13 +215,15 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
     }
 
     private fun setupPrimaryButton() {
-        viewModel.primaryButtonOnClick.observe(this) { action ->
-            primaryButton.setOnClickListener {
-                action()
+        viewModel.primaryButtonUIState.observe(this) { state ->
+            state?.let {
+                primaryButton.setOnClickListener {
+                    state.onClick()
+                }
+                primaryButton.setLabel(state.label)
+                primaryButton.isVisible = state.visible
+                bottomSpacer.isVisible = state.visible
             }
-        }
-        viewModel.primaryButtonText.observe(this) { text ->
-            primaryButton.setLabel(text)
         }
         viewModel.ctaEnabled.observe(this) { isEnabled ->
             primaryButton.isEnabled = isEnabled
@@ -244,17 +244,6 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
                 }
             }
             notesView.isVisible = showNotes
-            primaryButton.updateLayoutParams {
-                (this as? FrameLayout.LayoutParams)?.updateMargins(
-                    bottom = if (showNotes) {
-                        0
-                    } else {
-                        resources.getDimensionPixelSize(
-                            R.dimen.stripe_paymentsheet_button_container_spacing_bottom
-                        )
-                    }
-                )
-            }
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/LpmSelectorText.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/LpmSelectorText.kt
@@ -1,27 +1,46 @@
 package com.stripe.android.paymentsheet.ui
 
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.dp
 import com.stripe.android.ui.core.PaymentsTheme
 
 @Composable
 internal fun LpmSelectorText(
+    @DrawableRes icon: Int? = null,
     text: String,
     textColor: Color,
     modifier: Modifier,
     isEnabled: Boolean
 ) {
-    Text(
-        text = text,
-        style = PaymentsTheme.typography.caption,
-        color = if (isEnabled) textColor else textColor.copy(alpha = 0.6f),
-        lineHeight = 1.sp,
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis,
-        modifier = modifier
-    )
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        icon?.let {
+            Icon(
+                modifier = Modifier.padding(horizontal = 4.dp),
+                painter = painterResource(it),
+                contentDescription = null,
+                tint = MaterialTheme.colors.onSurface
+            )
+        }
+        Text(
+            text = text,
+            style = PaymentsTheme.typography.caption,
+            color = if (isEnabled) textColor else textColor.copy(alpha = 0.6f),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUiExtension.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodsUiExtension.kt
@@ -5,12 +5,14 @@ import androidx.annotation.DrawableRes
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.paymentdatacollection.ach.TransformToBankIcon
 
 @DrawableRes
 internal fun PaymentMethod.getSavedPaymentMethodIcon(): Int? = when (type) {
     PaymentMethod.Type.Card -> card?.brand?.getCardBrandIcon()
         ?: R.drawable.stripe_ic_paymentsheet_card_unknown
     PaymentMethod.Type.SepaDebit -> R.drawable.stripe_ic_paymentsheet_pm_sepa_debit
+    PaymentMethod.Type.USBankAccount -> usBankAccount?.bankName?.let { TransformToBankIcon(it) }
     else -> null
 }
 
@@ -32,6 +34,15 @@ internal fun PaymentMethod.getLabel(resources: Resources): String? = when (type)
         R.string.paymentsheet_payment_method_item_card_number,
         sepaDebit?.last4
     )
+    PaymentMethod.Type.USBankAccount -> resources.getString(
+        R.string.paymentsheet_payment_method_item_card_number,
+        usBankAccount?.last4
+    )
+    else -> null
+}
+
+internal fun PaymentMethod.getLabelIcon(): Int? = when (type) {
+    PaymentMethod.Type.USBankAccount -> R.drawable.stripe_ic_bank
     else -> null
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
@@ -206,6 +206,16 @@ internal class PrimaryButton @JvmOverloads constructor(
         object StartProcessing : State()
         data class FinishProcessing(val onComplete: () -> Unit) : State()
     }
+
+    /**
+     * Used to override the current UI state of the Primary Button
+     */
+    internal data class UIState(
+        val label: String,
+        val onClick: () -> Unit,
+        val enabled: Boolean,
+        val visible: Boolean
+    )
 }
 
 @Composable

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -325,7 +325,7 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
         _primaryButtonUIState.value = state
     }
 
-    fun updateNotes(text: String?) {
+    fun updateBelowButtonText(text: String?) {
         _notesText.value = text
     }
 
@@ -336,7 +336,7 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
 
         savedStateHandle[SAVE_SELECTION] = selection
 
-        updateNotes(null)
+        updateBelowButtonText(null)
         updatePrimaryButtonUIState(null)
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -3,6 +3,10 @@ package com.stripe.android.paymentsheet.viewmodels
 import android.app.Application
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
+import androidx.annotation.NonNull
+import androidx.annotation.Nullable
+import androidx.annotation.RestrictTo
+import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
@@ -27,6 +31,7 @@ import com.stripe.android.paymentsheet.PaymentOptionsActivity
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetActivity
 import com.stripe.android.paymentsheet.PrefsRepository
+import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -344,6 +349,17 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
         }
         primaryButtonEnabled.value = null
         savedStateHandle[SAVE_SELECTION] = selection
+        _notesText.value = when (selection) {
+            is PaymentSelection.Saved -> {
+                when (selection.paymentMethod.type) {
+                    PaymentMethod.Type.USBankAccount -> {
+                        R.string.us_bank_account_payment_sheet_saved_mandate
+                    }
+                    else -> null
+                }
+            }
+            else -> null
+        }
     }
 
     fun setAddFragmentSelectedLPM(lpm: SupportedPaymentMethod) {

--- a/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsFixtures.kt
@@ -54,6 +54,16 @@ internal object PaymentMethodCreateParamsFixtures {
         BILLING_DETAILS
     )
 
+    internal val US_BANK_ACCOUNT = PaymentMethodCreateParams.create(
+        PaymentMethodCreateParams.USBankAccount(
+            accountNumber = "000000",
+            routingNumber = "000123456",
+            accountType = PaymentMethod.USBankAccount.USBankAccountType.CHECKING,
+            accountHolderType = PaymentMethod.USBankAccount.USBankAccountHolderType.INDIVIDUAL
+        ),
+        BILLING_DETAILS
+    )
+
     internal val BACS_DEBIT = PaymentMethodCreateParams.create(
         bacsDebit = PaymentMethodCreateParams.BacsDebit(
             accountNumber = "00012345",

--- a/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
@@ -289,6 +289,43 @@ internal object PaymentMethodFixtures {
     )
 
     val AU_BECS_DEBIT = PaymentMethodJsonParser().parse(AU_BECS_DEBIT_JSON)
+
+    val US_BANK_ACCOUNT_JSON = JSONObject(
+        """
+        {
+            "id": "pm_1Kr4seLu5o3P18ZperrPnk39",
+            "object": "payment_method",
+            "us_bank_account": {
+                "account_holder_type": "individual",
+                "account_type": "checking",
+                "bank_name": "STRIPE TEST BANK",
+                "fingerprint": "FFDMA0xfhBjWSZLu",
+                "last4": "6789",
+                "routing_number": "110000000"
+            },
+            "billing_details": {
+                "address": {
+                    "city": null,
+                    "country": null,
+                    "line1": null,
+                    "line2": null,
+                    "postal_code": null,
+                    "state": null
+                },
+                "email": "jenny.rosen@example.com",
+                "name": "Jenny Rosen",
+                "phone": null
+            },
+            "created": 1583356750,
+            "customer": null,
+            "livemode": false,
+            "metadata": null,
+            "type": "us_bank_account"
+        }
+        """.trimIndent()
+    )
+
+    val US_BANK_ACCOUNT = PaymentMethodJsonParser().parse(US_BANK_ACCOUNT_JSON)
 //
 //    val BACS_DEBIT_JSON = JSONObject(
 //        """

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -353,7 +353,7 @@ class PaymentOptionsActivityTest {
             createIntent()
         ).use {
             it.onActivity { activity ->
-                viewModel.updateNotes(
+                viewModel.updateBelowButtonText(
                     ApplicationProvider.getApplicationContext<Context>().getString(
                         com.stripe.android.paymentsheet.R.string.stripe_paymentsheet_payment_method_us_bank_account
                     )
@@ -371,7 +371,7 @@ class PaymentOptionsActivityTest {
         ).use {
             idleLooper()
             it.onActivity { activity ->
-                viewModel.updateNotes(null)
+                viewModel.updateBelowButtonText(null)
                 assertThat(activity.viewBinding.notes.isVisible).isFalse()
             }
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.paymentsheet.PaymentSheetFixtures.PAYMENT_OPTIONS_CONT
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.databinding.PrimaryButtonBinding
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.ui.core.address.AddressFieldElementRepository
 import com.stripe.android.ui.core.elements.BankRepository
@@ -48,6 +49,13 @@ class PaymentOptionsActivityTest {
 
     private val eventReporter = mock<EventReporter>()
     private val viewModel = createViewModel()
+
+    private val primaryButtonUIState = PrimaryButton.UIState(
+        label = "Test",
+        onClick = {},
+        enabled = true,
+        visible = true
+    )
 
     @BeforeTest
     fun setup() {
@@ -271,7 +279,11 @@ class PaymentOptionsActivityTest {
             createIntent()
         ).use {
             it.onActivity { activity ->
-                viewModel.updatePrimaryButtonEnabled(true)
+                viewModel.updatePrimaryButtonUIState(
+                    primaryButtonUIState.copy(
+                        enabled = true
+                    )
+                )
                 assertThat(activity.viewBinding.continueButton.isEnabled).isTrue()
             }
         }
@@ -284,7 +296,11 @@ class PaymentOptionsActivityTest {
             createIntent()
         ).use {
             it.onActivity { activity ->
-                viewModel.updatePrimaryButtonEnabled(false)
+                viewModel.updatePrimaryButtonUIState(
+                    primaryButtonUIState.copy(
+                        enabled = false
+                    )
+                )
                 assertThat(activity.viewBinding.continueButton.isEnabled).isFalse()
             }
         }
@@ -297,21 +313,29 @@ class PaymentOptionsActivityTest {
             createIntent()
         ).use {
             it.onActivity { activity ->
-                viewModel.updatePrimaryButtonText("Some text")
+                viewModel.updatePrimaryButtonUIState(
+                    primaryButtonUIState.copy(
+                        label = "Some text"
+                    )
+                )
                 assertThat(activity.viewBinding.continueButton.externalLabel).isEqualTo("Some text")
             }
         }
     }
 
     @Test
-    fun `ContinueButton should go back to initial state after resetPrimaryButton called`() {
+    fun `ContinueButton should go back to initial state after updating selection`() {
         val scenario = activityScenario()
         scenario.launch(
             createIntent()
         ).use {
             it.onActivity { activity ->
-                viewModel.updatePrimaryButtonText("Some text")
-                viewModel.updatePrimaryButtonEnabled(false)
+                viewModel.updatePrimaryButtonUIState(
+                    primaryButtonUIState.copy(
+                        label = "Some text",
+                        enabled = false
+                    )
+                )
                 assertThat(activity.viewBinding.continueButton.externalLabel).isEqualTo("Some text")
                 assertThat(activity.viewBinding.continueButton.isEnabled).isFalse()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -37,6 +37,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
 import com.stripe.android.paymentsheet.model.StripeIntentValidator
 import com.stripe.android.paymentsheet.repositories.StripeIntentRepository
+import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.ui.PrimaryButtonAnimator
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.utils.InjectableActivityScenario
@@ -86,6 +87,13 @@ internal class PaymentSheetActivityTest {
             PaymentSheetFixtures.CONFIG_CUSTOMER,
             statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR,
         )
+    )
+
+    private val primaryButtonUIState = PrimaryButton.UIState(
+        label = "Test",
+        onClick = {},
+        enabled = true,
+        visible = true
     )
 
     @BeforeTest
@@ -883,7 +891,11 @@ internal class PaymentSheetActivityTest {
             // wait for bottom sheet to animate in
             idleLooper()
 
-            viewModel.updatePrimaryButtonEnabled(true)
+            viewModel.updatePrimaryButtonUIState(
+                primaryButtonUIState.copy(
+                    enabled = true
+                )
+            )
             assertThat(activity.viewBinding.buyButton.isEnabled).isTrue()
         }
     }
@@ -895,7 +907,11 @@ internal class PaymentSheetActivityTest {
             // wait for bottom sheet to animate in
             idleLooper()
 
-            viewModel.updatePrimaryButtonEnabled(false)
+            viewModel.updatePrimaryButtonUIState(
+                primaryButtonUIState.copy(
+                    enabled = false
+                )
+            )
             assertThat(activity.viewBinding.buyButton.isEnabled).isFalse()
         }
     }
@@ -907,7 +923,11 @@ internal class PaymentSheetActivityTest {
             // wait for bottom sheet to animate in
             idleLooper()
 
-            viewModel.updatePrimaryButtonText("Some text")
+            viewModel.updatePrimaryButtonUIState(
+                primaryButtonUIState.copy(
+                    label = "Some text"
+                )
+            )
             assertThat(activity.viewBinding.buyButton.externalLabel).isEqualTo("Some text")
         }
     }
@@ -921,8 +941,12 @@ internal class PaymentSheetActivityTest {
 
             viewModel._viewState.value = PaymentSheetViewState.Reset(null)
 
-            viewModel.updatePrimaryButtonText("Some text")
-            viewModel.updatePrimaryButtonEnabled(false)
+            viewModel.updatePrimaryButtonUIState(
+                primaryButtonUIState.copy(
+                    label = "Some text",
+                    enabled = false
+                )
+            )
             assertThat(activity.viewBinding.buyButton.externalLabel).isEqualTo("Some text")
             assertThat(activity.viewBinding.buyButton.isEnabled).isFalse()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -964,7 +964,7 @@ internal class PaymentSheetActivityTest {
             // wait for bottom sheet to animate in
             idleLooper()
 
-            viewModel.updateNotes(
+            viewModel.updateBelowButtonText(
                 context.getString(
                     R.string.stripe_paymentsheet_payment_method_us_bank_account
                 )
@@ -980,7 +980,7 @@ internal class PaymentSheetActivityTest {
             // wait for bottom sheet to animate in
             idleLooper()
 
-            viewModel.updateNotes(null)
+            viewModel.updateBelowButtonText(null)
             assertThat(activity.viewBinding.notes.isVisible).isFalse()
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -902,6 +902,40 @@ internal class PaymentSheetViewModelTest {
         )
     }
 
+    @Test
+    fun `updateSelection() posts mandate text when selected payment is us_bank_account`() {
+        val viewModel = createViewModel()
+        viewModel.updateSelection(
+            PaymentSelection.Saved(
+                PaymentMethodFixtures.US_BANK_ACCOUNT
+            )
+        )
+
+        assertThat(viewModel.mandateText.value)
+            .isEqualTo(R.string.us_bank_account_payment_sheet_saved_mandate)
+
+        viewModel.updateSelection(
+            PaymentSelection.New.GenericPaymentMethod(
+                iconResource = 0,
+                labelResource = 0,
+                paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.US_BANK_ACCOUNT,
+                customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest
+            )
+        )
+
+        assertThat(viewModel.mandateText.value)
+            .isEqualTo(null)
+
+        viewModel.updateSelection(
+            PaymentSelection.Saved(
+                PaymentMethodFixtures.CARD_PAYMENT_METHOD
+            )
+        )
+
+        assertThat(viewModel.mandateText.value)
+            .isEqualTo(null)
+    }
+
     private fun createViewModel(
         args: PaymentSheetContract.Args = ARGS_CUSTOMER_WITH_GOOGLEPAY,
         stripeIntentRepository: StripeIntentRepository = StripeIntentRepository.Static(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet
 
 import android.app.Application
+import android.content.Context
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ApplicationProvider
@@ -38,6 +39,7 @@ import com.stripe.android.paymentsheet.model.SupportedPaymentMethod
 import com.stripe.android.paymentsheet.repositories.CustomerApiRepository
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.StripeIntentRepository
+import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.UserErrorMessage
 import com.stripe.android.utils.TestUtils.idleLooper
@@ -80,6 +82,13 @@ internal class PaymentSheetViewModelTest {
     private val eventReporter = mock<EventReporter>()
     private val viewModel: PaymentSheetViewModel by lazy { createViewModel() }
     private val application = ApplicationProvider.getApplicationContext<Application>()
+
+    private val primaryButtonUIState = PrimaryButton.UIState(
+        label = "Test",
+        onClick = {},
+        enabled = true,
+        visible = true
+    )
 
     @Captor
     private lateinit var paymentMethodTypeCaptor: ArgumentCaptor<List<PaymentMethod.Type>>
@@ -803,11 +812,19 @@ internal class PaymentSheetViewModelTest {
         assertThat(isEnabled)
             .isFalse()
 
-        viewModel.updatePrimaryButtonEnabled(true)
+        viewModel.updatePrimaryButtonUIState(
+            primaryButtonUIState.copy(
+                enabled = true
+            )
+        )
         assertThat(isEnabled)
             .isTrue()
 
-        viewModel.updatePrimaryButtonEnabled(false)
+        viewModel.updatePrimaryButtonUIState(
+            primaryButtonUIState.copy(
+                enabled = false
+            )
+        )
         assertThat(isEnabled)
             .isFalse()
 
@@ -911,8 +928,12 @@ internal class PaymentSheetViewModelTest {
             )
         )
 
-        assertThat(viewModel.mandateText.value)
-            .isEqualTo(R.string.us_bank_account_payment_sheet_saved_mandate)
+        assertThat(viewModel.notesText.value)
+            .isEqualTo(
+                ApplicationProvider.getApplicationContext<Context?>().getString(
+                    R.string.us_bank_account_payment_sheet_saved_mandate
+                )
+            )
 
         viewModel.updateSelection(
             PaymentSelection.New.GenericPaymentMethod(
@@ -923,7 +944,7 @@ internal class PaymentSheetViewModelTest {
             )
         )
 
-        assertThat(viewModel.mandateText.value)
+        assertThat(viewModel.notesText.value)
             .isEqualTo(null)
 
         viewModel.updateSelection(
@@ -932,7 +953,7 @@ internal class PaymentSheetViewModelTest {
             )
         )
 
-        assertThat(viewModel.mandateText.value)
+        assertThat(viewModel.notesText.value)
             .isEqualTo(null)
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Add support for us_bank_account saved payment method for returning customers for both checkout complete and custom flows.

To test this flow, uncomment `USBankAccount` in `SupportedPaymentMethod`.

Select USD, Delayed Payment Methods ON, Automatic Payment Methods OFF

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

ACHv2

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

Checkout complete

https://user-images.githubusercontent.com/99316447/165998232-90eca7f1-5be4-4331-ba87-c0b36909144d.mov

Checkout custom

https://user-images.githubusercontent.com/99316447/165998147-29365d00-3be5-491f-9ddd-b02160b38ca9.mov


