### PR TITLE
Add ability to override primary button and notes

### DIFF
--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -104,6 +104,9 @@ public final class com/stripe/android/ui/core/elements/H4TextKt {
 public final class com/stripe/android/ui/core/elements/H6TextKt {
 }
 
+public final class com/stripe/android/ui/core/elements/HtmlKt {
+}
+
 public final class com/stripe/android/ui/core/elements/IdentifierSpec$CardBrand : com/stripe/android/ui/core/elements/IdentifierSpec {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/Html.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/Html.kt
@@ -10,6 +10,7 @@ import android.text.style.StyleSpan
 import android.text.style.URLSpan
 import android.text.style.UnderlineSpan
 import androidx.annotation.DrawableRes
+import androidx.annotation.RestrictTo
 import androidx.annotation.StringRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -47,7 +48,8 @@ import com.stripe.android.ui.core.PaymentsTheme
 
 private const val LINK_TAG = "URL"
 
-internal data class EmbeddableImage(
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class EmbeddableImage(
     @DrawableRes val id: Int,
     @StringRes val contentDescription: Int
 )
@@ -58,7 +60,8 @@ internal data class EmbeddableImage(
  * The source value in the img tab, must map to something in the imageGetter.
  */
 @Composable
-internal fun Html(
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun Html(
     html: String,
     imageGetter: Map<String, EmbeddableImage>,
     modifier: Modifier = Modifier,

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -353,6 +353,7 @@ public final class com/stripe/android/paymentsheet/databinding/ActivityPaymentOp
 	public final field fragmentContainerParent Landroid/widget/LinearLayout;
 	public final field header Landroidx/compose/ui/platform/ComposeView;
 	public final field message Landroid/widget/TextView;
+	public final field notes Landroidx/compose/ui/platform/ComposeView;
 	public final field scrollView Landroid/widget/ScrollView;
 	public final field testmode Landroid/widget/TextView;
 	public final field toolbar Lcom/google/android/material/appbar/MaterialToolbar;
@@ -376,6 +377,7 @@ public final class com/stripe/android/paymentsheet/databinding/ActivityPaymentSh
 	public final field header Landroidx/compose/ui/platform/ComposeView;
 	public final field linkButton Lcom/stripe/android/link/ui/LinkViewButton;
 	public final field message Landroid/widget/TextView;
+	public final field notes Landroidx/compose/ui/platform/ComposeView;
 	public final field scrollView Landroid/widget/ScrollView;
 	public final field testmode Landroid/widget/TextView;
 	public final field toolbar Lcom/google/android/material/appbar/MaterialToolbar;

--- a/paymentsheet/res/layout/activity_payment_options.xml
+++ b/paymentsheet/res/layout/activity_payment_options.xml
@@ -96,10 +96,18 @@
                         android:layout_marginBottom="@dimen/stripe_paymentsheet_button_container_spacing_bottom"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:text="@string/stripe_paymentsheet_continue_button_label"
                         android:visibility="gone" />
 
                 </FrameLayout>
+
+                <androidx.compose.ui.platform.ComposeView
+                    android:id="@+id/notes"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:visibility="gone"
+                    android:layout_marginVertical="2dp"
+                    android:layout_marginHorizontal="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
+                    android:layout_marginBottom="@dimen/stripe_paymentsheet_button_container_spacing_bottom" />
             </LinearLayout>
         </ScrollView>
     </LinearLayout>

--- a/paymentsheet/res/layout/activity_payment_sheet.xml
+++ b/paymentsheet/res/layout/activity_payment_sheet.xml
@@ -138,6 +138,15 @@
                         android:text="@string/stripe_paymentsheet_pay_button_label"
                         android:layout_marginVertical="2dp" />
                 </FrameLayout>
+
+                <androidx.compose.ui.platform.ComposeView
+                    android:id="@+id/notes"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:visibility="gone"
+                    android:layout_marginVertical="2dp"
+                    android:layout_marginHorizontal="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
+                    android:layout_marginBottom="@dimen/stripe_paymentsheet_button_container_spacing_bottom" />
             </LinearLayout>
         </ScrollView>
     </LinearLayout>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import android.content.res.ColorStateList
 import android.os.Bundle
 import android.view.ViewGroup
-import android.widget.FrameLayout
 import android.widget.ScrollView
 import android.widget.TextView
 import androidx.activity.viewModels
@@ -12,12 +11,9 @@ import androidx.annotation.IdRes
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.text.style.TextAlign
 import androidx.core.os.bundleOf
 import androidx.core.view.doOnNextLayout
 import androidx.core.view.isVisible
-import androidx.core.view.updateLayoutParams
-import androidx.core.view.updateMargins
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
@@ -29,7 +25,6 @@ import com.stripe.android.paymentsheet.ui.AnimationConstants
 import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.ui.core.PaymentsTheme
-import com.stripe.android.ui.core.elements.Html
 import com.stripe.android.ui.core.getBackgroundColor
 
 /**
@@ -70,6 +65,8 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
     override val header: ComposeView by lazy { viewBinding.header }
     override val fragmentContainerParent: ViewGroup by lazy { viewBinding.fragmentContainerParent }
     override val messageView: TextView by lazy { viewBinding.message }
+    override val notesView: ComposeView by lazy { viewBinding.notes }
+    override val primaryButton: PrimaryButton by lazy { viewBinding.continueButton }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -90,7 +87,6 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
         }
 
         setupContinueButton()
-        setupNotes()
 
         viewModel.transition.observe(this) { event ->
             event?.getContentIfNotHandled()?.let { transitionTarget ->
@@ -172,34 +168,6 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
 
         viewModel.updatePrimaryButtonOnPress(initial = true) {
             viewModel.onUserSelection()
-        }
-    }
-
-    private fun setupNotes() {
-        viewModel.notesText.observe(this) { stringRes ->
-            val showNotes = stringRes != null
-            stringRes?.let {
-                viewBinding.notes.setContent {
-                    Html(
-                        html = getString(stringRes),
-                        imageGetter = mapOf(),
-                        color = PaymentsTheme.colors.subtitle,
-                        style = PaymentsTheme.typography.body1.copy(textAlign = TextAlign.Center)
-                    )
-                }
-            }
-            viewBinding.notes.isVisible = showNotes
-            viewBinding.continueButton.updateLayoutParams {
-                (this as? FrameLayout.LayoutParams)?.updateMargins(
-                    bottom = if (showNotes) {
-                        0
-                    } else {
-                        resources.getDimensionPixelSize(
-                            R.dimen.stripe_paymentsheet_button_container_spacing_bottom
-                        )
-                    }
-                )
-            }
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -143,30 +143,12 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
             )
         }
 
-        viewModel.primaryButtonOnPress.observe(this) { action ->
-            viewBinding.continueButton.setOnClickListener {
-                action()
-            }
-        }
-
-        viewModel.primaryButtonText.observe(this) { text ->
-            viewBinding.continueButton.setLabel(text)
-        }
-
-        viewModel.ctaEnabled.observe(this) { isEnabled ->
-            viewBinding.continueButton.isEnabled = isEnabled
-        }
-
-        viewModel.ctaEnabled.observe(this) { isEnabled ->
-            viewBinding.continueButton.isEnabled = isEnabled
-        }
-
         viewModel.updatePrimaryButtonText(
             initial = true,
             text = getString(R.string.stripe_paymentsheet_continue_button_label)
         )
 
-        viewModel.updatePrimaryButtonOnPress(initial = true) {
+        viewModel.updatePrimaryButtonOnClick(initial = true) {
             viewModel.onUserSelection()
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -118,6 +118,10 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
             }
         }
 
+        viewModel.selection.observe(this) {
+            setupContinueButton()
+        }
+
         supportFragmentManager.registerFragmentLifecycleCallbacks(
             object : FragmentManager.FragmentLifecycleCallbacks() {
                 override fun onFragmentStarted(fm: FragmentManager, fragment: Fragment) {
@@ -143,12 +147,11 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
             )
         }
 
-        viewModel.updatePrimaryButtonText(
-            initial = true,
-            text = getString(R.string.stripe_paymentsheet_continue_button_label)
+        viewBinding.continueButton.setLabel(
+            getString(R.string.stripe_paymentsheet_continue_button_label)
         )
 
-        viewModel.updatePrimaryButtonOnClick(initial = true) {
+        viewBinding.continueButton.setOnClickListener {
             viewModel.onUserSelection()
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.content.res.ColorStateList
 import android.os.Bundle
 import android.view.ViewGroup
+import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.TextView
 import androidx.activity.viewModels
@@ -12,9 +13,12 @@ import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.text.style.TextAlign
 import androidx.core.os.bundleOf
 import androidx.core.view.doOnNextLayout
 import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updateMargins
 import androidx.fragment.app.commit
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -31,6 +35,7 @@ import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.GooglePayDividerUi
 import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.PaymentsThemeDefaults
+import com.stripe.android.ui.core.elements.Html
 import com.stripe.android.ui.core.getBackgroundColor
 import com.stripe.android.ui.core.isSystemDarkTheme
 import com.stripe.android.ui.core.shouldUseDarkDynamicColor
@@ -133,6 +138,7 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
 
         setupBuyButton()
         setupTopContainer()
+        setupNotes()
 
         linkButton.apply {
             onClick = viewModel::launchLink
@@ -253,11 +259,15 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
     private fun setupBuyButton() {
         if (viewModel.isProcessingPaymentIntent) {
             viewModel.amount.observe(this) {
-                viewBinding.buyButton.setLabel(requireNotNull(it).buildPayButtonLabel(resources))
+                viewModel.updatePrimaryButtonText(
+                    initial = true,
+                    text = requireNotNull(it).buildPayButtonLabel(resources)
+                )
             }
         } else {
-            viewBinding.buyButton.setLabel(
-                resources.getString(R.string.stripe_setup_button_label)
+            viewModel.updatePrimaryButtonText(
+                initial = true,
+                text = resources.getString(R.string.stripe_setup_button_label)
             )
         }
 
@@ -272,13 +282,23 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
             buttonColor
         )
 
-        viewBinding.buyButton.setOnClickListener {
-            clearErrorMessages()
-            viewModel.checkout(CheckoutIdentifier.SheetBottomBuy)
-        }
-
         viewModel.ctaEnabled.observe(this) { isEnabled ->
             viewBinding.buyButton.isEnabled = isEnabled
+        }
+
+        viewModel.primaryButtonOnPress.observe(this) { action ->
+            viewBinding.buyButton.setOnClickListener {
+                action()
+            }
+        }
+
+        viewModel.primaryButtonText.observe(this) { text ->
+            viewBinding.buyButton.setLabel(text)
+        }
+
+        viewModel.updatePrimaryButtonOnPress(initial = true) {
+            clearErrorMessages()
+            viewModel.checkout(CheckoutIdentifier.SheetBottomBuy)
         }
     }
 
@@ -306,6 +326,34 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
             linkButton.isVisible = viewModel.isLinkEnabled.value == true
             googlePayButton.isVisible = viewModel.isGooglePayReady.value == true
             topContainer.isVisible = visible
+        }
+    }
+
+    private fun setupNotes() {
+        viewModel.notesText.observe(this) { stringRes ->
+            val showNotes = stringRes != null
+            stringRes?.let {
+                viewBinding.notes.setContent {
+                    Html(
+                        html = getString(stringRes),
+                        imageGetter = mapOf(),
+                        color = PaymentsTheme.colors.subtitle,
+                        style = PaymentsTheme.typography.body1.copy(textAlign = TextAlign.Center)
+                    )
+                }
+            }
+            viewBinding.notes.isVisible = showNotes
+            viewBinding.buttonContainer.updateLayoutParams {
+                (this as? LinearLayout.LayoutParams)?.updateMargins(
+                    bottom = if (showNotes) {
+                        0
+                    } else {
+                        resources.getDimensionPixelSize(
+                            R.dimen.stripe_paymentsheet_button_container_spacing_bottom
+                        )
+                    }
+                )
+            }
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -198,7 +198,11 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
 
         viewModel.selection.observe(this) {
             clearErrorMessages()
+            setupBuyButton()
         }
+
+        viewModel.getButtonStateObservable(CheckoutIdentifier.SheetBottomBuy)
+            .observe(this, buyButtonStateObserver)
     }
 
     private fun onTransitionTarget(
@@ -256,20 +260,15 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
     private fun setupBuyButton() {
         if (viewModel.isProcessingPaymentIntent) {
             viewModel.amount.observe(this) {
-                viewModel.updatePrimaryButtonText(
-                    initial = true,
-                    text = requireNotNull(it).buildPayButtonLabel(resources)
+                viewBinding.buyButton.setLabel(
+                    requireNotNull(it).buildPayButtonLabel(resources)
                 )
             }
         } else {
-            viewModel.updatePrimaryButtonText(
-                initial = true,
-                text = resources.getString(R.string.stripe_setup_button_label)
+            viewBinding.buyButton.setLabel(
+                resources.getString(R.string.stripe_setup_button_label)
             )
         }
-
-        viewModel.getButtonStateObservable(CheckoutIdentifier.SheetBottomBuy)
-            .observe(this, buyButtonStateObserver)
 
         val buttonColor = viewModel.config?.primaryButtonColor ?: ColorStateList.valueOf(
             PaymentsTheme.primaryButtonStyle.getBackgroundColor(baseContext)
@@ -279,7 +278,7 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
             buttonColor
         )
 
-        viewModel.updatePrimaryButtonOnClick(initial = true) {
+        viewBinding.buyButton.setOnClickListener {
             clearErrorMessages()
             viewModel.checkout(CheckoutIdentifier.SheetBottomBuy)
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.content.res.ColorStateList
 import android.os.Bundle
 import android.view.ViewGroup
-import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.TextView
 import androidx.activity.viewModels
@@ -13,12 +12,9 @@ import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.compose.ui.text.style.TextAlign
 import androidx.core.os.bundleOf
 import androidx.core.view.doOnNextLayout
 import androidx.core.view.isVisible
-import androidx.core.view.updateLayoutParams
-import androidx.core.view.updateMargins
 import androidx.fragment.app.commit
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -33,9 +29,9 @@ import com.stripe.android.paymentsheet.model.SupportedPaymentMethod
 import com.stripe.android.paymentsheet.ui.AnimationConstants
 import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.GooglePayDividerUi
+import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.PaymentsThemeDefaults
-import com.stripe.android.ui.core.elements.Html
 import com.stripe.android.ui.core.getBackgroundColor
 import com.stripe.android.ui.core.isSystemDarkTheme
 import com.stripe.android.ui.core.shouldUseDarkDynamicColor
@@ -76,6 +72,8 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
     override val header: ComposeView by lazy { viewBinding.header }
     override val fragmentContainerParent: ViewGroup by lazy { viewBinding.fragmentContainerParent }
     override val messageView: TextView by lazy { viewBinding.message }
+    override val notesView: ComposeView by lazy { viewBinding.notes }
+    override val primaryButton: PrimaryButton by lazy { viewBinding.buyButton }
 
     private val buttonContainer: ViewGroup by lazy { viewBinding.buttonContainer }
     private val topContainer by lazy { viewBinding.topContainer }
@@ -138,7 +136,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
 
         setupBuyButton()
         setupTopContainer()
-        setupNotes()
 
         linkButton.apply {
             onClick = viewModel::launchLink
@@ -326,34 +323,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
             linkButton.isVisible = viewModel.isLinkEnabled.value == true
             googlePayButton.isVisible = viewModel.isGooglePayReady.value == true
             topContainer.isVisible = visible
-        }
-    }
-
-    private fun setupNotes() {
-        viewModel.notesText.observe(this) { stringRes ->
-            val showNotes = stringRes != null
-            stringRes?.let {
-                viewBinding.notes.setContent {
-                    Html(
-                        html = getString(stringRes),
-                        imageGetter = mapOf(),
-                        color = PaymentsTheme.colors.subtitle,
-                        style = PaymentsTheme.typography.body1.copy(textAlign = TextAlign.Center)
-                    )
-                }
-            }
-            viewBinding.notes.isVisible = showNotes
-            viewBinding.buttonContainer.updateLayoutParams {
-                (this as? LinearLayout.LayoutParams)?.updateMargins(
-                    bottom = if (showNotes) {
-                        0
-                    } else {
-                        resources.getDimensionPixelSize(
-                            R.dimen.stripe_paymentsheet_button_container_spacing_bottom
-                        )
-                    }
-                )
-            }
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -279,21 +279,7 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
             buttonColor
         )
 
-        viewModel.ctaEnabled.observe(this) { isEnabled ->
-            viewBinding.buyButton.isEnabled = isEnabled
-        }
-
-        viewModel.primaryButtonOnPress.observe(this) { action ->
-            viewBinding.buyButton.setOnClickListener {
-                action()
-            }
-        }
-
-        viewModel.primaryButtonText.observe(this) { text ->
-            viewBinding.buyButton.setLabel(text)
-        }
-
-        viewModel.updatePrimaryButtonOnPress(initial = true) {
+        viewModel.updatePrimaryButtonOnClick(initial = true) {
             clearErrorMessages()
             viewModel.checkout(CheckoutIdentifier.SheetBottomBuy)
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -231,12 +231,12 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
     }
 
     private fun setupNotes() {
-        viewModel.notesText.observe(this) { stringRes ->
-            val showNotes = stringRes != null
-            stringRes?.let {
+        viewModel.notesText.observe(this) { text ->
+            val showNotes = text != null
+            text?.let {
                 notesView.setContent {
                     Html(
-                        html = getString(stringRes),
+                        html = text,
                         imageGetter = mapOf(),
                         color = PaymentsTheme.colors.subtitle,
                         style = PaymentsTheme.typography.body1.copy(textAlign = TextAlign.Center)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -127,6 +127,7 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
 
         updateToolbarButton(supportFragmentManager.backStackEntryCount == 0)
         setupHeader()
+        setupPrimaryButton()
         setupNotes()
 
         // Make `bottomSheet` clickable to prevent clicks on the bottom sheet from triggering
@@ -212,6 +213,20 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
                     )
                 }
             }
+        }
+    }
+
+    private fun setupPrimaryButton() {
+        viewModel.primaryButtonOnClick.observe(this) { action ->
+            primaryButton.setOnClickListener {
+                action()
+            }
+        }
+        viewModel.primaryButtonText.observe(this) { text ->
+            primaryButton.setLabel(text)
+        }
+        viewModel.ctaEnabled.observe(this) { isEnabled ->
+            primaryButton.isEnabled = isEnabled
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -11,6 +11,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.WindowInsets
 import android.view.WindowMetrics
+import android.widget.FrameLayout
 import android.widget.ScrollView
 import android.widget.TextView
 import androidx.annotation.DrawableRes
@@ -24,17 +25,22 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updateMargins
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.stripe.android.paymentsheet.BottomSheetController
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
+import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.PaymentsThemeDefaults
 import com.stripe.android.ui.core.createTextSpanFromTextStyle
 import com.stripe.android.ui.core.elements.H4Text
+import com.stripe.android.ui.core.elements.Html
 import com.stripe.android.ui.core.isSystemDarkTheme
 import com.stripe.android.view.KeyboardController
 import kotlin.math.roundToInt
@@ -58,6 +64,8 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
     abstract val header: ComposeView
     abstract val fragmentContainerParent: ViewGroup
     abstract val testModeIndicator: TextView
+    abstract val notesView: ComposeView
+    abstract val primaryButton: PrimaryButton
 
     abstract fun setActivityResult(result: ResultType)
 
@@ -119,6 +127,7 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
 
         updateToolbarButton(supportFragmentManager.backStackEntryCount == 0)
         setupHeader()
+        setupNotes()
 
         // Make `bottomSheet` clickable to prevent clicks on the bottom sheet from triggering
         // `rootView`'s click listener
@@ -202,6 +211,34 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
                         modifier = Modifier.padding(bottom = 2.dp)
                     )
                 }
+            }
+        }
+    }
+
+    private fun setupNotes() {
+        viewModel.notesText.observe(this) { stringRes ->
+            val showNotes = stringRes != null
+            stringRes?.let {
+                notesView.setContent {
+                    Html(
+                        html = getString(stringRes),
+                        imageGetter = mapOf(),
+                        color = PaymentsTheme.colors.subtitle,
+                        style = PaymentsTheme.typography.body1.copy(textAlign = TextAlign.Center)
+                    )
+                }
+            }
+            notesView.isVisible = showNotes
+            primaryButton.updateLayoutParams {
+                (this as? FrameLayout.LayoutParams)?.updateMargins(
+                    bottom = if (showNotes) {
+                        0
+                    } else {
+                        resources.getDimensionPixelSize(
+                            R.dimen.stripe_paymentsheet_button_container_spacing_bottom
+                        )
+                    }
+                )
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -148,9 +148,9 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
 
     private val primaryButtonEnabled = MutableLiveData<Boolean?>()
 
-    private val _primaryButtonOnPress = MutableLiveData<() -> Unit>()
-    val primaryButtonOnPress: LiveData<() -> Unit>
-        get() = _primaryButtonOnPress
+    private val _primaryButtonOnClick = MutableLiveData<() -> Unit>()
+    val primaryButtonOnClick: LiveData<() -> Unit>
+        get() = _primaryButtonOnClick
 
     @VisibleForTesting
     @StringRes
@@ -339,11 +339,11 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
         primaryButtonEnabled.value = enabled
     }
 
-    fun updatePrimaryButtonOnPress(initial: Boolean = false, onPress: () -> Unit) {
+    fun updatePrimaryButtonOnClick(initial: Boolean = false, onPress: () -> Unit) {
         if (initial) {
             initialPrimaryButtonOnPress = onPress
         }
-        _primaryButtonOnPress.value = onPress
+        _primaryButtonOnClick.value = onPress
     }
 
     fun resetPrimaryButton() {
@@ -351,7 +351,7 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
             _primaryButtonText.value = it
         }
         primaryButtonEnabled.value = null
-        _primaryButtonOnPress.value = initialPrimaryButtonOnPress
+        _primaryButtonOnClick.value = initialPrimaryButtonOnPress
     }
 
     fun updateSelection(selection: PaymentSelection?) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet.viewmodels
 import android.app.Application
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
-import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
@@ -152,14 +151,9 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
     val primaryButtonOnClick: LiveData<() -> Unit>
         get() = _primaryButtonOnClick
 
-    @VisibleForTesting
-    @StringRes
-    internal val _notesText = MutableLiveData<Int?>()
-    internal val notesText: LiveData<Int?>
-        @StringRes get() = _notesText
-
-    private var initialPrimaryButtonText: String? = null
-    private var initialPrimaryButtonOnPress: () -> Unit = {}
+    private val _notesText = MutableLiveData<String?>()
+    internal val notesText: LiveData<String?>
+        get() = _notesText
 
     protected var linkActivityResultLauncher:
         ActivityResultLauncher<LinkActivityContract.Args>? = null
@@ -328,10 +322,7 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
         logger.warning(message)
     }
 
-    fun updatePrimaryButtonText(text: String, initial: Boolean = false) {
-        if (initial) {
-            initialPrimaryButtonText = text
-        }
+    fun updatePrimaryButtonText(text: String) {
         _primaryButtonText.value = text
     }
 
@@ -339,25 +330,19 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
         primaryButtonEnabled.value = enabled
     }
 
-    fun updatePrimaryButtonOnClick(initial: Boolean = false, onPress: () -> Unit) {
-        if (initial) {
-            initialPrimaryButtonOnPress = onPress
-        }
+    fun updatePrimaryButtonOnClick(onPress: () -> Unit) {
         _primaryButtonOnClick.value = onPress
     }
 
-    fun resetPrimaryButton() {
-        initialPrimaryButtonText?.let {
-            _primaryButtonText.value = it
-        }
-        primaryButtonEnabled.value = null
-        _primaryButtonOnClick.value = initialPrimaryButtonOnPress
+    fun updateNotes(text: String?) {
+        _notesText.value = text
     }
 
     fun updateSelection(selection: PaymentSelection?) {
         if (selection is PaymentSelection.New) {
             newLpm = selection
         }
+        primaryButtonEnabled.value = null
         savedStateHandle[SAVE_SELECTION] = selection
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -265,6 +265,91 @@ class PaymentOptionsActivityTest {
         }
     }
 
+    @Test
+    fun `ContinueButton should be enabled when primaryButtonEnabled is true`() {
+        val scenario = activityScenario()
+        scenario.launch(
+            createIntent()
+        ).use {
+            it.onActivity { activity ->
+                viewModel.updatePrimaryButtonEnabled(true)
+                assertThat(activity.viewBinding.continueButton.isEnabled).isTrue()
+            }
+        }
+    }
+
+    @Test
+    fun `ContinueButton should be disabled when primaryButtonEnabled is false`() {
+        val scenario = activityScenario()
+        scenario.launch(
+            createIntent()
+        ).use {
+            it.onActivity { activity ->
+                viewModel.updatePrimaryButtonEnabled(false)
+                assertThat(activity.viewBinding.continueButton.isEnabled).isFalse()
+            }
+        }
+    }
+
+    @Test
+    fun `ContinueButton text should update when primaryButtonText updates`() {
+        val scenario = activityScenario()
+        scenario.launch(
+            createIntent()
+        ).use {
+            it.onActivity { activity ->
+                viewModel.updatePrimaryButtonText("Some text")
+                assertThat(activity.viewBinding.continueButton.externalLabel).isEqualTo("Some text")
+            }
+        }
+    }
+
+    @Test
+    fun `ContinueButton should go back to initial state after resetPrimaryButton called`() {
+        val scenario = activityScenario()
+        scenario.launch(
+            createIntent()
+        ).use {
+            it.onActivity { activity ->
+                viewModel.updatePrimaryButtonText("Some text")
+                viewModel.updatePrimaryButtonEnabled(true)
+                assertThat(activity.viewBinding.continueButton.externalLabel).isEqualTo("Some text")
+                assertThat(activity.viewBinding.continueButton.isEnabled).isTrue()
+
+                viewModel.resetPrimaryButton()
+                assertThat(activity.viewBinding.continueButton.externalLabel).isEqualTo("Continue")
+                assertThat(activity.viewBinding.continueButton.isEnabled).isFalse()
+            }
+        }
+    }
+
+    @Test
+    fun `notes visibility is visible`() {
+        val scenario = activityScenario()
+        scenario.launch(
+            createIntent()
+        ).use {
+            it.onActivity { activity ->
+                viewModel._notesText.value = com.stripe.android.paymentsheet.R.string.stripe_paymentsheet_payment_method_us_bank_account
+                assertThat(activity.viewBinding.notes.isVisible).isTrue()
+            }
+        }
+    }
+
+    @Test
+    fun `notes visibility is gone`() {
+        val scenario = activityScenario()
+        scenario.launch(
+            createIntent()
+        ).use {
+            idleLooper()
+            it.onActivity { activity ->
+                viewModel._notesText.value = null
+                assertThat(activity.viewBinding.notes.isVisible).isFalse()
+            }
+        }
+    }
+
     private fun createIntent(
         args: PaymentOptionContract.Args = PAYMENT_OPTIONS_CONTRACT_ARGS
     ): Intent {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -35,7 +35,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.times
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.BeforeTest
 
@@ -312,13 +311,13 @@ class PaymentOptionsActivityTest {
         ).use {
             it.onActivity { activity ->
                 viewModel.updatePrimaryButtonText("Some text")
-                viewModel.updatePrimaryButtonEnabled(true)
+                viewModel.updatePrimaryButtonEnabled(false)
                 assertThat(activity.viewBinding.continueButton.externalLabel).isEqualTo("Some text")
-                assertThat(activity.viewBinding.continueButton.isEnabled).isTrue()
-
-                viewModel.resetPrimaryButton()
-                assertThat(activity.viewBinding.continueButton.externalLabel).isEqualTo("Continue")
                 assertThat(activity.viewBinding.continueButton.isEnabled).isFalse()
+
+                viewModel.updateSelection(mock())
+                assertThat(activity.viewBinding.continueButton.externalLabel).isEqualTo("Continue")
+                assertThat(activity.viewBinding.continueButton.isEnabled).isTrue()
             }
         }
     }
@@ -330,7 +329,11 @@ class PaymentOptionsActivityTest {
             createIntent()
         ).use {
             it.onActivity { activity ->
-                viewModel._notesText.value = com.stripe.android.paymentsheet.R.string.stripe_paymentsheet_payment_method_us_bank_account
+                viewModel.updateNotes(
+                    ApplicationProvider.getApplicationContext<Context>().getString(
+                        com.stripe.android.paymentsheet.R.string.stripe_paymentsheet_payment_method_us_bank_account
+                    )
+                )
                 assertThat(activity.viewBinding.notes.isVisible).isTrue()
             }
         }
@@ -344,7 +347,7 @@ class PaymentOptionsActivityTest {
         ).use {
             idleLooper()
             it.onActivity { activity ->
-                viewModel._notesText.value = null
+                viewModel.updateNotes(null)
                 assertThat(activity.viewBinding.notes.isVisible).isFalse()
             }
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -926,7 +926,7 @@ internal class PaymentSheetActivityTest {
             assertThat(activity.viewBinding.buyButton.externalLabel).isEqualTo("Some text")
             assertThat(activity.viewBinding.buyButton.isEnabled).isFalse()
 
-            viewModel.resetPrimaryButton()
+            viewModel.updateSelection(mock())
             assertThat(activity.viewBinding.buyButton.externalLabel)
                 .isEqualTo(viewModel.amount.value?.buildPayButtonLabel(context.resources))
             assertThat(activity.viewBinding.buyButton.isEnabled).isTrue()
@@ -940,7 +940,11 @@ internal class PaymentSheetActivityTest {
             // wait for bottom sheet to animate in
             idleLooper()
 
-            viewModel._notesText.value = R.string.stripe_paymentsheet_payment_method_us_bank_account
+            viewModel.updateNotes(
+                context.getString(
+                    R.string.stripe_paymentsheet_payment_method_us_bank_account
+                )
+            )
             assertThat(activity.viewBinding.notes.isVisible).isTrue()
         }
     }
@@ -952,7 +956,7 @@ internal class PaymentSheetActivityTest {
             // wait for bottom sheet to animate in
             idleLooper()
 
-            viewModel._notesText.value = null
+            viewModel.updateNotes(null)
             assertThat(activity.viewBinding.notes.isVisible).isFalse()
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -876,6 +876,87 @@ internal class PaymentSheetActivityTest {
         }
     }
 
+    @Test
+    fun `Buy button should be enabled when primaryButtonEnabled is true`() {
+        val scenario = activityScenario(viewModel)
+        scenario.launch(intent).onActivity { activity ->
+            // wait for bottom sheet to animate in
+            idleLooper()
+
+            viewModel.updatePrimaryButtonEnabled(true)
+            assertThat(activity.viewBinding.buyButton.isEnabled).isTrue()
+        }
+    }
+
+    @Test
+    fun `Buy button should be disabled when primaryButtonEnabled is false`() {
+        val scenario = activityScenario(viewModel)
+        scenario.launch(intent).onActivity { activity ->
+            // wait for bottom sheet to animate in
+            idleLooper()
+
+            viewModel.updatePrimaryButtonEnabled(false)
+            assertThat(activity.viewBinding.buyButton.isEnabled).isFalse()
+        }
+    }
+
+    @Test
+    fun `Buy button text should update when primaryButtonText updates`() {
+        val scenario = activityScenario(viewModel)
+        scenario.launch(intent).onActivity { activity ->
+            // wait for bottom sheet to animate in
+            idleLooper()
+
+            viewModel.updatePrimaryButtonText("Some text")
+            assertThat(activity.viewBinding.buyButton.externalLabel).isEqualTo("Some text")
+        }
+    }
+
+    @Test
+    fun `Buy button should go back to initial state after resetPrimaryButton called`() {
+        val scenario = activityScenario(viewModel)
+        scenario.launch(intent).onActivity { activity ->
+            // wait for bottom sheet to animate in
+            idleLooper()
+
+            viewModel._viewState.value = PaymentSheetViewState.Reset(null)
+
+            viewModel.updatePrimaryButtonText("Some text")
+            viewModel.updatePrimaryButtonEnabled(false)
+            assertThat(activity.viewBinding.buyButton.externalLabel).isEqualTo("Some text")
+            assertThat(activity.viewBinding.buyButton.isEnabled).isFalse()
+
+            viewModel.resetPrimaryButton()
+            assertThat(activity.viewBinding.buyButton.externalLabel)
+                .isEqualTo(viewModel.amount.value?.buildPayButtonLabel(context.resources))
+            assertThat(activity.viewBinding.buyButton.isEnabled).isTrue()
+        }
+    }
+
+    @Test
+    fun `notes visibility is visible`() {
+        val scenario = activityScenario(viewModel)
+        scenario.launch(intent).onActivity { activity ->
+            // wait for bottom sheet to animate in
+            idleLooper()
+
+            viewModel._notesText.value = R.string.stripe_paymentsheet_payment_method_us_bank_account
+            assertThat(activity.viewBinding.notes.isVisible).isTrue()
+        }
+    }
+
+    @Test
+    fun `notes visibility is gone`() {
+        val scenario = activityScenario(viewModel)
+        scenario.launch(intent).onActivity { activity ->
+            // wait for bottom sheet to animate in
+            idleLooper()
+
+            viewModel._notesText.value = null
+            assertThat(activity.viewBinding.notes.isVisible).isFalse()
+        }
+    }
+
     private fun currentFragment(activity: PaymentSheetActivity) =
         activity.supportFragmentManager.findFragmentById(activity.viewBinding.fragmentContainer.id)
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -815,7 +815,7 @@ internal class PaymentSheetViewModelTest {
         assertThat(isEnabled)
             .isFalse()
 
-        viewModel.resetPrimaryButton()
+        viewModel.updateSelection(mock())
         assertThat(isEnabled)
             .isTrue()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -780,7 +780,7 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
-    fun `buyButton is only enabled when not processing, not editing, and a selection has been made`() {
+    fun `buyButton is enabled when primaryButtonEnabled is true, else not processing, not editing, and a selection has been made`() {
         var isEnabled = false
         viewModel.savedStateHandle.set(BaseSheetViewModel.SAVE_PROCESSING, true)
         viewModel.ctaEnabled.observeForever {
@@ -802,6 +802,22 @@ internal class PaymentSheetViewModelTest {
         viewModel.setEditing(true)
         assertThat(isEnabled)
             .isFalse()
+
+        viewModel.updatePrimaryButtonEnabled(true)
+        assertThat(isEnabled)
+            .isTrue()
+
+        viewModel.updatePrimaryButtonEnabled(false)
+        assertThat(isEnabled)
+            .isFalse()
+
+        viewModel.setEditing(false)
+        assertThat(isEnabled)
+            .isFalse()
+
+        viewModel.resetPrimaryButton()
+        assertThat(isEnabled)
+            .isTrue()
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

- Add the ability to override the primary button: onClick, label, and enabled through view model
- Add notes compose view, which is below the primary button
- Add the ability to override the notes through view model

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Instead of hiding the primary button and adding it to each fragment, this PR adds the ability to override the primary button. This was needed because there are other flows which don't have form fragments involved.

There are a couple flows which require overriding the primary button and notes:
- US Bank account form flow, this custom form will need to override the primary button flows
- US Bank account saved payment method, this flow will need to display a mandate below the selected payment method

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified
