### PR TITLE
add configuration metrics for payment sheet

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsRequestFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsRequestFactory.kt
@@ -179,17 +179,6 @@ class PaymentAnalyticsRequestFactory @VisibleForTesting internal constructor(
     }
 
     @JvmSynthetic
-    fun createRequest(
-        event: String,
-        deviceId: String
-    ): AnalyticsRequest {
-        return createRequest(
-            event,
-            mapOf(FIELD_DEVICE_ID to deviceId)
-        )
-    }
-
-    @JvmSynthetic
     internal fun createRequest(
         event: PaymentAnalyticsEvent,
         productUsageTokens: Set<String> = emptySet(),
@@ -262,7 +251,6 @@ class PaymentAnalyticsRequestFactory @VisibleForTesting internal constructor(
 
     internal companion object {
         internal const val FIELD_TOKEN_TYPE = "token_type"
-        internal const val FIELD_DEVICE_ID = "device_id"
         internal const val FIELD_PRODUCT_USAGE = "product_usage"
         internal const val FIELD_SOURCE_TYPE = "source_type"
         internal const val FIELD_3DS2_UI_TYPE = "3ds2_ui_type"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -87,10 +87,14 @@ internal class DefaultEventReporter @Inject internal constructor(
             val deviceId = deviceIdRepository.get()
             analyticsRequestExecutor.executeAsync(
                 paymentAnalyticsRequestFactory.createRequest(
-                    event.toString(),
-                    deviceId.value
+                    event,
+                    event.additionalParams.plus(FIELD_DEVICE_ID to deviceId.value)
                 )
             )
         }
+    }
+
+    internal companion object {
+        internal const val FIELD_DEVICE_ID = "device_id"
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -1,58 +1,76 @@
 package com.stripe.android.paymentsheet.analytics
 
+import com.stripe.android.core.networking.AnalyticsEvent
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 
-internal sealed class PaymentSheetEvent(
-    private val mode: EventReporter.Mode
-) {
-    abstract val event: String
+internal sealed class PaymentSheetEvent : AnalyticsEvent {
+    abstract val additionalParams: Map<String, Any>
 
     class Init(
-        mode: EventReporter.Mode,
+        private val mode: EventReporter.Mode,
         private val configuration: PaymentSheet.Configuration?
-    ) : PaymentSheetEvent(mode) {
-        override val event: String
+    ) : PaymentSheetEvent() {
+        override val eventName: String
             get() {
                 val configValue = listOfNotNull(
-                    "customer".takeIf { configuration?.customer != null },
-                    "googlepay".takeIf { configuration?.googlePay != null }
+                    FIELD_CUSTOMER.takeIf { configuration?.customer != null },
+                    FIELD_GOOGLE_PAY.takeIf { configuration?.googlePay != null }
                 ).takeUnless { it.isEmpty() }?.joinToString(separator = "_") ?: "default"
-                return "init_$configValue"
+                return formatEventName(mode, "init_$configValue")
+            }
+        override val additionalParams: Map<String, Any>
+            get() {
+                val configurationMap = mapOf(
+                    // todo skyler: add project wardrobe configs here too.
+                    FIELD_CUSTOMER to (configuration?.customer != null),
+                    FIELD_GOOGLE_PAY to (configuration?.googlePay != null),
+                    FIELD_PRIMARY_BUTTON_COLOR to (configuration?.primaryButtonColor != null),
+                    FIELD_BILLING to (configuration?.defaultBillingDetails != null),
+                    FIELD_DELAYED_PMS to (configuration?.allowsDelayedPaymentMethods),
+                )
+                return mapOf(FIELD_PAYMENT_SHEET_CONFIGURATION to configurationMap)
             }
     }
 
     class Dismiss(
         mode: EventReporter.Mode
-    ) : PaymentSheetEvent(mode) {
-        override val event: String = "dismiss"
+    ) : PaymentSheetEvent() {
+        override val eventName: String = formatEventName(mode, "dismiss")
+        override val additionalParams: Map<String, Any> = mapOf()
     }
 
     class ShowNewPaymentOptionForm(
         mode: EventReporter.Mode
-    ) : PaymentSheetEvent(mode) {
-        override val event: String = "sheet_newpm_show"
+    ) : PaymentSheetEvent() {
+        override val eventName: String = formatEventName(mode, "sheet_newpm_show")
+        override val additionalParams: Map<String, Any> = mapOf()
     }
 
     class ShowExistingPaymentOptions(
         mode: EventReporter.Mode
-    ) : PaymentSheetEvent(mode) {
-        override val event: String = "sheet_savedpm_show"
+    ) : PaymentSheetEvent() {
+        override val eventName: String = formatEventName(mode, "sheet_savedpm_show")
+        override val additionalParams: Map<String, Any> = mapOf()
     }
 
     class SelectPaymentOption(
         mode: EventReporter.Mode,
         paymentSelection: PaymentSelection?
-    ) : PaymentSheetEvent(mode) {
-        override val event: String = "paymentoption_${analyticsValue(paymentSelection)}_select"
+    ) : PaymentSheetEvent() {
+        override val eventName: String =
+            formatEventName(mode, "paymentoption_${analyticsValue(paymentSelection)}_select")
+        override val additionalParams: Map<String, Any> = mapOf()
     }
 
     class Payment(
         mode: EventReporter.Mode,
         result: Result,
         paymentSelection: PaymentSelection?
-    ) : PaymentSheetEvent(mode) {
-        override val event: String = "payment_${analyticsValue(paymentSelection)}_$result"
+    ) : PaymentSheetEvent() {
+        override val eventName: String =
+            formatEventName(mode, "payment_${analyticsValue(paymentSelection)}_$result")
+        override val additionalParams: Map<String, Any> = mapOf()
 
         enum class Result(private val code: String) {
             Success("success"),
@@ -60,10 +78,6 @@ internal sealed class PaymentSheetEvent(
 
             override fun toString(): String = code
         }
-    }
-
-    override fun toString(): String {
-        return "mc_${mode}_$event"
     }
 
     internal companion object {
@@ -75,5 +89,16 @@ internal sealed class PaymentSheetEvent(
             is PaymentSelection.New -> "newpm"
             else -> "unknown"
         }
+
+        private fun formatEventName(mode: EventReporter.Mode, eventName: String): String {
+            return "mc_${mode}_$eventName"
+        }
+
+        const val FIELD_CUSTOMER = "customer"
+        const val FIELD_GOOGLE_PAY = "googlepay"
+        const val FIELD_PRIMARY_BUTTON_COLOR = "primary_button_color"
+        const val FIELD_BILLING = "default_billing_details"
+        const val FIELD_DELAYED_PMS = "allows_delayed_payment_methods"
+        const val FIELD_PAYMENT_SHEET_CONFIGURATION = "payment_sheet_configuration"
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.paymentsheet
 
+import android.content.res.ColorStateList
+import android.graphics.Color
 import androidx.core.graphics.toColorInt
 import com.stripe.android.core.injection.DUMMY_INJECTOR_KEY
 import com.stripe.android.model.PaymentIntentFixtures
@@ -22,6 +24,18 @@ internal object PaymentSheetFixtures {
 
     internal val CONFIG_MINIMUM = PaymentSheet.Configuration(
         merchantDisplayName = MERCHANT_DISPLAY_NAME
+    )
+
+    internal val CONFIG_WITH_EVERYTHING = PaymentSheet.Configuration(
+        merchantDisplayName = MERCHANT_DISPLAY_NAME,
+        customer = PaymentSheet.CustomerConfiguration(
+            "customer_id",
+            "ephemeral_key"
+        ),
+        googlePay = ConfigFixtures.GOOGLE_PAY,
+        primaryButtonColor = ColorStateList.valueOf(Color.BLACK),
+        defaultBillingDetails = PaymentSheet.BillingDetails(name = "Skyler"),
+        allowsDelayedPaymentMethods = true
     )
 
     internal val CONFIG_CUSTOMER = PaymentSheet.Configuration(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -16,7 +16,7 @@ class PaymentSheetEventTest {
             PaymentSheetEvent.Init(
                 mode = EventReporter.Mode.Complete,
                 configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
-            ).toString()
+            ).eventName
         ).isEqualTo(
             "mc_complete_init_customer_googlepay"
         )
@@ -28,7 +28,7 @@ class PaymentSheetEventTest {
             PaymentSheetEvent.Init(
                 mode = EventReporter.Mode.Complete,
                 configuration = PaymentSheetFixtures.CONFIG_MINIMUM
-            ).toString()
+            ).eventName
         ).isEqualTo(
             "mc_complete_init_default"
         )
@@ -41,7 +41,7 @@ class PaymentSheetEventTest {
                 mode = EventReporter.Mode.Complete,
                 paymentSelection = PaymentSelection.GooglePay,
                 result = PaymentSheetEvent.Payment.Result.Success
-            ).toString()
+            ).eventName
         ).isEqualTo(
             "mc_complete_payment_googlepay_success"
         )
@@ -53,9 +53,47 @@ class PaymentSheetEventTest {
             PaymentSheetEvent.SelectPaymentOption(
                 mode = EventReporter.Mode.Custom,
                 paymentSelection = PaymentSelection.GooglePay
-            ).toString()
+            ).eventName
         ).isEqualTo(
             "mc_custom_paymentoption_googlepay_select"
+        )
+    }
+
+    @Test
+    fun `Init event should have default params if config is all defaults`() {
+        val expectedConfigMap = mapOf(
+            "customer" to false,
+            "googlepay" to false,
+            "primary_button_color" to false,
+            "default_billing_details" to false,
+            "allows_delayed_payment_methods" to false,
+        )
+        assertThat(
+            PaymentSheetEvent.Init(
+                mode = EventReporter.Mode.Complete,
+                configuration = PaymentSheetFixtures.CONFIG_MINIMUM
+            ).additionalParams
+        ).isEqualTo(
+            mapOf("payment_sheet_configuration" to expectedConfigMap)
+        )
+    }
+
+    @Test
+    fun `Init event should should mark all optional params present if there are there`() {
+        val expectedConfigMap = mapOf(
+            "customer" to true,
+            "googlepay" to true,
+            "primary_button_color" to true,
+            "default_billing_details" to true,
+            "allows_delayed_payment_methods" to true,
+        )
+        assertThat(
+            PaymentSheetEvent.Init(
+                mode = EventReporter.Mode.Complete,
+                configuration = PaymentSheetFixtures.CONFIG_WITH_EVERYTHING
+            ).additionalParams
+        ).isEqualTo(
+            mapOf("payment_sheet_configuration" to expectedConfigMap)
         )
     }
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestFactory.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestFactory.kt
@@ -35,24 +35,6 @@ open class AnalyticsRequestFactory(
         )
     }
 
-    /**
-     * Backwards compatible for events not inheriting [AnalyticsEvent].
-     *
-     * @see createRequest
-     */
-    @Deprecated("use {@link #createRequest(AnalyticsEvent, Map<String, Any>)}")
-    fun createRequest(
-        event: String,
-        additionalParams: Map<String, Any>
-    ): AnalyticsRequest {
-        return createRequest(
-            event = object : AnalyticsEvent {
-                override val eventName: String = event
-            },
-            additionalParams = additionalParams
-        )
-    }
-
     private fun createParams(
         event: AnalyticsEvent
     ): Map<String, Any> {

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestFactoryTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestFactoryTest.kt
@@ -112,12 +112,4 @@ class AnalyticsRequestFactoryTest : TestCase() {
         assertThat(AnalyticsRequestFactory.ANALYTICS_UA)
             .isEqualTo("analytics.stripe_android-1.0")
     }
-
-    @Test
-    fun `createEvent(String) - event name field matches passed string`() {
-        val event = "my_event_name"
-        val request = factory.createRequest(event, emptyMap())
-
-        assertThat(request.params["event"]).isEqualTo(event)
-    }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Adds fields for the existing `PaymentSheet.configuration` in our `init` event.
* Makes `PaymentSheetEvent` an `AnalyticsEvent` so that we can clean out a bunch of deprecated code.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
* project wardrobe is adding new configs, so I wanted to start here with the existing ones.
* Deprecated code removal while I'm here. 
* Matches iOS here: https://github.com/stripe-ios/stripe-ios/pull/1011/files

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

```
AnalyticsRequest("params="{
   analytics_ua=analytics.stripe_android-1.0,
   publishable_key=pk_test_blahblah,
   "os_name=REL",
   os_release=11,
   os_version=30,
   device_type=Google_google_Pixel 3a,
   bindings_version=20.2.0,
   "is_development=true",
   "app_name=PaymentSheet Example",
   app_version=1,
   "event=init_customer_googlepay",
   "payment_sheet_configuration="{
      "customer=true",
      "googlepay=true",
      "primary_button_color=false",
      "default_billing_details=false",
      "allows_delayed_payment_methods=true"
   },
   device_id=3e88722b-7e64-4024-a2d3-2294d65e8c1e
},
"headers="{
   User-Agent=Stripe/v1 AndroidBindings/20.2.0,
```
