### PR TITLE
[Identity] Fix ErrorFragment's backbutton behavior

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/navigation/ErrorFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ErrorFragment.kt
@@ -47,11 +47,13 @@ internal class ErrorFragment(
                 bottomButton.setOnClickListener {
                     val destination = args[ARG_GO_BACK_BUTTON_DESTINATION] as Int
                     if (destination == UNEXPECTED_DESTINATION) {
-                        findNavController().navigate(DEFAULT_BACK_BUTTON_DESTINATION)
+                        findNavController().navigate(DEFAULT_BACK_BUTTON_NAVIGATION)
                     } else {
                         findNavController().let { navController ->
-                            while (navController.currentDestination?.id != destination) {
-                                navController.navigateUpAndSetArgForUploadFragment()
+                            var shouldContinueNavigateUp = true
+                            while (shouldContinueNavigateUp && navController.currentDestination?.id != destination) {
+                                shouldContinueNavigateUp =
+                                    navController.navigateUpAndSetArgForUploadFragment()
                             }
                         }
                     }
@@ -75,7 +77,7 @@ internal class ErrorFragment(
         // If this happens, set the back button destination to [DEFAULT_BACK_BUTTON_DESTINATION]
         internal const val UNEXPECTED_DESTINATION = -1
 
-        private val DEFAULT_BACK_BUTTON_DESTINATION =
+        private val DEFAULT_BACK_BUTTON_NAVIGATION =
             R.id.action_errorFragment_to_consentFragment
 
         fun NavController.navigateToErrorFragmentWithRequirementError(
@@ -105,7 +107,7 @@ internal class ErrorFragment(
                 bundleOf(
                     ARG_ERROR_TITLE to context.getString(R.string.error),
                     ARG_ERROR_CONTENT to context.getString(R.string.unexpected_error_try_again),
-                    ARG_GO_BACK_BUTTON_DESTINATION to R.id.action_errorFragment_to_consentFragment,
+                    ARG_GO_BACK_BUTTON_DESTINATION to R.id.consentFragment,
                     ARG_GO_BACK_BUTTON_TEXT to context.getString(R.string.go_back)
                 )
             )

--- a/identity/src/main/java/com/stripe/android/identity/utils/navigationUtils.kt
+++ b/identity/src/main/java/com/stripe/android/identity/utils/navigationUtils.kt
@@ -147,7 +147,7 @@ internal fun Fragment.navigateToUploadFragment(
  * This makes it possible to tell in upload fragment whether it is reached through
  * [NavController.navigateUp] or [NavController.navigate].
  */
-internal fun NavController.navigateUpAndSetArgForUploadFragment() {
+internal fun NavController.navigateUpAndSetArgForUploadFragment(): Boolean {
     if (isBackingToUploadFragment()) {
         previousBackStackEntry?.destination?.addArgument(
             ARG_IS_NAVIGATED_UP_TO,
@@ -156,7 +156,7 @@ internal fun NavController.navigateUpAndSetArgForUploadFragment() {
                 .build()
         )
     }
-    navigateUp()
+    return navigateUp()
 }
 
 internal fun NavController.isNavigatedUpTo(): Boolean {

--- a/identity/src/test/java/com/stripe/android/identity/navigation/ErrorFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/ErrorFragmentTest.kt
@@ -100,6 +100,67 @@ class ErrorFragmentTest {
         }
     }
 
+    @Test
+    fun `when destination is present in backstack, clicking back keep popping until destination is reached`() {
+        val navigationDestination = R.id.consentFragment
+
+        launchErrorFragment(navigationDestination).onFragment {
+            val navController = TestNavHostController(
+                ApplicationProvider.getApplicationContext()
+            )
+            navController.setGraph(
+                R.navigation.identity_nav_graph
+            )
+            navController.setCurrentDestination(R.id.consentFragment)
+            navController.navigate(R.id.action_consentFragment_to_docSelectionFragment)
+            navController.navigate(R.id.action_global_errorFragment)
+
+            Navigation.setViewNavController(
+                it.requireView(),
+                navController
+            )
+
+            // back stack: [consentFragment, docSelectionFragment, errorFragment]
+            assertThat(navController.currentDestination?.id).isEqualTo(R.id.errorFragment)
+
+            // keep popping until navigationDestination(consentFragment) is reached
+            BaseErrorFragmentBinding.bind(it.requireView()).bottomButton.callOnClick()
+
+            assertThat(navController.currentDestination?.id).isEqualTo(navigationDestination)
+        }
+    }
+
+    @Test
+    fun `when destination is not present in backstack, clicking back reaches the first entry`() {
+        val navigationDestination = R.id.confirmationFragment
+        val firstEntry = R.id.consentFragment
+        launchErrorFragment(navigationDestination).onFragment {
+            val navController = TestNavHostController(
+                ApplicationProvider.getApplicationContext()
+            )
+            navController.setGraph(
+                R.navigation.identity_nav_graph
+            )
+            navController.setCurrentDestination(firstEntry)
+            navController.navigate(R.id.action_consentFragment_to_docSelectionFragment)
+            navController.navigate(R.id.action_global_errorFragment)
+
+            Navigation.setViewNavController(
+                it.requireView(),
+                navController
+            )
+
+            // back stack: [consentFragment, docSelectionFragment, errorFragment]
+            assertThat(navController.currentDestination?.id).isEqualTo(R.id.errorFragment)
+
+            // navigationDestination(confirmationFragment) is not in backstack,
+            // keep popping until firstEntry(consentFragment) is reached
+            BaseErrorFragmentBinding.bind(it.requireView()).bottomButton.callOnClick()
+
+            assertThat(navController.currentDestination?.id).isEqualTo(firstEntry)
+        }
+    }
+
     private fun launchErrorFragment(
         navigationDestination: Int? = null
     ) = launchFragmentInContainer(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Fix the final destination of default error - it should be `consentFragment`(a navigation node) instead of `action_errorFragment_to_consentFragment`(a navigation edge)
* Rename `DEFAULT_BACK_BUTTON_DESTINATION` to `DEFAULT_BACK_BUTTON_NAVIGATION` as it is an navigate edge instead of an navigation node
* Add the safety check when popping back stack - if the destination is not present in the back stack, stop popping until there is only one item in backstack(`navigateUp` would return false in this case) - this would prevent a dead loop in `while` 


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix an navigation bug

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
