### PR TITLE
[Identity] Add dependency injection

### DIFF
--- a/identity/api/identity.api
+++ b/identity/api/identity.api
@@ -200,6 +200,48 @@ public final class com/stripe/android/identity/databinding/LoadingButtonBinding 
 	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;)Lcom/stripe/android/identity/databinding/LoadingButtonBinding;
 }
 
+public final class com/stripe/android/identity/injection/DaggerIdentityVerificationSheetComponent : com/stripe/android/identity/injection/IdentityVerificationSheetComponent {
+	public static fun builder ()Lcom/stripe/android/identity/injection/IdentityVerificationSheetComponent$Builder;
+	public fun inject (Lcom/stripe/android/identity/viewmodel/IdentityViewModel$IdentityViewModelFactory;)V
+}
+
+public final class com/stripe/android/identity/injection/DaggerIdentityViewModelFactoryComponent : com/stripe/android/identity/injection/IdentityViewModelFactoryComponent {
+	public static fun builder ()Lcom/stripe/android/identity/injection/IdentityViewModelFactoryComponent$Builder;
+	public fun inject (Lcom/stripe/android/identity/viewmodel/IdentityViewModel$IdentityViewModelFactory;)V
+}
+
+public final class com/stripe/android/identity/injection/IdentityCommonModule_Companion_ProvideStripeNetworkClientFactory : dagger/internal/Factory {
+	public fun <init> ()V
+	public static fun create ()Lcom/stripe/android/identity/injection/IdentityCommonModule_Companion_ProvideStripeNetworkClientFactory;
+	public fun get ()Lcom/stripe/android/core/networking/StripeNetworkClient;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideStripeNetworkClient ()Lcom/stripe/android/core/networking/StripeNetworkClient;
+}
+
+public final class com/stripe/android/identity/navigation/IdentityFragmentFactory_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/identity/navigation/IdentityFragmentFactory_Factory;
+	public fun get ()Lcom/stripe/android/identity/navigation/IdentityFragmentFactory;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Lcom/stripe/android/camera/CameraPermissionEnsureable;Lcom/stripe/android/camera/AppSettingsOpenable;Lcom/stripe/android/identity/VerificationFlowFinishable;Lcom/stripe/android/identity/viewmodel/IdentityScanViewModel$IdentityScanViewModelFactory;Lcom/stripe/android/identity/viewmodel/IdentityUploadViewModel$FrontBackUploadViewModelFactory;Lcom/stripe/android/identity/viewmodel/ConsentFragmentViewModel$ConsentFragmentViewModelFactory;Lcom/stripe/android/identity/viewmodel/IdentityViewModel$IdentityViewModelFactory;)Lcom/stripe/android/identity/navigation/IdentityFragmentFactory;
+}
+
+public final class com/stripe/android/identity/networking/DefaultIDDetectorFetcher_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/identity/networking/DefaultIDDetectorFetcher_Factory;
+	public fun get ()Lcom/stripe/android/identity/networking/DefaultIDDetectorFetcher;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Lcom/stripe/android/identity/networking/IdentityRepository;Lcom/stripe/android/identity/utils/IdentityIO;)Lcom/stripe/android/identity/networking/DefaultIDDetectorFetcher;
+}
+
+public final class com/stripe/android/identity/networking/DefaultIdentityRepository_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/identity/networking/DefaultIdentityRepository_Factory;
+	public fun get ()Lcom/stripe/android/identity/networking/DefaultIdentityRepository;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Lcom/stripe/android/core/networking/StripeNetworkClient;Lcom/stripe/android/identity/utils/IdentityIO;)Lcom/stripe/android/identity/networking/DefaultIdentityRepository;
+}
+
 public final class com/stripe/android/identity/utils/ContentUriResult {
 	public fun <init> (Landroid/net/Uri;Ljava/lang/String;)V
 	public final fun component1 ()Landroid/net/Uri;
@@ -213,7 +255,51 @@ public final class com/stripe/android/identity/utils/ContentUriResult {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/stripe/android/identity/viewmodel/CameraErrorViewModel : androidx/lifecycle/ViewModel {
+public final class com/stripe/android/identity/utils/DefaultIdentityIO_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/identity/utils/DefaultIdentityIO_Factory;
+	public fun get ()Lcom/stripe/android/identity/utils/DefaultIdentityIO;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Landroid/content/Context;)Lcom/stripe/android/identity/utils/DefaultIdentityIO;
+}
+
+public final class com/stripe/android/identity/viewmodel/ConsentFragmentViewModel_ConsentFragmentViewModelFactory_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/identity/viewmodel/ConsentFragmentViewModel_ConsentFragmentViewModelFactory_Factory;
+	public fun get ()Lcom/stripe/android/identity/viewmodel/ConsentFragmentViewModel$ConsentFragmentViewModelFactory;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Lcom/stripe/android/identity/utils/IdentityIO;Lcom/stripe/android/identity/networking/IdentityRepository;)Lcom/stripe/android/identity/viewmodel/ConsentFragmentViewModel$ConsentFragmentViewModelFactory;
+}
+
+public final class com/stripe/android/identity/viewmodel/IdentityScanViewModel_IdentityScanViewModelFactory_Factory : dagger/internal/Factory {
 	public fun <init> ()V
+	public static fun create ()Lcom/stripe/android/identity/viewmodel/IdentityScanViewModel_IdentityScanViewModelFactory_Factory;
+	public fun get ()Lcom/stripe/android/identity/viewmodel/IdentityScanViewModel$IdentityScanViewModelFactory;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance ()Lcom/stripe/android/identity/viewmodel/IdentityScanViewModel$IdentityScanViewModelFactory;
+}
+
+public final class com/stripe/android/identity/viewmodel/IdentityUploadViewModel_FrontBackUploadViewModelFactory_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/identity/viewmodel/IdentityUploadViewModel_FrontBackUploadViewModelFactory_Factory;
+	public fun get ()Lcom/stripe/android/identity/viewmodel/IdentityUploadViewModel$FrontBackUploadViewModelFactory;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Lcom/stripe/android/identity/utils/IdentityIO;)Lcom/stripe/android/identity/viewmodel/IdentityUploadViewModel$FrontBackUploadViewModelFactory;
+}
+
+public final class com/stripe/android/identity/viewmodel/IdentityViewModel_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/identity/viewmodel/IdentityViewModel_Factory;
+	public fun get ()Lcom/stripe/android/identity/viewmodel/IdentityViewModel;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Lcom/stripe/android/identity/IdentityVerificationSheetContract$Args;Lcom/stripe/android/identity/networking/IdentityRepository;Lcom/stripe/android/identity/networking/IDDetectorFetcher;Lcom/stripe/android/identity/utils/IdentityIO;Lcom/stripe/android/identity/navigation/IdentityFragmentFactory;)Lcom/stripe/android/identity/viewmodel/IdentityViewModel;
+}
+
+public final class com/stripe/android/identity/viewmodel/IdentityViewModel_IdentityViewModelFactory_MembersInjector : dagger/MembersInjector {
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Ldagger/MembersInjector;
+	public fun injectMembers (Lcom/stripe/android/identity/viewmodel/IdentityViewModel$IdentityViewModelFactory;)V
+	public synthetic fun injectMembers (Ljava/lang/Object;)V
+	public static fun injectSubComponentBuilderProvider (Lcom/stripe/android/identity/viewmodel/IdentityViewModel$IdentityViewModelFactory;Ljavax/inject/Provider;)V
 }
 

--- a/identity/build.gradle
+++ b/identity/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'org.jetbrains.dokka'
     id 'org.jetbrains.kotlin.plugin.parcelize'
     id 'org.jetbrains.kotlin.plugin.serialization'
+    id 'kotlin-kapt'
 }
 
 assemble.dependsOn('lint')
@@ -48,6 +49,8 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"
     implementation "com.google.android.material:material:$materialVersion"
     implementation "androidx.constraintlayout:constraintlayout:$androidxConstraintlayoutVersion"
+    implementation "com.google.dagger:dagger:$daggerVersion"
+    kapt "com.google.dagger:dagger-compiler:$daggerVersion"
 
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"

--- a/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
@@ -17,7 +17,6 @@ import com.stripe.android.camera.CameraPermissionCheckingActivity
 import com.stripe.android.identity.IdentityVerificationSheet.VerificationFlowResult
 import com.stripe.android.identity.databinding.IdentityActivityBinding
 import com.stripe.android.identity.navigation.ErrorFragment
-import com.stripe.android.identity.navigation.IdentityFragmentFactory
 import com.stripe.android.identity.utils.navigateUpAndSetArgForUploadFragment
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 
@@ -26,17 +25,17 @@ import com.stripe.android.identity.viewmodel.IdentityViewModel
  */
 internal class IdentityActivity : CameraPermissionCheckingActivity(), VerificationFlowFinishable {
     @VisibleForTesting
-    internal var identityFragmentFactory = IdentityFragmentFactory(
-        this,
-        this,
-        this,
-        { starterArgs },
-        this
-    )
-
-    @VisibleForTesting
     internal lateinit var navController: NavController
 
+    @VisibleForTesting
+    internal var viewModelFactory: ViewModelProvider.Factory =
+        IdentityViewModel.IdentityViewModelFactory(
+            this,
+            { starterArgs },
+            this,
+            this,
+            this
+        )
     private val binding by lazy {
         IdentityActivityBinding.inflate(layoutInflater)
     }
@@ -45,10 +44,6 @@ internal class IdentityActivity : CameraPermissionCheckingActivity(), Verificati
         requireNotNull(IdentityVerificationSheetContract.Args.fromIntent(intent)) {
             EMPTY_ARG_ERROR
         }
-    }
-
-    private val viewModelFactory: ViewModelProvider.Factory by lazy {
-        identityFragmentFactory.identityViewModelFactory
     }
 
     private val identityViewModel: IdentityViewModel by viewModels { viewModelFactory }
@@ -63,7 +58,7 @@ internal class IdentityActivity : CameraPermissionCheckingActivity(), Verificati
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
-        supportFragmentManager.fragmentFactory = identityFragmentFactory
+        supportFragmentManager.fragmentFactory = identityViewModel.identityFragmentFactory
         setUpNavigationController()
         identityViewModel.retrieveAndBufferVerificationPage()
     }

--- a/identity/src/main/java/com/stripe/android/identity/IdentityVerificationSheetContract.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityVerificationSheetContract.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.core.os.bundleOf
+import com.stripe.android.core.injection.InjectorKey
 import kotlinx.parcelize.Parcelize
 
 internal class IdentityVerificationSheetContract :
@@ -15,7 +16,8 @@ internal class IdentityVerificationSheetContract :
     internal data class Args(
         val verificationSessionId: String,
         val ephemeralKeySecret: String,
-        val brandLogo: Uri
+        val brandLogo: Uri,
+        @InjectorKey val injectorKey: String
     ) : Parcelable {
         fun toBundle() = bundleOf(EXTRA_ARGS to this)
 

--- a/identity/src/main/java/com/stripe/android/identity/StripeIdentityVerificationSheet.kt
+++ b/identity/src/main/java/com/stripe/android/identity/StripeIdentityVerificationSheet.kt
@@ -1,27 +1,59 @@
 package com.stripe.android.identity
 
+import android.content.Context
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import androidx.fragment.app.Fragment
+import com.stripe.android.core.injection.Injectable
+import com.stripe.android.core.injection.Injector
+import com.stripe.android.core.injection.InjectorKey
+import com.stripe.android.core.injection.WeakMapInjectorRegistry
+import com.stripe.android.identity.injection.DaggerIdentityVerificationSheetComponent
+import com.stripe.android.identity.injection.IdentityVerificationSheetComponent
+import com.stripe.android.identity.viewmodel.IdentityViewModel
 
 internal class StripeIdentityVerificationSheet private constructor(
     activityResultCaller: ActivityResultCaller,
+    context: Context,
     private val configuration: IdentityVerificationSheet.Configuration,
     identityVerificationCallback: IdentityVerificationSheet.IdentityVerificationCallback
-) : IdentityVerificationSheet {
+) : IdentityVerificationSheet, Injector {
 
     constructor(
         from: ComponentActivity,
         configuration: IdentityVerificationSheet.Configuration,
         identityVerificationCallback: IdentityVerificationSheet.IdentityVerificationCallback
-    ) : this(from as ActivityResultCaller, configuration, identityVerificationCallback)
+    ) : this(
+        from as ActivityResultCaller,
+        from,
+        configuration,
+        identityVerificationCallback
+    )
 
     constructor(
         from: Fragment,
         configuration: IdentityVerificationSheet.Configuration,
         identityVerificationCallback: IdentityVerificationSheet.IdentityVerificationCallback
-    ) : this(from as ActivityResultCaller, configuration, identityVerificationCallback)
+    ) : this(
+        from as ActivityResultCaller,
+        from.requireContext(),
+        configuration,
+        identityVerificationCallback
+    )
+
+    @InjectorKey
+    private val injectorKey: String =
+        WeakMapInjectorRegistry.nextKey(requireNotNull(StripeIdentityVerificationSheet::class.simpleName))
+
+    init {
+        WeakMapInjectorRegistry.register(this, injectorKey)
+    }
+
+    private val identityVerificationSheetComponent: IdentityVerificationSheetComponent =
+        DaggerIdentityVerificationSheetComponent.builder()
+            .context(context)
+            .build()
 
     private val activityResultLauncher: ActivityResultLauncher<IdentityVerificationSheetContract.Args> =
         activityResultCaller.registerForActivityResult(
@@ -37,8 +69,20 @@ internal class StripeIdentityVerificationSheet private constructor(
             IdentityVerificationSheetContract.Args(
                 verificationSessionId,
                 ephemeralKeySecret,
-                configuration.brandLogo
+                configuration.brandLogo,
+                injectorKey
             )
         )
+    }
+
+    override fun inject(injectable: Injectable<*>) {
+        when (injectable) {
+            is IdentityViewModel.IdentityViewModelFactory -> {
+                identityVerificationSheetComponent.inject(injectable)
+            }
+            else -> {
+                throw IllegalArgumentException("invalid Injectable $injectable requested in $this")
+            }
+        }
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/injection/IdentityCommonModule.kt
+++ b/identity/src/main/java/com/stripe/android/identity/injection/IdentityCommonModule.kt
@@ -1,0 +1,37 @@
+package com.stripe.android.identity.injection
+
+import com.stripe.android.core.networking.DefaultStripeNetworkClient
+import com.stripe.android.core.networking.StripeNetworkClient
+import com.stripe.android.identity.networking.DefaultIDDetectorFetcher
+import com.stripe.android.identity.networking.DefaultIdentityRepository
+import com.stripe.android.identity.networking.IDDetectorFetcher
+import com.stripe.android.identity.networking.IdentityRepository
+import com.stripe.android.identity.utils.DefaultIdentityIO
+import com.stripe.android.identity.utils.IdentityIO
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import javax.inject.Singleton
+
+@Module(
+    subcomponents = [IdentityViewModelSubcomponent::class]
+)
+internal abstract class IdentityCommonModule {
+    @Binds
+    @Singleton
+    abstract fun bindIdentityIO(defaultIdentityIO: DefaultIdentityIO): IdentityIO
+
+    @Binds
+    @Singleton
+    abstract fun bindRepository(defaultIdentityRepository: DefaultIdentityRepository): IdentityRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindIDDetectorFetcher(defaultIDDetectorFetcher: DefaultIDDetectorFetcher): IDDetectorFetcher
+
+    companion object {
+        @Provides
+        @Singleton
+        fun provideStripeNetworkClient(): StripeNetworkClient = DefaultStripeNetworkClient()
+    }
+}

--- a/identity/src/main/java/com/stripe/android/identity/injection/IdentityVerificationSheetComponent.kt
+++ b/identity/src/main/java/com/stripe/android/identity/injection/IdentityVerificationSheetComponent.kt
@@ -1,0 +1,25 @@
+package com.stripe.android.identity.injection
+
+import android.content.Context
+import com.stripe.android.identity.viewmodel.IdentityViewModel
+import dagger.BindsInstance
+import dagger.Component
+import javax.inject.Singleton
+
+@Singleton
+@Component(
+    modules = [
+        IdentityCommonModule::class
+    ]
+)
+internal interface IdentityVerificationSheetComponent {
+    fun inject(identityViewModelFactory: IdentityViewModel.IdentityViewModelFactory)
+
+    @Component.Builder
+    interface Builder {
+        @BindsInstance
+        fun context(context: Context): Builder
+
+        fun build(): IdentityVerificationSheetComponent
+    }
+}

--- a/identity/src/main/java/com/stripe/android/identity/injection/IdentityViewModelFactoryComponent.kt
+++ b/identity/src/main/java/com/stripe/android/identity/injection/IdentityViewModelFactoryComponent.kt
@@ -1,0 +1,25 @@
+package com.stripe.android.identity.injection
+
+import android.content.Context
+import com.stripe.android.identity.viewmodel.IdentityViewModel
+import dagger.BindsInstance
+import dagger.Component
+import javax.inject.Singleton
+
+@Singleton
+@Component(
+    modules = [
+        IdentityCommonModule::class
+    ]
+)
+internal interface IdentityViewModelFactoryComponent {
+    fun inject(factory: IdentityViewModel.IdentityViewModelFactory)
+
+    @Component.Builder
+    interface Builder {
+        @BindsInstance
+        fun context(context: Context): Builder
+
+        fun build(): IdentityViewModelFactoryComponent
+    }
+}

--- a/identity/src/main/java/com/stripe/android/identity/injection/IdentityViewModelSubcomponent.kt
+++ b/identity/src/main/java/com/stripe/android/identity/injection/IdentityViewModelSubcomponent.kt
@@ -1,0 +1,35 @@
+package com.stripe.android.identity.injection
+
+import com.stripe.android.camera.AppSettingsOpenable
+import com.stripe.android.camera.CameraPermissionEnsureable
+import com.stripe.android.identity.IdentityVerificationSheetContract
+import com.stripe.android.identity.VerificationFlowFinishable
+import com.stripe.android.identity.viewmodel.IdentityViewModel
+import dagger.BindsInstance
+import dagger.Subcomponent
+
+@Subcomponent
+internal interface IdentityViewModelSubcomponent {
+    val viewModel: IdentityViewModel
+
+    @Subcomponent.Builder
+    interface Builder {
+
+        @BindsInstance
+        fun args(args: IdentityVerificationSheetContract.Args): Builder
+
+        @BindsInstance
+        fun cameraPermissionEnsureable(cameraPermissionEnsureable: CameraPermissionEnsureable): Builder
+
+        @BindsInstance
+        fun appSettingsOpenable(appSettingsOpenable: AppSettingsOpenable): Builder
+
+        @BindsInstance
+        fun verificationFlowFinishable(verificationFlowFinishable: VerificationFlowFinishable): Builder
+
+        @BindsInstance
+        fun identityViewModelFactory(identityViewModelFactory: IdentityViewModel.IdentityViewModelFactory): Builder
+
+        fun build(): IdentityViewModelSubcomponent
+    }
+}

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
@@ -1,64 +1,28 @@
 package com.stripe.android.identity.navigation
 
-import android.content.Context
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentFactory
-import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.camera.AppSettingsOpenable
 import com.stripe.android.camera.CameraPermissionEnsureable
-import com.stripe.android.identity.IdentityVerificationSheetContract
 import com.stripe.android.identity.VerificationFlowFinishable
-import com.stripe.android.identity.networking.DefaultIDDetectorFetcher
-import com.stripe.android.identity.networking.DefaultIdentityRepository
-import com.stripe.android.identity.networking.IdentityRepository
-import com.stripe.android.identity.utils.DefaultIdentityIO
-import com.stripe.android.identity.utils.IdentityIO
 import com.stripe.android.identity.viewmodel.ConsentFragmentViewModel
 import com.stripe.android.identity.viewmodel.IdentityScanViewModel
 import com.stripe.android.identity.viewmodel.IdentityUploadViewModel
 import com.stripe.android.identity.viewmodel.IdentityViewModel
+import javax.inject.Inject
 
 /**
  * Factory for creating Identity fragments.
- *
- * TODO(ccen) Daggerize the dependencies
  */
-internal class IdentityFragmentFactory(
-    context: Context,
+internal class IdentityFragmentFactory @Inject constructor(
     private val cameraPermissionEnsureable: CameraPermissionEnsureable,
     private val appSettingsOpenable: AppSettingsOpenable,
-    verificationArgsSupplier: () -> IdentityVerificationSheetContract.Args,
     private val verificationFlowFinishable: VerificationFlowFinishable,
-    private val identityIO: IdentityIO = DefaultIdentityIO(context),
-    private val identityRepository: IdentityRepository =
-        DefaultIdentityRepository(identityIO = identityIO),
-    private val identityScanViewModelFactory: ViewModelProvider.Factory =
-        IdentityScanViewModel.IdentityScanViewModelFactory(),
-    private val identityUploadViewModelFactory: ViewModelProvider.Factory =
-        IdentityUploadViewModel.FrontBackUploadViewModelFactory(identityIO),
-    private val consentFragmentViewModelFactory: ViewModelProvider.Factory =
-        ConsentFragmentViewModel.ConsentFragmentViewModelFactory(
-            identityIO,
-            identityRepository
-        ),
-    internal val identityViewModelFactory: ViewModelProvider.Factory =
-        IdentityViewModel.IdentityViewModelFactory(
-            identityRepository,
-            DefaultIDDetectorFetcher(identityRepository, identityIO),
-            verificationArgsSupplier,
-            identityIO
-        )
+    private val identityScanViewModelFactory: IdentityScanViewModel.IdentityScanViewModelFactory,
+    private val identityUploadViewModelFactory: IdentityUploadViewModel.FrontBackUploadViewModelFactory,
+    private val consentFragmentViewModelFactory: ConsentFragmentViewModel.ConsentFragmentViewModelFactory,
+    internal val identityViewModelFactory: IdentityViewModel.IdentityViewModelFactory
 ) : FragmentFactory() {
-
-//    internal val identityViewModelFactory by lazy {
-//        IdentityViewModel.IdentityViewModelFactory(
-//            verificationArgsSupplier(),
-//            identityRepository,
-//            DefaultIDDetectorFetcher(identityRepository, identityIO),
-//            verificationArgsSupplier(),
-//            identityIO
-//        )
-//    }
 
     override fun instantiate(classLoader: ClassLoader, className: String): Fragment {
         return when (className) {

--- a/identity/src/main/java/com/stripe/android/identity/networking/DefaultIDDetectorFetcher.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/DefaultIDDetectorFetcher.kt
@@ -2,8 +2,9 @@ package com.stripe.android.identity.networking
 
 import com.stripe.android.identity.utils.IdentityIO
 import java.io.File
+import javax.inject.Inject
 
-internal class DefaultIDDetectorFetcher(
+internal class DefaultIDDetectorFetcher @Inject constructor(
     private val identityRepository: IdentityRepository,
     private val identityIO: IdentityIO
 ) :

--- a/identity/src/main/java/com/stripe/android/identity/networking/DefaultIdentityRepository.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/DefaultIdentityRepository.kt
@@ -11,7 +11,6 @@ import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.core.model.parsers.StripeErrorJsonParser
 import com.stripe.android.core.model.parsers.StripeFileJsonParser
 import com.stripe.android.core.networking.ApiRequest
-import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.core.networking.StripeNetworkClient
 import com.stripe.android.core.networking.StripeRequest
 import com.stripe.android.core.networking.responseJson
@@ -25,9 +24,10 @@ import com.stripe.android.identity.utils.IdentityIO
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 import java.io.File
+import javax.inject.Inject
 
-internal class DefaultIdentityRepository(
-    private val stripeNetworkClient: StripeNetworkClient = DefaultStripeNetworkClient(),
+internal class DefaultIdentityRepository @Inject constructor(
+    private val stripeNetworkClient: StripeNetworkClient,
     private val identityIO: IdentityIO
 ) : IdentityRepository {
 

--- a/identity/src/main/java/com/stripe/android/identity/utils/DefaultIdentityIO.kt
+++ b/identity/src/main/java/com/stripe/android/identity/utils/DefaultIdentityIO.kt
@@ -22,11 +22,12 @@ import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import javax.inject.Inject
 
 /**
  * Default implementation of [IdentityIO].
  */
-internal class DefaultIdentityIO(private val context: Context) : IdentityIO {
+internal class DefaultIdentityIO @Inject constructor(private val context: Context) : IdentityIO {
     override fun createInternalFileUri(): ContentUriResult {
         createImageFile().also { file ->
             return ContentUriResult(

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/CameraErrorViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/CameraErrorViewModel.kt
@@ -1,7 +1,0 @@
-package com.stripe.android.identity.viewmodel
-
-import androidx.lifecycle.ViewModel
-
-class CameraErrorViewModel : ViewModel() {
-    // TODO: Implement the ViewModel
-}

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/ConsentFragmentViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/ConsentFragmentViewModel.kt
@@ -10,6 +10,7 @@ import com.stripe.android.identity.networking.IdentityRepository
 import com.stripe.android.identity.utils.IdentityIO
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 internal class ConsentFragmentViewModel(
     private val identityIO: IdentityIO,
@@ -39,7 +40,7 @@ internal class ConsentFragmentViewModel(
         }
     }
 
-    internal class ConsentFragmentViewModelFactory(
+    internal class ConsentFragmentViewModelFactory @Inject constructor(
         private val identityIO: IdentityIO,
         private val identityRepository: IdentityRepository
     ) : ViewModelProvider.Factory {

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityScanViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityScanViewModel.kt
@@ -3,6 +3,7 @@ package com.stripe.android.identity.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.identity.states.IdentityScanState
+import javax.inject.Inject
 
 internal class IdentityScanViewModel : CameraViewModel() {
 
@@ -11,7 +12,7 @@ internal class IdentityScanViewModel : CameraViewModel() {
      */
     internal var targetScanType: IdentityScanState.ScanType? = null
 
-    internal class IdentityScanViewModelFactory : ViewModelProvider.Factory {
+    internal class IdentityScanViewModelFactory @Inject constructor() : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             return IdentityScanViewModel() as T

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityUploadViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityUploadViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.identity.utils.IdentityIO
 import com.stripe.android.identity.utils.ImageChooser
 import com.stripe.android.identity.utils.PhotoTaker
+import javax.inject.Inject
 
 /**
  * ViewModel to upload front and back image of a document either through camera or from local
@@ -72,7 +73,7 @@ internal class IdentityUploadViewModel(
         backImageChooser.chooseImage(onImageChosen)
     }
 
-    internal class FrontBackUploadViewModelFactory(
+    internal class FrontBackUploadViewModelFactory @Inject constructor(
         private val identityIO: IdentityIO
     ) :
         ViewModelProvider.Factory {

--- a/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
@@ -11,6 +11,7 @@ import com.google.android.material.button.MaterialButton
 import com.google.android.material.progressindicator.CircularProgressIndicator
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.exception.APIException
+import com.stripe.android.core.injection.DUMMY_INJECTOR_KEY
 import com.stripe.android.identity.IdentityVerificationSheetContract
 import com.stripe.android.identity.R
 import com.stripe.android.identity.databinding.ConsentFragmentBinding
@@ -111,7 +112,8 @@ internal class ConsentFragmentTest {
             IdentityVerificationSheetContract.Args(
                 verificationSessionId = VERIFICATION_SESSION_ID,
                 ephemeralKeySecret = EPHEMERAL_KEY,
-                brandLogo = BRAND_LOGO
+                brandLogo = BRAND_LOGO,
+                injectorKey = DUMMY_INJECTOR_KEY
             )
         )
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
## Add dependency injection to Identity SDK, similar to payment injections, the following components are created:
	
1. The parent dagger `IdentityVerificationSheetComponent` is created and stored in `StripeIdentityVerificationSheet` when the API object is created, sharable across mutiple `IdentityVerificationSheet#present` calls
2. A subcomponent `IdentityViewModelSubcomponent` will be created with arguments passed from `IdentityVerificationSheet#present`, created with the component above
3. When `IdentityVerificationSheetComponent` is not available due to "don't keep activity" or hosting app process kill, `IdentityViewModelFactoryComponent` will be used as fallback. It access `IdentityViewModelSubcomponent` through `WeakMapInjectorRegistry`


## Also Investigated [the approach](https://pedrookawa.medium.com/content-providers-dependency-injection-dagger-2-4ee3e49777b) to use a `ContentProvider` to initialize, with the following changes

1. Create a generic `IdentityComponent` that doesn't initialize any dependency, it gets created and saved in a static instance through `ContentProvider`
2. Make `IdentityVerificationSheetComponent` a subcomponent, it's created when an `StripeIdentityVerificationSheet` is created. It needs to be saved as a static instance and be accessible in step `3`
3. `IdentityViewModelSubcomponent` is created similarly with the previous approach

The problem of this apporach is that in the case when activity is killed, we can only guarantee `IdentityComponent` is recreated, there is no guarantee `IdentityVerificationSheetComponent` as it's dictated by the host app. Therefore we will still need to implement the fallback injection. Also in step 2, `IdentityVerificationSheetComponent` needs somehow accessible from `IdentityViewModelFactory`, we still need a key-map mechanism to make it available there. (can't use a single static holder as the user might create multiple `StripeIdentityVerificationSheet`, in which case each one needs to have a standalone `IdentityVerificationSheetComponent`)


Given the `ContentProvider` approach would still require us to register the component instance and provide fallback mechanism, will stick with the exsiting apporach for payments for now.


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
DI

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
