### PR TITLE
Fix playground tests on emulators

### DIFF
--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/PaymentSelection.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/PaymentSelection.kt
@@ -20,7 +20,7 @@ class PaymentSelection(val composeTestRule: ComposeTestRule, @StringRes val labe
             .performScrollToNode(hasText(resource.getString(label)))
         composeTestRule.waitForIdle()
         composeTestRule
-            .onNodeWithText(resource.getString(label))
+            .onNodeWithTag(TEST_TAG_LIST + resource.getString(label))
             .assertIsDisplayed()
             .assertIsEnabled()
             .performClick()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Fixes payment selection crashing because there are two tags that match
```
java.lang.AssertionError: Failed to perform isDisplayed check.
Reason: Expected exactly '1' node but found '2' nodes that satisfy: (Text + EditableText contains 'Card' (ignoreCase: false))
Nodes found:
1) Node #10 at (l=64.0, t=874.0, r=359.0, b=1039.0)px, Tag: 'PaymentMethodsUITestTagCard'
Focused = 'false'
Selected = 'true'
Text = '[Card]'
Actions = [OnClick, GetTextLayoutResult]
MergeDescendants = 'true'
Has 7 siblings
2) Node #9 at (l=47.0, t=874.0, r=118.0, b=918.0)px
Text = '[Card]'
Actions = [GetTextLayoutResult]
Has 7 siblings
```
* fixes google pay divider having its content set when not visible (this causes tests to hang on emulators)
```
Caused by: androidx.test.espresso.IdlingResourceTimeoutException: Wait for [Compose-Espresso link] to become idle timed out
at androidx.test.espresso.IdlingPolicy.handleTimeout(IdlingPolicy.java:4)
```

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
* Hopefully less flakiness across devices. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

`./gradlew connectedAndroidTest` on my emulator and my actual device.

# Screenshots
| Before  | After |
| ------------- | ------------- |
|![testsMaster](https://user-images.githubusercontent.com/89166418/165859253-09fe3fc4-1a19-4106-9164-a2a56dd6df60.png)| ![testsBranch](https://user-images.githubusercontent.com/89166418/165859248-739482ae-feb7-4762-882e-11c0921b83de.png)|
|![testsMasterNoGooglePay](https://user-images.githubusercontent.com/89166418/165859254-218dc5dc-439f-4a1c-8c6f-b3c4fc63295c.png)|![testsBranchNoGooglePay](https://user-images.githubusercontent.com/89166418/165859251-8f8acc90-f3df-4acd-9016-7b5b6083dfca.png)|





