### PR TITLE
[camera-core] Add the ability to start camera from back

### DIFF
--- a/camera-core/src/main/java/com/stripe/android/camera/Camera1Adapter.kt
+++ b/camera-core/src/main/java/com/stripe/android/camera/Camera1Adapter.kt
@@ -88,7 +88,8 @@ class Camera1Adapter(
     private var cameraPreview: CameraPreview? = null
     private var mRotation = 0
     private var onCameraAvailableListener: WeakReference<((Camera) -> Unit)?> = WeakReference(null)
-    private var currentCameraId = if (startWithBackCamera) 0 else 1
+    private var currentCameraId =
+        if (startWithBackCamera) Camera.CameraInfo.CAMERA_FACING_BACK else Camera.CameraInfo.CAMERA_FACING_FRONT
 
     private val mainThreadHandler = Handler(activity.mainLooper)
     private var cameraThread: HandlerThread? = null
@@ -149,9 +150,17 @@ class Camera1Adapter(
         // exception was due to the camera already having been closed or from an error with camera
         // hardware.
         val imageWidth =
-            try { camera.parameters.previewSize.width } catch (t: Throwable) { return }
+            try {
+                camera.parameters.previewSize.width
+            } catch (t: Throwable) {
+                return
+            }
         val imageHeight =
-            try { camera.parameters.previewSize.height } catch (t: Throwable) { return }
+            try {
+                camera.parameters.previewSize.height
+            } catch (t: Throwable) {
+                return
+            }
 
         if (bytes != null) {
             try {

--- a/camera-core/src/main/java/com/stripe/android/camera/Camera1Adapter.kt
+++ b/camera-core/src/main/java/com/stripe/android/camera/Camera1Adapter.kt
@@ -150,17 +150,9 @@ class Camera1Adapter(
         // exception was due to the camera already having been closed or from an error with camera
         // hardware.
         val imageWidth =
-            try {
-                camera.parameters.previewSize.width
-            } catch (t: Throwable) {
-                return
-            }
+            try { camera.parameters.previewSize.width } catch (t: Throwable) { return }
         val imageHeight =
-            try {
-                camera.parameters.previewSize.height
-            } catch (t: Throwable) {
-                return
-            }
+            try { camera.parameters.previewSize.height } catch (t: Throwable) { return }
 
         if (bytes != null) {
             try {

--- a/camera-core/src/main/java/com/stripe/android/camera/Camera1Adapter.kt
+++ b/camera-core/src/main/java/com/stripe/android/camera/Camera1Adapter.kt
@@ -44,7 +44,6 @@ import com.stripe.android.camera.framework.image.NV21Image
 import com.stripe.android.camera.framework.image.getRenderScript
 import com.stripe.android.camera.framework.util.retrySync
 import java.lang.ref.WeakReference
-import java.util.ArrayList
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
@@ -81,6 +80,7 @@ class Camera1Adapter(
     private val previewView: ViewGroup,
     private val minimumResolution: Size,
     private val cameraErrorListener: CameraErrorListener,
+    startWithBackCamera: Boolean = true
 ) : CameraAdapter<CameraPreviewImage<Bitmap>>(), PreviewCallback {
     override val implementationName: String = "Camera1"
 
@@ -88,7 +88,7 @@ class Camera1Adapter(
     private var cameraPreview: CameraPreview? = null
     private var mRotation = 0
     private var onCameraAvailableListener: WeakReference<((Camera) -> Unit)?> = WeakReference(null)
-    private var currentCameraId = 0
+    private var currentCameraId = if (startWithBackCamera) 0 else 1
 
     private val mainThreadHandler = Handler(activity.mainLooper)
     private var cameraThread: HandlerThread? = null


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Note: This will make Camera1Adapter's constructor not matching the ones used through reflection in [CameraSelector](https://github.com/stripe/stripe-android/blob/6f7d837d4f5128578b6bb0ef39be3acec1ba3047/stripecardscan/src/main/java/com/stripe/android/stripecardscan/camera/CameraSelector.kt#L35), atm it's only used by Identity's selfie feature.
Will do some refactor once we have other `CameraAdaptor` implementations pulled into the codebase.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
