### PR TITLE
[Identity] Initial selfie's UI

### DIFF
--- a/identity/api/identity.api
+++ b/identity/api/identity.api
@@ -200,6 +200,32 @@ public final class com/stripe/android/identity/databinding/LoadingButtonBinding 
 	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;)Lcom/stripe/android/identity/databinding/LoadingButtonBinding;
 }
 
+public final class com/stripe/android/identity/databinding/SelfieItemBinding : androidx/viewbinding/ViewBinding {
+	public final field scanningView Lcom/google/android/material/card/MaterialCardView;
+	public final field selfieItem Landroid/widget/ImageView;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/identity/databinding/SelfieItemBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroid/widget/FrameLayout;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/identity/databinding/SelfieItemBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/identity/databinding/SelfieItemBinding;
+}
+
+public final class com/stripe/android/identity/databinding/SelfieScanFragmentBinding : androidx/viewbinding/ViewBinding {
+	public final field cameraView Lcom/stripe/android/camera/scanui/CameraView;
+	public final field capturedImages Landroidx/recyclerview/widget/RecyclerView;
+	public final field flashMask Landroid/view/View;
+	public final field headerTitle Landroid/widget/TextView;
+	public final field kontinue Lcom/stripe/android/identity/ui/LoadingButton;
+	public final field message Landroid/widget/TextView;
+	public final field resultView Landroid/widget/LinearLayout;
+	public final field scanningView Lcom/google/android/material/card/MaterialCardView;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/identity/databinding/SelfieScanFragmentBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroid/widget/LinearLayout;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/identity/databinding/SelfieScanFragmentBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/identity/databinding/SelfieScanFragmentBinding;
+}
+
 public final class com/stripe/android/identity/injection/DaggerIdentityVerificationSheetComponent : com/stripe/android/identity/injection/IdentityVerificationSheetComponent {
 	public static fun builder ()Lcom/stripe/android/identity/injection/IdentityVerificationSheetComponent$Builder;
 	public fun inject (Lcom/stripe/android/identity/viewmodel/IdentityViewModel$IdentityViewModelFactory;)V

--- a/identity/res/layout/selfie_item.xml
+++ b/identity/res/layout/selfie_item.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_height="wrap_content"
+    android:layout_width="wrap_content"
+    android:padding="5dp">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/scanning_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:cardCornerRadius="@dimen/view_finder_corner_radius">
+
+        <ImageView
+            android:id="@+id/selfie_item"
+            android:layout_width="200dp"
+            android:layout_height="200dp"
+            android:scaleType="centerCrop"
+            android:contentDescription="@string/selfie_item_description" />
+    </com.google.android.material.card.MaterialCardView>
+</FrameLayout>

--- a/identity/res/layout/selfie_scan_fragment.xml
+++ b/identity/res/layout/selfie_scan_fragment.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_marginTop="@dimen/page_vertical_margin"
+    android:layout_marginBottom="@dimen/page_vertical_margin"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_marginStart="@dimen/page_horizontal_margin"
+        android:layout_marginEnd="@dimen/page_horizontal_margin"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/header_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:textStyle="bold"
+            android:textSize="@dimen/scan_title_text_size"
+            android:text="@string/selfie_captures"
+            android:layout_marginBottom="20dp"
+            app:layout_constraintBottom_toTopOf="@id/message"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Front of driver's license" />
+
+        <TextView
+            android:id="@+id/message"
+            android:layout_width="0dp"
+            android:lines="3"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/page_vertical_margin"
+            app:layout_constraintBottom_toTopOf="@id/scanning_view"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/header_title"
+            tools:text="Position your driver's license in the center of the frame" />
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/scanning_view"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:visibility="visible"
+            app:cardCornerRadius="@dimen/view_finder_corner_radius"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/message">
+
+            <com.stripe.android.camera.scanui.CameraView
+                android:id="@+id/camera_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:viewFinderType="fill" />
+
+            <View
+                android:id="@+id/flash_mask"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:alpha="0"
+                android:background="@color/flash_mask_color"
+                android:contentDescription="@string/flash_mask" />
+
+        </com.google.android.material.card.MaterialCardView>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+    <LinearLayout
+        android:id="@+id/result_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        android:orientation="vertical">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/captured_images"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+
+        <CheckBox
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginStart="@dimen/page_horizontal_margin"
+            android:layout_marginEnd="@dimen/page_horizontal_margin"
+            android:layout_marginTop="20dp"
+            android:text="@string/allow_image_collection" />
+    </LinearLayout>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+    <com.stripe.android.identity.ui.LoadingButton
+        android:id="@+id/kontinue"
+        android:layout_marginStart="@dimen/page_horizontal_margin"
+        android:layout_marginEnd="@dimen/page_horizontal_margin"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom" />
+
+</LinearLayout>

--- a/identity/res/navigation/identity_nav_graph.xml
+++ b/identity/res/navigation/identity_nav_graph.xml
@@ -152,5 +152,12 @@
         <action
             android:id="@+id/action_couldNotCaptureFragment_to_driverLicenseScanFragment"
             app:destination="@id/driverLicenseScanFragment" />
+        <action
+            android:id="@+id/action_couldNotCaptureFragment_to_selfieFragment"
+            app:destination="@id/selfieFragment" />
     </fragment>
+    <fragment
+        android:id="@+id/selfieFragment"
+        android:name="com.stripe.android.identity.navigation.SelfieFragment"
+        android:label="SelfieFragment" /><action android:id="@+id/action_global_selfieFragment" app:destination="@id/selfieFragment"/>
 </navigation>

--- a/identity/res/values/colors.xml
+++ b/identity/res/values/colors.xml
@@ -8,4 +8,7 @@
     <color name="plus_icon_tint">#1C1C1E</color>
     <color name="privacy_policy_icon_tint">#1C1C1E</color>
     <color name="time_estimate_icon_tint">#1C1C1E</color>
+
+    <color name="flash_mask_color">#FFFFFF</color>
+
 </resources>

--- a/identity/res/values/strings.xml
+++ b/identity/res/values/strings.xml
@@ -95,4 +95,18 @@
   <string name="upload_dialog_title_passport">Upload passport</string>
   <!-- Message for alternative options when uploading a document -->
   <string name="upload_file_text">Alternatively, you may manually upload a photo of your %1$s</string>
+  <!-- Instructional text for capturing selfie -->
+  <string name="position_selfie">Position your face in the center of the frame</string>
+  <!-- Instructional text during selfie is being captured -->
+  <string name="capturing">Capturing…</string>
+  <!-- Instructional text when selfie is captured -->
+  <string name="selfie_capture_complete">Selfie captures are complete</string>
+  <!-- Title of selfie capture -->
+  <string name="selfie_captures">Selfie captures</string>
+  <!-- Content description of selfie flash animation mask -->
+  <string name="flash_mask">Mask color to flash selfie</string>
+  <!-- Consent message to allow stripe uses the image to improve biometric verification technology -->
+  <string name="allow_image_collection">Allow Stripe to use your image to improve our biometric verification technology. You can remove Stripe\'s permissions at any time by contacting Stripe. Learn how Stripe uses data</string>
+  <!-- Content description of a captured selfie -->
+  <string name="selfie_item_description">one selfie captured</string>
 </resources>

--- a/identity/res/values/strings.xml
+++ b/identity/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
   <!-- Opens the app's settings in the Settings app -->
   <string name="app_settings">App Settings</string>
   <!-- Description of back of driver's license image -->

--- a/identity/res/values/strings.xml
+++ b/identity/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
+<resources>
   <!-- Opens the app's settings in the Settings app -->
   <string name="app_settings">App Settings</string>
   <!-- Description of back of driver's license image -->
@@ -95,18 +95,4 @@
   <string name="upload_dialog_title_passport">Upload passport</string>
   <!-- Message for alternative options when uploading a document -->
   <string name="upload_file_text">Alternatively, you may manually upload a photo of your %1$s</string>
-  <!-- Instructional text for capturing selfie -->
-  <string name="position_selfie">Position your face in the center of the frame</string>
-  <!-- Instructional text during selfie is being captured -->
-  <string name="capturing">Capturing…</string>
-  <!-- Instructional text when selfie is captured -->
-  <string name="selfie_capture_complete">Selfie captures are complete</string>
-  <!-- Title of selfie capture -->
-  <string name="selfie_captures">Selfie captures</string>
-  <!-- Content description of selfie flash animation mask -->
-  <string name="flash_mask">Mask color to flash selfie</string>
-  <!-- Consent message to allow stripe uses the image to improve biometric verification technology -->
-  <string name="allow_image_collection">Allow Stripe to use your image to improve our biometric verification technology. You can remove Stripe\'s permissions at any time by contacting Stripe. Learn how Stripe uses data</string>
-  <!-- Content description of a captured selfie -->
-  <string name="selfie_item_description">one selfie captured</string>
 </resources>

--- a/identity/res/values/totranslate.xml
+++ b/identity/res/values/totranslate.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
+    <!-- Instructional text for capturing selfie -->
+    <string name="position_selfie">Position your face in the center of the frame</string>
+    <!-- Instructional text during selfie is being captured -->
+    <string name="capturing">Capturing…</string>
+    <!-- Instructional text when selfie is captured -->
+    <string name="selfie_capture_complete">Selfie captures are complete</string>
+    <!-- Title of selfie capture -->
+    <string name="selfie_captures">Selfie captures</string>
+    <!-- Content description of selfie flash animation mask -->
+    <string name="flash_mask">Mask color to flash selfie</string>
+    <!-- Consent message to allow stripe uses the image to improve biometric verification technology -->
+    <string name="allow_image_collection">Allow Stripe to use your image to improve our biometric verification technology. You can remove Stripe\'s permissions at any time by contacting Stripe. Learn how Stripe uses data</string>
+    <!-- Content description of a captured selfie -->
+    <string name="selfie_item_description">one selfie captured</string>
+</resources>

--- a/identity/src/main/java/com/stripe/android/identity/navigation/CouldNotCaptureFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/CouldNotCaptureFragment.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.identity.navigation
 
+import android.view.View
 import androidx.annotation.IdRes
 import androidx.core.os.bundleOf
 import androidx.navigation.fragment.findNavController
@@ -22,15 +23,20 @@ internal class CouldNotCaptureFragment : BaseErrorFragment() {
 
         title.text = getString(R.string.could_not_capture_title)
         message1.text = getString(R.string.could_not_capture_body1)
-        message2.text = getString(R.string.could_not_capture_body2)
 
-        topButton.text = getString(R.string.file_upload)
-        topButton.setOnClickListener {
-            navigateToUploadFragment(
-                scanType.toUploadDestinationId(),
-                shouldShowTakePhoto = true,
-                shouldShowChoosePhoto = !requireLiveCapture
-            )
+        if (scanType == IdentityScanState.ScanType.SELFIE) {
+            topButton.visibility = View.GONE
+            message2.visibility = View.GONE
+        } else {
+            message2.text = getString(R.string.could_not_capture_body2)
+            topButton.text = getString(R.string.file_upload)
+            topButton.setOnClickListener {
+                navigateToUploadFragment(
+                    scanType.toUploadDestinationId(),
+                    shouldShowTakePhoto = true,
+                    shouldShowChoosePhoto = !requireLiveCapture
+                )
+            }
         }
 
         bottomButton.text = getString(R.string.try_again)
@@ -56,8 +62,8 @@ internal class CouldNotCaptureFragment : BaseErrorFragment() {
                 IdentityScanState.ScanType.DL_FRONT -> R.id.action_couldNotCaptureFragment_to_driverLicenseUploadFragment
                 IdentityScanState.ScanType.DL_BACK -> R.id.action_couldNotCaptureFragment_to_driverLicenseUploadFragment
                 IdentityScanState.ScanType.PASSPORT -> R.id.action_couldNotCaptureFragment_to_passportUploadFragment
-                else -> {
-                    throw IllegalArgumentException("Unknown scan type: $this")
+                IdentityScanState.ScanType.SELFIE -> {
+                    throw IllegalArgumentException("SELFIE doesn't support upload")
                 }
             }
 
@@ -69,9 +75,7 @@ internal class CouldNotCaptureFragment : BaseErrorFragment() {
                 IdentityScanState.ScanType.DL_FRONT -> R.id.action_couldNotCaptureFragment_to_driverLicenseScanFragment
                 IdentityScanState.ScanType.DL_BACK -> R.id.action_couldNotCaptureFragment_to_driverLicenseScanFragment
                 IdentityScanState.ScanType.PASSPORT -> R.id.action_couldNotCaptureFragment_to_passportScanFragment
-                else -> {
-                    throw IllegalArgumentException("Unknown scan type: $this")
-                }
+                IdentityScanState.ScanType.SELFIE -> R.id.action_couldNotCaptureFragment_to_selfieFragment
             }
 
         private fun IdentityScanState.ScanType.toShouldStartFromBack() =
@@ -81,9 +85,7 @@ internal class CouldNotCaptureFragment : BaseErrorFragment() {
                 IdentityScanState.ScanType.DL_FRONT -> false
                 IdentityScanState.ScanType.DL_BACK -> true
                 IdentityScanState.ScanType.PASSPORT -> false
-                else -> {
-                    throw IllegalArgumentException("Unknown scan type: $this")
-                }
+                IdentityScanState.ScanType.SELFIE -> false
             }
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
@@ -91,14 +91,7 @@ internal abstract class IdentityCameraScanFragment(
             )
             stopScanning()
         }
-        cameraAdapter = Camera1Adapter(
-            requireNotNull(activity),
-            cameraView.previewFrame,
-            MINIMUM_RESOLUTION,
-            DefaultCameraErrorListener(requireNotNull(activity)) { cause ->
-                Log.e(TAG, "scan fails with exception: $cause")
-            }
-        )
+        cameraAdapter = createCameraAdapter()
 
         identityViewModel.pageAndModel.observe(viewLifecycleOwner) {
             when (it.status) {
@@ -123,6 +116,16 @@ internal abstract class IdentityCameraScanFragment(
             }
         }
     }
+
+    protected open fun createCameraAdapter() =
+        Camera1Adapter(
+            requireNotNull(activity),
+            cameraView.previewFrame,
+            MINIMUM_RESOLUTION,
+            DefaultCameraErrorListener(requireNotNull(activity)) { cause ->
+                Log.e(TAG, "scan fails with exception: $cause")
+            }
+        )
 
     /**
      * Called back each time when [CameraViewModel.displayStateChanged] is changed.
@@ -153,7 +156,7 @@ internal abstract class IdentityCameraScanFragment(
     /**
      * Stop scanning, may start again later.
      */
-    private fun stopScanning() {
+    protected fun stopScanning() {
         identityScanViewModel.identityScanFlow.resetFlow()
         cameraAdapter.unbindFromLifecycle(this)
     }
@@ -166,6 +169,6 @@ internal abstract class IdentityCameraScanFragment(
 
     internal companion object {
         private val TAG: String = IdentityCameraScanFragment::class.java.simpleName
-        private val MINIMUM_RESOLUTION = Size(1067, 600) // TODO: decide what to use
+        val MINIMUM_RESOLUTION = Size(1067, 600)
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
@@ -38,6 +38,10 @@ internal class IdentityFragmentFactory @Inject constructor(
                 identityScanViewModelFactory,
                 identityViewModelFactory
             )
+            SelfieFragment::class.java.name -> SelfieFragment(
+                identityScanViewModelFactory,
+                identityViewModelFactory
+            )
             CameraPermissionDeniedFragment::class.java.name -> CameraPermissionDeniedFragment(
                 appSettingsOpenable
             )

--- a/identity/src/main/java/com/stripe/android/identity/navigation/SelfieFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/SelfieFragment.kt
@@ -1,0 +1,159 @@
+package com.stripe.android.identity.navigation
+
+import android.animation.AnimatorSet
+import android.animation.ObjectAnimator
+import android.graphics.Bitmap
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.cardview.widget.CardView
+import androidx.lifecycle.ViewModelProvider
+import androidx.recyclerview.widget.RecyclerView
+import com.stripe.android.camera.Camera1Adapter
+import com.stripe.android.camera.DefaultCameraErrorListener
+import com.stripe.android.identity.R
+import com.stripe.android.identity.databinding.SelfieScanFragmentBinding
+import com.stripe.android.identity.states.IdentityScanState
+import com.stripe.android.identity.ui.LoadingButton
+import com.stripe.android.identity.ui.SelfieResultAdapter
+
+/**
+ * Fragment to capture selfie.
+ */
+internal class SelfieFragment(
+    identityCameraScanViewModelFactory: ViewModelProvider.Factory,
+    identityViewModelFactory: ViewModelProvider.Factory
+) : IdentityCameraScanFragment(identityCameraScanViewModelFactory, identityViewModelFactory) {
+    override val fragmentId = R.id.selfieFragment
+
+    private lateinit var flashAnimatorSet: AnimatorSet
+    private lateinit var binding: SelfieScanFragmentBinding
+    private lateinit var continueButton: LoadingButton
+    private lateinit var messageView: TextView
+    private lateinit var flashMask: View
+    private lateinit var scanningView: CardView
+    private lateinit var resultView: LinearLayout
+    private lateinit var capturedImages: RecyclerView
+
+    private val selfieResultAdapter = SelfieResultAdapter()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = SelfieScanFragmentBinding.inflate(inflater, container, false)
+        cameraView = binding.cameraView
+        continueButton = binding.kontinue
+        messageView = binding.message
+        flashMask = binding.flashMask
+        scanningView = binding.scanningView
+        resultView = binding.resultView
+        capturedImages = binding.capturedImages
+        capturedImages.adapter = selfieResultAdapter
+
+        flashAnimatorSet = AnimatorSet().apply {
+            playSequentially(
+                ObjectAnimator.ofFloat(flashMask, "alpha", FLASH_MAX_ALPHA).setDuration(
+                    FLASH_ANIMATION_TIME
+                ),
+                ObjectAnimator.ofFloat(flashMask, "alpha", 0f).setDuration(
+                    FLASH_ANIMATION_TIME
+                )
+            )
+        }
+
+        messageView.setText(R.string.position_selfie)
+        continueButton.setText(getString(R.string.kontinue))
+        continueButton.isEnabled = false
+
+        continueButton.setOnClickListener {
+            // TODO(ccen) collect 3 images from ML pipe line and upload them
+        }
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        // TODO(ccen) track identityScanViewModel.finalResult and upload processed images
+    }
+
+    /**
+     * Collect the 3 results from ML pipe line.
+     *
+     * TODO(ccen): replace the place holder with bitmap from ML pipe line.
+     */
+    private fun getResults(): List<Bitmap> {
+        return listOf()
+    }
+
+    override fun createCameraAdapter(): Camera1Adapter {
+        return Camera1Adapter(
+            requireNotNull(activity),
+            cameraView.previewFrame,
+            MINIMUM_RESOLUTION,
+            DefaultCameraErrorListener(requireNotNull(activity)) { cause ->
+                Log.e(TAG, "scan fails with exception: $cause")
+            },
+            false
+        )
+    }
+
+    override fun onCameraReady() {
+        startScanning(IdentityScanState.ScanType.SELFIE)
+    }
+
+    override fun updateUI(identityScanState: IdentityScanState) {
+        when (identityScanState) {
+            is IdentityScanState.Initial -> {
+                resetUI()
+            }
+            is IdentityScanState.Found -> {
+                binding.message.text = requireContext().getText(R.string.capturing)
+            }
+            is IdentityScanState.Unsatisfied -> {} // no-op
+            is IdentityScanState.Satisfied -> {
+                binding.message.text = requireContext().getText(R.string.selfie_capture_complete)
+            }
+            is IdentityScanState.Finished -> {
+                flash()
+                // TODO(ccen) - get result from identityScanState
+                toggleResultViewWithResult(getResults())
+            }
+            is IdentityScanState.TimeOut -> {
+                // no-op, transitions to CouldNotCaptureFragment
+            }
+        }
+    }
+
+    override fun resetUI() {
+        scanningView.visibility = View.VISIBLE
+        resultView.visibility = View.GONE
+        continueButton.isEnabled = false
+        messageView.text = requireContext().getText(R.string.position_selfie)
+    }
+
+    /**
+     * Animate the selfie view with a flash.
+     */
+    private fun flash() {
+        flashAnimatorSet.start()
+    }
+
+    private fun toggleResultViewWithResult(resultList: List<Bitmap>) {
+        scanningView.visibility = View.GONE
+        resultView.visibility = View.VISIBLE
+        continueButton.isEnabled = true
+        selfieResultAdapter.submitList(resultList)
+    }
+
+    internal companion object {
+        private val TAG: String = SelfieFragment::class.java.simpleName
+        private const val FLASH_MAX_ALPHA = 0.5f
+        private const val FLASH_ANIMATION_TIME = 200L
+    }
+}

--- a/identity/src/main/java/com/stripe/android/identity/ui/SelfieResultAdapter.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/SelfieResultAdapter.kt
@@ -1,0 +1,38 @@
+package com.stripe.android.identity.ui
+
+import android.graphics.Bitmap
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.stripe.android.identity.databinding.SelfieItemBinding
+
+internal class SelfieResultAdapter :
+    ListAdapter<Bitmap, SelfieViewHolder>(SelfieDiffCallback()) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SelfieViewHolder {
+        return SelfieViewHolder(SelfieItemBinding.inflate(LayoutInflater.from(parent.context)))
+    }
+
+    override fun onBindViewHolder(holder: SelfieViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+}
+
+internal class SelfieViewHolder(private val selfieItemBinding: SelfieItemBinding) :
+    RecyclerView.ViewHolder(selfieItemBinding.root) {
+    fun bind(bm: Bitmap) {
+        selfieItemBinding.selfieItem.setImageBitmap(bm)
+    }
+}
+
+internal class SelfieDiffCallback : DiffUtil.ItemCallback<Bitmap>() {
+    override fun areItemsTheSame(oldItem: Bitmap, newItem: Bitmap): Boolean {
+        return oldItem.sameAs(newItem)
+    }
+
+    override fun areContentsTheSame(oldItem: Bitmap, newItem: Bitmap): Boolean {
+        return oldItem.sameAs(newItem)
+    }
+}

--- a/identity/src/test/java/com/stripe/android/identity/navigation/CouldNotCaptureFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/CouldNotCaptureFragmentTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.identity.navigation
 
+import android.view.View
 import android.widget.Button
 import androidx.annotation.IdRes
 import androidx.core.os.bundleOf
@@ -95,6 +96,11 @@ internal class CouldNotCaptureFragmentTest {
         testClickingRetry(ScanType.PASSPORT, R.id.passportScanFragment, false)
     }
 
+    @Test
+    fun `SELFIE navigates to SelfieFragment`() {
+        testClickingRetry(ScanType.SELFIE, R.id.selfieFragment, false)
+    }
+
     private fun testClickingFileUpload(
         scanType: ScanType,
         requireLiveCapture: Boolean,
@@ -157,6 +163,21 @@ internal class CouldNotCaptureFragmentTest {
             it.requireView(),
             navController
         )
+
+        assertThat(binding.titleText.text).isEqualTo(it.getString(R.string.could_not_capture_title))
+        assertThat(binding.message1.text).isEqualTo(it.getString(R.string.could_not_capture_body1))
+        assertThat(binding.bottomButton.text).isEqualTo(it.getString(R.string.try_again))
+
+        if (type == ScanType.SELFIE) {
+            assertThat(binding.topButton.visibility).isEqualTo(View.GONE)
+            assertThat(binding.message2.visibility).isEqualTo(View.GONE)
+        } else {
+            assertThat(binding.topButton.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.message2.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.topButton.text).isEqualTo(it.getString(R.string.file_upload))
+            assertThat(binding.message2.text).isEqualTo(it.getString(R.string.could_not_capture_body2))
+        }
+
         testBlock(binding.topButton, binding.bottomButton, navController)
     }
 }

--- a/identity/src/test/java/com/stripe/android/identity/navigation/SelfieFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/SelfieFragmentTest.kt
@@ -1,0 +1,99 @@
+package com.stripe.android.identity.navigation
+
+import android.view.View
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.lifecycle.MediatorLiveData
+import androidx.navigation.Navigation
+import androidx.navigation.testing.TestNavHostController
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.identity.R
+import com.stripe.android.identity.camera.IDDetectorAggregator
+import com.stripe.android.identity.camera.IdentityScanFlow
+import com.stripe.android.identity.databinding.SelfieScanFragmentBinding
+import com.stripe.android.identity.networking.Resource
+import com.stripe.android.identity.networking.models.VerificationPage
+import com.stripe.android.identity.states.IdentityScanState
+import com.stripe.android.identity.utils.SingleLiveEvent
+import com.stripe.android.identity.viewModelFactoryFor
+import com.stripe.android.identity.viewmodel.IdentityScanViewModel
+import com.stripe.android.identity.viewmodel.IdentityViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+internal class SelfieFragmentTest {
+    @get:Rule
+    var rule: TestRule = InstantTaskExecutorRule()
+
+    private val finalResultLiveData = SingleLiveEvent<IDDetectorAggregator.FinalResult>()
+    private val displayStateChanged = SingleLiveEvent<Pair<IdentityScanState, IdentityScanState?>>()
+    private val mockScanFlow = mock<IdentityScanFlow>()
+
+    private val mockIdentityScanViewModel = mock<IdentityScanViewModel> {
+        on { it.identityScanFlow } doReturn mockScanFlow
+        on { it.finalResult } doReturn finalResultLiveData
+        on { it.displayStateChanged } doReturn displayStateChanged
+    }
+
+    private val mockPageAndModel = MediatorLiveData<Resource<Pair<VerificationPage, File>>>()
+    private val uploadState =
+        MutableStateFlow(IdentityViewModel.UploadState())
+
+    private val mockIdentityViewModel = mock<IdentityViewModel> {
+        on { pageAndModel } doReturn mockPageAndModel
+        on { uploadState } doReturn uploadState
+    }
+
+    @Test
+    fun `when initialized UI is reset`() {
+        launchSelfieFragment { binding, _ ->
+            assertThat(binding.scanningView.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.resultView.visibility).isEqualTo(View.GONE)
+            assertThat(binding.kontinue.isEnabled).isEqualTo(false)
+        }
+    }
+
+    @Test
+    fun `when finished UI is toggled`() {
+        launchSelfieFragment { binding, _ ->
+            // mock success of front scan
+            displayStateChanged.postValue((mock<IdentityScanState.Finished>() to mock()))
+
+            assertThat(binding.scanningView.visibility).isEqualTo(View.GONE)
+            assertThat(binding.resultView.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.kontinue.isEnabled).isEqualTo(true)
+        }
+    }
+
+    private fun launchSelfieFragment(testBlock: (SelfieScanFragmentBinding, TestNavHostController) -> Unit) =
+        launchFragmentInContainer(
+            themeResId = R.style.Theme_MaterialComponents
+        ) {
+            SelfieFragment(
+                viewModelFactoryFor(mockIdentityScanViewModel),
+                viewModelFactoryFor(mockIdentityViewModel)
+            )
+        }.onFragment {
+            val navController = TestNavHostController(
+                ApplicationProvider.getApplicationContext()
+            )
+            navController.setGraph(
+                R.navigation.identity_nav_graph
+            )
+            navController.setCurrentDestination(R.id.couldNotCaptureFragment)
+            Navigation.setViewNavController(
+                it.requireView(),
+                navController
+            )
+            testBlock(SelfieScanFragmentBinding.bind(it.requireView()), navController)
+        }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Build the initial UI of Scanning view, use a simple recyclerview to hold the 3 ML pipeline results that are about to upload

* Added simple UI tests for `SelfieFragment`
* Added tests for `SelfieFragment`'s navigation between to `CouldNotScanFragment`


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Selfie


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
![selfieDemo](https://user-images.githubusercontent.com/79880926/166324669-a92b96fb-315b-499c-876d-fb27bb1659fe.gif)


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
