### PR TITLE
[StripeCardScan Android] Remove outer base64 encoding in verify payload

### DIFF
--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/api/StripeApi.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/api/StripeApi.kt
@@ -204,11 +204,9 @@ internal suspend fun uploadSavedFrames(
         path = "card_image_verifications/$civId/verify_frames",
         data = VerifyFramesRequest(
             clientSecret = civSecret,
-            verificationFramesData = b64Encode(
-                encodeToJson(
-                    ListSerializer(VerificationFrameData.serializer()),
-                    verificationFramesData,
-                ),
+            verificationFramesData = encodeToJson(
+                ListSerializer(VerificationFrameData.serializer()),
+                verificationFramesData,
             ),
         ),
         requestSerializer = VerifyFramesRequest.serializer(),


### PR DESCRIPTION
Remove second base64 encoding from verify frames call

# Summary
Removing this extra base64 encoding call reduces our payload to roughly 3/4 the size of the previously encoded version. Since we don't need this extra encoding, remove it.

# Motivation
[[StripeCardScan Android] Remove outer base64 encoding in verify payload](https://jira.corp.stripe.com/browse/BOUNCER-943)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified
- [X] Automated tests run

# Screenshots
No visual changes.