### PR TITLE
[PaymentSheet] Fix issue opening the keyboard with small form

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet.ui
 
-import android.animation.LayoutTransition
 import android.content.pm.ActivityInfo
 import android.content.res.ColorStateList
 import android.graphics.Insets

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -95,9 +95,6 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
             }
         }
 
-        bottomSheet.layoutTransition.enableTransitionType(LayoutTransition.CHANGING)
-        fragmentContainerParent.layoutTransition.enableTransitionType(LayoutTransition.CHANGING)
-
         bottomSheetController.setup()
 
         bottomSheetController.shouldFinish.observe(this) { shouldFinish ->

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet
 
-import android.animation.LayoutTransition
 import android.content.Context
 import androidx.activity.result.ActivityResultLauncher
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
@@ -396,28 +395,6 @@ internal class PaymentSheetActivityTest {
             assertThat(googlePayButton.primaryButton.isVisible).isTrue()
             assertThat(googlePayIconComponent.isVisible).isFalse()
             assertThat(finishProcessingCalled).isTrue()
-        }
-    }
-
-    @Test
-    fun `Verify animation is enabled for layout transition changes`() {
-        val scenario = activityScenario()
-        scenario.launch(intent).onActivity { activity ->
-            // wait for bottom sheet to animate in
-            idleLooper()
-
-            assertThat(
-                activity.viewBinding.bottomSheet.layoutTransition.isTransitionTypeEnabled(
-                    LayoutTransition.CHANGING
-                )
-            ).isTrue()
-
-            assertThat(
-                activity.viewBinding.fragmentContainerParent.layoutTransition
-                    .isTransitionTypeEnabled(
-                        LayoutTransition.CHANGING
-                    )
-            ).isTrue()
         }
     }
 


### PR DESCRIPTION
# Summary
When google pay is not available and a single LPM with a single input field is shown, when the keyboard is open it is immediately dismissed.  Upon investigation this is because the bottom sheet size goes to 0 - clearing the focus of the field prior to bringing up the keyboard.

# Motivation
#4570 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
    - [Fixed] Fixed issue where text could not be inputted on small forms.

