### PR TITLE
Enable US Bank Account and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # CHANGELOG
 ## XX.X.X - 2022-05.XX
+This release adds `us_bank_account` PaymentMethod to PaymentSheet.
 
 ### PaymentSheet
 * [FIXED][5011](https://github.com/stripe/stripe-android/pull/5011) fix flying payment sheet by downgrading material from 1.6 to 1.5
+* [ADDED][4964](https://github.com/stripe/stripe-android/pull/4964) `us_bank_account` PaymentMethod is now available in PaymentSheet
 
 ## 20.2.2 - 2022-05-09
 This release contains bug fixes in PaymentSheet.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethod.kt
@@ -406,9 +406,9 @@ sealed class SupportedPaymentMethod(
                 Klarna,
                 PayPal,
                 AfterpayClearpay,
+                USBankAccount,
                 // Affirm // TODO: uncomment once we are ready to go live
                 // AuBecsDebit // TODO: uncomment once we are ready to go live
-                // USBankAccount // TODO: uncomment once we are ready to go live
             )
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethodTest.kt
@@ -16,6 +16,10 @@ import java.io.File
 
 @RunWith(AndroidJUnit4::class)
 class SupportedPaymentMethodTest {
+    /**
+     * To create a baseline for a payment method, create a new file <payment_method>-support.csv,
+     * comment out the assert in this test, and copy the output into the new csv file
+     */
     @Test
     fun `Test supported payment method baseline`() {
         SupportedPaymentMethod.values()

--- a/paymentsheet/src/test/resources/us_bank_account-support.csv
+++ b/paymentsheet/src/test/resources/us_bank_account-support.csv
@@ -1,0 +1,49 @@
+lpm, hasCustomer, allowsDelayedPayment, intentSetupFutureUsage, intentHasShipping, intentLpms, supportCustomerSavedCard, formExists, formType, supportsAdding
+us_bank_account, true, true, off_session, false, card/us_bank_account, true, true, merchantRequiredSave, true
+us_bank_account, true, true, off_session, false, card/eps/us_bank_account, true, true, merchantRequiredSave, true
+us_bank_account, true, false, off_session, false, card/us_bank_account, false, false, not available, false
+us_bank_account, true, false, off_session, false, card/eps/us_bank_account, false, false, not available, false
+us_bank_account, true, true, on_session, false, card/us_bank_account, true, true, merchantRequiredSave, true
+us_bank_account, true, true, on_session, false, card/eps/us_bank_account, true, true, merchantRequiredSave, true
+us_bank_account, true, false, on_session, false, card/us_bank_account, false, false, not available, false
+us_bank_account, true, false, on_session, false, card/eps/us_bank_account, false, false, not available, false
+us_bank_account, true, true, null, false, card/us_bank_account, true, true, userSelectedSave, true
+us_bank_account, true, true, null, false, card/eps/us_bank_account, true, true, userSelectedSave, true
+us_bank_account, true, false, null, false, card/us_bank_account, false, false, not available, false
+us_bank_account, true, false, null, false, card/eps/us_bank_account, false, false, not available, false
+us_bank_account, false, true, off_session, false, card/us_bank_account, true, true, merchantRequiredSave, true
+us_bank_account, false, true, off_session, false, card/eps/us_bank_account, true, true, merchantRequiredSave, true
+us_bank_account, false, false, off_session, false, card/us_bank_account, false, false, not available, false
+us_bank_account, false, false, off_session, false, card/eps/us_bank_account, false, false, not available, false
+us_bank_account, false, true, on_session, false, card/us_bank_account, true, true, merchantRequiredSave, true
+us_bank_account, false, true, on_session, false, card/eps/us_bank_account, true, true, merchantRequiredSave, true
+us_bank_account, false, false, on_session, false, card/us_bank_account, false, false, not available, false
+us_bank_account, false, false, on_session, false, card/eps/us_bank_account, false, false, not available, false
+us_bank_account, false, true, null, false, card/us_bank_account, true, true, oneTime, true
+us_bank_account, false, true, null, false, card/eps/us_bank_account, true, true, oneTime, true
+us_bank_account, false, false, null, false, card/us_bank_account, false, false, not available, false
+us_bank_account, false, false, null, false, card/eps/us_bank_account, false, false, not available, false
+us_bank_account, true, true, off_session, true, card/us_bank_account, true, true, merchantRequiredSave, true
+us_bank_account, true, true, off_session, true, card/eps/us_bank_account, true, true, merchantRequiredSave, true
+us_bank_account, true, false, off_session, true, card/us_bank_account, false, false, not available, false
+us_bank_account, true, false, off_session, true, card/eps/us_bank_account, false, false, not available, false
+us_bank_account, true, true, on_session, true, card/us_bank_account, true, true, merchantRequiredSave, true
+us_bank_account, true, true, on_session, true, card/eps/us_bank_account, true, true, merchantRequiredSave, true
+us_bank_account, true, false, on_session, true, card/us_bank_account, false, false, not available, false
+us_bank_account, true, false, on_session, true, card/eps/us_bank_account, false, false, not available, false
+us_bank_account, true, true, null, true, card/us_bank_account, true, true, userSelectedSave, true
+us_bank_account, true, true, null, true, card/eps/us_bank_account, true, true, userSelectedSave, true
+us_bank_account, true, false, null, true, card/us_bank_account, false, false, not available, false
+us_bank_account, true, false, null, true, card/eps/us_bank_account, false, false, not available, false
+us_bank_account, false, true, off_session, true, card/us_bank_account, true, true, merchantRequiredSave, true
+us_bank_account, false, true, off_session, true, card/eps/us_bank_account, true, true, merchantRequiredSave, true
+us_bank_account, false, false, off_session, true, card/us_bank_account, false, false, not available, false
+us_bank_account, false, false, off_session, true, card/eps/us_bank_account, false, false, not available, false
+us_bank_account, false, true, on_session, true, card/us_bank_account, true, true, merchantRequiredSave, true
+us_bank_account, false, true, on_session, true, card/eps/us_bank_account, true, true, merchantRequiredSave, true
+us_bank_account, false, false, on_session, true, card/us_bank_account, false, false, not available, false
+us_bank_account, false, false, on_session, true, card/eps/us_bank_account, false, false, not available, false
+us_bank_account, false, true, null, true, card/us_bank_account, true, true, oneTime, true
+us_bank_account, false, true, null, true, card/eps/us_bank_account, true, true, oneTime, true
+us_bank_account, false, false, null, true, card/us_bank_account, false, false, not available, false
+us_bank_account, false, false, null, true, card/eps/us_bank_account, false, false, not available, false


### PR DESCRIPTION
# Summary

Enable US Bank Account for PaymentSheet and update changelog

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

ACHv2 GA

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

- [Added] `us_bank_account` PaymentMethod is now available in PaymentSheet
