### PR TITLE
Fix androidx.lifecycle dependencies

### DIFF
--- a/link/build.gradle
+++ b/link/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation "androidx.compose.material:material-icons-core:$androidxComposeVersion"
     // Integration with activities
     implementation "androidx.activity:activity-compose:$androidxActivityVersion"
-    implementation "androidx.navigation:navigation-compose:2.5.0-beta01"
+    implementation "androidx.navigation:navigation-compose:$androidxNavigationVersion"
     // Integration with observables
     implementation "androidx.compose.runtime:runtime-livedata:$androidxComposeVersion"
     implementation "com.google.accompanist:accompanist-flowlayout:$flowlayoutVersion"
@@ -103,7 +103,6 @@ android {
 
     kotlinOptions {
         freeCompilerArgs = [
-                "-Xjvm-default=enable",
                 "-Xuse-experimental=androidx.compose.ui.ExperimentalComposeUiApi",
                 "-Xuse-experimental=kotlinx.coroutines.FlowPreview"
         ]

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation "androidx.browser:browser:$androidxBrowserVersion"
     implementation "androidx.recyclerview:recyclerview:$androidxRecyclerviewVersion"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$androidxLifecycleVersion"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:$androidxLifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$androidxLifecycleVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:$androidxLifecycleVersion"
     implementation "androidx.fragment:fragment-ktx:$androidxFragmentVersion"
@@ -132,8 +133,6 @@ android {
     }
 
     kotlinOptions {
-        // Needed to support @JvmDefault inheritance in ViewModels
-        freeCompilerArgs = ["-Xjvm-default=enable"]
         jvmTarget = "1.8"
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Depending on `androidx.navigation` `2.5.0-beta01` was pulling `androidx.lifecycle` `2.5.0-beta01`, which requires the [`-Xjvm-default` compiler argument](https://issuetracker.google.com/issues/217593040) and was causing issues.
Revert to 2.4.2, add dependency to `androidx.lifecycle:lifecycle-runtime-ktx` so we can keep using `repeatOnLifecycle`, `flowWithLifecycle`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix #4933, #4922, #4960 (hopefully)