### PR TITLE
Add project wardrobe configs to init events

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.analytics
 import com.stripe.android.core.networking.AnalyticsEvent
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.ui.core.PaymentsThemeDefaults
 
 internal sealed class PaymentSheetEvent : AnalyticsEvent {
     abstract val additionalParams: Map<String, Any>
@@ -21,13 +22,51 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
             }
         override val additionalParams: Map<String, Any>
             get() {
+                val primaryButtonConfig = configuration?.appearance?.primaryButton
+                val primaryButtonConfigMap = mapOf(
+                    FIELD_COLORS_LIGHT to (
+                        primaryButtonConfig?.colorsLight
+                            != PaymentSheet.PrimaryButtonColors.defaultLight
+                        ),
+                    FIELD_COLORS_DARK to (
+                        primaryButtonConfig?.colorsDark
+                            != PaymentSheet.PrimaryButtonColors.defaultDark
+                        ),
+                    FIELD_CORNER_RADIUS to (primaryButtonConfig?.shape?.cornerRadiusDp != null),
+                    FIELD_BORDER_WIDTH to (primaryButtonConfig?.shape?.borderStrokeWidthDp != null),
+                    FIELD_FONT to (primaryButtonConfig?.typography?.fontResId != null)
+                )
+                val appearanceConfigMap = mapOf(
+                    FIELD_COLORS_LIGHT to (
+                        configuration?.appearance?.colorsLight
+                            != PaymentSheet.Colors.defaultLight
+                        ),
+                    FIELD_COLORS_DARK to (
+                        configuration?.appearance?.colorsDark
+                            != PaymentSheet.Colors.defaultDark
+                        ),
+                    FIELD_CORNER_RADIUS to (
+                        configuration?.appearance?.shapes?.cornerRadiusDp
+                            != PaymentsThemeDefaults.shapes.cornerRadius
+                        ),
+                    FIELD_BORDER_WIDTH to (
+                        configuration?.appearance?.shapes?.borderStrokeWidthDp
+                            != PaymentsThemeDefaults.shapes.borderStrokeWidth
+                        ),
+                    FIELD_FONT to (configuration?.appearance?.typography?.fontResId != null),
+                    FIELD_SIZE_SCALE_FACTOR to (
+                        configuration?.appearance?.typography?.sizeScaleFactor
+                            != PaymentsThemeDefaults.typography.fontSizeMultiplier
+                        ),
+                    FIELD_PRIMARY_BUTTON to primaryButtonConfigMap
+                )
                 val configurationMap = mapOf(
-                    // todo skyler: add project wardrobe configs here too.
                     FIELD_CUSTOMER to (configuration?.customer != null),
                     FIELD_GOOGLE_PAY to (configuration?.googlePay != null),
                     FIELD_PRIMARY_BUTTON_COLOR to (configuration?.primaryButtonColor != null),
                     FIELD_BILLING to (configuration?.defaultBillingDetails != null),
                     FIELD_DELAYED_PMS to (configuration?.allowsDelayedPaymentMethods),
+                    FIELD_APPEARANCE to appearanceConfigMap
                 )
                 return mapOf(FIELD_PAYMENT_SHEET_CONFIGURATION to configurationMap)
             }
@@ -100,5 +139,13 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         const val FIELD_BILLING = "default_billing_details"
         const val FIELD_DELAYED_PMS = "allows_delayed_payment_methods"
         const val FIELD_PAYMENT_SHEET_CONFIGURATION = "payment_sheet_configuration"
+        const val FIELD_APPEARANCE = "appearance"
+        const val FIELD_COLORS_LIGHT = "colorsLight"
+        const val FIELD_COLORS_DARK = "colorsDark"
+        const val FIELD_CORNER_RADIUS = "corner_radius"
+        const val FIELD_BORDER_WIDTH = "border_width"
+        const val FIELD_FONT = "font"
+        const val FIELD_SIZE_SCALE_FACTOR = "size_scale_factor"
+        const val FIELD_PRIMARY_BUTTON = "primary_button"
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -68,7 +68,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
                     FIELD_DELAYED_PMS to (configuration?.allowsDelayedPaymentMethods),
                     FIELD_APPEARANCE to appearanceConfigMap
                 )
-                return mapOf(FIELD_PAYMENT_SHEET_CONFIGURATION to configurationMap)
+                return mapOf(FIELD_MOBILE_PAYMENT_ELEMENT_CONFIGURATION to configurationMap)
             }
     }
 
@@ -138,7 +138,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         const val FIELD_PRIMARY_BUTTON_COLOR = "primary_button_color"
         const val FIELD_BILLING = "default_billing_details"
         const val FIELD_DELAYED_PMS = "allows_delayed_payment_methods"
-        const val FIELD_PAYMENT_SHEET_CONFIGURATION = "payment_sheet_configuration"
+        const val FIELD_MOBILE_PAYMENT_ELEMENT_CONFIGURATION = "mpe_config"
         const val FIELD_APPEARANCE = "appearance"
         const val FIELD_COLORS_LIGHT = "colorsLight"
         const val FIELD_COLORS_DARK = "colorsDark"

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -35,7 +35,30 @@ internal object PaymentSheetFixtures {
         googlePay = ConfigFixtures.GOOGLE_PAY,
         primaryButtonColor = ColorStateList.valueOf(Color.BLACK),
         defaultBillingDetails = PaymentSheet.BillingDetails(name = "Skyler"),
-        allowsDelayedPaymentMethods = true
+        allowsDelayedPaymentMethods = true,
+        appearance = PaymentSheet.Appearance(
+            colorsLight = PaymentSheet.Colors.defaultLight.copy(primary = 0),
+            colorsDark = PaymentSheet.Colors.defaultDark.copy(primary = 0),
+            shapes = PaymentSheet.Shapes(
+                cornerRadiusDp = 0.0f,
+                borderStrokeWidthDp = 0.0f
+            ),
+            typography = PaymentSheet.Typography.default.copy(
+                sizeScaleFactor = 1.1f,
+                fontResId = 0,
+            ),
+            primaryButton = PaymentSheet.PrimaryButton(
+                colorsLight = PaymentSheet.PrimaryButtonColors.defaultLight.copy(background = 0),
+                colorsDark = PaymentSheet.PrimaryButtonColors.defaultLight.copy(background = 0),
+                shape = PaymentSheet.PrimaryButtonShape(
+                    cornerRadiusDp = 0.0f,
+                    borderStrokeWidthDp = 20.0f,
+                ),
+                typography = PaymentSheet.PrimaryButtonTypography(
+                    fontResId = 0
+                )
+            )
+        )
     )
 
     internal val CONFIG_CUSTOMER = PaymentSheet.Configuration(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -91,7 +91,7 @@ class PaymentSheetEventTest {
                 configuration = PaymentSheetFixtures.CONFIG_MINIMUM
             ).additionalParams
         ).isEqualTo(
-            mapOf("payment_sheet_configuration" to expectedConfigMap)
+            mapOf("mpe_config" to expectedConfigMap)
         )
     }
 
@@ -127,7 +127,7 @@ class PaymentSheetEventTest {
                 configuration = PaymentSheetFixtures.CONFIG_WITH_EVERYTHING
             ).additionalParams
         ).isEqualTo(
-            mapOf("payment_sheet_configuration" to expectedConfigMap)
+            mapOf("mpe_config" to expectedConfigMap)
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -61,12 +61,29 @@ class PaymentSheetEventTest {
 
     @Test
     fun `Init event should have default params if config is all defaults`() {
+        val expectedPrimaryButton = mapOf(
+            "colorsLight" to false,
+            "colorsDark" to false,
+            "corner_radius" to false,
+            "border_width" to false,
+            "font" to false,
+        )
+        val expectedAppearance = mapOf(
+            "colorsLight" to false,
+            "colorsDark" to false,
+            "corner_radius" to false,
+            "border_width" to false,
+            "size_scale_factor" to false,
+            "font" to false,
+            "primary_button" to expectedPrimaryButton
+        )
         val expectedConfigMap = mapOf(
             "customer" to false,
             "googlepay" to false,
             "primary_button_color" to false,
             "default_billing_details" to false,
             "allows_delayed_payment_methods" to false,
+            "appearance" to expectedAppearance
         )
         assertThat(
             PaymentSheetEvent.Init(
@@ -79,13 +96,30 @@ class PaymentSheetEventTest {
     }
 
     @Test
-    fun `Init event should should mark all optional params present if there are there`() {
+    fun `Init event should should mark all optional params present if they are there`() {
+        val expectedPrimaryButton = mapOf(
+            "colorsLight" to true,
+            "colorsDark" to true,
+            "corner_radius" to true,
+            "border_width" to true,
+            "font" to true,
+        )
+        val expectedAppearance = mapOf(
+            "colorsLight" to true,
+            "colorsDark" to true,
+            "corner_radius" to true,
+            "border_width" to true,
+            "size_scale_factor" to true,
+            "font" to true,
+            "primary_button" to expectedPrimaryButton
+        )
         val expectedConfigMap = mapOf(
             "customer" to true,
             "googlepay" to true,
             "primary_button_color" to true,
             "default_billing_details" to true,
             "allows_delayed_payment_methods" to true,
+            "appearance" to expectedAppearance
         )
         assertThat(
             PaymentSheetEvent.Init(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* adds project wardrobe configuration values to our metric events.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
* better visibility 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
* Added a unit test here to check parsing on the scala side: https://git.corp.stripe.com/stripe-internal/zoolander/pull/139802
