### PR TITLE
Prevent `CollectBankAccountViewModel#init` logic to run on process kill. 

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -5002,11 +5002,11 @@ public final class com/stripe/android/payments/bankaccount/navigation/CollectBan
 }
 
 public final class com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel_Factory;
 	public fun get ()Lcom/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/payments/bankaccount/navigation/CollectBankAccountContract$Args;Lkotlinx/coroutines/flow/MutableSharedFlow;Lcom/stripe/android/payments/bankaccount/domain/CreateFinancialConnectionsSession;Lcom/stripe/android/payments/bankaccount/domain/AttachFinancialConnectionsSession;Lcom/stripe/android/payments/bankaccount/domain/RetrieveStripeIntent;Lcom/stripe/android/core/Logger;)Lcom/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel;
+	public static fun newInstance (Lcom/stripe/android/payments/bankaccount/navigation/CollectBankAccountContract$Args;Lkotlinx/coroutines/flow/MutableSharedFlow;Lcom/stripe/android/payments/bankaccount/domain/CreateFinancialConnectionsSession;Lcom/stripe/android/payments/bankaccount/domain/AttachFinancialConnectionsSession;Lcom/stripe/android/payments/bankaccount/domain/RetrieveStripeIntent;Landroidx/lifecycle/SavedStateHandle;Lcom/stripe/android/core/Logger;)Lcom/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel;
 }
 
 public final class com/stripe/android/payments/core/ActivityResultLauncherHost$DefaultImpls {

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/di/CollectBankAccountComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/di/CollectBankAccountComponent.kt
@@ -36,7 +36,7 @@ internal interface CollectBankAccountComponent {
         fun viewEffect(application: MutableSharedFlow<CollectBankAccountViewEffect>): Builder
 
         @BindsInstance
-        fun savedStateHandle(savedStateHandle:SavedStateHandle): Builder
+        fun savedStateHandle(savedStateHandle: SavedStateHandle): Builder
 
         @BindsInstance
         fun configuration(configuration: CollectBankAccountContract.Args): Builder

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/di/CollectBankAccountComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/di/CollectBankAccountComponent.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.payments.bankaccount.di
 
 import android.app.Application
+import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.core.injection.LoggingModule
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountContract
@@ -33,6 +34,9 @@ internal interface CollectBankAccountComponent {
 
         @BindsInstance
         fun viewEffect(application: MutableSharedFlow<CollectBankAccountViewEffect>): Builder
+
+        @BindsInstance
+        fun savedStateHandle(savedStateHandle:SavedStateHandle): Builder
 
         @BindsInstance
         fun configuration(configuration: CollectBankAccountContract.Args): Builder

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountActivity.kt
@@ -55,7 +55,7 @@ internal class CollectBankAccountActivity : AppCompatActivity() {
 
     private fun OpenConnectionsFlow.launch() {
         financialConnectionsPaymentsProxy.present(
-            linkedAccountSessionClientSecret,
+            financialConnectionsSessionSecret,
             publishableKey
         )
     }

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewEffect.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewEffect.kt
@@ -15,7 +15,7 @@ internal sealed class CollectBankAccountViewEffect {
      */
     data class OpenConnectionsFlow(
         val publishableKey: String,
-        val linkedAccountSessionClientSecret: String
+        val financialConnectionsSessionSecret: String
     ) : CollectBankAccountViewEffect()
 
     /**

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel.kt
@@ -42,8 +42,8 @@ internal class CollectBankAccountViewModel @Inject constructor(
 ) : ViewModel() {
 
     private var hasLaunched: Boolean
-        get() = savedStateHandle.get<Boolean>("has_launched") == true
-        set(value) = savedStateHandle.set("has_launched", value)
+        get() = savedStateHandle.get<Boolean>(KEY_HAS_LAUNCHED) == true
+        set(value) = savedStateHandle.set(KEY_HAS_LAUNCHED, value)
 
     val viewEffect: SharedFlow<CollectBankAccountViewEffect> = _viewEffect
 
@@ -176,5 +176,9 @@ internal class CollectBankAccountViewModel @Inject constructor(
                 .configuration(argsSupplier()).build()
                 .viewModel as T
         }
+    }
+
+    companion object {
+        private const val KEY_HAS_LAUNCHED = "key_has_launched"
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-@Suppress("ConstructorParameterNaming")
+@Suppress("ConstructorParameterNaming", "LongParameterList")
 internal class CollectBankAccountViewModel @Inject constructor(
     // bound instances
     private val args: CollectBankAccountContract.Args,
@@ -72,12 +72,12 @@ internal class CollectBankAccountViewModel @Inject constructor(
                 )
             }
                 .mapCatching { requireNotNull(it.clientSecret) }
-                .onSuccess { linkedAccountSessionSecret: String ->
-                    logger.debug("Bank account session created! $linkedAccountSessionSecret.")
+                .onSuccess { financialConnectionsSessionSecret: String ->
+                    logger.debug("Bank account session created! $financialConnectionsSessionSecret.")
                     hasLaunched = true
                     _viewEffect.emit(
                         OpenConnectionsFlow(
-                            linkedAccountSessionClientSecret = linkedAccountSessionSecret,
+                            financialConnectionsSessionSecret = financialConnectionsSessionSecret,
                             publishableKey = args.publishableKey
                         )
                     )
@@ -142,7 +142,14 @@ internal class CollectBankAccountViewModel @Inject constructor(
                     linkedAccountSessionId = financialConnectionsSession.id
                 )
             }
-                .mapCatching { Completed(CollectBankAccountResponse(it, financialConnectionsSession)) }
+                .mapCatching {
+                    Completed(
+                        CollectBankAccountResponse(
+                            it,
+                            financialConnectionsSession
+                        )
+                    )
+                }
                 .onSuccess { result: Completed ->
                     logger.debug("Bank account session attached to  intent!!")
                     finishWithResult(result)

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.payments.bankaccount.ui
 
+import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.Logger
@@ -311,6 +312,7 @@ class CollectBankAccountViewModelTest {
         attachFinancialConnectionsSession = attachFinancialConnectionsSession,
         retrieveStripeIntent = retrieveStripeIntent,
         logger = Logger.noop(),
+        savedStateHandle = SavedStateHandle(),
         _viewEffect = viewEffect
     )
 


### PR DESCRIPTION
# Summary
- If process gets killed while connecting an account, `CollectBankAccountViewModel#init` gets retriggered, which reopens the Financial Connections Flow.
- This saves a flag in `SavedStateHandle` (hasLaunched), set to true while in the Financial Connections flow, to prevent it from happening.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified
