### PR TITLE
Send email when creating Payment Details

### DIFF
--- a/link/src/main/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModel.kt
@@ -53,7 +53,8 @@ internal class PaymentMethodViewModel @Inject constructor(
             FieldValuesToParamsMapConverter.transformToPaymentMethodCreateParams(
                 formValues,
                 paymentMethod.type
-            )
+            ),
+            linkAccount.email
         )
 
         viewModelScope.launch {

--- a/link/src/main/java/com/stripe/android/link/ui/paymentmethod/SupportedPaymentMethod.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/paymentmethod/SupportedPaymentMethod.kt
@@ -24,8 +24,10 @@ internal sealed class SupportedPaymentMethod(
     /**
      * Builds the [ConsumerPaymentDetailsCreateParams] used to create this payment method.
      */
-    abstract fun createParams(paymentMethodCreateParams: PaymentMethodCreateParams):
-        ConsumerPaymentDetailsCreateParams
+    abstract fun createParams(
+        paymentMethodCreateParams: PaymentMethodCreateParams,
+        email: String
+    ): ConsumerPaymentDetailsCreateParams
 
     /**
      * Creates a map containing additional parameters that must be sent during payment confirmation.
@@ -38,8 +40,13 @@ internal sealed class SupportedPaymentMethod(
         PaymentMethod.Type.Card,
         LinkCardForm
     ) {
-        override fun createParams(paymentMethodCreateParams: PaymentMethodCreateParams) =
-            ConsumerPaymentDetailsCreateParams.Card(paymentMethodCreateParams.toParamMap())
+        override fun createParams(
+            paymentMethodCreateParams: PaymentMethodCreateParams,
+            email: String
+        ) = ConsumerPaymentDetailsCreateParams.Card(
+            paymentMethodCreateParams.toParamMap(),
+            email
+        )
 
         /**
          * CVC is not passed during creation, and must be included when confirming the payment.

--- a/link/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/link/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -253,7 +253,8 @@ class LinkApiRepositoryTest {
     @Test
     fun `createPaymentDetails sends correct parameters`() = runTest {
         val secret = "secret"
-        val consumerPaymentDetailsCreateParams = ConsumerPaymentDetailsCreateParams.Card(emptyMap())
+        val consumerPaymentDetailsCreateParams =
+            ConsumerPaymentDetailsCreateParams.Card(emptyMap(), "email@stripe.com")
 
         linkRepository.createPaymentDetails(
             consumerPaymentDetailsCreateParams,
@@ -274,7 +275,7 @@ class LinkApiRepositoryTest {
             .thenReturn(paymentDetails)
 
         val result = linkRepository.createPaymentDetails(
-            ConsumerPaymentDetailsCreateParams.Card(emptyMap()),
+            ConsumerPaymentDetailsCreateParams.Card(emptyMap(), "email@stripe.com"),
             "secret"
         )
 
@@ -288,7 +289,7 @@ class LinkApiRepositoryTest {
             .thenThrow(RuntimeException("error"))
 
         val result = linkRepository.createPaymentDetails(
-            ConsumerPaymentDetailsCreateParams.Card(emptyMap()),
+            ConsumerPaymentDetailsCreateParams.Card(emptyMap(), "email@stripe.com"),
             "secret"
         )
 

--- a/link/src/test/java/com/stripe/android/link/ui/paymentmethod/SupportedPaymentMethodTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/paymentmethod/SupportedPaymentMethodTest.kt
@@ -25,10 +25,12 @@ class SupportedPaymentMethodTest {
         )
 
         assertThat(
-            ConsumerPaymentDetailsCreateParams.Card(paymentMethodCreateParams).toParamMap()
+            ConsumerPaymentDetailsCreateParams.Card(paymentMethodCreateParams, "email@test.com")
+                .toParamMap()
         ).isEqualTo(
             mapOf(
                 "type" to "card",
+                "billing_email_address" to "email@test.com",
                 "card" to mapOf(
                     "number" to "5555555555554444",
                     "exp_month" to "12",

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -1960,7 +1960,7 @@ public final class com/stripe/android/model/ConsumerPaymentDetailsCreateParams$C
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/ConsumerPaymentDetailsCreateParams$Card$Companion;
-	public fun <init> (Ljava/util/Map;)V
+	public fun <init> (Ljava/util/Map;Ljava/lang/String;)V
 	public fun describeContents ()I
 	public fun toParamMap ()Ljava/util/Map;
 	public fun writeToParcel (Landroid/os/Parcel;I)V

--- a/payments-core/src/main/java/com/stripe/android/model/ConsumerPaymentDetailsCreateParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConsumerPaymentDetailsCreateParams.kt
@@ -25,13 +25,16 @@ sealed class ConsumerPaymentDetailsCreateParams(
      */
     @Parcelize
     class Card(
-        private val cardPaymentMethodCreateParamsMap: Map<String, @RawValue Any>
+        private val cardPaymentMethodCreateParamsMap: Map<String, @RawValue Any>,
+        private val email: String
     ) : ConsumerPaymentDetailsCreateParams(PaymentMethod.Type.Card) {
         override fun toParamMap() = super.toParamMap()
             .plus(convertParamsMap())
 
         private fun convertParamsMap(): Map<String, Any> {
             val params: MutableMap<String, Any> = mutableMapOf()
+            params[PARAM_BILLING_EMAIL_ADDRESS] = email
+
             // card["billing_details"]["address"] becomes card["billing_address"]
             (
                 (cardPaymentMethodCreateParamsMap[PARAM_BILLING_DETAILS] as? Map<*, *>)
@@ -44,6 +47,7 @@ sealed class ConsumerPaymentDetailsCreateParams(
                     PARAM_POSTAL_CODE to it[PARAM_POSTAL_CODE]
                 )
             }
+
             // only card number, exp_month and exp_year are included
             (cardPaymentMethodCreateParamsMap[PARAM_CARD] as? Map<*, *>)?.let {
                 params[PARAM_CARD] = it.toMutableMap().filterKeys { key ->
@@ -58,6 +62,7 @@ sealed class ConsumerPaymentDetailsCreateParams(
             private const val PARAM_CARD_NUMBER = "number"
             private const val PARAM_CARD_EXP_MONTH = "exp_month"
             private const val PARAM_CARD_EXP_YEAR = "exp_year"
+            private const val PARAM_BILLING_EMAIL_ADDRESS = "billing_email_address"
             private const val PARAM_BILLING_ADDRESS = "billing_address"
             private const val PARAM_COUNTRY_CODE = "country_code"
             private const val PARAM_POSTAL_CODE = "postal_code"

--- a/payments-core/src/test/java/com/stripe/android/model/ConsumerPaymentDetailsCreateParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ConsumerPaymentDetailsCreateParamsTest.kt
@@ -25,11 +25,13 @@ class ConsumerPaymentDetailsCreateParamsTest {
                             "extra" to "1"
                         )
                     )
-                )
+                ),
+                "email@stripe.com"
             ).toParamMap()
         ).isEqualTo(
             mapOf(
                 "type" to "card",
+                "billing_email_address" to "email@stripe.com",
                 "card" to mapOf(
                     "number" to "123",
                     "exp_month" to "12",

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -1806,8 +1806,10 @@ internal class StripeApiRepositoryTest {
                 .thenReturn(stripeResponse)
 
             val clientSecret = "secret"
+            val email = "email@stripe.com"
             val paymentDetailsCreateParams = ConsumerPaymentDetailsCreateParams.Card(
-                PaymentMethodCreateParamsFixtures.DEFAULT_CARD.toParamMap()
+                PaymentMethodCreateParamsFixtures.DEFAULT_CARD.toParamMap(),
+                email
             )
             create().createPaymentDetails(
                 clientSecret,
@@ -1824,6 +1826,7 @@ internal class StripeApiRepositoryTest {
                 }
                 assertEquals(this["active"], false)
                 assertEquals(this["type"], "card")
+                assertEquals(this["billing_email_address"], email)
                 withNestedParams("billing_address") {
                     assertEquals(this["country_code"], "US")
                     assertEquals(this["postal_code"], "94111")


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Send email when creating `consumers/payment_details`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
API change.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified