### PR TITLE
Allow the server to control what settings are used for images in card scan

### DIFF
--- a/camera-core/api/camera-core.api
+++ b/camera-core/api/camera-core.api
@@ -26,6 +26,7 @@ public final class com/stripe/android/camera/framework/image/BitmapExtensionsKt 
 	public static synthetic fun scale$default (Landroid/graphics/Bitmap;Landroid/util/Size;ZILjava/lang/Object;)Landroid/graphics/Bitmap;
 	public static synthetic fun scaleAndCrop$default (Landroid/graphics/Bitmap;Landroid/util/Size;ZILjava/lang/Object;)Landroid/graphics/Bitmap;
 	public static synthetic fun toJpeg$default (Landroid/graphics/Bitmap;IILjava/lang/Object;)[B
+	public static synthetic fun toWebP$default (Landroid/graphics/Bitmap;IILjava/lang/Object;)[B
 }
 
 public final class com/stripe/android/camera/framework/image/ImageKt {

--- a/camera-core/src/main/java/com/stripe/android/camera/framework/image/BitmapExtensions.kt
+++ b/camera-core/src/main/java/com/stripe/android/camera/framework/image/BitmapExtensions.kt
@@ -21,13 +21,13 @@ import kotlin.math.min
 
 @CheckResult
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-fun Bitmap.toWebP(): ByteArray =
+fun Bitmap.toWebP(quality: Int = 92): ByteArray =
     ByteArrayOutputStream().use {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            this.compress(Bitmap.CompressFormat.WEBP_LOSSY, 92, it)
+            this.compress(Bitmap.CompressFormat.WEBP_LOSSY, quality, it)
         } else {
             @Suppress("deprecation")
-            this.compress(Bitmap.CompressFormat.WEBP, 92, it)
+            this.compress(Bitmap.CompressFormat.WEBP, quality, it)
         }
         it.flush()
         it.toByteArray()

--- a/stripecardscan/src/androidTest/java/com/stripe/android/stripecardscan/framework/api/dto/CardImageVerificationDetailsTest.kt
+++ b/stripecardscan/src/androidTest/java/com/stripe/android/stripecardscan/framework/api/dto/CardImageVerificationDetailsTest.kt
@@ -1,6 +1,9 @@
 package com.stripe.android.stripecardscan.framework.api.dto
 
+import android.util.Size
 import androidx.test.filters.SmallTest
+import com.stripe.android.stripecardscan.framework.util.AcceptedImageConfigs
+import com.stripe.android.stripecardscan.framework.util.ImageFormat
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import org.junit.Test
@@ -49,31 +52,29 @@ class CardImageVerificationDetailsTest {
         assertNotNull(result.acceptedImageConfigs)
 
         result.acceptedImageConfigs?.let {
-            val heicSettings = it.imageSettings(CardImageVerificationDetailsFormat.HEIC)
+            val acceptedImageConfigs = AcceptedImageConfigs(it)
+            val heicSettings = acceptedImageConfigs.imageSettings(ImageFormat.HEIC)
             assertNotNull(heicSettings)
 
             heicSettings?.let {
-                assertEquals(it.compressionRatio, 0.5)
-                assertEquals(it.imageSize?.first(), 1080.0)
-                assertEquals(it.imageSize?.last(), 1920.0)
+                assertEquals(it.first, 0.5)
+                assertEquals(it.second, Size(1080, 1920))
             }
 
-            val jpegSettings = it.imageSettings(CardImageVerificationDetailsFormat.JPEG)
+            val jpegSettings = acceptedImageConfigs.imageSettings(ImageFormat.JPEG)
             assertNotNull(jpegSettings)
 
             jpegSettings?.let {
-                assertEquals(it.compressionRatio, 0.8)
-                assertEquals(it.imageSize?.first(), 1080.0)
-                assertEquals(it.imageSize?.last(), 1920.0)
+                assertEquals(it.first, 0.8)
+                assertEquals(it.second, Size(1080, 1920))
             }
 
-            val webpSettings = it.imageSettings(CardImageVerificationDetailsFormat.WEBP)
+            val webpSettings = acceptedImageConfigs.imageSettings(ImageFormat.WEBP)
             assertNotNull(webpSettings)
 
             webpSettings?.let {
-                assertEquals(it.compressionRatio, 0.7)
-                assertEquals(it.imageSize?.first(), 2160.0)
-                assertEquals(it.imageSize?.last(), 1920.0)
+                assertEquals(it.first, 0.7)
+                assertEquals(it.second, Size(2160, 1920))
             }
         }
     }

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationActivity.kt
@@ -25,6 +25,7 @@ import com.stripe.android.stripecardscan.cardimageverification.exception.Unknown
 import com.stripe.android.stripecardscan.cardimageverification.result.MainLoopAggregator
 import com.stripe.android.stripecardscan.cardimageverification.result.MainLoopState
 import com.stripe.android.stripecardscan.framework.api.NetworkResult
+import com.stripe.android.stripecardscan.framework.api.dto.CardImageVerificationDetailsAcceptedImageConfigs
 import com.stripe.android.stripecardscan.framework.api.dto.ScanStatistics
 import com.stripe.android.stripecardscan.framework.api.getCardImageVerificationIntentDetails
 import com.stripe.android.stripecardscan.framework.api.uploadSavedFrames
@@ -139,6 +140,11 @@ internal open class CardImageVerificationActivity :
     private var requiredCardLastFour: String? = null
 
     /**
+     * The image format to send to verify_frames
+     */
+    private var imageConfigs: CardImageVerificationDetailsAcceptedImageConfigs? = null
+
+    /**
      * The listener which handles results from the scan.
      */
     override val resultListener: CardImageVerificationResultListener =
@@ -166,6 +172,7 @@ internal open class CardImageVerificationActivity :
                             civId = params.cardImageVerificationIntentId,
                             civSecret = params.cardImageVerificationIntentSecret,
                             savedFrames = frames,
+                            imageConfigs = imageConfigs,
                         )
                     ) {
                         is NetworkResult.Success ->
@@ -335,6 +342,8 @@ internal open class CardImageVerificationActivity :
                 if (expectedCard.lastFour.isNullOrEmpty() ||
                     isValidPanLastFour(expectedCard.lastFour)
                 ) {
+                    imageConfigs = result.body.acceptedImageConfigs
+
                     CardVerificationFlowParameters(
                         cardIssuer = getIssuerByDisplayName(expectedCard.issuer),
                         lastFour = expectedCard.lastFour,

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationActivity.kt
@@ -25,11 +25,11 @@ import com.stripe.android.stripecardscan.cardimageverification.exception.Unknown
 import com.stripe.android.stripecardscan.cardimageverification.result.MainLoopAggregator
 import com.stripe.android.stripecardscan.cardimageverification.result.MainLoopState
 import com.stripe.android.stripecardscan.framework.api.NetworkResult
-import com.stripe.android.stripecardscan.framework.api.dto.CardImageVerificationDetailsAcceptedImageConfigs
 import com.stripe.android.stripecardscan.framework.api.dto.ScanStatistics
 import com.stripe.android.stripecardscan.framework.api.getCardImageVerificationIntentDetails
 import com.stripe.android.stripecardscan.framework.api.uploadSavedFrames
 import com.stripe.android.stripecardscan.framework.api.uploadScanStatsCIV
+import com.stripe.android.stripecardscan.framework.util.AcceptedImageConfigs
 import com.stripe.android.stripecardscan.framework.util.AppDetails
 import com.stripe.android.stripecardscan.framework.util.Device
 import com.stripe.android.stripecardscan.framework.util.ScanConfig
@@ -142,7 +142,7 @@ internal open class CardImageVerificationActivity :
     /**
      * The image format to send to verify_frames
      */
-    private var imageConfigs: CardImageVerificationDetailsAcceptedImageConfigs? = null
+    private var imageConfigs: AcceptedImageConfigs = AcceptedImageConfigs()
 
     /**
      * The listener which handles results from the scan.
@@ -342,7 +342,7 @@ internal open class CardImageVerificationActivity :
                 if (expectedCard.lastFour.isNullOrEmpty() ||
                     isValidPanLastFour(expectedCard.lastFour)
                 ) {
-                    imageConfigs = result.body.acceptedImageConfigs
+                    imageConfigs = AcceptedImageConfigs(result.body.acceptedImageConfigs)
 
                     CardVerificationFlowParameters(
                         cardIssuer = getIssuerByDisplayName(expectedCard.issuer),

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/api/StripeApi.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/api/StripeApi.kt
@@ -218,13 +218,15 @@ internal suspend fun uploadSavedFrames(
 }
 
 internal fun isformatSupport(format: CardImageVerificationDetailsFormat) =
-    (format == CardImageVerificationDetailsFormat.JPEG ||
-        format == CardImageVerificationDetailsFormat.WEBP)
+    format == CardImageVerificationDetailsFormat.JPEG ||
+        format == CardImageVerificationDetailsFormat.WEBP
 
 internal fun imageWithConfig(
     image: Bitmap,
     format: CardImageVerificationDetailsFormat,
-    configs: CardImageVerificationDetailsAcceptedImageConfigs): Pair<ByteArray?, Rect> {
+    configs: CardImageVerificationDetailsAcceptedImageConfigs
+): Pair<ByteArray?, Rect> {
+
     val imageSettings = configs.imageSettings(format)
 
     // Size and crop the image per the settings.
@@ -242,7 +244,7 @@ internal fun imageWithConfig(
     val compressionRatio = imageSettings.compressionRatio!!
 
     // Convert to 0..100
-    val convertedRatio = compressionRatio.times( 100.0).toInt()
+    val convertedRatio = compressionRatio.times(100.0).toInt()
 
     var result: ByteArray? = null
 
@@ -258,7 +260,11 @@ internal fun imageWithConfig(
     return Pair(result, cropRect)
 }
 
-internal fun getImageData(image: Bitmap, configs: CardImageVerificationDetailsAcceptedImageConfigs?): Pair<ByteArray?, Rect> {
+internal fun getImageData(
+    image: Bitmap,
+    configs: CardImageVerificationDetailsAcceptedImageConfigs?
+): Pair<ByteArray?, Rect> {
+
     val imageConfigs = configs ?: CardImageVerificationDetailsAcceptedImageConfigs()
 
     // Attempt to get image data using the configs from the server.

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/api/StripeApi.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/api/StripeApi.kt
@@ -251,7 +251,8 @@ internal fun imageWithConfig(
     return Pair(result, cropRect)
 }
 
-internal fun getImageData(image: Bitmap, imageConfigs: AcceptedImageConfigs): Pair<ByteArray, Rect> {
+internal fun getImageData(image: Bitmap, imageConfigs: AcceptedImageConfigs):
+    Pair<ByteArray, Rect> {
 
     // Attempt to get image data using the configs from the server.
     var result = imageConfigs.preferredFormats?.firstNotNullOfOrNull {

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/api/StripeApi.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/api/StripeApi.kt
@@ -228,7 +228,7 @@ internal fun imageWithConfig(
     val cropRect = maxImageSize
         .scaleAndCenterWithin(image.size())
 
-    val image = image
+    val croppedImage = image
         .crop(cropRect)
         .constrainToSize(maxImageSize)
 
@@ -239,9 +239,9 @@ internal fun imageWithConfig(
     val convertedRatio = compressionRatio.times(100.0).toInt()
 
     var result = when (format) {
-        ImageFormat.WEBP -> image.toWebP(convertedRatio)
+        ImageFormat.WEBP -> croppedImage.toWebP(convertedRatio)
         ImageFormat.HEIC,
-        ImageFormat.JPEG -> image.toJpeg(convertedRatio)
+        ImageFormat.JPEG -> croppedImage.toJpeg(convertedRatio)
     }
 
     if (result.size == 0) {
@@ -263,6 +263,6 @@ internal fun getImageData(image: Bitmap, imageConfigs: AcceptedImageConfigs):
         // Fallback to JPEG format
         result = imageWithConfig(image, ImageFormat.JPEG, imageConfigs)
     }
-    
+
     return result ?: Pair(ByteArray(0), Rect())
 }

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/api/StripeApi.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/api/StripeApi.kt
@@ -263,7 +263,6 @@ internal fun getImageData(image: Bitmap, imageConfigs: AcceptedImageConfigs):
         // Fallback to JPEG format
         result = imageWithConfig(image, ImageFormat.JPEG, imageConfigs)
     }
-
-    // Fallback to JPEG format
+    
     return result ?: Pair(ByteArray(0), Rect())
 }

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/api/dto/CardImageVerificationDetails.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/api/dto/CardImageVerificationDetails.kt
@@ -37,52 +37,20 @@ internal enum class CardImageVerificationDetailsFormat {
 
 @Serializable
 internal data class CardImageVerificationDetailsImageSettings(
-    @SerialName("compression_ratio") var compressionRatio: Double? = null,
-    @SerialName("image_size") var imageSize: DoubleArray? = null,
-) {
-    companion object {
-        // These default values are what Android was using before the addition of a server config.
-        val DEFAULT = CardImageVerificationDetailsImageSettings(
-            0.92,
-            doubleArrayOf(1080.0, 1920.0)
-        )
-    }
-}
+    @SerialName("compression_ratio") val compressionRatio: Double? = null,
+    @SerialName("image_size") val imageSize: DoubleArray? = null,
+)
 
 @Serializable
 internal data class CardImageVerificationDetailsAcceptedImageConfigs(
     @SerialName("default_settings")
-    private val defaultSettings: CardImageVerificationDetailsImageSettings? =
-        CardImageVerificationDetailsImageSettings.DEFAULT,
+    val defaultSettings: CardImageVerificationDetailsImageSettings? = null,
 
     @SerialName("format_settings")
-    private val formatSettings:
+    val formatSettings:
         HashMap<CardImageVerificationDetailsFormat,
             CardImageVerificationDetailsImageSettings?>? = null,
 
     @SerialName("preferred_formats")
-    val preferredFormats: Array<CardImageVerificationDetailsFormat>? =
-        Array<CardImageVerificationDetailsFormat>(1) {
-            CardImageVerificationDetailsFormat.JPEG
-        }
-) {
-    fun imageSettings(format: CardImageVerificationDetailsFormat):
-        CardImageVerificationDetailsImageSettings {
-        // Default to client default settings
-        var result = CardImageVerificationDetailsImageSettings.DEFAULT
-
-        // Override with server default settings
-        defaultSettings?.let {
-            result.compressionRatio = it.compressionRatio ?: result.compressionRatio
-            result.imageSize = it.imageSize ?: result.imageSize
-        }
-
-        // Take format specific settings
-        formatSettings?.get(format)?.let {
-            result.compressionRatio = it.compressionRatio ?: result.compressionRatio
-            result.imageSize = it.imageSize ?: result.imageSize
-        }
-
-        return result
-    }
-}
+    val preferredFormats: Array<CardImageVerificationDetailsFormat>? = null,
+)

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/api/dto/CardImageVerificationDetails.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/api/dto/CardImageVerificationDetails.kt
@@ -10,11 +10,63 @@ internal data class CardImageVerificationDetailsRequest(
 
 @Serializable
 internal data class CardImageVerificationDetailsResult(
-    @SerialName("expected_card") val expectedCard: CardImageVerificationDetailsResultCard?
+    @SerialName("expected_card") val expectedCard: CardImageVerificationDetailsExpectedCard?,
+    @SerialName("accepted_image_configs") val acceptedImageConfigs: CardImageVerificationDetailsAcceptedImageConfigs? = null,
 )
 
 @Serializable
-internal data class CardImageVerificationDetailsResultCard(
+internal data class CardImageVerificationDetailsExpectedCard(
     @SerialName("issuer") val issuer: String?,
     @SerialName("last4") val lastFour: String?,
 )
+
+@Serializable
+internal enum class CardImageVerificationDetailsFormat {
+    @SerialName("heic")
+    HEIC,
+
+    @SerialName("jpeg")
+    JPEG,
+
+    @SerialName("webp")
+    WEBP;
+}
+
+@Serializable
+internal data class CardImageVerificationDetailsImageSettings(
+    @SerialName("compression_ratio") var compressionRatio: Double? = null,
+    @SerialName("image_size") var imageSize: DoubleArray? = null,
+) {
+    companion object {
+        // These default values are what Android was using before the addition of a server config.
+        val DEFAULT = CardImageVerificationDetailsImageSettings(0.92, doubleArrayOf(1080.0, 1920.0))
+    }
+}
+
+@Serializable
+internal data class CardImageVerificationDetailsAcceptedImageConfigs(
+    @SerialName("default_settings") private val defaultSettings: CardImageVerificationDetailsImageSettings? = CardImageVerificationDetailsImageSettings.DEFAULT,
+    @SerialName("format_settings") private val formatSettings: HashMap<CardImageVerificationDetailsFormat, CardImageVerificationDetailsImageSettings?>? = null,
+    @SerialName("preferred_formats") val preferredFormats: Array<CardImageVerificationDetailsFormat>? = Array<CardImageVerificationDetailsFormat>(1) {
+        CardImageVerificationDetailsFormat.JPEG
+    }
+) {
+    fun imageSettings(format: CardImageVerificationDetailsFormat): CardImageVerificationDetailsImageSettings {
+        // Default to client default settings
+        var result = CardImageVerificationDetailsImageSettings.DEFAULT
+
+        // Override with server default settings
+        defaultSettings?.let {
+            result.compressionRatio = it.compressionRatio ?: result.compressionRatio
+            result.imageSize = it.imageSize ?: result.imageSize
+        }
+
+        // Take format specific settings
+        formatSettings?.get(format)?.let {
+            result.compressionRatio = it.compressionRatio ?: result.compressionRatio
+            result.imageSize = it.imageSize ?: result.imageSize
+        }
+
+        return result
+    }
+}

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/api/dto/CardImageVerificationDetails.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/api/dto/CardImageVerificationDetails.kt
@@ -10,8 +10,11 @@ internal data class CardImageVerificationDetailsRequest(
 
 @Serializable
 internal data class CardImageVerificationDetailsResult(
-    @SerialName("expected_card") val expectedCard: CardImageVerificationDetailsExpectedCard?,
-    @SerialName("accepted_image_configs") val acceptedImageConfigs: CardImageVerificationDetailsAcceptedImageConfigs? = null,
+    @SerialName("expected_card")
+    val expectedCard: CardImageVerificationDetailsExpectedCard?,
+
+    @SerialName("accepted_image_configs")
+    val acceptedImageConfigs: CardImageVerificationDetailsAcceptedImageConfigs? = null,
 )
 
 @Serializable
@@ -39,19 +42,32 @@ internal data class CardImageVerificationDetailsImageSettings(
 ) {
     companion object {
         // These default values are what Android was using before the addition of a server config.
-        val DEFAULT = CardImageVerificationDetailsImageSettings(0.92, doubleArrayOf(1080.0, 1920.0))
+        val DEFAULT = CardImageVerificationDetailsImageSettings(
+            0.92,
+            doubleArrayOf(1080.0, 1920.0)
+        )
     }
 }
 
 @Serializable
 internal data class CardImageVerificationDetailsAcceptedImageConfigs(
-    @SerialName("default_settings") private val defaultSettings: CardImageVerificationDetailsImageSettings? = CardImageVerificationDetailsImageSettings.DEFAULT,
-    @SerialName("format_settings") private val formatSettings: HashMap<CardImageVerificationDetailsFormat, CardImageVerificationDetailsImageSettings?>? = null,
-    @SerialName("preferred_formats") val preferredFormats: Array<CardImageVerificationDetailsFormat>? = Array<CardImageVerificationDetailsFormat>(1) {
-        CardImageVerificationDetailsFormat.JPEG
-    }
+    @SerialName("default_settings")
+    private val defaultSettings: CardImageVerificationDetailsImageSettings? =
+        CardImageVerificationDetailsImageSettings.DEFAULT,
+
+    @SerialName("format_settings")
+    private val formatSettings:
+        HashMap<CardImageVerificationDetailsFormat,
+            CardImageVerificationDetailsImageSettings?>? = null,
+
+    @SerialName("preferred_formats")
+    val preferredFormats: Array<CardImageVerificationDetailsFormat>? =
+        Array<CardImageVerificationDetailsFormat>(1) {
+            CardImageVerificationDetailsFormat.JPEG
+        }
 ) {
-    fun imageSettings(format: CardImageVerificationDetailsFormat): CardImageVerificationDetailsImageSettings {
+    fun imageSettings(format: CardImageVerificationDetailsFormat):
+        CardImageVerificationDetailsImageSettings {
         // Default to client default settings
         var result = CardImageVerificationDetailsImageSettings.DEFAULT
 

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/util/AcceptedImageConfigs.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/util/AcceptedImageConfigs.kt
@@ -1,0 +1,96 @@
+package com.stripe.android.stripecardscan.framework.util
+
+import android.util.Size
+import com.stripe.android.stripecardscan.framework.api.dto.CardImageVerificationDetailsAcceptedImageConfigs
+import com.stripe.android.stripecardscan.framework.api.dto.CardImageVerificationDetailsFormat
+import com.stripe.android.stripecardscan.framework.api.dto.CardImageVerificationDetailsImageSettings
+
+internal enum class ImageFormat {
+    HEIC,
+    JPEG,
+    WEBP;
+
+    companion object {
+        fun fromValue(value: CardImageVerificationDetailsFormat): ImageFormat =
+            when (value) {
+                CardImageVerificationDetailsFormat.HEIC -> ImageFormat.HEIC
+                CardImageVerificationDetailsFormat.JPEG -> ImageFormat.JPEG
+                CardImageVerificationDetailsFormat.WEBP -> ImageFormat.WEBP
+            }
+    }
+}
+
+internal data class ImageSettings(
+    var compressionRatio: Double? = null,
+    var imageSize: Size? = null
+) {
+    companion object {
+        // These default values are what Android was using before the addition of a server config.
+        val DEFAULT = ImageSettings(0.92, Size(1080, 1920))
+    }
+
+    constructor(settings: CardImageVerificationDetailsImageSettings?) : this() {
+        settings?.let {
+            compressionRatio = it.compressionRatio ?: compressionRatio
+
+            it.imageSize?.takeIf { it.size > 1 }?.let {
+                var pendingSize = imageSize ?: ImageSettings.DEFAULT.imageSize!!
+                val width = it.first().toInt() ?: pendingSize.width
+                val height = it.last().toInt() ?: pendingSize.height
+                imageSize = Size(width, height)
+            }
+        }
+    }
+}
+
+internal data class AcceptedImageConfigs(
+    private var defaultSettings: ImageSettings? = ImageSettings.DEFAULT,
+    private var formatSettings: HashMap<ImageFormat, ImageSettings?>? = null,
+    var preferredFormats: Array<ImageFormat>? = Array<ImageFormat>(1) { ImageFormat.JPEG }
+) {
+    constructor(configs: CardImageVerificationDetailsAcceptedImageConfigs?): this() {
+        configs?.let {
+            it.formatSettings?.takeIf { it.size > 0 }.also { formatSettings = HashMap() }?.forEach {
+                val value = ImageSettings(it.value)
+                val key = ImageFormat.fromValue(it.key)
+                formatSettings?.put(key, value)
+            }
+
+            val mappedFormats = it.preferredFormats?.map {
+                f -> ImageFormat.fromValue(f)
+            }?.filter {
+                isformatSupport(it)
+            }?.takeIf {
+                it.count() > 0
+            }?.let {
+                preferredFormats = it.toTypedArray()
+            }
+
+            it.defaultSettings?.let {
+                defaultSettings = ImageSettings(it)
+            }
+        }
+    }
+
+    internal fun isformatSupport(format: ImageFormat) =
+        format == ImageFormat.JPEG || format == ImageFormat.WEBP
+
+    fun imageSettings(format: ImageFormat): Pair<Double, Size> {
+        // Default to client default settings
+        var result = ImageSettings.DEFAULT
+
+        // Override with server default settings
+        defaultSettings?.let {
+            result.compressionRatio = it.compressionRatio ?: result.compressionRatio
+            result.imageSize = it.imageSize ?: result.imageSize
+        }
+
+        // Take format specific settings
+        formatSettings?.get(format)?.let {
+            result.compressionRatio = it.compressionRatio ?: result.compressionRatio
+            result.imageSize = it.imageSize ?: result.imageSize
+        }
+
+        return Pair(result.compressionRatio!!, result.imageSize!!)
+    }
+}

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/util/AcceptedImageConfigs.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/util/AcceptedImageConfigs.kt
@@ -48,7 +48,7 @@ internal data class AcceptedImageConfigs(
     private var formatSettings: HashMap<ImageFormat, ImageSettings?>? = null,
     var preferredFormats: Array<ImageFormat>? = Array<ImageFormat>(1) { ImageFormat.JPEG }
 ) {
-    constructor(configs: CardImageVerificationDetailsAcceptedImageConfigs?): this() {
+    constructor(configs: CardImageVerificationDetailsAcceptedImageConfigs?) : this() {
         configs?.let {
             it.formatSettings?.takeIf { it.size > 0 }.also { formatSettings = HashMap() }?.forEach {
                 val value = ImageSettings(it.value)
@@ -56,19 +56,12 @@ internal data class AcceptedImageConfigs(
                 formatSettings?.put(key, value)
             }
 
-            val mappedFormats = it.preferredFormats?.map {
-                f -> ImageFormat.fromValue(f)
-            }?.filter {
-                isformatSupport(it)
-            }?.takeIf {
-                it.count() > 0
-            }?.let {
-                preferredFormats = it.toTypedArray()
-            }
+            val mappedFormats = it.preferredFormats?.map { ImageFormat.fromValue(it) }
+                ?.filter { isformatSupport(it) }
+                ?.takeIf { it.count() > 0 }
+                ?.let { preferredFormats = it.toTypedArray() }
 
-            it.defaultSettings?.let {
-                defaultSettings = ImageSettings(it)
-            }
+            it.defaultSettings?.let { defaultSettings = ImageSettings(it) }
         }
     }
 

--- a/stripecardscan/src/test/java/com/stripe/android/stripecardscan/framework/api/dto/CardImageVerificationDetailsTest.kt
+++ b/stripecardscan/src/test/java/com/stripe/android/stripecardscan/framework/api/dto/CardImageVerificationDetailsTest.kt
@@ -1,0 +1,80 @@
+package com.stripe.android.stripecardscan.framework.api.dto
+
+import androidx.test.filters.SmallTest
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class CardImageVerificationDetailsTest {
+
+    @Test
+    @SmallTest
+    fun testImageSettingsMethod() {
+        val json = "{\n" +
+            "  \"accepted_image_configs\": {\n" +
+            "    \"default_settings\": {\n" +
+            "      \"compression_ratio\": 0.8,\n" +
+            "      \"image_size\": [\n" +
+            "        1080,\n" +
+            "        1920\n" +
+            "      ]\n" +
+            "    },\n" +
+            "    \"format_settings\": {\n" +
+            "      \"heic\": {\n" +
+            "        \"compression_ratio\": 0.5\n" +
+            "      },\n" +
+            "      \"webp\": {\n" +
+            "        \"compression_ratio\": 0.7\n" +
+            "        \"image_size\": [\n" +
+            "            2160,\n" +
+            "            1920\n" +
+            "      ]\n" +
+            "      }\n" +
+            "    },\n" +
+            "    \"preferred_formats\": [\n" +
+            "      \"heic\",\n" +
+            "      \"webp\",\n" +
+            "      \"jpeg\"\n" +
+            "    ]\n" +
+            "  },\n" +
+            "  \"expected_card\": {\n" +
+            "    \"last4\": \"9012\",\n" +
+            "    \"issuer\": \"Visa\"\n" +
+            "  }\n" +
+            "}";
+
+        val result = Json.decodeFromString<CardImageVerificationDetailsResult>(json)
+        assertNotNull(result.acceptedImageConfigs)
+
+        result.acceptedImageConfigs?.let {
+            val heicSettings = it.imageSettings(CardImageVerificationDetailsFormat.HEIC)
+            assertNotNull(heicSettings)
+
+            heicSettings?.let {
+                assertEquals(it.compressionRatio, 0.5)
+                assertEquals(it.imageSize?.first(), 1080.0)
+                assertEquals(it.imageSize?.last(), 1920.0)
+            }
+
+            val jpegSettings = it.imageSettings(CardImageVerificationDetailsFormat.JPEG)
+            assertNotNull(jpegSettings)
+
+            jpegSettings?.let {
+                assertEquals(it.compressionRatio, 0.8)
+                assertEquals(it.imageSize?.first(), 1080.0)
+                assertEquals(it.imageSize?.last(), 1920.0)
+            }
+
+            val webpSettings = it.imageSettings(CardImageVerificationDetailsFormat.WEBP)
+            assertNotNull(webpSettings)
+
+            webpSettings?.let {
+                assertEquals(it.compressionRatio, 0.7)
+                assertEquals(it.imageSize?.first(), 2160.0)
+                assertEquals(it.imageSize?.last(), 1920.0)
+            }
+        }
+    }
+}

--- a/stripecardscan/src/test/java/com/stripe/android/stripecardscan/framework/api/dto/CardImageVerificationDetailsTest.kt
+++ b/stripecardscan/src/test/java/com/stripe/android/stripecardscan/framework/api/dto/CardImageVerificationDetailsTest.kt
@@ -43,7 +43,7 @@ class CardImageVerificationDetailsTest {
             "    \"last4\": \"9012\",\n" +
             "    \"issuer\": \"Visa\"\n" +
             "  }\n" +
-            "}";
+            "}"
 
         val result = Json.decodeFromString<CardImageVerificationDetailsResult>(json)
         assertNotNull(result.acceptedImageConfigs)

--- a/stripecardscan/src/test/java/com/stripe/android/stripecardscan/framework/api/dto/CardImageVerificationDetailsTest.kt
+++ b/stripecardscan/src/test/java/com/stripe/android/stripecardscan/framework/api/dto/CardImageVerificationDetailsTest.kt
@@ -12,38 +12,38 @@ class CardImageVerificationDetailsTest {
     @Test
     @SmallTest
     fun testImageSettingsMethod() {
-        val json = "{\n" +
-            "  \"accepted_image_configs\": {\n" +
-            "    \"default_settings\": {\n" +
-            "      \"compression_ratio\": 0.8,\n" +
-            "      \"image_size\": [\n" +
-            "        1080,\n" +
-            "        1920\n" +
-            "      ]\n" +
-            "    },\n" +
-            "    \"format_settings\": {\n" +
-            "      \"heic\": {\n" +
-            "        \"compression_ratio\": 0.5\n" +
-            "      },\n" +
-            "      \"webp\": {\n" +
-            "        \"compression_ratio\": 0.7\n" +
-            "        \"image_size\": [\n" +
-            "            2160,\n" +
-            "            1920\n" +
-            "      ]\n" +
-            "      }\n" +
-            "    },\n" +
-            "    \"preferred_formats\": [\n" +
-            "      \"heic\",\n" +
-            "      \"webp\",\n" +
-            "      \"jpeg\"\n" +
-            "    ]\n" +
-            "  },\n" +
-            "  \"expected_card\": {\n" +
-            "    \"last4\": \"9012\",\n" +
-            "    \"issuer\": \"Visa\"\n" +
-            "  }\n" +
-            "}"
+        val json = """{
+              "accepted_image_configs": {
+                "default_settings": {
+                  "compression_ratio": 0.8,
+                  "image_size": [
+                    1080,
+                    1920
+                  ]
+                },
+                "format_settings": {
+                  "heic": {
+                    "compression_ratio": 0.5
+                  },
+                  "webp": {
+                    "compression_ratio": 0.7
+                    "image_size": [
+                        2160,
+                        1920
+                  ]
+                  }
+                },
+                "preferred_formats": [
+                  "heic",
+                  "webp",
+                  "jpeg"
+                ]
+              },
+              "expected_card": {
+                "last4": "9012",
+                "issuer": "Visa"
+              }
+            }"""
 
         val result = Json.decodeFromString<CardImageVerificationDetailsResult>(json)
         assertNotNull(result.acceptedImageConfigs)


### PR DESCRIPTION
# Summary
Three core pieces to this change:
1) Add code for deserializing JSON from `initialize_client` calls
2) Allow webp compression to be configurable
3) Plumb image configs through to code where image compression is actually done

# Motivation
To reduce the payload size for card scan (https://jira.corp.stripe.com/browse/BOUNCER-963)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screenshots
No visual changes.