### PR TITLE
[camera-core] Fix front camera callback

### DIFF
--- a/camera-core/src/main/java/com/stripe/android/camera/Camera1Adapter.kt
+++ b/camera-core/src/main/java/com/stripe/android/camera/Camera1Adapter.kt
@@ -160,7 +160,13 @@ class Camera1Adapter(
                     CameraPreviewImage(
                         image = NV21Image(imageWidth, imageHeight, bytes)
                             .toBitmap(getRenderScript(activity))
-                            .rotate(mRotation.toFloat()),
+                            .rotate(
+                                if (currentCameraId == Camera.CameraInfo.CAMERA_FACING_BACK) {
+                                    mRotation.toFloat()
+                                } else {
+                                    -mRotation.toFloat()
+                                }
+                            ),
                         viewBounds = Rect(
                             previewView.left,
                             previewView.top,
@@ -405,7 +411,7 @@ class Camera1Adapter(
     private fun setCameraDisplayOrientation(activity: Activity) {
         val camera = mCamera ?: return
         val info = Camera.CameraInfo()
-        Camera.getCameraInfo(Camera.CameraInfo.CAMERA_FACING_BACK, info)
+        Camera.getCameraInfo(currentCameraId, info)
 
         val rotation = activity.windowManager.defaultDisplay.rotation
         val degrees = rotation.rotationToDegrees()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
`Camera1Adapter` sends upside down images when using front face camera. The two changes are made
* Check `CameraInfo` for `currentCameraId` instead of `Camera.CameraInfo.CAMERA_FACING_BACK`
* When currentCameraId is front facing camera, apply the rotate counterclock-wise, this would ensure the image is in the correct orientation

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
fix camera callback

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified - Verified with stripecardscan example app - the `CARDSCANSHEET` was not able to correctly scan a card in front camera, this change fixed it.


# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
