### PR TITLE
[camera-core][cardscan] Move FrameSaver to camera-core

### DIFF
--- a/camera-core/src/main/java/com/stripe/android/camera/framework/util/FrameSaver.kt
+++ b/camera-core/src/main/java/com/stripe/android/camera/framework/util/FrameSaver.kt
@@ -1,6 +1,7 @@
-package com.stripe.android.stripecardscan.framework.util
+package com.stripe.android.camera.framework.util
 
 import androidx.annotation.CheckResult
+import androidx.annotation.RestrictTo
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.util.LinkedList
@@ -8,7 +9,8 @@ import java.util.LinkedList
 /**
  * Save data frames for later retrieval.
  */
-internal abstract class FrameSaver<Identifier, Frame, MetaData> {
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+abstract class FrameSaver<Identifier, Frame, MetaData> {
 
     private val saveFrameMutex = Mutex()
     private val savedFrames = mutableMapOf<Identifier, LinkedList<Frame>>()

--- a/camera-core/src/test/java/com/stripe/android/camera/framework/util/FrameSaverTest.kt
+++ b/camera-core/src/test/java/com/stripe/android/camera/framework/util/FrameSaverTest.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.stripecardscan.framework.util
+package com.stripe.android.camera.framework.util
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/result/MainLoopAggregator.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/result/MainLoopAggregator.kt
@@ -7,7 +7,7 @@ import com.stripe.android.stripecardscan.cardimageverification.SavedFrameType
 import com.stripe.android.stripecardscan.cardimageverification.analyzer.MainLoopAnalyzer
 import com.stripe.android.stripecardscan.cardimageverification.result.MainLoopAggregator.FinalResult
 import com.stripe.android.stripecardscan.cardimageverification.result.MainLoopAggregator.InterimResult
-import com.stripe.android.stripecardscan.framework.util.FrameSaver
+import com.stripe.android.camera.framework.util.FrameSaver
 import com.stripe.android.stripecardscan.payment.card.CardIssuer
 import com.stripe.android.stripecardscan.payment.card.CardMatchResult
 import com.stripe.android.stripecardscan.payment.card.RequiresMatchingCard
@@ -33,8 +33,8 @@ internal class MainLoopAggregator(
         MainLoopAnalyzer.Input,
         MainLoopState,
         MainLoopAnalyzer.Prediction,
-        MainLoopAggregator.InterimResult,
-        MainLoopAggregator.FinalResult
+        InterimResult,
+        FinalResult
         >(
         listener = listener,
         initialState = MainLoopState.Initial(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
`FrameSaver` could be reused to collect a list of selfies taken for Identity

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
code reuse

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
