### PR TITLE
fix flying payment sheet by downgrading material from 1.6 to 1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # CHANGELOG
+## XX.X.X - 2022-05.XX
+
+### PaymentSheet
+* [FIXED][5011](https://github.com/stripe/stripe-android/pull/5011) fix flying payment sheet by downgrading material from 1.6 to 1.5
+
 ## 20.2.2 - 2022-05-09
 This release contains bug fixes in PaymentSheet.
 

--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,9 @@ ext {
     kotlinSerializationVersion = '1.3.3'
     flowlayoutVersion = '0.23.1'
     ktlintVersion = '0.45.2'
-    materialVersion = '1.6.0'
+    // material 1.6 causes paymentsheet to not render correctly.
+    // see here: https://github.com/material-components/material-components-android/issues/2702
+    materialVersion = '1.5.0'
     daggerVersion = '2.41'
     playServicesWalletVersion = '19.1.0'
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* reverts material from 1.6 to 1.5

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
* This change was causing payment sheet to be positioned incorrectly. I think it's fine to downgrade and investigate further, since this would block monday's release. 
* Issue on material here: https://github.com/material-components/material-components-android/issues/2702

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

* I wanted to add a screenshot test for this, but we currently do not have custom flow working for returning users. That might take longer than a day and I don't want to block the release. We should have a test for this in the future since we'll add tests for returning custom flow anyways. 

Before: 



https://user-images.githubusercontent.com/89166418/168394568-71e26642-d6f8-47af-8b6b-c6c883e90a32.mov

After:

https://user-images.githubusercontent.com/89166418/168394548-043da01d-88fe-46be-bd6a-53799059b758.mov







# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
