### PR TITLE
[Identity] Add FaceDetector state machine 

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/camera/IdentityAggregator.kt
+++ b/identity/src/main/java/com/stripe/android/identity/camera/IdentityAggregator.kt
@@ -86,9 +86,9 @@ internal class IdentityAggregator(
             val previousState = state
             state = previousState.consumeTransition(frame, result)
             val interimResult = InterimResult(state)
-            return when (state) {
+            return interimResult to when (state) {
                 is IdentityScanState.Finished -> {
-                    interimResult to FinalResult(
+                    FinalResult(
                         frame,
                         result,
                         state,
@@ -96,7 +96,7 @@ internal class IdentityAggregator(
                     )
                 }
                 is IdentityScanState.TimeOut -> {
-                    interimResult to FinalResult(
+                    FinalResult(
                         frame,
                         result,
                         state,
@@ -104,7 +104,7 @@ internal class IdentityAggregator(
                     )
                 }
                 else -> {
-                    interimResult to null
+                    null
                 }
             }
         } else {

--- a/identity/src/main/java/com/stripe/android/identity/ml/modelIO.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ml/modelIO.kt
@@ -30,7 +30,7 @@ internal data class AnalyzerInput(
 /**
  * Output interface of ML models
  */
-internal interface AnalyzerOutput
+internal sealed interface AnalyzerOutput
 
 /**
  * Output of IDDetector
@@ -40,4 +40,12 @@ internal data class IDDetectorOutput(
     val category: Category,
     val resultScore: Float,
     val allScores: List<Float>
+) : AnalyzerOutput
+
+/**
+ * Output of FaceDetector
+ */
+internal data class FaceDetectorOutput(
+    val boundingBox: BoundingBox,
+    val resultScore: Float
 ) : AnalyzerOutput

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageStaticContentSelfieCapturePage.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageStaticContentSelfieCapturePage.kt
@@ -1,0 +1,21 @@
+package com.stripe.android.identity.networking.models
+
+// TODO(ccen) Generate from schema and populate from network response
+internal data class VerificationPageStaticContentSelfieCapturePage(
+    val autoCaptureTimeout: Int,
+    val filePurpose: String,
+    val numSamples: Int,
+    val sampleInterval: Int,
+    val faceDetectorThreshold: Float,
+    val maxCenteredThresholdX: Float,
+    val maxCenteredThresholdY: Float,
+    val minEdgeThreshold: Float,
+    val minCoverageThreshold: Float,
+    val maxCoverageThreshold: Float,
+    val lowResImageMaxDimension: Int,
+    val lowResImageCompressionQuality: Float,
+    val highResImageMaxDimension: Int,
+    val highResImageCompressionQuality: Float,
+    val highResImageCropPadding: Float,
+    val consentText: String
+)

--- a/identity/src/main/java/com/stripe/android/identity/states/FaceDetectorTransitioner.kt
+++ b/identity/src/main/java/com/stripe/android/identity/states/FaceDetectorTransitioner.kt
@@ -1,0 +1,232 @@
+package com.stripe.android.identity.states
+
+import android.util.Log
+import com.stripe.android.camera.framework.time.Clock
+import com.stripe.android.camera.framework.time.ClockMark
+import com.stripe.android.camera.framework.time.milliseconds
+import com.stripe.android.camera.framework.util.FrameSaver
+import com.stripe.android.identity.ml.AnalyzerInput
+import com.stripe.android.identity.ml.AnalyzerOutput
+import com.stripe.android.identity.ml.BoundingBox
+import com.stripe.android.identity.ml.FaceDetectorOutput
+import com.stripe.android.identity.networking.models.VerificationPageStaticContentSelfieCapturePage
+import com.stripe.android.identity.states.IdentityScanState.Finished
+import com.stripe.android.identity.states.IdentityScanState.Found
+import com.stripe.android.identity.states.IdentityScanState.Initial
+import com.stripe.android.identity.states.IdentityScanState.Satisfied
+import com.stripe.android.identity.states.IdentityScanState.Unsatisfied
+import kotlin.math.abs
+
+/**
+ * [IdentityScanStateTransitioner] for FaceDetector model.
+ *
+ * To transition from [Initial] state -
+ * * Check if it's timeout since the start of the scan.
+ * * Check if a valid face is present, see [isFaceValid] for details. Save the frame and transition to Found if so.
+ * * Otherwise stay in [Initial]
+ *
+ * To transition from [Found] state -
+ * * Check if it's timeout since the start of the scan.
+ * * Wait for an internal between two Found state, if the interval is not reached, keep waiting.
+ * * Check if a valid face is present, save the frame and check if enough frames have been collected
+ *  * If so, transition to Satisfied
+ *  * Otherwise stay in [Found]
+ *
+ * To transition from [Satisfied] state -
+ * * Directly transitions to [Finished]
+ *
+ * Note FaceDetector doesn't have a [Unsatisfied] state.
+ *
+ */
+internal class FaceDetectorTransitioner(
+    private val selfieCapturePage: VerificationPageStaticContentSelfieCapturePage,
+    internal val timeoutAt: ClockMark =
+        Clock.markNow() + selfieCapturePage.autoCaptureTimeout.milliseconds,
+    internal val selfieFrameSaver: SelfieFrameSaver = SelfieFrameSaver()
+) : IdentityScanStateTransitioner {
+    internal val filteredFrames: List<AnalyzerInput>
+        get() {
+            val savedFrames = requireNotNull(selfieFrameSaver.getSavedFrames()[SELFIES]) {
+                "No frames saved"
+            }
+            require(savedFrames.size >= NUM_FILTERED_FRAMES) {
+                "Not enough frames saved, frames saved: ${savedFrames.size}"
+            }
+
+            // return the first, the best(based on resultScore) and the last frame collected
+            return mutableListOf(
+                savedFrames.last.first,
+                requireNotNull(
+                    savedFrames.subList(1, savedFrames.size - 1)
+                        .maxByOrNull { it.second }
+                ) { "Couldn't find best frame" }
+                    .first,
+                savedFrames.first.first
+            )
+        }
+
+    internal class SelfieFrameSaver :
+        FrameSaver<String, Pair<AnalyzerInput, Float>, AnalyzerOutput>() {
+        // Don't limit max number of saved frames, let the transitioner decide when to stop saving
+        // new frames.
+        override fun getMaxSavedFrames(savedFrameIdentifier: String) = Int.MAX_VALUE
+
+        override fun getSaveFrameIdentifier(
+            frame: Pair<AnalyzerInput, Float>,
+            metaData: AnalyzerOutput
+        ) = SELFIES
+
+
+        fun selfieCollected(): Int = getSavedFrames()[SELFIES]?.size ?: 0
+    }
+
+
+    override suspend fun transitionFromInitial(
+        initialState: Initial,
+        analyzerInput: AnalyzerInput,
+        analyzerOutput: AnalyzerOutput
+    ): IdentityScanState {
+        require(analyzerOutput is FaceDetectorOutput) {
+            "Unexpected output type: $analyzerOutput"
+        }
+        selfieFrameSaver.reset()
+        return when {
+            timeoutAt.hasPassed() -> {
+                Log.d(TAG, "Timeout in Initial state: $initialState")
+                IdentityScanState.TimeOut(initialState.type, this)
+            }
+            isFaceValid(analyzerOutput) -> {
+                Log.d(TAG, "Valid face found, transition to Found")
+                selfieFrameSaver.saveFrame(
+                    (analyzerInput to analyzerOutput.resultScore),
+                    analyzerOutput
+                )
+                Found(initialState.type, this)
+            }
+            else -> {
+                Log.d(TAG, "Valid face not found, stay in Initial")
+                initialState
+            }
+        }
+    }
+
+    override suspend fun transitionFromFound(
+        foundState: Found,
+        analyzerInput: AnalyzerInput,
+        analyzerOutput: AnalyzerOutput
+    ): IdentityScanState {
+        require(analyzerOutput is FaceDetectorOutput) {
+            "Unexpected output type: $analyzerOutput"
+        }
+        return when {
+            timeoutAt.hasPassed() -> {
+                Log.d(TAG, "Timeout in Found state: $foundState")
+                IdentityScanState.TimeOut(foundState.type, this)
+            }
+            foundState.reachedStateAt.elapsedSince() < selfieCapturePage.sampleInterval.milliseconds -> {
+                Log.d(
+                    TAG,
+                    "Get a selfie before selfie capture interval, ignored. " +
+                        "Current selfieCollected: ${selfieFrameSaver.selfieCollected()}"
+                )
+                foundState
+            }
+            isFaceValid(analyzerOutput) -> {
+                selfieFrameSaver.saveFrame(
+                    (analyzerInput to analyzerOutput.resultScore),
+                    analyzerOutput
+                )
+                if (selfieFrameSaver.selfieCollected() >= selfieCapturePage.numSamples) {
+                    Log.d(
+                        TAG, "A valid selfie captured, enough selfie " +
+                            "collected(${selfieCapturePage.numSamples}), transitions to Satisfied"
+                    )
+                    Satisfied(foundState.type, this)
+                } else {
+                    Log.d(
+                        TAG,
+                        "A valid selfie captured, need ${selfieCapturePage.numSamples} selfies" +
+                            " but has ${selfieFrameSaver.selfieCollected()}, stays in Found"
+                    )
+                    Found(foundState.type, this)
+                }
+            }
+            else -> {
+                Log.d(
+                    TAG,
+                    "Get an invalid selfie in Found state, stays in Found. " +
+                        "Current selfieCollected: ${selfieFrameSaver.selfieCollected()}"
+                )
+                return Found(foundState.type, this)
+            }
+        }
+    }
+
+    override suspend fun transitionFromSatisfied(
+        satisfiedState: Satisfied,
+        analyzerInput: AnalyzerInput,
+        analyzerOutput: AnalyzerOutput
+    ): IdentityScanState {
+        return Finished(satisfiedState.type, this)
+    }
+
+    override suspend fun transitionFromUnsatisfied(
+        unsatisfiedState: Unsatisfied,
+        analyzerInput: AnalyzerInput,
+        analyzerOutput: AnalyzerOutput
+    ): IdentityScanState {
+        throw IllegalStateException("Unsatisfied state not allowed for FaceDetector.")
+    }
+
+    private fun isFaceValid(analyzerOutput: FaceDetectorOutput) =
+        isFaceCentered(analyzerOutput.boundingBox)
+            && isFaceFocused()
+            && isFaceAwayFromEdges(analyzerOutput.boundingBox)
+            && isFaceCoverageOK(analyzerOutput.boundingBox)
+            && isFaceScoreOverThreshold(analyzerOutput.resultScore)
+
+    /**
+     * Check face is centered by making sure center of face is
+     * within corresponding threshold of center of image in both dimensions.
+     */
+    private fun isFaceCentered(boundingBox: BoundingBox): Boolean {
+        return abs(1 - (boundingBox.top + boundingBox.top + boundingBox.height)) < selfieCapturePage.maxCenteredThresholdY &&
+            abs(1 - (boundingBox.left + boundingBox.left + boundingBox.width)) < selfieCapturePage.maxCenteredThresholdX
+    }
+
+    /**
+     * TODO(ccen) Decide blur detection algorithm
+     */
+    private fun isFaceFocused(): Boolean {
+        return true
+    }
+
+    private fun isFaceAwayFromEdges(boundingBox: BoundingBox): Boolean {
+        selfieCapturePage.minEdgeThreshold.let { edgeThreshold ->
+            return boundingBox.top > edgeThreshold && boundingBox.left > edgeThreshold
+                && (boundingBox.top + boundingBox.height) < (1 - edgeThreshold)
+                && (boundingBox.left + boundingBox.width) < (1 - edgeThreshold)
+        }
+    }
+
+    /**
+     * Check coverage is within range.
+     *
+     * coverage = (area of bounding box)/(area of input image)
+     */
+    private fun isFaceCoverageOK(boundingBox: BoundingBox): Boolean {
+        (boundingBox.width * boundingBox.height).let { coverage ->
+            return coverage < selfieCapturePage.maxCoverageThreshold &&
+                coverage > selfieCapturePage.minCoverageThreshold
+        }
+    }
+
+    private fun isFaceScoreOverThreshold(actualScore: Float) =
+        actualScore > selfieCapturePage.faceDetectorThreshold
+
+    internal companion object {
+        val TAG: String = FaceDetectorTransitioner::class.java.simpleName
+        const val SELFIES = "SELFIES"
+        const val NUM_FILTERED_FRAMES = 3
+    }
+}

--- a/identity/src/main/java/com/stripe/android/identity/states/FaceDetectorTransitioner.kt
+++ b/identity/src/main/java/com/stripe/android/identity/states/FaceDetectorTransitioner.kt
@@ -76,10 +76,8 @@ internal class FaceDetectorTransitioner(
             metaData: AnalyzerOutput
         ) = SELFIES
 
-
         fun selfieCollected(): Int = getSavedFrames()[SELFIES]?.size ?: 0
     }
-
 
     override suspend fun transitionFromInitial(
         initialState: Initial,
@@ -138,7 +136,8 @@ internal class FaceDetectorTransitioner(
                 )
                 if (selfieFrameSaver.selfieCollected() >= selfieCapturePage.numSamples) {
                     Log.d(
-                        TAG, "A valid selfie captured, enough selfie " +
+                        TAG,
+                        "A valid selfie captured, enough selfie " +
                             "collected(${selfieCapturePage.numSamples}), transitions to Satisfied"
                     )
                     Satisfied(foundState.type, this)
@@ -179,11 +178,11 @@ internal class FaceDetectorTransitioner(
     }
 
     private fun isFaceValid(analyzerOutput: FaceDetectorOutput) =
-        isFaceCentered(analyzerOutput.boundingBox)
-            && isFaceFocused()
-            && isFaceAwayFromEdges(analyzerOutput.boundingBox)
-            && isFaceCoverageOK(analyzerOutput.boundingBox)
-            && isFaceScoreOverThreshold(analyzerOutput.resultScore)
+        isFaceCentered(analyzerOutput.boundingBox) &&
+            isFaceFocused() &&
+            isFaceAwayFromEdges(analyzerOutput.boundingBox) &&
+            isFaceCoverageOK(analyzerOutput.boundingBox) &&
+            isFaceScoreOverThreshold(analyzerOutput.resultScore)
 
     /**
      * Check face is centered by making sure center of face is
@@ -203,9 +202,9 @@ internal class FaceDetectorTransitioner(
 
     private fun isFaceAwayFromEdges(boundingBox: BoundingBox): Boolean {
         selfieCapturePage.minEdgeThreshold.let { edgeThreshold ->
-            return boundingBox.top > edgeThreshold && boundingBox.left > edgeThreshold
-                && (boundingBox.top + boundingBox.height) < (1 - edgeThreshold)
-                && (boundingBox.left + boundingBox.width) < (1 - edgeThreshold)
+            return boundingBox.top > edgeThreshold && boundingBox.left > edgeThreshold &&
+                (boundingBox.top + boundingBox.height) < (1 - edgeThreshold) &&
+                (boundingBox.left + boundingBox.width) < (1 - edgeThreshold)
         }
     }
 

--- a/identity/src/main/java/com/stripe/android/identity/states/IDDetectorTransitioner.kt
+++ b/identity/src/main/java/com/stripe/android/identity/states/IDDetectorTransitioner.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.stripe.android.camera.framework.time.Clock
 import com.stripe.android.camera.framework.time.ClockMark
 import com.stripe.android.camera.framework.time.milliseconds
+import com.stripe.android.identity.ml.AnalyzerInput
 import com.stripe.android.identity.ml.AnalyzerOutput
 import com.stripe.android.identity.ml.BoundingBox
 import com.stripe.android.identity.ml.Category
@@ -38,8 +39,9 @@ internal class IDDetectorTransitioner(
 ) : IdentityScanStateTransitioner {
     private var previousBoundingBox: BoundingBox? = null
     private var unmatchedFrame = 0
-    override fun transitionFromInitial(
+    override suspend fun transitionFromInitial(
         initialState: Initial,
+        analyzerInput: AnalyzerInput,
         analyzerOutput: AnalyzerOutput
     ): IdentityScanState {
         require(analyzerOutput is IDDetectorOutput) {
@@ -68,8 +70,9 @@ internal class IDDetectorTransitioner(
         }
     }
 
-    override fun transitionFromFound(
+    override suspend fun transitionFromFound(
         foundState: Found,
+        analyzerInput: AnalyzerInput,
         analyzerOutput: AnalyzerOutput
     ): IdentityScanState {
         require(analyzerOutput is IDDetectorOutput) {
@@ -96,8 +99,9 @@ internal class IDDetectorTransitioner(
         }
     }
 
-    override fun transitionFromSatisfied(
+    override suspend fun transitionFromSatisfied(
         satisfiedState: Satisfied,
+        analyzerInput: AnalyzerInput,
         analyzerOutput: AnalyzerOutput
     ): IdentityScanState {
         return if (satisfiedState.reachedStateAt.elapsedSince() > displaySatisfiedDuration.milliseconds) {
@@ -108,8 +112,9 @@ internal class IDDetectorTransitioner(
         }
     }
 
-    override fun transitionFromUnsatisfied(
+    override suspend fun transitionFromUnsatisfied(
         unsatisfiedState: Unsatisfied,
+        analyzerInput: AnalyzerInput,
         analyzerOutput: AnalyzerOutput
     ): IdentityScanState {
         return when {

--- a/identity/src/main/java/com/stripe/android/identity/states/IdentityScanState.kt
+++ b/identity/src/main/java/com/stripe/android/identity/states/IdentityScanState.kt
@@ -45,7 +45,7 @@ internal sealed class IdentityScanState(
         /**
          * Only transitions to [Found] when ML output type matches scan type
          */
-        override suspend  fun consumeTransition(
+        override suspend fun consumeTransition(
             analyzerInput: AnalyzerInput,
             analyzerOutput: AnalyzerOutput
         ) =
@@ -61,7 +61,7 @@ internal sealed class IdentityScanState(
         transitioner: IdentityScanStateTransitioner,
         internal var reachedStateAt: ClockMark = Clock.markNow()
     ) : IdentityScanState(type, transitioner, false) {
-        override suspend  fun consumeTransition(
+        override suspend fun consumeTransition(
             analyzerInput: AnalyzerInput,
             analyzerOutput: AnalyzerOutput
         ) =
@@ -78,7 +78,7 @@ internal sealed class IdentityScanState(
         transitioner: IdentityScanStateTransitioner,
         val reachedStateAt: ClockMark = Clock.markNow()
     ) : IdentityScanState(type, transitioner, false) {
-        override suspend  fun consumeTransition(
+        override suspend fun consumeTransition(
             analyzerInput: AnalyzerInput,
             analyzerOutput: AnalyzerOutput
         ) =

--- a/identity/src/main/java/com/stripe/android/identity/states/IdentityScanState.kt
+++ b/identity/src/main/java/com/stripe/android/identity/states/IdentityScanState.kt
@@ -3,6 +3,7 @@ package com.stripe.android.identity.states
 import com.stripe.android.camera.framework.time.Clock
 import com.stripe.android.camera.framework.time.ClockMark
 import com.stripe.android.camera.scanui.ScanState
+import com.stripe.android.identity.ml.AnalyzerInput
 import com.stripe.android.identity.ml.AnalyzerOutput
 
 /**
@@ -29,7 +30,8 @@ internal sealed class IdentityScanState(
     /**
      * Transitions to the next state based on model output.
      */
-    internal abstract fun consumeTransition(
+    internal abstract suspend fun consumeTransition(
+        analyzerInput: AnalyzerInput,
         analyzerOutput: AnalyzerOutput
     ): IdentityScanState
 
@@ -43,8 +45,11 @@ internal sealed class IdentityScanState(
         /**
          * Only transitions to [Found] when ML output type matches scan type
          */
-        override fun consumeTransition(analyzerOutput: AnalyzerOutput) =
-            transitioner.transitionFromInitial(this, analyzerOutput)
+        override suspend  fun consumeTransition(
+            analyzerInput: AnalyzerInput,
+            analyzerOutput: AnalyzerOutput
+        ) =
+            transitioner.transitionFromInitial(this, analyzerInput, analyzerOutput)
     }
 
     /**
@@ -56,8 +61,11 @@ internal sealed class IdentityScanState(
         transitioner: IdentityScanStateTransitioner,
         internal var reachedStateAt: ClockMark = Clock.markNow()
     ) : IdentityScanState(type, transitioner, false) {
-        override fun consumeTransition(analyzerOutput: AnalyzerOutput) =
-            transitioner.transitionFromFound(this, analyzerOutput)
+        override suspend  fun consumeTransition(
+            analyzerInput: AnalyzerInput,
+            analyzerOutput: AnalyzerOutput
+        ) =
+            transitioner.transitionFromFound(this, analyzerInput, analyzerOutput)
     }
 
     /**
@@ -70,8 +78,11 @@ internal sealed class IdentityScanState(
         transitioner: IdentityScanStateTransitioner,
         val reachedStateAt: ClockMark = Clock.markNow()
     ) : IdentityScanState(type, transitioner, false) {
-        override fun consumeTransition(analyzerOutput: AnalyzerOutput) =
-            transitioner.transitionFromSatisfied(this, analyzerOutput)
+        override suspend  fun consumeTransition(
+            analyzerInput: AnalyzerInput,
+            analyzerOutput: AnalyzerOutput
+        ) =
+            transitioner.transitionFromSatisfied(this, analyzerInput, analyzerOutput)
     }
 
     /**
@@ -83,9 +94,10 @@ internal sealed class IdentityScanState(
         transitioner: IdentityScanStateTransitioner,
         val reachedStateAt: ClockMark = Clock.markNow(),
     ) : IdentityScanState(type, transitioner, false) {
-
-        override fun consumeTransition(analyzerOutput: AnalyzerOutput) =
-            transitioner.transitionFromUnsatisfied(this, analyzerOutput)
+        override suspend fun consumeTransition(
+            analyzerInput: AnalyzerInput,
+            analyzerOutput: AnalyzerOutput
+        ) = transitioner.transitionFromUnsatisfied(this, analyzerInput, analyzerOutput)
     }
 
     /**
@@ -95,7 +107,10 @@ internal sealed class IdentityScanState(
         type: ScanType,
         transitioner: IdentityScanStateTransitioner
     ) : IdentityScanState(type, transitioner, true) {
-        override fun consumeTransition(analyzerOutput: AnalyzerOutput) = this
+        override suspend fun consumeTransition(
+            analyzerInput: AnalyzerInput,
+            analyzerOutput: AnalyzerOutput
+        ) = this
     }
 
     /**
@@ -105,6 +120,9 @@ internal sealed class IdentityScanState(
         type: ScanType,
         transitioner: IdentityScanStateTransitioner
     ) : IdentityScanState(type, transitioner, true) {
-        override fun consumeTransition(analyzerOutput: AnalyzerOutput) = this
+        override suspend fun consumeTransition(
+            analyzerInput: AnalyzerInput,
+            analyzerOutput: AnalyzerOutput
+        ) = this
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/states/IdentityScanStateTransitioner.kt
+++ b/identity/src/main/java/com/stripe/android/identity/states/IdentityScanStateTransitioner.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.identity.states
 
+import com.stripe.android.identity.ml.AnalyzerInput
 import com.stripe.android.identity.ml.AnalyzerOutput
 import com.stripe.android.identity.states.IdentityScanState.Found
 import com.stripe.android.identity.states.IdentityScanState.Initial
@@ -10,23 +11,27 @@ import com.stripe.android.identity.states.IdentityScanState.Unsatisfied
  * Interface to determine how to transition between [IdentityScanState]s.
  */
 internal interface IdentityScanStateTransitioner {
-    fun transitionFromInitial(
+    suspend fun transitionFromInitial(
         initialState: Initial,
+        analyzerInput: AnalyzerInput,
         analyzerOutput: AnalyzerOutput
     ): IdentityScanState
 
-    fun transitionFromFound(
+    suspend fun transitionFromFound(
         foundState: Found,
+        analyzerInput: AnalyzerInput,
         analyzerOutput: AnalyzerOutput
     ): IdentityScanState
 
-    fun transitionFromSatisfied(
+    suspend fun transitionFromSatisfied(
         satisfiedState: Satisfied,
+        analyzerInput: AnalyzerInput,
         analyzerOutput: AnalyzerOutput
     ): IdentityScanState
 
-    fun transitionFromUnsatisfied(
+    suspend fun transitionFromUnsatisfied(
         unsatisfiedState: Unsatisfied,
+        analyzerInput: AnalyzerInput,
         analyzerOutput: AnalyzerOutput
     ): IdentityScanState
 }

--- a/identity/src/test/java/com/stripe/android/identity/states/FaceDetectorTransitionerTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/states/FaceDetectorTransitionerTest.kt
@@ -31,7 +31,6 @@ internal class FaceDetectorTransitionerTest {
 
     private val mockSelfieFrameSaver = mock<FaceDetectorTransitioner.SelfieFrameSaver>()
 
-
     @Test
     fun `Initial transitions to TimeOut when timeout`() = runBlocking {
         val transitioner =

--- a/identity/src/test/java/com/stripe/android/identity/states/FaceDetectorTransitionerTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/states/FaceDetectorTransitionerTest.kt
@@ -1,0 +1,273 @@
+package com.stripe.android.identity.states
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.camera.framework.time.ClockMark
+import com.stripe.android.camera.framework.time.milliseconds
+import com.stripe.android.identity.ml.AnalyzerInput
+import com.stripe.android.identity.ml.BoundingBox
+import com.stripe.android.identity.ml.FaceDetectorOutput
+import com.stripe.android.identity.networking.models.VerificationPageStaticContentSelfieCapturePage
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.same
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class FaceDetectorTransitionerTest {
+    private val mockNeverTimeoutClockMark = mock<ClockMark>().also {
+        whenever(it.hasPassed()).thenReturn(false)
+    }
+
+    private val mockAlwaysTimeoutClockMark = mock<ClockMark>().also {
+        whenever(it.hasPassed()).thenReturn(true)
+    }
+
+    private val mockReachedStateAt = mock<ClockMark>()
+
+    private val mockSelfieFrameSaver = mock<FaceDetectorTransitioner.SelfieFrameSaver>()
+
+
+    @Test
+    fun `Initial transitions to TimeOut when timeout`() = runBlocking {
+        val transitioner =
+            FaceDetectorTransitioner(SELFIE_CAPTURE_PAGE, timeoutAt = mockAlwaysTimeoutClockMark)
+
+        assertThat(
+            transitioner.transitionFromInitial(
+                IdentityScanState.Initial(
+                    IdentityScanState.ScanType.SELFIE,
+                    transitioner
+                ),
+                mock(),
+                mock<FaceDetectorOutput>()
+            )
+        ).isInstanceOf(IdentityScanState.TimeOut::class.java)
+    }
+
+    @Test
+    fun `Initial transitions to Found when face is valid and frame is saved`() = runBlocking {
+        val transitioner =
+            FaceDetectorTransitioner(
+                SELFIE_CAPTURE_PAGE,
+                timeoutAt = mockNeverTimeoutClockMark,
+                selfieFrameSaver = mockSelfieFrameSaver
+            )
+        val initialState = IdentityScanState.Initial(
+            IdentityScanState.ScanType.SELFIE,
+            transitioner
+        )
+
+        val mockInput = mock<AnalyzerInput>()
+
+        val resultState = transitioner.transitionFromInitial(
+            initialState,
+            mockInput,
+            VALID_OUTPUT
+        )
+
+        verify(mockSelfieFrameSaver).saveFrame(
+            eq((mockInput to VALID_SCORE)),
+            same(VALID_OUTPUT)
+        )
+        assertThat(
+            resultState
+        ).isInstanceOf(IdentityScanState.Found::class.java)
+    }
+
+    @Test
+    fun `Initial stays in Initial when face is invalid`() = runBlocking {
+        val transitioner =
+            FaceDetectorTransitioner(SELFIE_CAPTURE_PAGE, timeoutAt = mockNeverTimeoutClockMark)
+        val initialState = IdentityScanState.Initial(
+            IdentityScanState.ScanType.SELFIE,
+            transitioner
+        )
+
+        val resultState = transitioner.transitionFromInitial(
+            initialState,
+            mock(),
+            INVALID_OUTPUT
+        )
+
+        assertThat(
+            resultState
+        ).isInstanceOf(IdentityScanState.Initial::class.java)
+    }
+
+    @Test
+    fun `Found transitions to TimeOut when timeout`() = runBlocking {
+        val transitioner =
+            FaceDetectorTransitioner(SELFIE_CAPTURE_PAGE, timeoutAt = mockAlwaysTimeoutClockMark)
+
+        assertThat(
+            transitioner.transitionFromFound(
+                IdentityScanState.Found(
+                    IdentityScanState.ScanType.SELFIE,
+                    transitioner
+                ),
+                mock(),
+                mock<FaceDetectorOutput>()
+            )
+        ).isInstanceOf(IdentityScanState.TimeOut::class.java)
+    }
+
+    @Test
+    fun `Found stays in to Found when sample interval not reached`() = runBlocking {
+        val transitioner =
+            FaceDetectorTransitioner(SELFIE_CAPTURE_PAGE, timeoutAt = mockNeverTimeoutClockMark)
+
+        whenever(mockReachedStateAt.elapsedSince()).thenReturn((SAMPLE_INTERVAL - 10).milliseconds)
+
+        val foundState = IdentityScanState.Found(
+            IdentityScanState.ScanType.SELFIE,
+            transitioner,
+            reachedStateAt = mockReachedStateAt
+        )
+
+        assertThat(
+            transitioner.transitionFromFound(
+                foundState,
+                mock(),
+                mock<FaceDetectorOutput>()
+            )
+        ).isSameInstanceAs(foundState)
+    }
+
+    @Test
+    fun `Found stays in to Found when face is valid and not enough selfie collected`() =
+        runBlocking {
+            val transitioner =
+                FaceDetectorTransitioner(
+                    selfieCapturePage = SELFIE_CAPTURE_PAGE,
+                    timeoutAt = mockNeverTimeoutClockMark,
+                    selfieFrameSaver = mockSelfieFrameSaver
+                )
+
+            whenever(mockReachedStateAt.elapsedSince()).thenReturn((SAMPLE_INTERVAL + 10).milliseconds)
+            whenever(mockSelfieFrameSaver.selfieCollected()).thenReturn(NUM_SAMPLES - 1)
+
+            val foundState = IdentityScanState.Found(
+                IdentityScanState.ScanType.SELFIE,
+                transitioner,
+                reachedStateAt = mockReachedStateAt
+            )
+
+            val resultState =
+                transitioner.transitionFromFound(
+                    foundState,
+                    mock(),
+                    VALID_OUTPUT
+                )
+
+            assertThat(resultState).isNotSameInstanceAs(foundState)
+            assertThat(resultState).isInstanceOf(IdentityScanState.Found::class.java)
+        }
+
+    @Test
+    fun `Found transitions to Satisfed when face is valid and enough selfie collected`() =
+        runBlocking {
+            val transitioner =
+                FaceDetectorTransitioner(
+                    selfieCapturePage = SELFIE_CAPTURE_PAGE,
+                    timeoutAt = mockNeverTimeoutClockMark,
+                    selfieFrameSaver = mockSelfieFrameSaver
+                )
+
+            whenever(mockReachedStateAt.elapsedSince()).thenReturn((SAMPLE_INTERVAL + 10).milliseconds)
+            whenever(mockSelfieFrameSaver.selfieCollected()).thenReturn(NUM_SAMPLES)
+
+            assertThat(
+                transitioner.transitionFromFound(
+                    IdentityScanState.Found(
+                        IdentityScanState.ScanType.SELFIE,
+                        transitioner,
+                        reachedStateAt = mockReachedStateAt
+                    ),
+                    mock(),
+                    VALID_OUTPUT
+                )
+            ).isInstanceOf(IdentityScanState.Satisfied::class.java)
+        }
+
+    @Test
+    fun `Found stays in Found when face is invalid`() =
+        runBlocking {
+            val transitioner =
+                FaceDetectorTransitioner(
+                    selfieCapturePage = SELFIE_CAPTURE_PAGE,
+                    timeoutAt = mockNeverTimeoutClockMark,
+                    selfieFrameSaver = mockSelfieFrameSaver
+                )
+
+            whenever(mockReachedStateAt.elapsedSince()).thenReturn((SAMPLE_INTERVAL + 10).milliseconds)
+            whenever(mockSelfieFrameSaver.selfieCollected()).thenReturn(NUM_SAMPLES - 1)
+
+            val foundState = IdentityScanState.Found(
+                IdentityScanState.ScanType.SELFIE,
+                transitioner,
+                reachedStateAt = mockReachedStateAt
+            )
+
+            val resultState =
+                transitioner.transitionFromFound(
+                    foundState,
+                    mock(),
+                    INVALID_OUTPUT
+                )
+
+            assertThat(resultState).isNotSameInstanceAs(foundState)
+            assertThat(resultState).isInstanceOf(IdentityScanState.Found::class.java)
+        }
+
+    private companion object {
+
+        const val SCORE_THRESHOLD = 0.8f
+        const val VALID_SCORE = SCORE_THRESHOLD + 0.1f
+        const val INVALID_SCORE = SCORE_THRESHOLD - 0.1f
+        const val SAMPLE_INTERVAL = 200
+        const val NUM_SAMPLES = 8
+        val SELFIE_CAPTURE_PAGE = VerificationPageStaticContentSelfieCapturePage(
+            autoCaptureTimeout = 15000,
+            filePurpose = "selfie",
+            numSamples = NUM_SAMPLES,
+            sampleInterval = SAMPLE_INTERVAL,
+            faceDetectorThreshold = SCORE_THRESHOLD,
+            maxCenteredThresholdX = 0.2f,
+            maxCenteredThresholdY = 0.2f,
+            minEdgeThreshold = 0.05f,
+            minCoverageThreshold = 0.07f,
+            maxCoverageThreshold = 0.8f,
+            lowResImageMaxDimension = 800,
+            lowResImageCompressionQuality = 0.82f,
+            highResImageMaxDimension = 1440,
+            highResImageCompressionQuality = 0.92f,
+            highResImageCropPadding = 0.5f,
+            consentText = "consent"
+        )
+
+        val VALID_OUTPUT = FaceDetectorOutput(
+            boundingBox = BoundingBox(
+                0.2f,
+                0.2f,
+                0.6f,
+                0.6f
+            ),
+            resultScore = VALID_SCORE
+        )
+
+        val INVALID_OUTPUT = FaceDetectorOutput(
+            boundingBox = BoundingBox(
+                0.2f,
+                0.2f,
+                0.6f,
+                0.6f
+            ),
+            resultScore = INVALID_SCORE
+        )
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Add the state transition logic for FaceDetector in `FaceDetectorTransitioner`
  * Holds a `FrameSaver` inside to save frames and expose them to results
* Change the `IdentityScanState` interface to take both `AnalyzerInput` and `AnalyzerOutput`, this is required `AnalyzerInput` contains the frames that need to be saved in `FrameSaver`
* Added a dataclass `VerificationPageStaticContentSelfieCapturePage`, currently provide dummy values, will get the value from network responses in a follow up. 
# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
implement FaceDetector
# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
