### PR TITLE
Show the privacy link in the scan ui

### DIFF
--- a/stripecardscan/res/values/colors.xml
+++ b/stripecardscan/res/values/colors.xml
@@ -25,6 +25,8 @@
     <color name="stripeCardExpiryOutlineColor" description="The outline color of the card expiry displayed over the scan window">@android:color/black</color>
 
     <color name="stripeInstructionsColorDark" description="The color of the instructions text above the scan window when the background is a dark color">@android:color/white</color>
+    <color name="stripePrivacyLinkColorLight" description="The color of the privacy text below the scan window when the background is a light color">@android:color/darker_gray</color>
+    <color name="stripePrivacyLinkColorDark" description="The color of the privacy text below the scan window when the background is a dark color">#D3D3D3</color>
     <color name="stripeInstructionsColorLight" description="The color of the instructions text above the scan window when the background is a light color">@android:color/black</color>
     <color name="stripeSecurityColorDark" description="The color of the security notification shown below the scan window when the background is a dark color">@android:color/white</color>
     <color name="stripeSecurityColorLight" description="The color of the security notification shown below the scan window when the background is a light color">@android:color/black</color>

--- a/stripecardscan/res/values/dimensions.xml
+++ b/stripecardscan/res/values/dimensions.xml
@@ -35,6 +35,7 @@
     <item name="stripeExpiryStrokeSize" format="float" type="dimen" description="The size of the outline of the expiry text displayed in the middle of the view finder window">2.5</item>
 
     <dimen name="stripeInstructionsTextSize" description="The size of the instructions text above the view finder window">22sp</dimen>
+    <dimen name="stripePrivacyLinkTextSize" description="The size of the privacy link text below the view finder window">14sp</dimen>
     <dimen name="stripeSecurityTextSize" description="The size of the security text below the view finder window">14sp</dimen>
 
     <dimen name="stripeLogoMargin" description="The minimum amount of space surrounding the logo">16dp</dimen>

--- a/stripecardscan/res/values/strings.xml
+++ b/stripecardscan/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="stripe_card_scan_title" description="Text displayed above the scan window for paymentsheet, instructing the user how to scan card">Position your card in the rectangle to scan</string>
     <string name="stripe_card_scan_instructions" description="Text displayed above the scan window, instructing the user how to scan card">Scan Your Card</string>
     <string name="stripe_card_scan_security" description="Security notification displayed below the scan window">Your card info is secure</string>
+    <string name="stripe_card_scan_privacy_link_text" description="Privacy link text in scan window"><![CDATA[We use Stripe to verify your card details. Stripe may use and store your data according its privacy policy. <a style="color: white" href="https://support.stripe.com/questions/stripes-card-image-verification"><u>Learn more</u></a>]]></string>
     <string name="stripe_scanned_wrong_card" description="Text displayed above the scan window when the wrong card is scanned">Card doesn\'t match</string>
 
     <string name="stripe_camera_permission_denied_message" description="Message shown to the user when camera permission is denied">Please allow camera access to scan your card</string>

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/scanui/SimpleScanActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/scanui/SimpleScanActivity.kt
@@ -20,6 +20,7 @@ import com.stripe.android.camera.scanui.ScanFlow
 import com.stripe.android.camera.scanui.ViewFinderBackground
 import com.stripe.android.camera.scanui.util.asRect
 import com.stripe.android.camera.scanui.util.setDrawable
+import com.stripe.android.identity.utils.setHtmlString
 import com.stripe.android.stripecardscan.R
 import com.stripe.android.stripecardscan.scanui.util.getColorByRes
 import com.stripe.android.stripecardscan.scanui.util.getDrawableByRes
@@ -82,6 +83,11 @@ internal abstract class SimpleScanActivity<ScanFlowParameters> : ScanActivity() 
      * The text view used to inform the user that the scanned card is secure.
      */
     protected open val securityTextView: TextView by lazy { TextView(this) }
+
+    /**
+     * The text view used to inform user that Stripe is used to verify card data.
+     */
+    protected open val privacyLinkTextView: TextView by lazy { TextView(this) }
 
     /**
      * The background that draws the user focus to the view finder.
@@ -181,6 +187,7 @@ internal abstract class SimpleScanActivity<ScanFlowParameters> : ScanActivity() 
             swapCameraButtonView,
             cardNameTextView,
             cardNumberTextView,
+            privacyLinkTextView,
         )
     }
 
@@ -202,6 +209,7 @@ internal abstract class SimpleScanActivity<ScanFlowParameters> : ScanActivity() 
         setupInstructionsViewUi()
         setupSecurityNoticeUi()
         setupCardDetailsUi()
+        setupPrivacyLinkTextUi()
     }
 
     protected open fun setupCloseButtonViewUi() {
@@ -331,6 +339,20 @@ internal abstract class SimpleScanActivity<ScanFlowParameters> : ScanActivity() 
         )
     }
 
+    protected open fun setupPrivacyLinkTextUi() {
+        privacyLinkTextView.setHtmlString(getString(R.string.stripe_card_scan_privacy_link_text))
+        privacyLinkTextView.setTextSizeByRes(R.dimen.stripePrivacyLinkTextSize)
+        privacyLinkTextView.gravity = Gravity.CENTER
+
+        var textColor = getColorByRes(R.color.stripePrivacyLinkColorLight)
+        if (isBackgroundDark()) {
+            textColor = getColorByRes(R.color.stripePrivacyLinkColorDark)
+        }
+
+        privacyLinkTextView.setTextColor(textColor)
+        privacyLinkTextView.setLinkTextColor(textColor)
+    }
+
     protected open fun setupUiConstraints() {
         setupPreviewFrameConstraints()
         setupCloseButtonViewConstraints()
@@ -340,6 +362,7 @@ internal abstract class SimpleScanActivity<ScanFlowParameters> : ScanActivity() 
         setupInstructionsViewConstraints()
         setupSecurityNoticeConstraints()
         setupCardDetailsConstraints()
+        setupPrivacyLinkViewConstraints()
     }
 
     protected open fun setupPreviewFrameConstraints() {
@@ -442,6 +465,24 @@ internal abstract class SimpleScanActivity<ScanFlowParameters> : ScanActivity() 
 
         instructionsTextView.addConstraints {
             connect(it.id, ConstraintSet.BOTTOM, viewFinderWindowView.id, ConstraintSet.TOP)
+            connect(it.id, ConstraintSet.START, ConstraintSet.PARENT_ID, ConstraintSet.START)
+            connect(it.id, ConstraintSet.END, ConstraintSet.PARENT_ID, ConstraintSet.END)
+        }
+    }
+
+    protected open fun setupPrivacyLinkViewConstraints() {
+        privacyLinkTextView.layoutParams = ConstraintLayout.LayoutParams(
+            0, // width
+            ViewGroup.LayoutParams.WRAP_CONTENT, // height
+        ).apply {
+            topMargin = resources.getDimensionPixelSize(R.dimen.stripeInstructionsMargin)
+            bottomMargin = resources.getDimensionPixelSize(R.dimen.stripeInstructionsMargin)
+            marginStart = resources.getDimensionPixelSize(R.dimen.stripeInstructionsMargin)
+            marginEnd = resources.getDimensionPixelSize(R.dimen.stripeInstructionsMargin)
+        }
+
+        privacyLinkTextView.addConstraints {
+            connect(it.id, ConstraintSet.TOP, securityTextView.id, ConstraintSet.BOTTOM)
             connect(it.id, ConstraintSet.START, ConstraintSet.PARENT_ID, ConstraintSet.START)
             connect(it.id, ConstraintSet.END, ConstraintSet.PARENT_ID, ConstraintSet.END)
         }

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/scanui/util/TextUtils.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/scanui/util/TextUtils.kt
@@ -1,0 +1,21 @@
+package com.stripe.android.identity.utils
+
+import android.os.Build
+import android.text.Html
+import android.text.Spanned
+import android.text.method.LinkMovementMethod
+import android.widget.TextView
+
+/**
+ * Set a html string to this TextView and make links clickable.
+ */
+internal fun TextView.setHtmlString(htmlString: String) {
+    var spannedText: Spanned? = null
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        spannedText = Html.fromHtml(htmlString, Html.FROM_HTML_MODE_LEGACY)
+    } else {
+        spannedText = Html.fromHtml(htmlString)
+    }
+    this.text = spannedText
+    this.movementMethod = LinkMovementMethod.getInstance()
+}


### PR DESCRIPTION
# Summary
Changed the scan card UI to show a privacy policy string and link to the Stripe website

# Motivation
To comply with privacy policies, we need to allow the user to understand how their data is used.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

# Screenshots
WIP
