### PR TITLE
Fix missing translations for card information

### DIFF
--- a/payments-ui-core/res/values-b+es+419/strings.xml
+++ b/payments-ui-core/res/values-b+es+419/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Continuar</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Pagar %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Información de la tarjeta</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Configurar</string>
 </resources>

--- a/payments-ui-core/res/values-ca-rES/strings.xml
+++ b/payments-ui-core/res/values-ca-rES/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Continua</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Pagar %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Informació de targeta</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Configuració</string>
 </resources>

--- a/payments-ui-core/res/values-cs-rCZ/strings.xml
+++ b/payments-ui-core/res/values-cs-rCZ/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Pokračovat</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Zaplatit %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Informace o kartě</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Nastavit</string>
 </resources>

--- a/payments-ui-core/res/values-da/strings.xml
+++ b/payments-ui-core/res/values-da/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Fortsæt</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Betal %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Kortoplysninger</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Opsætning</string>
 </resources>

--- a/payments-ui-core/res/values-de/strings.xml
+++ b/payments-ui-core/res/values-de/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Weiter</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">%s zahlen</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Kartendaten</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Einrichten</string>
 </resources>

--- a/payments-ui-core/res/values-el-rGR/strings.xml
+++ b/payments-ui-core/res/values-el-rGR/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Συνέχεια</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Πληρωμή %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Στοιχεία κάρτας</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Διαμόρφωση</string>
 </resources>

--- a/payments-ui-core/res/values-en-rGB/strings.xml
+++ b/payments-ui-core/res/values-en-rGB/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Continue</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Pay %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Card information</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Set up</string>
 </resources>

--- a/payments-ui-core/res/values-es/strings.xml
+++ b/payments-ui-core/res/values-es/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Continuar</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Pagar %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Información de la tarjeta</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Configurar</string>
 </resources>

--- a/payments-ui-core/res/values-et-rEE/strings.xml
+++ b/payments-ui-core/res/values-et-rEE/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Jätka</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Maksa %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Kaardi andmed</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Seadista</string>
 </resources>

--- a/payments-ui-core/res/values-fi/strings.xml
+++ b/payments-ui-core/res/values-fi/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Jatka</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Maksa %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Kortin tiedot</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Määritä</string>
 </resources>

--- a/payments-ui-core/res/values-fil/strings.xml
+++ b/payments-ui-core/res/values-fil/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Magpatuloy</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Magbayad ng %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Impormasyon ng kard</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">I-set up</string>
 </resources>

--- a/payments-ui-core/res/values-fr-rCA/strings.xml
+++ b/payments-ui-core/res/values-fr-rCA/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Continuer</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Payer %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Informations de la carte</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Configurer</string>
 </resources>

--- a/payments-ui-core/res/values-fr/strings.xml
+++ b/payments-ui-core/res/values-fr/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Continuer</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Payer %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Informations concernant la carte bancaire</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Configurer</string>
 </resources>

--- a/payments-ui-core/res/values-hr/strings.xml
+++ b/payments-ui-core/res/values-hr/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Nastavi</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Plati %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Informacije o kartici</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Postavi</string>
 </resources>

--- a/payments-ui-core/res/values-hu/strings.xml
+++ b/payments-ui-core/res/values-hu/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Folytatás</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">%s kifizetése</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Kártyaadatok</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Beállítás</string>
 </resources>

--- a/payments-ui-core/res/values-in/strings.xml
+++ b/payments-ui-core/res/values-in/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Lanjutkan</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Bayar %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Informasi kartu</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Siapkan</string>
 </resources>

--- a/payments-ui-core/res/values-it/strings.xml
+++ b/payments-ui-core/res/values-it/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Continua</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Paga %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Dati della carta</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Imposta</string>
 </resources>

--- a/payments-ui-core/res/values-ja/strings.xml
+++ b/payments-ui-core/res/values-ja/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">続ける</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">%s を支払う</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">カード情報</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">設定</string>
 </resources>

--- a/payments-ui-core/res/values-ko/strings.xml
+++ b/payments-ui-core/res/values-ko/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">계속</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">%s 결제</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">카드 정보</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">설정</string>
 </resources>

--- a/payments-ui-core/res/values-lt-rLT/strings.xml
+++ b/payments-ui-core/res/values-lt-rLT/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Tęsti</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Mokėti %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Kortelės duomenys</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Nustatyti</string>
 </resources>

--- a/payments-ui-core/res/values-lv-rLV/strings.xml
+++ b/payments-ui-core/res/values-lv-rLV/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Turpināt</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Maksāt %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Kartes informācija</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Iestatīt</string>
 </resources>

--- a/payments-ui-core/res/values-ms-rMY/strings.xml
+++ b/payments-ui-core/res/values-ms-rMY/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Teruskan</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Bayar %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Maklumat kad</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Sediakan</string>
 </resources>

--- a/payments-ui-core/res/values-mt/strings.xml
+++ b/payments-ui-core/res/values-mt/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Kompli</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Ħallas %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">L-informazzjoni tal-kard</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Stabilixxi</string>
 </resources>

--- a/payments-ui-core/res/values-nb/strings.xml
+++ b/payments-ui-core/res/values-nb/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Fortsett</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Betal %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Kortinformasjon</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Konfigurer</string>
 </resources>

--- a/payments-ui-core/res/values-nl/strings.xml
+++ b/payments-ui-core/res/values-nl/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Doorgaan</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">%s betalen</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Kaartgegevens</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Instellen</string>
 </resources>

--- a/payments-ui-core/res/values-nn-rNO/strings.xml
+++ b/payments-ui-core/res/values-nn-rNO/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Fortsett</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Betal %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Kortinformasjon</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Opprett</string>
 </resources>

--- a/payments-ui-core/res/values-pl-rPL/strings.xml
+++ b/payments-ui-core/res/values-pl-rPL/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Kontynuuj</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Zapłać %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Dane karty</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Ustaw</string>
 </resources>

--- a/payments-ui-core/res/values-pt-rBR/strings.xml
+++ b/payments-ui-core/res/values-pt-rBR/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Continuar</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Pagar %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Dados do cartão</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Configurar</string>
 </resources>

--- a/payments-ui-core/res/values-pt-rPT/strings.xml
+++ b/payments-ui-core/res/values-pt-rPT/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Continuar</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Pagar %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Informações do cartão</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Configurar</string>
 </resources>

--- a/payments-ui-core/res/values-ro-rRO/strings.xml
+++ b/payments-ui-core/res/values-ro-rRO/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Continuare</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Plătiți %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Informații privind cardul</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Configurare</string>
 </resources>

--- a/payments-ui-core/res/values-ru/strings.xml
+++ b/payments-ui-core/res/values-ru/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Продолжить</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Оплатить %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Данные платежной карты</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Настроить</string>
 </resources>

--- a/payments-ui-core/res/values-sk-rSK/strings.xml
+++ b/payments-ui-core/res/values-sk-rSK/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Pokračovať</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Zaplatiť %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Informácie o karte</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Nastaviť</string>
 </resources>

--- a/payments-ui-core/res/values-sl-rSI/strings.xml
+++ b/payments-ui-core/res/values-sl-rSI/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Nadaljuj</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Plačaj %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Podatki o kartici</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Nastavi</string>
 </resources>

--- a/payments-ui-core/res/values-sv/strings.xml
+++ b/payments-ui-core/res/values-sv/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Fortsätt</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Betala %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Kortinformation</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Konfigurera</string>
 </resources>

--- a/payments-ui-core/res/values-th/strings.xml
+++ b/payments-ui-core/res/values-th/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">ดำเนินการต่อ</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">ชำระ %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">ข้อมูลบัตร</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">ตั้งค่า</string>
 </resources>

--- a/payments-ui-core/res/values-tr/strings.xml
+++ b/payments-ui-core/res/values-tr/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Devam et</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">%s öde</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Kart bilgileri</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Ayarla</string>
 </resources>

--- a/payments-ui-core/res/values-vi/strings.xml
+++ b/payments-ui-core/res/values-vi/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Tiếp tục</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Thanh toán %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Thông tin thẻ</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Cài đặt</string>
 </resources>

--- a/payments-ui-core/res/values-zh-rHK/strings.xml
+++ b/payments-ui-core/res/values-zh-rHK/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">繼續</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">支付%s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">銀行卡資訊</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">設置</string>
 </resources>

--- a/payments-ui-core/res/values-zh-rTW/strings.xml
+++ b/payments-ui-core/res/values-zh-rTW/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">繼續</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">支付 %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">金融卡資訊</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">設定</string>
 </resources>

--- a/payments-ui-core/res/values-zh/strings.xml
+++ b/payments-ui-core/res/values-zh/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">继续</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">支付%s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">银行卡信息</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">设置</string>
 </resources>

--- a/payments-ui-core/res/values/strings.xml
+++ b/payments-ui-core/res/values/strings.xml
@@ -78,6 +78,8 @@
   <string name="stripe_continue_button_label">Continue</string>
   <!-- Label of a button that initiates payment when tapped -->
   <string name="stripe_pay_button_amount">Pay %s</string>
+  <!-- Card details entry form header title -->
+  <string name="stripe_paymentsheet_add_payment_method_card_information">Card information</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Set up</string>
 </resources>

--- a/payments-ui-core/res/values/totranslate.xml
+++ b/payments-ui-core/res/values/totranslate.xml
@@ -3,9 +3,6 @@
     <!--
     Items here need to be entered in our translation tool
     -->
-    <!-- Card details section title for card form entry -->
-    <string name="card_information" tools:ignore="ExtraTranslation">Card information</string>
-
     <!-- ACHv2 -->
     <string name="stripe_paymentsheet_ach_something_went_wrong">Something went wrong when linking your account.\nPlease try again later.</string>
     <string name="stripe_paymentsheet_pay_with_bank_title">Pay with your bank account in just a few steps.</string>

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUI.kt
@@ -30,7 +30,7 @@ fun CardDetailsSectionElementUI(
             .fillMaxWidth()
     ) {
         H6Text(
-            text = stringResource(R.string.card_information),
+            text = stringResource(R.string.stripe_paymentsheet_add_payment_method_card_information),
             modifier = Modifier
                 .semantics(mergeDescendants = true) { // Need to prevent form as focusable accessibility
                     heading()

--- a/paymentsheet/res/values-b+es+419/strings.xml
+++ b/paymentsheet/res/values-b+es+419/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Al guardar tu cuenta bancaria para %s, aceptas autorizar pagos conforme a estas <terms>condiciones</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">Agregar otro</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Información de la tarjeta</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">País o región</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-ca-rES/strings.xml
+++ b/paymentsheet/res/values-ca-rES/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[En desar el compte bancari per a %s, accepteu l\'autorització de pagaments d\'acord amb <terms>aquests termes</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Afegir</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Informació de targeta</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">País o regió</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-cs-rCZ/strings.xml
+++ b/paymentsheet/res/values-cs-rCZ/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Uložením bankovního účtu pro společnost %s souhlasíte s autorizací plateb podle <terms>těchto podmínek</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Přidat</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Informace o kartě</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Země nebo region</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-da/strings.xml
+++ b/paymentsheet/res/values-da/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Ved at gemme din bankkonto for %s accepterer du at godkende betalinger i henhold til <terms>disse vilkår</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Tilføj</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Kortoplysninger</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Land eller region</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-de/strings.xml
+++ b/paymentsheet/res/values-de/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Indem Sie Ihr Bankkonto für %s speichern, akzeptieren Sie die Autorisierung von Zahlungen gemäß <terms>diesen Bedingungen</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Hinzufügen</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Kartendaten</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Land oder Region</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-el-rGR/strings.xml
+++ b/paymentsheet/res/values-el-rGR/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Αποθηκεύοντας τον τραπεζικό λογαριασμό σας για την %s, συμφωνείτε να εξουσιοδοτείτε πληρωμές σύμφωνα με <terms>αυτούς τους όρους</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Προσθήκη</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Στοιχεία κάρτας</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Χώρα ή περιοχή</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-en-rGB/strings.xml
+++ b/paymentsheet/res/values-en-rGB/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[By saving your bank account for %s you agree to authorize payments pursuant to <terms>these terms</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Add</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Card information</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Country or region</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-es/strings.xml
+++ b/paymentsheet/res/values-es/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Al guardar tu cuenta bancaria para %s, aceptas autorizar pagos con arreglo a <terms> estas condiciones</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Añadir más datos</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Información de la tarjeta</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">País o región</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-et-rEE/strings.xml
+++ b/paymentsheet/res/values-et-rEE/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Salvestades oma pangakonto %s, nõustute maksete autoriseerimisega vastavalt nendele <terms>tingimustele</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ lisa</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Kaardi andmed</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Riik või regioon</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-fi/strings.xml
+++ b/paymentsheet/res/values-fi/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Tallentamalla pankkitilisi yritykselle %s, hyväksyt maksujen valtuutuksen <terms>näiden ehtojen mukaisesti</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Lisää</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Kortin tiedot</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Maa tai alue</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-fil/strings.xml
+++ b/paymentsheet/res/values-fil/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Sa pag-save ng iyong account sa bangko para sa %s sumasang-ayon ka na pahintulutan ang mga pagbabayad alinsunod sa <terms>mga tuntuning ito</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+Magdagdag</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Impormasyon ng kard</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Bansa o rehiyon</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-fr-rCA/strings.xml
+++ b/paymentsheet/res/values-fr-rCA/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[En enregistrant votre compte bancaire pour %s, vous autorisez les paiements conformément à <terms>ces conditions</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Ajouter</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Informations de la carte</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Pays ou région</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-fr/strings.xml
+++ b/paymentsheet/res/values-fr/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[En enregistrant votre compte bancaire pour %s, vous autorisez les paiements conformément à <terms>ces conditions</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Ajouter</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Informations concernant la carte bancaire</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Pays ou région</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-hr/strings.xml
+++ b/paymentsheet/res/values-hr/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Spremanjem bankovnog računa za %s pristajete na autorizaciju plaćanja u skladu s <terms>ovim uvjetima</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Dodaj</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Informacije o kartici</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Zemlja ili regija</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-hu/strings.xml
+++ b/paymentsheet/res/values-hu/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Azzal, hogy elmenti a bankszámlát a(z) %s számára, beleegyezik a kifizetések engedélyezésébe ezen <terms>feltételek</terms> szerint.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Hozzáadás</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Kártyaadatok</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Ország vagy régió</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-in/strings.xml
+++ b/paymentsheet/res/values-in/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Dengan menyimpan rekening bank Anda untuk %s, Anda berarti setuju untuk mengotorisasi pembayaran sesuai dengan <terms>ketentuan-ketentuan berikut</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Tambahkan</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Informasi kartu</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Negara atau wilayah</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-it/strings.xml
+++ b/paymentsheet/res/values-it/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Salvando il tuo conto bancario per %s, accetti di autorizzare i pagamenti conformemente a <terms>questi termini</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Aggiungi</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Dati della carta</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Paese o area geografica</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-ja/strings.xml
+++ b/paymentsheet/res/values-ja/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[%s の銀行口座を保存すると、<terms>これらの規約</terms>に従って支払いをオーソリすることに同意したものと見なされます。]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ 追加</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">カード情報</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">国または地域</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-ko/strings.xml
+++ b/paymentsheet/res/values-ko/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[%s에 대해 귀하의 은행 계좌를 저장하면 <terms>해당 약관</terms>에 따라 결제를 승인하는 데 동의하는 것입니다.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ 추가</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">카드 정보</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">국가 또는 지역</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-lt-rLT/strings.xml
+++ b/paymentsheet/res/values-lt-rLT/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Išsaugodami savo banko sąskaitą %s, sutinkate autorizuoti mokėjimus pagal šias <terms>sąlygas</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Pridėti</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Kortelės duomenys</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Šalis arba regionas</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-lv-rLV/strings.xml
+++ b/paymentsheet/res/values-lv-rLV/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Saglabājot savu bankas kontu %s, jūs piekrītat apstiprināt maksājumus saskaņā ar <terms>šiem noteikumiem</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Pievienot</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Kartes informācija</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Valsts vai reģions</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-ms-rMY/strings.xml
+++ b/paymentsheet/res/values-ms-rMY/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Dengan menyimpan akaun bank anda untuk %s, anda bersetuju untuk mengizinkan pembayaran menurut <terms>terma ini</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Tambah</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Maklumat kad</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Negara atau rantau</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-mt/strings.xml
+++ b/paymentsheet/res/values-mt/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Meta tissejvja l-kont tal-bank tiegħek għal %s tkun qed taqbel li tawtorizza l-pagamenti skont <terms>dar-regoli</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Żid</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">L-informazzjoni tal-kard</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Pajjiż jew reġjun</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-nb/strings.xml
+++ b/paymentsheet/res/values-nb/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Ved å lagre bankkontoen for %s godtar du å autorisere betalinger i samsvar med <terms>disse vilkårene</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Legg til</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Kortinformasjon</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Land eller region</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-nl/strings.xml
+++ b/paymentsheet/res/values-nl/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Als je je bankrekening voor %s opslaat, ga je ermee akkoord betalingen in overeenstemming met <terms>deze voorwaarden</terms> te autoriseren.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Toevoegen</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Kaartgegevens</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Land of regio</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-nn-rNO/strings.xml
+++ b/paymentsheet/res/values-nn-rNO/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Ved å lagre bankkontoen din for %s godtek du å autorisere betalingar i samsvar med desse <terms>vilkåra</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Legg til</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Kortinformasjon</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Land eller region</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-pl-rPL/strings.xml
+++ b/paymentsheet/res/values-pl-rPL/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Zapisując swoje konto bankowe dla %s, zgadzasz się na autoryzowanie płatności zgodnie z <terms>tymi warunkami</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Dodaj</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Dane karty</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Kraj lub region</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-pt-rBR/strings.xml
+++ b/paymentsheet/res/values-pt-rBR/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Ao salvar sua conta bancária para %s, você autoriza pagamentos de acordo com <terms>estes termos</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Adicionar</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Dados do cartão</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">País ou região</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-pt-rPT/strings.xml
+++ b/paymentsheet/res/values-pt-rPT/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Ao guardar a sua conta bancária para %s, concorda em autorizar pagamentos de acordo com <terms>estas condições</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Adicionar</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Informações do cartão</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">País ou região</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-ro-rRO/strings.xml
+++ b/paymentsheet/res/values-ro-rRO/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Prin salvarea contului dvs. bancar pentru %s sunteți de acord să autorizați plățile în conformitate cu <terms>acești termeni</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Adăugare</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Informații privind cardul</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Țară sau regiune</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-ru/strings.xml
+++ b/paymentsheet/res/values-ru/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Сохраняя реквизиты своего банковского счета у %s, вы соглашаетесь авторизовать платежи в соответствии с <terms>этими условиями</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Добавить</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Данные платежной карты</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Страна или регион</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-sk-rSK/strings.xml
+++ b/paymentsheet/res/values-sk-rSK/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Uložením bankového účtu pre spoločnosť %s súhlasíte s autorizáciou platieb podľa <terms>týchto podmienok</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Pridať</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Informácie o karte</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Krajina alebo región</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-sl-rSI/strings.xml
+++ b/paymentsheet/res/values-sl-rSI/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Če shranite bančni račun za %s, se strinjate z odobritvijo plačil v skladu s <terms>temi pogoji</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Dodaj</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Podatki o kartici</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Država ali regija</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-sv/strings.xml
+++ b/paymentsheet/res/values-sv/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Genom att spara ditt bankkonto för %s samtycker du till att godkänna betalningar i enlighet med <terms>dessa villkor</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Lägg till</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Kortinformation</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Land eller region</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-th/strings.xml
+++ b/paymentsheet/res/values-th/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[การบันทึกบัญชีธนาคารของ %s หมายความว่าคุณตกลงที่จะอนุมัติการชำระเงินซึ่งดำเนินการตาม<terms>ข้อกำหนดเหล่านี้</terms>]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ เพิ่ม</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">ข้อมูลบัตร</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">ประเทศหรือภูมิภาค</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-tr/strings.xml
+++ b/paymentsheet/res/values-tr/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[%s için banka hesabınızı kaydettiğinizde ödemeleri <terms>bu koşullara</terms> göre yetkilendirmeyi kabul etmiş olursunuz.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Ekle</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Kart bilgileri</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Ülke veya bölge</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-vi/strings.xml
+++ b/paymentsheet/res/values-vi/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[Bằng việc lưu tài khoản ngân hàng của bạn cho %s bạn đồng ý cho phép thanh toán tuân theo <terms>các điều khoản này</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Thêm</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Thông tin thẻ</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Quốc gia hoặc khu vực</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-zh-rHK/strings.xml
+++ b/paymentsheet/res/values-zh-rHK/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[保存您的 %s 銀行帳戶即表示您同意按照<terms>這些條款</terms>授權付款。]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ 添加</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">銀行卡資訊</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">國家或地區</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-zh-rTW/strings.xml
+++ b/paymentsheet/res/values-zh-rTW/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[保存您的 %s 銀行帳戶即表示您同意按照<terms>這些條款</terms>授權付款。]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ 添加</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">金融卡資訊</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">國家或地區</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values-zh/strings.xml
+++ b/paymentsheet/res/values-zh/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[保存您的 %s 银行账户即表示您同意按照<terms>这些条款</terms>授权付款。]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ 添加</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">银行卡信息</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">国家或地区</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -23,8 +23,6 @@
   <string name="stripe_paymentsheet_ach_save_mandate"><![CDATA[By saving your bank account for %s you agree to authorize payments pursuant to <terms>these terms</terms>.]]></string>
   <!-- Text for a button that, when tapped, displays another screen where the customer can add payment method details -->
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Add</string>
-  <!-- Card details entry form header title -->
-  <string name="stripe_paymentsheet_add_payment_method_card_information">Card information</string>
   <!-- Country selector and postal code entry form header title -->
   <string name="stripe_paymentsheet_add_payment_method_country_or_region">Country or region</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Fix an issue with missing translations for "Card information" in the add payment details screen.

Fixes: https://github.com/stripe/stripe-android/issues/5014

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

<img src="https://user-images.githubusercontent.com/99316447/168699407-55ee52c2-7cfc-490e-b8d7-cd42fcf3e73d.png" height=400 />

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
- [Fixed] "Card information" is now translated in the add payment information screen
