### PR TITLE
[Identity] Add data classes for seflie network response

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/camera/IdentityAggregator.kt
+++ b/identity/src/main/java/com/stripe/android/identity/camera/IdentityAggregator.kt
@@ -8,6 +8,7 @@ import com.stripe.android.identity.ml.AnalyzerInput
 import com.stripe.android.identity.ml.AnalyzerOutput
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentSelfieCapturePage
+import com.stripe.android.identity.networking.models.VerificationPageStaticContentSelfieModels
 import com.stripe.android.identity.states.FaceDetectorTransitioner
 import com.stripe.android.identity.states.IDDetectorTransitioner
 import com.stripe.android.identity.states.IdentityScanState
@@ -42,7 +43,11 @@ internal class IdentityAggregator(
                     filePurpose = "selfie",
                     numSamples = 8,
                     sampleInterval = 200,
-                    faceDetectorThreshold = 0.8f,
+                    models = VerificationPageStaticContentSelfieModels(
+                        faceDetectorUrl = "",
+                        faceDetectorMinScore = 0.8f,
+                        faceDetectorIou = 0.5f
+                    ),
                     maxCenteredThresholdX = 0.2f,
                     maxCenteredThresholdY = 0.2f,
                     minEdgeThreshold = 0.05f,

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/ClearDataParam.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/ClearDataParam.kt
@@ -14,7 +14,12 @@ internal data class ClearDataParam(
     @SerialName("id_document_front")
     val idDocumentFront: Boolean = false,
     @SerialName("id_document_back")
-    val idDocumentBack: Boolean = false
+    val idDocumentBack: Boolean = false,
+    // TODO(IDPROD-3944) - verify with server change
+    @SerialName("face")
+    val face: Boolean? = null,
+    @SerialName("training_consent")
+    val trainingConsent: Boolean? = null,
 ) {
     internal companion object {
         private const val CLEAR_DATA_PARAM = "clear_data"

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/CollectedDataParam.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/CollectedDataParam.kt
@@ -16,7 +16,12 @@ internal data class CollectedDataParam(
     @SerialName("id_document_front")
     val idDocumentFront: DocumentUploadParam? = null,
     @SerialName("id_document_back")
-    val idDocumentBack: DocumentUploadParam? = null
+    val idDocumentBack: DocumentUploadParam? = null,
+    // TODO(IDPROD-3944) - verify with server change
+    @SerialName("training_consent")
+    val trainingConsent: Boolean? = null,
+    @SerialName("face")
+    val face: FaceUploadParam? = null
 ) {
     @Serializable
     internal enum class Type {
@@ -108,5 +113,9 @@ internal data class CollectedDataParam(
                     ),
                     idDocumentType = type
                 )
+
+        fun createForSelfie(): CollectedDataParam {
+            return CollectedDataParam(true)
+        }
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/FaceUploadParam.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/FaceUploadParam.kt
@@ -1,0 +1,27 @@
+package com.stripe.android.identity.networking.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// TODO(IDPROD-3944) - verify with server change
+@Serializable
+internal data class FaceUploadParam(
+    @SerialName("best_high_res_image")
+    val bestHighResImage: String? = null,
+    @SerialName("best_low_res_image")
+    val bestLowResImage: String? = null,
+    @SerialName("first_high_res_image")
+    val firstHighResImage: String? = null,
+    @SerialName("first_low_res_image")
+    val firstLowResImage: String? = null,
+    @SerialName("last_high_res_image")
+    val lastHighResImage: String? = null,
+    @SerialName("last_low_res_image")
+    val lastLowResImage: String? = null,
+    @SerialName("face_score_variance")
+    val faceScoreVariance: Float? = null,
+    @SerialName("num_frames")
+    val numFrames: Int? = null,
+    @SerialName("focal_length")
+    val focalLength: Float? = null,
+)

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPage.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPage.kt
@@ -14,6 +14,8 @@ internal data class VerificationPage(
     val documentCapture: VerificationPageStaticContentDocumentCapturePage,
     @SerialName("document_select")
     val documentSelect: VerificationPageStaticContentDocumentSelectPage,
+    @SerialName("selfie") // TODO(IDPROD-3944) Verifi with server change
+    val selfieCapture: VerificationPageStaticContentSelfieCapturePage? = null,
     /* The short-lived URL that can be used in the case that the client cannot support the VerificationSession. */
     @SerialName("fallback_url")
     val fallbackUrl: String,

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageRequirements.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageRequirements.kt
@@ -20,6 +20,13 @@ internal data class VerificationPageRequirements(
         IDDOCUMENTFRONT,
 
         @SerialName("id_document_type")
-        IDDOCUMENTTYPE
+        IDDOCUMENTTYPE,
+
+        // TODO(IDPROD-3944) - verify with server change
+        @SerialName("face")
+        FACE,
+
+        @SerialName("training_consent")
+        TRAININGCONSENT
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageStaticContentSelfieCapturePage.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageStaticContentSelfieCapturePage.kt
@@ -1,21 +1,41 @@
 package com.stripe.android.identity.networking.models
 
-// TODO(ccen) Generate from schema and populate from network response
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// TODO(IDPROD-3944) - verify with server change
+@Serializable
 internal data class VerificationPageStaticContentSelfieCapturePage(
+    @SerialName("autocapture_timeout")
     val autoCaptureTimeout: Int,
+    @SerialName("file_purpose")
     val filePurpose: String,
+    @SerialName("num_samples")
     val numSamples: Int,
+    @SerialName("sample_interval")
     val sampleInterval: Int,
-    val faceDetectorThreshold: Float,
+    @SerialName("models")
+    val models: VerificationPageStaticContentSelfieModels,
+    @SerialName("max_centered_threshold_x")
     val maxCenteredThresholdX: Float,
+    @SerialName("max_centered_threshold_y")
     val maxCenteredThresholdY: Float,
+    @SerialName("min_edge_threshold")
     val minEdgeThreshold: Float,
+    @SerialName("min_coverage_threshold")
     val minCoverageThreshold: Float,
+    @SerialName("max_coverage_threshold")
     val maxCoverageThreshold: Float,
+    @SerialName("low_res_image_max_dimension")
     val lowResImageMaxDimension: Int,
+    @SerialName("low_res_image_compression_quality")
     val lowResImageCompressionQuality: Float,
+    @SerialName("high_res_image_max_dimension")
     val highResImageMaxDimension: Int,
+    @SerialName("high_res_image_compression_quality")
     val highResImageCompressionQuality: Float,
+    @SerialName("high_res_image_crop_padding")
     val highResImageCropPadding: Float,
+    @SerialName("consent_text")
     val consentText: String
 )

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageStaticContentSelfieModels.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageStaticContentSelfieModels.kt
@@ -1,0 +1,15 @@
+package com.stripe.android.identity.networking.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// TODO(IDPROD-3944) - verify with server change
+@Serializable
+internal data class VerificationPageStaticContentSelfieModels(
+    @SerialName("face_detector_url")
+    val faceDetectorUrl: String,
+    @SerialName("face_detector_min_score")
+    val faceDetectorMinScore: Float,
+    @SerialName("face_detector_iou")
+    val faceDetectorIou: Float
+)

--- a/identity/src/main/java/com/stripe/android/identity/states/FaceDetectorTransitioner.kt
+++ b/identity/src/main/java/com/stripe/android/identity/states/FaceDetectorTransitioner.kt
@@ -221,7 +221,7 @@ internal class FaceDetectorTransitioner(
     }
 
     private fun isFaceScoreOverThreshold(actualScore: Float) =
-        actualScore > selfieCapturePage.faceDetectorThreshold
+        actualScore > selfieCapturePage.models.faceDetectorMinScore
 
     internal companion object {
         val TAG: String = FaceDetectorTransitioner::class.java.simpleName

--- a/identity/src/test/java/com/stripe/android/identity/states/FaceDetectorTransitionerTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/states/FaceDetectorTransitionerTest.kt
@@ -7,6 +7,7 @@ import com.stripe.android.identity.ml.AnalyzerInput
 import com.stripe.android.identity.ml.BoundingBox
 import com.stripe.android.identity.ml.FaceDetectorOutput
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentSelfieCapturePage
+import com.stripe.android.identity.networking.models.VerificationPageStaticContentSelfieModels
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -235,7 +236,11 @@ internal class FaceDetectorTransitionerTest {
             filePurpose = "selfie",
             numSamples = NUM_SAMPLES,
             sampleInterval = SAMPLE_INTERVAL,
-            faceDetectorThreshold = SCORE_THRESHOLD,
+            models = VerificationPageStaticContentSelfieModels(
+                faceDetectorUrl = "",
+                faceDetectorMinScore = SCORE_THRESHOLD,
+                faceDetectorIou = 0.5f
+            ),
             maxCenteredThresholdX = 0.2f,
             maxCenteredThresholdY = 0.2f,
             minEdgeThreshold = 0.05f,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add required network data classes for selfie responses. Will [verify](https://jira.corp.stripe.com/browse/IDPROD-3944) the response when backend change is ready.
Please refer to [this](https://docs.google.com/document/d/1fqZlX5WZXoopQdfEMxS6tMuFMqOM3iQLysWn6WeR5cY/edit#heading=h.lclm4ablip0v) internal doc for response change details


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Selfie

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
