### PR TITLE
Make link views work with/ignore project wardrobe configurations

### DIFF
--- a/link/src/main/java/com/stripe/android/link/theme/Color.kt
+++ b/link/src/main/java/com/stripe/android/link/theme/Color.kt
@@ -5,7 +5,7 @@ import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.ui.graphics.Color
 
-private val LinkGreen = Color(0xFF33DDB3)
+val LinkGreen = Color(0xFF33DDB3)
 private val ButtonLabel = Color(0xFF1D3944)
 
 private val LightComponentBackground = Color.White

--- a/link/src/main/java/com/stripe/android/link/theme/Theme.kt
+++ b/link/src/main/java/com/stripe/android/link/theme/Theme.kt
@@ -18,6 +18,8 @@ internal val HorizontalPadding = 20.dp
 internal fun linkTextFieldColors() =
     TextFieldDefaults.textFieldColors(
         backgroundColor = MaterialTheme.colors.background,
+        cursorColor = LinkGreen,
+        focusedLabelColor = LinkGreen,
         focusedIndicatorColor = Color.Transparent,
         disabledIndicatorColor = Color.Transparent,
         unfocusedIndicatorColor = Color.Transparent,

--- a/link/src/main/java/com/stripe/android/link/ui/LinkTerms.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/LinkTerms.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import com.stripe.android.link.R
-import com.stripe.android.ui.core.PaymentsTheme
 
 @Preview
 @Composable
@@ -19,7 +18,7 @@ fun LinkTerms(
     Text(
         text = stringResource(R.string.sign_up_terms),
         modifier = modifier,
-        color = PaymentsTheme.colors.material.onSurface,
+        color = MaterialTheme.colors.onSurface,
         textAlign = textAlign,
         style = MaterialTheme.typography.caption
     )

--- a/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignupView.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignupView.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -45,7 +46,10 @@ import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.elements.EmailSpec
 import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.ui.core.elements.SectionFieldElement
+import com.stripe.android.ui.core.elements.TextFieldColors
 import com.stripe.android.ui.core.elements.menu.Checkbox
+import com.stripe.android.ui.core.getBorderStroke
+import com.stripe.android.ui.core.paymentsColors
 import kotlinx.coroutines.flow.MutableStateFlow
 
 @Preview
@@ -124,18 +128,14 @@ internal fun LinkInlineSignup(
     CompositionLocalProvider(
         LocalContentAlpha provides if (enabled) ContentAlpha.high else ContentAlpha.disabled,
     ) {
-        DefaultLinkTheme {
+        PaymentsTheme {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .border(
-                        width = 1.dp,
-                        color = PaymentsTheme.colors.colorComponentBorder,
-                        shape = PaymentsTheme.shapes.material.medium
-                    )
+                    .border(MaterialTheme.getBorderStroke(isSelected = false))
                     .background(
-                        color = PaymentsTheme.colors.component,
-                        shape = PaymentsTheme.shapes.material.medium
+                        color = MaterialTheme.paymentsColors.component,
+                        shape = MaterialTheme.shapes.medium
                     )
             ) {
                 Row(
@@ -155,8 +155,8 @@ internal fun LinkInlineSignup(
                     Column {
                         Text(
                             text = stringResource(id = R.string.inline_sign_up_header),
-                            style = PaymentsTheme.typography.body1.copy(fontWeight = FontWeight.Bold),
-                            color = PaymentsTheme.colors.material.onSurface
+                            style = MaterialTheme.typography.body1.copy(fontWeight = FontWeight.Bold),
+                            color = MaterialTheme.colors.onSurface
                                 .copy(alpha = LocalContentAlpha.current)
                         )
                         Text(
@@ -164,8 +164,8 @@ internal fun LinkInlineSignup(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(top = 4.dp),
-                            style = PaymentsTheme.typography.body1,
-                            color = PaymentsTheme.colors.material.onSurface
+                            style = MaterialTheme.typography.body1,
+                            color = MaterialTheme.colors.onSurface
                                 .copy(alpha = LocalContentAlpha.current)
                         )
                     }
@@ -188,26 +188,29 @@ internal fun LinkInlineSignup(
                         AnimatedVisibility(
                             visible = signUpState == SignUpState.InputtingPhone
                         ) {
-                            Column(modifier = Modifier.fillMaxWidth()) {
-                                // TODO(brnunes-stripe): Migrate to phone number collection element
-                                PhoneCollectionSection(
-                                    phoneNumber = phoneNumber,
-                                    onPhoneNumberChanged = {
-                                        phoneNumber = it
-                                        if (phoneNumber.length == 10) {
-                                            onPhoneInput(phoneNumber)
-                                            keyboardController?.hide()
-                                        } else {
-                                            onPhoneInput(null)
+                            PaymentsTheme {
+                                Column(modifier = Modifier.fillMaxWidth()) {
+                                    // TODO(brnunes-stripe): Migrate to phone number collection element
+                                    PhoneCollectionSection(
+                                        phoneNumber = phoneNumber,
+                                        textFieldColors = TextFieldColors(),
+                                        onPhoneNumberChanged = {
+                                            phoneNumber = it
+                                            if (phoneNumber.length == 10) {
+                                                onPhoneInput(phoneNumber)
+                                                keyboardController?.hide()
+                                            } else {
+                                                onPhoneInput(null)
+                                            }
                                         }
-                                    }
-                                )
-                                LinkTerms(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(top = 16.dp),
-                                    textAlign = TextAlign.Left
-                                )
+                                    )
+                                    LinkTerms(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(top = 16.dp),
+                                        textAlign = TextAlign.Left
+                                    )
+                                }
                             }
                         }
                     }

--- a/link/src/main/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreen.kt
@@ -28,6 +28,7 @@ import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.link.ui.PrimaryButton
 import com.stripe.android.link.ui.PrimaryButtonState
 import com.stripe.android.link.ui.primaryButtonLabel
+import com.stripe.android.ui.core.PaymentsThemeStatic
 
 @Preview
 @Composable
@@ -103,7 +104,9 @@ internal fun PaymentMethodBody(
             style = MaterialTheme.typography.h2,
             color = MaterialTheme.colors.onPrimary
         )
-        formContent()
+        PaymentsThemeStatic {
+            formContent()
+        }
         PrimaryButton(
             label = primaryButtonLabel,
             state = when {

--- a/link/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
+import androidx.compose.material.TextFieldColors
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -40,6 +41,7 @@ import com.stripe.android.link.ui.LinkTerms
 import com.stripe.android.link.ui.PrimaryButton
 import com.stripe.android.link.ui.PrimaryButtonState
 import com.stripe.android.link.ui.progressIndicatorTestTag
+import com.stripe.android.ui.core.PaymentsThemeStatic
 import com.stripe.android.ui.core.elements.EmailSpec
 import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.ui.core.elements.SectionCard
@@ -126,22 +128,27 @@ internal fun SignUpBody(
             style = MaterialTheme.typography.body1,
             color = MaterialTheme.colors.onSecondary
         )
-        EmailCollectionSection(
-            enabled = true,
-            emailElement = emailElement,
-            signUpState = signUpState
-        )
+        PaymentsThemeStatic {
+            EmailCollectionSection(
+                enabled = true,
+                emailElement = emailElement,
+                signUpState = signUpState
+            )
+        }
         AnimatedVisibility(
             visible = signUpState == SignUpState.InputtingPhone
         ) {
             Column(modifier = Modifier.fillMaxWidth()) {
                 // TODO(brnunes-stripe): Migrate to phone number collection element
-                PhoneCollectionSection(
-                    phoneNumber = phoneNumber,
-                    onPhoneNumberChanged = {
-                        phoneNumber = it
-                    }
-                )
+                PaymentsThemeStatic {
+                    PhoneCollectionSection(
+                        phoneNumber = phoneNumber,
+                        onPhoneNumberChanged = {
+                            phoneNumber = it
+                        },
+                        textFieldColors = linkTextFieldColors()
+                    )
+                }
                 LinkTerms(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -212,6 +219,7 @@ internal fun EmailCollectionSection(
 @Composable
 internal fun PhoneCollectionSection(
     phoneNumber: String,
+    textFieldColors: TextFieldColors = linkTextFieldColors(),
     onPhoneNumberChanged: (String) -> Unit
 ) {
     Column(
@@ -228,7 +236,7 @@ internal fun PhoneCollectionSection(
                     Text(text = "Mobile Number")
                 },
                 shape = MaterialTheme.shapes.medium,
-                colors = linkTextFieldColors(),
+                colors = textFieldColors,
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Phone,
                     imeAction = ImeAction.Go

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/PaymentsTheme.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/PaymentsTheme.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.Colors
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Shapes
 import androidx.compose.material.Typography
+import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -40,8 +41,6 @@ import androidx.core.graphics.ColorUtils
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class PaymentsColors(
-    val primary: Color,
-    val surface: Color,
     val component: Color,
     val componentBorder: Color,
     val componentDivider: Color,
@@ -49,9 +48,8 @@ data class PaymentsColors(
     val subtitle: Color,
     val textCursor: Color,
     val placeholderText: Color,
-    val onSurface: Color,
     val appBarIcon: Color,
-    val error: Color,
+    val materialColors: Colors
 )
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -111,8 +109,6 @@ object PaymentsThemeDefaults {
     }
 
     val colorsLight = PaymentsColors(
-        primary = Color(0xFF007AFF),
-        surface = Color.White,
         component = Color.White,
         componentBorder = Color(0x33787880),
         componentDivider = Color(0x33787880),
@@ -120,14 +116,16 @@ object PaymentsThemeDefaults {
         subtitle = Color(0x99000000),
         textCursor = Color.Black,
         placeholderText = Color(0x993C3C43),
-        onSurface = Color.Black,
         appBarIcon = Color(0x99000000),
-        error = Color.Red,
+        materialColors = lightColors(
+            primary = Color(0xFF007AFF),
+            surface = Color.White,
+            onSurface = Color.Black,
+            error = Color.Red
+        )
     )
 
     val colorsDark = PaymentsColors(
-        primary = Color(0xFF0074D4),
-        surface = Color(0xff2e2e2e),
         component = Color.DarkGray,
         componentBorder = Color(0xFF787880),
         componentDivider = Color(0xFF787880),
@@ -135,9 +133,13 @@ object PaymentsThemeDefaults {
         subtitle = Color(0x99FFFFFF),
         textCursor = Color.White,
         placeholderText = Color(0x61FFFFFF),
-        onSurface = Color.White,
         appBarIcon = Color.White,
-        error = Color.Red,
+        materialColors = darkColors(
+            primary = Color(0xFF0074D4),
+            surface = Color(0xff2e2e2e),
+            onSurface = Color.White,
+            error = Color.Red
+        )
     )
 
     val shapes = PaymentsShapes(
@@ -162,12 +164,12 @@ object PaymentsThemeDefaults {
 
     val primaryButtonStyle = PrimaryButtonStyle(
         colorsLight = PrimaryButtonColors(
-            background = colors(false).primary,
+            background = colors(false).materialColors.primary,
             onBackground = Color.White,
             border = Color.Transparent
         ),
         colorsDark = PrimaryButtonColors(
-            background = colors(true).primary,
+            background = colors(true).materialColors.primary,
             onBackground = Color.White,
             border = Color.Transparent
         ),
@@ -182,45 +184,11 @@ object PaymentsThemeDefaults {
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-data class PaymentsComposeColors(
-    val component: Color,
-    val colorComponentBorder: Color,
-    val colorComponentDivider: Color,
-    val subtitle: Color,
-    val colorTextCursor: Color,
-    val placeholderText: Color,
-    val onComponent: Color,
-    val material: Colors
-)
-
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class PaymentsComposeShapes(
     val borderStrokeWidth: Dp,
     val borderStrokeWidthSelected: Dp,
     val material: Shapes
 )
-
-@Composable
-@ReadOnlyComposable
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-fun PaymentsColors.toComposeColors(): PaymentsComposeColors {
-    return PaymentsComposeColors(
-        component = component,
-        colorComponentBorder = componentBorder,
-        colorComponentDivider = componentDivider,
-        onComponent = onComponent,
-        subtitle = subtitle,
-        colorTextCursor = textCursor,
-        placeholderText = placeholderText,
-
-        material = lightColors(
-            primary = primary,
-            surface = surface,
-            onSurface = onSurface,
-            error = error,
-        )
-    )
-}
 
 @Composable
 @ReadOnlyComposable
@@ -313,30 +281,75 @@ fun PaymentsTypography.toComposeTypography(): Typography {
     )
 }
 
+val LocalColors = staticCompositionLocalOf { PaymentsTheme.getColors(false) }
+val LocalShapes = staticCompositionLocalOf { PaymentsTheme.shapesMutable }
+val LocalTypography = staticCompositionLocalOf { PaymentsTheme.typographyMutable }
+
+// CAUTION: This theme is mutable by merchant configurations.
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun PaymentsTheme(
     content: @Composable () -> Unit
 ) {
-    val colors = PaymentsTheme.colors
-    val localColors = staticCompositionLocalOf { colors }
-
-    val shapes = PaymentsTheme.shapes
-    val localShapes = staticCompositionLocalOf { shapes }
+    val colors = PaymentsTheme.getColors(isSystemInDarkTheme())
+    val shapes = PaymentsTheme.shapesMutable
+    val typography = PaymentsTheme.typographyMutable
 
     CompositionLocalProvider(
-        localColors provides colors,
-        localShapes provides shapes
+        LocalColors provides colors,
+        LocalShapes provides shapes,
+        LocalTypography provides typography
     ) {
         MaterialTheme(
-            colors = colors.material,
-            typography = PaymentsTheme.typography,
-            shapes = shapes.material,
+            colors = colors.materialColors,
+            typography = typography.toComposeTypography(),
+            shapes = shapes.toComposeShapes().material,
             content = content
         )
     }
 }
 
+// Use this theme if you do not want merchant configurations to change your UI
+@Composable
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun PaymentsThemeStatic(
+    content: @Composable () -> Unit
+) {
+    val colors = PaymentsThemeDefaults.colors(isSystemInDarkTheme())
+    val shapes = PaymentsThemeDefaults.shapes
+    val typography = PaymentsThemeDefaults.typography
+
+    CompositionLocalProvider(
+        LocalColors provides colors,
+        LocalShapes provides shapes,
+        LocalTypography provides typography
+    ) {
+        MaterialTheme(
+            colors = colors.materialColors,
+            typography = typography.toComposeTypography(),
+            shapes = shapes.toComposeShapes().material,
+            content = content
+        )
+    }
+}
+
+val MaterialTheme.paymentsColors: PaymentsColors
+    @Composable
+    @ReadOnlyComposable
+    get() = LocalColors.current
+
+val MaterialTheme.paymentsShapes: PaymentsShapes
+    @Composable
+    @ReadOnlyComposable
+    get() = LocalShapes.current
+
+@Composable
+@ReadOnlyComposable
+fun MaterialTheme.getBorderStroke(isSelected: Boolean): BorderStroke {
+    val width = if (isSelected) paymentsShapes.borderStrokeWidthSelected else paymentsShapes.borderStrokeWidth
+    val color = if (isSelected) paymentsColors.materialColors.primary else paymentsColors.componentBorder
+    return BorderStroke(width.dp, color)
+}
 // This object lets you access colors in composables via
 // StripeTheme.colors.primary etc
 // This mirrors an object that lives inside of MaterialTheme.
@@ -346,31 +359,14 @@ object PaymentsTheme {
     var colorsDarkMutable = PaymentsThemeDefaults.colorsDark
     var colorsLightMutable = PaymentsThemeDefaults.colorsLight
 
-    val colors: PaymentsComposeColors
-        @Composable
-        @ReadOnlyComposable
-        get() = (if (isSystemInDarkTheme()) colorsDarkMutable else colorsLightMutable).toComposeColors()
-
     var shapesMutable = PaymentsThemeDefaults.shapes
-    val shapes: PaymentsComposeShapes
-        @Composable
-        @ReadOnlyComposable
-        get() = shapesMutable.toComposeShapes()
 
     var typographyMutable = PaymentsThemeDefaults.typography
-    val typography: Typography
-        @Composable
-        @ReadOnlyComposable
-        get() = typographyMutable.toComposeTypography()
 
     var primaryButtonStyle = PaymentsThemeDefaults.primaryButtonStyle
 
-    @Composable
-    @ReadOnlyComposable
-    fun getBorderStroke(isSelected: Boolean): BorderStroke {
-        val width = if (isSelected) shapes.borderStrokeWidthSelected else shapes.borderStrokeWidth
-        val color = if (isSelected) colors.material.primary else colors.colorComponentBorder
-        return BorderStroke(width, color)
+    fun getColors(isDark: Boolean): PaymentsColors {
+        return if (isDark) colorsDarkMutable else colorsLightMutable
     }
 }
 
@@ -470,7 +466,7 @@ fun PrimaryButtonStyle.getBorderStrokeColor(context: Context): Int {
 @ReadOnlyComposable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun PrimaryButtonStyle.getComposeTextStyle(): TextStyle {
-    val baseStyle = PaymentsTheme.typography.h5.copy(
+    val baseStyle = MaterialTheme.typography.h5.copy(
         color = (if (isSystemInDarkTheme()) colorsDark else colorsLight).onBackground,
     )
     return if (typography.fontFamily != null) {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressElementUI.kt
@@ -3,11 +3,14 @@ package com.stripe.android.ui.core.elements
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import com.stripe.android.ui.core.PaymentsTheme
+import androidx.compose.ui.unit.dp
+import com.stripe.android.ui.core.paymentsColors
+import com.stripe.android.ui.core.paymentsShapes
 
 @Composable
 internal fun AddressElementUI(
@@ -33,10 +36,10 @@ internal fun AddressElementUI(
                 )
                 if (index != fieldList.lastIndex) {
                     Divider(
-                        color = PaymentsTheme.colors.colorComponentDivider,
-                        thickness = PaymentsTheme.shapes.borderStrokeWidth,
+                        color = MaterialTheme.paymentsColors.componentDivider,
+                        thickness = MaterialTheme.paymentsShapes.borderStrokeWidth.dp,
                         modifier = Modifier.padding(
-                            horizontal = PaymentsTheme.shapes.borderStrokeWidth
+                            horizontal = MaterialTheme.paymentsShapes.borderStrokeWidth.dp
                         )
                     )
                 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AffirmElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AffirmElementUI.kt
@@ -2,12 +2,13 @@ package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.R
+import com.stripe.android.ui.core.paymentsColors
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -21,7 +22,7 @@ fun AffirmElementUI() {
             )
         ),
         modifier = Modifier.padding(bottom = 4.dp),
-        color = PaymentsTheme.colors.subtitle,
-        style = PaymentsTheme.typography.h6
+        color = MaterialTheme.paymentsColors.subtitle,
+        style = MaterialTheme.typography.h6
     )
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayElementUI.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
@@ -21,8 +22,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.flowlayout.FlowCrossAxisAlignment
 import com.google.accompanist.flowlayout.FlowRow
-import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.R
+import com.stripe.android.ui.core.paymentsColors
 import com.stripe.android.ui.core.shouldUseDarkDynamicColor
 
 @Composable
@@ -41,14 +42,14 @@ fun AfterpayClearpayElementUI(
             element.getLabel(context.resources),
             Modifier
                 .padding(end = 4.dp),
-            color = PaymentsTheme.colors.subtitle
+            color = MaterialTheme.paymentsColors.subtitle
         )
         Image(
             painter = painterResource(R.drawable.stripe_ic_afterpay_clearpay_logo),
             contentDescription = stringResource(
                 R.string.afterpay_clearpay_message
             ),
-            colorFilter = if (PaymentsTheme.colors.material.surface.shouldUseDarkDynamicColor()) {
+            colorFilter = if (MaterialTheme.colors.surface.shouldUseDarkDynamicColor()) {
                 null
             } else {
                 ColorFilter.tint(Color.White)
@@ -68,7 +69,7 @@ fun AfterpayClearpayElementUI(
                 text = "ⓘ",
                 modifier = Modifier.padding(0.dp),
                 style = TextStyle(fontWeight = FontWeight.Bold),
-                color = PaymentsTheme.colors.subtitle
+                color = MaterialTheme.paymentsColors.subtitle
             )
         }
     }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBecsDebitMandateElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBecsDebitMandateElementUI.kt
@@ -1,10 +1,11 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.stringResource
-import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.R
+import com.stripe.android.ui.core.paymentsColors
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -14,7 +15,7 @@ fun AuBecsDebitMandateElementUI(
     Html(
         html = stringResource(id = R.string.au_becs_mandate, element.merchantName ?: ""),
         imageGetter = emptyMap(),
-        color = PaymentsTheme.colors.subtitle,
-        style = PaymentsTheme.typography.body2,
+        color = MaterialTheme.paymentsColors.subtitle,
+        style = MaterialTheme.typography.body2,
     )
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbElementUI.kt
@@ -2,13 +2,14 @@ package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
 import androidx.compose.foundation.layout.Column
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
-import com.stripe.android.ui.core.PaymentsTheme
+import com.stripe.android.ui.core.paymentsColors
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -46,7 +47,7 @@ fun BsbElementUI(
                 bankName?.let {
                     Text(
                         it,
-                        color = PaymentsTheme.colors.subtitle
+                        color = MaterialTheme.paymentsColors.subtitle
                     )
                 }
             }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElementUI.kt
@@ -2,9 +2,12 @@ package com.stripe.android.ui.core.elements
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.stripe.android.ui.core.PaymentsTheme
+import androidx.compose.ui.unit.dp
+import com.stripe.android.ui.core.paymentsColors
+import com.stripe.android.ui.core.paymentsShapes
 
 @Composable
 internal fun CardDetailsElementUI(
@@ -22,10 +25,10 @@ internal fun CardDetailsElementUI(
         )
         if (index != controller.fields.lastIndex) {
             Divider(
-                color = PaymentsTheme.colors.colorComponentDivider,
-                thickness = PaymentsTheme.shapes.borderStrokeWidth,
+                color = MaterialTheme.paymentsColors.componentDivider,
+                thickness = MaterialTheme.paymentsShapes.borderStrokeWidth.dp,
                 modifier = Modifier.padding(
-                    horizontal = PaymentsTheme.shapes.borderStrokeWidth
+                    horizontal = MaterialTheme.paymentsShapes.borderStrokeWidth.dp
                 )
             )
         }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownFieldUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownFieldUI.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.material.icons.Icons
@@ -36,11 +37,11 @@ import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.menu.DropdownMenuItemDefaultMaxWidth
 import com.stripe.android.ui.core.elements.menu.DropdownMenuItemDefaultMinHeight
 import com.stripe.android.ui.core.elements.menu.DropdownMenuItemDefaultMinWidth
+import com.stripe.android.ui.core.paymentsColors
 import kotlin.math.max
 import kotlin.math.min
 
@@ -69,7 +70,7 @@ internal fun DropDown(
     var expanded by remember { mutableStateOf(false) }
     val interactionSource = remember { MutableInteractionSource() }
     val currentTextColor = if (enabled) {
-        PaymentsTheme.colors.onComponent
+        MaterialTheme.paymentsColors.onComponent
     } else {
         TextFieldDefaults
             .textFieldColors()
@@ -81,7 +82,7 @@ internal fun DropDown(
     Box(
         modifier = Modifier
             .wrapContentSize(Alignment.TopStart)
-            .background(PaymentsTheme.colors.component)
+            .background(MaterialTheme.paymentsColors.component)
     ) {
         // Click handling happens on the box, so that it is a single accessible item
         Box(
@@ -139,7 +140,7 @@ internal fun DropDown(
             },
             onDismissRequest = { expanded = false },
             modifier = Modifier
-                .background(color = PaymentsTheme.colors.component)
+                .background(color = MaterialTheme.paymentsColors.component)
                 .width(DropdownMenuItemDefaultMaxWidth)
                 .requiredSizeIn(maxHeight = DropdownMenuItemDefaultMinHeight * 8.9f)
         ) {
@@ -191,7 +192,7 @@ internal fun DropdownMenuItem(
                 )
                 .fillMaxWidth(.8f),
             color = if (isSelected) {
-                PaymentsTheme.colors.material.primary
+                MaterialTheme.colors.primary
             } else {
                 currentTextColor
             },
@@ -208,7 +209,7 @@ internal fun DropdownMenuItem(
                 contentDescription = null,
                 modifier = Modifier
                     .height(24.dp),
-                tint = PaymentsTheme.colors.material.primary
+                tint = MaterialTheme.colors.primary
             )
         }
     }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownItemSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownItemSpec.kt
@@ -3,7 +3,6 @@ package com.stripe.android.ui.core.elements
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import kotlinx.parcelize.Parcelize
-import kotlinx.serialization.Serializable
 
 @Parcelize
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/FormLabel.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/FormLabel.kt
@@ -1,19 +1,20 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.compose.material.ContentAlpha
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import com.stripe.android.ui.core.PaymentsTheme
+import com.stripe.android.ui.core.paymentsColors
 
 @Composable
 internal fun FormLabel(
     text: String,
     enabled: Boolean = true
 ) {
-    val color = PaymentsTheme.colors.placeholderText
+    val color = MaterialTheme.paymentsColors.placeholderText
     Text(
         color = if (enabled) color else color.copy(alpha = ContentAlpha.disabled),
         text = text,
-        style = PaymentsTheme.typography.subtitle1
+        style = MaterialTheme.typography.subtitle1
     )
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/H4Text.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/H4Text.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -12,10 +13,12 @@ fun H4Text(
     text: String,
     modifier: Modifier = Modifier,
 ) {
-    Text(
-        text = text,
-        color = PaymentsTheme.colors.material.onSurface,
-        style = PaymentsTheme.typography.h4,
-        modifier = modifier
-    )
+    PaymentsTheme {
+        Text(
+            text = text,
+            color = MaterialTheme.colors.onSurface,
+            style = MaterialTheme.typography.h4,
+            modifier = modifier
+        )
+    }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/H6Text.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/H6Text.kt
@@ -1,10 +1,11 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.stripe.android.ui.core.PaymentsTheme
+import com.stripe.android.ui.core.paymentsColors
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -14,8 +15,8 @@ fun H6Text(
 ) {
     Text(
         text = text,
-        color = PaymentsTheme.colors.subtitle,
-        style = PaymentsTheme.typography.h6,
+        color = MaterialTheme.paymentsColors.subtitle,
+        style = MaterialTheme.typography.h6,
         modifier = modifier
     )
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/Html.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/Html.kt
@@ -44,7 +44,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.core.text.HtmlCompat
-import com.stripe.android.ui.core.PaymentsTheme
+import com.stripe.android.ui.core.paymentsColors
 
 private const val LINK_TAG = "URL"
 
@@ -208,8 +208,8 @@ private fun ClickableText(
     text: AnnotatedString,
     inlineContent: Map<String, InlineTextContent> = mapOf(),
     @SuppressLint("ModifierParameter") modifier: Modifier = Modifier,
-    color: Color = PaymentsTheme.colors.subtitle,
-    style: TextStyle = PaymentsTheme.typography.body2,
+    color: Color = MaterialTheme.paymentsColors.subtitle,
+    style: TextStyle = MaterialTheme.typography.body2,
     softWrap: Boolean = true,
     overflow: TextOverflow = TextOverflow.Clip,
     maxLines: Int = Int.MAX_VALUE,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateTextUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateTextUI.kt
@@ -2,13 +2,14 @@ package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
-import com.stripe.android.ui.core.PaymentsTheme
+import com.stripe.android.ui.core.paymentsColors
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -17,8 +18,8 @@ fun MandateTextUI(
 ) {
     Text(
         text = stringResource(element.stringResId, element.merchantName ?: ""),
-        style = PaymentsTheme.typography.body2,
-        color = PaymentsTheme.colors.subtitle,
+        style = MaterialTheme.typography.body2,
+        color = MaterialTheme.paymentsColors.subtitle,
         modifier = Modifier
             .padding(vertical = 8.dp)
             .semantics(mergeDescendants = true) {}, // makes it a separate accessibile item

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/RowElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/RowElementUI.kt
@@ -4,11 +4,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
-import com.stripe.android.ui.core.PaymentsTheme
+import com.stripe.android.ui.core.paymentsColors
+import com.stripe.android.ui.core.paymentsShapes
 
 @Composable
 internal fun RowElementUI(
@@ -64,10 +67,10 @@ internal fun RowElementUI(
                                 height = (Dimension.fillToConstraints)
                             }
                             .padding(
-                                horizontal = PaymentsTheme.shapes.borderStrokeWidth
+                                horizontal = MaterialTheme.paymentsShapes.borderStrokeWidth.dp
                             )
-                            .width(PaymentsTheme.shapes.borderStrokeWidth),
-                        color = PaymentsTheme.colors.colorComponentDivider
+                            .width(MaterialTheme.paymentsShapes.borderStrokeWidth.dp),
+                        color = MaterialTheme.paymentsColors.componentDivider
                     )
                 }
             }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/ScanCardButtonUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/ScanCardButtonUI.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -20,7 +21,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.cardscan.CardScanActivity
 
@@ -56,7 +56,7 @@ internal fun ScanCardButtonUI(
             contentDescription = stringResource(
                 R.string.scan_card
             ),
-            colorFilter = ColorFilter.tint(PaymentsTheme.colors.material.primary),
+            colorFilter = ColorFilter.tint(MaterialTheme.colors.primary),
             modifier = Modifier
                 .width(18.dp)
                 .height(18.dp)
@@ -65,8 +65,8 @@ internal fun ScanCardButtonUI(
             stringResource(R.string.scan_card),
             Modifier
                 .padding(start = 4.dp),
-            color = PaymentsTheme.colors.material.primary,
-            style = PaymentsTheme.typography.h6,
+            color = MaterialTheme.colors.primary,
+            style = MaterialTheme.typography.h6,
         )
     }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionElementUI.kt
@@ -3,12 +3,15 @@ package com.stripe.android.ui.core.elements
 import androidx.annotation.RestrictTo
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import com.stripe.android.ui.core.PaymentsTheme
+import androidx.compose.ui.unit.dp
+import com.stripe.android.ui.core.paymentsColors
+import com.stripe.android.ui.core.paymentsShapes
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -41,10 +44,10 @@ fun SectionElementUI(
                 )
                 if (index != element.fields.lastIndex) {
                     Divider(
-                        color = PaymentsTheme.colors.colorComponentDivider,
-                        thickness = PaymentsTheme.shapes.borderStrokeWidth,
+                        color = MaterialTheme.paymentsColors.componentDivider,
+                        thickness = MaterialTheme.paymentsShapes.borderStrokeWidth.dp,
                         modifier = Modifier.padding(
-                            horizontal = PaymentsTheme.shapes.borderStrokeWidth
+                            horizontal = MaterialTheme.paymentsShapes.borderStrokeWidth.dp
                         )
                     )
                 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionUI.kt
@@ -5,6 +5,7 @@ import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Card
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -12,7 +13,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
-import com.stripe.android.ui.core.PaymentsTheme
+import com.stripe.android.ui.core.getBorderStroke
+import com.stripe.android.ui.core.paymentsColors
 
 /**
  * This is a simple section that holds content in a card view.  It has a label, content specified
@@ -63,11 +65,11 @@ fun SectionCard(
     content: @Composable () -> Unit
 ) {
     Card(
-        border = PaymentsTheme.getBorderStroke(isSelected),
+        border = MaterialTheme.getBorderStroke(isSelected),
         // TODO(skyler-stripe): this will change when we add shadow configurations.
         elevation = if (isSelected) 1.5.dp else 0.dp,
-        backgroundColor = PaymentsTheme.colors.component,
-        shape = PaymentsTheme.shapes.material.medium,
+        backgroundColor = MaterialTheme.paymentsColors.component,
+        shape = MaterialTheme.shapes.medium,
         modifier = modifier
     ) {
         Column {
@@ -83,8 +85,8 @@ fun SectionCard(
 internal fun SectionError(error: String) {
     Text(
         text = error,
-        color = PaymentsTheme.colors.material.error,
-        style = PaymentsTheme.typography.h6,
+        color = MaterialTheme.colors.error,
+        style = MaterialTheme.typography.h6,
         modifier = Modifier.semantics(mergeDescendants = true) { }
     )
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
@@ -1,12 +1,14 @@
 package com.stripe.android.ui.core.elements
 
 import android.view.KeyEvent
+import androidx.annotation.RestrictTo
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.TextField
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
@@ -30,8 +32,8 @@ import androidx.compose.ui.semantics.editableText
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.ImeAction
-import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.R
+import com.stripe.android.ui.core.paymentsColors
 
 /**
  * This is focused on converting an `Element` into what is displayed in a textField.
@@ -140,22 +142,23 @@ internal fun TextField(
 }
 
 @Composable
-internal fun TextFieldColors(
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun TextFieldColors(
     shouldShowError: Boolean = false
 ) = TextFieldDefaults.textFieldColors(
     textColor = if (shouldShowError) {
-        PaymentsTheme.colors.material.error
+        MaterialTheme.colors.error
     } else {
-        PaymentsTheme.colors.onComponent
+        MaterialTheme.paymentsColors.onComponent
     },
-    unfocusedLabelColor = PaymentsTheme.colors.placeholderText,
-    focusedLabelColor = PaymentsTheme.colors.placeholderText,
-    placeholderColor = PaymentsTheme.colors.placeholderText,
-    backgroundColor = PaymentsTheme.colors.component,
+    unfocusedLabelColor = MaterialTheme.paymentsColors.placeholderText,
+    focusedLabelColor = MaterialTheme.paymentsColors.placeholderText,
+    placeholderColor = MaterialTheme.paymentsColors.placeholderText,
+    backgroundColor = MaterialTheme.paymentsColors.component,
     focusedIndicatorColor = Color.Transparent,
     disabledIndicatorColor = Color.Transparent,
     unfocusedIndicatorColor = Color.Transparent,
-    cursorColor = PaymentsTheme.colors.colorTextCursor
+    cursorColor = MaterialTheme.paymentsColors.textCursor
 )
 
 @Composable

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/menu/Checkbox.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/menu/Checkbox.kt
@@ -2,9 +2,10 @@ package com.stripe.android.ui.core.elements.menu
 
 import androidx.annotation.RestrictTo
 import androidx.compose.material.CheckboxDefaults
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import com.stripe.android.ui.core.PaymentsTheme
+import com.stripe.android.ui.core.paymentsColors
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -15,9 +16,9 @@ fun Checkbox(
     enabled: Boolean = true,
 ) {
     val checkboxColors = CheckboxDefaults.colors(
-        checkedColor = PaymentsTheme.colors.material.primary,
-        uncheckedColor = PaymentsTheme.colors.subtitle,
-        checkmarkColor = PaymentsTheme.colors.material.surface
+        checkedColor = MaterialTheme.colors.primary,
+        uncheckedColor = MaterialTheme.paymentsColors.subtitle,
+        checkmarkColor = MaterialTheme.colors.surface
     )
 
     androidx.compose.material.Checkbox(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/menu/Menu.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/menu/Menu.kt
@@ -59,7 +59,8 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.PopupPositionProvider
-import com.stripe.android.ui.core.PaymentsTheme
+import com.stripe.android.ui.core.paymentsColors
+import com.stripe.android.ui.core.paymentsShapes
 import kotlin.math.max
 import kotlin.math.min
 
@@ -124,8 +125,8 @@ internal fun DropdownMenuContent(
     // TODO: Make sure this gets the rounded corner values
     Card(
         border = BorderStroke(
-            PaymentsTheme.shapes.borderStrokeWidth,
-            PaymentsTheme.colors.colorComponentBorder
+            MaterialTheme.paymentsShapes.borderStrokeWidth.dp,
+            MaterialTheme.paymentsColors.componentBorder
         ),
         modifier = Modifier.graphicsLayer {
             scaleX = scale

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentMethodsUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentMethodsUI.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.selection.selectable
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberCoroutineScope
@@ -28,6 +29,7 @@ import com.stripe.android.paymentsheet.ui.LpmSelectorText
 import com.stripe.android.ui.core.MeasureComposableWidth
 import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.elements.SectionCard
+import com.stripe.android.ui.core.paymentsColors
 
 internal const val ADD_PM_DEFAULT_PADDING = 12.0f
 internal const val CARD_HORIZONTAL_PADDING = 6.0f
@@ -57,40 +59,41 @@ internal fun PaymentMethodsUI(
             state.disableScrolling(scope)
         }
     }
-
-    BoxWithConstraints(
-        modifier = Modifier
-            .testTag(TEST_TAG_LIST + "1")
-    ) {
-        val viewWidth = calculateViewWidth(
-            this.maxWidth,
-            paymentMethods.size
-        )
-
-        // TODO: userScrollEnabled will be available in compose version 1.2.0-alpha01+
-        LazyRow(
-            state = state,
+    PaymentsTheme {
+        BoxWithConstraints(
             modifier = Modifier
-                .padding(start = PM_LIST_PADDING.dp)
-                .testTag(TEST_TAG_LIST)
+                .testTag(TEST_TAG_LIST + "1")
         ) {
-            itemsIndexed(items = paymentMethods, itemContent = { index, item ->
-                PaymentMethodUI(
-                    modifier = Modifier.testTag(
-                        TEST_TAG_LIST + stringResource(item.displayNameResource)
-                    ),
-                    viewWidth = viewWidth,
-                    iconRes = item.iconResource,
-                    title = stringResource(item.displayNameResource),
-                    isSelected = index == selectedIndex,
-                    isEnabled = isEnabled,
-                    tintOnSelected = item.shouldTintOnSelection(),
-                    itemIndex = index,
-                    onItemSelectedListener = {
-                        onItemSelectedListener(paymentMethods[it])
-                    }
-                )
-            })
+            val viewWidth = calculateViewWidth(
+                this.maxWidth,
+                paymentMethods.size
+            )
+
+            // TODO: userScrollEnabled will be available in compose version 1.2.0-alpha01+
+            LazyRow(
+                state = state,
+                modifier = Modifier
+                    .padding(start = PM_LIST_PADDING.dp)
+                    .testTag(TEST_TAG_LIST)
+            ) {
+                itemsIndexed(items = paymentMethods, itemContent = { index, item ->
+                    PaymentMethodUI(
+                        modifier = Modifier.testTag(
+                            TEST_TAG_LIST + stringResource(item.displayNameResource)
+                        ),
+                        viewWidth = viewWidth,
+                        iconRes = item.iconResource,
+                        title = stringResource(item.displayNameResource),
+                        isSelected = index == selectedIndex,
+                        isEnabled = isEnabled,
+                        tintOnSelected = item.shouldTintOnSelection(),
+                        itemIndex = index,
+                        onItemSelectedListener = {
+                            onItemSelectedListener(paymentMethods[it])
+                        }
+                    )
+                })
+            }
         }
     }
 }
@@ -124,8 +127,8 @@ internal fun PaymentMethodUI(
     modifier: Modifier = Modifier,
     onItemSelectedListener: (Int) -> Unit
 ) {
-    val color = if (isSelected) PaymentsTheme.colors.material.primary
-    else PaymentsTheme.colors.onComponent
+    val color = if (isSelected) MaterialTheme.colors.primary
+    else MaterialTheme.paymentsColors.onComponent
 
     val lpmTextSelector: @Composable () -> Unit = {
         LpmSelectorText(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.Composable
@@ -55,6 +56,7 @@ import com.stripe.android.paymentsheet.ui.getSavedPaymentMethodIcon
 import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.elements.SectionCard
 import com.stripe.android.ui.core.elements.SimpleDialogElementUI
+import com.stripe.android.ui.core.paymentsColors
 import com.stripe.android.ui.core.shouldUseDarkDynamicColor
 import kotlin.properties.Delegates
 
@@ -378,7 +380,9 @@ internal class PaymentOptionsAdapter(
             position: Int
         ) {
             composeView.setContent {
-                val iconRes = if (PaymentsTheme.colors.component.shouldUseDarkDynamicColor()) {
+                val iconRes = if (
+                    MaterialTheme.paymentsColors.component.shouldUseDarkDynamicColor()
+                ) {
                     R.drawable.stripe_ic_paymentsheet_add_dark
                 } else {
                     R.drawable.stripe_ic_paymentsheet_add_light
@@ -588,129 +592,131 @@ internal fun PaymentOptionUi(
 ) {
     // An attempt was made to not use constraint layout here but it was unsuccessful in
     // precisely positioning the check and delete icons to match the mocks.
-    ConstraintLayout(
-        modifier = Modifier
-            .padding(top = 12.dp)
-            .width(viewWidth)
-            .alpha(alpha = if (isEnabled) 1.0F else 0.6F)
-            .selectable(selected = isSelected, enabled = isEnabled, onClick = {
-                onItemSelectedListener()
-            })
-    ) {
-        val (checkIcon, deleteIcon, label, card) = createRefs()
-        SectionCard(
-            isSelected = isSelected,
+    PaymentsTheme {
+        ConstraintLayout(
             modifier = Modifier
-                .height(64.dp)
-                .padding(horizontal = PM_OPTIONS_DEFAULT_PADDING.dp)
-                .fillMaxWidth()
-                .constrainAs(card) {
-                    top.linkTo(parent.top)
-                    start.linkTo(parent.start)
-                    end.linkTo(parent.end)
-                }
+                .padding(top = 12.dp)
+                .width(viewWidth)
+                .alpha(alpha = if (isEnabled) 1.0F else 0.6F)
+                .selectable(selected = isSelected, enabled = isEnabled, onClick = {
+                    onItemSelectedListener()
+                })
         ) {
-            Column(
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier.fillMaxSize()
-            ) {
-                Image(
-                    painter = painterResource(iconRes),
-                    contentDescription = null,
-                    modifier = Modifier
-                        .height(40.dp)
-                        .width(56.dp)
-                )
-            }
-        }
-        if (isSelected) {
-            val iconColor = PaymentsTheme.colors.material.primary
-            val checkSymbolColor = if (iconColor.shouldUseDarkDynamicColor()) {
-                Color.Black
-            } else {
-                Color.White
-            }
-            Box(
-                contentAlignment = Alignment.Center,
+            val (checkIcon, deleteIcon, label, card) = createRefs()
+            SectionCard(
+                isSelected = isSelected,
                 modifier = Modifier
-                    .clip(CircleShape)
-                    .size(24.dp)
-                    .background(PaymentsTheme.colors.material.primary)
-                    .constrainAs(checkIcon) {
-                        top.linkTo(card.bottom, (-18).dp)
-                        end.linkTo(card.end)
+                    .height(64.dp)
+                    .padding(horizontal = PM_OPTIONS_DEFAULT_PADDING.dp)
+                    .fillMaxWidth()
+                    .constrainAs(card) {
+                        top.linkTo(parent.top)
+                        start.linkTo(parent.start)
+                        end.linkTo(parent.end)
                     }
             ) {
-                Icon(
-                    imageVector = Icons.Filled.Check,
-                    contentDescription = null,
-                    tint = checkSymbolColor,
-                    modifier = Modifier
-                        .size(12.dp)
-                )
-            }
-        }
-        if (isEditing && onRemoveListener != null) {
-            val openDialog = remember { mutableStateOf(false) }
-
-            SimpleDialogElementUI(
-                openDialog = openDialog,
-                titleText = removePmDialogTitle,
-                messageText = description,
-                confirmText = stringResource(R.string.remove),
-                dismissText = stringResource(R.string.cancel),
-                onConfirmListener = onRemoveListener
-            )
-
-            // tint the delete symbol so it contrasts well with the error color around it.
-            val iconColor = PaymentsTheme.colors.material.error
-            val deleteIconColor = if (iconColor.shouldUseDarkDynamicColor()) {
-                Color.Black
-            } else {
-                Color.White
-            }
-            Image(
-                painter = painterResource(R.drawable.stripe_ic_delete_symbol),
-                contentDescription = onRemoveAccessibilityDescription,
-                colorFilter = ColorFilter.tint(deleteIconColor),
-                modifier = Modifier
-                    .constrainAs(deleteIcon) {
-                        top.linkTo(card.top, margin = (-9).dp)
-                        end.linkTo(card.end)
-                    }
-                    .size(20.dp)
-                    .clip(CircleShape)
-                    .background(color = iconColor)
-                    .clickable(
-                        onClick = {
-                            openDialog.value = true
-                        }
+                Column(
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    Image(
+                        painter = painterResource(iconRes),
+                        contentDescription = null,
+                        modifier = Modifier
+                            .height(40.dp)
+                            .width(56.dp)
                     )
+                }
+            }
+            if (isSelected) {
+                val iconColor = MaterialTheme.colors.primary
+                val checkSymbolColor = if (iconColor.shouldUseDarkDynamicColor()) {
+                    Color.Black
+                } else {
+                    Color.White
+                }
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier
+                        .clip(CircleShape)
+                        .size(24.dp)
+                        .background(MaterialTheme.colors.primary)
+                        .constrainAs(checkIcon) {
+                            top.linkTo(card.bottom, (-18).dp)
+                            end.linkTo(card.end)
+                        }
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Check,
+                        contentDescription = null,
+                        tint = checkSymbolColor,
+                        modifier = Modifier
+                            .size(12.dp)
+                    )
+                }
+            }
+            if (isEditing && onRemoveListener != null) {
+                val openDialog = remember { mutableStateOf(false) }
+
+                SimpleDialogElementUI(
+                    openDialog = openDialog,
+                    titleText = removePmDialogTitle,
+                    messageText = description,
+                    confirmText = stringResource(R.string.remove),
+                    dismissText = stringResource(R.string.cancel),
+                    onConfirmListener = onRemoveListener
+                )
+
+                // tint the delete symbol so it contrasts well with the error color around it.
+                val iconColor = MaterialTheme.colors.error
+                val deleteIconColor = if (iconColor.shouldUseDarkDynamicColor()) {
+                    Color.Black
+                } else {
+                    Color.White
+                }
+                Image(
+                    painter = painterResource(R.drawable.stripe_ic_delete_symbol),
+                    contentDescription = onRemoveAccessibilityDescription,
+                    colorFilter = ColorFilter.tint(deleteIconColor),
+                    modifier = Modifier
+                        .constrainAs(deleteIcon) {
+                            top.linkTo(card.top, margin = (-9).dp)
+                            end.linkTo(card.end)
+                        }
+                        .size(20.dp)
+                        .clip(CircleShape)
+                        .background(color = iconColor)
+                        .clickable(
+                            onClick = {
+                                openDialog.value = true
+                            }
+                        )
+                )
+            }
+
+            LpmSelectorText(
+                icon = labelIcon,
+                text = labelText,
+                textColor = MaterialTheme.colors.onSurface,
+                isEnabled = isEnabled,
+                modifier = Modifier
+                    .constrainAs(label) {
+                        top.linkTo(card.bottom)
+                        start.linkTo(card.start)
+                    }
+                    .padding(
+                        top = 4.dp,
+                        start = PM_OPTIONS_DEFAULT_PADDING.dp,
+                        end = PM_OPTIONS_DEFAULT_PADDING.dp
+                    )
+                    .semantics {
+                        // This makes the screen reader read out numbers digit by digit
+                        // one one one one vs one thousand one hundred eleven
+                        this.contentDescription =
+                            description.replace("\\d".toRegex(), "$0 ")
+                    },
             )
         }
-
-        LpmSelectorText(
-            icon = labelIcon,
-            text = labelText,
-            textColor = PaymentsTheme.colors.material.onSurface,
-            isEnabled = isEnabled,
-            modifier = Modifier
-                .constrainAs(label) {
-                    top.linkTo(card.bottom)
-                    start.linkTo(card.start)
-                }
-                .padding(
-                    top = 4.dp,
-                    start = PM_OPTIONS_DEFAULT_PADDING.dp,
-                    end = PM_OPTIONS_DEFAULT_PADDING.dp
-                )
-                .semantics {
-                    // This makes the screen reader read out numbers digit by digit
-                    // one one one one vs one thousand one hundred eleven
-                    this.contentDescription =
-                        description.replace("\\d".toRegex(), "$0 ")
-                },
-        )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -326,31 +326,31 @@ class PaymentSheet internal constructor(
 
         companion object {
             val defaultLight = Colors(
-                primary = PaymentsThemeDefaults.colorsLight.primary,
-                surface = PaymentsThemeDefaults.colorsLight.surface,
+                primary = PaymentsThemeDefaults.colorsLight.materialColors.primary,
+                surface = PaymentsThemeDefaults.colorsLight.materialColors.surface,
                 component = PaymentsThemeDefaults.colorsLight.component,
                 componentBorder = PaymentsThemeDefaults.colorsLight.componentBorder,
                 componentDivider = PaymentsThemeDefaults.colorsLight.componentDivider,
                 onComponent = PaymentsThemeDefaults.colorsLight.onComponent,
                 subtitle = PaymentsThemeDefaults.colorsLight.subtitle,
                 placeholderText = PaymentsThemeDefaults.colorsLight.placeholderText,
-                onSurface = PaymentsThemeDefaults.colorsLight.onSurface,
+                onSurface = PaymentsThemeDefaults.colorsLight.materialColors.onSurface,
                 appBarIcon = PaymentsThemeDefaults.colorsLight.appBarIcon,
-                error = PaymentsThemeDefaults.colorsLight.error,
+                error = PaymentsThemeDefaults.colorsLight.materialColors.error,
             )
 
             val defaultDark = Colors(
-                primary = PaymentsThemeDefaults.colorsDark.primary,
-                surface = PaymentsThemeDefaults.colorsDark.surface,
+                primary = PaymentsThemeDefaults.colorsDark.materialColors.primary,
+                surface = PaymentsThemeDefaults.colorsDark.materialColors.surface,
                 component = PaymentsThemeDefaults.colorsDark.component,
                 componentBorder = PaymentsThemeDefaults.colorsDark.componentBorder,
                 componentDivider = PaymentsThemeDefaults.colorsDark.componentDivider,
                 onComponent = PaymentsThemeDefaults.colorsDark.onComponent,
                 subtitle = PaymentsThemeDefaults.colorsDark.subtitle,
                 placeholderText = PaymentsThemeDefaults.colorsDark.placeholderText,
-                onSurface = PaymentsThemeDefaults.colorsDark.onSurface,
+                onSurface = PaymentsThemeDefaults.colorsDark.materialColors.onSurface,
                 appBarIcon = PaymentsThemeDefaults.colorsDark.appBarIcon,
-                error = PaymentsThemeDefaults.colorsDark.error,
+                error = PaymentsThemeDefaults.colorsDark.materialColors.error,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationKtx.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.paymentsheet
 
+import androidx.compose.material.darkColors
+import androidx.compose.material.lightColors
 import androidx.compose.ui.graphics.Color
 import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.PaymentsThemeDefaults
@@ -34,31 +36,35 @@ internal fun PaymentSheet.Configuration.validate() {
 
 internal fun PaymentSheet.Appearance.parseAppearance() {
     PaymentsTheme.colorsLightMutable = PaymentsThemeDefaults.colorsLight.copy(
-        primary = Color(colorsLight.primary),
-        surface = Color(colorsLight.surface),
         component = Color(colorsLight.component),
         componentBorder = Color(colorsLight.componentBorder),
         componentDivider = Color(colorsLight.componentDivider),
         onComponent = Color(colorsLight.onComponent),
         subtitle = Color(colorsLight.subtitle),
         placeholderText = Color(colorsLight.placeholderText),
-        onSurface = Color(colorsLight.onSurface),
         appBarIcon = Color(colorsLight.appBarIcon),
-        error = Color(colorsLight.error)
+        materialColors = lightColors(
+            primary = Color(colorsLight.primary),
+            surface = Color(colorsLight.surface),
+            onSurface = Color(colorsLight.onSurface),
+            error = Color(colorsLight.error)
+        )
     )
 
     PaymentsTheme.colorsDarkMutable = PaymentsThemeDefaults.colorsDark.copy(
-        primary = Color(colorsDark.primary),
-        surface = Color(colorsDark.surface),
         component = Color(colorsDark.component),
         componentBorder = Color(colorsDark.componentBorder),
         componentDivider = Color(colorsDark.componentDivider),
         onComponent = Color(colorsDark.onComponent),
         subtitle = Color(colorsDark.subtitle),
         placeholderText = Color(colorsDark.placeholderText),
-        onSurface = Color(colorsDark.onSurface),
         appBarIcon = Color(colorsDark.appBarIcon),
-        error = Color(colorsDark.error)
+        materialColors = darkColors(
+            primary = Color(colorsDark.primary),
+            surface = Color(colorsDark.surface),
+            onSurface = Color(colorsDark.onSurface),
+            error = Color(colorsDark.error)
+        )
     )
 
     PaymentsTheme.shapesMutable = PaymentsThemeDefaults.shapes.copy(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormUI.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -13,7 +14,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.dimensionResource
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.ui.core.FormUI
-import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.elements.FormElement
 import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.ui.core.shouldUseDarkDynamicColor
@@ -59,7 +59,7 @@ private fun Loading() {
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.Center
     ) {
-        val isDark = PaymentsTheme.colors.material.surface.shouldUseDarkDynamicColor()
+        val isDark = MaterialTheme.colors.surface.shouldUseDarkDynamicColor()
         CircularProgressIndicator(
             modifier = Modifier.size(
                 dimensionResource(R.dimen.stripe_paymentsheet_loading_indicator_size)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormFragment.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -57,6 +58,7 @@ import com.stripe.android.ui.core.elements.SectionController
 import com.stripe.android.ui.core.elements.SectionElement
 import com.stripe.android.ui.core.elements.SectionElementUI
 import com.stripe.android.ui.core.elements.SimpleDialogElementUI
+import com.stripe.android.ui.core.paymentsColors
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -480,7 +482,7 @@ internal class USBankAccountFormFragment : Fragment() {
                         Text(
                             text = "$bankName ••••$last4",
                             modifier = Modifier.alpha(if (processing.value) 0.5f else 1f),
-                            color = PaymentsTheme.colors.onComponent
+                            color = MaterialTheme.paymentsColors.onComponent
                         )
                     }
                     Image(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -18,6 +18,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -41,6 +42,7 @@ import com.stripe.android.ui.core.elements.H4Text
 import com.stripe.android.ui.core.elements.Html
 import com.stripe.android.ui.core.getBackgroundColor
 import com.stripe.android.ui.core.isSystemDarkTheme
+import com.stripe.android.ui.core.paymentsColors
 import com.stripe.android.view.KeyboardController
 import kotlin.math.roundToInt
 
@@ -280,8 +282,8 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
                     Html(
                         html = text,
                         imageGetter = mapOf(),
-                        color = PaymentsTheme.colors.subtitle,
-                        style = PaymentsTheme.typography.body1.copy(textAlign = TextAlign.Center)
+                        color = MaterialTheme.paymentsColors.subtitle,
+                        style = MaterialTheme.typography.body1.copy(textAlign = TextAlign.Center)
                     )
                 }
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/GooglePayDivider.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/GooglePayDivider.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -14,33 +15,37 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.ui.core.PaymentsTheme
+import com.stripe.android.ui.core.paymentsColors
+import com.stripe.android.ui.core.paymentsShapes
 import com.stripe.android.ui.core.shouldUseDarkDynamicColor
 
 @Composable
 internal fun GooglePayDividerUi(
     text: String = stringResource(R.string.stripe_paymentsheet_or_pay_with_card)
 ) {
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(top = 16.dp)
-    ) {
-        GooglePayDividerLine()
-        Text(
-            text = text,
-            style = PaymentsTheme.typography.body1,
-            color = PaymentsTheme.colors.subtitle,
+    PaymentsTheme {
+        Box(
+            contentAlignment = Alignment.Center,
             modifier = Modifier
-                .background(PaymentsTheme.colors.material.surface)
-                .padding(horizontal = 8.dp)
-        )
+                .fillMaxWidth()
+                .padding(top = 16.dp)
+        ) {
+            GooglePayDividerLine()
+            Text(
+                text = text,
+                style = MaterialTheme.typography.body1,
+                color = MaterialTheme.paymentsColors.subtitle,
+                modifier = Modifier
+                    .background(MaterialTheme.colors.surface)
+                    .padding(horizontal = 8.dp)
+            )
+        }
     }
 }
 
 @Composable
 internal fun GooglePayDividerLine() {
-    val color = if (PaymentsTheme.colors.material.surface.shouldUseDarkDynamicColor()) {
+    val color = if (MaterialTheme.colors.surface.shouldUseDarkDynamicColor()) {
         Color.Black.copy(alpha = .20f)
     } else {
         Color.White.copy(alpha = .20f)
@@ -48,7 +53,7 @@ internal fun GooglePayDividerLine() {
     Box(
         Modifier
             .background(color)
-            .height(PaymentsTheme.shapes.borderStrokeWidth)
+            .height(MaterialTheme.paymentsShapes.borderStrokeWidth.dp)
             .fillMaxWidth()
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/LpmSelectorText.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/LpmSelectorText.kt
@@ -4,6 +4,7 @@ import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -12,7 +13,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.stripe.android.ui.core.PaymentsTheme
 
 @Composable
 internal fun LpmSelectorText(
@@ -31,12 +31,12 @@ internal fun LpmSelectorText(
                 modifier = Modifier.padding(horizontal = 4.dp),
                 painter = painterResource(it),
                 contentDescription = null,
-                tint = PaymentsTheme.colors.material.onSurface
+                tint = MaterialTheme.colors.onSurface
             )
         }
         Text(
             text = text,
-            style = PaymentsTheme.typography.caption,
+            style = MaterialTheme.typography.caption,
             color = if (isEnabled) textColor else textColor.copy(alpha = 0.6f),
             maxLines = 1,
             overflow = TextOverflow.Ellipsis

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
@@ -222,11 +222,13 @@ internal class PrimaryButton @JvmOverloads constructor(
 
 @Composable
 private fun LabelUI(label: String) {
-    Text(
-        text = label,
-        textAlign = TextAlign.Center,
-        style = PaymentsTheme.primaryButtonStyle.getComposeTextStyle(),
-        modifier = Modifier
-            .padding(start = 4.dp, end = 4.dp, top = 4.dp, bottom = 5.dp)
-    )
+    PaymentsTheme {
+        Text(
+            text = label,
+            textAlign = TextAlign.Center,
+            style = PaymentsTheme.primaryButtonStyle.getComposeTextStyle(),
+            modifier = Modifier
+                .padding(start = 4.dp, end = 4.dp, top = 4.dp, bottom = 5.dp)
+        )
+    }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Match link inline signup to provided merchant theme
* Internal link screens ignore merchant theme
* convert `PaymentsTheme` to use composition local and create a `PaymentsThemeStatic` for UIs we don't want to change.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
* Link should be themed correctly. Composition Local is nice for future UI elements. We can now choose which ones are themed or not and reuse them in the other way if needed without much effort.
* Most of these changes are converting `PaymentsTheme` -> `MaterialTheme` and adding themes to unthemed components. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

Ran screenshot regression tests, ran through the dog fooding doc for link, manually verified with both playgrounds. 

# Screenshots
| Before  | After |
| ------------- | ------------- |
|![link-verification-screen-before](https://user-images.githubusercontent.com/89166418/169109359-2887acaf-eb8b-40b5-98de-0b6012213c60.png)|![link-verification-screen-after](https://user-images.githubusercontent.com/89166418/169110350-46a91807-f954-4d21-9f5a-ba091e3b65f0.png)|
|![link-signup-screen-before](https://user-images.githubusercontent.com/89166418/169109356-c97efe20-dce4-4b00-9cd6-c79a339dba10.png)|![link-signup-screen-after](https://user-images.githubusercontent.com/89166418/169109353-23fa0af8-e43f-4e3f-bfb5-2882a976fea6.png)|
|![link-inline-before](https://user-images.githubusercontent.com/89166418/169109351-d563918e-c00d-4eaa-abc0-878570e89297.png)|![link-inline-after](https://user-images.githubusercontent.com/89166418/169109349-e25aa970-04d2-43dd-b213-2bd43165d26e.png)|
|![link-add-new-pm-before](https://user-images.githubusercontent.com/89166418/169109346-fa5c6b8f-9d7d-4633-9c3f-3f68ff52f781.png)|![link-add-new-pm-after](https://user-images.githubusercontent.com/89166418/169109345-bfb9b867-0ad7-4a8e-a697-4c0140f9a298.png)

