### PR TITLE
Implement SelfieScan

### DIFF
--- a/camera-core/src/main/java/com/stripe/android/camera/framework/image/BitmapExtensions.kt
+++ b/camera-core/src/main/java/com/stripe/android/camera/framework/image/BitmapExtensions.kt
@@ -3,6 +3,7 @@ package com.stripe.android.camera.framework.image
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
+import android.graphics.Matrix
 import android.graphics.Rect
 import android.os.Build
 import android.util.Size
@@ -226,3 +227,31 @@ fun Bitmap.shorterEdge(): Int =
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun Bitmap.longerEdge(): Int =
     if (width > height) width else height
+
+@CheckResult
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun Bitmap.mirrorHorizontally(): Bitmap =
+    Bitmap.createBitmap(
+        this, 0, 0, this.width, this.height,
+        Matrix().also {
+            it.preScale(
+                -1f,
+                1f
+            )
+        },
+        false
+    )
+
+@CheckResult
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun Bitmap.mirrorVertically(): Bitmap =
+    Bitmap.createBitmap(
+        this, 0, 0, this.width, this.height,
+        Matrix().also {
+            it.preScale(
+                1f,
+                -1f
+            )
+        },
+        false
+    )

--- a/identity/api/identity.api
+++ b/identity/api/identity.api
@@ -211,6 +211,7 @@ public final class com/stripe/android/identity/databinding/SelfieItemBinding : a
 }
 
 public final class com/stripe/android/identity/databinding/SelfieScanFragmentBinding : androidx/viewbinding/ViewBinding {
+	public final field allowImageCollection Landroid/widget/CheckBox;
 	public final field cameraView Lcom/stripe/android/camera/scanui/CameraView;
 	public final field capturedImages Landroidx/recyclerview/widget/RecyclerView;
 	public final field flashMask Landroid/view/View;

--- a/identity/res/layout/selfie_scan_fragment.xml
+++ b/identity/res/layout/selfie_scan_fragment.xml
@@ -73,7 +73,7 @@
 
     <LinearLayout
         android:id="@+id/result_view"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:visibility="gone"
         android:orientation="vertical">
@@ -86,8 +86,9 @@
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 
         <CheckBox
+            android:id="@+id/allow_image_collection"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/page_horizontal_margin"
             android:layout_marginEnd="@dimen/page_horizontal_margin"
             android:layout_marginTop="20dp"

--- a/identity/src/main/java/com/stripe/android/identity/ml/FaceDetectorAnalyzer.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ml/FaceDetectorAnalyzer.kt
@@ -1,0 +1,106 @@
+package com.stripe.android.identity.ml
+
+import com.stripe.android.camera.framework.Analyzer
+import com.stripe.android.camera.framework.AnalyzerFactory
+import com.stripe.android.camera.framework.image.cropCenter
+import com.stripe.android.camera.framework.image.size
+import com.stripe.android.camera.framework.util.maxAspectRatioInSize
+import com.stripe.android.identity.states.IdentityScanState
+import org.tensorflow.lite.DataType
+import org.tensorflow.lite.Interpreter
+import org.tensorflow.lite.support.common.ops.NormalizeOp
+import org.tensorflow.lite.support.image.ImageProcessor
+import org.tensorflow.lite.support.image.TensorImage
+import org.tensorflow.lite.support.image.ops.ResizeOp
+import java.io.File
+
+/**
+ * Analyzer to run FaceDetector.
+ */
+internal class FaceDetectorAnalyzer(
+    modelFile: File
+) : Analyzer<AnalyzerInput, IdentityScanState, AnalyzerOutput> {
+
+    private val tfliteInterpreter = Interpreter(modelFile)
+
+    override suspend fun analyze(
+        data: AnalyzerInput,
+        state: IdentityScanState
+    ): AnalyzerOutput {
+
+        var tensorImage = TensorImage(INPUT_TENSOR_TYPE)
+
+        val croppedImage = data.cameraPreviewImage.image.cropCenter(
+            maxAspectRatioInSize(
+                data.cameraPreviewImage.image.size(),
+                1f
+            )
+        )
+
+        tensorImage.load(croppedImage)
+
+        // preprocess - resize the image to model input
+        val imageProcessor =
+            ImageProcessor.Builder()
+                .add(
+                    ResizeOp(INPUT_HEIGHT, INPUT_WIDTH, ResizeOp.ResizeMethod.BILINEAR)
+                )
+                .add(
+                    NormalizeOp(NORMALIZE_MEAN, NORMALIZE_STD) // normalize to [0, 1)
+                )
+                .build()
+        tensorImage = imageProcessor.process(tensorImage)
+
+        // inference - input: (1, 128, 128, 3), output: (1, 4), (1, 1)
+        val boundingBoxes = Array(1) { FloatArray(OUTPUT_BOUNDING_BOX_TENSOR_SIZE) }
+        val score = FloatArray(OUTPUT_SCORE_TENSOR_SIZE)
+        tfliteInterpreter.runForMultipleInputsOutputs(
+            arrayOf(tensorImage.buffer),
+            mapOf(
+                OUTPUT_BOUNDING_BOX_TENSOR_INDEX to boundingBoxes,
+                OUTPUT_SCORE_TENSOR_INDEX to score,
+            )
+        )
+
+        // FaceDetector outputs (left, top, right, bottom) with absolute value
+        // convert them to (left, top, width, height) with fractional value
+        return FaceDetectorOutput(
+            boundingBox = BoundingBox(
+                left = boundingBoxes[0][0] / INPUT_WIDTH,
+                top = boundingBoxes[0][1] / INPUT_HEIGHT,
+                width = (boundingBoxes[0][2] - boundingBoxes[0][0]) / INPUT_WIDTH,
+                height = (boundingBoxes[0][3] - boundingBoxes[0][1]) / INPUT_HEIGHT,
+            ),
+            resultScore = score[0]
+        )
+    }
+
+    override val statsName: String? = null
+
+    internal class Factory(
+        private val modelFile: File
+    ) : AnalyzerFactory<
+            AnalyzerInput,
+            IdentityScanState,
+            AnalyzerOutput,
+            Analyzer<AnalyzerInput, IdentityScanState, AnalyzerOutput>
+            > {
+        override suspend fun newInstance(): Analyzer<AnalyzerInput, IdentityScanState, AnalyzerOutput> {
+            return FaceDetectorAnalyzer(modelFile)
+        }
+    }
+
+    internal companion object {
+        const val INPUT_WIDTH = 128
+        const val INPUT_HEIGHT = 128
+        const val OUTPUT_BOUNDING_BOX_TENSOR_INDEX = 0
+        const val OUTPUT_SCORE_TENSOR_INDEX = 1
+        const val OUTPUT_BOUNDING_BOX_TENSOR_SIZE = 4
+        const val OUTPUT_SCORE_TENSOR_SIZE = 1
+        const val NORMALIZE_MEAN = 0f
+        const val NORMALIZE_STD = 255f
+
+        val INPUT_TENSOR_TYPE: DataType = DataType.FLOAT32
+        val TAG: String = FaceDetectorAnalyzer::class.java.simpleName
+    }
+}

--- a/identity/src/main/java/com/stripe/android/identity/ml/IDDetectorAnalyzer.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ml/IDDetectorAnalyzer.kt
@@ -16,7 +16,7 @@ import java.io.File
 import kotlin.math.roundToInt
 
 /**
- * Analyzer to run a model input.
+ * Analyzer to run IDDetector.
  *
  * TODO(ccen): reimplement with ImageClassifier
  */

--- a/identity/src/main/java/com/stripe/android/identity/navigation/CouldNotCaptureFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/CouldNotCaptureFragment.kt
@@ -19,7 +19,6 @@ internal class CouldNotCaptureFragment : BaseErrorFragment() {
             "Argument to CouldNotCaptureFragment is null"
         }
         val scanType = args[ARG_COULD_NOT_CAPTURE_SCAN_TYPE] as IdentityScanState.ScanType
-        val requireLiveCapture = args[ARG_REQUIRE_LIVE_CAPTURE] as Boolean
 
         title.text = getString(R.string.could_not_capture_title)
         message1.text = getString(R.string.could_not_capture_body1)
@@ -34,7 +33,7 @@ internal class CouldNotCaptureFragment : BaseErrorFragment() {
                 navigateToUploadFragment(
                     scanType.toUploadDestinationId(),
                     shouldShowTakePhoto = true,
-                    shouldShowChoosePhoto = !requireLiveCapture
+                    shouldShowChoosePhoto = !(args[ARG_REQUIRE_LIVE_CAPTURE] as Boolean)
                 )
             }
         }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
@@ -29,6 +29,7 @@ import com.stripe.android.identity.viewmodel.IdentityScanViewModel
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.io.File
 
 /**
  * An abstract [Fragment] class to access camera scanning for Identity.
@@ -71,7 +72,7 @@ internal abstract class IdentityCameraScanFragment(
                     if (finalResult.identityState is IdentityScanState.Finished) {
                         identityViewModel.uploadScanResult(
                             finalResult,
-                            verificationPage.documentCapture,
+                            verificationPage,
                             identityScanViewModel.targetScanType
                         )
                     } else if (finalResult.identityState is IdentityScanState.TimeOut) {
@@ -103,9 +104,12 @@ internal abstract class IdentityCameraScanFragment(
             when (it.status) {
                 Status.SUCCESS -> {
                     requireNotNull(it.data).let { pageFilePair ->
+                        // TODO(IDPROD-3944) - download faceDetector model file
+                        val faceDetectorModelFile = File("path/to/faceDetector")
                         identityScanViewModel.initializeScanFlow(
                             pageFilePair.first,
-                            pageFilePair.second
+                            idDetectorModelFile = pageFilePair.second,
+                            faceDetectorModelFile = faceDetectorModelFile
                         )
                         lifecycleScope.launch(Dispatchers.Main) {
                             onCameraReady()

--- a/identity/src/main/java/com/stripe/android/identity/navigation/SelfieFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/SelfieFragment.kt
@@ -169,38 +169,36 @@ internal class SelfieFragment(
                             continueButton.toggleToLoading()
                         }
                         it.isAllUploaded() -> {
-                            lifecycleScope.launch {
-                                runCatching {
-                                    val faceDetectorTransitioner =
-                                        requireNotNull(
-                                            identityScanViewModel.finalResult.value?.identityState?.transitioner as? FaceDetectorTransitioner
-                                        ) {
-                                            "Failed to retrieve final result for Selfie"
-                                        }
-                                    postVerificationPageDataAndMaybeSubmit(
-                                        identityViewModel = identityViewModel,
-                                        collectedDataParam = CollectedDataParam.createForSelfie(
-                                            firstHighResResult = requireNotNull(it.firstHighResResult.data),
-                                            firstLowResResult = requireNotNull(it.firstLowResResult.data),
-                                            lastHighResResult = requireNotNull(it.lastHighResResult.data),
-                                            lastLowResResult = requireNotNull(it.lastLowResResult.data),
-                                            bestHighResResult = requireNotNull(it.bestHighResResult.data),
-                                            bestLowResResult = requireNotNull(it.bestLowResResult.data),
-                                            trainingConsent = allowImageCollection.isChecked,
-                                            faceScoreVariance = faceDetectorTransitioner.scoreVariance,
-                                            numFrames = faceDetectorTransitioner.numFrames
-                                        ),
-                                        fromFragment = fragmentId,
-                                        clearDataParam = ClearDataParam.SELFIE_TO_CONFIRM,
-                                        shouldNotSubmit = { false }
-                                    )
-                                }.onFailure { throwable ->
-                                    Log.e(
-                                        TAG,
-                                        "fail to submit uploaded files: $throwable"
-                                    )
-                                    navigateToDefaultErrorFragment()
-                                }
+                            runCatching {
+                                val faceDetectorTransitioner =
+                                    requireNotNull(
+                                        identityScanViewModel.finalResult.value?.identityState?.transitioner as? FaceDetectorTransitioner
+                                    ) {
+                                        "Failed to retrieve final result for Selfie"
+                                    }
+                                postVerificationPageDataAndMaybeSubmit(
+                                    identityViewModel = identityViewModel,
+                                    collectedDataParam = CollectedDataParam.createForSelfie(
+                                        firstHighResResult = requireNotNull(it.firstHighResResult.data),
+                                        firstLowResResult = requireNotNull(it.firstLowResResult.data),
+                                        lastHighResResult = requireNotNull(it.lastHighResResult.data),
+                                        lastLowResResult = requireNotNull(it.lastLowResResult.data),
+                                        bestHighResResult = requireNotNull(it.bestHighResResult.data),
+                                        bestLowResResult = requireNotNull(it.bestLowResResult.data),
+                                        trainingConsent = allowImageCollection.isChecked,
+                                        faceScoreVariance = faceDetectorTransitioner.scoreVariance,
+                                        numFrames = faceDetectorTransitioner.numFrames
+                                    ),
+                                    fromFragment = fragmentId,
+                                    clearDataParam = ClearDataParam.SELFIE_TO_CONFIRM,
+                                    shouldNotSubmit = { false }
+                                )
+                            }.onFailure { throwable ->
+                                Log.e(
+                                    TAG,
+                                    "fail to submit uploaded files: $throwable"
+                                )
+                                navigateToDefaultErrorFragment()
                             }
                         }
                         else -> {

--- a/identity/src/main/java/com/stripe/android/identity/networking/SelfieUploadState.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/SelfieUploadState.kt
@@ -1,0 +1,148 @@
+package com.stripe.android.identity.networking
+
+import com.stripe.android.identity.states.FaceDetectorTransitioner
+
+/**
+ * Indicates the update states of images for selfie.
+ */
+internal data class SelfieUploadState(
+    val firstHighResResult: Resource<UploadedResult> = Resource.loading(),
+    val firstLowResResult: Resource<UploadedResult> = Resource.loading(),
+    val lastHighResResult: Resource<UploadedResult> = Resource.loading(),
+    val lastLowResResult: Resource<UploadedResult> = Resource.loading(),
+    val bestHighResResult: Resource<UploadedResult> = Resource.loading(),
+    val bestLowResResult: Resource<UploadedResult> = Resource.loading()
+) {
+
+    private val allResults = listOf(
+        firstHighResResult,
+        firstLowResResult,
+        lastHighResResult,
+        lastLowResResult,
+        bestHighResResult,
+        bestLowResResult
+    )
+
+    fun update(
+        isHighRes: Boolean,
+        newResult: UploadedResult,
+        selfie: FaceDetectorTransitioner.Selfie
+    ) = if (isHighRes) {
+        when (selfie) {
+            FaceDetectorTransitioner.Selfie.FIRST -> {
+                this.copy(
+                    firstHighResResult = Resource.success(newResult)
+                )
+            }
+            FaceDetectorTransitioner.Selfie.LAST -> {
+                this.copy(
+                    lastHighResResult = Resource.success(newResult)
+                )
+            }
+            FaceDetectorTransitioner.Selfie.BEST -> {
+                this.copy(
+                    bestHighResResult = Resource.success(newResult)
+                )
+            }
+        }
+    } else {
+        when (selfie) {
+            FaceDetectorTransitioner.Selfie.FIRST -> {
+                this.copy(
+                    firstLowResResult = Resource.success(newResult)
+                )
+            }
+            FaceDetectorTransitioner.Selfie.LAST -> {
+                this.copy(
+                    lastLowResResult = Resource.success(newResult)
+                )
+            }
+            FaceDetectorTransitioner.Selfie.BEST -> {
+                this.copy(
+                    bestLowResResult = Resource.success(newResult)
+                )
+            }
+        }
+    }
+
+    fun updateError(
+        isHighRes: Boolean,
+        selfie: FaceDetectorTransitioner.Selfie,
+        message: String,
+        throwable: Throwable
+    ) = if (isHighRes) {
+        when (selfie) {
+            FaceDetectorTransitioner.Selfie.FIRST -> {
+                this.copy(
+                    firstHighResResult = Resource.error(msg = message, throwable = throwable)
+                )
+            }
+            FaceDetectorTransitioner.Selfie.LAST -> {
+                this.copy(
+                    lastHighResResult = Resource.error(msg = message, throwable = throwable)
+                )
+            }
+            FaceDetectorTransitioner.Selfie.BEST -> {
+                this.copy(
+                    bestHighResResult = Resource.error(msg = message, throwable = throwable)
+                )
+            }
+        }
+    } else {
+        when (selfie) {
+            FaceDetectorTransitioner.Selfie.FIRST -> {
+                this.copy(
+                    firstLowResResult = Resource.error(msg = message, throwable = throwable)
+                )
+            }
+            FaceDetectorTransitioner.Selfie.LAST -> {
+                this.copy(
+                    lastLowResResult = Resource.error(msg = message, throwable = throwable)
+                )
+            }
+            FaceDetectorTransitioner.Selfie.BEST -> {
+                this.copy(
+                    bestLowResResult = Resource.error(msg = message, throwable = throwable)
+                )
+            }
+        }
+    }
+
+    fun hasError(): Boolean {
+        allResults.forEach { result ->
+            if (result.status == Status.ERROR) {
+                return true
+            }
+        }
+        return false
+    }
+
+    fun getError(): Throwable {
+        StringBuilder().let { errorMessageBuilder ->
+            allResults.forEach { result ->
+                if (result.status == Status.ERROR) {
+                    errorMessageBuilder.appendLine(result.message)
+                }
+            }
+            return IllegalStateException(errorMessageBuilder.toString())
+        }
+    }
+
+    fun isAnyLoading(): Boolean {
+        allResults.forEach { result ->
+            if (result.status == Status.LOADING) {
+                return true
+            }
+        }
+        return false
+    }
+
+    fun isAllUploaded(): Boolean {
+        allResults.forEach { result ->
+            if (result.status != Status.SUCCESS) {
+                return false
+            }
+        }
+        return true
+    }
+}

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/ClearDataParam.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/ClearDataParam.kt
@@ -53,5 +53,14 @@ internal data class ClearDataParam(
             idDocumentFront = false,
             idDocumentBack = false
         )
+
+        internal val SELFIE_TO_CONFIRM = ClearDataParam(
+            biometricConsent = false,
+            idDocumentType = false,
+            idDocumentFront = false,
+            idDocumentBack = false,
+            face = false,
+            trainingConsent = false
+        )
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/CollectedDataParam.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/CollectedDataParam.kt
@@ -114,8 +114,28 @@ internal data class CollectedDataParam(
                     idDocumentType = type
                 )
 
-        fun createForSelfie(): CollectedDataParam {
-            return CollectedDataParam(true)
-        }
+        fun createForSelfie(
+            firstHighResResult: UploadedResult,
+            firstLowResResult: UploadedResult,
+            lastHighResResult: UploadedResult,
+            lastLowResResult: UploadedResult,
+            bestHighResResult: UploadedResult,
+            bestLowResResult: UploadedResult,
+            trainingConsent: Boolean,
+            faceScoreVariance: Float,
+            numFrames: Int
+        ) = CollectedDataParam(
+            trainingConsent = trainingConsent,
+            face = FaceUploadParam(
+                bestHighResImage = bestHighResResult.uploadedStripeFile.id,
+                bestLowResImage = bestLowResResult.uploadedStripeFile.id,
+                firstHighResImage = firstHighResResult.uploadedStripeFile.id,
+                firstLowResImage = firstLowResResult.uploadedStripeFile.id,
+                lastHighResImage = lastHighResResult.uploadedStripeFile.id,
+                lastLowResImage = lastLowResResult.uploadedStripeFile.id,
+                faceScoreVariance = faceScoreVariance,
+                numFrames = numFrames
+            )
+        )
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/FaceUploadParam.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/FaceUploadParam.kt
@@ -22,6 +22,4 @@ internal data class FaceUploadParam(
     val faceScoreVariance: Float? = null,
     @SerialName("num_frames")
     val numFrames: Int? = null,
-    @SerialName("focal_length")
-    val focalLength: Float? = null,
 )

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPage.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPage.kt
@@ -14,7 +14,7 @@ internal data class VerificationPage(
     val documentCapture: VerificationPageStaticContentDocumentCapturePage,
     @SerialName("document_select")
     val documentSelect: VerificationPageStaticContentDocumentSelectPage,
-    @SerialName("selfie") // TODO(IDPROD-3944) Verifi with server change
+    @SerialName("selfie") // TODO(IDPROD-3944) Verify with server change
     val selfieCapture: VerificationPageStaticContentSelfieCapturePage? = null,
     /* The short-lived URL that can be used in the case that the client cannot support the VerificationSession. */
     @SerialName("fallback_url")

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/CameraViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/CameraViewModel.kt
@@ -32,8 +32,18 @@ internal open class CameraViewModel :
 
     internal lateinit var identityScanFlow: IdentityScanFlow
 
-    internal fun initializeScanFlow(verificationPage: VerificationPage, identityModelFile: File) {
-        identityScanFlow = IdentityScanFlow(this, this, identityModelFile, verificationPage)
+    internal fun initializeScanFlow(
+        verificationPage: VerificationPage,
+        idDetectorModelFile: File,
+        faceDetectorModelFile: File
+    ) {
+        identityScanFlow = IdentityScanFlow(
+            this,
+            this,
+            idDetectorModelFile,
+            faceDetectorModelFile,
+            verificationPage
+        )
     }
 
     override var scanState: IdentityScanState? = null

--- a/identity/src/test/java/com/stripe/android/identity/navigation/DriverLicenseScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/DriverLicenseScanFragmentTest.kt
@@ -27,7 +27,6 @@ import com.stripe.android.identity.networking.models.ClearDataParam
 import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.networking.models.DocumentUploadParam
 import com.stripe.android.identity.networking.models.VerificationPage
-import com.stripe.android.identity.networking.models.VerificationPageStaticContentDocumentCapturePage
 import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.utils.SingleLiveEvent
 import com.stripe.android.identity.viewModelFactoryFor
@@ -390,14 +389,11 @@ internal class DriverLicenseScanFragmentTest {
             any()
         )
 
-        val mockDocumentCapture = mock<VerificationPageStaticContentDocumentCapturePage>()
-        val mockVerificationPage = mock<VerificationPage> {
-            on { documentCapture } doReturn mockDocumentCapture
-        }
+        val mockVerificationPage = mock<VerificationPage>()
         successCaptor.lastValue.invoke(mockVerificationPage)
         verify(mockIdentityViewModel).uploadScanResult(
             same(finalResult),
-            same(mockDocumentCapture),
+            same(mockVerificationPage),
             eq(targetType)
         )
     }

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IDScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IDScanFragmentTest.kt
@@ -28,7 +28,6 @@ import com.stripe.android.identity.networking.models.ClearDataParam
 import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.networking.models.DocumentUploadParam
 import com.stripe.android.identity.networking.models.VerificationPage
-import com.stripe.android.identity.networking.models.VerificationPageStaticContentDocumentCapturePage
 import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.utils.SingleLiveEvent
 import com.stripe.android.identity.viewModelFactoryFor
@@ -96,7 +95,14 @@ internal class IDScanFragmentTest {
 
     @Before
     fun simulateModelDownloaded() {
-        mockPageAndModel.postValue(Resource.success(Pair(SUCCESS_VERIFICATION_PAGE_NOT_REQUIRE_LIVE_CAPTURE, mock())))
+        mockPageAndModel.postValue(
+            Resource.success(
+                Pair(
+                    SUCCESS_VERIFICATION_PAGE_NOT_REQUIRE_LIVE_CAPTURE,
+                    mock()
+                )
+            )
+        )
     }
 
     @Test
@@ -369,14 +375,11 @@ internal class IDScanFragmentTest {
             any()
         )
 
-        val mockDocumentCapture = mock<VerificationPageStaticContentDocumentCapturePage>()
-        val mockVerificationPage = mock<VerificationPage> {
-            on { documentCapture } doReturn mockDocumentCapture
-        }
+        val mockVerificationPage = mock<VerificationPage>()
         successCaptor.lastValue.invoke(mockVerificationPage)
         verify(mockIdentityViewModel).uploadScanResult(
             same(finalResult),
-            same(mockDocumentCapture),
+            same(mockVerificationPage),
             eq(targetType)
         )
     }

--- a/identity/src/test/java/com/stripe/android/identity/navigation/PassportScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/PassportScanFragmentTest.kt
@@ -25,7 +25,6 @@ import com.stripe.android.identity.networking.models.ClearDataParam
 import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.networking.models.DocumentUploadParam
 import com.stripe.android.identity.networking.models.VerificationPage
-import com.stripe.android.identity.networking.models.VerificationPageStaticContentDocumentCapturePage
 import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.utils.SingleLiveEvent
 import com.stripe.android.identity.viewModelFactoryFor
@@ -90,7 +89,14 @@ class PassportScanFragmentTest {
 
     @Before
     fun simulateModelDownloaded() {
-        mockPageAndModel.postValue(Resource.success(Pair(SUCCESS_VERIFICATION_PAGE_NOT_REQUIRE_LIVE_CAPTURE, mock())))
+        mockPageAndModel.postValue(
+            Resource.success(
+                Pair(
+                    SUCCESS_VERIFICATION_PAGE_NOT_REQUIRE_LIVE_CAPTURE,
+                    mock()
+                )
+            )
+        )
     }
 
     @Test
@@ -263,15 +269,12 @@ class PassportScanFragmentTest {
                 any()
             )
 
-            val mockDocumentCapture = mock<VerificationPageStaticContentDocumentCapturePage>()
-            val mockVerificationPage = mock<VerificationPage> {
-                on { documentCapture } doReturn mockDocumentCapture
-            }
+            val mockVerificationPage = mock<VerificationPage>()
             whenever(mockIdentityScanViewModel.targetScanType).thenReturn(IdentityScanState.ScanType.PASSPORT)
             successCaptor.lastValue.invoke(mockVerificationPage)
             verify(mockIdentityViewModel).uploadScanResult(
                 same(mockFrontFinalResult),
-                same(mockDocumentCapture),
+                same(mockVerificationPage),
                 eq(IdentityScanState.ScanType.PASSPORT)
             )
 

--- a/identity/src/test/java/com/stripe/android/identity/navigation/SelfieFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/SelfieFragmentTest.kt
@@ -1,32 +1,48 @@
 package com.stripe.android.identity.navigation
 
+import android.graphics.Bitmap
 import android.view.View
+import android.widget.Button
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.lifecycle.MediatorLiveData
 import androidx.navigation.Navigation
 import androidx.navigation.testing.TestNavHostController
 import androidx.test.core.app.ApplicationProvider
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.progressindicator.CircularProgressIndicator
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.camera.CameraPreviewImage
 import com.stripe.android.identity.R
 import com.stripe.android.identity.camera.IdentityAggregator
 import com.stripe.android.identity.camera.IdentityScanFlow
 import com.stripe.android.identity.databinding.SelfieScanFragmentBinding
+import com.stripe.android.identity.ml.AnalyzerInput
+import com.stripe.android.identity.ml.FaceDetectorOutput
 import com.stripe.android.identity.networking.DocumentUploadState
 import com.stripe.android.identity.networking.Resource
+import com.stripe.android.identity.networking.SelfieUploadState
+import com.stripe.android.identity.networking.UploadedResult
+import com.stripe.android.identity.networking.models.ClearDataParam
+import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.networking.models.VerificationPage
+import com.stripe.android.identity.states.FaceDetectorTransitioner
 import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.utils.SingleLiveEvent
 import com.stripe.android.identity.viewModelFactoryFor
 import com.stripe.android.identity.viewmodel.IdentityScanViewModel
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.runBlocking
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 import java.io.File
 
@@ -49,14 +65,39 @@ internal class SelfieFragmentTest {
     private val documentUploadState =
         MutableStateFlow(DocumentUploadState())
 
+    private val selfieUploadState = MutableStateFlow(SelfieUploadState())
+
+    private val errorUploadState = mock<SelfieUploadState> {
+        on { hasError() } doReturn true
+    }
+
+    private val loadingUploadState = mock<SelfieUploadState> {
+        on { hasError() } doReturn false
+        on { isAnyLoading() } doReturn true
+    }
+
+    private val mockUploadedResult = mock<UploadedResult> {
+        on { uploadedStripeFile }.thenReturn(mock())
+    }
+    private val successUploadState = SelfieUploadState(
+        firstHighResResult = Resource.success(mockUploadedResult),
+        firstLowResResult = Resource.success(mockUploadedResult),
+        lastHighResResult = Resource.success(mockUploadedResult),
+        lastLowResResult = Resource.success(mockUploadedResult),
+        bestHighResResult = Resource.success(mockUploadedResult),
+        bestLowResResult = Resource.success(mockUploadedResult)
+    )
+
     private val mockIdentityViewModel = mock<IdentityViewModel> {
         on { pageAndModel } doReturn mockPageAndModel
         on { documentUploadState } doReturn documentUploadState
+        on { selfieUploadState } doReturn selfieUploadState
     }
 
     @Test
     fun `when initialized UI is reset`() {
-        launchSelfieFragment { binding, _ ->
+        launchSelfieFragment { binding, _, _ ->
+            verify(mockIdentityViewModel).resetSelfieUploadedState()
             assertThat(binding.scanningView.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.resultView.visibility).isEqualTo(View.GONE)
             assertThat(binding.kontinue.isEnabled).isEqualTo(false)
@@ -64,18 +105,123 @@ internal class SelfieFragmentTest {
     }
 
     @Test
+    fun `when Found UI is set and flash once`() {
+        launchSelfieFragment { binding, _, fragment ->
+            assertThat(fragment.flashed).isFalse()
+
+            displayStateChanged.postValue((mock<IdentityScanState.Found>() to mock()))
+            assertThat(binding.message.text).isEqualTo(fragment.getText(R.string.capturing))
+            assertThat(fragment.flashed).isTrue()
+
+            displayStateChanged.postValue((mock<IdentityScanState.Found>() to mock()))
+            assertThat(binding.message.text).isEqualTo(fragment.getText(R.string.capturing))
+            assertThat(fragment.flashed).isTrue()
+        }
+    }
+
+    @Test
+    fun `when Satisfied UI is set`() {
+        launchSelfieFragment { binding, _, fragment ->
+            assertThat(fragment.flashed).isFalse()
+
+            displayStateChanged.postValue((mock<IdentityScanState.Satisfied>() to mock()))
+            assertThat(binding.message.text).isEqualTo(fragment.getText(R.string.selfie_capture_complete))
+        }
+    }
+
+    @Test
     fun `when finished UI is toggled`() {
-        launchSelfieFragment { binding, _ ->
-            // mock success of front scan
-            displayStateChanged.postValue((mock<IdentityScanState.Finished>() to mock()))
+        launchSelfieFragment { binding, _, fragment ->
+            assertThat(fragment.selfieResultAdapter.itemCount).isEqualTo(0)
+
+            displayStateChanged.postValue((FINISHED to mock()))
 
             assertThat(binding.scanningView.visibility).isEqualTo(View.GONE)
             assertThat(binding.resultView.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.kontinue.isEnabled).isEqualTo(true)
+            assertThat(fragment.selfieResultAdapter.itemCount).isEqualTo(FILTERED_FRAMES.size)
         }
     }
 
-    private fun launchSelfieFragment(testBlock: (SelfieScanFragmentBinding, TestNavHostController) -> Unit) =
+    @Test
+    fun `when selfieUploadState all uploaded, clicking continue triggers navigation`() {
+        launchSelfieFragment { binding, _, _ ->
+            runBlocking {
+                displayStateChanged.postValue((FINISHED to mock()))
+                assertThat(binding.kontinue.isEnabled).isEqualTo(true)
+                selfieUploadState.update {
+                    successUploadState
+                }
+                finalResultLiveData.postValue(
+                    IdentityAggregator.FinalResult(
+                        mock(),
+                        mock(),
+                        FINISHED
+                    )
+                )
+                binding.kontinue.findViewById<Button>(R.id.button).callOnClick()
+
+                verify(mockIdentityViewModel).postVerificationPageData(
+                    eq(
+                        CollectedDataParam.createForSelfie(
+                            firstHighResResult = requireNotNull(successUploadState.firstHighResResult.data),
+                            firstLowResResult = requireNotNull(successUploadState.firstLowResResult.data),
+                            lastHighResResult = requireNotNull(successUploadState.lastHighResResult.data),
+                            lastLowResResult = requireNotNull(successUploadState.lastLowResResult.data),
+                            bestHighResResult = requireNotNull(successUploadState.bestHighResResult.data),
+                            bestLowResResult = requireNotNull(successUploadState.bestLowResResult.data),
+                            trainingConsent = binding.allowImageCollection.isChecked,
+                            faceScoreVariance = SCORE_VARIANCE,
+                            numFrames = NUM_FRAMES
+                        )
+                    ),
+                    eq(ClearDataParam.SELFIE_TO_CONFIRM)
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `when selfieUploadState hasError, clicking continue navigates to ErrorFragment`() {
+        launchSelfieFragment { binding, navController, _ ->
+            runBlocking {
+                displayStateChanged.postValue((FINISHED to mock()))
+                assertThat(binding.kontinue.isEnabled).isEqualTo(true)
+                selfieUploadState.update {
+                    errorUploadState
+                }
+                binding.kontinue.findViewById<Button>(R.id.button).callOnClick()
+
+                assertThat(navController.currentDestination?.id)
+                    .isEqualTo(R.id.errorFragment)
+            }
+        }
+    }
+
+    @Test
+    fun `when selfieUploadState isLoading, clicking continue triggers toggles loading state`() {
+        launchSelfieFragment { binding, navController, _ ->
+            runBlocking {
+                displayStateChanged.postValue((FINISHED to mock()))
+                assertThat(binding.kontinue.isEnabled).isEqualTo(true)
+                selfieUploadState.update {
+                    loadingUploadState
+                }
+                binding.kontinue.findViewById<Button>(R.id.button).callOnClick()
+
+                assertThat(
+                    binding.kontinue.findViewById<MaterialButton>(R.id.button).isEnabled
+                ).isFalse()
+                assertThat(
+                    binding.kontinue.findViewById<CircularProgressIndicator>(R.id.indicator).visibility
+                ).isEqualTo(
+                    View.VISIBLE
+                )
+            }
+        }
+    }
+
+    private fun launchSelfieFragment(testBlock: (SelfieScanFragmentBinding, TestNavHostController, SelfieFragment) -> Unit) =
         launchFragmentInContainer(
             themeResId = R.style.Theme_MaterialComponents
         ) {
@@ -95,6 +241,54 @@ internal class SelfieFragmentTest {
                 it.requireView(),
                 navController
             )
-            testBlock(SelfieScanFragmentBinding.bind(it.requireView()), navController)
+            testBlock(SelfieScanFragmentBinding.bind(it.requireView()), navController, it)
         }
+
+    private companion object {
+        val dummyBitmap: Bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888)
+        val FILTERED_FRAMES = listOf(
+            AnalyzerInput(
+                cameraPreviewImage = CameraPreviewImage(
+                    image = dummyBitmap,
+                    viewBounds = mock()
+                ),
+                viewFinderBounds = mock()
+            ) to FaceDetectorOutput(
+                boundingBox = mock(),
+                resultScore = 0.81f
+            ), // first
+            AnalyzerInput(
+                cameraPreviewImage = CameraPreviewImage(
+                    image = dummyBitmap,
+                    viewBounds = mock()
+                ),
+                viewFinderBounds = mock()
+            ) to FaceDetectorOutput(
+                boundingBox = mock(),
+                resultScore = 0.9f
+            ), // best
+            AnalyzerInput(
+                cameraPreviewImage = CameraPreviewImage(
+                    image = dummyBitmap,
+                    viewBounds = mock()
+                ),
+                viewFinderBounds = mock()
+            ) to FaceDetectorOutput(
+                boundingBox = mock(),
+                resultScore = 0.82f
+            ), // last
+        )
+
+        const val SCORE_VARIANCE = 0.1f
+        const val NUM_FRAMES = 8
+
+        val FINISHED = IdentityScanState.Finished(
+            type = IdentityScanState.ScanType.SELFIE,
+            transitioner = mock<FaceDetectorTransitioner> {
+                on { filteredFrames }.thenReturn(FILTERED_FRAMES)
+                on { scoreVariance }.thenReturn(SCORE_VARIANCE)
+                on { numFrames }.thenReturn(NUM_FRAMES)
+            }
+        )
+    }
 }

--- a/identity/src/test/java/com/stripe/android/identity/states/FaceDetectorTransitionerTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/states/FaceDetectorTransitionerTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.identity.states
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.camera.framework.time.ClockMark
 import com.stripe.android.camera.framework.time.milliseconds
+import com.stripe.android.core.model.StripeFilePurpose
 import com.stripe.android.identity.ml.AnalyzerInput
 import com.stripe.android.identity.ml.BoundingBox
 import com.stripe.android.identity.ml.FaceDetectorOutput
@@ -71,7 +72,7 @@ internal class FaceDetectorTransitionerTest {
         )
 
         verify(mockSelfieFrameSaver).saveFrame(
-            eq((mockInput to VALID_SCORE)),
+            eq((mockInput to VALID_OUTPUT)),
             same(VALID_OUTPUT)
         )
         assertThat(
@@ -233,7 +234,7 @@ internal class FaceDetectorTransitionerTest {
         const val NUM_SAMPLES = 8
         val SELFIE_CAPTURE_PAGE = VerificationPageStaticContentSelfieCapturePage(
             autoCaptureTimeout = 15000,
-            filePurpose = "selfie",
+            filePurpose = StripeFilePurpose.IdentityPrivate.code,
             numSamples = NUM_SAMPLES,
             sampleInterval = SAMPLE_INTERVAL,
             models = VerificationPageStaticContentSelfieModels(

--- a/identity/src/test/java/com/stripe/android/identity/viewmodel/IdentityViewModelTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/viewmodel/IdentityViewModelTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.identity.IdentityVerificationSheetContract
 import com.stripe.android.identity.camera.IdentityAggregator
 import com.stripe.android.identity.ml.AnalyzerInput
 import com.stripe.android.identity.ml.BoundingBox
+import com.stripe.android.identity.ml.FaceDetectorOutput
 import com.stripe.android.identity.ml.IDDetectorOutput
 import com.stripe.android.identity.networking.DocumentUploadState
 import com.stripe.android.identity.networking.IdentityModelFetcher
@@ -23,6 +24,9 @@ import com.stripe.android.identity.networking.models.DocumentUploadParam
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentDocumentCaptureModels
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentDocumentCapturePage
+import com.stripe.android.identity.networking.models.VerificationPageStaticContentSelfieCapturePage
+import com.stripe.android.identity.networking.models.VerificationPageStaticContentSelfieModels
+import com.stripe.android.identity.states.FaceDetectorTransitioner
 import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.utils.IdentityIO
 import com.stripe.android.identity.viewmodel.IdentityViewModel.Companion.BACK
@@ -48,6 +52,7 @@ internal class IdentityViewModelTest {
 
     private val mockVerificationPage = mock<VerificationPage> {
         on { documentCapture }.thenReturn(DOCUMENT_CAPTURE)
+        on { selfieCapture }.thenReturn(SELFIE_CAPTURE)
     }
     private val mockIdentityRepository = mock<IdentityRepository> {
         onBlocking {
@@ -56,8 +61,11 @@ internal class IdentityViewModelTest {
     }
     private val mockIdentityModelFetcher = mock<IdentityModelFetcher> {
         onBlocking {
-            fetchIdentityModel(any())
+            fetchIdentityModel(eq(ID_DETECTOR_URL))
         }.thenReturn(ID_DETECTOR_FILE)
+        onBlocking {
+            fetchIdentityModel(eq(FACE_DETECTOR_URL))
+        }.thenReturn(FACE_DETECTOR_FILE)
     }
     private val mockIdentityIO = mock<IdentityIO> {
         on { resizeUriAndCreateFileToUpload(any(), any(), any(), any(), any(), any()) }.thenReturn(
@@ -66,6 +74,10 @@ internal class IdentityViewModelTest {
 
         on { resizeBitmapAndCreateFileToUpload(any(), any(), any(), any(), any()) }.thenReturn(
             File(IMAGE_FILE_NAME)
+        )
+
+        on { cropAndPadBitmap(any(), any(), any()) }.thenReturn(
+            CROPPED_BITMAP
         )
     }
 
@@ -122,16 +134,62 @@ internal class IdentityViewModelTest {
 
     @Test
     fun `uploadScanResult front success uploads both files and notifies _documentUploadedState`() {
-        testUploadScanSuccessResult(true)
+        testUploadDocumentScanSuccessResult(true)
     }
 
     @Test
     fun `uploadScanResult back success uploads both files and notifies _documentUploadedState`() {
-        testUploadScanSuccessResult(false)
+        testUploadDocumentScanSuccessResult(false)
     }
 
     @Test
-    fun `retrieveAndBufferVerificationPage retrives model and notifies _verificationPage`() =
+    fun `uploadScanResult uploads all files and notifies _selfieUploadedState`() {
+        mockUploadSuccess()
+        viewModel.uploadScanResult(
+            FINAL_FACE_DETECTOR_RESULT,
+            mockVerificationPage,
+            IdentityScanState.ScanType.SELFIE
+        )
+
+        listOf(
+            (FaceDetectorTransitioner.Selfie.FIRST),
+            (FaceDetectorTransitioner.Selfie.BEST),
+            (FaceDetectorTransitioner.Selfie.LAST)
+        ).forEach { selfie ->
+            listOf(true, false).forEach { isHighRes ->
+                testUploadSelfieScanSuccessResult(selfie, isHighRes)
+            }
+        }
+    }
+
+    @Test
+    fun `uploadScanResult upload failure notifies _selfieUploadedState`() {
+        mockUploadFailure()
+        viewModel.uploadScanResult(
+            FINAL_FACE_DETECTOR_RESULT,
+            mockVerificationPage,
+            IdentityScanState.ScanType.SELFIE
+        )
+
+        listOf(
+            (viewModel.selfieUploadState.value.firstHighResResult),
+            (viewModel.selfieUploadState.value.firstLowResResult),
+            (viewModel.selfieUploadState.value.bestHighResResult),
+            (viewModel.selfieUploadState.value.bestLowResResult),
+            (viewModel.selfieUploadState.value.lastHighResResult),
+            (viewModel.selfieUploadState.value.lastLowResResult),
+        ).forEach { uploadedResult ->
+            assertThat(uploadedResult).isEqualTo(
+                Resource.error<UploadedResult>(
+                    msg = "Failed to upload file : $IMAGE_FILE_NAME",
+                    throwable = UPLOADED_FAILURE_EXCEPTION
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `retrieveAndBufferVerificationPage retrieves model and notifies _verificationPage`() =
         runBlocking {
             viewModel.retrieveAndBufferVerificationPage()
 
@@ -148,8 +206,16 @@ internal class IdentityViewModelTest {
                 eq(ID_DETECTOR_URL)
             )
 
+            verify(mockIdentityModelFetcher).fetchIdentityModel(
+                eq(FACE_DETECTOR_URL)
+            )
+
             assertThat(viewModel.idDetectorModelFile.value).isEqualTo(
                 Resource.success(ID_DETECTOR_FILE)
+            )
+
+            assertThat(viewModel.faceDetectorModelFile.value).isEqualTo(
+                Resource.success(FACE_DETECTOR_FILE)
             )
         }
 
@@ -190,14 +256,12 @@ internal class IdentityViewModelTest {
         }
     }
 
-    private fun testUploadScanSuccessResult(isFront: Boolean) {
+    private fun testUploadDocumentScanSuccessResult(isFront: Boolean) {
         mockUploadSuccess()
-        val mockCroppedBitmap = mock<Bitmap>()
-        whenever(mockIdentityIO.cropAndPadBitmap(any(), any(), any())).thenReturn(mockCroppedBitmap)
 
         viewModel.uploadScanResult(
             FINAL_ID_DETECTOR_RESULT,
-            DOCUMENT_CAPTURE,
+            mockVerificationPage,
             if (isFront)
                 IdentityScanState.ScanType.ID_FRONT
             else
@@ -212,7 +276,7 @@ internal class IdentityViewModelTest {
         )
 
         verify(mockIdentityIO).resizeBitmapAndCreateFileToUpload(
-            same(mockCroppedBitmap),
+            same(CROPPED_BITMAP),
             eq(VERIFICATION_SESSION_ID),
             eq(
                 if (isFront)
@@ -270,6 +334,73 @@ internal class IdentityViewModelTest {
         }
     }
 
+    private fun testUploadSelfieScanSuccessResult(
+        selfie: FaceDetectorTransitioner.Selfie,
+        isHighRes: Boolean
+    ) {
+        if (isHighRes) { // high res
+            verify(mockIdentityIO).cropAndPadBitmap(
+                same(FILTERED_FRAMES[selfie.index].first.cameraPreviewImage.image),
+                same(FILTERED_FRAMES[selfie.index].second.boundingBox),
+                any()
+            )
+
+            verify(mockIdentityIO).resizeBitmapAndCreateFileToUpload(
+                same(CROPPED_BITMAP),
+                eq(VERIFICATION_SESSION_ID),
+                eq(
+                    when (selfie) {
+                        FaceDetectorTransitioner.Selfie.FIRST -> "${VERIFICATION_SESSION_ID}_face_first_crop_frame.jpeg"
+                        FaceDetectorTransitioner.Selfie.BEST -> "${VERIFICATION_SESSION_ID}_face.jpeg"
+                        FaceDetectorTransitioner.Selfie.LAST -> "${VERIFICATION_SESSION_ID}_face_last_crop_frame.jpeg"
+                    }
+                ),
+                eq(HIGH_RES_IMAGE_MAX_DIMENSION),
+                eq(HIGH_RES_COMPRESSION_QUALITY)
+            )
+            assertThat(
+                when (selfie) {
+                    FaceDetectorTransitioner.Selfie.FIRST -> viewModel.selfieUploadState.value.firstHighResResult
+                    FaceDetectorTransitioner.Selfie.BEST -> viewModel.selfieUploadState.value.bestHighResResult
+                    FaceDetectorTransitioner.Selfie.LAST -> viewModel.selfieUploadState.value.lastHighResResult
+                }
+            ).isEqualTo(
+                Resource.success(
+                    UploadedResult(
+                        UPLOADED_STRIPE_FILE,
+                    )
+                )
+            )
+        } else { // low res
+            verify(mockIdentityIO).resizeBitmapAndCreateFileToUpload(
+                same(FILTERED_FRAMES[selfie.index].first.cameraPreviewImage.image),
+                eq(VERIFICATION_SESSION_ID),
+                eq(
+                    when (selfie) {
+                        FaceDetectorTransitioner.Selfie.FIRST -> "${VERIFICATION_SESSION_ID}_face_first_full_frame.jpeg"
+                        FaceDetectorTransitioner.Selfie.BEST -> "${VERIFICATION_SESSION_ID}_face_full_frame.jpeg"
+                        FaceDetectorTransitioner.Selfie.LAST -> "${VERIFICATION_SESSION_ID}_face_last_full_frame.jpeg"
+                    }
+                ),
+                eq(LOW_RES_IMAGE_MAX_DIMENSION),
+                eq(LOW_RES_COMPRESSION_QUALITY)
+            )
+            assertThat(
+                when (selfie) {
+                    FaceDetectorTransitioner.Selfie.FIRST -> viewModel.selfieUploadState.value.firstLowResResult
+                    FaceDetectorTransitioner.Selfie.BEST -> viewModel.selfieUploadState.value.bestLowResResult
+                    FaceDetectorTransitioner.Selfie.LAST -> viewModel.selfieUploadState.value.lastLowResResult
+                }
+            ).isEqualTo(
+                Resource.success(
+                    UploadedResult(
+                        UPLOADED_STRIPE_FILE,
+                    )
+                )
+            )
+        }
+    }
+
     private fun testUploadManualFailureResult(isFront: Boolean) {
         mockUploadFailure()
 
@@ -303,7 +434,9 @@ internal class IdentityViewModelTest {
         const val HIGH_RES_COMPRESSION_QUALITY = 0.9f
         const val LOW_RES_IMAGE_MAX_DIMENSION = 256
         const val LOW_RES_COMPRESSION_QUALITY = 0.4f
+        const val NUM_SAMPLES = 8
         const val ID_DETECTOR_URL = "path/to/idDetector"
+        const val FACE_DETECTOR_URL = "path/to/faceDetector"
         val DOCUMENT_CAPTURE =
             VerificationPageStaticContentDocumentCapturePage(
                 autocaptureTimeout = 0,
@@ -321,6 +454,31 @@ internal class IdentityViewModelTest {
                 motionBlurMinDuration = 500,
                 motionBlurMinIou = 0.95f
             )
+
+        val SELFIE_CAPTURE =
+            VerificationPageStaticContentSelfieCapturePage(
+                autoCaptureTimeout = 15000,
+                filePurpose = StripeFilePurpose.IdentityPrivate.code,
+                numSamples = NUM_SAMPLES,
+                sampleInterval = 200,
+                models = VerificationPageStaticContentSelfieModels(
+                    faceDetectorUrl = FACE_DETECTOR_URL,
+                    faceDetectorMinScore = 0.8f,
+                    faceDetectorIou = 0.5f
+                ),
+                maxCenteredThresholdX = 0.2f,
+                maxCenteredThresholdY = 0.2f,
+                minEdgeThreshold = 0.05f,
+                minCoverageThreshold = 0.07f,
+                maxCoverageThreshold = 0.8f,
+                lowResImageMaxDimension = LOW_RES_IMAGE_MAX_DIMENSION,
+                lowResImageCompressionQuality = LOW_RES_COMPRESSION_QUALITY,
+                highResImageMaxDimension = HIGH_RES_IMAGE_MAX_DIMENSION,
+                highResImageCompressionQuality = HIGH_RES_COMPRESSION_QUALITY,
+                highResImageCropPadding = 0.5f,
+                consentText = "consent"
+            )
+
         val UPLOADED_STRIPE_FILE = StripeFile()
         val UPLOADED_FAILURE_EXCEPTION = APIException()
 
@@ -341,9 +499,63 @@ internal class IdentityViewModelTest {
                 resultScore = 0.8f,
                 allScores = ALL_SCORES
             ),
-            identityState = mock<IdentityScanState.Finished>(),
-            savedFrames = null
+            identityState = mock<IdentityScanState.Finished>()
         )
+
+        val FILTERED_FRAMES = listOf(
+            AnalyzerInput(
+                cameraPreviewImage = CameraPreviewImage(
+                    image = mock(),
+                    viewBounds = mock()
+                ),
+                viewFinderBounds = mock()
+            ) to FaceDetectorOutput(
+                boundingBox = mock(),
+                resultScore = 0.81f
+            ), // first
+            AnalyzerInput(
+                cameraPreviewImage = CameraPreviewImage(
+                    image = mock(),
+                    viewBounds = mock()
+                ),
+                viewFinderBounds = mock()
+            ) to FaceDetectorOutput(
+                boundingBox = mock(),
+                resultScore = 0.9f
+            ), // best
+            AnalyzerInput(
+                cameraPreviewImage = CameraPreviewImage(
+                    image = mock(),
+                    viewBounds = mock()
+                ),
+                viewFinderBounds = mock()
+            ) to FaceDetectorOutput(
+                boundingBox = mock(),
+                resultScore = 0.82f
+            ), // last
+        )
+        val FINAL_FACE_DETECTOR_RESULT = IdentityAggregator.FinalResult(
+            frame = AnalyzerInput(
+                CameraPreviewImage(
+                    INPUT_BITMAP,
+                    mock()
+                ),
+                mock()
+            ),
+            result = FaceDetectorOutput(
+                boundingBox = BOUNDING_BOX,
+                resultScore = 0.8f
+            ),
+            identityState = IdentityScanState.Finished(
+                type = IdentityScanState.ScanType.SELFIE,
+                transitioner = mock<FaceDetectorTransitioner> {
+                    on { filteredFrames }.thenReturn(FILTERED_FRAMES)
+                }
+            )
+        )
+
         val ID_DETECTOR_FILE = mock<File>()
+        val FACE_DETECTOR_FILE = mock<File>()
+        val CROPPED_BITMAP = mock<Bitmap>()
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Created a `FaceDetectorAnalyzer`, similar to `IDDetectorAnalyzer` to run face detector model
  * `IdentityScanFlow.analyzerPool` will contain `FaceDetectorAnalyzer.Factory` when the ScanType is `SELFIE` and contain `IDDetectorAnalyzer.Facetory` when ScanType is one of the document types
* Calculate the standard deviation for frames saved in `FaceDetectorTransitioner` and wire them over to `SelfieFragment` when the continue button is clicked, these information is sent to the `postVerificationPageData` endpoint.
* Added the logic to upload and notify collected selfie image in `IdentityViewModel`, sharing some common infra with document image
* [camera-core] added `Bitmap.mirrorHorizontally` and `Bitmap.mirrorVertically` - this is required to display captured selfie with mirrored diretion


* Note: currently the server side change is not ready yet, `SelfieFragment` logic won't be triggered anywhere in current flow. Will enable it afterwards.


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Selfie
# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
