### PR TITLE
Add usage field to Appearance API metrics

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -36,7 +36,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
                     FIELD_BORDER_WIDTH to (primaryButtonConfig?.shape?.borderStrokeWidthDp != null),
                     FIELD_FONT to (primaryButtonConfig?.typography?.fontResId != null)
                 )
-                val appearanceConfigMap = mapOf(
+                val appearanceConfigMap = mutableMapOf(
                     FIELD_COLORS_LIGHT to (
                         configuration?.appearance?.colorsLight
                             != PaymentSheet.Colors.defaultLight
@@ -60,6 +60,14 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
                         ),
                     FIELD_PRIMARY_BUTTON to primaryButtonConfigMap
                 )
+                // We add a usage field to make queries easier.
+                val usedPrimaryButtonApi = primaryButtonConfigMap.values.contains(true)
+                val usedAppearanceApi = appearanceConfigMap
+                    .values.filterIsInstance<Boolean>().contains(true)
+
+                appearanceConfigMap[FIELD_APPEARANCE_USAGE] =
+                    usedAppearanceApi || usedPrimaryButtonApi
+
                 val configurationMap = mapOf(
                     FIELD_CUSTOMER to (configuration?.customer != null),
                     FIELD_GOOGLE_PAY to (configuration?.googlePay != null),
@@ -140,6 +148,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         const val FIELD_DELAYED_PMS = "allows_delayed_payment_methods"
         const val FIELD_MOBILE_PAYMENT_ELEMENT_CONFIGURATION = "mpe_config"
         const val FIELD_APPEARANCE = "appearance"
+        const val FIELD_APPEARANCE_USAGE = "usage"
         const val FIELD_COLORS_LIGHT = "colorsLight"
         const val FIELD_COLORS_DARK = "colorsDark"
         const val FIELD_CORNER_RADIUS = "corner_radius"

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -75,7 +75,8 @@ class PaymentSheetEventTest {
             "border_width" to false,
             "size_scale_factor" to false,
             "font" to false,
-            "primary_button" to expectedPrimaryButton
+            "primary_button" to expectedPrimaryButton,
+            "usage" to false
         )
         val expectedConfigMap = mapOf(
             "customer" to false,
@@ -111,7 +112,8 @@ class PaymentSheetEventTest {
             "border_width" to true,
             "size_scale_factor" to true,
             "font" to true,
-            "primary_button" to expectedPrimaryButton
+            "primary_button" to expectedPrimaryButton,
+            "usage" to true
         )
         val expectedConfigMap = mapOf(
             "customer" to true,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Adds a higher level `usage` field to our appearance metrics.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
* easy to query and easy to quickly see if a merchant is using any sort of customization.
* iOS is doing this too: https://github.com/stripe-ios/stripe-ios/pull/1135

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
