### PR TITLE
Remove force portrait from Google Pay activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # CHANGELOG
+## 20.x.x - xxxx-xx-xx
+
+### Payments
+* [CHANGED] [5038](https://github.com/stripe/stripe-android/pull/5038) Remove force portrait mode in Google Pay.
+
 ## 20.3.0 - 2022-05.16
 This release adds `us_bank_account` PaymentMethod to PaymentSheet.
 

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherActivity.kt
@@ -2,8 +2,6 @@ package com.stripe.android.googlepaylauncher
 
 import android.annotation.SuppressLint
 import android.content.Intent
-import android.content.pm.ActivityInfo
-import android.os.Build
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -46,11 +44,6 @@ internal class GooglePayLauncherActivity : AppCompatActivity() {
     @SuppressLint("SourceLockedOrientationActivity")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        if (Build.VERSION.SDK_INT != Build.VERSION_CODES.O) {
-            // In Oreo, Activities where `android:windowIsTranslucent=true` can't request
-            // orientation. See https://stackoverflow.com/a/50832408/11103900
-            requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        }
 
         disableAnimations()
 

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherActivity.kt
@@ -1,8 +1,6 @@
 package com.stripe.android.googlepaylauncher
 
 import android.content.Intent
-import android.content.pm.ActivityInfo
-import android.os.Build
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -46,12 +44,6 @@ internal class GooglePayPaymentMethodLauncherActivity : AppCompatActivity() {
         val statusColor = intent.getIntExtra(GooglePayPaymentMethodLauncherContract.EXTRA_STATUS_BAR_COLOR, -1)
         if (statusColor != -1) {
             window.statusBarColor = statusColor
-        }
-
-        if (Build.VERSION.SDK_INT != Build.VERSION_CODES.O) {
-            // In Oreo, Activities where `android:windowIsTranslucent=true` can't request
-            // orientation. See https://stackoverflow.com/a/50832408/11103900
-            requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         }
 
         disableAnimations()

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/StripeGooglePayActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/StripeGooglePayActivity.kt
@@ -1,8 +1,6 @@
 package com.stripe.android.googlepaylauncher
 
 import android.content.Intent
-import android.content.pm.ActivityInfo
-import android.os.Build
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -49,11 +47,6 @@ internal class StripeGooglePayActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        if (Build.VERSION.SDK_INT != Build.VERSION_CODES.O) {
-            // In Oreo, Activities where `android:windowIsTranslucent=true` can't request
-            // orientation. See https://stackoverflow.com/a/50832408/11103900
-            requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        }
 
         overridePendingTransition(0, 0)
         setResult(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Remove force portrait mode in Google Pay activity.

Similar fix https://github.com/stripe/stripe-android/pull/4855

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Fixes https://github.com/stripe/stripe-android/issues/5037

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

- [CHANGED] Remove force portrait mode in Google Pay.
