### PR TITLE
Create `flagMode` for country dropdown.

### DIFF
--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -82,6 +82,10 @@ public final class com/stripe/android/ui/core/elements/ComposableSingletons$Sect
 	public final fun getLambda-1$payments_ui_core_release ()Lkotlin/jvm/functions/Function2;
 }
 
+public final class com/stripe/android/ui/core/elements/DropdownConfig$DefaultImpls {
+	public static fun getTinyMode (Lcom/stripe/android/ui/core/elements/DropdownConfig;)Z
+}
+
 public final class com/stripe/android/ui/core/elements/EmailConfig$Companion {
 	public final fun getPATTERN ()Ljava/util/regex/Pattern;
 }
@@ -252,8 +256,8 @@ public final class com/stripe/android/ui/core/elements/StaticTextElementUIKt {
 }
 
 public final class com/stripe/android/ui/core/elements/TextFieldUIKt {
-	public static final fun TextField-skw0Wq0 (Lcom/stripe/android/ui/core/elements/TextFieldController;Landroidx/compose/ui/Modifier;IZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
-	public static final fun TextFieldSection-7FxtGnE (Lcom/stripe/android/ui/core/elements/TextFieldController;Ljava/lang/Integer;Landroidx/compose/ui/Modifier;IZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun TextField-PwfN4xk (Lcom/stripe/android/ui/core/elements/TextFieldController;Landroidx/compose/ui/Modifier;IZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun TextFieldSection-VyDzSTg (Lcom/stripe/android/ui/core/elements/TextFieldController;Landroidx/compose/ui/Modifier;Ljava/lang/Integer;IZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/stripe/android/ui/core/elements/menu/CheckboxKt {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CountryConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CountryConfig.kt
@@ -74,7 +74,7 @@ class CountryConfig(
     }
 
     private fun getCountryName(displayName: String) = if (flagMode) {
-        // In flag mode, remove the flag which is located beforet the first space
+        // In flag mode, remove the flag which is located before the first space
         displayName.substring(displayName.indexOf(" ") + 1)
     } else {
         displayName

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CountryConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CountryConfig.kt
@@ -49,8 +49,12 @@ class CountryConfig(
         } ?: ""
 
     override fun convertFromRaw(rawValue: String) =
-        CountryUtils.getCountryByCode(CountryCode.create(rawValue), Locale.getDefault())?.name
-            ?: displayItems[0]
+        CountryUtils.getCountryByCode(CountryCode.create(rawValue), Locale.getDefault())
+            ?.let { country ->
+                countries.indexOf(country).takeUnless { it == -1 }?.let {
+                    displayItems[it]
+                }
+            } ?: displayItems.firstOrNull() ?: ""
 
     override fun convertToRaw(displayName: String) =
         CountryUtils.getCountryCodeByName(getCountryName(displayName), Locale.getDefault())?.value

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CountryConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CountryConfig.kt
@@ -36,21 +36,17 @@ class CountryConfig(
         }
 
     override val displayItems: List<String> = countries.map { country ->
-        if (flagMode) {
-            "${countryCodeToEmoji(country.code.value)} ${country.name}"
-        } else {
-            country.name
-        }
+        "${countryCodeToEmoji(country.code.value)} ${country.name}"
     }
 
     override fun getSelectedItemLabel(index: Int) =
-        if (index < 0 || index >= countries.size) {
-            ""
-        } else if (flagMode) {
-            countryCodeToEmoji(countries[index].code.value)
-        } else {
-            displayItems[index]
-        }
+        countries.getOrNull(index)?.let {
+            if (flagMode) {
+                countryCodeToEmoji(it.code.value)
+            } else {
+                it.name
+            }
+        } ?: ""
 
     override fun convertFromRaw(rawValue: String) =
         CountryUtils.getCountryByCode(CountryCode.create(rawValue), Locale.getDefault())?.name
@@ -73,10 +69,7 @@ class CountryConfig(
         return String(Character.toChars(firstLetter)) + String(Character.toChars(secondLetter))
     }
 
-    private fun getCountryName(displayName: String) = if (flagMode) {
-        // In flag mode, remove the flag which is located before the first space
+    private fun getCountryName(displayName: String) =
+        // Remove the flag which is located before the first space
         displayName.substring(displayName.indexOf(" ") + 1)
-    } else {
-        displayName
-    }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownConfig.kt
@@ -11,7 +11,14 @@ sealed interface DropdownConfig {
     val label: Int
 
     /** This is the list of displayable items to show in the drop down **/
-    fun getDisplayItems(): List<String>
+    val displayItems: List<String>
+
+    /** Whether the dropdown menu should be shown in a small form when collapsed **/
+    val tinyMode: Boolean
+        get() = false
+
+    /** The label identifying the selected item used when the dropdown menu is collapsed **/
+    fun getSelectedItemLabel(index: Int): String
 
     /**
      * This will convert the field to a raw value to use in the parameter map

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownConfig.kt
@@ -7,7 +7,7 @@ sealed interface DropdownConfig {
     /** This is a label for debug logs **/
     val debugLabel: String
 
-    /** This is the label to describe the field */
+    /** This is the label to describe the field **/
     val label: Int
 
     /** This is the list of displayable items to show in the drop down **/
@@ -20,13 +20,9 @@ sealed interface DropdownConfig {
     /** The label identifying the selected item used when the dropdown menu is collapsed **/
     fun getSelectedItemLabel(index: Int): String
 
-    /**
-     * This will convert from a raw value used in the parameter map to a displayValue
-     */
+    /** This will convert from a raw value used in the parameter map to a display value **/
     fun convertFromRaw(rawValue: String): String
 
-    /**
-     * This will convert the field to a raw value to use in the parameter map
-     */
+    /** This will convert the field to a raw value to use in the parameter map **/
     fun convertToRaw(displayName: String): String?
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownConfig.kt
@@ -21,12 +21,12 @@ sealed interface DropdownConfig {
     fun getSelectedItemLabel(index: Int): String
 
     /**
-     * This will convert the field to a raw value to use in the parameter map
+     * This will convert from a raw value used in the parameter map to a displayValue
      */
     fun convertFromRaw(rawValue: String): String
 
     /**
-     * This will convert from a raw value used in the parameter map to a disiplayValue
+     * This will convert the field to a raw value to use in the parameter map
      */
     fun convertToRaw(displayName: String): String?
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownFieldController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownFieldController.kt
@@ -4,6 +4,7 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.ui.core.forms.FormFieldEntry
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 
@@ -17,9 +18,9 @@ class DropdownFieldController(
     private val config: DropdownConfig,
     initialValue: String? = null
 ) : InputController, SectionFieldErrorController {
-    val displayItems: List<String> = config.getDisplayItems()
+    val displayItems: List<String> = config.displayItems
     private val _selectedIndex = MutableStateFlow(0)
-    val selectedIndex: Flow<Int> = _selectedIndex
+    val selectedIndex: StateFlow<Int> = _selectedIndex
     override val label: Flow<Int> = MutableStateFlow(config.label)
     override val fieldValue = selectedIndex.map { displayItems[it] }
     override val rawFieldValue = fieldValue.map { config.convertToRaw(it) }
@@ -31,9 +32,16 @@ class DropdownFieldController(
             FormFieldEntry(value, complete)
         }
 
+    val tinyMode = config.tinyMode
+
     init {
         initialValue?.let { onRawValueChange(it) }
     }
+
+    /**
+     * Get the label for the selected item, shown when the dropdown list is collapsed.
+     */
+    fun getSelectedItemLabel(index: Int) = config.getSelectedItemLabel(index)
 
     /**
      * This is called when the value changed to is a display value.

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownFieldUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DropdownFieldUI.kt
@@ -61,12 +61,11 @@ internal fun DropDown(
     controller: DropdownFieldController,
     enabled: Boolean,
 ) {
-    val label by controller.label.collectAsState(
-        null
-    )
+    val label by controller.label.collectAsState(null)
     val selectedIndex by controller.selectedIndex.collectAsState(0)
     val items = controller.displayItems
     var expanded by remember { mutableStateOf(false) }
+    val selectedItemLabel = controller.getSelectedItemLabel(selectedIndex)
     val interactionSource = remember { MutableInteractionSource() }
     val currentTextColor = if (enabled) {
         MaterialTheme.paymentsColors.onComponent
@@ -96,31 +95,45 @@ internal fun DropDown(
                     expanded = true
                 }
         ) {
-            Column(
-                modifier = Modifier.padding(
-                    start = 16.dp,
-                    top = 4.dp,
-                    bottom = 8.dp
-                )
-            ) {
-                label?.let {
-                    FormLabel(stringResource(it), enabled)
-                }
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.Bottom
-                ) {
+            if (controller.tinyMode) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(
-                        items[selectedIndex],
-                        modifier = Modifier.fillMaxWidth(.9f),
+                        selectedItemLabel,
                         color = currentTextColor
                     )
                     Icon(
                         Icons.Filled.ArrowDropDown,
                         contentDescription = null,
-                        modifier = Modifier.height(24.dp),
                         tint = currentTextColor
                     )
+                }
+            } else {
+                Column(
+                    modifier = Modifier.padding(
+                        start = 16.dp,
+                        top = 4.dp,
+                        bottom = 8.dp
+                    )
+                ) {
+                    label?.let {
+                        FormLabel(stringResource(it), enabled = enabled)
+                    }
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.Bottom
+                    ) {
+                        Text(
+                            selectedItemLabel,
+                            modifier = Modifier.fillMaxWidth(.9f),
+                            color = currentTextColor
+                        )
+                        Icon(
+                            Icons.Filled.ArrowDropDown,
+                            contentDescription = null,
+                            modifier = Modifier.height(24.dp),
+                            tint = currentTextColor
+                        )
+                    }
                 }
             }
         }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/FormLabel.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/FormLabel.kt
@@ -4,17 +4,20 @@ import androidx.compose.material.ContentAlpha
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import com.stripe.android.ui.core.paymentsColors
 
 @Composable
 internal fun FormLabel(
     text: String,
+    modifier: Modifier = Modifier,
     enabled: Boolean = true
 ) {
     val color = MaterialTheme.paymentsColors.placeholderText
     Text(
-        color = if (enabled) color else color.copy(alpha = ContentAlpha.disabled),
         text = text,
+        modifier = modifier,
+        color = if (enabled) color else color.copy(alpha = ContentAlpha.disabled),
         style = MaterialTheme.typography.subtitle1
     )
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SimpleDropdownConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SimpleDropdownConfig.kt
@@ -10,8 +10,10 @@ class SimpleDropdownConfig(
 ) : DropdownConfig {
     override val debugLabel = "simple_dropdown"
 
-    override fun getDisplayItems(): List<String> =
+    override val displayItems: List<String> =
         items.map { it.display_text }
+
+    override fun getSelectedItemLabel(index: Int) = displayItems[index]
 
     override fun convertFromRaw(rawValue: String) =
         items

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
@@ -45,11 +45,10 @@ import com.stripe.android.ui.core.paymentsColors
 @Composable
 fun TextFieldSection(
     textFieldController: TextFieldController,
-    @StringRes sectionTitle: Int? = null,
     modifier: Modifier = Modifier,
+    @StringRes sectionTitle: Int? = null,
     imeAction: ImeAction,
     enabled: Boolean,
-    onValueChanged: (String) -> Unit = {},
     onTextStateChanged: (TextFieldState?) -> Unit = {}
 ) {
     val error by textFieldController.error.collectAsState(null)
@@ -69,7 +68,6 @@ fun TextFieldSection(
             enabled = enabled,
             imeAction = imeAction,
             modifier = modifier,
-            onValueChanged = onValueChanged,
             onTextStateChanged = onTextStateChanged
         )
     }
@@ -86,7 +84,6 @@ fun TextField(
     modifier: Modifier = Modifier,
     imeAction: ImeAction,
     enabled: Boolean,
-    onValueChanged: (String) -> Unit = {},
     onTextStateChanged: (TextFieldState?) -> Unit = {}
 ) {
     val focusManager = LocalFocusManager.current
@@ -101,9 +98,7 @@ fun TextField(
     val fieldState by textFieldController.fieldState.collectAsState(
         TextFieldStateConstants.Error.Blank
     )
-    val label by textFieldController.label.collectAsState(
-        null
-    )
+    val label by textFieldController.label.collectAsState(null)
     var processedIsFull by rememberSaveable { mutableStateOf(false) }
 
     /**
@@ -166,7 +161,7 @@ fun TextField(
             )
         },
         trailingIcon = trailingIcon?.let {
-            { TrailingIcon(it, colors, loading) }
+            { TrailingIcon(it, loading) }
         },
         isError = shouldShowError,
         visualTransformation = textFieldController.visualTransformation,
@@ -211,7 +206,6 @@ fun TextFieldColors(
 @Composable
 internal fun TrailingIcon(
     trailingIcon: TextFieldIcon,
-    colors: androidx.compose.material.TextFieldColors,
     loading: Boolean
 ) {
     if (loading) {

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CountryConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CountryConfigTest.kt
@@ -10,7 +10,7 @@ class CountryConfigTest {
     @Test
     fun `Verify the displayed country list`() {
         assertThat(CountryConfig(locale = Locale.US).displayItems[0])
-            .isEqualTo("United States")
+            .isEqualTo("🇺🇸 United States")
     }
 
     @Test
@@ -26,7 +26,7 @@ class CountryConfigTest {
                 onlyShowCountryCodes = setOf("AT"),
                 locale = Locale.US
             ).displayItems[0]
-        ).isEqualTo("Austria")
+        ).isEqualTo("🇦🇹 Austria")
     }
 
     @Test
@@ -41,14 +41,14 @@ class CountryConfigTest {
     }
 
     @Test
-    fun `Flag mode shows flag next to country name`() {
+    fun `Regular mode shows only country name when collapsed`() {
         assertThat(
             CountryConfig(
                 onlyShowCountryCodes = setOf("AT"),
                 locale = Locale.US,
-                flagMode = true
-            ).displayItems[0]
-        ).isEqualTo("🇦🇹 Austria")
+                flagMode = false
+            ).getSelectedItemLabel(0)
+        ).isEqualTo("Austria")
     }
 
     @Test

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CountryConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CountryConfigTest.kt
@@ -9,7 +9,7 @@ class CountryConfigTest {
 
     @Test
     fun `Verify the displayed country list`() {
-        assertThat(CountryConfig(locale = Locale.US).getDisplayItems()[0])
+        assertThat(CountryConfig(locale = Locale.US).displayItems[0])
             .isEqualTo("United States")
     }
 
@@ -25,8 +25,53 @@ class CountryConfigTest {
             CountryConfig(
                 onlyShowCountryCodes = setOf("AT"),
                 locale = Locale.US
-            ).getDisplayItems()[0]
+            ).displayItems[0]
         ).isEqualTo("Austria")
+    }
+
+    @Test
+    fun `Verify converts diplay name to country`() {
+        val config = CountryConfig(
+            onlyShowCountryCodes = setOf("AT"),
+            locale = Locale.US
+        )
+        assertThat(
+            config.convertToRaw(config.displayItems[0])
+        ).isEqualTo("AT")
+    }
+
+    @Test
+    fun `Flag mode shows flag next to country name`() {
+        assertThat(
+            CountryConfig(
+                onlyShowCountryCodes = setOf("AT"),
+                locale = Locale.US,
+                flagMode = true
+            ).displayItems[0]
+        ).isEqualTo("🇦🇹 Austria")
+    }
+
+    @Test
+    fun `Flag mode shows only flag when collapsed`() {
+        assertThat(
+            CountryConfig(
+                onlyShowCountryCodes = setOf("AT"),
+                locale = Locale.US,
+                flagMode = true
+            ).getSelectedItemLabel(0)
+        ).isEqualTo("🇦🇹")
+    }
+
+    @Test
+    fun `Flag mode converts diplay name to country`() {
+        val config = CountryConfig(
+            onlyShowCountryCodes = setOf("AT"),
+            locale = Locale.US,
+            flagMode = true
+        )
+        assertThat(
+            config.convertToRaw(config.displayItems[0])
+        ).isEqualTo("AT")
     }
 
     @Test
@@ -34,11 +79,11 @@ class CountryConfigTest {
         val defaultCountries = CountryConfig(
             onlyShowCountryCodes = emptySet(),
             locale = Locale.US
-        ).getDisplayItems()
+        ).displayItems
         val supportedCountries = CountryConfig(
             onlyShowCountryCodes = supportedBillingCountries,
             locale = Locale.US
-        ).getDisplayItems()
+        ).displayItems
 
         val excludedCountries = setOf(
             "American Samoa", "Christmas Island", "Cocos (Keeling) Islands", "Cuba",

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/DropdownFieldControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/DropdownFieldControllerTest.kt
@@ -3,7 +3,6 @@ package com.stripe.android.ui.core.elements
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
 import java.util.Locale
 
@@ -21,11 +20,11 @@ class DropdownFieldControllerTest {
 
     @Test
     fun `Verify display items gets the display items form the config`() {
-        assertThat(controller.displayItems).isEqualTo(countryConfig.getDisplayItems())
+        assertThat(controller.displayItems).isEqualTo(countryConfig.displayItems)
     }
 
     @Test
-    fun `Verify label gets the label from the config`() = runBlockingTest {
+    fun `Verify label gets the label from the config`() = runBlocking {
         assertThat(controller.label.first()).isEqualTo(countryConfig.label)
     }
 

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/DropdownFieldControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/DropdownFieldControllerTest.kt
@@ -13,9 +13,9 @@ class DropdownFieldControllerTest {
     @Test
     fun `Verify that when the selected index changes the paymentMethod param value updates`() =
         runBlocking {
-            assertThat(controller.fieldValue.first()).isEqualTo("United States")
+            assertThat(controller.fieldValue.first()).isEqualTo("🇺🇸 United States")
             controller.onValueChange(1)
-            assertThat(controller.fieldValue.first()).isEqualTo("Afghanistan")
+            assertThat(controller.fieldValue.first()).isEqualTo("🇦🇫 Afghanistan")
         }
 
     @Test

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/SimpleDropdownConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/SimpleDropdownConfigTest.kt
@@ -25,7 +25,7 @@ class SimpleDropdownConfigTest {
 
     @Test
     fun `Verify getDisplayItems gets list of display strings`() {
-        assertThat(config.getDisplayItems())
+        assertThat(config.displayItems)
             .isEqualTo(
                 listOf(
                     "ABN AMRO",

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/TransformSpecToElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/TransformSpecToElementTest.kt
@@ -74,7 +74,7 @@ internal class TransformSpecToElementTest {
             val countryElement = countrySectionElement.fields[0] as CountryElement
 
             assertThat(countryElement.controller.displayItems).hasSize(1)
-            assertThat(countryElement.controller.displayItems[0]).isEqualTo("Austria")
+            assertThat(countryElement.controller.displayItems[0]).isEqualTo("🇦🇹 Austria")
 
             // Verify the correct config is setup for the controller
             assertThat(countryElement.controller.label.first()).isEqualTo(CountryConfig().label)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Create a small-form country code selector to be used in the phone number collection UI.
When collapsed, shows only the country flag. When expanded, shows country flag plus country name.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Phone Number collection UI

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
<img width="412" alt="image" src="https://user-images.githubusercontent.com/77990083/169623856-5d565b40-fe3b-43e2-927a-596c6e86ac9b.png">
<img width="328" alt="image" src="https://user-images.githubusercontent.com/77990083/169623870-cdaa0efc-dfde-45da-b88f-5009f58d56cf.png">

