### PR TITLE
Fix crash when removing payment method

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
@@ -268,6 +268,7 @@ internal class PaymentOptionsAdapter(
                         force = true
                     )
                     paymentMethodDeleteListener(items[position] as Item.SavedPaymentMethod)
+                    notifyItemRemoved(position)
                 }
         }
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Fix an issue where PaymentSheet would crash when deleting a payment method in the custom flow editor.

This was happening because the position of the payment method was not being updated properly.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Fixes https://github.com/stripe/stripe-android/issues/5043

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

- [Fixed] Fixed an issue where PaymentSheet would crash when deleting a payment method in the custom flow editor
