### PR TITLE
Download the system image for the screenshot emulator.

### DIFF
--- a/scripts/create_screenshot_test_emulator.sh
+++ b/scripts/create_screenshot_test_emulator.sh
@@ -11,6 +11,9 @@ if [ ! -d "$ANDROID_HOME/cmdline-tools" ]; then
   exit
 fi
 
+echo "download system image, if not already downloaded"
+"$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" "--install" "system-images;android-28;google_apis;x86_64"
+
 echo "creating emulator"
 "$ANDROID_HOME/cmdline-tools/latest/bin/avdmanager" "--verbose" "create" "avd" "--force" "--name" "screenshot_test_local" "--device" "Nexus 6" "--package" "system-images;android-28;google_apis;x86_64" "--tag" "google_apis" "--abi" "x86_64" "--sdcard" "512M"
 


### PR DESCRIPTION
# Summary
Download the system image required for the screenshot emulator, or update it if needed and it is already downloaded.

# Motivation
This will make spinning up an emulator for screenshot testing faster.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
