### PR TITLE
Add Deprecated annotation to old primaryButtonColor api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # CHANGELOG
+## XX.X.X - 2022-XX-XX
+
+### PaymentSheet
+* [DEPRECATED][5061](https://github.com/stripe/stripe-android/pull/5061) Add Deprecated annotation to old primaryButtonColor api.
 
 ## 20.4.0 - 2022-05-23
 This release adds [appearance customization APIs](https://github.com/stripe/stripe-android/blob/master/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt#L186) to payment sheet and enables Affirm and AU BECS direct debit as payment methods within Payment Sheet.

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,11 @@
 # Migration Guide
 
+## Migrating from versions < 20.X.X
+- Changes to `PaymentSheet.Configuration`
+  * `primaryButtonColor` is now deprecated. Please use the new `Appearance` parameter instead:
+    * `Appearance.colorsLight/colorsDark.primary`
+    * `PrimaryButton.colorsLight/colorsDark.backgroundColor`
+
 ## Migrating from versions < 20.2.0
 
 - Changes to `CollectBankAccountLauncher`

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -108,6 +108,13 @@ class PaymentSheet internal constructor(
          *
          * If set, PaymentSheet displays the button with this color.
          */
+        @Deprecated(
+            message = "Use Appearance parameter to customize primary button color",
+            replaceWith = ReplaceWith(
+                expression = "Appearance.colorsLight/colorsDark.primary " +
+                    "or PrimaryButton.colorsLight/colorsDark.background"
+            )
+        )
         val primaryButtonColor: ColorStateList? = null,
 
         /**
@@ -158,6 +165,13 @@ class PaymentSheet internal constructor(
             fun googlePay(googlePay: GooglePayConfiguration?) =
                 apply { this.googlePay = googlePay }
 
+            @Deprecated(
+                message = "Use Appearance parameter to customize primary button color",
+                replaceWith = ReplaceWith(
+                    expression = "Appearance.colorsLight/colorsDark.primary " +
+                        "or PrimaryButton.colorsLight/colorsDark.background"
+                )
+            )
             fun primaryButtonColor(primaryButtonColor: ColorStateList?) =
                 apply { this.primaryButtonColor = primaryButtonColor }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Adds a deprecation warning to the old primaryButtonColor API.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
* We have three ways to change the color of the primary button. This reduces it down to the two APIs that are with the other appearance customization APIs.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

Tried to use the api and Android Studio warned me. 

# Changelog



