### PR TITLE
Fix Link state when navigating between PMs

### DIFF
--- a/link/api/link.api
+++ b/link/api/link.api
@@ -291,6 +291,38 @@ public final class com/stripe/android/link/ui/inline/InlineSignupViewModel_Facto
 	public static fun injectViewModel (Lcom/stripe/android/link/ui/inline/InlineSignupViewModel$Factory;Lcom/stripe/android/link/ui/inline/InlineSignupViewModel;)V
 }
 
+public abstract class com/stripe/android/link/ui/inline/UserInput {
+	public static final field $stable I
+}
+
+public final class com/stripe/android/link/ui/inline/UserInput$SignIn : com/stripe/android/link/ui/inline/UserInput {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/link/ui/inline/UserInput$SignIn;
+	public static synthetic fun copy$default (Lcom/stripe/android/link/ui/inline/UserInput$SignIn;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/link/ui/inline/UserInput$SignIn;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEmail ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/link/ui/inline/UserInput$SignUp : com/stripe/android/link/ui/inline/UserInput {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/link/ui/inline/UserInput$SignUp;
+	public static synthetic fun copy$default (Lcom/stripe/android/link/ui/inline/UserInput$SignUp;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/link/ui/inline/UserInput$SignUp;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCountry ()Ljava/lang/String;
+	public final fun getEmail ()Ljava/lang/String;
+	public final fun getPhone ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/stripe/android/link/ui/paymentmethod/ComposableSingletons$FormUIKt {
 	public static final field INSTANCE Lcom/stripe/android/link/ui/paymentmethod/ComposableSingletons$FormUIKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function3;

--- a/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
@@ -21,6 +21,7 @@ import com.stripe.android.link.injection.NonFallbackInjectable
 import com.stripe.android.link.injection.NonFallbackInjector
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.inline.InlineSignupViewModel
+import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.link.ui.paymentmethod.FormViewModel
 import com.stripe.android.link.ui.paymentmethod.PaymentMethodViewModel
 import com.stripe.android.link.ui.paymentmethod.SupportedPaymentMethod
@@ -132,9 +133,11 @@ class LinkPaymentLauncher @AssistedInject internal constructor(
     }
 
     /**
-     * Trigger Link sign up with the input collected from the user.
+     * Trigger Link sign in with the input collected from the user, whether it's a new or existing
+     * account.
      */
-    suspend fun signUpWithUserInput() = linkAccountManager.signUpWithUserInput().map { true }
+    suspend fun signInWithUserInput(userInput: UserInput) =
+        linkAccountManager.signInWithUserInput(userInput).map { true }
 
     /**
      * Attach a new Card to the currently signed in Link account.

--- a/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignupView.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignupView.kt
@@ -75,7 +75,7 @@ private fun LinkInlineSignup(
     enabled: Boolean,
     onUserInteracted: () -> Unit,
     onSelected: (Boolean) -> Unit,
-    onReady: (Boolean) -> Unit
+    onUserInput: (UserInput?) -> Unit
 ) {
     val viewModel: InlineSignupViewModel = viewModel(
         factory = InlineSignupViewModel.Factory(injector)
@@ -83,15 +83,15 @@ private fun LinkInlineSignup(
 
     val signUpState by viewModel.signUpState.collectAsState(SignUpState.InputtingEmail)
     val isExpanded by viewModel.isExpanded.collectAsState(false)
-    val isReady by viewModel.isReady.collectAsState()
+    val userInput by viewModel.userInput.collectAsState()
 
     onSelected(isExpanded)
-    onReady(isReady)
+    onUserInput(userInput)
 
     val focusManager = LocalFocusManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
     LaunchedEffect(signUpState) {
-        if (signUpState == SignUpState.InputtingEmail && isReady) {
+        if (signUpState == SignUpState.InputtingEmail && userInput != null) {
             focusManager.clearFocus(true)
             keyboardController?.hide()
         }
@@ -225,11 +225,12 @@ class LinkInlineSignupView @JvmOverloads constructor(
     var hasUserInteracted = false
 
     /**
-     * Whether enough information has been collected to proceed with the payment flow.
-     * This will be true when the user has entered an email that already has a link account and just
-     * needs verification, or when they entered a new email and phone number.
+     * The collected input from the user, always valid unless null.
+     * When not null, enough information has been collected to proceed with the payment flow.
+     * This means that the user has entered an email that already has a link account and just
+     * needs verification, or entered a new email and phone number.
      */
-    val isReady = MutableStateFlow(true)
+    val userInput = MutableStateFlow<UserInput?>(null)
 
     val isSelected = MutableStateFlow(false)
 
@@ -249,7 +250,7 @@ class LinkInlineSignupView @JvmOverloads constructor(
                     enabled = enabledState,
                     onUserInteracted = { hasUserInteracted = true },
                     onSelected = { isSelected.value = it },
-                    onReady = { isReady.value = it }
+                    onUserInput = { userInput.value = it }
                 )
             }
         }

--- a/link/src/main/java/com/stripe/android/link/ui/inline/UserInput.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/UserInput.kt
@@ -1,0 +1,22 @@
+package com.stripe.android.link.ui.inline
+
+/**
+ * Valid user input into the inline sign up view.
+ */
+sealed class UserInput {
+    /**
+     * Represents an input that is valid for signing in to a link account.
+     */
+    data class SignIn(
+        val email: String
+    ) : UserInput()
+
+    /**
+     * Represents an input that is valid for signing up to a link account.
+     */
+    data class SignUp(
+        val email: String,
+        val phone: String,
+        val country: String
+    ) : UserInput()
+}

--- a/link/src/test/java/com/stripe/android/link/ui/inline/InlineSignupViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/inline/InlineSignupViewModelTest.kt
@@ -51,11 +51,12 @@ class InlineSignupViewModelTest {
         }
 
     @Test
-    fun `When entered existing account then it becomes ready`() =
+    fun `When entered existing account then it emits user input`() =
         runTest(UnconfinedTestDispatcher()) {
+            val email = "valid@email.com"
             val viewModel = createViewModel()
             viewModel.toggleExpanded()
-            viewModel.emailController.onRawValueChange("valid@email.com")
+            viewModel.emailController.onRawValueChange(email)
 
             val linkAccount = LinkAccount(
                 mockConsumerSessionWithVerificationSession(
@@ -69,7 +70,7 @@ class InlineSignupViewModelTest {
             // Advance past lookup debounce delay
             advanceTimeBy(SignUpViewModel.LOOKUP_DEBOUNCE_MS + 100)
 
-            Truth.assertThat(viewModel.isReady.value).isTrue()
+            Truth.assertThat(viewModel.userInput.value).isEqualTo(UserInput.SignIn(email))
         }
 
     @Test
@@ -85,8 +86,62 @@ class InlineSignupViewModelTest {
             // Advance past lookup debounce delay
             advanceTimeBy(SignUpViewModel.LOOKUP_DEBOUNCE_MS + 100)
 
-            Truth.assertThat(viewModel.isReady.value).isFalse()
+            Truth.assertThat(viewModel.userInput.value).isNull()
             Truth.assertThat(viewModel.signUpState.value).isEqualTo(SignUpState.InputtingPhone)
+        }
+
+    @Test
+    fun `When entered all fields for new account then it emits user input`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val email = "valid@email.com"
+            val viewModel = createViewModel()
+            viewModel.toggleExpanded()
+            viewModel.emailController.onRawValueChange(email)
+
+            Truth.assertThat(viewModel.userInput.value).isNull()
+
+            whenever(linkAccountManager.lookupConsumer(any(), any()))
+                .thenReturn(Result.success(null))
+
+            // Advance past lookup debounce delay
+            advanceTimeBy(SignUpViewModel.LOOKUP_DEBOUNCE_MS + 100)
+
+            Truth.assertThat(viewModel.userInput.value).isNull()
+
+            val phone = "1234567890"
+            viewModel.phoneController.onRawValueChange(phone)
+
+            Truth.assertThat(viewModel.userInput.value)
+                .isEqualTo(UserInput.SignUp(email, "+1$phone", "US"))
+        }
+
+    @Test
+    fun `When user input becomes invalid then it emits null user input`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val email = "valid@email.com"
+            val viewModel = createViewModel()
+            viewModel.toggleExpanded()
+            viewModel.emailController.onRawValueChange(email)
+
+            Truth.assertThat(viewModel.userInput.value).isNull()
+
+            whenever(linkAccountManager.lookupConsumer(any(), any()))
+                .thenReturn(Result.success(null))
+
+            // Advance past lookup debounce delay
+            advanceTimeBy(SignUpViewModel.LOOKUP_DEBOUNCE_MS + 100)
+
+            Truth.assertThat(viewModel.userInput.value).isNull()
+
+            val phone = "1234567890"
+            viewModel.phoneController.onRawValueChange(phone)
+
+            Truth.assertThat(viewModel.userInput.value)
+                .isEqualTo(UserInput.SignUp(email, "+1$phone", "US"))
+
+            viewModel.phoneController.onRawValueChange("")
+
+            Truth.assertThat(viewModel.userInput.value).isNull()
         }
 
     private fun createViewModel() = InlineSignupViewModel(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
@@ -91,21 +91,32 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 combine(
                     viewBinding.linkInlineSignup.isSelected,
-                    viewBinding.linkInlineSignup.isReady,
+                    viewBinding.linkInlineSignup.userInput,
                     sheetViewModel.selection.asFlow()
-                ) { isSelected, isReady, selection ->
+                ) { isSelected, userInput, selection ->
                     if (isSelected) {
-                        PrimaryButton.UIState(
-                            label = null,
-                            onClick = sheetViewModel::payWithLink,
-                            enabled = isReady && selection != null,
-                            visible = true
-                        )
+                        if (userInput != null && selection != null) {
+                            PrimaryButton.UIState(
+                                label = null,
+                                onClick = { sheetViewModel.payWithLink(userInput) },
+                                enabled = true,
+                                visible = true
+                            )
+                        } else {
+                            PrimaryButton.UIState(
+                                label = null,
+                                onClick = null,
+                                enabled = false,
+                                visible = true
+                            )
+                        }
                     } else {
                         null
                     }
                 }.collect {
-                    sheetViewModel.updatePrimaryButtonUIState(it)
+                    if (showLinkInlineSignup) {
+                        sheetViewModel.updatePrimaryButtonUIState(it)
+                    }
                 }
             }
         }
@@ -157,6 +168,7 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
         ViewCompat.getWindowInsetsController(requireView())
             ?.hide(WindowInsetsCompat.Type.ime())
 
+        sheetViewModel.updatePrimaryButtonUIState(null)
         updateLinkInlineSignupVisibility(paymentMethod)
         replacePaymentMethodFragment(paymentMethod)
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -110,9 +110,12 @@ internal class PaymentOptionsViewModel @Inject constructor(
         onUserSelection()
     }
 
-    override fun onError(@StringRes error: Int?) {
+    override fun onError(@StringRes error: Int?) =
+        onError(error?.let { getApplication<Application>().getString(it) })
+
+    override fun onError(error: String?) {
         error?.let {
-            _error.value = getApplication<Application>().getString(error)
+            _error.value = it
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -283,19 +283,13 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                 }.orEmpty()
             }.fold(
                 onSuccess = {
-                    savedStateHandle.set(SAVE_PAYMENT_METHODS, it)
+                    savedStateHandle[SAVE_PAYMENT_METHODS] = it
                     setStripeIntent(stripeIntent)
                     resetViewState()
                 },
                 onFailure = ::onFatal
             )
         }
-    }
-
-    private fun resetViewState(@IntegerRes stringResId: Int?) {
-        resetViewState(
-            stringResId?.let { getApplication<Application>().resources.getString(it) }
-        )
     }
 
     private fun resetViewState(userErrorMessage: String? = null) {
@@ -354,8 +348,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
     override fun updateSelection(selection: PaymentSelection?) {
         super.updateSelection(selection)
-
-        updatePrimaryButtonUIState(null)
 
         when (selection) {
             is PaymentSelection.Saved -> {
@@ -467,7 +459,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                     onSuccess = {
                         resetViewState(
                             when (paymentResult) {
-                                is PaymentResult.Failed -> paymentResult.throwable.message
+                                is PaymentResult.Failed -> paymentResult.throwable.localizedMessage
                                 else -> null // indicates canceled payment
                             }
                         )
@@ -486,7 +478,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             is GooglePayPaymentMethodLauncher.Result.Failed -> {
                 logger.error("Error processing Google Pay payment", result.error)
                 eventReporter.onPaymentFailure(PaymentSelection.GooglePay)
-                resetViewState(
+                onError(
                     when (result.errorCode) {
                         GooglePayPaymentMethodLauncher.NETWORK_ERROR ->
                             R.string.stripe_failure_connection_error
@@ -512,9 +504,10 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         _paymentSheetResult.value = PaymentSheetResult.Completed
     }
 
-    override fun onError(@IntegerRes error: Int?) {
-        resetViewState(error)
-    }
+    override fun onError(@IntegerRes error: Int?) =
+        onError(error?.let { getApplication<Application>().resources.getString(it) })
+
+    override fun onError(error: String?) = resetViewState(error)
 
     private fun LinkActivityResult.convertToPaymentResult() =
         when (this) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -21,6 +21,7 @@ import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.injection.LinkPaymentLauncherFactory
 import com.stripe.android.link.model.AccountStatus
+import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.link.ui.verification.LinkVerificationCallback
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
@@ -97,7 +98,7 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
         ) ?: emptyList()
         set(value) = savedStateHandle.set(SAVE_SUPPORTED_PAYMENT_METHOD, value)
 
-    @VisibleForTesting
+    @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
     internal val _paymentMethods =
         savedStateHandle.getLiveData<List<PaymentMethod>>(SAVE_PAYMENT_METHODS)
 
@@ -145,7 +146,7 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
 
     private val editing = MutableLiveData(false)
 
-    @VisibleForTesting
+    @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
     internal val _processing = savedStateHandle.getLiveData<Boolean>(SAVE_PROCESSING)
     val processing: LiveData<Boolean> = _processing
 
@@ -454,7 +455,7 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
         }
     }
 
-    fun payWithLink() {
+    fun payWithLink(userInput: UserInput) {
         (selection.value as? PaymentSelection.New.Card)?.paymentMethodCreateParams?.let { params ->
             savedStateHandle[SAVE_PROCESSING] = true
             updatePrimaryButtonState(PrimaryButton.State.StartProcessing)
@@ -478,11 +479,13 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
                 }
                 AccountStatus.SignedOut -> {
                     viewModelScope.launch {
-                        linkLauncher.signUpWithUserInput().fold(
+                        linkLauncher.signInWithUserInput(userInput).fold(
                             onSuccess = {
-                                createLinkPaymentDetails(params)
+                                // If successful, the account was fetched or created, so try again
+                                payWithLink(userInput)
                             },
                             onFailure = {
+                                onError(it.localizedMessage)
                                 savedStateHandle[SAVE_PROCESSING] = false
                                 updatePrimaryButtonState(PrimaryButton.State.Ready)
                             }
@@ -537,6 +540,8 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
     abstract fun onFinish()
 
     abstract fun onError(@StringRes error: Int? = null)
+
+    abstract fun onError(error: String? = null)
 
     /**
      * Used to set up any dependencies that require a reference to the current Activity.

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -927,7 +927,7 @@ internal class PaymentSheetActivityTest {
             assertThat(activity.viewBinding.buyButton.externalLabel).isEqualTo("Some text")
             assertThat(activity.viewBinding.buyButton.isEnabled).isFalse()
 
-            viewModel.updateSelection(mock())
+            viewModel.updatePrimaryButtonUIState(null)
             assertThat(activity.viewBinding.buyButton.externalLabel)
                 .isEqualTo(viewModel.amount.value?.buildPayButtonLabel(context.resources))
             assertThat(activity.viewBinding.buyButton.isEnabled).isTrue()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddPaymentMethodFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddPaymentMethodFragmentTest.kt
@@ -32,6 +32,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SupportedPaymentMethod
 import com.stripe.android.paymentsheet.paymentdatacollection.ComposeFormDataCollectionFragment
 import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
+import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.utils.TestUtils.idleLooper
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -238,17 +239,16 @@ internal class PaymentSheetAddPaymentMethodFragmentTest : PaymentSheetViewModelT
                 addedFragment?.arguments?.getParcelable<FormFragmentArguments>(
                     ComposeFormDataCollectionFragment.EXTRA_CONFIG
                 )
-            )
-                .isEqualTo(
-                    FormFragmentArguments(
-                        SupportedPaymentMethod.Bancontact,
-                        showCheckbox = false,
-                        showCheckboxControlledFields = false,
-                        merchantName = PaymentSheetFixtures.MERCHANT_DISPLAY_NAME,
-                        amount = createAmount(),
-                        injectorKey = "testInjectorKeyAddFragmentTest"
-                    )
+            ).isEqualTo(
+                FormFragmentArguments(
+                    SupportedPaymentMethod.Bancontact,
+                    showCheckbox = false,
+                    showCheckboxControlledFields = false,
+                    merchantName = MERCHANT_DISPLAY_NAME,
+                    amount = createAmount(),
+                    injectorKey = "testInjectorKeyAddFragmentTest"
                 )
+            )
         }.recreate().onFragment { fragment ->
             val addedFragment = fragment.childFragmentManager.findFragmentById(
                 FragmentPaymentsheetAddPaymentMethodBinding.bind(
@@ -261,17 +261,16 @@ internal class PaymentSheetAddPaymentMethodFragmentTest : PaymentSheetViewModelT
                 addedFragment?.arguments?.getParcelable<FormFragmentArguments>(
                     ComposeFormDataCollectionFragment.EXTRA_CONFIG
                 )
-            )
-                .isEqualTo(
-                    FormFragmentArguments(
-                        SupportedPaymentMethod.Bancontact,
-                        showCheckbox = false,
-                        showCheckboxControlledFields = false,
-                        merchantName = PaymentSheetFixtures.MERCHANT_DISPLAY_NAME,
-                        amount = createAmount(),
-                        injectorKey = "testInjectorKeyAddFragmentTest"
-                    )
+            ).isEqualTo(
+                FormFragmentArguments(
+                    SupportedPaymentMethod.Bancontact,
+                    showCheckbox = false,
+                    showCheckboxControlledFields = false,
+                    merchantName = MERCHANT_DISPLAY_NAME,
+                    amount = createAmount(),
+                    injectorKey = "testInjectorKeyAddFragmentTest"
                 )
+            )
         }
     }
 
@@ -302,16 +301,15 @@ internal class PaymentSheetAddPaymentMethodFragmentTest : PaymentSheetViewModelT
                 addedFragment?.arguments?.getParcelable<FormFragmentArguments>(
                     ComposeFormDataCollectionFragment.EXTRA_CONFIG
                 )
+            ).isEqualTo(
+                COMPOSE_FRAGMENT_ARGS.copy(
+                    paymentMethod = SupportedPaymentMethod.Card,
+                    amount = createAmount(),
+                    showCheckbox = true,
+                    showCheckboxControlledFields = false,
+                    billingDetails = null
+                ),
             )
-                .isEqualTo(
-                    COMPOSE_FRAGMENT_ARGS.copy(
-                        paymentMethod = SupportedPaymentMethod.Card,
-                        amount = createAmount(),
-                        showCheckbox = true,
-                        showCheckboxControlledFields = false,
-                        billingDetails = null
-                    ),
-                )
         }
     }
 
@@ -337,16 +335,15 @@ internal class PaymentSheetAddPaymentMethodFragmentTest : PaymentSheetViewModelT
                 addedFragment?.arguments?.getParcelable<FormFragmentArguments>(
                     ComposeFormDataCollectionFragment.EXTRA_CONFIG
                 )
+            ).isEqualTo(
+                COMPOSE_FRAGMENT_ARGS.copy(
+                    paymentMethod = SupportedPaymentMethod.Card,
+                    amount = createAmount(),
+                    showCheckbox = true,
+                    showCheckboxControlledFields = false,
+                    billingDetails = null
+                ),
             )
-                .isEqualTo(
-                    COMPOSE_FRAGMENT_ARGS.copy(
-                        paymentMethod = SupportedPaymentMethod.Card,
-                        amount = createAmount(),
-                        showCheckbox = true,
-                        showCheckboxControlledFields = false,
-                        billingDetails = null
-                    ),
-                )
         }
     }
 
@@ -372,6 +369,42 @@ internal class PaymentSheetAddPaymentMethodFragmentTest : PaymentSheetViewModelT
             fragment.onPaymentMethodSelected(SupportedPaymentMethod.Card)
             idleLooper()
             assertThat(paymentSelection).isInstanceOf(PaymentSelection.Saved::class.java)
+        }
+    }
+
+    @Test
+    fun `when payment method is selected then primary button action is reset`() {
+        val paymentIntent = PaymentIntentFixtures.PI_SUCCEEDED.copy(
+            paymentMethodTypes = listOf("card", "bancontact")
+        )
+        createFragment(stripeIntent = paymentIntent) { fragment, viewBinding, _ ->
+            idleLooper()
+            assertThat(
+                fragment.childFragmentManager.findFragmentById(
+                    viewBinding.paymentMethodFragmentContainer.id
+                )
+            ).isInstanceOf(ComposeFormDataCollectionFragment::class.java)
+
+            var primaryButtonState: PrimaryButton.UIState? = null
+            fragment.sheetViewModel.primaryButtonUIState.observeForever {
+                primaryButtonState = it
+            }
+
+            val manualState = PrimaryButton.UIState(
+                label = "Test",
+                onClick = {},
+                enabled = false,
+                visible = true
+            )
+
+            fragment.sheetViewModel.updatePrimaryButtonUIState(manualState)
+
+            assertThat(primaryButtonState).isEqualTo(manualState)
+
+            fragment.onPaymentMethodSelected(SupportedPaymentMethod.Bancontact)
+            idleLooper()
+
+            assertThat(primaryButtonState).isEqualTo(null)
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -42,6 +42,7 @@ import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.StripeIntentRepository
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
+import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.Companion.SAVE_PROCESSING
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.UserErrorMessage
 import com.stripe.android.utils.TestUtils.idleLooper
 import kotlinx.coroutines.Dispatchers
@@ -819,7 +820,7 @@ internal class PaymentSheetViewModelTest {
     @Test
     fun `buyButton is enabled when primaryButtonEnabled is true, else not processing, not editing, and a selection has been made`() {
         var isEnabled = false
-        viewModel.savedStateHandle.set(BaseSheetViewModel.SAVE_PROCESSING, true)
+        viewModel.savedStateHandle[SAVE_PROCESSING] = true
         viewModel.ctaEnabled.observeForever {
             isEnabled = it
         }
@@ -860,10 +861,6 @@ internal class PaymentSheetViewModelTest {
         viewModel.setEditing(false)
         assertThat(isEnabled)
             .isFalse()
-
-        viewModel.updateSelection(mock())
-        assertThat(isEnabled)
-            .isTrue()
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Properly keep the state of the inline sign up view and `LinkAccountManager` when the user navigates to a different payment method.
Previously when the card form emitted a new value, `PaymentSheetViewModel.updateSelection` would reset the button action, which is not desirable. Instead, resetting in `BaseAddPaymentMethodFragment.onPaymentMethodSelected` before the fragment for the newly selected PM is added.
Pass the user input from the inline sign up view into PaymentSheet, instead of storing in `LinkAccountManager`, so that no internal Link state is changed.
Create `BaseSheetViewModel.onError` method that takes a string instead of string resource.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix Link inline sign up

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
