### PR TITLE
Create endpoint to delete consumer payment details

### DIFF
--- a/link/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/link/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -232,4 +232,28 @@ internal class LinkApiRepository @Inject constructor(
             }
         )
     }
+
+    override suspend fun deletePaymentDetails(
+        consumerSessionClientSecret: String,
+        paymentDetailsId: String
+    ): Result<Unit> = withContext(workContext) {
+        runCatching {
+            stripeRepository.deletePaymentDetails(
+                consumerSessionClientSecret,
+                paymentDetailsId,
+                ApiRequest.Options(
+                    publishableKeyProvider(),
+                    stripeAccountIdProvider()
+                )
+            )
+        }.fold(
+            onSuccess = {
+                Result.success(Unit)
+            },
+            onFailure = {
+                logger.error("Error deleting consumer payment method", it)
+                Result.failure(it)
+            }
+        )
+    }
 }

--- a/link/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
+++ b/link/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
@@ -71,4 +71,12 @@ internal interface LinkRepository {
         stripeIntent: StripeIntent,
         extraConfirmationParams: Map<String, Any>? = null
     ): Result<LinkPaymentDetails>
+
+    /**
+     * Delete the payment method from the consumer account.
+     */
+    suspend fun deletePaymentDetails(
+        consumerSessionClientSecret: String,
+        paymentDetailsId: String
+    ): Result<Unit>
 }

--- a/link/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/link/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -258,6 +258,38 @@ class LinkApiRepositoryTest {
     }
 
     @Test
+    fun `deletePaymentDetails sends correct parameters`() = runTest {
+        val secret = "secret"
+        val id = "payment_details_id"
+        linkRepository.deletePaymentDetails(secret, id)
+
+        verify(stripeRepository).deletePaymentDetails(
+            eq(secret),
+            eq(id),
+            eq(ApiRequest.Options(PUBLISHABLE_KEY, STRIPE_ACCOUNT_ID))
+        )
+    }
+
+    @Test
+    fun `deletePaymentDetails returns successful result`() = runTest {
+        whenever(stripeRepository.deletePaymentDetails(any(), any(), any())).thenReturn(Unit)
+
+        val result = linkRepository.deletePaymentDetails("secret", "id")
+
+        assertThat(result.isSuccess).isTrue()
+    }
+
+    @Test
+    fun `deletePaymentDetails catches exception and returns failure`() = runTest {
+        whenever(stripeRepository.deletePaymentDetails(any(), any(), any()))
+            .thenThrow(RuntimeException("error"))
+
+        val result = linkRepository.deletePaymentDetails("secret", "id")
+
+        assertThat(result.isFailure).isTrue()
+    }
+
+    @Test
     fun `createPaymentDetails sends correct parameters`() = runTest {
         val secret = "secret"
         val consumerPaymentDetailsCreateParams =

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1373,6 +1373,26 @@ class StripeApiRepository @JvmOverloads internal constructor(
         }
     }
 
+    override suspend fun deletePaymentDetails(
+        consumerSessionClientSecret: String,
+        paymentDetailsId: String,
+        requestOptions: ApiRequest.Options
+    ) {
+        makeApiRequest(
+            apiRequestFactory.createDelete(
+                getConsumerPaymentDetailsUrl(paymentDetailsId),
+                requestOptions,
+                mapOf(
+                    "credentials" to mapOf(
+                        "consumer_session_client_secret" to consumerSessionClientSecret
+                    )
+                )
+            )
+        ) {
+            // no-op
+        }
+    }
+
     override suspend fun createPaymentIntentFinancialConnectionsSession(
         paymentIntentId: String,
         params: CreateFinancialConnectionsSessionParams,
@@ -1462,7 +1482,10 @@ class StripeApiRepository @JvmOverloads internal constructor(
     ): SetupIntent? {
         return fetchStripeModel(
             apiRequestFactory.createPost(
-                getAttachFinancialConnectionsSessionToSetupIntentUrl(setupIntentId, financialConnectionsSessionId),
+                getAttachFinancialConnectionsSessionToSetupIntentUrl(
+                    setupIntentId,
+                    financialConnectionsSessionId
+                ),
                 requestOptions,
                 mapOf(
                     "client_secret" to clientSecret
@@ -1902,6 +1925,15 @@ class StripeApiRepository @JvmOverloads internal constructor(
         internal val consumerPaymentDetailsUrl: String
             @JvmSynthetic
             get() = getApiUrl("consumers/payment_details")
+
+        /**
+         * @return `https://api.stripe.com/v1/consumers/payment_details/:id`
+         */
+        @VisibleForTesting
+        @JvmSynthetic
+        internal fun getConsumerPaymentDetailsUrl(paymentDetailsId: String): String {
+            return getApiUrl("consumers/payment_details/$paymentDetailsId")
+        }
 
         /**
          * @return `https://api.stripe.com/v1/payment_intents/:id`

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -449,6 +449,13 @@ abstract class StripeRepository {
         requestOptions: ApiRequest.Options
     ): ConsumerPaymentDetails?
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    abstract suspend fun deletePaymentDetails(
+        consumerSessionClientSecret: String,
+        paymentDetailsId: String,
+        requestOptions: ApiRequest.Options
+    )
+
     // ACHv2 endpoints
 
     internal abstract suspend fun createPaymentIntentFinancialConnectionsSession(

--- a/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
@@ -342,6 +342,13 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         return null
     }
 
+    override suspend fun deletePaymentDetails(
+        consumerSessionClientSecret: String,
+        paymentDetailsId: String,
+        requestOptions: ApiRequest.Options
+    ) {
+    }
+
     override suspend fun attachFinancialConnectionsSessionToPaymentIntent(
         clientSecret: String,
         paymentIntentId: String,

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -280,6 +280,14 @@ internal class StripeApiRepositoryTest {
     }
 
     @Test
+    fun testGetConsumerPaymentDetailsUrl() {
+        assertEquals(
+            "https://api.stripe.com/v1/consumers/payment_details/csmrpd*123",
+            StripeApiRepository.getConsumerPaymentDetailsUrl("csmrpd*123")
+        )
+    }
+
+    @Test
     fun createSource_shouldLogSourceCreation_andReturnSource() = runTest {
         // Check that we get a token back; we don't care about its fields for this test.
         requireNotNull(
@@ -1863,6 +1871,38 @@ internal class StripeApiRepositoryTest {
             val credentials = params["credentials"] as Map<*, *>
             assertEquals(credentials["consumer_session_client_secret"], clientSecret)
             assertContentEquals(params["types"] as? List<*>, paymentMethodTypes.toList())
+        }
+
+    @Test
+    fun `deletePaymentDetails() sends all parameters`() =
+        runTest {
+            val stripeResponse = StripeResponse(
+                200,
+                "",
+                emptyMap()
+            )
+            whenever(stripeNetworkClient.executeRequest(any<ApiRequest>()))
+                .thenReturn(stripeResponse)
+
+            val clientSecret = "secret"
+            val paymentDetailsId = "id"
+            create().deletePaymentDetails(
+                clientSecret,
+                paymentDetailsId,
+                DEFAULT_OPTIONS
+            )
+
+            verify(stripeNetworkClient).executeRequest(apiRequestArgumentCaptor.capture())
+            val request = apiRequestArgumentCaptor.firstValue
+            val params = requireNotNull(request.params)
+
+            assertEquals(
+                "https://api.stripe.com/v1/consumers/payment_details/$paymentDetailsId",
+                request.baseUrl
+            )
+
+            val credentials = params["credentials"] as Map<*, *>
+            assertEquals(credentials["consumer_session_client_secret"], clientSecret)
         }
 
     @Test

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/ApiRequest.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/ApiRequest.kt
@@ -57,11 +57,11 @@ data class ApiRequest internal constructor(
     override val retryResponseCodes: Iterable<Int> = DEFAULT_RETRY_CODES
 
     /**
-     * If the HTTP method is [Method.GET], this is the URL with query string;
-     * otherwise, just the URL.
+     * If the HTTP method is [StripeRequest.Method.GET] or [StripeRequest.Method.DELETE], this is
+     * the URL with query string; otherwise, just the URL.
      */
     override val url: String
-        get() = if (Method.GET == method) {
+        get() = if (Method.GET == method || Method.DELETE == method) {
             listOfNotNull(
                 baseUrl,
                 query.takeIf { it.isNotEmpty() }
@@ -173,11 +173,13 @@ data class ApiRequest internal constructor(
 
         fun createDelete(
             url: String,
-            options: Options
+            options: Options,
+            params: Map<String, *>? = null
         ): ApiRequest {
             return ApiRequest(
                 Method.DELETE,
                 url,
+                params = params,
                 options = options,
                 appInfo = appInfo,
                 apiVersion = apiVersion,

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/ApiRequestTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/ApiRequestTest.kt
@@ -74,6 +74,26 @@ internal class ApiRequestTest {
         )
     }
 
+    @Test
+    fun getIncludesQueryParametersInUrl() {
+        val url = FACTORY.createGet(
+            SOURCES_URL,
+            OPTIONS,
+            mapOf("param" to "123")
+        ).url
+        assertEquals(url, "sources?param=123")
+    }
+
+    @Test
+    fun deleteIncludesQueryParametersInUrl() {
+        val url = FACTORY.createDelete(
+            SOURCES_URL,
+            OPTIONS,
+            mapOf("param" to "123")
+        ).url
+        assertEquals(url, "sources?param=123")
+    }
+
     private companion object {
         private val OPTIONS = ApiRequest.Options(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY)
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
API endpoint used to delete a saved payment method in Link.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Link support.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified