### PR TITLE
Add 3ds2 url to list of completion URLs so callbacks work correctly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * [FIXED][5068](https://github.com/stripe/stripe-android/pull/5068) Fix missing theming for add lpm button and notes text
 
 ### Payments
-* [FIXED][XXXX](https://github.com/stripe/stripe-android/pull/XXXX) Add 3ds2 url to list of completion URLs so callbacks work correctly.
+* [FIXED][5079](https://github.com/stripe/stripe-android/pull/5079) Add 3ds2 url to list of completion URLs so callbacks work correctly.
 
 ## 20.4.0 - 2022-05-23
 This release adds [appearance customization APIs](https://github.com/stripe/stripe-android/blob/master/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt#L186) to payment sheet and enables Affirm and AU BECS direct debit as payment methods within Payment Sheet.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * [DEPRECATED][5061](https://github.com/stripe/stripe-android/pull/5061) Add Deprecated annotation to old primaryButtonColor api.
 * [FIXED][5068](https://github.com/stripe/stripe-android/pull/5068) Fix missing theming for add lpm button and notes text
 
+### Payments
+* [FIXED][XXXX](https://github.com/stripe/stripe-android/pull/XXXX) Add 3ds2 url to list of completion URLs so callbacks work correctly.
+
 ## 20.4.0 - 2022-05-23
 This release adds [appearance customization APIs](https://github.com/stripe/stripe-android/blob/master/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt#L186) to payment sheet and enables Affirm and AU BECS direct debit as payment methods within Payment Sheet.
 

--- a/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewClient.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewClient.kt
@@ -184,7 +184,8 @@ internal class PaymentAuthWebViewClient(
 
         private val COMPLETION_URLS = setOf(
             "https://hooks.stripe.com/redirect/complete/",
-            "https://hooks.stripe.com/3d_secure/complete/"
+            "https://hooks.stripe.com/3d_secure/complete/",
+            "https://hooks.stripe.com/3d_secure_2/hosted/complete"
         )
 
         private const val PARAM_RETURN_URL = "return_url"

--- a/payments-core/src/test/java/com/stripe/android/view/PaymentAuthWebViewClientTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/PaymentAuthWebViewClientTest.kt
@@ -346,6 +346,14 @@ class PaymentAuthWebViewClientTest {
         assertThat(
             isCompletionUrl("https://hooks.stripe.com/3d_secure/complete/Xyza1b2C345/tdsrc_456")
         ).isTrue()
+
+        assertThat(
+            isCompletionUrl("https://hooks.stripe.com/3d_secure_2/hosted/complete")
+        ).isTrue()
+
+        assertThat(
+            isCompletionUrl("https://hooks.stripe.com/3d_secure_2/hosted/complete/")
+        ).isTrue()
     }
 
     private fun createWebViewClient(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Adds the 3ds2 URL to the list of completion URLs. This means that the webview will close when not given a return URL. Previously it would get stuck. This is really only the case when using `Stripe.handleNextAction` or `PaymentLauncher.handleNextAction`.
* Our normal confirm flows with both classes append a return URL which makes 3ds2 not land in this situation. `handleNextAction` does not do this, so we need add to our list of URLs so the activity result is fired correctly.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
* https://github.com/stripe/stripe-android/issues/5059
* https://jira.corp.stripe.com/browse/RUN_MOBILESDK-1023

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Created a PI with a next-action of 3ds, and hard coded it both with `PaymentLauncher` and `Stripe`. I confirmed that the webview would not hang and fires the callback correctly. 




