### PR TITLE
Show keyboard when OTP dialog launches

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPController.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class OTPController(val otpLength: Int = 6) : Controller {
-    internal val keyboardType = KeyboardType.Number
+    internal val keyboardType = KeyboardType.NumberPassword
 
     internal val fieldValues: List<MutableStateFlow<String>> = (0 until otpLength).map {
         MutableStateFlow("")

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPElementUI.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
@@ -29,6 +30,7 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.TextRange
@@ -36,6 +38,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun OTPElementUI(
@@ -45,6 +48,7 @@ fun OTPElementUI(
 ) {
     val focusManager = LocalFocusManager.current
     val focusRequester = remember { FocusRequester() }
+    val keyboardController = LocalSoftwareKeyboardController.current
 
     Row(
         modifier = modifier.fillMaxWidth(),
@@ -140,6 +144,7 @@ fun OTPElementUI(
 
         LaunchedEffect(Unit) {
             focusRequester.requestFocus()
+            keyboardController?.show()
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowManager
 import android.widget.ScrollView
 import android.widget.TextView
 import androidx.activity.viewModels
@@ -178,6 +179,7 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
         viewModel.startConfirm.observe(this) { event ->
             val confirmParams = event.getContentIfNotHandled()
             if (confirmParams != null) {
+                window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN)
                 lifecycleScope.launch {
                     viewModel.confirmStripeIntent(confirmParams)
                 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Show keyboard when OTP dialog launches, change keyboard type to `NumberPassword`.
Hide keyboard on complete flow when confirmation starts. Sometimes it would reopen after confirmation is completed.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Keyboard issues.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
Before
https://user-images.githubusercontent.com/77990083/170608322-b1aefc32-ec76-49bf-a71b-836875fc1b79.mp4

After
https://user-images.githubusercontent.com/77990083/170608349-7aa64bad-f2ed-4009-8b7b-dd55d43b8771.mp4


