### PR TITLE
Fix instrumentation tests

### DIFF
--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -21,10 +21,7 @@ jobs:
           api-level: 29
           arch: x86
           disable-animations: true
-          script: |
-            adb logcat -c
-            adb logcat &
-            ./gradlew connectedAndroidTest -x :paymentsheet-example:connectedAndroidTest
+          script: bash ./scripts/execute_instrumentation_tests.sh
         env:
           STRIPE_EXAMPLE_BACKEND_URL: ${{ secrets.STRIPE_EXAMPLE_BACKEND_URL }}
           STRIPE_EXAMPLE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_EXAMPLE_PUBLISHABLE_KEY }}
@@ -33,7 +30,7 @@ jobs:
         if: failure()
         with:
           name: instrumentation-test-report
-          path: example/build/reports/androidTests/connected/index.html | paymentsheet-example/build/reports/androidTests/connected/index.html
+          path: camera-core/build/reports/androidTests/connected/index.html | example/build/reports/androidTests/connected/index.html | identity/build/reports/androidTests/connected/index.html | link/build/reports/androidTests/connected/index.html |  paymentsheet-example/build/reports/androidTests/connected/index.html | stripecardscan/build/reports/androidTests/connected/index.html
 
       - name: Notify failure endpoint
         id: notifyFailureEndpoint

--- a/scripts/execute_instrumentation_tests.sh
+++ b/scripts/execute_instrumentation_tests.sh
@@ -1,0 +1,11 @@
+# Uncomment if tests are working locally but not in the github action. Keeping logcat output makes
+# github perform slow (and can crash your browser) because of all of the logs and isn't necessary
+# for debugging all issues.
+# adb logcat -c
+# adb logcat &
+
+# Exclude any modules with screenshot tests here. Then run them with the screenshot test package excluded.
+# Don't forget to add your module to actions/upload-artifact@v2 task.
+./gradlew connectedAndroidTest -x :paymentsheet-example:connectedAndroidTest -x :paymentsheet:connectedAndroidTest
+
+./gradlew :paymentsheet:connectedAndroidTest -Pandroid.testInstrumentationRunnerArguments.notPackage=com.stripe.android.paymentsheet.screenshot


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Converts our instrumentation tests to run from a script.
* Adds the test reports for all modules if there's a failure.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
* The script allows us to configure classes to not run during this job. Specifically we're excluding any screenshot tests because they won't run on the react circus emulator. Before this change, the screenshot tests in the `paymentsheet` module are failing. This should fix the instrumentation test runs. 
* Also prevents screenshot tests from being run twice. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

Ran 4x to make sure it passed each time.