### PR TITLE
Create view only card number form controller

### DIFF
--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -191,6 +191,13 @@ public final class com/stripe/android/ui/core/elements/CardDetailsSectionSpec$Co
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public abstract class com/stripe/android/ui/core/elements/CardNumberController : com/stripe/android/ui/core/elements/SectionFieldErrorController, com/stripe/android/ui/core/elements/TextFieldController {
+	public static final field $stable I
+	public abstract fun getCardBrandFlow ()Lkotlinx/coroutines/flow/Flow;
+	public fun getEnabled ()Z
+	public final fun onCardScanResult (Lcom/stripe/android/stripecardscan/cardscan/CardScanSheetResult;)V
+}
+
 public final class com/stripe/android/ui/core/elements/ComposableSingletons$AfterpayClearpayElementUIKt {
 	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/ComposableSingletons$AfterpayClearpayElementUIKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function3;

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -194,6 +194,7 @@ public final class com/stripe/android/ui/core/elements/CardDetailsSectionSpec$Co
 public abstract class com/stripe/android/ui/core/elements/CardNumberController : com/stripe/android/ui/core/elements/SectionFieldErrorController, com/stripe/android/ui/core/elements/TextFieldController {
 	public static final field $stable I
 	public abstract fun getCardBrandFlow ()Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getCardScanEnabled ()Z
 	public fun getEnabled ()Z
 	public final fun onCardScanResult (Lcom/stripe/android/stripecardscan/cardscan/CardScanSheetResult;)V
 }

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -357,6 +357,8 @@ public final class com/stripe/android/ui/core/elements/IdentifierSpec$Companion 
 	public final fun Generic (Ljava/lang/String;)Lcom/stripe/android/ui/core/elements/IdentifierSpec;
 	public final fun getCardBrand ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
 	public final fun getCardCvc ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
+	public final fun getCardExpMonth ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
+	public final fun getCardExpYear ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
 	public final fun getCardNumber ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
 	public final fun getCity ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
 	public final fun getCountry ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
@@ -531,6 +533,10 @@ public final class com/stripe/android/ui/core/elements/SimpleTextSpec$Companion 
 public final class com/stripe/android/ui/core/elements/StaticTextElementUIKt {
 }
 
+public final class com/stripe/android/ui/core/elements/TextFieldController$DefaultImpls {
+	public static fun getEnabled (Lcom/stripe/android/ui/core/elements/TextFieldController;)Z
+}
+
 public final class com/stripe/android/ui/core/elements/TextFieldUIKt {
 	public static final fun TextField-PwfN4xk (Lcom/stripe/android/ui/core/elements/TextFieldController;Landroidx/compose/ui/Modifier;IZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun TextFieldSection-VyDzSTg (Lcom/stripe/android/ui/core/elements/TextFieldController;Landroidx/compose/ui/Modifier;Ljava/lang/Integer;IZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
@@ -623,7 +629,8 @@ public final class com/stripe/android/ui/core/forms/SofortSpecKt {
 
 public final class com/stripe/android/ui/core/forms/TransformSpecToElements {
 	public static final field $stable I
-	public fun <init> (Lcom/stripe/android/ui/core/forms/resources/ResourceRepository;Ljava/util/Map;Lcom/stripe/android/ui/core/Amount;ZLjava/lang/String;Landroid/content/Context;)V
+	public fun <init> (Lcom/stripe/android/ui/core/forms/resources/ResourceRepository;Ljava/util/Map;Lcom/stripe/android/ui/core/Amount;ZLjava/lang/String;Landroid/content/Context;Ljava/util/Set;)V
+	public synthetic fun <init> (Lcom/stripe/android/ui/core/forms/resources/ResourceRepository;Ljava/util/Map;Lcom/stripe/android/ui/core/Amount;ZLjava/lang/String;Landroid/content/Context;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun transform (Ljava/util/List;)Ljava/util/List;
 }
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
@@ -19,7 +19,7 @@ internal class CardDetailsController constructor(
                 initialValues
             )
         } else {
-            CardNumberControllerEditable(
+            CardNumberEditableController(
                 CardNumberConfig(),
                 context,
                 initialValues[IdentifierSpec.CardNumber]

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
@@ -6,17 +6,25 @@ import java.util.UUID
 
 internal class CardDetailsController constructor(
     context: Context,
-    initialValues: Map<IdentifierSpec, String?>
+    initialValues: Map<IdentifierSpec, String?>,
+    viewOnlyFields: Set<IdentifierSpec>
 ) : SectionFieldErrorController {
 
     val label: Int? = null
     val numberElement = CardNumberElement(
         IdentifierSpec.CardNumber,
-        CardNumberController(
-            CardNumberConfig(),
-            context,
-            initialValue = initialValues[IdentifierSpec.CardNumber]
-        )
+        if (viewOnlyFields.contains(IdentifierSpec.CardNumber)) {
+            CardNumberViewOnlyController(
+                CardNumberConfig(),
+                initialValues
+            )
+        } else {
+            CardNumberControllerEditable(
+                CardNumberConfig(),
+                context,
+                initialValues[IdentifierSpec.CardNumber]
+            )
+        }
     )
 
     val cvcElement = CvcElement(
@@ -32,8 +40,8 @@ internal class CardDetailsController constructor(
         IdentifierSpec.Generic("date"),
         SimpleTextFieldController(
             DateConfig(),
-            initialValue = initialValues[IdentifierSpec.Generic("card[exp_month]")] +
-                initialValues[IdentifierSpec.Generic("card[exp_year]")]?.takeLast(2)
+            initialValue = initialValues[IdentifierSpec.CardExpMonth] +
+                initialValues[IdentifierSpec.CardExpYear]?.takeLast(2)
         ),
     )
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
@@ -7,13 +7,13 @@ import java.util.UUID
 internal class CardDetailsController constructor(
     context: Context,
     initialValues: Map<IdentifierSpec, String?>,
-    viewOnlyFields: Set<IdentifierSpec>
+    cardNumberReadOnly: Boolean = false
 ) : SectionFieldErrorController {
 
     val label: Int? = null
     val numberElement = CardNumberElement(
         IdentifierSpec.CardNumber,
-        if (viewOnlyFields.contains(IdentifierSpec.CardNumber)) {
+        if (cardNumberReadOnly) {
             CardNumberViewOnlyController(
                 CardNumberConfig(),
                 initialValues

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
@@ -18,7 +18,7 @@ internal class CardDetailsElement(
     val controller: CardDetailsController = CardDetailsController(
         context,
         initialValues,
-        viewOnlyFields
+        viewOnlyFields.contains(IdentifierSpec.CardNumber)
     ),
 ) : SectionMultiFieldElement(identifier) {
     val isCardScanEnabled = controller.numberElement.controller.cardScanEnabled

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
@@ -21,6 +21,8 @@ internal class CardDetailsElement(
         viewOnlyFields
     ),
 ) : SectionMultiFieldElement(identifier) {
+    val isCardScanEnabled = controller.numberElement.controller.cardScanEnabled
+
     override fun sectionFieldErrorController(): SectionFieldErrorController =
         controller
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
@@ -14,7 +14,12 @@ internal class CardDetailsElement(
     identifier: IdentifierSpec,
     context: Context,
     initialValues: Map<IdentifierSpec, String?>,
-    val controller: CardDetailsController = CardDetailsController(context, initialValues),
+    viewOnlyFields: Set<IdentifierSpec> = emptySet(),
+    val controller: CardDetailsController = CardDetailsController(
+        context,
+        initialValues,
+        viewOnlyFields
+    ),
 ) : SectionMultiFieldElement(identifier) {
     override fun sectionFieldErrorController(): SectionFieldErrorController =
         controller
@@ -52,10 +57,10 @@ internal class CardDetailsElement(
             controller.numberElement.identifier to number,
             controller.cvcElement.identifier to cvc,
             IdentifierSpec.CardBrand to FormFieldEntry(brand.code, true),
-            IdentifierSpec.Generic("card[exp_month]") to expirationDate.copy(
+            IdentifierSpec.CardExpMonth to expirationDate.copy(
                 value = month.toString()
             ),
-            IdentifierSpec.Generic("card[exp_year]") to expirationDate.copy(
+            IdentifierSpec.CardExpYear to expirationDate.copy(
                 value = year.toString()
             )
         )

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionController.kt
@@ -7,13 +7,15 @@ import com.stripe.android.ui.core.DefaultIsStripeCardScanAvailable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class CardDetailsSectionController(
     context: Context,
-    initialValues: Map<IdentifierSpec, String?>
+    initialValues: Map<IdentifierSpec, String?>,
+    viewOnlyFields: Set<IdentifierSpec>
 ) : SectionFieldErrorController {
 
     internal val cardDetailsElement = CardDetailsElement(
         IdentifierSpec.Generic("card_detail"),
         context,
-        initialValues
+        initialValues,
+        viewOnlyFields
     )
 
     internal val isStripeCardScanAvailable = DefaultIsStripeCardScanAvailable()

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionController.kt
@@ -18,6 +18,7 @@ class CardDetailsSectionController(
         viewOnlyFields
     )
 
+    internal val isCardScanEnabled = cardDetailsElement.isCardScanEnabled
     internal val isStripeCardScanAvailable = DefaultIsStripeCardScanAvailable()
 
     override val error = cardDetailsElement.controller.error

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElement.kt
@@ -9,9 +9,10 @@ import kotlinx.coroutines.flow.Flow
 class CardDetailsSectionElement(
     val context: Context,
     initialValues: Map<IdentifierSpec, String?>,
+    viewOnlyFields: Set<IdentifierSpec>,
     override val identifier: IdentifierSpec,
     override val controller: CardDetailsSectionController =
-        CardDetailsSectionController(context, initialValues)
+        CardDetailsSectionController(context, initialValues, viewOnlyFields)
 ) : FormElement() {
     override fun getFormFieldValueFlow(): Flow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
         controller.cardDetailsElement.getFormFieldValueFlow()

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUI.kt
@@ -36,7 +36,7 @@ fun CardDetailsSectionElementUI(
                     heading()
                 }
         )
-        if (controller.isStripeCardScanAvailable()) {
+        if (controller.isCardScanEnabled && controller.isStripeCardScanAvailable()) {
             ScanCardButtonUI {
                 controller.cardDetailsElement.controller.numberElement.controller.onCardScanResult(
                     it.getParcelableExtra(CardScanActivity.CARD_SCAN_PARCELABLE_NAME)
@@ -52,7 +52,10 @@ fun CardDetailsSectionElementUI(
         SectionElement(
             IdentifierSpec.Generic("credit_details"),
             listOf(controller.cardDetailsElement),
-            SectionController(null, listOf(controller.cardDetailsElement.sectionFieldErrorController()))
+            SectionController(
+                null,
+                listOf(controller.cardDetailsElement.sectionFieldErrorController())
+            )
         ),
         hiddenIdentifiers ?: emptyList(),
         IdentifierSpec.Generic("card_details")

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionSpec.kt
@@ -12,10 +12,15 @@ import kotlinx.serialization.Serializable
 data class CardDetailsSectionSpec(
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("card_details")
 ) : FormItemSpec() {
-    fun transform(context: Context, initialValues: Map<IdentifierSpec, String?>): FormElement =
+    fun transform(
+        context: Context,
+        initialValues: Map<IdentifierSpec, String?>,
+        viewOnlyFields: Set<IdentifierSpec>
+    ): FormElement =
         CardDetailsSectionElement(
-            context,
-            initialValues,
-            apiPath
+            context = context,
+            initialValues = initialValues,
+            viewOnlyFields = viewOnlyFields,
+            identifier = apiPath
         )
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
@@ -21,8 +21,8 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlin.coroutines.CoroutineContext
 
-internal interface CardNumberController : TextFieldController, SectionFieldErrorController {
-    val cardBrandFlow: Flow<CardBrand>
+sealed class CardNumberController : TextFieldController, SectionFieldErrorController {
+    abstract val cardBrandFlow: Flow<CardBrand>
 
     fun onCardScanResult(cardScanSheetResult: CardScanSheetResult) {
         // Don't need to populate the card number if the result is Canceled or Failed
@@ -39,7 +39,7 @@ internal class CardNumberControllerEditable constructor(
     staticCardAccountRanges: StaticCardAccountRanges = DefaultStaticCardAccountRanges(),
     initialValue: String?,
     override val showOptionalLabel: Boolean = false
-) : CardNumberController {
+) : CardNumberController() {
 
     constructor(
         cardTextFieldConfig: CardNumberConfig,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
@@ -24,6 +24,8 @@ import kotlin.coroutines.CoroutineContext
 sealed class CardNumberController : TextFieldController, SectionFieldErrorController {
     abstract val cardBrandFlow: Flow<CardBrand>
 
+    abstract val cardScanEnabled: Boolean
+
     fun onCardScanResult(cardScanSheetResult: CardScanSheetResult) {
         // Don't need to populate the card number if the result is Canceled or Failed
         if (cardScanSheetResult is CardScanSheetResult.Completed) {
@@ -71,6 +73,8 @@ internal class CardNumberEditableController constructor(
         accountRangeService.accountRange?.brand ?: CardBrand.getCardBrands(it).firstOrNull()
             ?: CardBrand.Unknown
     }
+
+    override val cardScanEnabled = true
 
     override val trailingIcon: Flow<TextFieldIcon?> = _fieldValue.map {
         val cardBrands = CardBrand.getCardBrands(it)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
@@ -32,7 +32,7 @@ sealed class CardNumberController : TextFieldController, SectionFieldErrorContro
     }
 }
 
-internal class CardNumberControllerEditable constructor(
+internal class CardNumberEditableController constructor(
     private val cardTextFieldConfig: CardNumberConfig,
     cardAccountRangeRepository: CardAccountRangeRepository,
     workContext: CoroutineContext,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberViewOnlyController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberViewOnlyController.kt
@@ -13,9 +13,12 @@ import kotlinx.coroutines.flow.map
 
 /**
  * Controller for the card number field which is view only and never changes.
+ * The card number UI element will be shown as disabled to the user.
  *
  * @param initialValues The initial values of the field, which will never change.
  *      Should contain values for both [IdentifierSpec.CardNumber] and [IdentifierSpec.CardBrand].
+ *      These are the values that will be emitted in the completed FormFieldEntry flow, which means
+ *      empty values will be emitted if the initial values were not set.
  */
 internal class CardNumberViewOnlyController(
     cardTextFieldConfig: CardNumberConfig,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberViewOnlyController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberViewOnlyController.kt
@@ -42,6 +42,8 @@ internal class CardNumberViewOnlyController(
         } ?: CardBrand.Unknown
     )
 
+    override val cardScanEnabled = false
+
     override val trailingIcon = cardBrandFlow.map { TextFieldIcon(it.icon, isIcon = false) }
 
     override val fieldState = flowOf(TextFieldStateConstants.Valid.Full)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberViewOnlyController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberViewOnlyController.kt
@@ -1,0 +1,68 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.VisualTransformation
+import com.stripe.android.model.CardBrand
+import com.stripe.android.ui.core.forms.FormFieldEntry
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+
+/**
+ * Controller for the card number field which is view only and never changes.
+ *
+ * @param initialValues The initial values of the field, which will never change.
+ *      Should contain values for both [IdentifierSpec.CardNumber] and [IdentifierSpec.CardBrand]
+ */
+internal class CardNumberViewOnlyController(
+    cardTextFieldConfig: CardNumberConfig,
+    initialValues: Map<IdentifierSpec, String?>
+) : CardNumberController {
+
+    override val capitalization: KeyboardCapitalization = cardTextFieldConfig.capitalization
+    override val keyboardType: KeyboardType = cardTextFieldConfig.keyboard
+    override val visualTransformation = VisualTransformation.None
+    override val debugLabel = cardTextFieldConfig.debugLabel
+
+    override val label = MutableStateFlow(cardTextFieldConfig.label)
+
+    private val _fieldValue = MutableStateFlow(initialValues[IdentifierSpec.CardNumber] ?: "")
+    override val fieldValue: Flow<String> = _fieldValue
+
+    override val rawFieldValue = fieldValue
+
+    override val contentDescription = fieldValue
+
+    override val cardBrandFlow = flowOf(
+        initialValues[IdentifierSpec.CardBrand]?.let {
+            CardBrand.fromCode(it)
+        } ?: CardBrand.Unknown
+    )
+
+    override val trailingIcon = cardBrandFlow.map { TextFieldIcon(it.icon, isIcon = false) }
+
+    override val fieldState = flowOf(TextFieldStateConstants.Valid.Full)
+
+    override val enabled = false
+
+    override val showOptionalLabel = false
+
+    override val isComplete = flowOf(true)
+    override val formFieldValue =
+        combine(isComplete, rawFieldValue) { complete, value ->
+            FormFieldEntry(value, complete)
+        }
+
+    override val error = flowOf(null)
+    override val loading = flowOf(false)
+    override val visibleError = flowOf(false)
+
+    override fun onValueChange(displayFormatted: String): TextFieldState? = null
+
+    override fun onRawValueChange(rawValue: String) {}
+
+    override fun onFocusChange(newHasFocus: Boolean) {}
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberViewOnlyController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberViewOnlyController.kt
@@ -15,12 +15,12 @@ import kotlinx.coroutines.flow.map
  * Controller for the card number field which is view only and never changes.
  *
  * @param initialValues The initial values of the field, which will never change.
- *      Should contain values for both [IdentifierSpec.CardNumber] and [IdentifierSpec.CardBrand]
+ *      Should contain values for both [IdentifierSpec.CardNumber] and [IdentifierSpec.CardBrand].
  */
 internal class CardNumberViewOnlyController(
     cardTextFieldConfig: CardNumberConfig,
     initialValues: Map<IdentifierSpec, String?>
-) : CardNumberController {
+) : CardNumberController() {
 
     override val capitalization: KeyboardCapitalization = cardTextFieldConfig.capitalization
     override val keyboardType: KeyboardType = cardTextFieldConfig.keyboard

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IdentifierSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IdentifierSpec.kt
@@ -24,6 +24,10 @@ data class IdentifierSpec(val v1: String) {
 
         val CardCvc = IdentifierSpec("card[cvc]")
 
+        val CardExpMonth = IdentifierSpec("card[exp_month]")
+
+        val CardExpYear = IdentifierSpec("card[exp_year]")
+
         val Email = IdentifierSpec("billing_details[email]")
 
         val Phone = IdentifierSpec("billing_details[phone]")

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldController.kt
@@ -29,6 +29,11 @@ interface TextFieldController : InputController {
     override val fieldValue: Flow<String>
     val visibleError: Flow<Boolean>
     val loading: Flow<Boolean>
+
+    // Whether the TextField should be enabled or not
+    val enabled: Boolean
+        get() = true
+
     // This dictates how the accessibility reader reads the text in the field.
     // Default this to _fieldValue to read the field normally
     val contentDescription: Flow<String>

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
@@ -77,6 +77,10 @@ fun TextFieldSection(
  * This is focused on converting an [TextFieldController] into what is displayed in a textField.
  * - some focus logic
  * - observes values that impact how things show on the screen
+ *
+ * @param enabled Whether to show this TextField as enabled or not. Note that the `enabled`
+ * attribute of [textFieldController] is also taken into account to decide if the UI should be
+ * enabled.
  */
 @Composable
 fun TextField(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
@@ -147,7 +147,7 @@ fun TextField(
                 this.contentDescription = contentDescription
                 this.editableText = AnnotatedString("")
             },
-        enabled = enabled,
+        enabled = enabled && textFieldController.enabled,
         label = {
             FormLabel(
                 text = if (textFieldController.showOptionalLabel) {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/TransformSpecToElements.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/TransformSpecToElements.kt
@@ -35,6 +35,9 @@ import com.stripe.android.ui.core.forms.resources.ResourceRepository
  * Transform a [LayoutSpec] data object into an Element, which
  * has a controller and identifier.  With only a single field in a section the section
  * controller will be a pass through the field controller.
+ *
+ * @param viewOnlyFields A set of identifiers for the fields that should be view-only, non-editable.
+ * Currently only [IdentifierSpec.CardNumber] is supported and any other identifier is ignored.
  */
 class TransformSpecToElements(
     private val resourceRepository: ResourceRepository,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/TransformSpecToElements.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/TransformSpecToElements.kt
@@ -42,7 +42,8 @@ class TransformSpecToElements(
     private val amount: Amount?,
     private val saveForFutureUseInitialValue: Boolean,
     private val merchantName: String,
-    private val context: Context
+    private val context: Context,
+    private val viewOnlyFields: Set<IdentifierSpec> = emptySet()
 ) {
     fun transform(
         list: List<FormItemSpec>
@@ -61,7 +62,7 @@ class TransformSpecToElements(
                     it.transform()
                 is EmptyFormSpec -> EmptyFormElement()
                 is AuBecsDebitMandateTextSpec -> it.transform(merchantName)
-                is CardDetailsSectionSpec -> it.transform(context, initialValues)
+                is CardDetailsSectionSpec -> it.transform(context, initialValues, viewOnlyFields)
                 is BsbSpec -> it.transform(initialValues)
                 is OTPSpec -> it.transform()
                 is EmailSpec -> it.transform(initialValues)
@@ -85,10 +86,8 @@ class TransformSpecToElements(
                     resourceRepository.getAddressRepository(),
                     initialValues
                 )
-                is SimpleTextSpec -> it.transform(initialValues)
                 is KlarnaHeaderStaticTextSpec -> it.transform()
                 is SepaMandateTextSpec -> it.transform(merchantName)
-                else -> EmptyFormElement()
             }
         }
 }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
@@ -3,7 +3,7 @@ package com.stripe.android.ui.core.elements
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.lifecycle.asLiveData
 import androidx.test.core.app.ApplicationProvider
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ui.core.R
 import com.stripe.android.utils.TestUtils.idleLooper
 import org.junit.Test
@@ -13,11 +13,12 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class CardDetailsControllerTest {
 
-    private val context = ContextThemeWrapper(ApplicationProvider.getApplicationContext(), R.style.StripeDefaultTheme)
+    private val context =
+        ContextThemeWrapper(ApplicationProvider.getApplicationContext(), R.style.StripeDefaultTheme)
 
     @Test
     fun `Verify the first field in error is returned in error flow`() {
-        val cardController = CardDetailsController(context, emptyMap())
+        val cardController = CardDetailsController(context, emptyMap(), emptySet())
 
         val flowValues = mutableListOf<FieldError?>()
         cardController.error.asLiveData()
@@ -31,15 +32,33 @@ class CardDetailsControllerTest {
 
         idleLooper()
 
-        Truth.assertThat(flowValues[flowValues.size - 1]?.errorMessage).isEqualTo(
+        assertThat(flowValues[flowValues.size - 1]?.errorMessage).isEqualTo(
             R.string.invalid_card_number
         )
 
         cardController.numberElement.controller.onValueChange("4242424242424242")
         idleLooper()
 
-        Truth.assertThat(flowValues[flowValues.size - 1]?.errorMessage).isEqualTo(
+        assertThat(flowValues[flowValues.size - 1]?.errorMessage).isEqualTo(
             R.string.incomplete_expiry_date
         )
+    }
+
+    @Test
+    fun `When card number is not view only then CardNumberControllerEditable is used`() {
+        val cardController =
+            CardDetailsController(context, emptyMap(), emptySet())
+
+        assertThat(cardController.numberElement.controller)
+            .isInstanceOf(CardNumberControllerEditable::class.java)
+    }
+
+    @Test
+    fun `When card number is view only then CardNumberControllerViewOnly is used`() {
+        val cardController =
+            CardDetailsController(context, emptyMap(), setOf(IdentifierSpec.CardNumber))
+
+        assertThat(cardController.numberElement.controller)
+            .isInstanceOf(CardNumberViewOnlyController::class.java)
     }
 }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
@@ -50,7 +50,7 @@ class CardDetailsControllerTest {
             CardDetailsController(context, emptyMap(), emptySet())
 
         assertThat(cardController.numberElement.controller)
-            .isInstanceOf(CardNumberControllerEditable::class.java)
+            .isInstanceOf(CardNumberEditableController::class.java)
     }
 
     @Test

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
@@ -18,7 +18,7 @@ class CardDetailsControllerTest {
 
     @Test
     fun `Verify the first field in error is returned in error flow`() {
-        val cardController = CardDetailsController(context, emptyMap(), emptySet())
+        val cardController = CardDetailsController(context, emptyMap())
 
         val flowValues = mutableListOf<FieldError?>()
         cardController.error.asLiveData()
@@ -47,7 +47,7 @@ class CardDetailsControllerTest {
     @Test
     fun `When card number is not view only then CardNumberControllerEditable is used`() {
         val cardController =
-            CardDetailsController(context, emptyMap(), emptySet())
+            CardDetailsController(context, emptyMap())
 
         assertThat(cardController.numberElement.controller)
             .isInstanceOf(CardNumberEditableController::class.java)
@@ -56,7 +56,7 @@ class CardDetailsControllerTest {
     @Test
     fun `When card number is view only then CardNumberControllerViewOnly is used`() {
         val cardController =
-            CardDetailsController(context, emptyMap(), setOf(IdentifierSpec.CardNumber))
+            CardDetailsController(context, emptyMap(), true)
 
         assertThat(cardController.numberElement.controller)
             .isInstanceOf(CardNumberViewOnlyController::class.java)

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsElementTest.kt
@@ -4,6 +4,7 @@ import androidx.appcompat.view.ContextThemeWrapper
 import androidx.lifecycle.asLiveData
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth
+import com.stripe.android.model.CardBrand
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.forms.FormFieldEntry
 import com.stripe.android.utils.TestUtils.idleLooper
@@ -19,11 +20,12 @@ class CardDetailsElementTest {
 
     @Test
     fun `test form field values returned and expiration date parsing`() {
-        val cardController = CardDetailsController(context, emptyMap())
+        val cardController = CardDetailsController(context, emptyMap(), emptySet())
         val cardDetailsElement = CardDetailsElement(
             IdentifierSpec.Generic("card_details"),
             context,
             initialValues = emptyMap(),
+            viewOnlyFields = emptySet(),
             cardController,
         )
 
@@ -44,8 +46,42 @@ class CardDetailsElementTest {
                 IdentifierSpec.CardNumber to FormFieldEntry("4242424242424242", true),
                 IdentifierSpec.CardCvc to FormFieldEntry("321", true),
                 IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
-                IdentifierSpec.Generic("card[exp_month]") to FormFieldEntry("1", true),
-                IdentifierSpec.Generic("card[exp_year]") to FormFieldEntry("2030", true),
+                IdentifierSpec.CardExpMonth to FormFieldEntry("1", true),
+                IdentifierSpec.CardExpYear to FormFieldEntry("2030", true),
+            )
+        )
+    }
+
+    @Test
+    fun `test view only form field values returned and expiration date parsing`() {
+        val cardDetailsElement = CardDetailsElement(
+            IdentifierSpec.Generic("card_details"),
+            context,
+            initialValues = mapOf(
+                IdentifierSpec.CardNumber to "4242424242424242",
+                IdentifierSpec.CardBrand to CardBrand.Visa.code
+            ),
+            viewOnlyFields = setOf(IdentifierSpec.CardNumber)
+        )
+
+        val flowValues = mutableListOf<List<Pair<IdentifierSpec, FormFieldEntry>>>()
+        cardDetailsElement.getFormFieldValueFlow().asLiveData()
+            .observeForever {
+                flowValues.add(it)
+            }
+
+        cardDetailsElement.controller.cvcElement.controller.onValueChange("321")
+        cardDetailsElement.controller.expirationDateElement.controller.onValueChange("130")
+
+        idleLooper()
+
+        Truth.assertThat(flowValues[flowValues.size - 1]).isEqualTo(
+            listOf(
+                IdentifierSpec.CardNumber to FormFieldEntry("4242424242424242", true),
+                IdentifierSpec.CardCvc to FormFieldEntry("321", true),
+                IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
+                IdentifierSpec.CardExpMonth to FormFieldEntry("1", true),
+                IdentifierSpec.CardExpYear to FormFieldEntry("2030", true),
             )
         )
     }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsElementTest.kt
@@ -20,7 +20,7 @@ class CardDetailsElementTest {
 
     @Test
     fun `test form field values returned and expiration date parsing`() {
-        val cardController = CardDetailsController(context, emptyMap(), emptySet())
+        val cardController = CardDetailsController(context, emptyMap())
         val cardDetailsElement = CardDetailsElement(
             IdentifierSpec.Generic("card_details"),
             context,

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
@@ -24,7 +24,7 @@ internal class CardNumberControllerTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
-    private val cardNumberController = CardNumberControllerEditable(
+    private val cardNumberController = CardNumberEditableController(
         CardNumberConfig(), FakeCardAccountRangeRepository(), testDispatcher, initialValue = null
     )
 
@@ -100,7 +100,7 @@ internal class CardNumberControllerTest {
     @Test
     fun `Entering VISA BIN does not call accountRangeRepository`() {
         var repositoryCalls = 0
-        val cardNumberController = CardNumberControllerEditable(
+        val cardNumberController = CardNumberEditableController(
             CardNumberConfig(),
             object : CardAccountRangeRepository {
                 private val staticCardAccountRangeSource = StaticCardAccountRangeSource()

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
@@ -24,7 +24,7 @@ internal class CardNumberControllerTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
-    private val cardNumberController = CardNumberController(
+    private val cardNumberController = CardNumberControllerEditable(
         CardNumberConfig(), FakeCardAccountRangeRepository(), testDispatcher, initialValue = null
     )
 
@@ -100,7 +100,7 @@ internal class CardNumberControllerTest {
     @Test
     fun `Entering VISA BIN does not call accountRangeRepository`() {
         var repositoryCalls = 0
-        val cardNumberController = CardNumberController(
+        val cardNumberController = CardNumberControllerEditable(
             CardNumberConfig(),
             object : CardAccountRangeRepository {
                 private val staticCardAccountRangeSource = StaticCardAccountRangeSource()

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberViewOnlyControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberViewOnlyControllerTest.kt
@@ -1,0 +1,57 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.lifecycle.asLiveData
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.CardBrand
+import com.stripe.android.ui.core.forms.FormFieldEntry
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class CardNumberViewOnlyControllerTest {
+
+    private val cardNumber = "123"
+    private val cardNumberController = CardNumberViewOnlyController(
+        CardNumberConfig(), mapOf(
+            IdentifierSpec.CardNumber to cardNumber,
+            IdentifierSpec.CardBrand to CardBrand.Visa.code
+        )
+    )
+
+    @Test
+    fun `Verify no error`() {
+        val errorFlowValues = mutableListOf<FieldError?>()
+        cardNumberController.error.asLiveData()
+            .observeForever {
+                errorFlowValues.add(it)
+            }
+
+        assertThat(errorFlowValues).containsExactly(null)
+    }
+
+    @Test
+    fun `Verify value does not change`() {
+        var formFieldValue: FormFieldEntry? = null
+        cardNumberController.formFieldValue.asLiveData()
+            .observeForever {
+                formFieldValue = it
+            }
+
+        assertThat(formFieldValue).isEqualTo(FormFieldEntry(cardNumber, true))
+
+        cardNumberController.onValueChange("012")
+        assertThat(formFieldValue).isEqualTo(FormFieldEntry(cardNumber, true))
+    }
+
+    @Test
+    fun `Verify card brand is emitted`() {
+        var cardBrand: CardBrand? = null
+        cardNumberController.cardBrandFlow.asLiveData()
+            .observeForever {
+                cardBrand = it
+            }
+
+        assertThat(cardBrand).isEqualTo(CardBrand.Visa)
+    }
+}

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberViewOnlyControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberViewOnlyControllerTest.kt
@@ -13,7 +13,8 @@ internal class CardNumberViewOnlyControllerTest {
 
     private val cardNumber = "123"
     private val cardNumberController = CardNumberViewOnlyController(
-        CardNumberConfig(), mapOf(
+        CardNumberConfig(),
+        mapOf(
             IdentifierSpec.CardNumber to cardNumber,
             IdentifierSpec.CardBrand to CardBrand.Visa.code
         )

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/TransformSpecToElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/TransformSpecToElementTest.kt
@@ -6,6 +6,8 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.Capitalization
+import com.stripe.android.ui.core.elements.CardDetailsSectionElement
+import com.stripe.android.ui.core.elements.CardNumberViewOnlyController
 import com.stripe.android.ui.core.elements.CountryConfig
 import com.stripe.android.ui.core.elements.CountryElement
 import com.stripe.android.ui.core.elements.CountrySpec
@@ -178,6 +180,31 @@ internal class TransformSpecToElementTest {
         assertThat(staticTextElement.controller).isNull()
         assertThat(staticTextElement.stringResId).isEqualTo(staticText.stringResId)
         assertThat(staticTextElement.identifier).isEqualTo(staticText.apiPath)
+    }
+
+    @Test
+    fun `Setting card number to view only returns the correct elements`() {
+        transformSpecToElements =
+            TransformSpecToElements(
+                resourceRepository = StaticResourceRepository(
+                    mock(),
+                    mock()
+                ),
+                initialValues = mapOf(),
+                amount = null,
+                saveForFutureUseInitialValue = true,
+                merchantName = "Merchant, Inc.",
+                context,
+                viewOnlyFields = setOf(IdentifierSpec.CardNumber)
+            )
+
+        val formElements = transformSpecToElements.transform(CardForm.items)
+        val cardDetailsSection = formElements.first() as CardDetailsSectionElement
+        val cardNumberElement =
+            cardDetailsSection.controller.cardDetailsElement.controller.numberElement
+
+        assertThat(cardNumberElement.controller)
+            .isInstanceOf(CardNumberViewOnlyController::class.java)
     }
 
     companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/FormFragmentArgumentsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/FormFragmentArgumentsTest.kt
@@ -16,8 +16,7 @@ class FormFragmentArgumentsTest {
             city = "Dublin",
             state = "Co. Dublin",
             postalCode = "T37 F8HK",
-            country = "IE",
-
+            country = "IE"
         ),
         "email.email.com",
         "Jenny Smith"
@@ -78,8 +77,8 @@ class FormFragmentArgumentsTest {
                 IdentifierSpec.Country to "DE",
                 IdentifierSpec.Generic("type") to "card",
                 IdentifierSpec.CardNumber to "4242424242424242",
-                IdentifierSpec.Generic("card[exp_month]") to "1",
-                IdentifierSpec.Generic("card[exp_year]") to "2024",
+                IdentifierSpec.CardExpMonth to "1",
+                IdentifierSpec.CardExpYear to "2024",
                 IdentifierSpec.CardCvc to "111"
             )
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Create `CardNumberViewOnlyController`, which shows the card number passed in without any validation and can't be edited.
Refactor `CardNumberController` into a sealed class with two subclasses, `CardNumberViewOnlyController` and `CardNumberEditableController`.
Add new `viewOnlyFields` parameter to `TransformSpecToElements` to indicate which fields should be view only. Currently only `IdentifierSpec.CardNumber` is supported and any other identifier is ignored.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Need to show a redacted card number and prevent the user from editing it when updating a card in Link.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
