### PR TITLE
Navigating back on Link

### DIFF
--- a/link/api/link.api
+++ b/link/api/link.api
@@ -232,6 +232,10 @@ public final class com/stripe/android/link/model/AccountStatus : java/lang/Enum 
 	public static fun values ()[Lcom/stripe/android/link/model/AccountStatus;
 }
 
+public final class com/stripe/android/link/model/NavigatorKt {
+	public static final fun isOnRootScreen (Landroidx/navigation/NavHostController;)Z
+}
+
 public final class com/stripe/android/link/model/Navigator_Factory : dagger/internal/Factory {
 	public fun <init> ()V
 	public static fun create ()Lcom/stripe/android/link/model/Navigator_Factory;

--- a/link/res/drawable/ic_link_back.xml
+++ b/link/res/drawable/ic_link_back.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:autoMirrored="true"
+    android:width="14dp"
+    android:height="13dp"
+    android:viewportWidth="14"
+    android:viewportHeight="13">
+    <path
+        android:pathData="M3.0728,5.6L7.1364,1.5364C7.4879,1.1849 7.4879,0.6151 7.1364,0.2636C6.7849,-0.0879 6.2151,-0.0879 5.8636,0.2636L0.2636,5.8636C-0.0879,6.2151 -0.0879,6.7849 0.2636,7.1364L5.8636,12.7364C6.2151,13.0879 6.7849,13.0879 7.1364,12.7364C7.4879,12.3849 7.4879,11.8151 7.1364,11.4636L3.0728,7.4H13.1C13.5971,7.4 14,6.9971 14,6.5C14,6.0029 13.5971,5.6 13.1,5.6H3.0728Z"
+        android:fillColor="#000000"
+        android:fillType="evenOdd" />
+</vector>

--- a/link/res/values/strings.xml
+++ b/link/res/values/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="link">Link</string>
+    <string name="back">Back</string>
 
     <string name="inline_sign_up_header">Save my info for secure 1-click checkout</string>
 

--- a/link/src/androidTest/java/com/stripe/android/link/ui/LinkAppBarTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/LinkAppBarTest.kt
@@ -28,7 +28,7 @@ internal class LinkAppBarTest {
     @Test
     fun on_button_click_button_callback_is_called() {
         var count = 0
-        setContent(onCloseButtonClick = { count++ })
+        setContent(onButtonClick = { count++ })
 
         composeTestRule.onNodeWithContentDescription("Back").performClick()
         assertThat(count).isEqualTo(1)
@@ -36,13 +36,13 @@ internal class LinkAppBarTest {
 
     private fun setContent(
         email: String? = null,
-        onCloseButtonClick: () -> Unit = {}
+        onButtonClick: () -> Unit = {}
     ) = composeTestRule.setContent {
         DefaultLinkTheme {
             LinkAppBar(
                 email = email,
                 isRootScreen = true,
-                onButtonClick = onCloseButtonClick
+                onButtonClick = onButtonClick
             )
         }
     }

--- a/link/src/androidTest/java/com/stripe/android/link/ui/LinkAppBarTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/LinkAppBarTest.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.link.R
 import com.stripe.android.link.theme.DefaultLinkTheme
 import org.junit.Rule
 import org.junit.Test
@@ -42,7 +41,7 @@ internal class LinkAppBarTest {
         DefaultLinkTheme {
             LinkAppBar(
                 email = email,
-                buttonIconResource = R.drawable.ic_link_close,
+                isRootScreen = true,
                 onButtonClick = onCloseButtonClick
             )
         }

--- a/link/src/androidTest/java/com/stripe/android/link/ui/LinkAppBarTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/LinkAppBarTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.link.R
 import com.stripe.android.link.theme.DefaultLinkTheme
 import org.junit.Rule
 import org.junit.Test
@@ -26,11 +27,11 @@ internal class LinkAppBarTest {
     }
 
     @Test
-    fun close_button_callback_is_called() {
+    fun on_button_click_button_callback_is_called() {
         var count = 0
         setContent(onCloseButtonClick = { count++ })
 
-        composeTestRule.onNodeWithContentDescription("Close").performClick()
+        composeTestRule.onNodeWithContentDescription("Back").performClick()
         assertThat(count).isEqualTo(1)
     }
 
@@ -39,7 +40,11 @@ internal class LinkAppBarTest {
         onCloseButtonClick: () -> Unit = {}
     ) = composeTestRule.setContent {
         DefaultLinkTheme {
-            LinkAppBar(email = email, onCloseButtonClick = onCloseButtonClick)
+            LinkAppBar(
+                email = email,
+                buttonIconResource = R.drawable.ic_link_close,
+                onButtonClick = onCloseButtonClick
+            )
         }
     }
 }

--- a/link/src/androidTest/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreenTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreenTest.kt
@@ -36,7 +36,7 @@ internal class PaymentMethodScreenTest {
     }
 
     private val primaryButtonLabel = "Pay $10.99"
-    private val payAnotherWayButtonLabel = "Pay another way"
+    private val secondaryButtonLabel = "Cancel"
 
     @Test
     fun primary_button_shows_progress_indicator_when_processing() {
@@ -52,13 +52,13 @@ internal class PaymentMethodScreenTest {
             onPayButtonClick = {
                 count++
             },
-            onPayAnotherWayClick = {
+            onSecondaryButtonClick = {
                 count++
             }
         )
 
         onPrimaryButton().assertDoesNotExist()
-        onPayAnotherWayButton().performClick()
+        onSecondaryButton().performClick()
 
         assertThat(count).isEqualTo(0)
     }
@@ -80,15 +80,15 @@ internal class PaymentMethodScreenTest {
     }
 
     @Test
-    fun pay_another_way_click_triggers_action() {
+    fun secondary_button_click_triggers_action() {
         var count = 0
         setContent(
-            onPayAnotherWayClick = {
+            onSecondaryButtonClick = {
                 count++
             }
         )
 
-        onPayAnotherWayButton().performClick()
+        onSecondaryButton().performClick()
 
         assertThat(count).isEqualTo(1)
     }
@@ -105,22 +105,23 @@ internal class PaymentMethodScreenTest {
         payButtonEnabled: Boolean = false,
         errorMessage: ErrorMessage? = null,
         onPayButtonClick: () -> Unit = {},
-        onPayAnotherWayClick: () -> Unit = {}
+        onSecondaryButtonClick: () -> Unit = {}
     ) = composeTestRule.setContent {
         DefaultLinkTheme {
             PaymentMethodBody(
                 isProcessing = isProcessing,
                 primaryButtonLabel = primaryButtonLabel,
+                secondaryButtonLabel = secondaryButtonLabel,
                 primaryButtonEnabled = payButtonEnabled,
                 errorMessage = errorMessage,
                 onPrimaryButtonClick = onPayButtonClick,
-                onPayAnotherWayClick = onPayAnotherWayClick,
+                onSecondaryButtonClick = onSecondaryButtonClick,
                 formContent = {}
             )
         }
     }
 
     private fun onPrimaryButton() = composeTestRule.onNodeWithText(primaryButtonLabel)
-    private fun onPayAnotherWayButton() = composeTestRule.onNodeWithText(payAnotherWayButtonLabel)
+    private fun onSecondaryButton() = composeTestRule.onNodeWithText(secondaryButtonLabel)
     private fun onProgressIndicator() = composeTestRule.onNodeWithTag(progressIndicatorTestTag)
 }

--- a/link/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -46,6 +46,7 @@ import com.stripe.android.link.ui.signup.SignUpBody
 import com.stripe.android.link.ui.verification.VerificationBodyFullFlow
 import com.stripe.android.link.ui.wallet.WalletBody
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterialApi::class)
@@ -102,11 +103,13 @@ internal class LinkActivity : ComponentActivity() {
                     viewModel.navigator.navigationController = navController
 
                     Column(Modifier.fillMaxWidth()) {
-                        val linkAccount by viewModel.linkAccount.collectAsState(initial = null)
+                        val linkAccount by viewModel.linkAccount.collectAsState(null)
+                        val iconResource by getIconFlow().collectAsState(R.drawable.ic_link_close)
 
                         LinkAppBar(
                             email = linkAccount?.email,
-                            onCloseButtonClick = { dismiss() }
+                            buttonIconResource = iconResource,
+                            onButtonClick = { viewModel.navigator.onBack() }
                         )
 
                         NavHost(navController, LinkScreen.Loading.route) {
@@ -234,4 +237,15 @@ internal class LinkActivity : ComponentActivity() {
         )
         finish()
     }
+
+    private fun getIconFlow() =
+        navController.currentBackStackEntryFlow.map {
+            if (navController.backQueue.size > 2) {
+                // The Loading screen is always at the bottom of the stack, so a
+                // size of 2 means there's only one screen in the stack.
+                R.drawable.ic_link_back
+            } else {
+                R.drawable.ic_link_close
+            }
+        }
 }

--- a/link/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -37,6 +37,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.stripe.android.link.model.AccountStatus
+import com.stripe.android.link.model.isOnRootScreen
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.link.ui.BottomSheetContent
 import com.stripe.android.link.ui.LinkAppBar
@@ -104,11 +105,11 @@ internal class LinkActivity : ComponentActivity() {
 
                     Column(Modifier.fillMaxWidth()) {
                         val linkAccount by viewModel.linkAccount.collectAsState(null)
-                        val iconResource by getIconFlow().collectAsState(R.drawable.ic_link_close)
+                        val isOnRootScreen by isRootScreenFlow().collectAsState(true)
 
                         LinkAppBar(
                             email = linkAccount?.email,
-                            buttonIconResource = iconResource,
+                            isRootScreen = isOnRootScreen,
                             onButtonClick = { viewModel.navigator.onBack() }
                         )
 
@@ -238,14 +239,6 @@ internal class LinkActivity : ComponentActivity() {
         finish()
     }
 
-    private fun getIconFlow() =
-        navController.currentBackStackEntryFlow.map {
-            if (navController.backQueue.size > 2) {
-                // The Loading screen is always at the bottom of the stack, so a
-                // size of 2 means there's only one screen in the stack.
-                R.drawable.ic_link_back
-            } else {
-                R.drawable.ic_link_close
-            }
-        }
+    private fun isRootScreenFlow() =
+        navController.currentBackStackEntryFlow.map { navController.isOnRootScreen() }
 }

--- a/link/src/main/java/com/stripe/android/link/model/Navigator.kt
+++ b/link/src/main/java/com/stripe/android/link/model/Navigator.kt
@@ -55,4 +55,10 @@ internal class Navigator @Inject constructor() {
         onDismiss?.let {
             it(result)
         }
+
+    fun isOnRootScreen() = navigationController?.isOnRootScreen()
 }
+
+// The Loading screen is always at the bottom of the stack, so a size of 2 means the current
+// screen is at the bottom of the navigation stack.
+fun NavHostController.isOnRootScreen() = backQueue.size <= 2

--- a/link/src/main/java/com/stripe/android/link/theme/Theme.kt
+++ b/link/src/main/java/com/stripe/android/link/theme/Theme.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.unit.dp
 
-internal val CloseIconWidth = 24.dp
+internal val MinimumTouchTargetSize = 48.dp
 internal val AppBarHeight = 56.dp
 internal val HorizontalPadding = 20.dp
 

--- a/link/src/main/java/com/stripe/android/link/ui/LinkAppBar.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/LinkAppBar.kt
@@ -1,9 +1,8 @@
 package com.stripe.android.link.ui
 
+import androidx.annotation.DrawableRes
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -13,6 +12,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
@@ -25,8 +25,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.stripe.android.link.R
 import com.stripe.android.link.theme.AppBarHeight
-import com.stripe.android.link.theme.CloseIconWidth
 import com.stripe.android.link.theme.DefaultLinkTheme
+import com.stripe.android.link.theme.MinimumTouchTargetSize
 import com.stripe.android.link.theme.linkColors
 
 @Preview
@@ -36,7 +36,8 @@ internal fun LinkAppBar() {
         Surface {
             LinkAppBar(
                 email = "email@example.com",
-                onCloseButtonClick = {}
+                buttonIconResource = R.drawable.ic_link_close,
+                onButtonClick = {}
             )
         }
     }
@@ -45,61 +46,56 @@ internal fun LinkAppBar() {
 @Composable
 internal fun LinkAppBar(
     email: String?,
-    onCloseButtonClick: () -> Unit
+    @DrawableRes buttonIconResource: Int,
+    onButtonClick: () -> Unit
 ) {
-    Column(
+    Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 20.dp)
-            .defaultMinSize(minHeight = AppBarHeight)
+            .defaultMinSize(minHeight = AppBarHeight),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.Top
     ) {
-        Row(
+        IconButton(
+            onClick = onButtonClick,
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 18.dp),
-            horizontalArrangement = Arrangement.Center,
-            verticalAlignment = Alignment.CenterVertically
+                .padding(4.dp)
         ) {
-            Box(
-                modifier = Modifier
-                    .width(CloseIconWidth)
-                    .clickable(onClick = onCloseButtonClick),
-                contentAlignment = Alignment.Center
-            ) {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_link_close),
-                    contentDescription = stringResource(id = R.string.close),
-                    tint = MaterialTheme.linkColors.closeButton
-                )
-            }
-
-            Column(
-                modifier = Modifier.weight(1f),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_link_logo),
-                    contentDescription = stringResource(R.string.link),
-                    tint = MaterialTheme.linkColors.linkLogo
-                )
-            }
-
-            Spacer(modifier = Modifier.width(CloseIconWidth))
+            Icon(
+                painter = painterResource(id = buttonIconResource),
+                contentDescription = stringResource(id = R.string.back),
+                tint = MaterialTheme.linkColors.closeButton
+            )
         }
 
-        AnimatedVisibility(visible = !email.isNullOrEmpty()) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 8.dp)
-                    .height(24.dp),
-                horizontalArrangement = Arrangement.Center
-            ) {
-                Text(
-                    text = email.orEmpty(),
-                    color = MaterialTheme.linkColors.disabledText
-                )
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(top = 18.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_link_logo),
+                contentDescription = stringResource(R.string.link),
+                tint = MaterialTheme.linkColors.linkLogo
+            )
+
+            AnimatedVisibility(visible = !email.isNullOrEmpty()) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 8.dp)
+                        .height(24.dp),
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    Text(
+                        text = email.orEmpty(),
+                        color = MaterialTheme.linkColors.disabledText
+                    )
+                }
             }
         }
+
+        Spacer(modifier = Modifier.width(MinimumTouchTargetSize))
     }
 }

--- a/link/src/main/java/com/stripe/android/link/ui/LinkAppBar.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/LinkAppBar.kt
@@ -63,9 +63,9 @@ internal fun LinkAppBar(
             Icon(
                 painter = painterResource(
                     id = if (isRootScreen) {
-                        R.drawable.ic_link_back
-                    } else {
                         R.drawable.ic_link_close
+                    } else {
+                        R.drawable.ic_link_back
                     }
                 ),
                 contentDescription = stringResource(id = R.string.back),

--- a/link/src/main/java/com/stripe/android/link/ui/LinkAppBar.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/LinkAppBar.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.link.ui
 
-import androidx.annotation.DrawableRes
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -36,7 +35,7 @@ internal fun LinkAppBar() {
         Surface {
             LinkAppBar(
                 email = "email@example.com",
-                buttonIconResource = R.drawable.ic_link_close,
+                isRootScreen = true,
                 onButtonClick = {}
             )
         }
@@ -46,7 +45,7 @@ internal fun LinkAppBar() {
 @Composable
 internal fun LinkAppBar(
     email: String?,
-    @DrawableRes buttonIconResource: Int,
+    isRootScreen: Boolean,
     onButtonClick: () -> Unit
 ) {
     Row(
@@ -62,7 +61,13 @@ internal fun LinkAppBar(
                 .padding(4.dp)
         ) {
             Icon(
-                painter = painterResource(id = buttonIconResource),
+                painter = painterResource(
+                    id = if (isRootScreen) {
+                        R.drawable.ic_link_back
+                    } else {
+                        R.drawable.ic_link_close
+                    }
+                ),
                 contentDescription = stringResource(id = R.string.back),
                 tint = MaterialTheme.linkColors.closeButton
             )

--- a/link/src/main/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreen.kt
@@ -40,9 +40,10 @@ private fun PaymentMethodBodyPreview() {
                 isProcessing = false,
                 primaryButtonLabel = "Pay $10.99",
                 primaryButtonEnabled = true,
+                secondaryButtonLabel = "Cancel",
                 errorMessage = null,
                 onPrimaryButtonClick = {},
-                onPayAnotherWayClick = {},
+                onSecondaryButtonClick = {},
             ) {}
         }
     }
@@ -65,13 +66,14 @@ internal fun PaymentMethodBody(
         isProcessing = isProcessing,
         primaryButtonLabel = primaryButtonLabel(viewModel.args, LocalContext.current.resources),
         primaryButtonEnabled = formValues != null,
+        secondaryButtonLabel = stringResource(id = viewModel.secondaryButtonLabel),
         errorMessage = errorMessage,
         onPrimaryButtonClick = {
             formValues?.let {
                 viewModel.startPayment(it)
             }
         },
-        onPayAnotherWayClick = viewModel::payAnotherWay
+        onSecondaryButtonClick = viewModel::onSecondaryButtonClick
     ) {
         Form(
             viewModel.formController,
@@ -85,9 +87,10 @@ internal fun PaymentMethodBody(
     isProcessing: Boolean,
     primaryButtonLabel: String,
     primaryButtonEnabled: Boolean,
+    secondaryButtonLabel: String,
     errorMessage: ErrorMessage?,
     onPrimaryButtonClick: () -> Unit,
-    onPayAnotherWayClick: () -> Unit,
+    onSecondaryButtonClick: () -> Unit,
     formContent: @Composable ColumnScope.() -> Unit
 ) {
     ScrollableTopLevelColumn {
@@ -118,8 +121,8 @@ internal fun PaymentMethodBody(
         )
         SecondaryButton(
             enabled = !isProcessing,
-            label = stringResource(id = R.string.wallet_pay_another_way),
-            onClick = onPayAnotherWayClick
+            label = secondaryButtonLabel,
+            onClick = onSecondaryButtonClick
         )
     }
 }

--- a/link/src/main/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModel.kt
@@ -7,6 +7,7 @@ import com.stripe.android.core.Logger
 import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkPaymentDetails
+import com.stripe.android.link.R
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.confirmation.ConfirmStripeIntentParamsFactory
 import com.stripe.android.link.confirmation.ConfirmationManager
@@ -54,6 +55,14 @@ internal class PaymentMethodViewModel @Inject constructor(
     private val _errorMessage = MutableStateFlow<ErrorMessage?>(null)
     val errorMessage: StateFlow<ErrorMessage?> = _errorMessage
 
+    private val isRootScreen = navigator.isOnRootScreen() == true
+
+    val secondaryButtonLabel = if (isRootScreen) {
+        R.string.wallet_pay_another_way
+    } else {
+        R.string.cancel
+    }
+
     val paymentMethod = SupportedPaymentMethod.Card()
     val formController = formControllerProvider.get()
         .formSpec(paymentMethod.formSpec)
@@ -91,7 +100,15 @@ internal class PaymentMethodViewModel @Inject constructor(
         }
     }
 
-    fun payAnotherWay() {
+    fun onSecondaryButtonClick() {
+        if (isRootScreen) {
+            payAnotherWay()
+        } else {
+            navigator.onBack()
+        }
+    }
+
+    private fun payAnotherWay() {
         clearError()
         navigator.dismiss()
         linkAccountManager.logout()

--- a/link/src/main/java/com/stripe/android/link/ui/verification/VerificationDialog.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/verification/VerificationDialog.kt
@@ -68,7 +68,7 @@ fun LinkVerificationDialog(
                                 Column {
                                     LinkAppBar(
                                         email = account.email,
-                                        buttonIconResource = R.drawable.ic_link_close,
+                                        isRootScreen = true,
                                         onButtonClick = {
                                             openDialog = false
                                             verificationCallback(false)

--- a/link/src/main/java/com/stripe/android/link/ui/verification/VerificationDialog.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/verification/VerificationDialog.kt
@@ -68,7 +68,8 @@ fun LinkVerificationDialog(
                                 Column {
                                     LinkAppBar(
                                         email = account.email,
-                                        onCloseButtonClick = {
+                                        buttonIconResource = R.drawable.ic_link_close,
+                                        onButtonClick = {
                                             openDialog = false
                                             verificationCallback(false)
                                         }

--- a/link/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModelTest.kt
@@ -10,6 +10,7 @@ import com.stripe.android.core.injection.Injectable
 import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkPaymentDetails
+import com.stripe.android.link.R
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.confirmation.ConfirmationManager
 import com.stripe.android.link.confirmation.PaymentConfirmationCallback
@@ -297,8 +298,33 @@ class PaymentMethodViewModelTest {
     }
 
     @Test
+    fun `when screen is root then secondaryButtonLabel is correct`() = runTest {
+        whenever(navigator.isOnRootScreen()).thenReturn(true)
+
+        assertThat(createViewModel().secondaryButtonLabel).isEqualTo(R.string.wallet_pay_another_way)
+    }
+
+    @Test
+    fun `when screen is not root then secondaryButtonLabel is correct`() = runTest {
+        whenever(navigator.isOnRootScreen()).thenReturn(false)
+
+        assertThat(createViewModel().secondaryButtonLabel).isEqualTo(R.string.cancel)
+    }
+
+    @Test
+    fun `cancel navigates back`() = runTest {
+        whenever(navigator.isOnRootScreen()).thenReturn(false)
+
+        createViewModel().onSecondaryButtonClick()
+
+        verify(navigator).onBack()
+    }
+
+    @Test
     fun `payAnotherWay dismisses and logs out`() = runTest {
-        createViewModel().payAnotherWay()
+        whenever(navigator.isOnRootScreen()).thenReturn(true)
+
+        createViewModel().onSecondaryButtonClick()
 
         verify(navigator).dismiss()
         verify(linkAccountManager).logout()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update app bar button to show a back icon and navigate back when there's more than one screen in the back stack.
Update `PaymentMethodScreen` to show a `Cancel` button instead of `Pay another way` when it's not the root screen.
Before that, the app bar button and `PaymentMethodScreen` secondary button always closed the sheet.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fixing navigation.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
