### PR TITLE
Rename package for TextUtils

### DIFF
--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/scanui/SimpleScanActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/scanui/SimpleScanActivity.kt
@@ -20,11 +20,11 @@ import com.stripe.android.camera.scanui.ScanFlow
 import com.stripe.android.camera.scanui.ViewFinderBackground
 import com.stripe.android.camera.scanui.util.asRect
 import com.stripe.android.camera.scanui.util.setDrawable
-import com.stripe.android.identity.utils.setHtmlString
 import com.stripe.android.stripecardscan.R
 import com.stripe.android.stripecardscan.scanui.util.getColorByRes
 import com.stripe.android.stripecardscan.scanui.util.getDrawableByRes
 import com.stripe.android.stripecardscan.scanui.util.getFloatResource
+import com.stripe.android.stripecardscan.scanui.util.setHtmlString
 import com.stripe.android.stripecardscan.scanui.util.setTextSizeByRes
 import com.stripe.android.stripecardscan.scanui.util.setVisible
 import kotlinx.coroutines.Deferred

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/scanui/util/TextUtils.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/scanui/util/TextUtils.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.identity.utils
+package com.stripe.android.stripecardscan.scanui.util
 
 import android.os.Build
 import android.text.Html


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
File has the same package name as another one in `identity` module, causing a build issue when building with JitPack:
```
Duplicate class com.stripe.android.identity.utils.TextUtilsKt found in modules identity-link_beta_1-SNAPSHOT-runtime (com.github.stripe.stripe-android:identity:link_beta_1-SNAPSHOT:v20.4.0-gd3d54af-50) and stripecardscan-link_beta_1-SNAPSHOT-runtime (com.github.stripe.stripe-android:stripecardscan:link_beta_1-SNAPSHOT:v20.4.0-gd3d54af-50)
```

https://github.com/stripe/stripe-android/blob/master/identity/src/main/java/com/stripe/android/identity/utils/TextUtils.kt

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix build issue so we can use JitPack

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified
