### PR TITLE
Fix PaymentDetails card brand enum

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParser.kt
@@ -31,13 +31,24 @@ class ConsumerPaymentDetailsJsonParser : ModelJsonParser<ConsumerPaymentDetails>
                         json.getBoolean(FIELD_IS_DEFAULT),
                         cardDetails.getInt(FIELD_CARD_EXPIRY_YEAR),
                         cardDetails.getInt(FIELD_CARD_EXPIRY_MONTH),
-                        CardBrand.fromCode(cardDetails.getString(FIELD_CARD_BRAND)),
+                        CardBrand.fromCode(cardBrandFix(cardDetails.getString(FIELD_CARD_BRAND))),
                         cardDetails.getString(FIELD_CARD_LAST_4)
                     )
                 }
                 else -> null
             }
         }
+
+    /**
+     * Fixes the incorrect brand enum values returned from the server in this service.
+     */
+    private fun cardBrandFix(original: String) = original.lowercase().let {
+        when (it) {
+            "american_express" -> "amex"
+            "diners_club" -> "diners"
+            else -> it
+        }
+    }
 
     private companion object {
         private const val FIELD_PAYMENT_DETAILS = "redacted_payment_details"

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParserTest.kt
@@ -56,6 +56,7 @@ class ConsumerPaymentDetailsJsonParserTest {
         )
     }
 
+    @Suppress("LongMethod")
     @Test
     fun `AMERICAN_EXPRESS and DINERS_CLUB card brands are fixed`() {
         val json = JSONObject(

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParserTest.kt
@@ -122,7 +122,7 @@ class ConsumerPaymentDetailsJsonParserTest {
                 }
               ]
             }
-        """.trimIndent()
+            """.trimIndent()
         )
 
         assertEquals(

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParserTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.model.parsers
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerFixtures
 import com.stripe.android.model.ConsumerPaymentDetails
+import org.json.JSONObject
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -48,6 +49,101 @@ class ConsumerPaymentDetailsJsonParserTest {
                         expiryYear = 2024,
                         expiryMonth = 4,
                         brand = CardBrand.Visa,
+                        last4 = "4242"
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `AMERICAN_EXPRESS and DINERS_CLUB card brands are fixed`() {
+        val json = JSONObject(
+            """
+            {
+              "redacted_payment_details": [
+                {
+                  "id": "QAAAKJ6",
+                  "bank_account_details": null,
+                  "billing_address": {
+                    "administrative_area": null,
+                    "country_code": "US",
+                    "dependent_locality": null,
+                    "line_1": null,
+                    "line_2": null,
+                    "locality": null,
+                    "name": null,
+                    "postal_code": "12312",
+                    "sorting_code": null
+                  },
+                  "billing_email_address": "",
+                  "card_details": {
+                    "brand": "AMERICAN_EXPRESS",
+                    "checks": {
+                      "address_line1_check": "STATE_INVALID",
+                      "address_postal_code_check": "PASS",
+                      "cvc_check": "PASS"
+                    },
+                    "exp_month": 12,
+                    "exp_year": 2023,
+                    "last4": "4444"
+                  },
+                  "is_default": true,
+                  "type": "CARD"
+                },
+                {
+                  "id": "QAAAKIL",
+                  "bank_account_details": null,
+                  "billing_address": {
+                    "administrative_area": null,
+                    "country_code": "US",
+                    "dependent_locality": null,
+                    "line_1": null,
+                    "line_2": null,
+                    "locality": null,
+                    "name": null,
+                    "postal_code": "42424",
+                    "sorting_code": null
+                  },
+                  "billing_email_address": "",
+                  "card_details": {
+                    "brand": "DINERS_CLUB",
+                    "checks": {
+                      "address_line1_check": "STATE_INVALID",
+                      "address_postal_code_check": "PASS",
+                      "cvc_check": "PASS"
+                    },
+                    "exp_month": 4,
+                    "exp_year": 2024,
+                    "last4": "4242"
+                  },
+                  "is_default": false,
+                  "type": "CARD"
+                }
+              ]
+            }
+        """.trimIndent()
+        )
+
+        assertEquals(
+            ConsumerPaymentDetailsJsonParser()
+                .parse(json),
+            ConsumerPaymentDetails(
+                listOf(
+                    ConsumerPaymentDetails.Card(
+                        id = "QAAAKJ6",
+                        isDefault = true,
+                        expiryYear = 2023,
+                        expiryMonth = 12,
+                        brand = CardBrand.AmericanExpress,
+                        last4 = "4444"
+                    ),
+                    ConsumerPaymentDetails.Card(
+                        id = "QAAAKIL",
+                        isDefault = false,
+                        expiryYear = 2024,
+                        expiryMonth = 4,
+                        brand = CardBrand.DinersClub,
                         last4 = "4242"
                     )
                 )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
PaymentDetails service returns incorrect enum value, resulting in some card brands not being recognized correctly.
Fix that by converting them to the correct values.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix invalid card brands

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
