### PR TITLE
MOBILESDK-856: set request_surface parameter with Link APIs

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1283,7 +1283,6 @@ class StripeApiRepository @JvmOverloads internal constructor(
                     ),
                     "type" to "SMS",
                     "code" to verificationCode,
-                    "request_surface" to "android_payment_element"
                 ).plus(
                     authSessionCookie?.let {
                         mapOf(

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1171,13 +1171,15 @@ class StripeApiRepository @JvmOverloads internal constructor(
             apiRequestFactory.createPost(
                 consumerSessionLookupUrl,
                 requestOptions,
-                (
+                mapOf(
+                    "request_surface" to "android_payment_element"
+                ).plus(
                     email?.let {
                         mapOf(
                             "email_address" to it.lowercase()
                         )
                     } ?: emptyMap()
-                    ).plus(
+                ).plus(
                     authSessionCookie?.let {
                         mapOf(
                             "cookies" to
@@ -1207,6 +1209,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
                 consumerSignUpUrl,
                 requestOptions,
                 mapOf(
+                    "request_surface" to "android_payment_element",
                     "email_address" to email.lowercase(),
                     "phone_number" to phoneNumber,
                     "country" to country
@@ -1239,6 +1242,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
                 startConsumerVerificationUrl,
                 requestOptions,
                 mapOf(
+                    "request_surface" to "android_payment_element",
                     "credentials" to mapOf(
                         "consumer_session_client_secret" to consumerSessionClientSecret
                     ),
@@ -1273,12 +1277,13 @@ class StripeApiRepository @JvmOverloads internal constructor(
                 confirmConsumerVerificationUrl,
                 requestOptions,
                 mapOf(
+                    "request_surface" to "android_payment_element",
                     "credentials" to mapOf(
                         "consumer_session_client_secret" to consumerSessionClientSecret
                     ),
                     "type" to "SMS",
                     "code" to verificationCode,
-                    "client_type" to "MOBILE_SDK"
+                    "request_surface" to "android_payment_element"
                 ).plus(
                     authSessionCookie?.let {
                         mapOf(
@@ -1307,6 +1312,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
                 logoutConsumerUrl,
                 requestOptions,
                 mapOf(
+                    "request_surface" to "android_payment_element",
                     "credentials" to mapOf(
                         "consumer_session_client_secret" to consumerSessionClientSecret
                     ),
@@ -1335,6 +1341,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
                 consumerPaymentDetailsUrl,
                 requestOptions,
                 mapOf(
+                    "request_surface" to "android_payment_element",
                     "credentials" to mapOf(
                         "consumer_session_client_secret" to consumerSessionClientSecret
                     ),
@@ -1362,6 +1369,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
                 consumerPaymentDetailsUrl,
                 requestOptions,
                 mapOf(
+                    "request_surface" to "android_payment_element",
                     "credentials" to mapOf(
                         "consumer_session_client_secret" to consumerSessionClientSecret
                     ),
@@ -1387,6 +1395,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
                 getConsumerPaymentDetailsUrl(paymentDetailsId),
                 requestOptions,
                 mapOf(
+                    "request_surface" to "android_payment_element",
                     "credentials" to mapOf(
                         "consumer_session_client_secret" to consumerSessionClientSecret
                     )
@@ -1410,6 +1419,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
                 getConsumerPaymentDetailsUrl(paymentDetailsUpdateParams.id),
                 requestOptions,
                 mapOf(
+                    "request_surface" to "android_payment_element",
                     "credentials" to mapOf(
                         "consumer_session_client_secret" to consumerSessionClientSecret
                     )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Uses the `request_surface` parameter, which supersedes the `client_type` parameter (but has the same functionality).

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

https://jira.corp.stripe.com/browse/MOBILESDK-856

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
This is not a notable change and has no effect on users.