### PR TITLE
Retry API calls on authentication failure

### DIFF
--- a/link/api/link.api
+++ b/link/api/link.api
@@ -270,7 +270,7 @@ public final class com/stripe/android/link/ui/cardedit/CardEditViewModel_Factory
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/link/ui/cardedit/CardEditViewModel_Factory;
 	public fun get ()Lcom/stripe/android/link/ui/cardedit/CardEditViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/link/model/LinkAccount;Lcom/stripe/android/link/repositories/LinkRepository;Lcom/stripe/android/link/model/Navigator;Lcom/stripe/android/core/Logger;Ljavax/inject/Provider;)Lcom/stripe/android/link/ui/cardedit/CardEditViewModel;
+	public static fun newInstance (Lcom/stripe/android/link/model/LinkAccount;Lcom/stripe/android/link/account/LinkAccountManager;Lcom/stripe/android/link/model/Navigator;Lcom/stripe/android/core/Logger;Ljavax/inject/Provider;)Lcom/stripe/android/link/ui/cardedit/CardEditViewModel;
 }
 
 public final class com/stripe/android/link/ui/cardedit/CardEditViewModel_Factory_MembersInjector : dagger/MembersInjector {
@@ -376,11 +376,11 @@ public final class com/stripe/android/link/ui/paymentmethod/ComposableSingletons
 }
 
 public final class com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModel_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/link/ui/paymentmethod/PaymentMethodViewModel_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/link/ui/paymentmethod/PaymentMethodViewModel_Factory;
 	public fun get ()Lcom/stripe/android/link/ui/paymentmethod/PaymentMethodViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/link/LinkActivityContract$Args;Lcom/stripe/android/link/model/LinkAccount;Lcom/stripe/android/link/repositories/LinkRepository;Lcom/stripe/android/link/account/LinkAccountManager;Lcom/stripe/android/link/model/Navigator;Lcom/stripe/android/link/confirmation/ConfirmationManager;Lcom/stripe/android/core/Logger;Ljavax/inject/Provider;)Lcom/stripe/android/link/ui/paymentmethod/PaymentMethodViewModel;
+	public static fun newInstance (Lcom/stripe/android/link/LinkActivityContract$Args;Lcom/stripe/android/link/model/LinkAccount;Lcom/stripe/android/link/account/LinkAccountManager;Lcom/stripe/android/link/model/Navigator;Lcom/stripe/android/link/confirmation/ConfirmationManager;Lcom/stripe/android/core/Logger;Ljavax/inject/Provider;)Lcom/stripe/android/link/ui/paymentmethod/PaymentMethodViewModel;
 }
 
 public final class com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModel_Factory_MembersInjector : dagger/MembersInjector {
@@ -470,11 +470,11 @@ public final class com/stripe/android/link/ui/wallet/ComposableSingletons$Wallet
 }
 
 public final class com/stripe/android/link/ui/wallet/WalletViewModel_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/link/ui/wallet/WalletViewModel_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/link/ui/wallet/WalletViewModel_Factory;
 	public fun get ()Lcom/stripe/android/link/ui/wallet/WalletViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/link/LinkActivityContract$Args;Lcom/stripe/android/link/model/LinkAccount;Lcom/stripe/android/link/repositories/LinkRepository;Lcom/stripe/android/link/account/LinkAccountManager;Lcom/stripe/android/link/model/Navigator;Lcom/stripe/android/link/confirmation/ConfirmationManager;Lcom/stripe/android/core/Logger;)Lcom/stripe/android/link/ui/wallet/WalletViewModel;
+	public static fun newInstance (Lcom/stripe/android/link/LinkActivityContract$Args;Lcom/stripe/android/link/model/LinkAccount;Lcom/stripe/android/link/account/LinkAccountManager;Lcom/stripe/android/link/model/Navigator;Lcom/stripe/android/link/confirmation/ConfirmationManager;Lcom/stripe/android/core/Logger;)Lcom/stripe/android/link/ui/wallet/WalletViewModel;
 }
 
 public final class com/stripe/android/link/ui/wallet/WalletViewModel_Factory_MembersInjector : dagger/MembersInjector {

--- a/link/src/main/java/com/stripe/android/link/ui/cardedit/CardEditViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/cardedit/CardEditViewModel.kt
@@ -6,13 +6,13 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.stripe.android.core.Logger
+import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.injection.FormControllerSubcomponent
 import com.stripe.android.link.injection.NonFallbackInjectable
 import com.stripe.android.link.injection.NonFallbackInjector
 import com.stripe.android.link.injection.SignedInViewModelSubcomponent
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.model.Navigator
-import com.stripe.android.link.repositories.LinkRepository
 import com.stripe.android.link.ui.ErrorMessage
 import com.stripe.android.link.ui.forms.FormController
 import com.stripe.android.link.ui.getErrorMessage
@@ -34,7 +34,7 @@ import javax.inject.Provider
 
 internal class CardEditViewModel @Inject constructor(
     val linkAccount: LinkAccount,
-    private val linkRepository: LinkRepository,
+    private val linkAccountManager: LinkAccountManager,
     private val navigator: Navigator,
     private val logger: Logger,
     private val formControllerProvider: Provider<FormControllerSubcomponent.Builder>
@@ -58,7 +58,7 @@ internal class CardEditViewModel @Inject constructor(
     @VisibleForTesting
     fun initWithPaymentDetailsId(paymentDetailsId: String) {
         viewModelScope.launch {
-            linkRepository.listPaymentDetails(linkAccount.clientSecret).fold(
+            linkAccountManager.listPaymentDetails().fold(
                 onSuccess = { response ->
                     response.paymentDetails.filterIsInstance<ConsumerPaymentDetails.Card>()
                         .firstOrNull { it.id == paymentDetailsId }?.let {
@@ -104,7 +104,7 @@ internal class CardEditViewModel @Inject constructor(
                 paymentMethodCreateParams
             )
 
-            linkRepository.updatePaymentDetails(updateParams, linkAccount.clientSecret).fold(
+            linkAccountManager.updatePaymentDetails(updateParams).fold(
                 onSuccess = {
                     _isProcessing.value = false
                     dismiss(Result.Success)

--- a/link/src/main/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModel.kt
@@ -17,7 +17,6 @@ import com.stripe.android.link.injection.NonFallbackInjector
 import com.stripe.android.link.injection.SignedInViewModelSubcomponent
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.model.Navigator
-import com.stripe.android.link.repositories.LinkRepository
 import com.stripe.android.link.ui.ErrorMessage
 import com.stripe.android.link.ui.getErrorMessage
 import com.stripe.android.payments.paymentlauncher.PaymentResult
@@ -40,7 +39,6 @@ import javax.inject.Provider
 internal class PaymentMethodViewModel @Inject constructor(
     val args: LinkActivityContract.Args,
     val linkAccount: LinkAccount,
-    private val linkRepository: LinkRepository,
     private val linkAccountManager: LinkAccountManager,
     private val navigator: Navigator,
     private val confirmationManager: ConfirmationManager,
@@ -83,9 +81,8 @@ internal class PaymentMethodViewModel @Inject constructor(
         viewModelScope.launch {
             _isProcessing.value = true
 
-            linkRepository.createPaymentDetails(
+            linkAccountManager.createPaymentDetails(
                 paymentMethod.createParams(paymentMethodCreateParams, linkAccount.email),
-                linkAccount.clientSecret,
                 args.stripeIntent,
                 paymentMethod.extraConfirmationParams(paymentMethodCreateParams)
             ).fold(

--- a/link/src/test/java/com/stripe/android/link/account/LinkAccountManagerTest.kt
+++ b/link/src/test/java/com/stripe/android/link/account/LinkAccountManagerTest.kt
@@ -1,0 +1,282 @@
+package com.stripe.android.link.account
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.StripeError
+import com.stripe.android.core.exception.AuthenticationException
+import com.stripe.android.link.LinkActivityContract
+import com.stripe.android.link.model.AccountStatus
+import com.stripe.android.link.model.LinkAccount
+import com.stripe.android.link.repositories.LinkRepository
+import com.stripe.android.link.ui.inline.UserInput
+import com.stripe.android.model.ConsumerSession
+import com.stripe.android.model.ConsumerSessionLookup
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.mockito.Mockito.times
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LinkAccountManagerTest {
+    private val args = mock<LinkActivityContract.Args>()
+    private val linkRepository = mock<LinkRepository>()
+    private val cookieStore = mock<CookieStore>()
+
+    private val verifiedSession = mock<ConsumerSession.VerificationSession>().apply {
+        whenever(type).thenReturn(ConsumerSession.VerificationSession.SessionType.Sms)
+        whenever(state).thenReturn(ConsumerSession.VerificationSession.SessionState.Verified)
+    }
+    private val mockConsumerSession = mock<ConsumerSession>().apply {
+        whenever(clientSecret).thenReturn(CLIENT_SECRET)
+        whenever(verificationSessions).thenReturn(listOf(verifiedSession))
+    }
+    private val linkAccount = LinkAccount(mockConsumerSession)
+
+    @Test
+    fun `When auth cookie exists then it is used at start`() = runSuspendTest {
+        val cookie = "cookie"
+        whenever(cookieStore.getAuthSessionCookie()).thenReturn(cookie)
+
+        args.apply {
+            whenever(customerEmail).thenReturn(EMAIL)
+        }
+
+        assertThat(accountManager().accountStatus.first()).isEqualTo(AccountStatus.Verified)
+
+        verify(linkRepository).lookupConsumer(isNull(), eq(cookie))
+    }
+
+    @Test
+    fun `When customerEmail is set in arguments then it is looked up`() = runSuspendTest {
+        args.apply {
+            whenever(customerEmail).thenReturn(EMAIL)
+        }
+
+        assertThat(accountManager().accountStatus.first()).isEqualTo(AccountStatus.Verified)
+
+        verify(linkRepository).lookupConsumer(EMAIL, null)
+    }
+
+    @Test
+    fun `When customerEmail has signed out then it is not looked up`() = runSuspendTest {
+        whenever(cookieStore.isEmailLoggedOut(EMAIL)).thenReturn(true)
+
+        args.apply {
+            whenever(customerEmail).thenReturn(EMAIL)
+        }
+
+        assertThat(accountManager().accountStatus.first()).isEqualTo(AccountStatus.SignedOut)
+
+        verifyNoInteractions(linkRepository)
+    }
+
+    @Test
+    fun `lookupConsumer starts session when startSession is true`() = runSuspendTest {
+        mockUnverifiedAccountLookup()
+
+        val accountManager = accountManager()
+
+        accountManager.lookupConsumer(EMAIL, true)
+
+        verify(linkRepository).startVerification(anyOrNull(), anyOrNull())
+        assertThat(accountManager.linkAccount.value).isNotNull()
+    }
+
+    @Test
+    fun `lookupConsumer does not start session when startSession is false`() = runSuspendTest {
+        val accountManager = accountManager()
+
+        accountManager.lookupConsumer(EMAIL, false)
+
+        verify(linkRepository, times(0)).startVerification(anyOrNull(), anyOrNull())
+        assertThat(accountManager.linkAccount.value).isNull()
+    }
+
+    @Test
+    fun `signInWithUserInput sends correct parameters and starts session`() = runSuspendTest {
+        val accountManager = accountManager()
+
+        accountManager.signInWithUserInput(UserInput.SignIn(EMAIL))
+
+        verify(linkRepository).lookupConsumer(eq(EMAIL), anyOrNull())
+        assertThat(accountManager.linkAccount.value).isNotNull()
+    }
+
+    @Test
+    fun `signUp sends correct parameters and starts session`() = runSuspendTest {
+        val accountManager = accountManager()
+
+        accountManager.signInWithUserInput(UserInput.SignIn(EMAIL))
+
+        verify(linkRepository).lookupConsumer(eq(EMAIL), anyOrNull())
+        assertThat(accountManager.linkAccount.value).isNotNull()
+    }
+
+    @Test
+    fun `startVerification updates account`() = runSuspendTest {
+        val accountManager = accountManager()
+        accountManager.setAndReturnNullable(linkAccount)
+
+        accountManager.startVerification()
+
+        assertThat(accountManager.linkAccount.value).isNotNull()
+    }
+
+    @Test
+    fun `startVerification retries on auth error`() = runSuspendTest {
+        val accountManager = accountManager()
+        accountManager.setAndReturnNullable(linkAccount)
+
+        whenever(linkRepository.startVerification(anyOrNull(), anyOrNull()))
+            .thenReturn(
+                Result.failure(AuthenticationException(StripeError())),
+                Result.success(mockConsumerSession)
+            )
+
+        accountManager.startVerification()
+
+        verify(linkRepository, times(2)).startVerification(anyOrNull(), anyOrNull())
+        verify(linkRepository).lookupConsumer(anyOrNull(), anyOrNull())
+
+        assertThat(accountManager.linkAccount.value).isNotNull()
+    }
+
+    @Test
+    fun `confirmVerification retries on auth error`() = runSuspendTest {
+        val accountManager = accountManager()
+        accountManager.setAndReturnNullable(linkAccount)
+
+        whenever(linkRepository.confirmVerification(anyOrNull(), anyOrNull(), anyOrNull()))
+            .thenReturn(
+                Result.failure(AuthenticationException(StripeError())),
+                Result.success(mockConsumerSession)
+            )
+
+        accountManager.confirmVerification("123")
+
+        verify(linkRepository, times(2))
+            .confirmVerification(anyOrNull(), anyOrNull(), anyOrNull())
+        verify(linkRepository).lookupConsumer(anyOrNull(), anyOrNull())
+
+        assertThat(accountManager.linkAccount.value).isNotNull()
+    }
+
+    @Test
+    fun `listPaymentDetails retries on auth error`() = runSuspendTest {
+        val accountManager = accountManager()
+        accountManager.setAndReturnNullable(linkAccount)
+
+        whenever(linkRepository.listPaymentDetails(anyOrNull()))
+            .thenReturn(
+                Result.failure(AuthenticationException(StripeError())),
+                Result.success(mock())
+            )
+
+        accountManager.listPaymentDetails()
+
+        verify(linkRepository, times(2)).listPaymentDetails(anyOrNull())
+        verify(linkRepository).lookupConsumer(anyOrNull(), anyOrNull())
+
+        assertThat(accountManager.linkAccount.value).isNotNull()
+    }
+
+    @Test
+    fun `createPaymentDetails retries on auth error`() = runSuspendTest {
+        val accountManager = accountManager()
+        accountManager.setAndReturnNullable(linkAccount)
+
+        whenever(
+            linkRepository.createPaymentDetails(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull())
+        ).thenReturn(
+            Result.failure(AuthenticationException(StripeError())),
+            Result.success(mock())
+        )
+
+        accountManager.createPaymentDetails(mock(), mock(), mock())
+
+        verify(linkRepository, times(2))
+            .createPaymentDetails(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull())
+        verify(linkRepository).lookupConsumer(anyOrNull(), anyOrNull())
+
+        assertThat(accountManager.linkAccount.value).isNotNull()
+    }
+
+    @Test
+    fun `updatePaymentDetails retries on auth error`() = runSuspendTest {
+        val accountManager = accountManager()
+        accountManager.setAndReturnNullable(linkAccount)
+
+        whenever(linkRepository.updatePaymentDetails(anyOrNull(), anyOrNull()))
+            .thenReturn(
+                Result.failure(AuthenticationException(StripeError())),
+                Result.success(mock())
+            )
+
+        accountManager.updatePaymentDetails(mock())
+
+        verify(linkRepository, times(2)).updatePaymentDetails(anyOrNull(), anyOrNull())
+        verify(linkRepository).lookupConsumer(anyOrNull(), anyOrNull())
+
+        assertThat(accountManager.linkAccount.value).isNotNull()
+    }
+
+    @Test
+    fun `deletePaymentDetails retries on auth error`() = runSuspendTest {
+        val accountManager = accountManager()
+        accountManager.setAndReturnNullable(linkAccount)
+
+        whenever(linkRepository.deletePaymentDetails(anyOrNull(), anyOrNull()))
+            .thenReturn(
+                Result.failure(AuthenticationException(StripeError())),
+                Result.success(mock())
+            )
+
+        accountManager.deletePaymentDetails("id")
+
+        verify(linkRepository, times(2)).deletePaymentDetails(anyOrNull(), anyOrNull())
+        verify(linkRepository).lookupConsumer(anyOrNull(), anyOrNull())
+
+        assertThat(accountManager.linkAccount.value).isNotNull()
+    }
+
+    private fun runSuspendTest(testBody: suspend TestScope.() -> Unit) = runTest {
+        setupRepository()
+        testBody()
+    }
+
+    private suspend fun setupRepository() {
+        val consumerSessionLookup = mock<ConsumerSessionLookup>().apply {
+            whenever(consumerSession).thenReturn(mockConsumerSession)
+        }
+        whenever(linkRepository.lookupConsumer(anyOrNull(), anyOrNull()))
+            .thenReturn(Result.success(consumerSessionLookup))
+        whenever(linkRepository.startVerification(anyOrNull(), anyOrNull()))
+            .thenReturn(Result.success(mockConsumerSession))
+    }
+
+    private suspend fun mockUnverifiedAccountLookup() {
+        val mockConsumerSession = mock<ConsumerSession>().apply {
+            whenever(clientSecret).thenReturn(CLIENT_SECRET)
+        }
+        val consumerSessionLookup = mock<ConsumerSessionLookup>().apply {
+            whenever(consumerSession).thenReturn(mockConsumerSession)
+        }
+        whenever(linkRepository.lookupConsumer(anyOrNull(), anyOrNull()))
+            .thenReturn(Result.success(consumerSessionLookup))
+    }
+
+    private fun accountManager() = LinkAccountManager(args, linkRepository, cookieStore)
+
+    companion object {
+        const val EMAIL = "email@stripe.com"
+        const val CLIENT_SECRET = "client_secret"
+    }
+}

--- a/link/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModelTest.kt
@@ -21,7 +21,6 @@ import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.model.Navigator
 import com.stripe.android.link.model.PaymentDetailsFixtures
 import com.stripe.android.link.model.StripeIntentFixtures
-import com.stripe.android.link.repositories.LinkRepository
 import com.stripe.android.link.ui.ErrorMessage
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.ConsumerPaymentDetailsCreateParams
@@ -53,8 +52,7 @@ class PaymentMethodViewModelTest {
         whenever(clientSecret).thenReturn(CLIENT_SECRET)
     }
     private val args = mock<LinkActivityContract.Args>()
-    private lateinit var linkRepository: LinkRepository
-    private val linkAccountManager = mock<LinkAccountManager>()
+    private lateinit var linkAccountManager: LinkAccountManager
     private val navigator = mock<Navigator>()
     private val confirmationManager = mock<ConfirmationManager>()
     private val logger = Logger.noop()
@@ -81,23 +79,21 @@ class PaymentMethodViewModelTest {
 
     @Before
     fun before() {
-        linkRepository = mock()
+        linkAccountManager = mock()
         whenever(args.stripeIntent).thenReturn(StripeIntentFixtures.PI_SUCCEEDED)
         whenever(args.completePayment).thenReturn(true)
     }
 
     @Test
     fun `startPayment creates PaymentDetails`() = runTest {
-        whenever(
-            linkRepository.createPaymentDetails(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull())
-        ).thenReturn(Result.success(createLinkPaymentDetails()))
+        whenever(linkAccountManager.createPaymentDetails(anyOrNull(), anyOrNull(), anyOrNull()))
+            .thenReturn(Result.success(createLinkPaymentDetails()))
 
         createViewModel().startPayment(cardFormFieldValues)
 
         val paramsCaptor = argumentCaptor<ConsumerPaymentDetailsCreateParams>()
-        verify(linkRepository).createPaymentDetails(
+        verify(linkAccountManager).createPaymentDetails(
             paramsCaptor.capture(),
-            any(),
             any(),
             anyOrNull()
         )
@@ -124,14 +120,8 @@ class PaymentMethodViewModelTest {
         runTest {
             val value = createLinkPaymentDetails()
             whenever(
-                linkRepository.createPaymentDetails(
-                    anyOrNull(),
-                    anyOrNull(),
-                    anyOrNull(),
-                    anyOrNull()
-                )
-            )
-                .thenReturn(Result.success(value))
+                linkAccountManager.createPaymentDetails(anyOrNull(), anyOrNull(), anyOrNull())
+            ).thenReturn(Result.success(value))
 
             createViewModel().startPayment(cardFormFieldValues)
 
@@ -173,14 +163,8 @@ class PaymentMethodViewModelTest {
 
             val linkPaymentDetails = createLinkPaymentDetails()
             whenever(
-                linkRepository.createPaymentDetails(
-                    anyOrNull(),
-                    anyOrNull(),
-                    anyOrNull(),
-                    anyOrNull()
-                )
-            )
-                .thenReturn(Result.success(linkPaymentDetails))
+                linkAccountManager.createPaymentDetails(anyOrNull(), anyOrNull(), anyOrNull())
+            ).thenReturn(Result.success(linkPaymentDetails))
 
             createViewModel().startPayment(cardFormFieldValues)
 
@@ -195,14 +179,8 @@ class PaymentMethodViewModelTest {
     @Test
     fun `startPayment dismisses Link on success`() = runTest {
         whenever(
-            linkRepository.createPaymentDetails(
-                anyOrNull(),
-                anyOrNull(),
-                anyOrNull(),
-                anyOrNull()
-            )
-        )
-            .thenReturn(Result.success(createLinkPaymentDetails()))
+            linkAccountManager.createPaymentDetails(anyOrNull(), anyOrNull(), anyOrNull())
+        ).thenReturn(Result.success(createLinkPaymentDetails()))
 
         var callback: PaymentConfirmationCallback? = null
         whenever(
@@ -225,14 +203,8 @@ class PaymentMethodViewModelTest {
     @Test
     fun `startPayment starts processing`() = runTest {
         whenever(
-            linkRepository.createPaymentDetails(
-                anyOrNull(),
-                anyOrNull(),
-                anyOrNull(),
-                anyOrNull()
-            )
-        )
-            .thenReturn(Result.success(createLinkPaymentDetails()))
+            linkAccountManager.createPaymentDetails(anyOrNull(), anyOrNull(), anyOrNull())
+        ).thenReturn(Result.success(createLinkPaymentDetails()))
 
         val viewModel = createViewModel()
 
@@ -249,14 +221,8 @@ class PaymentMethodViewModelTest {
     @Test
     fun `startPayment stops processing on error`() = runTest {
         whenever(
-            linkRepository.createPaymentDetails(
-                anyOrNull(),
-                anyOrNull(),
-                anyOrNull(),
-                anyOrNull()
-            )
-        )
-            .thenReturn(Result.success(createLinkPaymentDetails()))
+            linkAccountManager.createPaymentDetails(anyOrNull(), anyOrNull(), anyOrNull())
+        ).thenReturn(Result.success(createLinkPaymentDetails()))
 
         var callback: PaymentConfirmationCallback? = null
         whenever(
@@ -287,7 +253,7 @@ class PaymentMethodViewModelTest {
     fun `when startPayment fails then an error message is shown`() = runTest {
         val errorMessage = "Error message"
         whenever(
-            linkRepository.createPaymentDetails(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull())
+            linkAccountManager.createPaymentDetails(anyOrNull(), anyOrNull(), anyOrNull())
         ).thenReturn(Result.failure(RuntimeException(errorMessage)))
 
         val viewModel = createViewModel()
@@ -368,7 +334,6 @@ class PaymentMethodViewModelTest {
         PaymentMethodViewModel(
             args,
             linkAccount,
-            linkRepository,
             linkAccountManager,
             navigator,
             confirmationManager,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Make all API calls go through `LinkAccountManager`. When they fail with `AuthenticationException`, use the stored cookie to fetch the user account again, which should return a valid `client_secret` to keep the user logged in.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
`client_secret` is only valid for a few minutes, so if the user leaves the app and comes back, API calls would fail.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
