### PR TITLE
Use Consumer's publishable key for API calls

### DIFF
--- a/link/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/link/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -92,6 +92,7 @@ internal class LinkApiRepository @Inject constructor(
 
     override suspend fun startVerification(
         consumerSessionClientSecret: String,
+        consumerPublishableKey: String?,
         authSessionCookie: String?
     ): Result<ConsumerSession> = withContext(workContext) {
         runCatching {
@@ -99,7 +100,9 @@ internal class LinkApiRepository @Inject constructor(
                 consumerSessionClientSecret,
                 locale ?: Locale.US,
                 authSessionCookie,
-                ApiRequest.Options(
+                consumerPublishableKey?.let {
+                    ApiRequest.Options(it)
+                } ?: ApiRequest.Options(
                     publishableKeyProvider(),
                     stripeAccountIdProvider()
                 )
@@ -118,8 +121,9 @@ internal class LinkApiRepository @Inject constructor(
     }
 
     override suspend fun confirmVerification(
-        consumerSessionClientSecret: String,
         verificationCode: String,
+        consumerSessionClientSecret: String,
+        consumerPublishableKey: String?,
         authSessionCookie: String?
     ): Result<ConsumerSession> = withContext(workContext) {
         runCatching {
@@ -127,7 +131,9 @@ internal class LinkApiRepository @Inject constructor(
                 consumerSessionClientSecret,
                 verificationCode,
                 authSessionCookie,
-                ApiRequest.Options(
+                consumerPublishableKey?.let {
+                    ApiRequest.Options(it)
+                } ?: ApiRequest.Options(
                     publishableKeyProvider(),
                     stripeAccountIdProvider()
                 )
@@ -147,13 +153,16 @@ internal class LinkApiRepository @Inject constructor(
 
     override suspend fun logout(
         consumerSessionClientSecret: String,
+        consumerPublishableKey: String?,
         authSessionCookie: String?
     ): Result<ConsumerSession> = withContext(workContext) {
         runCatching {
             stripeRepository.logoutConsumer(
                 consumerSessionClientSecret,
                 authSessionCookie,
-                ApiRequest.Options(
+                consumerPublishableKey?.let {
+                    ApiRequest.Options(it)
+                } ?: ApiRequest.Options(
                     publishableKeyProvider(),
                     stripeAccountIdProvider()
                 )
@@ -172,13 +181,16 @@ internal class LinkApiRepository @Inject constructor(
     }
 
     override suspend fun listPaymentDetails(
-        consumerSessionClientSecret: String
+        consumerSessionClientSecret: String,
+        consumerPublishableKey: String?
     ): Result<ConsumerPaymentDetails> = withContext(workContext) {
         runCatching {
             stripeRepository.listPaymentDetails(
                 consumerSessionClientSecret,
                 setOf("card"),
-                ApiRequest.Options(
+                consumerPublishableKey?.let {
+                    ApiRequest.Options(it)
+                } ?: ApiRequest.Options(
                     publishableKeyProvider(),
                     stripeAccountIdProvider()
                 )
@@ -198,15 +210,18 @@ internal class LinkApiRepository @Inject constructor(
 
     override suspend fun createPaymentDetails(
         paymentDetails: ConsumerPaymentDetailsCreateParams,
-        consumerSessionClientSecret: String,
         stripeIntent: StripeIntent,
-        extraConfirmationParams: Map<String, Any>?
+        extraConfirmationParams: Map<String, Any>?,
+        consumerSessionClientSecret: String,
+        consumerPublishableKey: String?
     ): Result<LinkPaymentDetails> = withContext(workContext) {
         runCatching {
             stripeRepository.createPaymentDetails(
                 consumerSessionClientSecret,
                 paymentDetails,
-                ApiRequest.Options(
+                consumerPublishableKey?.let {
+                    ApiRequest.Options(it)
+                } ?: ApiRequest.Options(
                     publishableKeyProvider(),
                     stripeAccountIdProvider()
                 )
@@ -236,13 +251,16 @@ internal class LinkApiRepository @Inject constructor(
 
     override suspend fun updatePaymentDetails(
         updateParams: ConsumerPaymentDetailsUpdateParams,
-        consumerSessionClientSecret: String
+        consumerSessionClientSecret: String,
+        consumerPublishableKey: String?
     ): Result<ConsumerPaymentDetails> = withContext(workContext) {
         runCatching {
             stripeRepository.updatePaymentDetails(
                 consumerSessionClientSecret,
                 updateParams,
-                ApiRequest.Options(
+                consumerPublishableKey?.let {
+                    ApiRequest.Options(it)
+                } ?: ApiRequest.Options(
                     publishableKeyProvider(),
                     stripeAccountIdProvider()
                 )
@@ -261,14 +279,17 @@ internal class LinkApiRepository @Inject constructor(
     }
 
     override suspend fun deletePaymentDetails(
+        paymentDetailsId: String,
         consumerSessionClientSecret: String,
-        paymentDetailsId: String
+        consumerPublishableKey: String?
     ): Result<Unit> = withContext(workContext) {
         runCatching {
             stripeRepository.deletePaymentDetails(
                 consumerSessionClientSecret,
                 paymentDetailsId,
-                ApiRequest.Options(
+                consumerPublishableKey?.let {
+                    ApiRequest.Options(it)
+                } ?: ApiRequest.Options(
                     publishableKeyProvider(),
                     stripeAccountIdProvider()
                 )

--- a/link/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
+++ b/link/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
@@ -36,6 +36,7 @@ internal interface LinkRepository {
      */
     suspend fun startVerification(
         consumerSessionClientSecret: String,
+        consumerPublishableKey: String?,
         authSessionCookie: String?
     ): Result<ConsumerSession>
 
@@ -43,8 +44,9 @@ internal interface LinkRepository {
      * Confirm an SMS verification code.
      */
     suspend fun confirmVerification(
-        consumerSessionClientSecret: String,
         verificationCode: String,
+        consumerSessionClientSecret: String,
+        consumerPublishableKey: String?,
         authSessionCookie: String?
     ): Result<ConsumerSession>
 
@@ -53,6 +55,7 @@ internal interface LinkRepository {
      */
     suspend fun logout(
         consumerSessionClientSecret: String,
+        consumerPublishableKey: String?,
         authSessionCookie: String?
     ): Result<ConsumerSession>
 
@@ -60,7 +63,8 @@ internal interface LinkRepository {
      * Fetch all saved payment methods for the consumer.
      */
     suspend fun listPaymentDetails(
-        consumerSessionClientSecret: String
+        consumerSessionClientSecret: String,
+        consumerPublishableKey: String?
     ): Result<ConsumerPaymentDetails>
 
     /**
@@ -68,9 +72,10 @@ internal interface LinkRepository {
      */
     suspend fun createPaymentDetails(
         paymentDetails: ConsumerPaymentDetailsCreateParams,
-        consumerSessionClientSecret: String,
         stripeIntent: StripeIntent,
-        extraConfirmationParams: Map<String, Any>? = null
+        extraConfirmationParams: Map<String, Any>? = null,
+        consumerSessionClientSecret: String,
+        consumerPublishableKey: String?
     ): Result<LinkPaymentDetails>
 
     /**
@@ -78,14 +83,16 @@ internal interface LinkRepository {
      */
     suspend fun updatePaymentDetails(
         updateParams: ConsumerPaymentDetailsUpdateParams,
-        consumerSessionClientSecret: String
+        consumerSessionClientSecret: String,
+        consumerPublishableKey: String?
     ): Result<ConsumerPaymentDetails>
 
     /**
      * Delete the payment method from the consumer account.
      */
     suspend fun deletePaymentDetails(
+        paymentDetailsId: String,
         consumerSessionClientSecret: String,
-        paymentDetailsId: String
+        consumerPublishableKey: String?
     ): Result<Unit>
 }

--- a/link/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/link/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -120,7 +120,22 @@ class LinkApiRepositoryTest {
     fun `startVerification sends correct parameters`() = runTest {
         val secret = "secret"
         val cookie = "cookie1"
-        linkRepository.startVerification(secret, cookie)
+        val consumerKey = "key"
+        linkRepository.startVerification(secret, consumerKey, cookie)
+
+        verify(stripeRepository).startConsumerVerification(
+            eq(secret),
+            eq(Locale.US),
+            eq(cookie),
+            eq(ApiRequest.Options(consumerKey))
+        )
+    }
+
+    @Test
+    fun `startVerification without consumerPublishableKey sends correct parameters`() = runTest {
+        val secret = "secret"
+        val cookie = "cookie1"
+        linkRepository.startVerification(secret, null, cookie)
 
         verify(stripeRepository).startConsumerVerification(
             eq(secret),
@@ -136,7 +151,7 @@ class LinkApiRepositoryTest {
         whenever(stripeRepository.startConsumerVerification(any(), any(), anyOrNull(), any()))
             .thenReturn(consumerSession)
 
-        val result = linkRepository.startVerification("secret", "cookie")
+        val result = linkRepository.startVerification("secret", "key", "cookie")
 
         assertThat(result.isSuccess).isTrue()
         assertThat(result.getOrNull()).isEqualTo(consumerSession)
@@ -147,7 +162,7 @@ class LinkApiRepositoryTest {
         whenever(stripeRepository.startConsumerVerification(any(), any(), anyOrNull(), any()))
             .thenThrow(RuntimeException("error"))
 
-        val result = linkRepository.startVerification("secret", "cookie")
+        val result = linkRepository.startVerification("secret", "key", "cookie")
 
         assertThat(result.isFailure).isTrue()
     }
@@ -157,7 +172,23 @@ class LinkApiRepositoryTest {
         val secret = "secret"
         val code = "code"
         val cookie = "cookie2"
-        linkRepository.confirmVerification(secret, code, cookie)
+        val consumerKey = "key2"
+        linkRepository.confirmVerification(code, secret, consumerKey, cookie)
+
+        verify(stripeRepository).confirmConsumerVerification(
+            eq(secret),
+            eq(code),
+            eq(cookie),
+            eq(ApiRequest.Options(consumerKey))
+        )
+    }
+
+    @Test
+    fun `confirmVerification without consumerPublishableKey sends correct parameters`() = runTest {
+        val secret = "secret"
+        val code = "code"
+        val cookie = "cookie2"
+        linkRepository.confirmVerification(code, secret, null, cookie)
 
         verify(stripeRepository).confirmConsumerVerification(
             eq(secret),
@@ -173,7 +204,7 @@ class LinkApiRepositoryTest {
         whenever(stripeRepository.confirmConsumerVerification(any(), any(), anyOrNull(), any()))
             .thenReturn(consumerSession)
 
-        val result = linkRepository.confirmVerification("secret", "code", "cookie")
+        val result = linkRepository.confirmVerification("code", "secret", "key", "cookie")
 
         assertThat(result.isSuccess).isTrue()
         assertThat(result.getOrNull()).isEqualTo(consumerSession)
@@ -184,7 +215,7 @@ class LinkApiRepositoryTest {
         whenever(stripeRepository.confirmConsumerVerification(any(), any(), anyOrNull(), any()))
             .thenThrow(RuntimeException("error"))
 
-        val result = linkRepository.confirmVerification("secret", "code", "cookie")
+        val result = linkRepository.confirmVerification("code", "secret", "key", "cookie")
 
         assertThat(result.isFailure).isTrue()
     }
@@ -193,7 +224,21 @@ class LinkApiRepositoryTest {
     fun `logout sends correct parameters`() = runTest {
         val secret = "secret"
         val cookie = "cookie2"
-        linkRepository.logout(secret, cookie)
+        val consumerKey = "key2"
+        linkRepository.logout(secret, consumerKey, cookie)
+
+        verify(stripeRepository).logoutConsumer(
+            eq(secret),
+            eq(cookie),
+            eq(ApiRequest.Options(consumerKey))
+        )
+    }
+
+    @Test
+    fun `logout without consumerPublishableKey sends correct parameters`() = runTest {
+        val secret = "secret"
+        val cookie = "cookie2"
+        linkRepository.logout(secret, null, cookie)
 
         verify(stripeRepository).logoutConsumer(
             eq(secret),
@@ -208,7 +253,7 @@ class LinkApiRepositoryTest {
         whenever(stripeRepository.logoutConsumer(any(), any(), any()))
             .thenReturn(consumerSession)
 
-        val result = linkRepository.logout("secret", "cookie")
+        val result = linkRepository.logout("secret", "key", "cookie")
 
         assertThat(result.isSuccess).isTrue()
         assertThat(result.getOrNull()).isEqualTo(consumerSession)
@@ -219,7 +264,7 @@ class LinkApiRepositoryTest {
         whenever(stripeRepository.logoutConsumer(any(), any(), any()))
             .thenThrow(RuntimeException("error"))
 
-        val result = linkRepository.logout("secret", "cookie")
+        val result = linkRepository.logout("secret", "key", "cookie")
 
         assertThat(result.isFailure).isTrue()
     }
@@ -227,7 +272,20 @@ class LinkApiRepositoryTest {
     @Test
     fun `listPaymentDetails sends correct parameters`() = runTest {
         val secret = "secret"
-        linkRepository.listPaymentDetails(secret)
+        val consumerKey = "key"
+        linkRepository.listPaymentDetails(secret, consumerKey)
+
+        verify(stripeRepository).listPaymentDetails(
+            eq(secret),
+            argThat { contains("card") && size == 1 },
+            eq(ApiRequest.Options(consumerKey))
+        )
+    }
+
+    @Test
+    fun `listPaymentDetails without consumerPublishableKey sends correct parameters`() = runTest {
+        val secret = "secret"
+        linkRepository.listPaymentDetails(secret, null)
 
         verify(stripeRepository).listPaymentDetails(
             eq(secret),
@@ -242,7 +300,7 @@ class LinkApiRepositoryTest {
         whenever(stripeRepository.listPaymentDetails(any(), any(), any()))
             .thenReturn(paymentDetails)
 
-        val result = linkRepository.listPaymentDetails("secret")
+        val result = linkRepository.listPaymentDetails("secret", "key")
 
         assertThat(result.isSuccess).isTrue()
         assertThat(result.getOrNull()).isEqualTo(paymentDetails)
@@ -253,7 +311,7 @@ class LinkApiRepositoryTest {
         whenever(stripeRepository.listPaymentDetails(any(), any(), any()))
             .thenThrow(RuntimeException("error"))
 
-        val result = linkRepository.listPaymentDetails("secret")
+        val result = linkRepository.listPaymentDetails("secret", "key")
 
         assertThat(result.isFailure).isTrue()
     }
@@ -262,7 +320,21 @@ class LinkApiRepositoryTest {
     fun `deletePaymentDetails sends correct parameters`() = runTest {
         val secret = "secret"
         val id = "payment_details_id"
-        linkRepository.deletePaymentDetails(secret, id)
+        val consumerKey = "key"
+        linkRepository.deletePaymentDetails(id, secret, consumerKey)
+
+        verify(stripeRepository).deletePaymentDetails(
+            eq(secret),
+            eq(id),
+            eq(ApiRequest.Options(consumerKey))
+        )
+    }
+
+    @Test
+    fun `deletePaymentDetails without consumerPublishableKey sends correct parameters`() = runTest {
+        val secret = "secret"
+        val id = "payment_details_id"
+        linkRepository.deletePaymentDetails(id, secret, null)
 
         verify(stripeRepository).deletePaymentDetails(
             eq(secret),
@@ -275,7 +347,7 @@ class LinkApiRepositoryTest {
     fun `deletePaymentDetails returns successful result`() = runTest {
         whenever(stripeRepository.deletePaymentDetails(any(), any(), any())).thenReturn(Unit)
 
-        val result = linkRepository.deletePaymentDetails("secret", "id")
+        val result = linkRepository.deletePaymentDetails("id", "secret", "key")
 
         assertThat(result.isSuccess).isTrue()
     }
@@ -285,7 +357,7 @@ class LinkApiRepositoryTest {
         whenever(stripeRepository.deletePaymentDetails(any(), any(), any()))
             .thenThrow(RuntimeException("error"))
 
-        val result = linkRepository.deletePaymentDetails("secret", "id")
+        val result = linkRepository.deletePaymentDetails("id", "secret", "key")
 
         assertThat(result.isFailure).isTrue()
     }
@@ -295,11 +367,35 @@ class LinkApiRepositoryTest {
         val secret = "secret"
         val consumerPaymentDetailsCreateParams =
             ConsumerPaymentDetailsCreateParams.Card(emptyMap(), "email@stripe.com")
+        val consumerKey = "key"
 
         linkRepository.createPaymentDetails(
-            consumerPaymentDetailsCreateParams,
-            secret,
-            paymentIntent,
+            paymentDetails = consumerPaymentDetailsCreateParams,
+            stripeIntent = paymentIntent,
+            extraConfirmationParams = null,
+            consumerSessionClientSecret = secret,
+            consumerPublishableKey = consumerKey
+        )
+
+        verify(stripeRepository).createPaymentDetails(
+            eq(secret),
+            eq(consumerPaymentDetailsCreateParams),
+            eq(ApiRequest.Options(consumerKey))
+        )
+    }
+
+    @Test
+    fun `createPaymentDetails without consumerPublishableKey sends correct parameters`() = runTest {
+        val secret = "secret"
+        val consumerPaymentDetailsCreateParams =
+            ConsumerPaymentDetailsCreateParams.Card(emptyMap(), "email@stripe.com")
+
+        linkRepository.createPaymentDetails(
+            paymentDetails = consumerPaymentDetailsCreateParams,
+            stripeIntent = paymentIntent,
+            extraConfirmationParams = null,
+            consumerSessionClientSecret = secret,
+            consumerPublishableKey = null
         )
 
         verify(stripeRepository).createPaymentDetails(
@@ -322,9 +418,14 @@ class LinkApiRepositoryTest {
             .thenReturn(consumerPaymentDetails)
 
         val result = linkRepository.createPaymentDetails(
-            ConsumerPaymentDetailsCreateParams.Card(emptyMap(), "email@stripe.com"),
-            secret,
-            paymentIntent
+            paymentDetails = ConsumerPaymentDetailsCreateParams.Card(
+                emptyMap(),
+                "email@stripe.com"
+            ),
+            stripeIntent = paymentIntent,
+            extraConfirmationParams = null,
+            consumerSessionClientSecret = secret,
+            consumerPublishableKey = null
         )
 
         assertThat(result.isSuccess).isTrue()
@@ -346,9 +447,14 @@ class LinkApiRepositoryTest {
             .thenThrow(RuntimeException("error"))
 
         val result = linkRepository.createPaymentDetails(
-            ConsumerPaymentDetailsCreateParams.Card(emptyMap(), "email@stripe.com"),
-            "secret",
-            paymentIntent
+            paymentDetails = ConsumerPaymentDetailsCreateParams.Card(
+                emptyMap(),
+                "email@stripe.com"
+            ),
+            stripeIntent = paymentIntent,
+            extraConfirmationParams = null,
+            consumerSessionClientSecret = "secret",
+            consumerPublishableKey = null
         )
 
         assertThat(result.isFailure).isTrue()
@@ -358,10 +464,30 @@ class LinkApiRepositoryTest {
     fun `updatePaymentDetails sends correct parameters`() = runTest {
         val secret = "secret"
         val params = ConsumerPaymentDetailsUpdateParams.Card("id")
+        val consumerKey = "key"
 
         linkRepository.updatePaymentDetails(
             params,
-            secret
+            secret,
+            consumerKey
+        )
+
+        verify(stripeRepository).updatePaymentDetails(
+            eq(secret),
+            eq(params),
+            eq(ApiRequest.Options(consumerKey))
+        )
+    }
+
+    @Test
+    fun `updatePaymentDetails without consumerPublishableKey sends correct parameters`() = runTest {
+        val secret = "secret"
+        val params = ConsumerPaymentDetailsUpdateParams.Card("id")
+
+        linkRepository.updatePaymentDetails(
+            params,
+            secret,
+            null
         )
 
         verify(stripeRepository).updatePaymentDetails(
@@ -373,7 +499,6 @@ class LinkApiRepositoryTest {
 
     @Test
     fun `updatePaymentDetails returns successful result`() = runTest {
-        val secret = "secret"
         val consumerPaymentDetails = mock<ConsumerPaymentDetails>()
 
         whenever(stripeRepository.updatePaymentDetails(any(), any(), any()))
@@ -381,7 +506,8 @@ class LinkApiRepositoryTest {
 
         val result = linkRepository.updatePaymentDetails(
             ConsumerPaymentDetailsUpdateParams.Card("id"),
-            secret
+            "secret",
+            "key"
         )
 
         assertThat(result.isSuccess).isTrue()
@@ -395,7 +521,8 @@ class LinkApiRepositoryTest {
 
         val result = linkRepository.updatePaymentDetails(
             ConsumerPaymentDetailsUpdateParams.Card("id"),
-            "secret"
+            "secret",
+            "key"
         )
 
         assertThat(result.isFailure).isTrue()

--- a/payments-core/src/main/java/com/stripe/android/model/ConsumerSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConsumerSession.kt
@@ -15,7 +15,8 @@ data class ConsumerSession internal constructor(
     val emailAddress: String,
     val redactedPhoneNumber: String,
     val verificationSessions: List<VerificationSession>,
-    val authSessionClientSecret: String?
+    val authSessionClientSecret: String?,
+    val publishableKey: String?
 ) : StripeModel {
 
     @Parcelize

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/ConsumerSessionJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/ConsumerSessionJsonParser.kt
@@ -22,7 +22,8 @@ internal class ConsumerSessionJsonParser : ModelJsonParser<ConsumerSession> {
             consumerSessionJson.getString(FIELD_CONSUMER_SESSION_EMAIL),
             consumerSessionJson.getString(FIELD_CONSUMER_SESSION_PHONE),
             verificationSession,
-            optString(json, FIELD_CONSUMER_SESSION_AUTH_SESSION_SECRET)
+            optString(json, FIELD_CONSUMER_SESSION_AUTH_SESSION_SECRET),
+            optString(json, FIELD_PUBLISHABLE_KEY)
         )
     }
 
@@ -38,6 +39,7 @@ internal class ConsumerSessionJsonParser : ModelJsonParser<ConsumerSession> {
 
     private companion object {
         private const val FIELD_CONSUMER_SESSION = "consumer_session"
+        private const val FIELD_PUBLISHABLE_KEY = "publishable_key"
 
         private const val FIELD_CONSUMER_SESSION_SECRET = "client_secret"
         private const val FIELD_CONSUMER_SESSION_EMAIL = "email_address"

--- a/payments-core/src/test/java/com/stripe/android/model/ConsumerFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ConsumerFixtures.kt
@@ -42,6 +42,7 @@ object ConsumerFixtures {
         """
             {
               "auth_session_client_secret": "21yKkFYNnhMVTlXbXdBQUFJRmEaJDNmZDE1",
+              "publishable_key": "asdfg123",
               "consumer_session": {
                 "client_secret": "12oBEhVjc21yKkFYNnhMVTlXbXdBQUFJRmEaJDNmZDE1MjA5LTM1YjctND",
                 "email_address": "test@stripe.com",

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerSessionJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerSessionJsonParserTest.kt
@@ -21,7 +21,8 @@ class ConsumerSessionJsonParserTest {
                         state = ConsumerSession.VerificationSession.SessionState.Started
                     )
                 ),
-                authSessionClientSecret = "21yKkFYNnhMVTlXbXdBQUFJRmEaJDNmZDE1"
+                authSessionClientSecret = "21yKkFYNnhMVTlXbXdBQUFJRmEaJDNmZDE1",
+                publishableKey = "asdfg123"
             )
         )
     }
@@ -40,7 +41,8 @@ class ConsumerSessionJsonParserTest {
                         state = ConsumerSession.VerificationSession.SessionState.Verified
                     )
                 ),
-                authSessionClientSecret = null
+                authSessionClientSecret = null,
+                publishableKey = null
             )
         )
     }
@@ -59,7 +61,8 @@ class ConsumerSessionJsonParserTest {
                         state = ConsumerSession.VerificationSession.SessionState.Started
                     )
                 ),
-                authSessionClientSecret = null
+                authSessionClientSecret = null,
+                publishableKey = null
             )
         )
     }

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerSessionLookupJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerSessionLookupJsonParserTest.kt
@@ -31,7 +31,8 @@ class ConsumerSessionLookupJsonParserTest {
                     emailAddress = "email@example.com",
                     redactedPhoneNumber = "+1********68",
                     verificationSessions = emptyList(),
-                    authSessionClientSecret = null
+                    authSessionClientSecret = null,
+                    publishableKey = null
                 ),
                 errorMessage = null
             )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Instead of using the merchant's publishable key, use the consumer's publishable key which is returned in calls to `consumers/sessions/lookup` and `consumers/accounts/sign_up`.
Only retry on authentication error if a cookie exists.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
MOBILESDK-817

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
