### PR TITLE
[Identity] Check unsupported_client field and navigates to error page

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
@@ -17,6 +17,7 @@ import com.stripe.android.identity.databinding.ConsentFragmentBinding
 import com.stripe.android.identity.networking.models.ClearDataParam
 import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.networking.models.VerificationPage.Companion.isMissingBiometricConsent
+import com.stripe.android.identity.networking.models.VerificationPage.Companion.isUnsupportedClient
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentConsentPage
 import com.stripe.android.identity.utils.navigateToErrorFragmentWithFailedReason
 import com.stripe.android.identity.utils.postVerificationPageDataAndMaybeSubmit
@@ -31,8 +32,7 @@ import kotlinx.coroutines.launch
  */
 internal class ConsentFragment(
     private val identityViewModelFactory: ViewModelProvider.Factory,
-    private val consentViewModelFactory: ViewModelProvider.Factory,
-    private val verificationFlowFinishable: VerificationFlowFinishable,
+    private val consentViewModelFactory: ViewModelProvider.Factory
 ) : Fragment() {
     private lateinit var binding: ConsentFragmentBinding
 
@@ -85,7 +85,10 @@ internal class ConsentFragment(
         identityViewModel.observeForVerificationPage(
             viewLifecycleOwner,
             onSuccess = { verificationPage ->
-                if (verificationPage.isMissingBiometricConsent()) {
+                if (verificationPage.isUnsupportedClient()) {
+                    Log.e(TAG, "Unsupported client")
+                    navigateToErrorFragmentWithFailedReason(IllegalStateException("Unsupported client"))
+                } else if (verificationPage.isMissingBiometricConsent()) {
                     setLoadingFinishedUI()
                     bindViewData(verificationPage.biometricConsent)
                 } else {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
@@ -59,8 +59,7 @@ internal class IdentityFragmentFactory @Inject constructor(
             )
             ConsentFragment::class.java.name -> ConsentFragment(
                 identityViewModelFactory,
-                consentFragmentViewModelFactory,
-                verificationFlowFinishable
+                consentFragmentViewModelFactory
             )
             DocSelectionFragment::class.java.name -> DocSelectionFragment(
                 identityViewModelFactory,

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPage.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPage.kt
@@ -62,5 +62,8 @@ internal data class VerificationPage(
     internal companion object {
         fun VerificationPage.isMissingBiometricConsent() =
             requirements.missing.contains(VerificationPageRequirements.Missing.BIOMETRICCONSENT)
+
+        fun VerificationPage.isUnsupportedClient() = unsupportedClient
+
     }
 }

--- a/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
@@ -150,7 +150,7 @@ internal class ConsentFragmentTest {
 
     @Test
     fun `when waiting verificationPage UI shows progress circular`() {
-        launchConsentFragment { binding, _ ->
+        launchConsentFragment { binding, _, _ ->
             assertThat(binding.loadings.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.texts.visibility).isEqualTo(View.GONE)
             assertThat(binding.buttons.visibility).isEqualTo(View.GONE)
@@ -164,7 +164,7 @@ internal class ConsentFragmentTest {
                 missing = emptyList()
             )
         )
-        launchConsentFragment { _, navController ->
+        launchConsentFragment { _, navController, _ ->
             setUpSuccessVerificationPage()
 
             assertThat(navController.currentDestination?.id)
@@ -172,9 +172,42 @@ internal class ConsentFragmentTest {
         }
     }
 
+
+    @Test
+    fun `when not unsupported_client navigate to errorFragment with failed reason`() {
+        whenever(verificationPageWithTimeAndPolicy.unsupportedClient).thenReturn(true)
+        launchConsentFragment { _, navController, fragment ->
+            setUpSuccessVerificationPage()
+
+            assertThat(navController.currentDestination?.id)
+                .isEqualTo(R.id.errorFragment)
+
+            requireNotNull(navController.backStack.last().arguments).let { args ->
+                assertThat(
+                    args[ErrorFragment.ARG_ERROR_TITLE]
+                ).isEqualTo(fragment.getString(R.string.error))
+
+                assertThat(
+                    args[ErrorFragment.ARG_ERROR_CONTENT]
+                ).isEqualTo(fragment.getString(R.string.unexpected_error_try_again))
+
+                assertThat(
+                    args[ErrorFragment.ARG_GO_BACK_BUTTON_TEXT]
+                ).isEqualTo(fragment.getString(R.string.go_back))
+
+                assertThat(
+                    args[ErrorFragment.ARG_FAILED_REASON]
+                ).isInstanceOf(IllegalStateException::class.java)
+                assertThat(
+                    (args[ErrorFragment.ARG_FAILED_REASON] as IllegalStateException).message
+                ).isEqualTo("Unsupported client")
+            }
+        }
+    }
+
     @Test
     fun `when verificationPage is ready UI is bound correctly`() {
-        launchConsentFragment { binding, _ ->
+        launchConsentFragment { binding, _, _ ->
             setUpSuccessVerificationPage()
 
             verify(
@@ -202,7 +235,7 @@ internal class ConsentFragmentTest {
 
     @Test
     fun `when verificationPage without time and policy is ready UI is bound correctly`() {
-        launchConsentFragment { binding, _ ->
+        launchConsentFragment { binding, _, _ ->
             setUpSuccessVerificationPage(verificationPageWithOutTimeAndPolicy)
 
             assertThat(binding.loadings.visibility).isEqualTo(View.GONE)
@@ -227,7 +260,7 @@ internal class ConsentFragmentTest {
 
     @Test
     fun `when verificationApiErrorLiveData is ready transitions to errorFragment`() {
-        launchConsentFragment { _, navController ->
+        launchConsentFragment { _, navController, _ ->
             setUpErrorVerificationPage()
 
             assertThat(navController.currentDestination?.id)
@@ -242,7 +275,7 @@ internal class ConsentFragmentTest {
                 mockIdentityViewModel.postVerificationPageData(any(), any())
             ).thenReturn(correctVerificationData)
 
-            launchConsentFragment { binding, navController ->
+            launchConsentFragment { binding, navController, _ ->
                 setUpSuccessVerificationPage()
 
                 binding.agree.findViewById<MaterialButton>(R.id.button).callOnClick()
@@ -265,7 +298,7 @@ internal class ConsentFragmentTest {
                 mockIdentityViewModel.postVerificationPageData(any(), any())
             ).thenThrow(APIException())
 
-            launchConsentFragment { binding, navController ->
+            launchConsentFragment { binding, navController, _ ->
                 setUpSuccessVerificationPage()
                 binding.agree.findViewById<MaterialButton>(R.id.button).callOnClick()
 
@@ -282,7 +315,7 @@ internal class ConsentFragmentTest {
                 mockIdentityViewModel.postVerificationPageData(any(), any())
             ).thenReturn(incorrectVerificationData)
 
-            launchConsentFragment { binding, navController ->
+            launchConsentFragment { binding, navController, _ ->
                 setUpSuccessVerificationPage()
                 binding.decline.findViewById<MaterialButton>(R.id.button).callOnClick()
 
@@ -315,7 +348,7 @@ internal class ConsentFragmentTest {
                 mockIdentityViewModel.postVerificationPageData(any(), any())
             ).thenThrow(APIException())
 
-            launchConsentFragment { binding, navController ->
+            launchConsentFragment { binding, navController, _ ->
                 setUpSuccessVerificationPage()
                 binding.decline.findViewById<MaterialButton>(R.id.button).callOnClick()
 
@@ -326,14 +359,13 @@ internal class ConsentFragmentTest {
     }
 
     private fun launchConsentFragment(
-        testBlock: (binding: ConsentFragmentBinding, navController: TestNavHostController) -> Unit
+        testBlock: (binding: ConsentFragmentBinding, navController: TestNavHostController, fragment: ConsentFragment) -> Unit
     ) = launchFragmentInContainer(
         themeResId = R.style.Theme_MaterialComponents
     ) {
         ConsentFragment(
             viewModelFactoryFor(mockIdentityViewModel),
             viewModelFactoryFor(mockConsentFragmentViewModel),
-            mock()
         )
     }.onFragment {
         val navController = TestNavHostController(
@@ -347,7 +379,7 @@ internal class ConsentFragmentTest {
             it.requireView(),
             navController
         )
-        testBlock(ConsentFragmentBinding.bind(it.requireView()), navController)
+        testBlock(ConsentFragmentBinding.bind(it.requireView()), navController, it)
     }
 
     private companion object {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
When `VerificationPage` has `unsupported_client` set to true, navigates to error page with failed reason.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Support `unsupported_client`

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
