### PR TITLE
Fix sofort country codes in PaymentSheet

### DIFF
--- a/link/src/test/java/com/stripe/android/link/ui/forms/FormControllerTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/forms/FormControllerTest.kt
@@ -56,7 +56,7 @@ class FormControllerTest {
             LayoutSpec.create(
                 NameSpec(),
                 EmailSpec(),
-                CountrySpec(allowCountryCodes = setOf("AT", "BE", "DE", "ES", "IT", "NL")),
+                CountrySpec(allowedCountryCodes = setOf("AT", "BE", "DE", "ES", "IT", "NL")),
                 SaveForFutureUseSpec()
             ),
             resourceRepository = resourceRepository,

--- a/payments-ui-core/src/main/assets/lpms.json
+++ b/payments-ui-core/src/main/assets/lpms.json
@@ -135,7 +135,7 @@
     "fields": [
       {
         "type": "billing_address",
-        "valid_country_codes": [
+        "allowed_country_codes": [
           "AT",
           "BE",
           "DE",

--- a/payments-ui-core/src/main/assets/lpms.json
+++ b/payments-ui-core/src/main/assets/lpms.json
@@ -135,7 +135,7 @@
     "fields": [
       {
         "type": "billing_address",
-        "allowed_country_codes": [
+        "valid_country_codes": [
           "AT",
           "BE",
           "DE",

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
@@ -17,8 +17,8 @@ enum class DisplayField {
 data class AddressSpec(
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("billing_details[address]"),
 
-    @SerialName("allow_country_codes")
-    val allowCountryCodes: Set<String> = supportedBillingCountries,
+    @SerialName("allowed_country_codes")
+    val allowedCountryCodes: Set<String> = supportedBillingCountries,
 
     @SerialName("display_fields")
     val displayFields: Set<DisplayField> = emptySet()
@@ -31,7 +31,7 @@ data class AddressSpec(
             CountryElement(
                 IdentifierSpec.Generic("billing_details[address][country]"),
                 DropdownFieldController(
-                    CountryConfig(this.allowCountryCodes),
+                    CountryConfig(this.allowedCountryCodes),
                     initialValue = initialValues[this.apiPath]
                 )
             )
@@ -40,7 +40,7 @@ data class AddressSpec(
                 apiPath,
                 addressRepository,
                 initialValues,
-                countryCodes = allowCountryCodes
+                countryCodes = allowedCountryCodes
             )
         },
         label = R.string.billing_details

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingSpec.kt
@@ -10,8 +10,8 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class CardBillingSpec(
     override val apiPath: IdentifierSpec = IdentifierSpec.Generic("card_billing"),
-    @SerialName("valid_country_codes")
-    val validCountryCodes: Set<String> = supportedBillingCountries
+    @SerialName("allowed_country_codes")
+    val allowedCountryCodes: Set<String> = supportedBillingCountries
 ) : FormItemSpec() {
     fun transform(
         addressRepository: AddressFieldElementRepository,
@@ -20,7 +20,7 @@ data class CardBillingSpec(
         CardBillingAddressElement(
             IdentifierSpec.Generic("credit_billing"),
             addressFieldRepository = addressRepository,
-            countryCodes = validCountryCodes,
+            countryCodes = allowedCountryCodes,
             rawValuesMap = initialValues
         ),
         label = R.string.billing_details

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CountrySpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CountrySpec.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * This is the specification for a country field.
- * @property allowCountryCodes: a list of country code that should be shown.  If empty all
+ * @property allowedCountryCodes: a list of country code that should be shown.  If empty all
  * countries will be shown.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -14,8 +14,8 @@ import kotlinx.serialization.Serializable
 data class CountrySpec(
     override val apiPath: IdentifierSpec = IdentifierSpec.Country,
 
-    @SerialName("allow_country_codes")
-    val allowCountryCodes: Set<String> = supportedBillingCountries
+    @SerialName("allowed_country_codes")
+    val allowedCountryCodes: Set<String> = supportedBillingCountries
 ) : FormItemSpec() {
     fun transform(
         initialValues: Map<IdentifierSpec, String?>
@@ -23,7 +23,7 @@ data class CountrySpec(
         CountryElement(
             this.apiPath,
             DropdownFieldController(
-                CountryConfig(this.allowCountryCodes),
+                CountryConfig(this.allowedCountryCodes),
                 initialValue = initialValues[this.apiPath]
             )
         )

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/LinkCardForm.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/LinkCardForm.kt
@@ -11,6 +11,6 @@ import com.stripe.android.ui.core.elements.supportedBillingCountries
 val LinkCardForm = LayoutSpec(
     listOf(
         CardDetailsSectionSpec(IdentifierSpec.Generic("card_details_section")),
-        CardBillingSpec(validCountryCodes = supportedBillingCountries)
+        CardBillingSpec(allowedCountryCodes = supportedBillingCountries)
     )
 )

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/LpmSerializerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/LpmSerializerTest.kt
@@ -114,7 +114,7 @@ class LpmSerializerTest {
                       },
                       {
                         "type": "billing_address",
-                        "valid_country_codes": [
+                        "allowed_country_codes": [
                           "AT",
                           "BE",
                           "DE",

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/TransformSpecToElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/TransformSpecToElementTest.kt
@@ -70,7 +70,7 @@ internal class TransformSpecToElementTest {
     @Test
     fun `Adding a country section sets up the section and country elements correctly`() =
         runBlocking {
-            val countrySection = CountrySpec(allowCountryCodes = setOf("AT"))
+            val countrySection = CountrySpec(allowedCountryCodes = setOf("AT"))
             val formElement = transformSpecToElements.transform(
                 listOf(countrySection)
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -373,7 +373,7 @@ internal class FormViewModelTest {
                 LayoutSpec.create(
                     NameSpec(),
                     EmailSpec(),
-                    CountrySpec(allowCountryCodes = setOf("AT", "BE", "DE", "ES", "IT", "NL")),
+                    CountrySpec(allowedCountryCodes = setOf("AT", "BE", "DE", "ES", "IT", "NL")),
                     SaveForFutureUseSpec()
                 )
             ),
@@ -426,7 +426,7 @@ internal class FormViewModelTest {
                     IbanSpec(),
                     AddressSpec(
                         IdentifierSpec.Generic("address"),
-                        allowCountryCodes = setOf("US", "JP")
+                        allowedCountryCodes = setOf("US", "JP")
                     ),
                     MandateTextSpec(
                         IdentifierSpec.Generic("mandate"),
@@ -512,7 +512,7 @@ internal class FormViewModelTest {
                     IbanSpec(),
                     AddressSpec(
                         IdentifierSpec.Generic("address"),
-                        allowCountryCodes = setOf("US", "JP")
+                        allowedCountryCodes = setOf("US", "JP")
                     ),
                     MandateTextSpec(
                         IdentifierSpec.Generic("mandate"),


### PR DESCRIPTION
# Summary
Updated the json country codes so that it deserializes correctly and the correct country codes are listed in the country dropdown.

# Motivation
PR#5104 renamed the serialized name, but not the underlying json

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

