### PR TITLE
[Identity] remove unused param in postVerificatinoPageDataAndMaybeSubmit

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
@@ -114,7 +114,6 @@ internal class ConsentFragment(
                 collectedDataParam,
                 ClearDataParam.CONSENT_TO_DOC_SELECT,
                 fromFragment = R.id.consentFragment,
-                shouldNotSubmit = { true },
                 notSubmitBlock = {
                     navigateToDocSelection()
                 }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
@@ -187,7 +187,6 @@ internal class DocSelectionFragment(
                 collectedDataParam = CollectedDataParam(idDocumentType = type),
                 clearDataParam = ClearDataParam.DOC_SELECT_TO_UPLOAD,
                 fromFragment = R.id.docSelectionFragment,
-                shouldNotSubmit = { true },
                 notSubmitBlock = {
                     cameraPermissionEnsureable.ensureCameraPermission(
                         onCameraReady = {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityDocumentScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityDocumentScanFragment.kt
@@ -147,7 +147,6 @@ internal abstract class IdentityDocumentScanFragment(
                                         ),
                                         fromFragment = fragmentId,
                                         clearDataParam = ClearDataParam.UPLOAD_TO_CONFIRM,
-                                        shouldNotSubmit = { false }
                                     )
                                 }.onFailure { throwable ->
                                     Log.e(

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityUploadFragment.kt
@@ -389,7 +389,6 @@ internal abstract class IdentityUploadFragment(
             collectedDataParam = collectedDataParam,
             clearDataParam = ClearDataParam.UPLOAD_TO_CONFIRM,
             fromFragment = fragmentId,
-            shouldNotSubmit = { false }
         )
     }
 

--- a/identity/src/main/java/com/stripe/android/identity/navigation/PassportScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/PassportScanFragment.kt
@@ -69,7 +69,6 @@ internal class PassportScanFragment(
                                         ),
                                         clearDataParam = ClearDataParam.UPLOAD_TO_CONFIRM,
                                         fromFragment = R.id.passportScanFragment,
-                                        shouldNotSubmit = { false }
                                     )
                                 }.onFailure { throwable ->
                                     Log.e(

--- a/identity/src/main/java/com/stripe/android/identity/navigation/SelfieFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/SelfieFragment.kt
@@ -191,7 +191,6 @@ internal class SelfieFragment(
                                     ),
                                     fromFragment = fragmentId,
                                     clearDataParam = ClearDataParam.SELFIE_TO_CONFIRM,
-                                    shouldNotSubmit = { false }
                                 )
                             }.onFailure { throwable ->
                                 Log.e(

--- a/identity/src/main/java/com/stripe/android/identity/utils/navigationUtils.kt
+++ b/identity/src/main/java/com/stripe/android/identity/utils/navigationUtils.kt
@@ -82,36 +82,6 @@ internal suspend fun Fragment.postVerificationPageDataAndMaybeSubmit(
                         }
                     )
                 }
-//                if (shouldNotSubmit(postedVerificationPageData)) {
-//                    notSubmitBlock?.invoke(postedVerificationPageData)
-//                } else {
-//                    runCatching {
-//                        identityViewModel.postVerificationPageSubmit()
-//                    }.fold(
-//                        onSuccess = { submittedVerificationPageData ->
-//                            when {
-//                                submittedVerificationPageData.hasError() -> {
-//                                    navigateToRequirementErrorFragment(
-//                                        fromFragment,
-//                                        submittedVerificationPageData.requirements.errors[0]
-//                                    )
-//                                }
-//                                submittedVerificationPageData.submitted -> {
-//                                    findNavController()
-//                                        .navigate(R.id.action_global_confirmationFragment)
-//                                }
-//                                else -> {
-//                                    Log.e(TAG, "VerificationPage submit failed")
-//                                    navigateToDefaultErrorFragment()
-//                                }
-//                            }
-//                        },
-//                        onFailure = {
-//                            Log.e(TAG, "Failed to postVerificationPageSubmit: $it")
-//                            navigateToDefaultErrorFragment()
-//                        }
-//                    )
-//                }
             }
         },
         onFailure = {

--- a/identity/src/test/java/com/stripe/android/identity/utils/NavigationUtilsTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/utils/NavigationUtilsTest.kt
@@ -186,8 +186,6 @@ internal class NavigationUtilsTest {
                 mock(),
                 mock(),
                 fromFragment,
-                { true },
-                {}
             )
 
             requireNotNull(navController.backStack.last().arguments).let { arguments ->
@@ -220,8 +218,6 @@ internal class NavigationUtilsTest {
                     mock(),
                     mock(),
                     R.id.consentFragment,
-                    { true },
-                    {}
                 )
 
                 assertThat(navController.currentDestination?.id)
@@ -245,12 +241,10 @@ internal class NavigationUtilsTest {
                     mockIdentityViewModel,
                     mock(),
                     mock(),
-                    R.id.consentFragment,
-                    { true },
-                    {
-                        blockExecuted = true
-                    }
-                )
+                    R.id.consentFragment
+                ) {
+                    blockExecuted = true
+                }
 
                 assertThat(blockExecuted).isEqualTo(true)
             }
@@ -275,8 +269,6 @@ internal class NavigationUtilsTest {
                     mock(),
                     mock(),
                     R.id.consentFragment,
-                    { false },
-                    {}
                 )
 
                 verify(mockIdentityViewModel).postVerificationPageSubmit()
@@ -303,8 +295,6 @@ internal class NavigationUtilsTest {
                     mock(),
                     mock(),
                     R.id.consentFragment,
-                    { false },
-                    {}
                 )
 
                 requireNotNull(navController.backStack.last().arguments).let { arguments ->
@@ -342,8 +332,6 @@ internal class NavigationUtilsTest {
                     mock(),
                     mock(),
                     R.id.consentFragment,
-                    { false },
-                    {}
                 )
 
                 assertThat(navController.currentDestination?.id)
@@ -371,8 +359,6 @@ internal class NavigationUtilsTest {
                     mock(),
                     mock(),
                     R.id.consentFragment,
-                    { false },
-                    {}
                 )
 
                 assertThat(navController.currentDestination?.id)
@@ -400,8 +386,6 @@ internal class NavigationUtilsTest {
                     mock(),
                     mock(),
                     R.id.consentFragment,
-                    { false },
-                    {}
                 )
 
                 assertThat(navController.currentDestination?.id)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This is a simple refactor - instead of passing a boolean to decide whether to execute the block, we could just determine that by checking if the block is null or not

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
cleaner code


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
