### PR TITLE
[Identity] Use identity v2 API and parse VerificationPage.selfieCapture

### DIFF
--- a/identity/res/layout/selfie_scan_fragment.xml
+++ b/identity/res/layout/selfie_scan_fragment.xml
@@ -91,8 +91,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/page_horizontal_margin"
             android:layout_marginEnd="@dimen/page_horizontal_margin"
-            android:layout_marginTop="20dp"
-            android:text="@string/allow_image_collection" />
+            android:layout_marginTop="20dp" />
     </LinearLayout>
 
     <View

--- a/identity/res/navigation/identity_nav_graph.xml
+++ b/identity/res/navigation/identity_nav_graph.xml
@@ -21,6 +21,10 @@
         android:id="@+id/action_global_couldNotCaptureFragment"
         app:destination="@id/couldNotCaptureFragment" />
 
+    <action
+        android:id="@+id/action_global_selfieFragment"
+        app:destination="@id/selfieFragment" />
+
     <fragment
         android:id="@+id/consentFragment"
         android:name="com.stripe.android.identity.navigation.ConsentFragment"
@@ -159,5 +163,5 @@
     <fragment
         android:id="@+id/selfieFragment"
         android:name="com.stripe.android.identity.navigation.SelfieFragment"
-        android:label="SelfieFragment" /><action android:id="@+id/action_global_selfieFragment" app:destination="@id/selfieFragment"/>
+        android:label="SelfieFragment" />
 </navigation>

--- a/identity/res/values/totranslate.xml
+++ b/identity/res/values/totranslate.xml
@@ -10,8 +10,6 @@
     <string name="selfie_captures">Selfie captures</string>
     <!-- Content description of selfie flash animation mask -->
     <string name="flash_mask">Mask color to flash selfie</string>
-    <!-- Consent message to allow stripe uses the image to improve biometric verification technology -->
-    <string name="allow_image_collection">Allow Stripe to use your image to improve our biometric verification technology. You can remove Stripe\'s permissions at any time by contacting Stripe. Learn how Stripe uses data</string>
     <!-- Content description of a captured selfie -->
     <string name="selfie_item_description">one selfie captured</string>
 </resources>

--- a/identity/src/main/java/com/stripe/android/identity/camera/IdentityAggregator.kt
+++ b/identity/src/main/java/com/stripe/android/identity/camera/IdentityAggregator.kt
@@ -35,7 +35,10 @@ internal class IdentityAggregator(
         transitioner =
         if (identityScanType == IdentityScanState.ScanType.SELFIE) {
             FaceDetectorTransitioner(
-                requireNotNull(verificationPage.selfieCapture)
+                requireNotNull(verificationPage.selfieCapture) {
+                    "Failed to initialize FaceDetectorTransitioner - " +
+                        "verificationPage.selfieCapture is null."
+                }
             )
         } else
             IDDetectorTransitioner(

--- a/identity/src/main/java/com/stripe/android/identity/camera/IdentityScanFlow.kt
+++ b/identity/src/main/java/com/stripe/android/identity/camera/IdentityScanFlow.kt
@@ -32,7 +32,7 @@ internal class IdentityScanFlow(
     private val analyzerLoopErrorListener: AnalyzerLoopErrorListener,
     private val aggregateResultListener: AggregateResultListener<IdentityAggregator.InterimResult, IdentityAggregator.FinalResult>,
     private val idDetectorModelFile: File,
-    private val faceDetectorModelFile: File,
+    private val faceDetectorModelFile: File?,
     private val verificationPage: VerificationPage
 ) : ScanFlow<IdentityScanState.ScanType, CameraPreviewImage<Bitmap>> {
     private var aggregator: IdentityAggregator? = null
@@ -91,7 +91,10 @@ internal class IdentityScanFlow(
                 AnalyzerPool.of(
                     if (parameters == IdentityScanState.ScanType.SELFIE) {
                         FaceDetectorAnalyzer.Factory(
-                            faceDetectorModelFile
+                            requireNotNull(faceDetectorModelFile) {
+                                "Failed to initialize FaceDetectorAnalyzer, " +
+                                    "faceDetectorModelFile is null"
+                            }
                         )
                     } else {
                         IDDetectorAnalyzer.Factory(
@@ -99,7 +102,6 @@ internal class IdentityScanFlow(
                             verificationPage.documentCapture.models.idDetectorMinScore
                         )
                     }
-
                 )
 
             loop = ProcessBoundAnalyzerLoop(

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
@@ -29,7 +29,6 @@ import com.stripe.android.identity.viewmodel.IdentityScanViewModel
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import java.io.File
 
 /**
  * An abstract [Fragment] class to access camera scanning for Identity.

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
@@ -100,16 +100,14 @@ internal abstract class IdentityCameraScanFragment(
         }
         cameraAdapter = createCameraAdapter()
 
-        identityViewModel.pageAndModel.observe(viewLifecycleOwner) {
+        identityViewModel.pageAndModelFiles.observe(viewLifecycleOwner) {
             when (it.status) {
                 Status.SUCCESS -> {
-                    requireNotNull(it.data).let { pageFilePair ->
-                        // TODO(IDPROD-3944) - download faceDetector model file
-                        val faceDetectorModelFile = File("path/to/faceDetector")
+                    requireNotNull(it.data).let { pageAndModelFiles ->
                         identityScanViewModel.initializeScanFlow(
-                            pageFilePair.first,
-                            idDetectorModelFile = pageFilePair.second,
-                            faceDetectorModelFile = faceDetectorModelFile
+                            pageAndModelFiles.page,
+                            idDetectorModelFile = pageAndModelFiles.idDetectorFile,
+                            faceDetectorModelFile = pageAndModelFiles.faceDetectorFile
                         )
                         lifecycleScope.launch(Dispatchers.Main) {
                             onCameraReady()

--- a/identity/src/main/java/com/stripe/android/identity/navigation/PassportScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/PassportScanFragment.kt
@@ -94,7 +94,6 @@ internal class PassportScanFragment(
                                     navigateToDefaultErrorFragment()
                                 }
                             )
-
                         }
                         else -> {
                             Log.d(

--- a/identity/src/main/java/com/stripe/android/identity/navigation/PassportScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/PassportScanFragment.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.fragment.findNavController
 import com.stripe.android.identity.R
 import com.stripe.android.identity.networking.models.ClearDataParam
 import com.stripe.android.identity.networking.models.CollectedDataParam
@@ -57,27 +58,43 @@ internal class PassportScanFragment(
                             continueButton.toggleToLoading()
                         }
                         it.isFrontUploaded() -> {
-                            lifecycleScope.launch {
-                                runCatching {
-                                    postVerificationPageDataAndMaybeSubmit(
-                                        identityViewModel = identityViewModel,
-                                        collectedDataParam =
-                                        CollectedDataParam.createFromUploadedResultsForAutoCapture(
-                                            type = CollectedDataParam.Type.PASSPORT,
-                                            frontHighResResult = requireNotNull(it.frontHighResResult.data),
-                                            frontLowResResult = requireNotNull(it.frontLowResResult.data)
-                                        ),
-                                        clearDataParam = ClearDataParam.UPLOAD_TO_CONFIRM,
-                                        fromFragment = R.id.passportScanFragment,
-                                    )
-                                }.onFailure { throwable ->
-                                    Log.e(
-                                        TAG,
-                                        "fail to submit uploaded files: $throwable"
-                                    )
+                            identityViewModel.observeForVerificationPage(
+                                viewLifecycleOwner,
+                                onSuccess = { verificationPage ->
+                                    lifecycleScope.launch {
+                                        runCatching {
+                                            postVerificationPageDataAndMaybeSubmit(
+                                                identityViewModel = identityViewModel,
+                                                collectedDataParam =
+                                                CollectedDataParam.createFromUploadedResultsForAutoCapture(
+                                                    type = CollectedDataParam.Type.PASSPORT,
+                                                    frontHighResResult = requireNotNull(it.frontHighResResult.data),
+                                                    frontLowResResult = requireNotNull(it.frontLowResResult.data)
+                                                ),
+                                                clearDataParam = ClearDataParam.UPLOAD_TO_CONFIRM,
+                                                fromFragment = R.id.passportScanFragment,
+                                                notSubmitBlock =
+                                                verificationPage.selfieCapture?.let {
+                                                    {
+                                                        findNavController().navigate(R.id.action_global_selfieFragment)
+                                                    }
+                                                }
+                                            )
+                                        }.onFailure { throwable ->
+                                            Log.e(
+                                                TAG,
+                                                "fail to submit uploaded files: $throwable"
+                                            )
+                                            navigateToDefaultErrorFragment()
+                                        }
+                                    }
+                                },
+                                onFailure = { throwable ->
+                                    Log.e(TAG, "Fail to observeForVerificationPage: $throwable")
                                     navigateToDefaultErrorFragment()
                                 }
-                            }
+                            )
+
                         }
                         else -> {
                             Log.d(

--- a/identity/src/main/java/com/stripe/android/identity/navigation/PassportUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/PassportUploadFragment.kt
@@ -2,14 +2,12 @@ package com.stripe.android.identity.navigation
 
 import android.util.Log
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.lifecycleScope
 import com.stripe.android.identity.R
 import com.stripe.android.identity.networking.DocumentUploadState
 import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.networking.models.DocumentUploadParam
 import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.utils.navigateToDefaultErrorFragment
-import kotlinx.coroutines.launch
 
 /**
  * Fragment to upload passport.
@@ -30,24 +28,22 @@ internal open class PassportUploadFragment(
         binding.kontinue.isEnabled = true
         binding.kontinue.setOnClickListener {
             binding.kontinue.toggleToLoading()
-            lifecycleScope.launch {
-                runCatching {
-                    val frontResult = requireNotNull(latestState.frontHighResResult.data)
-                    trySubmit(
-                        CollectedDataParam(
-                            idDocumentFront = DocumentUploadParam(
-                                highResImage = requireNotNull(frontResult.uploadedStripeFile.id) {
-                                    "front uploaded file id is null"
-                                },
-                                uploadMethod = requireNotNull(frontResult.uploadMethod)
-                            ),
-                            idDocumentType = CollectedDataParam.Type.PASSPORT
-                        )
+            runCatching {
+                val frontResult = requireNotNull(latestState.frontHighResResult.data)
+                trySubmit(
+                    CollectedDataParam(
+                        idDocumentFront = DocumentUploadParam(
+                            highResImage = requireNotNull(frontResult.uploadedStripeFile.id) {
+                                "front uploaded file id is null"
+                            },
+                            uploadMethod = requireNotNull(frontResult.uploadMethod)
+                        ),
+                        idDocumentType = CollectedDataParam.Type.PASSPORT
                     )
-                }.onFailure {
-                    Log.d(TAG, "fail to submit uploaded files: $it")
-                    navigateToDefaultErrorFragment()
-                }
+                )
+            }.onFailure {
+                Log.d(TAG, "fail to submit uploaded files: $it")
+                navigateToDefaultErrorFragment()
             }
         }
     }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/SelfieFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/SelfieFragment.kt
@@ -30,7 +30,9 @@ import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.ui.LoadingButton
 import com.stripe.android.identity.ui.SelfieResultAdapter
 import com.stripe.android.identity.utils.navigateToDefaultErrorFragment
+import com.stripe.android.identity.utils.navigateToErrorFragmentWithFailedReason
 import com.stripe.android.identity.utils.postVerificationPageDataAndMaybeSubmit
+import com.stripe.android.identity.utils.setHtmlString
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -100,6 +102,20 @@ internal class SelfieFragment(
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         identityViewModel.resetSelfieUploadedState()
+        identityViewModel.observeForVerificationPage(
+            viewLifecycleOwner,
+            onSuccess = {
+                binding.allowImageCollection.setHtmlString(
+                    requireNotNull(it.selfieCapture) { "VerificationPage.selfieCapture is null" }.consentText
+                )
+            },
+            onFailure = {
+                Log.e(TAG, "Failed to get verificationPage: $it")
+                navigateToErrorFragmentWithFailedReason(
+                    it ?: IllegalStateException("Failed to get verificationPage")
+                )
+            }
+        )
     }
 
     override fun createCameraAdapter(): Camera1Adapter {

--- a/identity/src/main/java/com/stripe/android/identity/networking/NetworkConstants.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/NetworkConstants.kt
@@ -3,4 +3,4 @@ package com.stripe.android.identity.networking
 internal const val BASE_URL = "https://api.stripe.com/v1"
 internal const val IDENTITY_VERIFICATION_PAGES = "identity/verification_pages"
 internal const val IDENTITY_STRIPE_API_VERSION_WITH_BETA_HEADER =
-    "2020-08-27;identity_client_api=v1"
+    "2020-08-27;identity_client_api=v2"

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPage.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPage.kt
@@ -14,7 +14,7 @@ internal data class VerificationPage(
     val documentCapture: VerificationPageStaticContentDocumentCapturePage,
     @SerialName("document_select")
     val documentSelect: VerificationPageStaticContentDocumentSelectPage,
-    @SerialName("selfie") // TODO(IDPROD-3944) Verify with server change
+    @SerialName("selfie")
     val selfieCapture: VerificationPageStaticContentSelfieCapturePage? = null,
     /* The short-lived URL that can be used in the case that the client cannot support the VerificationSession. */
     @SerialName("fallback_url")

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageRequirements.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageRequirements.kt
@@ -22,10 +22,10 @@ internal data class VerificationPageRequirements(
         @SerialName("id_document_type")
         IDDOCUMENTTYPE,
 
-        // TODO(IDPROD-3944) - verify with server change
         @SerialName("face")
         FACE,
 
+        // TODO(IDPROD-3944) - verify with server change
         @SerialName("training_consent")
         TRAININGCONSENT
     }

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageStaticContentSelfieCapturePage.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageStaticContentSelfieCapturePage.kt
@@ -3,7 +3,6 @@ package com.stripe.android.identity.networking.models
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-// TODO(IDPROD-3944) - verify with server change
 @Serializable
 internal data class VerificationPageStaticContentSelfieCapturePage(
     @SerialName("autocapture_timeout")
@@ -36,6 +35,6 @@ internal data class VerificationPageStaticContentSelfieCapturePage(
     val highResImageCompressionQuality: Float,
     @SerialName("high_res_image_crop_padding")
     val highResImageCropPadding: Float,
-    @SerialName("consent_text")
+    @SerialName("training_consent_text")
     val consentText: String
 )

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageStaticContentSelfieModels.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageStaticContentSelfieModels.kt
@@ -3,13 +3,12 @@ package com.stripe.android.identity.networking.models
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-// TODO(IDPROD-3944) - verify with server change
 @Serializable
 internal data class VerificationPageStaticContentSelfieModels(
     @SerialName("face_detector_url")
     val faceDetectorUrl: String,
     @SerialName("face_detector_min_score")
     val faceDetectorMinScore: Float,
-    @SerialName("face_detector_iou")
+    @SerialName("face_detector_min_iou")
     val faceDetectorIou: Float
 )

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/CameraViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/CameraViewModel.kt
@@ -35,7 +35,7 @@ internal open class CameraViewModel :
     internal fun initializeScanFlow(
         verificationPage: VerificationPage,
         idDetectorModelFile: File,
-        faceDetectorModelFile: File
+        faceDetectorModelFile: File?
     ) {
         identityScanFlow = IdentityScanFlow(
             this,

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
@@ -97,7 +97,6 @@ internal class IdentityViewModel @Inject constructor(
     private val _faceDetectorModelFile = MutableLiveData<Resource<File>>()
     val faceDetectorModelFile: LiveData<Resource<File>> = _faceDetectorModelFile
 
-
     data class PageAndModelFiles(
         val page: VerificationPage,
         val idDetectorFile: File,

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
@@ -97,12 +97,21 @@ internal class IdentityViewModel @Inject constructor(
     private val _faceDetectorModelFile = MutableLiveData<Resource<File>>()
     val faceDetectorModelFile: LiveData<Resource<File>> = _faceDetectorModelFile
 
+
+    data class PageAndModelFiles(
+        val page: VerificationPage,
+        val idDetectorFile: File,
+        val faceDetectorFile: File?
+    )
+
     /**
      * Wrapper for both page and model
      */
-    val pageAndModel = object : MediatorLiveData<Resource<Pair<VerificationPage, File>>>() {
+    val pageAndModelFiles = object : MediatorLiveData<Resource<PageAndModelFiles>>() {
         private var page: VerificationPage? = null
         private var idDetectorModel: File? = null
+        private var faceDetectorModel: File? = null
+        private var faceDetectorModelValueSet = false
 
         init {
             postValue(Resource.loading())
@@ -130,12 +139,35 @@ internal class IdentityViewModel @Inject constructor(
                     Status.LOADING -> {} // no-op
                 }
             }
+            addSource(faceDetectorModelFile) {
+                when (it.status) {
+                    Status.SUCCESS -> {
+                        faceDetectorModelValueSet = true
+                        faceDetectorModel = it.data
+                        maybePostSuccess()
+                    }
+                    Status.ERROR -> {
+                        postValue(Resource.error("$faceDetectorModelFile posts error"))
+                    }
+                    Status.LOADING -> {} // no-op
+                }
+            }
         }
 
         private fun maybePostSuccess() {
             page?.let { page ->
-                idDetectorModel?.let { model ->
-                    postValue(Resource.success(Pair(page, model)))
+                idDetectorModel?.let { idDetectorModel ->
+                    if (faceDetectorModelValueSet) {
+                        postValue(
+                            Resource.success(
+                                PageAndModelFiles(
+                                    page,
+                                    idDetectorModel,
+                                    faceDetectorModel
+                                )
+                            )
+                        )
+                    }
                 }
             }
         }
@@ -506,12 +538,14 @@ internal class IdentityViewModel @Inject constructor(
                             it.documentCapture.models.idDetectorUrl,
                             _idDetectorModelFile
                         )
-                        // TODO(IDPROD-3944): download FaceDetectorModel
                         it.selfieCapture?.let { selfieCapture ->
                             downloadModelAndPost(
                                 selfieCapture.models.faceDetectorUrl,
                                 _faceDetectorModelFile
                             )
+                        } ?: run {
+                            // Selfie not required, post null
+                            _faceDetectorModelFile.postValue(Resource.success(null))
                         }
                     }
                 },

--- a/identity/src/test/java/com/stripe/android/identity/IdentityActivityTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/IdentityActivityTest.kt
@@ -7,7 +7,6 @@ import android.view.View
 import android.widget.ImageButton
 import androidx.appcompat.widget.Toolbar
 import androidx.core.os.bundleOf
-import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.NavController
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat

--- a/identity/src/test/java/com/stripe/android/identity/IdentityActivityTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/IdentityActivityTest.kt
@@ -298,7 +298,7 @@ internal class IdentityActivityTest {
     ) {
         val injectableActivityScenario = injectableActivityScenario<IdentityActivity> {
             injectActivity {
-                viewModelFactory = mockIdentityViewModelFactory as ViewModelProvider.Factory
+                viewModelFactory = mockIdentityViewModelFactory
             }
         }.launch(
             IdentityVerificationSheetContract().createIntent(

--- a/identity/src/test/java/com/stripe/android/identity/navigation/DriverLicenseScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/DriverLicenseScanFragmentTest.kt
@@ -15,6 +15,7 @@ import com.google.android.material.button.MaterialButton
 import com.google.android.material.progressindicator.CircularProgressIndicator
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.model.StripeFile
+import com.stripe.android.identity.CORRECT_WITH_SUBMITTED_SUCCESS_VERIFICATION_PAGE_DATA
 import com.stripe.android.identity.R
 import com.stripe.android.identity.SUCCESS_VERIFICATION_PAGE_NOT_REQUIRE_LIVE_CAPTURE
 import com.stripe.android.identity.camera.IdentityAggregator
@@ -50,7 +51,6 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
-import java.io.File
 
 @RunWith(RobolectricTestRunner::class)
 internal class DriverLicenseScanFragmentTest {
@@ -67,13 +67,13 @@ internal class DriverLicenseScanFragmentTest {
         whenever(it.displayStateChanged).thenReturn(displayStateChanged)
     }
 
-    private val mockPageAndModel = MediatorLiveData<Resource<Pair<VerificationPage, File>>>()
+    private val mockPageAndModel = MediatorLiveData<Resource<IdentityViewModel.PageAndModelFiles>>()
 
     private val documentUploadState =
         MutableStateFlow(DocumentUploadState())
 
     private val mockIdentityViewModel = mock<IdentityViewModel>() {
-        on { pageAndModel } doReturn mockPageAndModel
+        on { pageAndModelFiles } doReturn mockPageAndModel
         on { documentUploadState } doReturn documentUploadState
     }
 
@@ -94,7 +94,15 @@ internal class DriverLicenseScanFragmentTest {
 
     @Before
     fun simulateModelDownloaded() {
-        mockPageAndModel.postValue(Resource.success(Pair(SUCCESS_VERIFICATION_PAGE_NOT_REQUIRE_LIVE_CAPTURE, mock())))
+        mockPageAndModel.postValue(
+            Resource.success(
+                IdentityViewModel.PageAndModelFiles(
+                    SUCCESS_VERIFICATION_PAGE_NOT_REQUIRE_LIVE_CAPTURE,
+                    mock(),
+                    mock()
+                )
+            )
+        )
     }
 
     @Test
@@ -164,13 +172,25 @@ internal class DriverLicenseScanFragmentTest {
     }
 
     @Test
-    fun `when both sides are scanned and files uploaded succeeded, clicking button triggers navigation`() {
+    fun `when both sides are scanned and files uploaded succeeded and no selfie required, clicking button triggers post`() {
         simulateBothSidesScanned { _, _ ->
             runBlocking {
+                whenever(mockIdentityViewModel.postVerificationPageData(any(), any())).thenReturn(
+                    CORRECT_WITH_SUBMITTED_SUCCESS_VERIFICATION_PAGE_DATA
+                )
                 // mock bothUploaded success
                 documentUploadState.update {
                     bothUploadedDocumentUploadState
                 }
+
+                // mock identityViewModel.observeForVerificationPage - already called 2 times
+                val successCaptor = argumentCaptor<(VerificationPage) -> Unit>()
+                verify(mockIdentityViewModel, times(3)).observeForVerificationPage(
+                    any(),
+                    successCaptor.capture(),
+                    any()
+                )
+                successCaptor.lastValue.invoke(mock())
 
                 // verify navigation attempts
                 verify(mockIdentityViewModel).postVerificationPageData(
@@ -187,6 +207,58 @@ internal class DriverLicenseScanFragmentTest {
                         ClearDataParam.UPLOAD_TO_CONFIRM
                     )
                 )
+
+                // no selfie required, send postVerificationPageSubmit
+                verify(mockIdentityViewModel).postVerificationPageSubmit()
+            }
+        }
+    }
+
+    @Test
+    fun `when both sides are scanned and files uploaded succeeded and selfie is required, clicking button navigates to selfie`() {
+        simulateBothSidesScanned { navController, _ ->
+            runBlocking {
+                whenever(mockIdentityViewModel.postVerificationPageData(any(), any())).thenReturn(
+                    CORRECT_WITH_SUBMITTED_SUCCESS_VERIFICATION_PAGE_DATA
+                )
+                whenever(mockIdentityViewModel.postVerificationPageData(any(), any())).thenReturn(
+                    CORRECT_WITH_SUBMITTED_SUCCESS_VERIFICATION_PAGE_DATA
+                )
+                // mock bothUploaded success
+                documentUploadState.update {
+                    bothUploadedDocumentUploadState
+                }
+
+                // mock identityViewModel.observeForVerificationPage - already called 2 times
+                val successCaptor = argumentCaptor<(VerificationPage) -> Unit>()
+                verify(mockIdentityViewModel, times(3)).observeForVerificationPage(
+                    any(),
+                    successCaptor.capture(),
+                    any()
+                )
+                val mockVerificationPage = mock<VerificationPage> {
+                    on { selfieCapture } doReturn mock() // return non null selfieCapture
+                }
+                successCaptor.lastValue.invoke(mockVerificationPage)
+
+                // verify navigation attempts
+                verify(mockIdentityViewModel).postVerificationPageData(
+                    eq(
+                        CollectedDataParam.createFromUploadedResultsForAutoCapture(
+                            type = CollectedDataParam.Type.DRIVINGLICENSE,
+                            frontHighResResult = FRONT_HIGH_RES_RESULT,
+                            frontLowResResult = FRONT_LOW_RES_RESULT,
+                            backHighResResult = BACK_HIGH_RES_RESULT,
+                            backLowResResult = BACK_LOW_RES_RESULT,
+                        )
+                    ),
+                    eq(
+                        ClearDataParam.UPLOAD_TO_CONFIRM
+                    )
+                )
+
+                // selfie required, navigates to selfie
+                assertThat(navController.currentDestination?.id).isEqualTo(R.id.selfieFragment)
             }
         }
     }

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IdentityDocumentScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IdentityDocumentScanFragmentTest.kt
@@ -201,11 +201,11 @@ class IdentityDocumentScanFragmentTest {
                 .isEqualTo(R.id.couldNotCaptureFragment)
             assertThat(
                 requireNotNull(navController.backStack.last().arguments)
-                    [CouldNotCaptureFragment.ARG_COULD_NOT_CAPTURE_SCAN_TYPE]
+                [CouldNotCaptureFragment.ARG_COULD_NOT_CAPTURE_SCAN_TYPE]
             ).isEqualTo(IdentityScanState.ScanType.ID_FRONT)
             assertThat(
                 requireNotNull(navController.backStack.last().arguments)
-                    [CouldNotCaptureFragment.ARG_REQUIRE_LIVE_CAPTURE]
+                [CouldNotCaptureFragment.ARG_REQUIRE_LIVE_CAPTURE]
             ).isEqualTo(false)
         }
     }
@@ -247,11 +247,11 @@ class IdentityDocumentScanFragmentTest {
                 .isEqualTo(R.id.couldNotCaptureFragment)
             assertThat(
                 requireNotNull(navController.backStack.last().arguments)
-                    [CouldNotCaptureFragment.ARG_COULD_NOT_CAPTURE_SCAN_TYPE]
+                [CouldNotCaptureFragment.ARG_COULD_NOT_CAPTURE_SCAN_TYPE]
             ).isEqualTo(IdentityScanState.ScanType.ID_FRONT)
             assertThat(
                 requireNotNull(navController.backStack.last().arguments)
-                    [CouldNotCaptureFragment.ARG_REQUIRE_LIVE_CAPTURE]
+                [CouldNotCaptureFragment.ARG_REQUIRE_LIVE_CAPTURE]
             ).isEqualTo(true)
         }
     }

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IdentityDocumentScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IdentityDocumentScanFragmentTest.kt
@@ -43,7 +43,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.shadows.ShadowLooper.idleMainLooper
-import java.io.File
 import kotlin.test.assertFailsWith
 
 @RunWith(RobolectricTestRunner::class)
@@ -65,9 +64,9 @@ class IdentityDocumentScanFragmentTest {
         whenever(it.displayStateChanged).thenReturn(displayStateChanged)
     }
 
-    private val mockPageAndModel = MediatorLiveData<Resource<Pair<VerificationPage, File>>>()
+    private val mockPageAndModel = MediatorLiveData<Resource<IdentityViewModel.PageAndModelFiles>>()
     private val mockIdentityViewModel = mock<IdentityViewModel>().also {
-        whenever(it.pageAndModel).thenReturn(mockPageAndModel)
+        whenever(it.pageAndModelFiles).thenReturn(mockPageAndModel)
     }
 
     internal class TestFragment(
@@ -120,8 +119,9 @@ class IdentityDocumentScanFragmentTest {
         launchTestFragment().onFragment {
             mockPageAndModel.postValue(
                 Resource.success(
-                    Pair(
+                    IdentityViewModel.PageAndModelFiles(
                         SUCCESS_VERIFICATION_PAGE_NOT_REQUIRE_LIVE_CAPTURE,
+                        mock(),
                         mock()
                     )
                 )
@@ -201,11 +201,11 @@ class IdentityDocumentScanFragmentTest {
                 .isEqualTo(R.id.couldNotCaptureFragment)
             assertThat(
                 requireNotNull(navController.backStack.last().arguments)
-                [CouldNotCaptureFragment.ARG_COULD_NOT_CAPTURE_SCAN_TYPE]
+                    [CouldNotCaptureFragment.ARG_COULD_NOT_CAPTURE_SCAN_TYPE]
             ).isEqualTo(IdentityScanState.ScanType.ID_FRONT)
             assertThat(
                 requireNotNull(navController.backStack.last().arguments)
-                [CouldNotCaptureFragment.ARG_REQUIRE_LIVE_CAPTURE]
+                    [CouldNotCaptureFragment.ARG_REQUIRE_LIVE_CAPTURE]
             ).isEqualTo(false)
         }
     }
@@ -247,11 +247,11 @@ class IdentityDocumentScanFragmentTest {
                 .isEqualTo(R.id.couldNotCaptureFragment)
             assertThat(
                 requireNotNull(navController.backStack.last().arguments)
-                [CouldNotCaptureFragment.ARG_COULD_NOT_CAPTURE_SCAN_TYPE]
+                    [CouldNotCaptureFragment.ARG_COULD_NOT_CAPTURE_SCAN_TYPE]
             ).isEqualTo(IdentityScanState.ScanType.ID_FRONT)
             assertThat(
                 requireNotNull(navController.backStack.last().arguments)
-                [CouldNotCaptureFragment.ARG_REQUIRE_LIVE_CAPTURE]
+                    [CouldNotCaptureFragment.ARG_REQUIRE_LIVE_CAPTURE]
             ).isEqualTo(true)
         }
     }

--- a/identity/src/test/java/com/stripe/android/identity/navigation/PassportUploadFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/PassportUploadFragmentTest.kt
@@ -68,7 +68,6 @@ class PassportUploadFragmentTest {
         whenever(it.documentCapture).thenReturn(DOCUMENT_CAPTURE)
     }
 
-
     private val verificationPageWithSelfie = mock<VerificationPage>().also {
         whenever(it.documentCapture).thenReturn(DOCUMENT_CAPTURE)
         whenever(it.selfieCapture).thenReturn(mock())

--- a/identity/src/test/java/com/stripe/android/identity/navigation/PassportUploadFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/PassportUploadFragmentTest.kt
@@ -68,6 +68,12 @@ class PassportUploadFragmentTest {
         whenever(it.documentCapture).thenReturn(DOCUMENT_CAPTURE)
     }
 
+
+    private val verificationPageWithSelfie = mock<VerificationPage>().also {
+        whenever(it.documentCapture).thenReturn(DOCUMENT_CAPTURE)
+        whenever(it.selfieCapture).thenReturn(mock())
+    }
+
     private val documentUploadState =
         MutableStateFlow(DocumentUploadState())
 
@@ -79,6 +85,14 @@ class PassportUploadFragmentTest {
         val successCaptor: KArgumentCaptor<(VerificationPage) -> Unit> = argumentCaptor()
         whenever(it.observeForVerificationPage(any(), successCaptor.capture(), any())).then {
             successCaptor.firstValue(verificationPage)
+        }
+        whenever(it.documentUploadState).thenReturn(documentUploadState)
+    }
+
+    private val mockIdentityViewModelWithSelfie = mock<IdentityViewModel>().also {
+        val successCaptor: KArgumentCaptor<(VerificationPage) -> Unit> = argumentCaptor()
+        whenever(it.observeForVerificationPage(any(), successCaptor.capture(), any())).then {
+            successCaptor.firstValue(verificationPageWithSelfie)
         }
         whenever(it.documentUploadState).thenReturn(documentUploadState)
     }
@@ -156,7 +170,7 @@ class PassportUploadFragmentTest {
     }
 
     @Test
-    fun `verify when kontinue is clicked navigates to confirmation`() {
+    fun `verify when selfie not required, kontinue is clicked navigates to confirmation`() {
         launchFragment { binding, navController, _ ->
             runBlocking {
                 documentUploadState.update {
@@ -197,6 +211,49 @@ class PassportUploadFragmentTest {
 
                 assertThat(navController.currentDestination?.id)
                     .isEqualTo(R.id.confirmationFragment)
+            }
+        }
+    }
+
+    @Test
+    fun `verify when selfie is required, clicking kontinue navigates to selfie`() {
+        launchFragment(requireSelfie = true) { binding, navController, _ ->
+            runBlocking {
+                documentUploadState.update {
+                    DocumentUploadState(
+                        frontHighResResult = Resource.success(FRONT_HIGH_RES_RESULT)
+                    )
+                }
+
+                val collectedDataParamCaptor: KArgumentCaptor<CollectedDataParam> = argumentCaptor()
+                val clearDataParamCaptor: KArgumentCaptor<ClearDataParam> = argumentCaptor()
+
+                whenever(
+                    mockIdentityViewModelWithSelfie.postVerificationPageData(
+                        collectedDataParamCaptor.capture(),
+                        clearDataParamCaptor.capture()
+                    )
+                ).thenReturn(
+                    CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
+                )
+
+                binding.kontinue.findViewById<MaterialButton>(R.id.button).callOnClick()
+
+                assertThat(collectedDataParamCaptor.firstValue).isEqualTo(
+                    CollectedDataParam(
+                        idDocumentFront = DocumentUploadParam(
+                            highResImage = FILE_ID,
+                            uploadMethod = UploadMethod.FILEUPLOAD
+                        ),
+                        idDocumentType = CollectedDataParam.Type.PASSPORT
+                    )
+                )
+                assertThat(clearDataParamCaptor.firstValue).isEqualTo(
+                    ClearDataParam.UPLOAD_TO_CONFIRM
+                )
+
+                assertThat(navController.currentDestination?.id)
+                    .isEqualTo(R.id.selfieFragment)
             }
         }
     }
@@ -272,6 +329,7 @@ class PassportUploadFragmentTest {
 
     private fun launchFragment(
         shouldShowTakePhoto: Boolean = true,
+        requireSelfie: Boolean = false,
         testBlock: (
             binding: IdentityUploadFragmentBinding,
             navController: TestNavHostController,
@@ -286,7 +344,7 @@ class PassportUploadFragmentTest {
     ) {
         TestPassportUploadFragment(
             viewModelFactoryFor(mockIdentityUploadViewModel),
-            viewModelFactoryFor(mockIdentityViewModel),
+            viewModelFactoryFor(if (requireSelfie) mockIdentityViewModelWithSelfie else mockIdentityViewModel),
             navController
         )
     }.onFragment {

--- a/identity/src/test/java/com/stripe/android/identity/navigation/SelfieFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/SelfieFragmentTest.kt
@@ -124,7 +124,6 @@ internal class SelfieFragmentTest {
             assertThat(binding.resultView.visibility).isEqualTo(View.GONE)
             assertThat(binding.kontinue.isEnabled).isEqualTo(false)
             assertThat(binding.allowImageCollection.text.toString()).isEqualTo(CONSENT_TEXT)
-
         }
     }
 

--- a/identity/src/test/java/com/stripe/android/identity/navigation/SelfieFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/SelfieFragmentTest.kt
@@ -26,6 +26,7 @@ import com.stripe.android.identity.networking.UploadedResult
 import com.stripe.android.identity.networking.models.ClearDataParam
 import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.networking.models.VerificationPage
+import com.stripe.android.identity.networking.models.VerificationPageStaticContentSelfieCapturePage
 import com.stripe.android.identity.states.FaceDetectorTransitioner
 import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.utils.SingleLiveEvent
@@ -39,12 +40,15 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
 import org.junit.runner.RunWith
+import org.mockito.kotlin.KArgumentCaptor
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
-import java.io.File
 
 @RunWith(RobolectricTestRunner::class)
 internal class SelfieFragmentTest {
@@ -61,7 +65,7 @@ internal class SelfieFragmentTest {
         on { it.displayStateChanged } doReturn displayStateChanged
     }
 
-    private val mockPageAndModel = MediatorLiveData<Resource<Pair<VerificationPage, File>>>()
+    private val mockPageAndModel = MediatorLiveData<Resource<IdentityViewModel.PageAndModelFiles>>()
     private val documentUploadState =
         MutableStateFlow(DocumentUploadState())
 
@@ -89,18 +93,38 @@ internal class SelfieFragmentTest {
     )
 
     private val mockIdentityViewModel = mock<IdentityViewModel> {
-        on { pageAndModel } doReturn mockPageAndModel
+        on { pageAndModelFiles } doReturn mockPageAndModel
         on { documentUploadState } doReturn documentUploadState
         on { selfieUploadState } doReturn selfieUploadState
     }
 
     @Test
-    fun `when initialized UI is reset`() {
+    fun `when initialized UI is reset and bound`() {
         launchSelfieFragment { binding, _, _ ->
+            val successCaptor: KArgumentCaptor<(VerificationPage) -> Unit> = argumentCaptor()
+            verify(
+                mockIdentityViewModel,
+                times(1)
+            ).observeForVerificationPage(
+                any(),
+                successCaptor.capture(),
+                any()
+            )
+            val mockSelfieCapture = mock<VerificationPageStaticContentSelfieCapturePage> {
+                on { consentText } doReturn CONSENT_TEXT
+            }
+            successCaptor.lastValue(
+                mock {
+                    on { selfieCapture } doReturn mockSelfieCapture
+                }
+            )
+
             verify(mockIdentityViewModel).resetSelfieUploadedState()
             assertThat(binding.scanningView.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.resultView.visibility).isEqualTo(View.GONE)
             assertThat(binding.kontinue.isEnabled).isEqualTo(false)
+            assertThat(binding.allowImageCollection.text.toString()).isEqualTo(CONSENT_TEXT)
+
         }
     }
 
@@ -200,7 +224,7 @@ internal class SelfieFragmentTest {
 
     @Test
     fun `when selfieUploadState isLoading, clicking continue triggers toggles loading state`() {
-        launchSelfieFragment { binding, navController, _ ->
+        launchSelfieFragment { binding, _, _ ->
             runBlocking {
                 displayStateChanged.postValue((FINISHED to mock()))
                 assertThat(binding.kontinue.isEnabled).isEqualTo(true)
@@ -281,6 +305,7 @@ internal class SelfieFragmentTest {
 
         const val SCORE_VARIANCE = 0.1f
         const val NUM_FRAMES = 8
+        const val CONSENT_TEXT = "TEST CONSENT TEXT"
 
         val FINISHED = IdentityScanState.Finished(
             type = IdentityScanState.ScanType.SELFIE,

--- a/identity/src/test/java/com/stripe/android/identity/utils/NavigationUtilsTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/utils/NavigationUtilsTest.kt
@@ -227,7 +227,7 @@ internal class NavigationUtilsTest {
     }
 
     @Test
-    fun `postVerificationPageDataAndMaybeSubmit executes notSubmitBlock when shouldNotSubmit`() {
+    fun `postVerificationPageDataAndMaybeSubmit executes notSubmitBlock when it's not null`() {
         runBlocking {
             val mockIdentityViewModel = mock<IdentityViewModel>().also {
                 whenever(it.postVerificationPageData(any(), any())).thenReturn(
@@ -252,7 +252,7 @@ internal class NavigationUtilsTest {
     }
 
     @Test
-    fun `postVerificationPageDataAndMaybeSubmit submits when shouldNotSubmit is false`() {
+    fun `postVerificationPageDataAndMaybeSubmit submits when notSubmitBlock is null`() {
         runBlocking {
             val mockIdentityViewModel = mock<IdentityViewModel>().also {
                 whenever(it.postVerificationPageData(any(), any())).thenReturn(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Parse the additional field, if it exists bring up selfie flow after livecapture/upload flow instead of submits.

Note the selfie flow submission is not ready yet, will do it in a follow up PR.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Support selfie

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
