### PR TITLE
Fix us bank account payment method end to end test

### DIFF
--- a/payments-core/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
@@ -122,7 +122,10 @@ internal class PaymentMethodEndToEndTest {
                 fingerprint = "FFDMA0xfhBjWSZLu",
                 last4 = "6789",
                 linkedAccount = null,
-                networks = null,
+                networks = PaymentMethod.USBankAccount.USBankNetworks(
+                    preferred = "ach",
+                    supported = listOf("ach", "us_domestic_wire")
+                ),
                 routingNumber = "110000000"
             )
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

The networks field now returns an object back when creating a us_bank_account payment method. This PR fixes the test.

The networks field was returning null and was removed in a previous PR: https://github.com/stripe/stripe-android/pull/4768

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified