### PR TITLE
Prefill phone number for new Link users

### DIFF
--- a/link/api/link.api
+++ b/link/api/link.api
@@ -18,8 +18,8 @@ public final class com/stripe/android/link/LinkActivityContract$Args : com/strip
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/link/LinkActivityContract$Args$Companion;
-	public final fun copy (Lcom/stripe/android/model/StripeIntent;ZLjava/lang/String;Ljava/lang/String;Lcom/stripe/android/link/LinkActivityContract$Args$InjectionParams;)Lcom/stripe/android/link/LinkActivityContract$Args;
-	public static synthetic fun copy$default (Lcom/stripe/android/link/LinkActivityContract$Args;Lcom/stripe/android/model/StripeIntent;ZLjava/lang/String;Ljava/lang/String;Lcom/stripe/android/link/LinkActivityContract$Args$InjectionParams;ILjava/lang/Object;)Lcom/stripe/android/link/LinkActivityContract$Args;
+	public final fun copy (Lcom/stripe/android/model/StripeIntent;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/link/LinkActivityContract$Args$InjectionParams;)Lcom/stripe/android/link/LinkActivityContract$Args;
+	public static synthetic fun copy$default (Lcom/stripe/android/link/LinkActivityContract$Args;Lcom/stripe/android/model/StripeIntent;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/link/LinkActivityContract$Args$InjectionParams;ILjava/lang/Object;)Lcom/stripe/android/link/LinkActivityContract$Args;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -141,8 +141,8 @@ public final class com/stripe/android/link/LinkPaymentDetails : android/os/Parce
 public final class com/stripe/android/link/LinkPaymentLauncher_Factory {
 	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/link/LinkPaymentLauncher_Factory;
-	public fun get (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/link/LinkPaymentLauncher;
-	public static fun newInstance (Ljava/lang/String;Ljava/lang/String;Landroid/content/Context;Ljava/util/Set;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ZLkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lcom/stripe/android/networking/PaymentAnalyticsRequestFactory;Lcom/stripe/android/core/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/StripeRepository;Lcom/stripe/android/ui/core/forms/resources/ResourceRepository;)Lcom/stripe/android/link/LinkPaymentLauncher;
+	public fun get (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/link/LinkPaymentLauncher;
+	public static fun newInstance (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Landroid/content/Context;Ljava/util/Set;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ZLkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lcom/stripe/android/networking/PaymentAnalyticsRequestFactory;Lcom/stripe/android/core/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/StripeRepository;Lcom/stripe/android/ui/core/forms/resources/ResourceRepository;)Lcom/stripe/android/link/LinkPaymentLauncher;
 }
 
 public final class com/stripe/android/link/account/CookieStore_Factory : dagger/internal/Factory {
@@ -209,7 +209,7 @@ public final class com/stripe/android/link/injection/FormControllerModule_Compan
 
 public final class com/stripe/android/link/injection/LinkPaymentLauncherFactory_Impl : com/stripe/android/link/injection/LinkPaymentLauncherFactory {
 	public static fun create (Lcom/stripe/android/link/LinkPaymentLauncher_Factory;)Ljavax/inject/Provider;
-	public fun create (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/link/LinkPaymentLauncher;
+	public fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/link/LinkPaymentLauncher;
 }
 
 public final class com/stripe/android/link/injection/LinkPaymentLauncherModule_Companion_ProvideLocaleFactory : dagger/internal/Factory {
@@ -317,11 +317,11 @@ public final class com/stripe/android/link/ui/inline/ComposableSingletons$LinkIn
 }
 
 public final class com/stripe/android/link/ui/inline/InlineSignupViewModel_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/link/ui/inline/InlineSignupViewModel_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/link/ui/inline/InlineSignupViewModel_Factory;
 	public fun get ()Lcom/stripe/android/link/ui/inline/InlineSignupViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/link/account/LinkAccountManager;Lcom/stripe/android/core/Logger;)Lcom/stripe/android/link/ui/inline/InlineSignupViewModel;
+	public static fun newInstance (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/link/account/LinkAccountManager;Lcom/stripe/android/core/Logger;)Lcom/stripe/android/link/ui/inline/InlineSignupViewModel;
 }
 
 public final class com/stripe/android/link/ui/inline/InlineSignupViewModel_Factory_MembersInjector : dagger/MembersInjector {

--- a/link/src/main/java/com/stripe/android/link/LinkActivityContract.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivityContract.kt
@@ -29,7 +29,8 @@ class LinkActivityContract :
      * @param completePayment Whether the payment should be completed, or the selected payment
      *                          method should be returned as a result.
      * @param merchantName The customer-facing business name.
-     * @param customerEmail Email of the customer used to pre-fill the form.
+     * @param customerEmail Email of the customer, used to pre-fill the form.
+     * @param customerEmail Phone number of the customer, used to pre-fill the form.
      * @param injectionParams Parameters needed to perform dependency injection.
      *                        If null, a new dependency graph will be created.
      */
@@ -39,6 +40,7 @@ class LinkActivityContract :
         internal val completePayment: Boolean,
         internal val merchantName: String,
         internal val customerEmail: String? = null,
+        internal val customerPhone: String? = null,
         internal val injectionParams: InjectionParams? = null
     ) : ActivityStarter.Args {
 

--- a/link/src/main/java/com/stripe/android/link/LinkActivityContract.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivityContract.kt
@@ -30,7 +30,7 @@ class LinkActivityContract :
      *                          method should be returned as a result.
      * @param merchantName The customer-facing business name.
      * @param customerEmail Email of the customer, used to pre-fill the form.
-     * @param customerEmail Phone number of the customer, used to pre-fill the form.
+     * @param customerPhone Phone number of the customer, used to pre-fill the form.
      * @param injectionParams Parameters needed to perform dependency injection.
      *                        If null, a new dependency graph will be created.
      */

--- a/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
@@ -14,6 +14,7 @@ import com.stripe.android.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.injection.CUSTOMER_EMAIL
+import com.stripe.android.link.injection.CUSTOMER_PHONE
 import com.stripe.android.link.injection.DaggerLinkPaymentLauncherComponent
 import com.stripe.android.link.injection.LinkPaymentLauncherComponent
 import com.stripe.android.link.injection.MERCHANT_NAME
@@ -49,6 +50,7 @@ import kotlin.coroutines.CoroutineContext
 class LinkPaymentLauncher @AssistedInject internal constructor(
     @Assisted(MERCHANT_NAME) private val merchantName: String,
     @Assisted(CUSTOMER_EMAIL) private val customerEmail: String?,
+    @Assisted(CUSTOMER_PHONE) private val customerPhone: String?,
     context: Context,
     @Named(PRODUCT_USAGE) private val productUsage: Set<String>,
     @Named(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String,
@@ -65,6 +67,7 @@ class LinkPaymentLauncher @AssistedInject internal constructor(
     private val launcherComponentBuilder = DaggerLinkPaymentLauncherComponent.builder()
         .merchantName(merchantName)
         .customerEmail(customerEmail)
+        .customerPhone(customerPhone)
         .context(context)
         .ioContext(ioContext)
         .uiContext(uiContext)
@@ -162,6 +165,7 @@ class LinkPaymentLauncher @AssistedInject internal constructor(
             completePayment,
             merchantName,
             customerEmail,
+            customerPhone,
             LinkActivityContract.Args.InjectionParams(
                 injectorKey,
                 productUsage,

--- a/link/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
+++ b/link/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
@@ -49,7 +49,7 @@ internal class LinkAccountManager @Inject constructor(
                     cookieStore.getAuthSessionCookie()?.let {
                         lookupConsumer(null).getOrNull()?.accountStatus
                     }
-                    // If the user recently signed up on this device, use their email
+                        // If the user recently signed up on this device, use their email
                         ?: cookieStore.getNewUserEmail()?.let {
                             lookupConsumer(it).getOrNull()?.accountStatus
                         }

--- a/link/src/main/java/com/stripe/android/link/injection/LinkPaymentLauncherComponent.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/LinkPaymentLauncherComponent.kt
@@ -58,6 +58,9 @@ internal abstract class LinkPaymentLauncherComponent {
         fun customerEmail(@Named(CUSTOMER_EMAIL) customerEmail: String?): Builder
 
         @BindsInstance
+        fun customerPhone(@Named(CUSTOMER_PHONE) customerPhone: String?): Builder
+
+        @BindsInstance
         fun context(context: Context): Builder
 
         @BindsInstance

--- a/link/src/main/java/com/stripe/android/link/injection/LinkPaymentLauncherFactory.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/LinkPaymentLauncherFactory.kt
@@ -10,6 +10,7 @@ import dagger.assisted.AssistedFactory
 interface LinkPaymentLauncherFactory {
     fun create(
         @Assisted(MERCHANT_NAME) merchantName: String,
-        @Assisted(CUSTOMER_EMAIL) customerEmail: String?
+        @Assisted(CUSTOMER_EMAIL) customerEmail: String?,
+        @Assisted(CUSTOMER_PHONE) customerPhone: String?
     ): LinkPaymentLauncher
 }

--- a/link/src/main/java/com/stripe/android/link/injection/NamedConstants.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/NamedConstants.kt
@@ -13,3 +13,9 @@ const val MERCHANT_NAME = "merchantName"
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 const val CUSTOMER_EMAIL = "customerEmail"
+
+/**
+ * Identifies the phone number of the customer using the app, used to pre-fill the form.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+const val CUSTOMER_PHONE = "customerPhone"

--- a/link/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewModel.kt
@@ -33,14 +33,10 @@ internal class InlineSignupViewModel @Inject constructor(
     private val prefilledEmail =
         if (linkAccountManager.hasUserLoggedOut(customerEmail)) null else customerEmail
     private val prefilledPhone =
-        if (linkAccountManager.hasUserLoggedOut(customerEmail)) null else customerPhone
+        customerPhone?.takeUnless { linkAccountManager.hasUserLoggedOut(customerEmail) } ?: ""
 
-    val emailController = SimpleTextFieldController.createEmailSectionController(
-        prefilledEmail
-    )
-
-    val phoneController: PhoneNumberController =
-        PhoneNumberController.createPhoneNumberController(prefilledPhone ?: "")
+    val emailController = SimpleTextFieldController.createEmailSectionController(prefilledEmail)
+    val phoneController = PhoneNumberController.createPhoneNumberController(prefilledPhone)
 
     /**
      * Emits the email entered in the form if valid, null otherwise.

--- a/link/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.stripe.android.core.Logger
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.injection.CUSTOMER_EMAIL
+import com.stripe.android.link.injection.CUSTOMER_PHONE
 import com.stripe.android.link.injection.MERCHANT_NAME
 import com.stripe.android.link.injection.NonFallbackInjectable
 import com.stripe.android.link.injection.NonFallbackInjector
@@ -25,18 +26,21 @@ import javax.inject.Named
 internal class InlineSignupViewModel @Inject constructor(
     @Named(MERCHANT_NAME) val merchantName: String,
     @Named(CUSTOMER_EMAIL) customerEmail: String?,
+    @Named(CUSTOMER_PHONE) customerPhone: String?,
     private val linkAccountManager: LinkAccountManager,
     private val logger: Logger
 ) : ViewModel() {
     private val prefilledEmail =
         if (linkAccountManager.hasUserLoggedOut(customerEmail)) null else customerEmail
+    private val prefilledPhone =
+        if (linkAccountManager.hasUserLoggedOut(customerEmail)) null else customerPhone
 
     val emailController = SimpleTextFieldController.createEmailSectionController(
         prefilledEmail
     )
 
     val phoneController: PhoneNumberController =
-        PhoneNumberController.createPhoneNumberController()
+        PhoneNumberController.createPhoneNumberController(prefilledPhone ?: "")
 
     /**
      * Emits the email entered in the form if valid, null otherwise.

--- a/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignupView.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignupView.kt
@@ -191,7 +191,8 @@ internal fun LinkInlineSignup(
                                 PhoneNumberCollectionSection(
                                     enabled = enabled,
                                     phoneNumberController = phoneNumberController,
-                                    requestFocusWhenShown = true
+                                    requestFocusWhenShown =
+                                        phoneNumberController.initialPhoneNumber.isEmpty()
                                 )
                                 LinkTerms(
                                     modifier = Modifier.padding(top = 8.dp),

--- a/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignupView.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignupView.kt
@@ -192,7 +192,7 @@ internal fun LinkInlineSignup(
                                     enabled = enabled,
                                     phoneNumberController = phoneNumberController,
                                     requestFocusWhenShown =
-                                        phoneNumberController.initialPhoneNumber.isEmpty()
+                                    phoneNumberController.initialPhoneNumber.isEmpty()
                                 )
                                 LinkTerms(
                                     modifier = Modifier.padding(top = 8.dp),

--- a/link/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
@@ -139,7 +139,7 @@ internal fun SignUpBody(
                     PhoneNumberCollectionSection(
                         enabled = true,
                         phoneNumberController = phoneNumberController,
-                        requestFocusWhenShown = true
+                        requestFocusWhenShown = phoneNumberController.initialPhoneNumber.isEmpty()
                     )
                     LinkTerms(
                         modifier = Modifier

--- a/link/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
@@ -45,15 +45,12 @@ internal class SignUpViewModel @Inject constructor(
     private val prefilledEmail =
         if (linkAccountManager.hasUserLoggedOut(customerEmail)) null else customerEmail
     private val prefilledPhone =
-        if (linkAccountManager.hasUserLoggedOut(customerEmail)) null else args.customerPhone
+        args.customerPhone?.takeUnless { linkAccountManager.hasUserLoggedOut(customerEmail) } ?: ""
 
     val merchantName: String = args.merchantName
 
-    val emailController: TextFieldController = SimpleTextFieldController
-        .createEmailSectionController(prefilledEmail)
-
-    val phoneController: PhoneNumberController =
-        PhoneNumberController.createPhoneNumberController(prefilledPhone ?: "")
+    val emailController = SimpleTextFieldController.createEmailSectionController(prefilledEmail)
+    val phoneController = PhoneNumberController.createPhoneNumberController(prefilledPhone)
 
     /**
      * Emits the email entered in the form if valid, null otherwise.

--- a/link/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
@@ -44,6 +44,8 @@ internal class SignUpViewModel @Inject constructor(
 ) : ViewModel() {
     private val prefilledEmail =
         if (linkAccountManager.hasUserLoggedOut(customerEmail)) null else customerEmail
+    private val prefilledPhone =
+        if (linkAccountManager.hasUserLoggedOut(customerEmail)) null else args.customerPhone
 
     val merchantName: String = args.merchantName
 
@@ -51,7 +53,7 @@ internal class SignUpViewModel @Inject constructor(
         .createEmailSectionController(prefilledEmail)
 
     val phoneController: PhoneNumberController =
-        PhoneNumberController.createPhoneNumberController()
+        PhoneNumberController.createPhoneNumberController(prefilledPhone ?: "")
 
     /**
      * Emits the email entered in the form if valid, null otherwise.

--- a/link/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
@@ -26,6 +26,7 @@ class LinkActivityContractTest {
             true,
             "Merchant, Inc",
             "customer@email.com",
+            "1234567890",
             injectionParams
         )
 

--- a/link/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -37,6 +37,7 @@ class LinkActivityViewModelTest {
         true,
         MERCHANT_NAME,
         CUSTOMER_EMAIL,
+        CUSTOMER_PHONE,
         LinkActivityContract.Args.InjectionParams(
             INJECTOR_KEY,
             setOf(PRODUCT_USAGE),
@@ -146,5 +147,6 @@ class LinkActivityViewModelTest {
 
         const val MERCHANT_NAME = "merchantName"
         const val CUSTOMER_EMAIL = "customer@email.com"
+        const val CUSTOMER_PHONE = "1234567890"
     }
 }

--- a/link/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
@@ -26,6 +26,7 @@ class LinkPaymentLauncherTest {
     private var linkPaymentLauncher = LinkPaymentLauncher(
         MERCHANT_NAME,
         null,
+        null,
         context,
         setOf(PRODUCT_USAGE),
         { PUBLISHABLE_KEY },
@@ -54,6 +55,7 @@ class LinkPaymentLauncherTest {
                 verify(mockHostActivityLauncher).launch(
                     argWhere { arg ->
                         arg.stripeIntent == stripeIntent &&
+                            arg.merchantName == MERCHANT_NAME &&
                             arg.injectionParams != null &&
                             arg.injectionParams.productUsage == setOf(PRODUCT_USAGE) &&
                             arg.injectionParams.injectorKey == LinkPaymentLauncher::class.simpleName + WeakMapInjectorRegistry.CURRENT_REGISTER_KEY.get() &&

--- a/link/src/test/java/com/stripe/android/link/ui/inline/InlineSignupViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/inline/InlineSignupViewModelTest.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.link.ui.inline
 
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.Logger
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.model.LinkAccount
@@ -45,7 +45,24 @@ class InlineSignupViewModelTest {
         runTest(UnconfinedTestDispatcher()) {
             val viewModel = createViewModel()
             viewModel.toggleExpanded()
-            Truth.assertThat(viewModel.signUpState.value).isEqualTo(SignUpState.InputtingPhone)
+            assertThat(viewModel.signUpState.value).isEqualTo(SignUpState.InputtingPhone)
+
+            verify(linkAccountManager, times(0)).lookupConsumer(any(), any())
+        }
+
+    @Test
+    fun `When email and phone are provided it should prefill all values`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val viewModel = InlineSignupViewModel(
+                merchantName = MERCHANT_NAME,
+                customerEmail = CUSTOMER_EMAIL,
+                customerPhone = CUSTOMER_PHONE,
+                linkAccountManager = linkAccountManager,
+                logger = Logger.noop()
+            )
+            viewModel.toggleExpanded()
+            assertThat(viewModel.signUpState.value).isEqualTo(SignUpState.InputtingPhone)
+            assertThat(viewModel.phoneController.initialPhoneNumber).isEqualTo(CUSTOMER_PHONE)
 
             verify(linkAccountManager, times(0)).lookupConsumer(any(), any())
         }
@@ -70,7 +87,7 @@ class InlineSignupViewModelTest {
             // Advance past lookup debounce delay
             advanceTimeBy(SignUpViewModel.LOOKUP_DEBOUNCE_MS + 100)
 
-            Truth.assertThat(viewModel.userInput.value).isEqualTo(UserInput.SignIn(email))
+            assertThat(viewModel.userInput.value).isEqualTo(UserInput.SignIn(email))
         }
 
     @Test
@@ -86,8 +103,8 @@ class InlineSignupViewModelTest {
             // Advance past lookup debounce delay
             advanceTimeBy(SignUpViewModel.LOOKUP_DEBOUNCE_MS + 100)
 
-            Truth.assertThat(viewModel.userInput.value).isNull()
-            Truth.assertThat(viewModel.signUpState.value).isEqualTo(SignUpState.InputtingPhone)
+            assertThat(viewModel.userInput.value).isNull()
+            assertThat(viewModel.signUpState.value).isEqualTo(SignUpState.InputtingPhone)
         }
 
     @Test
@@ -98,7 +115,7 @@ class InlineSignupViewModelTest {
             viewModel.toggleExpanded()
             viewModel.emailController.onRawValueChange(email)
 
-            Truth.assertThat(viewModel.userInput.value).isNull()
+            assertThat(viewModel.userInput.value).isNull()
 
             whenever(linkAccountManager.lookupConsumer(any(), any()))
                 .thenReturn(Result.success(null))
@@ -106,12 +123,12 @@ class InlineSignupViewModelTest {
             // Advance past lookup debounce delay
             advanceTimeBy(SignUpViewModel.LOOKUP_DEBOUNCE_MS + 100)
 
-            Truth.assertThat(viewModel.userInput.value).isNull()
+            assertThat(viewModel.userInput.value).isNull()
 
             val phone = "1234567890"
             viewModel.phoneController.onRawValueChange(phone)
 
-            Truth.assertThat(viewModel.userInput.value)
+            assertThat(viewModel.userInput.value)
                 .isEqualTo(UserInput.SignUp(email, "+1$phone", "US"))
         }
 
@@ -123,7 +140,7 @@ class InlineSignupViewModelTest {
             viewModel.toggleExpanded()
             viewModel.emailController.onRawValueChange(email)
 
-            Truth.assertThat(viewModel.userInput.value).isNull()
+            assertThat(viewModel.userInput.value).isNull()
 
             whenever(linkAccountManager.lookupConsumer(any(), any()))
                 .thenReturn(Result.success(null))
@@ -131,22 +148,23 @@ class InlineSignupViewModelTest {
             // Advance past lookup debounce delay
             advanceTimeBy(SignUpViewModel.LOOKUP_DEBOUNCE_MS + 100)
 
-            Truth.assertThat(viewModel.userInput.value).isNull()
+            assertThat(viewModel.userInput.value).isNull()
 
             val phone = "1234567890"
             viewModel.phoneController.onRawValueChange(phone)
 
-            Truth.assertThat(viewModel.userInput.value)
+            assertThat(viewModel.userInput.value)
                 .isEqualTo(UserInput.SignUp(email, "+1$phone", "US"))
 
             viewModel.phoneController.onRawValueChange("")
 
-            Truth.assertThat(viewModel.userInput.value).isNull()
+            assertThat(viewModel.userInput.value).isNull()
         }
 
     private fun createViewModel() = InlineSignupViewModel(
         merchantName = MERCHANT_NAME,
         customerEmail = CUSTOMER_EMAIL,
+        customerPhone = null,
         linkAccountManager = linkAccountManager,
         logger = Logger.noop()
     )
@@ -170,5 +188,6 @@ class InlineSignupViewModelTest {
     private companion object {
         const val MERCHANT_NAME = "merchantName"
         const val CUSTOMER_EMAIL = "customer@email.com"
+        const val CUSTOMER_PHONE = "1234567890"
     }
 }

--- a/link/src/test/java/com/stripe/android/link/ui/signup/SignUpViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/signup/SignUpViewModelTest.kt
@@ -50,6 +50,7 @@ class SignUpViewModelTest {
         true,
         MERCHANT_NAME,
         CUSTOMER_EMAIL,
+        CUSTOMER_PHONE,
         LinkActivityContract.Args.InjectionParams(
             INJECTOR_KEY,
             setOf(PRODUCT_USAGE),
@@ -280,5 +281,6 @@ class SignUpViewModelTest {
 
         const val MERCHANT_NAME = "merchantName"
         const val CUSTOMER_EMAIL = "customer@email.com"
+        const val CUSTOMER_PHONE = "1234567890"
     }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PhoneNumberController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PhoneNumberController.kt
@@ -85,7 +85,7 @@ class PhoneNumberController internal constructor(
             initialValue: String = "",
             initiallySelectedCountryCode: String? = null
         ): PhoneNumberController {
-            // Try to find the best initial country based on the phone number prefix and the
+            // Find the regions that match the phone number prefix, then pick the top match from the
             // device's locales
             if (initiallySelectedCountryCode == null && initialValue.startsWith("+")) {
                 var charIndex = 1

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PhoneNumberController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PhoneNumberController.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
+import androidx.core.os.LocaleListCompat
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.forms.FormFieldEntry
 import kotlinx.coroutines.flow.Flow
@@ -11,7 +12,7 @@ import kotlinx.coroutines.flow.map
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 class PhoneNumberController internal constructor(
-    initialPhoneNumber: String = "",
+    val initialPhoneNumber: String = "",
     initiallySelectedCountryCode: String? = null,
     overrideCountryCodes: Set<String> = emptySet()
 ) : InputController {
@@ -75,12 +76,45 @@ class PhoneNumberController internal constructor(
     }
 
     companion object {
+        /**
+         * Instantiate a [PhoneNumberController] with the given initial values.
+         * If [initialValue] is in the E.164 format, try to find the most likely country code based
+         * on the prefix and the device's locales list.
+         */
         fun createPhoneNumberController(
             initialValue: String = "",
             initiallySelectedCountryCode: String? = null
-        ) = PhoneNumberController(
-            initialPhoneNumber = initialValue,
-            initiallySelectedCountryCode = initiallySelectedCountryCode
-        )
+        ): PhoneNumberController {
+            // Try to find the best initial country based on the phone number prefix and the
+            // device's locales
+            if (initiallySelectedCountryCode == null && initialValue.startsWith("+")) {
+                var charIndex = 1
+                while (charIndex < initialValue.length - 1 && charIndex < 4) {
+                    charIndex++
+                    PhoneNumberFormatter.findBestCountryForPrefix(
+                        initialValue.substring(0, charIndex), LocaleListCompat.getAdjustedDefault()
+                    )?.let {
+                        return PhoneNumberController(
+                            initialPhoneNumber = initialValue.substring(charIndex),
+                            initiallySelectedCountryCode = it
+                        )
+                    }
+                }
+            }
+
+            // Clean up if initial country is set and country prefix is in initial phone number
+            if (initiallySelectedCountryCode != null && initialValue.startsWith("+")) {
+                val prefix = PhoneNumberFormatter.forCountry(initiallySelectedCountryCode).prefix
+                return PhoneNumberController(
+                    initialPhoneNumber = initialValue.removePrefix(prefix),
+                    initiallySelectedCountryCode = initiallySelectedCountryCode
+                )
+            }
+
+            return PhoneNumberController(
+                initialPhoneNumber = initialValue,
+                initiallySelectedCountryCode = initiallySelectedCountryCode
+            )
+        }
     }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PhoneNumberFormatter.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PhoneNumberFormatter.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
+import androidx.core.os.LocaleListCompat
 import kotlin.math.max
 import kotlin.math.min
 
@@ -189,6 +190,20 @@ internal sealed class PhoneNumberFormatter {
             allMetadata.find { countryCode.uppercase() == it.regionCode }?.let {
                 WithRegion(it)
             } ?: UnknownRegion(countryCode)
+
+        fun findBestCountryForPrefix(prefix: String, userLocales: LocaleListCompat) =
+            countryCodesForPrefix(prefix).takeIf { it.isNotEmpty() }?.let {
+                for (i in 0 until userLocales.size()) {
+                    val locale = userLocales.get(i)
+                    if (it.contains(locale.country)) {
+                        return locale.country
+                    }
+                }
+                it.first()
+            }
+
+        private fun countryCodesForPrefix(prefix: String) =
+            allMetadata.filter { it.prefix == prefix }.map { it.regionCode }
 
         // List shared with iOS: https://github.com/stripe/stripe-ios/blob/master/StripeUICore/StripeUICore/Source/Validators/PhoneNumber.swift
         private val allMetadata = listOf(

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PhoneNumberControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PhoneNumberControllerTest.kt
@@ -6,6 +6,7 @@ import com.stripe.android.utils.TestUtils.idleLooper
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 internal class PhoneNumberControllerTest {
@@ -48,5 +49,46 @@ internal class PhoneNumberControllerTest {
         phoneNumberController.onValueChange("")
         idleLooper()
         assertThat(isComplete.last()).isFalse()
+    }
+
+    @Test
+    fun `when initial number is in E164 format then initial country is set`() {
+        val phoneNumberController = PhoneNumberController.createPhoneNumberController(
+            initialValue = "+491234567890"
+        )
+
+        assertThat(phoneNumberController.getCountryCode()).isEqualTo("DE")
+        assertThat(phoneNumberController.initialPhoneNumber).isEqualTo("1234567890")
+    }
+
+    @Test
+    fun `when initial country is set then prefix is removed from initial number`() {
+        val phoneNumberController = PhoneNumberController.createPhoneNumberController(
+            initialValue = "+441234567890",
+            initiallySelectedCountryCode = "JE"
+        )
+
+        assertThat(phoneNumberController.getCountryCode()).isEqualTo("JE")
+        assertThat(phoneNumberController.initialPhoneNumber).isEqualTo("1234567890")
+    }
+
+    @Test @Config(qualifiers = "fr-rCA")
+    fun `when initial number is in E164 format with multiple regions then locale is used`() {
+        val phoneNumberController = PhoneNumberController.createPhoneNumberController(
+            initialValue = "+11234567890"
+        )
+
+        assertThat(phoneNumberController.getCountryCode()).isEqualTo("CA")
+        assertThat(phoneNumberController.initialPhoneNumber).isEqualTo("1234567890")
+    }
+
+    @Test @Config(qualifiers = "fr-rCA")
+    fun `when initial number is not in E164 format then locale is used`() {
+        val phoneNumberController = PhoneNumberController.createPhoneNumberController(
+            initialValue = "1234567890"
+        )
+
+        assertThat(phoneNumberController.getCountryCode()).isEqualTo("CA")
+        assertThat(phoneNumberController.initialPhoneNumber).isEqualTo("1234567890")
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -181,8 +181,11 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
 
     private var linkActivityResultLauncher:
         ActivityResultLauncher<LinkActivityContract.Args>? = null
-    val linkLauncher =
-        linkPaymentLauncherFactory.create(merchantName, config?.defaultBillingDetails?.email)
+    val linkLauncher = linkPaymentLauncherFactory.create(
+        merchantName = merchantName,
+        customerEmail = config?.defaultBillingDetails?.email,
+        customerPhone = config?.defaultBillingDetails?.phone
+    )
 
     private val _showLinkVerificationDialog = MutableLiveData(false)
     val showLinkVerificationDialog: LiveData<Boolean> = _showLinkVerificationDialog


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Pass `PaymentSheet.Configuration.defaultBillingDetails.phone` into Link, and use it to prefill the phone number field for new users.
Implement logic to set the country based on the phone number prefix and the device's locales.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Autofill phone number in Link.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
