### PR TITLE
Fix selection on Link wallet

### DIFF
--- a/link/api/link.api
+++ b/link/api/link.api
@@ -470,11 +470,11 @@ public final class com/stripe/android/link/ui/wallet/ComposableSingletons$Wallet
 }
 
 public final class com/stripe/android/link/ui/wallet/WalletViewModel_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/link/ui/wallet/WalletViewModel_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/link/ui/wallet/WalletViewModel_Factory;
 	public fun get ()Lcom/stripe/android/link/ui/wallet/WalletViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/link/LinkActivityContract$Args;Lcom/stripe/android/link/model/LinkAccount;Lcom/stripe/android/link/account/LinkAccountManager;Lcom/stripe/android/link/model/Navigator;Lcom/stripe/android/link/confirmation/ConfirmationManager;Lcom/stripe/android/core/Logger;)Lcom/stripe/android/link/ui/wallet/WalletViewModel;
+	public static fun newInstance (Lcom/stripe/android/link/LinkActivityContract$Args;Lcom/stripe/android/link/account/LinkAccountManager;Lcom/stripe/android/link/model/Navigator;Lcom/stripe/android/link/confirmation/ConfirmationManager;Lcom/stripe/android/core/Logger;)Lcom/stripe/android/link/ui/wallet/WalletViewModel;
 }
 
 public final class com/stripe/android/link/ui/wallet/WalletViewModel_Factory_MembersInjector : dagger/MembersInjector {

--- a/link/src/main/java/com/stripe/android/link/ui/cardedit/CardEditViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/cardedit/CardEditViewModel.kt
@@ -100,7 +100,7 @@ internal class CardEditViewModel @Inject constructor(
         viewModelScope.launch {
             val updateParams = ConsumerPaymentDetailsUpdateParams.Card(
                 paymentDetails.id,
-                setAsDefault.value.takeUnless { isDefault },
+                setAsDefault.value.takeUnless { isDefault || it == isDefault },
                 paymentMethodCreateParams
             )
 

--- a/link/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
@@ -208,7 +208,7 @@ internal class SignUpViewModel @Inject constructor(
 
     companion object {
         // How long to wait (in milliseconds) before triggering a call to lookup the email
-        const val LOOKUP_DEBOUNCE_MS = 700L
+        const val LOOKUP_DEBOUNCE_MS = 1000L
 
         const val PREFILLED_EMAIL = "prefilled_email"
     }

--- a/link/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
@@ -16,7 +16,6 @@ import com.stripe.android.link.ui.ErrorMessage
 import com.stripe.android.link.ui.getErrorMessage
 import com.stripe.android.ui.core.elements.PhoneNumberController
 import com.stripe.android.ui.core.elements.SimpleTextFieldController
-import com.stripe.android.ui.core.elements.TextFieldController
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -176,20 +176,22 @@ internal fun WalletBody(
         ScrollableTopLevelColumn {
             Spacer(modifier = Modifier.height(12.dp))
 
-            var selectedIndex by rememberSaveable {
-                mutableStateOf(
-                    paymentDetails.indexOfFirst { it.isDefault }
-                        .takeUnless { it == -1 } ?: 0
-                )
+            var selectedItemId by rememberSaveable {
+                mutableStateOf(getDefaultSelectedCard(paymentDetails))
+            }
+
+            // Update selected item if it's not on the list anymore
+            if (paymentDetails.firstOrNull { it.id == selectedItemId } == null) {
+                selectedItemId = getDefaultSelectedCard(paymentDetails)
             }
 
             if (isWalletExpanded) {
                 ExpandedPaymentDetails(
                     paymentDetails = paymentDetails,
-                    selectedIndex = selectedIndex,
+                    selectedItemId = selectedItemId,
                     enabled = !isProcessing,
                     onIndexSelected = {
-                        selectedIndex = it
+                        selectedItemId = paymentDetails[it].id
                     },
                     onMenuButtonClick = {
                         showBottomSheetContent {
@@ -215,7 +217,7 @@ internal fun WalletBody(
                 )
             } else {
                 CollapsedPaymentDetails(
-                    selectedPaymentMethod = paymentDetails[selectedIndex],
+                    selectedPaymentMethod = paymentDetails.first { it.id == selectedItemId },
                     enabled = !isProcessing,
                     onClick = {
                         isWalletExpanded = true
@@ -235,7 +237,7 @@ internal fun WalletBody(
                 },
                 icon = R.drawable.stripe_ic_lock
             ) {
-                onPrimaryButtonClick(paymentDetails[selectedIndex])
+                onPrimaryButtonClick(paymentDetails.first { it.id == selectedItemId })
             }
             SecondaryButton(
                 enabled = !isProcessing,
@@ -295,7 +297,7 @@ internal fun CollapsedPaymentDetails(
 @Composable
 internal fun ExpandedPaymentDetails(
     paymentDetails: List<ConsumerPaymentDetails.PaymentDetails>,
-    selectedIndex: Int,
+    selectedItemId: String,
     enabled: Boolean,
     onIndexSelected: (Int) -> Unit,
     onMenuButtonClick: (ConsumerPaymentDetails.Card) -> Unit,
@@ -349,7 +351,7 @@ internal fun ExpandedPaymentDetails(
                     CardPaymentMethodItem(
                         cardDetails = item,
                         enabled = enabled,
-                        isSelected = selectedIndex == index,
+                        isSelected = selectedItemId == item.id,
                         onClick = {
                             onIndexSelected(index)
                         },
@@ -465,3 +467,6 @@ internal fun CardDetails(
         )
     }
 }
+
+private fun getDefaultSelectedCard(paymentDetails: List<ConsumerPaymentDetails.PaymentDetails>) =
+    paymentDetails.firstOrNull { it.isDefault }?.id ?: paymentDetails.first().id

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -64,7 +64,7 @@ internal class WalletViewModel @Inject constructor(
     fun onSelectedPaymentDetails(selectedPaymentDetails: ConsumerPaymentDetails.PaymentDetails) {
         clearError()
         _isProcessing.value = true
-        
+
         runCatching { requireNotNull(linkAccountManager.linkAccount.value) }.fold(
             onSuccess = { linkAccount ->
                 if (args.completePayment) {

--- a/link/src/test/java/com/stripe/android/link/ui/cardedit/CardEditViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/cardedit/CardEditViewModelTest.kt
@@ -106,15 +106,13 @@ class CardEditViewModelTest {
         verify(linkAccountManager).updatePaymentDetails(
             argWhere {
                 it is ConsumerPaymentDetailsUpdateParams.Card &&
-                    it.toParamMap().equals(
-                        mapOf(
-                            "is_default" to true,
-                            "exp_month" to "12",
-                            "exp_year" to "2040",
-                            "billing_address" to mapOf(
-                                "country_code" to "US",
-                                "postal_code" to "12345"
-                            )
+                    it.toParamMap() == mapOf(
+                        "is_default" to true,
+                        "exp_month" to "12",
+                        "exp_year" to "2040",
+                        "billing_address" to mapOf(
+                            "country_code" to "US",
+                            "postal_code" to "12345"
                         )
                     )
             }
@@ -132,15 +130,12 @@ class CardEditViewModelTest {
             verify(linkAccountManager).updatePaymentDetails(
                 argWhere {
                     it is ConsumerPaymentDetailsUpdateParams.Card &&
-                        it.toParamMap().equals(
-                            mapOf(
-                                "is_default" to false,
-                                "exp_month" to "12",
-                                "exp_year" to "2040",
-                                "billing_address" to mapOf(
-                                    "country_code" to "US",
-                                    "postal_code" to "12345"
-                                )
+                        it.toParamMap() == mapOf(
+                            "exp_month" to "12",
+                            "exp_year" to "2040",
+                            "billing_address" to mapOf(
+                                "country_code" to "US",
+                                "postal_code" to "12345"
                             )
                         )
                 }
@@ -157,14 +152,12 @@ class CardEditViewModelTest {
         verify(linkAccountManager).updatePaymentDetails(
             argWhere {
                 it is ConsumerPaymentDetailsUpdateParams.Card &&
-                    it.toParamMap().equals(
-                        mapOf(
-                            "exp_month" to "12",
-                            "exp_year" to "2040",
-                            "billing_address" to mapOf(
-                                "country_code" to "US",
-                                "postal_code" to "12345"
-                            )
+                    it.toParamMap() == mapOf(
+                        "exp_month" to "12",
+                        "exp_year" to "2040",
+                        "billing_address" to mapOf(
+                            "country_code" to "US",
+                            "postal_code" to "12345"
                         )
                     )
             }

--- a/link/src/test/java/com/stripe/android/link/ui/cardedit/CardEditViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/cardedit/CardEditViewModelTest.kt
@@ -107,14 +107,14 @@ class CardEditViewModelTest {
             argWhere {
                 it is ConsumerPaymentDetailsUpdateParams.Card &&
                     it.toParamMap() == mapOf(
-                        "is_default" to true,
-                        "exp_month" to "12",
-                        "exp_year" to "2040",
-                        "billing_address" to mapOf(
-                            "country_code" to "US",
-                            "postal_code" to "12345"
-                        )
+                    "is_default" to true,
+                    "exp_month" to "12",
+                    "exp_year" to "2040",
+                    "billing_address" to mapOf(
+                        "country_code" to "US",
+                        "postal_code" to "12345"
                     )
+                )
             }
         )
     }
@@ -131,13 +131,13 @@ class CardEditViewModelTest {
                 argWhere {
                     it is ConsumerPaymentDetailsUpdateParams.Card &&
                         it.toParamMap() == mapOf(
-                            "exp_month" to "12",
-                            "exp_year" to "2040",
-                            "billing_address" to mapOf(
-                                "country_code" to "US",
-                                "postal_code" to "12345"
-                            )
+                        "exp_month" to "12",
+                        "exp_year" to "2040",
+                        "billing_address" to mapOf(
+                            "country_code" to "US",
+                            "postal_code" to "12345"
                         )
+                    )
                 }
             )
         }
@@ -153,13 +153,13 @@ class CardEditViewModelTest {
             argWhere {
                 it is ConsumerPaymentDetailsUpdateParams.Card &&
                     it.toParamMap() == mapOf(
-                        "exp_month" to "12",
-                        "exp_year" to "2040",
-                        "billing_address" to mapOf(
-                            "country_code" to "US",
-                            "postal_code" to "12345"
-                        )
+                    "exp_month" to "12",
+                    "exp_year" to "2040",
+                    "billing_address" to mapOf(
+                        "country_code" to "US",
+                        "postal_code" to "12345"
                     )
+                )
             }
         )
     }

--- a/link/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -311,7 +311,6 @@ class WalletViewModelTest {
     private fun createViewModel() =
         WalletViewModel(
             args,
-            linkAccount,
             linkAccountManager,
             navigator,
             confirmationManager,

--- a/link/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -47,9 +47,6 @@ import javax.inject.Provider
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 class WalletViewModelTest {
-    private val linkAccount = mock<LinkAccount>().apply {
-        whenever(clientSecret).thenReturn(CLIENT_SECRET)
-    }
     private val args = mock<LinkActivityContract.Args>()
     private lateinit var linkAccountManager: LinkAccountManager
     private val navigator = mock<Navigator>()
@@ -60,7 +57,12 @@ class WalletViewModelTest {
     fun before() {
         whenever(args.stripeIntent).thenReturn(StripeIntentFixtures.PI_SUCCEEDED)
         whenever(args.completePayment).thenReturn(true)
-        linkAccountManager = mock()
+        val mockLinkAccount = mock<LinkAccount>().apply {
+            whenever(clientSecret).thenReturn(CLIENT_SECRET)
+        }
+        linkAccountManager = mock<LinkAccountManager>().apply {
+            whenever(linkAccount).thenReturn(MutableStateFlow(mockLinkAccount))
+        }
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Use PaymentDetails id instead of index to determine the selected element. 
When the element is deleted, the default (if any) or the first element are selected. When element is edited and user comes back to the wallet, the same element will be selected.
Increase debounce for email typing, as 700ms was too fast.
Fix logic for setting card as default. Value should not be sent if it hasn't changed, or API call returns an error.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix selection

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified