### PR TITLE
[r.stripe.com] AnalyticsRequestV2

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetModule.kt
@@ -10,6 +10,7 @@ import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.core.networking.StripeNetworkClient
+import com.stripe.android.core.utils.ContextUtils.packageInfo
 import com.stripe.android.financialconnections.analytics.DefaultFinancialConnectionsEventReporter
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEventReporter
 import com.stripe.android.financialconnections.repository.FinancialConnectionsApiRepository
@@ -71,7 +72,7 @@ internal object FinancialConnectionsSheetModule {
     ): AnalyticsRequestFactory = AnalyticsRequestFactory(
         packageManager = application.packageManager,
         packageName = application.packageName.orEmpty(),
-        packageInfo = application.packageManager.getPackageInfo(application.packageName, 0),
+        packageInfo = application.packageInfo,
         publishableKeyProvider = { publishableKey }
     )
 }

--- a/payments-core/src/main/java/com/stripe/android/networking/FraudDetectionDataRequestParamsFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/FraudDetectionDataRequestParamsFactory.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import android.os.Build
 import android.util.DisplayMetrics
 import androidx.annotation.VisibleForTesting
+import com.stripe.android.core.utils.ContextUtils.packageInfo
 import com.stripe.android.core.version.StripeSdkVersion
-import com.stripe.android.utils.ContextUtils.packageInfo
 import java.math.BigDecimal
 import java.math.MathContext
 import java.util.Locale

--- a/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsRequestFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsRequestFactory.kt
@@ -8,11 +8,11 @@ import androidx.annotation.VisibleForTesting
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.AnalyticsRequestFactory
+import com.stripe.android.core.utils.ContextUtils.packageInfo
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.Source
 import com.stripe.android.model.Token
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
-import com.stripe.android.utils.ContextUtils.packageInfo
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Provider

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequest.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequest.kt
@@ -2,6 +2,13 @@ package com.stripe.android.core.networking
 
 import androidx.annotation.RestrictTo
 
+/**
+ * Analytics request sent to q.stripe.com, which is a legacy analytics service used mostly by
+ * Payment SDK, analytics are saved in a shared DB table with payment-specific schema.
+ *
+ * For other SDKs, it is recommended to create a dedicated DB table just for the SDK and write to
+ * this table through r.stripe.com. See [AnalyticsRequestV2] for details.
+ */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class AnalyticsRequest(
     val params: Map<String, *>,

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2.kt
@@ -1,0 +1,87 @@
+package com.stripe.android.core.networking
+
+import androidx.annotation.RestrictTo
+import androidx.annotation.VisibleForTesting
+import com.stripe.android.core.networking.AnalyticsRequestV2.Companion.HEADER_ORIGIN
+import com.stripe.android.core.networking.AnalyticsRequestV2.Companion.PARAM_CREATED
+import com.stripe.android.core.networking.AnalyticsRequestV2.Companion.PARAM_EVENT_ID
+import com.stripe.android.core.networking.AnalyticsRequestV2.Companion.PARAM_EVENT_NAME
+import com.stripe.android.core.networking.StripeRequest.MimeType
+import com.stripe.android.core.version.StripeSdkVersion.VERSION_NAME
+import java.io.OutputStream
+import java.io.UnsupportedEncodingException
+import java.util.UUID
+
+/**
+ * Analytics request sent to r.stripe.com.
+ * This is a POST request with [MimeType.Form] ContentType.
+ *
+ * It sets two headers required by r.stripe.com -
+ *   [HEADER_ORIGIN] - Set from analytics server
+ *   [HEADER_USER_AGENT] - Used for parsing client info, needs to conform the format starting with "Stripe/v1"
+ *
+ * It sets four params required r.stripe.com -
+ *   [PARAM_EVENT_ID] - A string identifying the client making the request, set from analytics server
+ *   [PARAM_CREATED] - Timestamp when the event was created in seconds
+ *   [PARAM_EVENT_NAME] - An identifying name for this type of event
+ *   [PARAM_EVENT_ID] - UUID used to deduplicate events
+ *
+ * Additional params can be passed as constructor parameters.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class AnalyticsRequestV2(
+    private val eventName: String,
+    private val clientId: String,
+    origin: String,
+    params: Map<String, *>
+) : StripeRequest() {
+    @VisibleForTesting
+    internal val postParameters: String =
+        QueryStringFactory.createFromParamsWithEmptyValues(params + analyticParams())
+
+    private val postBodyBytes: ByteArray
+        @Throws(UnsupportedEncodingException::class)
+        get() {
+            return postParameters.toByteArray(Charsets.UTF_8)
+        }
+
+    /**
+     * Parameters required by r.stripe.com
+     */
+    private fun analyticParams() = mapOf(
+        PARAM_CLIENT_ID to clientId,
+        PARAM_CREATED to System.currentTimeMillis() * 1000,
+        PARAM_EVENT_NAME to eventName,
+        PARAM_EVENT_ID to UUID.randomUUID().toString(),
+    )
+
+    override fun writePostBody(outputStream: OutputStream) {
+        postBodyBytes.let {
+            outputStream.write(it)
+            outputStream.flush()
+        }
+    }
+
+    override val headers = mapOf(
+        HEADER_CONTENT_TYPE to "${MimeType.Form}; charset=${Charsets.UTF_8.name()}",
+        HEADER_ORIGIN to origin, // required by r.stripe.com
+        HEADER_USER_AGENT to "Stripe/v1 android/$VERSION_NAME" // required by r.stripe.com
+    )
+    override val method: Method = Method.POST
+
+    override val mimeType: MimeType = MimeType.Form
+
+    override val retryResponseCodes: Iterable<Int> = HTTP_TOO_MANY_REQUESTS..HTTP_TOO_MANY_REQUESTS
+
+    override val url = ANALYTICS_HOST
+
+    internal companion object {
+        internal const val ANALYTICS_HOST = "https://r.stripe.com/0"
+        internal const val HEADER_ORIGIN = "origin"
+
+        internal const val PARAM_CLIENT_ID = "client_id"
+        internal const val PARAM_CREATED = "created"
+        internal const val PARAM_EVENT_NAME = "event_name"
+        internal const val PARAM_EVENT_ID = "event_id"
+    }
+}

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2.kt
@@ -50,7 +50,7 @@ class AnalyticsRequestV2(
      */
     private fun analyticParams() = mapOf(
         PARAM_CLIENT_ID to clientId,
-        PARAM_CREATED to System.currentTimeMillis() * 1000,
+        PARAM_CREATED to System.currentTimeMillis() * MILLIS_IN_SECOND,
         PARAM_EVENT_NAME to eventName,
         PARAM_EVENT_ID to UUID.randomUUID().toString(),
     )
@@ -78,6 +78,7 @@ class AnalyticsRequestV2(
     internal companion object {
         internal const val ANALYTICS_HOST = "https://r.stripe.com/0"
         internal const val HEADER_ORIGIN = "origin"
+        internal const val MILLIS_IN_SECOND = 1000
 
         internal const val PARAM_CLIENT_ID = "client_id"
         internal const val PARAM_CREATED = "created"

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2.kt
@@ -13,7 +13,7 @@ import java.io.UnsupportedEncodingException
 import java.util.UUID
 
 /**
- * Analytics request sent to r.stripe.com.
+ * Analytics request sent to r.stripe.com, which is the preferred service for analytics.
  * This is a POST request with [MimeType.Form] ContentType.
  *
  * It sets two headers required by r.stripe.com -

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2Factory.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2Factory.kt
@@ -16,6 +16,7 @@ import com.stripe.android.core.version.StripeSdkVersion
  *   app_name - the host application name
  *   app_version - the host app version
  *   plugin_type - whether SDK is integrated natively or through other wrappers(e.g react native)
+ *   platform_info - information about current platform
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class AnalyticsRequestV2Factory(
@@ -46,6 +47,7 @@ class AnalyticsRequestV2Factory(
         }
     )
 
+    // Common SDK related parameters, need dedicated ingestion logic on server side.
     private fun sdkParams() = mapOf(
         AnalyticsFields.OS_VERSION to Build.VERSION.SDK_INT,
         PARAM_SDK_PLATFORM to "android",
@@ -53,7 +55,10 @@ class AnalyticsRequestV2Factory(
         AnalyticsFields.DEVICE_TYPE to "${Build.MANUFACTURER}_${Build.BRAND}_${Build.MODEL}",
         AnalyticsFields.APP_NAME to getAppName(),
         AnalyticsFields.APP_VERSION to appContext.packageInfo?.versionCode,
-        PARAM_PLUGIN_TYPE to pluginType
+        PARAM_PLUGIN_TYPE to pluginType,
+        PARAM_PLATFORM_INFO to mapOf(
+            PARAM_PACKAGE_NAME to appContext.packageName
+        )
     )
 
     private fun getAppName(): CharSequence {
@@ -71,5 +76,7 @@ class AnalyticsRequestV2Factory(
         internal const val PARAM_SDK_PLATFORM = "sdk_platform"
         internal const val PARAM_SDK_VERSION = "sdk_version"
         internal const val PARAM_PLUGIN_TYPE = "plugin_type"
+        internal const val PARAM_PLATFORM_INFO = "platform_info"
+        internal const val PARAM_PACKAGE_NAME = "package_name"
     }
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2Factory.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2Factory.kt
@@ -1,0 +1,75 @@
+package com.stripe.android.core.networking
+
+import android.content.Context
+import android.os.Build
+import androidx.annotation.RestrictTo
+import com.stripe.android.core.utils.ContextUtils.packageInfo
+import com.stripe.android.core.version.StripeSdkVersion
+
+/**
+ * Factory to generate [AnalyticsRequestV2], can be optionally configured to add the following
+ * standard SDK specific parameters.
+ *   os_version - Android version
+ *   sdk_platform - always "android"
+ *   sdk_version - current SDK version
+ *   device_type - MANUFACTURER, brand and model
+ *   app_name - the host application name
+ *   app_version - the host app version
+ *   plugin_type - whether SDK is integrated natively or through other wrappers(e.g react native)
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class AnalyticsRequestV2Factory(
+    context: Context,
+    private val clientId: String,
+    private val origin: String,
+    private val pluginType: String = PLUGIN_NATIVE
+) {
+    private val appContext = context.applicationContext
+
+    /**
+     * Creates an [AnalyticsRequestV2] with parameters.
+     *
+     * @param includeSDKParams - whether to include default SDK params.
+     */
+    fun createRequestR(
+        eventName: String,
+        additionalParams: Map<String, Any> = mapOf(),
+        includeSDKParams: Boolean = true
+    ) = AnalyticsRequestV2(
+        eventName = eventName,
+        clientId = clientId,
+        origin = origin,
+        params = if (includeSDKParams) {
+            additionalParams + sdkParams()
+        } else {
+            additionalParams
+        }
+    )
+
+    private fun sdkParams() = mapOf(
+        AnalyticsFields.OS_VERSION to Build.VERSION.SDK_INT,
+        PARAM_SDK_PLATFORM to "android",
+        PARAM_SDK_VERSION to StripeSdkVersion.VERSION_NAME,
+        AnalyticsFields.DEVICE_TYPE to "${Build.MANUFACTURER}_${Build.BRAND}_${Build.MODEL}",
+        AnalyticsFields.APP_NAME to getAppName(),
+        AnalyticsFields.APP_VERSION to appContext.packageInfo?.versionCode,
+        PARAM_PLUGIN_TYPE to pluginType
+    )
+
+    private fun getAppName(): CharSequence {
+        return appContext.packageInfo?.applicationInfo?.loadLabel(appContext.packageManager)
+            .takeUnless {
+                it.isNullOrBlank()
+            } ?: appContext.packageName
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    companion object {
+        const val PLUGIN_NATIVE = "native"
+        const val PLUGIN_REACT_NATIVE = "react-native"
+
+        internal const val PARAM_SDK_PLATFORM = "sdk_platform"
+        internal const val PARAM_SDK_VERSION = "sdk_version"
+        internal const val PARAM_PLUGIN_TYPE = "plugin_type"
+    }
+}

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/ContextUtils.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/ContextUtils.kt
@@ -1,10 +1,12 @@
-package com.stripe.android.utils
+package com.stripe.android.core.utils
 
 import android.content.Context
 import android.content.pm.PackageInfo
+import androidx.annotation.RestrictTo
 
-internal object ContextUtils {
-    internal val Context.packageInfo: PackageInfo?
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+object ContextUtils {
+    val Context.packageInfo: PackageInfo?
         @JvmSynthetic
         get() = runCatching {
             packageManager.getPackageInfo(packageName, 0)

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestV2FactoryTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestV2FactoryTest.kt
@@ -1,0 +1,113 @@
+package com.stripe.android.core.networking
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.networking.AnalyticsRequestV2.Companion.PARAM_CLIENT_ID
+import com.stripe.android.core.networking.AnalyticsRequestV2Factory.Companion.PARAM_PLUGIN_TYPE
+import com.stripe.android.core.networking.AnalyticsRequestV2Factory.Companion.PARAM_SDK_PLATFORM
+import com.stripe.android.core.networking.AnalyticsRequestV2Factory.Companion.PARAM_SDK_VERSION
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AnalyticsRequestV2FactoryTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    private val factory = AnalyticsRequestV2Factory(
+        context,
+        CLIENT_ID,
+        ORIGIN
+    )
+
+    private val sdkParamKeys = setOf(
+        AnalyticsFields.OS_VERSION,
+        PARAM_SDK_PLATFORM,
+        PARAM_SDK_VERSION,
+        AnalyticsFields.DEVICE_TYPE,
+        AnalyticsFields.APP_NAME,
+        AnalyticsFields.APP_VERSION,
+        PARAM_PLUGIN_TYPE
+    )
+
+    @Test
+    fun `verify clientId and origin`() {
+        val requestR = factory.createRequestR(
+            "EVENT_NAME",
+            includeSDKParams = true
+        )
+
+        assertThat(requestR.postParameters.toMap()[PARAM_CLIENT_ID]).isEqualTo(CLIENT_ID)
+        assertThat(requestR.headers[AnalyticsRequestV2.HEADER_ORIGIN]).isEqualTo(ORIGIN)
+    }
+
+    @Test
+    fun `verify SDKParams are included`() {
+        val requestR = factory.createRequestR(
+            "EVENT_NAME",
+            includeSDKParams = true
+        )
+
+        requestR.postParameters.toMap().let { paramsMap ->
+            sdkParamKeys.forEach {
+                assertThat(paramsMap).containsKey(it)
+            }
+        }
+    }
+
+    @Test
+    fun `SDKParams are not included`() {
+        val requestR = factory.createRequestR(
+            "EVENT_NAME",
+            includeSDKParams = false
+        )
+
+        requestR.postParameters.toMap().let { paramsMap ->
+            sdkParamKeys.forEach {
+                assertThat(paramsMap).doesNotContainKey(it)
+            }
+        }
+    }
+
+    @Test
+    fun `verify additionalParams are included`() {
+        val additionalParam1 = "param1"
+        val additionalValue1 = "value1"
+        val additionalParam2 = "param2"
+        val additionalValue2 = "value2"
+        val additionalParam3 = "param3"
+        val additionalValue3 = "value3"
+
+        val requestR = factory.createRequestR(
+            "EVENT_NAME",
+            additionalParams = mapOf(
+                additionalParam1 to additionalValue1,
+                additionalParam2 to additionalValue2,
+                additionalParam3 to additionalValue3,
+            ),
+            includeSDKParams = true
+        )
+
+        requestR.postParameters.toMap().let { paramsMap ->
+            assertThat(paramsMap[additionalParam1]).isEqualTo(additionalValue1)
+            assertThat(paramsMap[additionalParam2]).isEqualTo(additionalValue2)
+            assertThat(paramsMap[additionalParam3]).isEqualTo(additionalValue3)
+        }
+    }
+
+    private fun String.toMap(): Map<String, String> {
+        val ret = mutableMapOf<String, String>()
+        split('&').forEach {
+            it.split('=').let { keyValue ->
+                ret[keyValue[0]] = keyValue[1]
+            }
+        }
+        return ret
+    }
+
+    private companion object {
+        const val CLIENT_ID = "test-client-id"
+        const val ORIGIN = "test-origin"
+    }
+}

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestV2FactoryTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestV2FactoryTest.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.networking.AnalyticsRequestV2.Companion.PARAM_CLIENT_ID
+import com.stripe.android.core.networking.AnalyticsRequestV2Factory.Companion.PARAM_PACKAGE_NAME
+import com.stripe.android.core.networking.AnalyticsRequestV2Factory.Companion.PARAM_PLATFORM_INFO
 import com.stripe.android.core.networking.AnalyticsRequestV2Factory.Companion.PARAM_PLUGIN_TYPE
 import com.stripe.android.core.networking.AnalyticsRequestV2Factory.Companion.PARAM_SDK_PLATFORM
 import com.stripe.android.core.networking.AnalyticsRequestV2Factory.Companion.PARAM_SDK_VERSION
@@ -28,7 +30,8 @@ class AnalyticsRequestV2FactoryTest {
         AnalyticsFields.DEVICE_TYPE,
         AnalyticsFields.APP_NAME,
         AnalyticsFields.APP_VERSION,
-        PARAM_PLUGIN_TYPE
+        PARAM_PLUGIN_TYPE,
+        "$PARAM_PLATFORM_INFO%5B$PARAM_PACKAGE_NAME%5D"
     )
 
     @Test

--- a/stripe-core/src/test/java/com/stripe/android/core/utils/ContextUtilsTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/utils/ContextUtilsTest.kt
@@ -1,10 +1,10 @@
-package com.stripe.android.model
+package com.stripe.android.core.utils
 
 import android.content.Context
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.utils.ContextUtils.packageInfo
+import com.stripe.android.core.utils.ContextUtils.packageInfo
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Create a new `StripeRequest` subclass - `AnalyticsRequestV2` and its Factory to send analytics event to `r.stripe.com`.

* `AnalyticsRequestV2` enforces required HTTP post parameters and headers. (Please see this internal doc for details on the params and headers)
* `AnalyticsRequestV2Factory` provides a option to include common reusable SDK params
* Did some refactor to collect application info from `stripe-core`

Please refer to [this](https://confluence.corp.stripe.com/display/AN/Analytics+Event+Logger+User+Guide#AnalyticsEventLoggerUserGuide-Makingarequest) internal doc for details on params and headers to r.stripe.com, [this](https://confluence.corp.stripe.com/display/MOBILE/Analytics+with+r.stripe.com) internal doc for how to set up one backend for a separate SDK and [this](https://docs.google.com/document/d/1LyVYV4mLaozxjJu-wkMojDdAkV8NajQ_E8NVNAQAGK4/edit#heading=h.rmz259ut9cfj) doc how Identity SDK's analytics plans.




# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Support analytics to r.stripe.com

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
