### PR TITLE
Fix issue with animations running on main thread

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
@@ -41,6 +42,7 @@ import androidx.compose.ui.unit.dp
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.paymentsColors
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 /**
  * This is focused on converting an [TextFieldController] into what is displayed in a section
@@ -216,11 +218,15 @@ fun AnimatedIcons(
 ) {
     if (icons.isEmpty()) return
 
+    val composableScope = rememberCoroutineScope()
+
     val target by produceState(initialValue = icons.first()) {
-        while (true) {
-            icons.forEach {
-                delay(1000)
-                value = it
+        composableScope.launch {
+            while (true) {
+                icons.forEach {
+                    delay(1000)
+                    value = it
+                }
             }
         }
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Fix an issue where animation is running on main thread causing android to skip frames consistently.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Performance

https://jira.corp.stripe.com/browse/RUN_MOBILESDK-1075

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified