### PR TITLE
Remove compose from stripecardscan

### DIFF
--- a/stripecardscan-example/build.gradle
+++ b/stripecardscan-example/build.gradle
@@ -34,23 +34,6 @@ dependencies {
     implementation 'com.squareup.okhttp3:logging-interceptor:4.9.3'
     implementation "com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:0.8.0"
 
-    implementation "androidx.compose.ui:ui:$androidxComposeVersion"
-    // Tooling support (Previews, etc.)
-    implementation "androidx.compose.ui:ui-tooling:$androidxComposeVersion"
-    // Foundation (Border, Background, Box, Image, Scroll, shapes, animations, etc.)
-    implementation "androidx.compose.foundation:foundation:$androidxComposeVersion"
-    // Material Design
-    implementation "androidx.compose.material:material:$androidxComposeVersion"
-    // Material design icons
-    implementation "androidx.compose.material:material-icons-core:$androidxComposeVersion"
-    implementation "androidx.compose.material:material-icons-extended:$androidxComposeVersion"
-    // Integration with activities
-    implementation "androidx.activity:activity-compose:$androidxActivityVersion"
-    // Integration with ViewModels
-    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$androidxLifecycleVersion"
-    // Integration with observables
-    implementation "androidx.compose.runtime:runtime-livedata:$androidxComposeVersion"
-
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.9.1'
 
     testImplementation "junit:junit:$junitVersion"
@@ -93,9 +76,5 @@ android {
     }
     buildFeatures {
         viewBinding true
-        compose true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion "$androidxComposeVersion"
     }
 }

--- a/stripecardscan/build.gradle
+++ b/stripecardscan/build.gradle
@@ -49,8 +49,6 @@ dependencies {
     androidTestImplementation "androidx.test:core-ktx:1.4.0"
     androidTestUtil "androidx.test:orchestrator:$androidTestVersion"
 
-    implementation "androidx.compose.runtime:runtime-livedata:$androidxComposeVersion"
-
     ktlint "com.pinterest:ktlint:$ktlintVersion"
 }
 
@@ -88,7 +86,6 @@ android {
     }
 
     buildFeatures {
-        compose = true
         viewBinding true
     }
 
@@ -105,10 +102,6 @@ android {
     packagingOptions {
         pickFirst 'META-INF/AL2.0'
         pickFirst 'META-INF/LGPL2.1'
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion "$androidxComposeVersion"
     }
 
     lintOptions {


### PR DESCRIPTION
# Summary
Remove the compose library from StripeCardScan

# Motivation
The StripeCardScan SDK does not use compose. Adding a dependency on compose has the potential to increase downstream app sizes by up to 6mb needlessly!

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified
