### PR TITLE
[Identity][stripe-core] send analytics events for Identity(1 of 4)

### DIFF
--- a/identity/api/identity.api
+++ b/identity/api/identity.api
@@ -56,6 +56,14 @@ public final class com/stripe/android/identity/IdentityVerificationSheet$Verific
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
+public final class com/stripe/android/identity/analytics/IdentityAnalyticsRequestFactory_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/identity/analytics/IdentityAnalyticsRequestFactory_Factory;
+	public fun get ()Lcom/stripe/android/identity/analytics/IdentityAnalyticsRequestFactory;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Landroid/content/Context;Lcom/stripe/android/identity/IdentityVerificationSheetContract$Args;)Lcom/stripe/android/identity/analytics/IdentityAnalyticsRequestFactory;
+}
+
 public final class com/stripe/android/identity/databinding/BaseErrorFragmentBinding : androidx/viewbinding/ViewBinding {
 	public final field bottomButton Lcom/google/android/material/button/MaterialButton;
 	public final field buttons Landroid/widget/LinearLayout;
@@ -315,11 +323,11 @@ public final class com/stripe/android/identity/viewmodel/IdentityUploadViewModel
 }
 
 public final class com/stripe/android/identity/viewmodel/IdentityViewModel_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/identity/viewmodel/IdentityViewModel_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/identity/viewmodel/IdentityViewModel_Factory;
 	public fun get ()Lcom/stripe/android/identity/viewmodel/IdentityViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/identity/IdentityVerificationSheetContract$Args;Lcom/stripe/android/identity/networking/IdentityRepository;Lcom/stripe/android/identity/networking/IdentityModelFetcher;Lcom/stripe/android/identity/utils/IdentityIO;Lcom/stripe/android/identity/navigation/IdentityFragmentFactory;)Lcom/stripe/android/identity/viewmodel/IdentityViewModel;
+	public static fun newInstance (Lcom/stripe/android/identity/IdentityVerificationSheetContract$Args;Lcom/stripe/android/identity/networking/IdentityRepository;Lcom/stripe/android/identity/networking/IdentityModelFetcher;Lcom/stripe/android/identity/utils/IdentityIO;Lcom/stripe/android/identity/navigation/IdentityFragmentFactory;Lcom/stripe/android/identity/analytics/IdentityAnalyticsRequestFactory;)Lcom/stripe/android/identity/viewmodel/IdentityViewModel;
 }
 
 public final class com/stripe/android/identity/viewmodel/IdentityViewModel_IdentityViewModelFactory_MembersInjector : dagger/MembersInjector {

--- a/identity/src/main/java/com/stripe/android/identity/analytics/IdentityAnalyticsRequestFactory.kt
+++ b/identity/src/main/java/com/stripe/android/identity/analytics/IdentityAnalyticsRequestFactory.kt
@@ -1,0 +1,257 @@
+package com.stripe.android.identity.analytics
+
+import android.content.Context
+import com.stripe.android.core.networking.AnalyticsRequestV2
+import com.stripe.android.core.networking.AnalyticsRequestV2Factory
+import com.stripe.android.identity.IdentityVerificationSheetContract
+import com.stripe.android.identity.networking.models.DocumentUploadParam
+import com.stripe.android.identity.states.IdentityScanState
+import javax.inject.Inject
+
+/**
+ * Factory for creating [AnalyticsRequestV2] for Identity.
+ */
+internal class IdentityAnalyticsRequestFactory @Inject constructor(
+    context: Context,
+    private val args: IdentityVerificationSheetContract.Args
+) {
+    private val requestFactory = AnalyticsRequestV2Factory(
+        context = context,
+        clientId = CLIENT_ID,
+        origin = ORIGIN
+    )
+
+    fun sheetPresented() = requestFactory.createRequestR(
+        EVENT_SHEET_PRESENTED,
+        additionalParams = mapOf(
+            PARAM_VERIFICATION_SESSION to args.verificationSessionId
+        )
+    )
+
+    fun sheetClosed(sessionResult: String) = requestFactory.createRequestR(
+        eventName = EVENT_SHEET_CLOSED,
+        additionalParams = mapOf(
+            PARAM_VERIFICATION_SESSION to args.verificationSessionId,
+            PARAM_SESSION_RESULT to sessionResult
+        )
+    )
+
+    fun verificationSucceed(
+        isFromFallbackUrl: Boolean,
+        scanType: IdentityScanState.ScanType? = null,
+        requireSelfie: Boolean? = null,
+        docFrontRetryTimes: Int? = null,
+        docBackRetryTimes: Int? = null,
+        selfieRetryTimes: Int? = null,
+        docFrontUploadType: DocumentUploadParam.UploadMethod? = null,
+        docBackUploadType: DocumentUploadParam.UploadMethod? = null,
+        docFrontModelScore: Float? = null,
+        docBackModelScore: Float? = null,
+        selfieModelScore: Float? = null,
+    ) = requestFactory.createRequestR(
+        eventName = EVENT_VERIFICATION_SUCCEED,
+        additionalParams =
+        mapOf(
+            PARAM_FROM_FALLBACK_URL to isFromFallbackUrl,
+            PARAM_VERIFICATION_SESSION to args.verificationSessionId,
+            PARAM_SCAN_TYPE to scanType?.toParam(),
+            PARAM_REQUIRE_SELFIE to requireSelfie,
+            PARAM_DOC_FRONT_RETRY_TIMES to docFrontRetryTimes,
+            PARAM_DOC_BACK_RETRY_TIMES to docBackRetryTimes,
+            PARAM_SELFIE_RETRY_TIMES to selfieRetryTimes,
+            PARAM_DOC_FRONT_UPLOAD_TYPE to docFrontUploadType?.name,
+            PARAM_DOC_BACK_UPLOAD_TYPE to docBackUploadType?.name,
+            PARAM_DOC_FRONT_MODEL_SCORE to docFrontModelScore,
+            PARAM_DOC_BACK_MODEL_SCORE to docBackModelScore,
+            PARAM_SELFIE_MODEL_SCORE to selfieModelScore,
+        )
+    )
+
+    fun verificationCanceled(
+        isFromFallbackUrl: Boolean,
+        lastScreenName: String? = null,
+        scanType: IdentityScanState.ScanType? = null,
+        requireSelfie: Boolean? = null,
+    ) = requestFactory.createRequestR(
+        eventName = EVENT_VERIFICATION_CANCELED,
+        additionalParams =
+        mapOf(
+            PARAM_FROM_FALLBACK_URL to isFromFallbackUrl,
+            PARAM_VERIFICATION_SESSION to args.verificationSessionId,
+            PARAM_SCAN_TYPE to scanType?.toParam(),
+            PARAM_REQUIRE_SELFIE to requireSelfie,
+            PARAM_LAST_SCREEN_NAME to lastScreenName,
+        )
+    )
+
+    fun verificationFailed(
+        isFromFallbackUrl: Boolean,
+        scanType: IdentityScanState.ScanType? = null,
+        requireSelfie: Boolean? = null,
+        docFrontUploadType: DocumentUploadParam.UploadMethod? = null,
+        docBackUploadType: DocumentUploadParam.UploadMethod? = null,
+        throwable: Throwable
+    ) = requestFactory.createRequestR(
+        eventName = EVENT_VERIFICATION_FAILED,
+        additionalParams =
+        mapOf(
+            PARAM_FROM_FALLBACK_URL to isFromFallbackUrl,
+            PARAM_VERIFICATION_SESSION to args.verificationSessionId,
+            PARAM_SCAN_TYPE to scanType?.toParam(),
+            PARAM_REQUIRE_SELFIE to requireSelfie,
+            PARAM_DOC_FRONT_UPLOAD_TYPE to docFrontUploadType?.name,
+            PARAM_DOC_BACK_UPLOAD_TYPE to docBackUploadType?.name,
+            PARAM_ERROR to mapOf(
+                PARAM_EXCEPTION to throwable.javaClass.name,
+                PARAM_STACKTRACE to throwable.stackTrace.toString()
+            )
+        )
+    )
+
+    fun screenPresented(
+        scanType: IdentityScanState.ScanType? = null,
+        screenName: String
+    ) = requestFactory.createRequestR(
+        eventName = EVENT_SCREEN_PRESENTED,
+        additionalParams = mapOf(
+            PARAM_VERIFICATION_SESSION to args.verificationSessionId,
+            PARAM_SCAN_TYPE to scanType?.toParam(),
+            PARAM_SCREEN_NAME to screenName
+        )
+    )
+
+    fun cameraError(
+        scanType: IdentityScanState.ScanType,
+        throwable: Throwable
+    ) = requestFactory.createRequestR(
+        eventName = EVENT_CAMERA_ERROR,
+        additionalParams = mapOf(
+            PARAM_VERIFICATION_SESSION to args.verificationSessionId,
+            PARAM_SCAN_TYPE to scanType.toParam(),
+            PARAM_ERROR to mapOf(
+                PARAM_EXCEPTION to throwable.javaClass.name,
+                PARAM_STACKTRACE to throwable.stackTrace.toString()
+            )
+        )
+    )
+
+    fun cameraPermissionDenied(
+        scanType: IdentityScanState.ScanType,
+    ) = requestFactory.createRequestR(
+        eventName = EVENT_CAMERA_PERMISSION_DENIED,
+        additionalParams = mapOf(
+            PARAM_VERIFICATION_SESSION to args.verificationSessionId,
+            PARAM_SCAN_TYPE to scanType.toParam(),
+        )
+    )
+
+    fun cameraPermissionGranted(
+        scanType: IdentityScanState.ScanType,
+    ) = requestFactory.createRequestR(
+        eventName = EVENT_CAMERA_PERMISSION_GRANTED,
+        additionalParams = mapOf(
+            PARAM_VERIFICATION_SESSION to args.verificationSessionId,
+            PARAM_SCAN_TYPE to scanType.toParam(),
+        )
+    )
+
+    fun documentTimeout(
+        scanType: IdentityScanState.ScanType,
+        count: Int
+    ) = requestFactory.createRequestR(
+        eventName = EVENT_DOCUMENT_TIMEOUT,
+        additionalParams = mapOf(
+            PARAM_VERIFICATION_SESSION to args.verificationSessionId,
+            PARAM_SCAN_TYPE to scanType.toParam(),
+            PARAM_SIDE to scanType.toSide(),
+            PARAM_COUNT to count
+        )
+    )
+
+    fun selfieTimeout(
+        scanType: IdentityScanState.ScanType,
+        count: Int
+    ) = requestFactory.createRequestR(
+        eventName = EVENT_SELFIE_TIMEOUT,
+        additionalParams = mapOf(
+            PARAM_VERIFICATION_SESSION to args.verificationSessionId,
+            PARAM_SCAN_TYPE to scanType.toParam(),
+            PARAM_COUNT to count
+        )
+    )
+
+    private fun IdentityScanState.ScanType.toParam(): String =
+        when (this) {
+            IdentityScanState.ScanType.ID_FRONT -> ID
+            IdentityScanState.ScanType.ID_BACK -> ID
+            IdentityScanState.ScanType.PASSPORT -> PASSPORT
+            IdentityScanState.ScanType.DL_FRONT -> DRIVER_LICENSE
+            IdentityScanState.ScanType.DL_BACK -> DRIVER_LICENSE
+            else -> {
+                throw IllegalArgumentException("Unknown type: $this")
+            }
+        }
+
+    private fun IdentityScanState.ScanType.toSide(): String =
+        when (this) {
+            IdentityScanState.ScanType.ID_FRONT -> FRONT
+            IdentityScanState.ScanType.ID_BACK -> BACK
+            IdentityScanState.ScanType.PASSPORT -> FRONT
+            IdentityScanState.ScanType.DL_FRONT -> FRONT
+            IdentityScanState.ScanType.DL_BACK -> BACK
+            else -> {
+                throw IllegalArgumentException("Unknown type: $this")
+            }
+        }
+
+    internal companion object {
+        const val CLIENT_ID = "mobile-identity-sdk"
+        const val ORIGIN = "stripe-identity-android"
+        const val ID = "id"
+        const val PASSPORT = "passport"
+        const val DRIVER_LICENSE = "driver_license"
+        const val FRONT = "front"
+        const val BACK = "back"
+
+        const val EVENT_SHEET_PRESENTED = "sheet_presented"
+        const val EVENT_SHEET_CLOSED = "sheet_closed"
+        const val EVENT_VERIFICATION_SUCCEED = "verification_succeed"
+        const val EVENT_VERIFICATION_FAILED = "verification_failed"
+        const val EVENT_VERIFICATION_CANCELED = "verification_canceled"
+        const val EVENT_SCREEN_PRESENTED = "screen_presented"
+        const val EVENT_CAMERA_ERROR = "camera_error"
+        const val EVENT_CAMERA_PERMISSION_DENIED = "camera_permission_denied"
+        const val EVENT_CAMERA_PERMISSION_GRANTED = "camera_permission_granted"
+        const val EVENT_DOCUMENT_TIMEOUT = "document_timeout"
+        const val EVENT_SELFIE_TIMEOUT = "selfie_timeout"
+
+        const val PARAM_FROM_FALLBACK_URL = "from_fallback_url"
+        const val PARAM_VERIFICATION_SESSION = "verification_session"
+        const val PARAM_SESSION_RESULT = "session_result"
+        const val PARAM_SCAN_TYPE = "scan_type"
+        const val PARAM_REQUIRE_SELFIE = "require_selfie"
+        const val PARAM_DOC_FRONT_RETRY_TIMES = "doc_front_retry_times"
+        const val PARAM_DOC_BACK_RETRY_TIMES = "doc_back_retry_times"
+        const val PARAM_SELFIE_RETRY_TIMES = "selfie_retry_times"
+        const val PARAM_DOC_FRONT_UPLOAD_TYPE = "doc_front_upload_type"
+        const val PARAM_DOC_BACK_UPLOAD_TYPE = "doc_back_upload_type"
+        const val PARAM_DOC_FRONT_MODEL_SCORE = "doc_front_model_score"
+        const val PARAM_DOC_BACK_MODEL_SCORE = "doc_back_model_score"
+        const val PARAM_SELFIE_MODEL_SCORE = "selfie_model_score"
+        const val PARAM_LAST_SCREEN_NAME = "last_screen_name"
+        const val PARAM_ERROR = "error"
+        const val PARAM_EXCEPTION = "exception"
+        const val PARAM_STACKTRACE = "stacktrace"
+        const val PARAM_SCREEN_NAME = "screen_name"
+        const val PARAM_COUNT = "count"
+        const val PARAM_SIDE = "side"
+
+        const val SCREEN_NAME_CONSENT = "consent"
+        const val SCREEN_NAME_DOC_SELECT = "document_select"
+        const val SCREEN_NAME_LIVE_CAPTURE = "live_capture"
+        const val SCREEN_NAME_FILE_UPLOAD = "file_upload"
+        const val SCREEN_NAME_SELFIE = "selfie"
+        const val SCREEN_NAME_CONFIRMATION = "confirmation"
+        const val SCREEN_NAME_ERROR = "error"
+    }
+}

--- a/identity/src/main/java/com/stripe/android/identity/navigation/BaseErrorFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/BaseErrorFragment.kt
@@ -6,13 +6,23 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.button.MaterialButton
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_ERROR
 import com.stripe.android.identity.databinding.BaseErrorFragmentBinding
+import com.stripe.android.identity.viewmodel.IdentityViewModel
 
 /**
  * Base error fragment displaying error messages and two buttons
  */
-internal abstract class BaseErrorFragment : Fragment() {
+internal abstract class BaseErrorFragment(
+    private val identityViewModelFactory: ViewModelProvider.Factory
+) : Fragment() {
+    private val identityViewModel: IdentityViewModel by activityViewModels {
+        identityViewModelFactory
+    }
+
     protected lateinit var title: TextView
     protected lateinit var message1: TextView
     protected lateinit var message2: TextView
@@ -32,6 +42,15 @@ internal abstract class BaseErrorFragment : Fragment() {
         bottomButton = binding.bottomButton
         onCustomizingViews()
         return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        identityViewModel.sendAnalyticsRequest(
+            identityViewModel.identityAnalyticsRequestFactory.screenPresented(
+                screenName = SCREEN_NAME_ERROR
+            )
+        )
     }
 
     protected abstract fun onCustomizingViews()

--- a/identity/src/main/java/com/stripe/android/identity/navigation/CameraPermissionDeniedFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/CameraPermissionDeniedFragment.kt
@@ -2,6 +2,7 @@ package com.stripe.android.identity.navigation
 
 import android.view.View
 import androidx.annotation.IdRes
+import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.findNavController
 import com.stripe.android.camera.AppSettingsOpenable
 import com.stripe.android.identity.R
@@ -12,8 +13,9 @@ import com.stripe.android.identity.utils.navigateToUploadFragment
  * Fragment to show user denies camera permission.
  */
 internal class CameraPermissionDeniedFragment(
-    private val appSettingsOpenable: AppSettingsOpenable
-) : BaseErrorFragment() {
+    private val appSettingsOpenable: AppSettingsOpenable,
+    identityViewModelFactory: ViewModelProvider.Factory
+) : BaseErrorFragment(identityViewModelFactory) {
     override fun onCustomizingViews() {
 
         title.text = getString(R.string.camera_permission)

--- a/identity/src/main/java/com/stripe/android/identity/navigation/ConfirmationFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ConfirmationFragment.kt
@@ -10,6 +10,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.identity.IdentityVerificationSheet
 import com.stripe.android.identity.VerificationFlowFinishable
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
 import com.stripe.android.identity.databinding.ConfirmationFragmentBinding
 import com.stripe.android.identity.utils.navigateToDefaultErrorFragment
 import com.stripe.android.identity.utils.setHtmlString
@@ -36,6 +37,7 @@ internal class ConfirmationFragment(
     ): View {
         binding = ConfirmationFragmentBinding.inflate(inflater, container, false)
         binding.kontinue.setOnClickListener {
+            // TODO: Send verificationSucceed analytics event
             verificationFlowFinishable.finishWithResult(
                 IdentityVerificationSheet.VerificationFlowResult.Completed
             )
@@ -57,6 +59,12 @@ internal class ConfirmationFragment(
                 Log.e(TAG, "Failed to get VerificationPage")
                 navigateToDefaultErrorFragment()
             }
+        )
+
+        identityViewModel.sendAnalyticsRequest(
+            identityViewModel.identityAnalyticsRequestFactory.screenPresented(
+                screenName = IdentityAnalyticsRequestFactory.SCREEN_NAME_CONFIRMATION
+            )
         )
     }
 

--- a/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.stripe.android.identity.FallbackUrlLauncher
 import com.stripe.android.identity.R
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_CONSENT
 import com.stripe.android.identity.databinding.ConsentFragmentBinding
 import com.stripe.android.identity.networking.models.ClearDataParam
 import com.stripe.android.identity.networking.models.CollectedDataParam
@@ -103,6 +104,12 @@ internal class ConsentFragment(
                     it ?: IllegalStateException("Failed to get verificationPage")
                 )
             }
+        )
+
+        identityViewModel.sendAnalyticsRequest(
+            identityViewModel.identityAnalyticsRequestFactory.screenPresented(
+                screenName = SCREEN_NAME_CONSENT
+            )
         )
     }
 

--- a/identity/src/main/java/com/stripe/android/identity/navigation/CouldNotCaptureFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/CouldNotCaptureFragment.kt
@@ -3,6 +3,7 @@ package com.stripe.android.identity.navigation
 import android.view.View
 import androidx.annotation.IdRes
 import androidx.core.os.bundleOf
+import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.fragment.findNavController
 import com.stripe.android.identity.R
 import com.stripe.android.identity.navigation.IdentityDocumentScanFragment.Companion.ARG_SHOULD_START_FROM_BACK
@@ -12,7 +13,9 @@ import com.stripe.android.identity.utils.navigateToUploadFragment
 /**
  * Fragment to indicate live capture failure.
  */
-internal class CouldNotCaptureFragment : BaseErrorFragment() {
+internal class CouldNotCaptureFragment(
+    identityViewModelFactory: ViewModelProvider.Factory
+) : BaseErrorFragment(identityViewModelFactory) {
 
     override fun onCustomizingViews() {
         val args = requireNotNull(arguments) {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/DriverLicenseScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/DriverLicenseScanFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.identity.R
 import com.stripe.android.identity.networking.models.CollectedDataParam
+import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.states.IdentityScanState.ScanType.DL_BACK
 import com.stripe.android.identity.states.IdentityScanState.ScanType.DL_FRONT
 
@@ -19,6 +20,8 @@ internal class DriverLicenseScanFragment(
     identityCameraScanViewModelFactory,
     identityViewModelFactory
 ) {
+    override val frontScanType: IdentityScanState.ScanType = DL_FRONT
+
     override val fragmentId = R.id.driverLicenseScanFragment
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/ErrorFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ErrorFragment.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.view.View
 import androidx.annotation.IdRes
 import androidx.core.os.bundleOf
+import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.NavController
 import androidx.navigation.fragment.findNavController
 import com.stripe.android.identity.IdentityVerificationSheet
@@ -18,8 +19,9 @@ import com.stripe.android.identity.utils.navigateUpAndSetArgForUploadFragment
  * Fragment to show generic error.
  */
 internal class ErrorFragment(
-    private val verificationFlowFinishable: VerificationFlowFinishable
-) : BaseErrorFragment() {
+    private val verificationFlowFinishable: VerificationFlowFinishable,
+    identityViewModelFactory: ViewModelProvider.Factory
+) : BaseErrorFragment(identityViewModelFactory) {
     override fun onCustomizingViews() {
         val args = requireNotNull(arguments)
         title.text = args[ARG_ERROR_TITLE] as String

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IDScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IDScanFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.identity.R
 import com.stripe.android.identity.networking.models.CollectedDataParam
+import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.states.IdentityScanState.ScanType.ID_BACK
 import com.stripe.android.identity.states.IdentityScanState.ScanType.ID_FRONT
 
@@ -19,6 +20,8 @@ internal class IDScanFragment(
     identityCameraScanViewModelFactory,
     identityViewModelFactory
 ) {
+    override val frontScanType: IdentityScanState.ScanType = ID_FRONT
+
     override val fragmentId = R.id.IDScanFragment
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
@@ -14,7 +14,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.stripe.android.camera.Camera1Adapter
-import com.stripe.android.camera.DefaultCameraErrorListener
 import com.stripe.android.camera.scanui.CameraView
 import com.stripe.android.camera.scanui.util.asRect
 import com.stripe.android.core.exception.InvalidResponseException
@@ -124,15 +123,7 @@ internal abstract class IdentityCameraScanFragment(
         }
     }
 
-    protected open fun createCameraAdapter() =
-        Camera1Adapter(
-            requireNotNull(activity),
-            cameraView.previewFrame,
-            MINIMUM_RESOLUTION,
-            DefaultCameraErrorListener(requireNotNull(activity)) { cause ->
-                Log.e(TAG, "scan fails with exception: $cause")
-            }
-        )
+    protected abstract fun createCameraAdapter(): Camera1Adapter
 
     /**
      * Called back each time when [CameraViewModel.displayStateChanged] is changed.

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
@@ -45,7 +45,8 @@ internal class IdentityFragmentFactory @Inject constructor(
                 identityViewModelFactory
             )
             CameraPermissionDeniedFragment::class.java.name -> CameraPermissionDeniedFragment(
-                appSettingsOpenable
+                appSettingsOpenable,
+                identityViewModelFactory
             )
             IDUploadFragment::class.java.name -> IDUploadFragment(
                 identityUploadViewModelFactory,
@@ -73,7 +74,11 @@ internal class IdentityFragmentFactory @Inject constructor(
                 verificationFlowFinishable
             )
             ErrorFragment::class.java.name -> ErrorFragment(
-                verificationFlowFinishable
+                verificationFlowFinishable,
+                identityViewModelFactory
+            )
+            CouldNotCaptureFragment::class.java.name -> CouldNotCaptureFragment(
+                identityViewModelFactory
             )
             else -> super.instantiate(classLoader, className)
         }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityUploadFragment.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavArgument
 import androidx.navigation.fragment.findNavController
 import com.stripe.android.identity.R
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
 import com.stripe.android.identity.databinding.IdentityUploadFragmentBinding
 import com.stripe.android.identity.networking.DocumentUploadState
 import com.stripe.android.identity.networking.models.ClearDataParam
@@ -159,6 +160,13 @@ internal abstract class IdentityUploadFragment(
         super.onViewCreated(view, savedInstanceState)
         maybeResetUploadedState()
         collectUploadedStateAndUpdateUI()
+
+        identityViewModel.sendAnalyticsRequest(
+            identityViewModel.identityAnalyticsRequestFactory.screenPresented(
+                scanType = frontScanType,
+                screenName = IdentityAnalyticsRequestFactory.SCREEN_NAME_FILE_UPLOAD
+            )
+        )
     }
 
     private fun checkBackFields(

--- a/identity/src/main/java/com/stripe/android/identity/navigation/PassportScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/PassportScanFragment.kt
@@ -28,6 +28,8 @@ internal class PassportScanFragment(
     identityCameraScanViewModelFactory,
     identityViewModelFactory
 ) {
+    override val frontScanType: IdentityScanState.ScanType = IdentityScanState.ScanType.PASSPORT
+
     override val fragmentId = R.id.passportScanFragment
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/SelfieFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/SelfieFragment.kt
@@ -22,6 +22,7 @@ import com.stripe.android.camera.Camera1Adapter
 import com.stripe.android.camera.DefaultCameraErrorListener
 import com.stripe.android.camera.framework.image.mirrorHorizontally
 import com.stripe.android.identity.R
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
 import com.stripe.android.identity.databinding.SelfieScanFragmentBinding
 import com.stripe.android.identity.networking.models.ClearDataParam
 import com.stripe.android.identity.networking.models.CollectedDataParam
@@ -116,6 +117,12 @@ internal class SelfieFragment(
                 )
             }
         )
+
+        identityViewModel.sendAnalyticsRequest(
+            identityViewModel.identityAnalyticsRequestFactory.screenPresented(
+                screenName = IdentityAnalyticsRequestFactory.SCREEN_NAME_SELFIE
+            )
+        )
     }
 
     override fun createCameraAdapter(): Camera1Adapter {
@@ -125,6 +132,12 @@ internal class SelfieFragment(
             MINIMUM_RESOLUTION,
             DefaultCameraErrorListener(requireNotNull(activity)) { cause ->
                 Log.e(TAG, "scan fails with exception: $cause")
+                identityViewModel.sendAnalyticsRequest(
+                    identityViewModel.identityAnalyticsRequestFactory.cameraError(
+                        scanType = IdentityScanState.ScanType.SELFIE,
+                        throwable = IllegalStateException(cause)
+                    )
+                )
             },
             false
         )

--- a/identity/src/main/java/com/stripe/android/identity/networking/DefaultIdentityRepository.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/DefaultIdentityRepository.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.identity.networking
 
+import android.util.Log
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.exception.APIException
@@ -10,6 +11,7 @@ import com.stripe.android.core.model.StripeModel
 import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.core.model.parsers.StripeErrorJsonParser
 import com.stripe.android.core.model.parsers.StripeFileJsonParser
+import com.stripe.android.core.networking.AnalyticsRequestV2
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.StripeNetworkClient
 import com.stripe.android.core.networking.StripeRequest
@@ -167,6 +169,14 @@ internal class DefaultIdentityRepository @Inject constructor(
         }
     )
 
+    override suspend fun sendAnalyticsRequest(analyticsRequestV2: AnalyticsRequestV2) {
+        runCatching {
+            stripeNetworkClient.executeRequest(analyticsRequestV2)
+        }.onFailure {
+            Log.e(TAG, "Exception while making analytics request")
+        }
+    }
+
     private suspend fun <Response> executeRequestWithKSerializer(
         request: StripeRequest,
         responseSerializer: KSerializer<Response>
@@ -233,5 +243,6 @@ internal class DefaultIdentityRepository @Inject constructor(
     internal companion object {
         const val SUBMIT = "submit"
         const val DATA = "data"
+        val TAG: String = DefaultIdentityRepository::class.java.simpleName
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/networking/IdentityRepository.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/IdentityRepository.kt
@@ -4,6 +4,7 @@ import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.model.StripeFile
 import com.stripe.android.core.model.StripeFilePurpose
+import com.stripe.android.core.networking.AnalyticsRequestV2
 import com.stripe.android.identity.networking.models.ClearDataParam
 import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.networking.models.VerificationPage
@@ -65,4 +66,9 @@ internal interface IdentityRepository {
         APIException::class
     )
     suspend fun downloadFile(fileUrl: String): File
+
+    /**
+     * Fire and forget the analytics request, log an error if exception happens.
+     */
+    suspend fun sendAnalyticsRequest(analyticsRequestV2: AnalyticsRequestV2)
 }

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPage.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPage.kt
@@ -64,5 +64,7 @@ internal data class VerificationPage(
             requirements.missing.contains(VerificationPageRequirements.Missing.BIOMETRICCONSENT)
 
         fun VerificationPage.isUnsupportedClient() = unsupportedClient
+
+        fun VerificationPage.requireSelfie() = selfieCapture != null
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
@@ -20,9 +20,11 @@ import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.injection.Injectable
 import com.stripe.android.core.injection.injectWithFallback
 import com.stripe.android.core.model.StripeFilePurpose
+import com.stripe.android.core.networking.AnalyticsRequestV2
 import com.stripe.android.identity.FallbackUrlLauncher
 import com.stripe.android.identity.IdentityVerificationSheetContract
 import com.stripe.android.identity.VerificationFlowFinishable
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
 import com.stripe.android.identity.camera.IdentityAggregator
 import com.stripe.android.identity.injection.DaggerIdentityViewModelFactoryComponent
 import com.stripe.android.identity.injection.IdentityViewModelSubcomponent
@@ -62,10 +64,11 @@ import javax.inject.Provider
 
 internal class IdentityViewModel @Inject constructor(
     internal val verificationArgs: IdentityVerificationSheetContract.Args,
-    private val identityRepository: IdentityRepository,
+    val identityRepository: IdentityRepository,
     private val identityModelFetcher: IdentityModelFetcher,
     private val identityIO: IdentityIO,
     val identityFragmentFactory: IdentityFragmentFactory,
+    val identityAnalyticsRequestFactory: IdentityAnalyticsRequestFactory
 ) : ViewModel() {
 
     /**
@@ -650,6 +653,14 @@ internal class IdentityViewModel @Inject constructor(
             DaggerIdentityViewModelFactoryComponent.builder()
                 .context(context)
                 .build().inject(this)
+        }
+    }
+
+    fun sendAnalyticsRequest(request: AnalyticsRequestV2) {
+        viewModelScope.launch {
+            identityRepository.sendAnalyticsRequest(
+                request
+            )
         }
     }
 

--- a/identity/src/test/java/com/stripe/android/identity/navigation/ConfirmationFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/ConfirmationFragmentTest.kt
@@ -8,6 +8,10 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.identity.IdentityVerificationSheet
 import com.stripe.android.identity.R
 import com.stripe.android.identity.VerificationFlowFinishable
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.EVENT_SCREEN_PRESENTED
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_SCREEN_NAME
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_CONFIRMATION
 import com.stripe.android.identity.databinding.ConfirmationFragmentBinding
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentTextPage
@@ -17,6 +21,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -30,7 +35,14 @@ class ConfirmationFragmentTest {
 
     private val mockVerificationFlowFinishable = mock<VerificationFlowFinishable>()
 
-    private val mockIdentityViewModel = mock<IdentityViewModel>()
+    private val mockIdentityViewModel = mock<IdentityViewModel> {
+        on { identityAnalyticsRequestFactory }.thenReturn(
+            IdentityAnalyticsRequestFactory(
+                context = ApplicationProvider.getApplicationContext(),
+                args = mock()
+            )
+        )
+    }
 
     private val verificationPage = mock<VerificationPage>().also {
         whenever(it.success).thenReturn(
@@ -72,6 +84,12 @@ class ConfirmationFragmentTest {
         launchConfirmationFragment { binding, _ ->
             setUpSuccessVerificationPage()
 
+            verify(mockIdentityViewModel).sendAnalyticsRequest(
+                argThat {
+                    eventName == EVENT_SCREEN_PRESENTED &&
+                        params[PARAM_SCREEN_NAME] == SCREEN_NAME_CONFIRMATION
+                }
+            )
             assertThat(binding.titleText.text).isEqualTo(CONFIRMATION_TITLE)
             assertThat(binding.contentText.text.toString()).isEqualTo(CONFIRMATION_BODY)
             assertThat(binding.kontinue.text).isEqualTo(CONFIRMATION_BUTTON_TEXT)

--- a/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
@@ -15,6 +15,10 @@ import com.stripe.android.core.injection.DUMMY_INJECTOR_KEY
 import com.stripe.android.identity.FallbackUrlLauncher
 import com.stripe.android.identity.IdentityVerificationSheetContract
 import com.stripe.android.identity.R
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.EVENT_SCREEN_PRESENTED
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_SCREEN_NAME
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_CONSENT
 import com.stripe.android.identity.databinding.ConsentFragmentBinding
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPageData
@@ -32,6 +36,7 @@ import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -109,13 +114,13 @@ internal class ConsentFragmentTest {
         )
     }
 
-    private val mockIdentityViewModel = mock<IdentityViewModel>().also {
-        whenever(it.verificationArgs).thenReturn(
-            IdentityVerificationSheetContract.Args(
-                verificationSessionId = VERIFICATION_SESSION_ID,
-                ephemeralKeySecret = EPHEMERAL_KEY,
-                brandLogo = BRAND_LOGO,
-                injectorKey = DUMMY_INJECTOR_KEY
+    private val mockIdentityViewModel = mock<IdentityViewModel> {
+        on { verificationArgs }.thenReturn(ARGS)
+
+        on { identityAnalyticsRequestFactory }.thenReturn(
+            IdentityAnalyticsRequestFactory(
+                context = ApplicationProvider.getApplicationContext(),
+                args = ARGS
             )
         )
     }
@@ -191,6 +196,12 @@ internal class ConsentFragmentTest {
         launchConsentFragment { binding, _, _ ->
             setUpSuccessVerificationPage()
 
+            verify(mockIdentityViewModel).sendAnalyticsRequest(
+                argThat {
+                    eventName == EVENT_SCREEN_PRESENTED &&
+                        params[PARAM_SCREEN_NAME] == SCREEN_NAME_CONSENT
+                }
+            )
             verify(
                 mockConsentFragmentViewModel
             ).loadUriIntoImageView(
@@ -382,5 +393,12 @@ internal class ConsentFragmentTest {
 
         const val FALLBACK_URL = "https://link/to/fallback"
         val BRAND_LOGO = mock<Uri>()
+
+        val ARGS = IdentityVerificationSheetContract.Args(
+            verificationSessionId = VERIFICATION_SESSION_ID,
+            ephemeralKeySecret = EPHEMERAL_KEY,
+            brandLogo = BRAND_LOGO,
+            injectorKey = DUMMY_INJECTOR_KEY
+        )
     }
 }

--- a/identity/src/test/java/com/stripe/android/identity/navigation/DriverLicenseScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/DriverLicenseScanFragmentTest.kt
@@ -18,6 +18,12 @@ import com.stripe.android.core.model.StripeFile
 import com.stripe.android.identity.CORRECT_WITH_SUBMITTED_SUCCESS_VERIFICATION_PAGE_DATA
 import com.stripe.android.identity.R
 import com.stripe.android.identity.SUCCESS_VERIFICATION_PAGE_NOT_REQUIRE_LIVE_CAPTURE
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.DRIVER_LICENSE
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.EVENT_SCREEN_PRESENTED
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_SCAN_TYPE
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_SCREEN_NAME
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_LIVE_CAPTURE
 import com.stripe.android.identity.camera.IdentityAggregator
 import com.stripe.android.identity.camera.IdentityScanFlow
 import com.stripe.android.identity.databinding.IdentityDocumentScanFragmentBinding
@@ -42,6 +48,7 @@ import org.junit.Test
 import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
@@ -72,9 +79,14 @@ internal class DriverLicenseScanFragmentTest {
     private val documentUploadState =
         MutableStateFlow(DocumentUploadState())
 
-    private val mockIdentityViewModel = mock<IdentityViewModel>() {
+    private val mockIdentityViewModel = mock<IdentityViewModel> {
         on { pageAndModelFiles } doReturn mockPageAndModel
         on { documentUploadState } doReturn documentUploadState
+        on { identityAnalyticsRequestFactory } doReturn
+            IdentityAnalyticsRequestFactory(
+                context = ApplicationProvider.getApplicationContext(),
+                args = mock()
+            )
     }
 
     private val errorDocumentUploadState = mock<DocumentUploadState> {
@@ -103,6 +115,19 @@ internal class DriverLicenseScanFragmentTest {
                 )
             )
         )
+    }
+
+    @Test
+    fun `when started analytics event is sent`() {
+        launchDriverLicenseFragment().onFragment {
+            verify(mockIdentityViewModel).sendAnalyticsRequest(
+                argThat {
+                    eventName == EVENT_SCREEN_PRESENTED &&
+                        params[PARAM_SCREEN_NAME] == SCREEN_NAME_LIVE_CAPTURE &&
+                        params[PARAM_SCAN_TYPE] == DRIVER_LICENSE
+                }
+            )
+        }
     }
 
     @Test

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IDScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IDScanFragmentTest.kt
@@ -18,6 +18,12 @@ import com.stripe.android.core.model.StripeFile
 import com.stripe.android.identity.CORRECT_WITH_SUBMITTED_SUCCESS_VERIFICATION_PAGE_DATA
 import com.stripe.android.identity.R
 import com.stripe.android.identity.SUCCESS_VERIFICATION_PAGE_NOT_REQUIRE_LIVE_CAPTURE
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.EVENT_SCREEN_PRESENTED
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.ID
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_SCAN_TYPE
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_SCREEN_NAME
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_LIVE_CAPTURE
 import com.stripe.android.identity.camera.IdentityAggregator
 import com.stripe.android.identity.camera.IdentityScanFlow
 import com.stripe.android.identity.databinding.IdentityDocumentScanFragmentBinding
@@ -43,6 +49,7 @@ import org.junit.Test
 import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
@@ -76,6 +83,11 @@ internal class IDScanFragmentTest {
     private val mockIdentityViewModel = mock<IdentityViewModel> {
         on { pageAndModelFiles } doReturn mockPageAndModel
         on { documentUploadState } doReturn documentUploadState
+        on { identityAnalyticsRequestFactory } doReturn
+            IdentityAnalyticsRequestFactory(
+                context = ApplicationProvider.getApplicationContext(),
+                args = mock()
+            )
     }
 
     private val errorDocumentUploadState = mock<DocumentUploadState> {
@@ -104,6 +116,19 @@ internal class IDScanFragmentTest {
                 )
             )
         )
+    }
+
+    @Test
+    fun `when started analytics event is sent`() {
+        launchIDScanFragment().onFragment {
+            verify(mockIdentityViewModel).sendAnalyticsRequest(
+                argThat {
+                    eventName == EVENT_SCREEN_PRESENTED &&
+                        params[PARAM_SCREEN_NAME] == SCREEN_NAME_LIVE_CAPTURE &&
+                        params[PARAM_SCAN_TYPE] == ID
+                }
+            )
+        }
     }
 
     @Test

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IdentityDocumentScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IdentityDocumentScanFragmentTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.core.exception.InvalidResponseException
 import com.stripe.android.identity.R
 import com.stripe.android.identity.SUCCESS_VERIFICATION_PAGE_NOT_REQUIRE_LIVE_CAPTURE
 import com.stripe.android.identity.SUCCESS_VERIFICATION_PAGE_REQUIRE_LIVE_CAPTURE
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
 import com.stripe.android.identity.camera.IdentityAggregator
 import com.stripe.android.identity.camera.IdentityScanFlow
 import com.stripe.android.identity.networking.Resource
@@ -67,6 +68,12 @@ class IdentityDocumentScanFragmentTest {
     private val mockPageAndModel = MediatorLiveData<Resource<IdentityViewModel.PageAndModelFiles>>()
     private val mockIdentityViewModel = mock<IdentityViewModel>().also {
         whenever(it.pageAndModelFiles).thenReturn(mockPageAndModel)
+        whenever(it.identityAnalyticsRequestFactory).thenReturn(
+            IdentityAnalyticsRequestFactory(
+                context = ApplicationProvider.getApplicationContext(),
+                args = mock()
+            )
+        )
     }
 
     internal class TestFragment(
@@ -79,6 +86,7 @@ class IdentityDocumentScanFragmentTest {
         override val fragmentId = R.id.IDScanFragment
         var currentState: IdentityScanState? = null
         var onCameraReadyIsCalled = false
+        override val frontScanType = IdentityScanState.ScanType.ID_FRONT
 
         override fun onCreateView(
             inflater: LayoutInflater,

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IdentityUploadFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IdentityUploadFragmentTest.kt
@@ -23,6 +23,10 @@ import com.stripe.android.core.model.StripeFilePurpose
 import com.stripe.android.identity.CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
 import com.stripe.android.identity.CORRECT_WITH_SUBMITTED_SUCCESS_VERIFICATION_PAGE_DATA
 import com.stripe.android.identity.R
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.EVENT_SCREEN_PRESENTED
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_SCAN_TYPE
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_SCREEN_NAME
 import com.stripe.android.identity.databinding.IdentityUploadFragmentBinding
 import com.stripe.android.identity.networking.DocumentUploadState
 import com.stripe.android.identity.networking.Resource
@@ -48,6 +52,7 @@ import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
@@ -87,6 +92,13 @@ class IdentityUploadFragmentTest {
             successCaptor.firstValue(verificationPage)
         }
         whenever(it.documentUploadState).thenReturn(documentUploadState)
+
+        whenever(it.identityAnalyticsRequestFactory).thenReturn(
+            IdentityAnalyticsRequestFactory(
+                context = ApplicationProvider.getApplicationContext(),
+                args = mock()
+            )
+        )
     }
 
     private val mockIdentityViewModelWithSelfie = mock<IdentityViewModel>().also {
@@ -95,6 +107,12 @@ class IdentityUploadFragmentTest {
             successCaptor.firstValue(verificationPageWithSelfie)
         }
         whenever(it.documentUploadState).thenReturn(documentUploadState)
+        whenever(it.identityAnalyticsRequestFactory).thenReturn(
+            IdentityAnalyticsRequestFactory(
+                context = ApplicationProvider.getApplicationContext(),
+                args = mock()
+            )
+        )
     }
 
     private val mockFrontBackUploadViewModel = mock<IdentityUploadViewModel>()
@@ -588,6 +606,15 @@ class IdentityUploadFragmentTest {
             navController
         )
     }.onFragment {
+        (if (requireSelfie) mockIdentityViewModelWithSelfie else mockIdentityViewModel).let { identityViewModel ->
+            verify(identityViewModel).sendAnalyticsRequest(
+                argThat {
+                    eventName == EVENT_SCREEN_PRESENTED &&
+                        params[PARAM_SCREEN_NAME] == IdentityAnalyticsRequestFactory.SCREEN_NAME_FILE_UPLOAD &&
+                        params[PARAM_SCAN_TYPE] == IdentityAnalyticsRequestFactory.ID // from frontScanType = IdentityScanState.ScanType.ID_FRONT
+                }
+            )
+        }
         testBlock(IdentityUploadFragmentBinding.bind(it.requireView()), navController, it)
     }
 

--- a/identity/src/test/java/com/stripe/android/identity/navigation/PassportScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/PassportScanFragmentTest.kt
@@ -16,6 +16,12 @@ import com.stripe.android.core.model.StripeFile
 import com.stripe.android.identity.CORRECT_WITH_SUBMITTED_SUCCESS_VERIFICATION_PAGE_DATA
 import com.stripe.android.identity.R
 import com.stripe.android.identity.SUCCESS_VERIFICATION_PAGE_NOT_REQUIRE_LIVE_CAPTURE
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.EVENT_SCREEN_PRESENTED
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_SCAN_TYPE
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_SCREEN_NAME
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PASSPORT
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_LIVE_CAPTURE
 import com.stripe.android.identity.camera.IdentityAggregator
 import com.stripe.android.identity.camera.IdentityScanFlow
 import com.stripe.android.identity.databinding.IdentityDocumentScanFragmentBinding
@@ -40,6 +46,7 @@ import org.junit.Test
 import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
@@ -73,6 +80,11 @@ class PassportScanFragmentTest {
     private val mockIdentityViewModel = mock<IdentityViewModel> {
         on { pageAndModelFiles } doReturn mockPageAndModel
         on { documentUploadState } doReturn documentUploadState
+        on { identityAnalyticsRequestFactory } doReturn
+            IdentityAnalyticsRequestFactory(
+                context = ApplicationProvider.getApplicationContext(),
+                args = mock()
+            )
     }
 
     private val errorDocumentUploadState = mock<DocumentUploadState> {
@@ -99,6 +111,19 @@ class PassportScanFragmentTest {
                 )
             )
         )
+    }
+
+    @Test
+    fun `when started analytics event is sent`() {
+        launchPassportScanFragment().onFragment {
+            verify(mockIdentityViewModel).sendAnalyticsRequest(
+                argThat {
+                    eventName == EVENT_SCREEN_PRESENTED &&
+                        params[PARAM_SCREEN_NAME] == SCREEN_NAME_LIVE_CAPTURE &&
+                        params[PARAM_SCAN_TYPE] == PASSPORT
+                }
+            )
+        }
     }
 
     @Test

--- a/identity/src/test/java/com/stripe/android/identity/navigation/PassportUploadFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/PassportUploadFragmentTest.kt
@@ -22,6 +22,7 @@ import com.stripe.android.core.model.StripeFilePurpose
 import com.stripe.android.identity.CORRECT_WITH_SUBMITTED_FAILURE_VERIFICATION_PAGE_DATA
 import com.stripe.android.identity.CORRECT_WITH_SUBMITTED_SUCCESS_VERIFICATION_PAGE_DATA
 import com.stripe.android.identity.R
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
 import com.stripe.android.identity.databinding.IdentityUploadFragmentBinding
 import com.stripe.android.identity.networking.DocumentUploadState
 import com.stripe.android.identity.networking.Resource
@@ -86,6 +87,12 @@ class PassportUploadFragmentTest {
             successCaptor.firstValue(verificationPage)
         }
         whenever(it.documentUploadState).thenReturn(documentUploadState)
+        whenever(it.identityAnalyticsRequestFactory).thenReturn(
+            IdentityAnalyticsRequestFactory(
+                context = ApplicationProvider.getApplicationContext(),
+                args = mock()
+            )
+        )
     }
 
     private val mockIdentityViewModelWithSelfie = mock<IdentityViewModel>().also {
@@ -94,6 +101,12 @@ class PassportUploadFragmentTest {
             successCaptor.firstValue(verificationPageWithSelfie)
         }
         whenever(it.documentUploadState).thenReturn(documentUploadState)
+        whenever(it.identityAnalyticsRequestFactory).thenReturn(
+            IdentityAnalyticsRequestFactory(
+                context = ApplicationProvider.getApplicationContext(),
+                args = mock()
+            )
+        )
     }
 
     private val navController = TestNavHostController(

--- a/identity/src/test/java/com/stripe/android/identity/navigation/SelfieFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/SelfieFragmentTest.kt
@@ -14,6 +14,10 @@ import com.google.android.material.progressindicator.CircularProgressIndicator
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.camera.CameraPreviewImage
 import com.stripe.android.identity.R
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.EVENT_SCREEN_PRESENTED
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_SCREEN_NAME
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_SELFIE
 import com.stripe.android.identity.camera.IdentityAggregator
 import com.stripe.android.identity.camera.IdentityScanFlow
 import com.stripe.android.identity.databinding.SelfieScanFragmentBinding
@@ -42,6 +46,7 @@ import org.junit.rules.TestRule
 import org.junit.runner.RunWith
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
@@ -96,11 +101,23 @@ internal class SelfieFragmentTest {
         on { pageAndModelFiles } doReturn mockPageAndModel
         on { documentUploadState } doReturn documentUploadState
         on { selfieUploadState } doReturn selfieUploadState
+        on { identityAnalyticsRequestFactory } doReturn
+            IdentityAnalyticsRequestFactory(
+                context = ApplicationProvider.getApplicationContext(),
+                args = mock()
+            )
     }
 
     @Test
     fun `when initialized UI is reset and bound`() {
         launchSelfieFragment { binding, _, _ ->
+            verify(mockIdentityViewModel).sendAnalyticsRequest(
+                argThat {
+                    eventName == EVENT_SCREEN_PRESENTED &&
+                        params[PARAM_SCREEN_NAME] == SCREEN_NAME_SELFIE
+                }
+            )
+
             val successCaptor: KArgumentCaptor<(VerificationPage) -> Unit> = argumentCaptor()
             verify(
                 mockIdentityViewModel,

--- a/identity/src/test/java/com/stripe/android/identity/viewmodel/IdentityViewModelTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/viewmodel/IdentityViewModelTest.kt
@@ -91,6 +91,7 @@ internal class IdentityViewModelTest {
         mockIdentityRepository,
         mockIdentityModelFetcher,
         mockIdentityIO,
+        mock(),
         mock()
     )
 

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2.kt
@@ -30,10 +30,12 @@ import java.util.UUID
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class AnalyticsRequestV2(
-    private val eventName: String,
+    @get:VisibleForTesting
+    val eventName: String,
     private val clientId: String,
     origin: String,
-    params: Map<String, *>
+    @get:VisibleForTesting
+    val params: Map<String, *>
 ) : StripeRequest() {
     @VisibleForTesting
     internal val postParameters: String =

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2Factory.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2Factory.kt
@@ -34,7 +34,7 @@ class AnalyticsRequestV2Factory(
      */
     fun createRequestR(
         eventName: String,
-        additionalParams: Map<String, Any> = mapOf(),
+        additionalParams: Map<String, Any?> = mapOf(),
         includeSDKParams: Boolean = true
     ) = AnalyticsRequestV2(
         eventName = eventName,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Send most `status tracking` events from this internal [doc](https://docs.google.com/document/d/1LyVYV4mLaozxjJu-wkMojDdAkV8NajQ_E8NVNAQAGK4/edit#bookmark=id.gxdz3g2cbq1j)

Note: `verification_succeed`, `document_timeout` and `selfie_timeout` are not yet sent, a global singleton to track the accumulated states is needed for these events. Will send them in a separate PR


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Analytics for identity


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
