### PR TITLE
[Identity] keep track of fallbackUrlLaunch and recover

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
@@ -68,9 +68,11 @@ internal class IdentityActivity :
     }
     private lateinit var fallbackUrlLauncher: ActivityResultLauncher<Intent>
 
+    private var launchedFallbackUrl: Boolean = false
+
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        outState.putBoolean(KEY_LAUNCHED, true)
+        outState.putBoolean(KEY_LAUNCHED_FALLBACK_URL, launchedFallbackUrl)
         outState.putBoolean(KEY_PRESENTED, true)
     }
 
@@ -119,7 +121,11 @@ internal class IdentityActivity :
             )
         }
 
-        if (savedInstanceState == null || !savedInstanceState.getBoolean(KEY_LAUNCHED, false)) {
+        if (savedInstanceState == null || !savedInstanceState.getBoolean(
+                KEY_LAUNCHED_FALLBACK_URL,
+                false
+            )
+        ) {
             // The Activity is newly created, set up navigation flow normally
             setContentView(binding.root)
             setUpNavigationController()
@@ -316,6 +322,7 @@ internal class IdentityActivity :
     }
 
     override fun launchFallbackUrl(fallbackUrl: String) {
+        launchedFallbackUrl = true
         val customTabsIntent = CustomTabsIntent.Builder()
             .build()
         customTabsIntent.intent.data = Uri.parse(fallbackUrl)
@@ -326,7 +333,7 @@ internal class IdentityActivity :
         const val EMPTY_ARG_ERROR =
             "IdentityActivity was started without arguments"
 
-        const val KEY_LAUNCHED = "launched"
+        const val KEY_LAUNCHED_FALLBACK_URL = "launched_fallback_url"
 
         const val KEY_PRESENTED = "presented"
 

--- a/identity/src/test/java/com/stripe/android/identity/IdentityActivityTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/IdentityActivityTest.kt
@@ -340,7 +340,27 @@ internal class IdentityActivityTest {
     }
 
     @Test
-    fun `when activity is recreated finishes with result`() {
+    fun `when activity is recreated after launchFallbackUrl no fragment is recreated`() {
+        injectableActivityScenario<IdentityActivity> {
+            injectActivity {
+                viewModelFactory = mockIdentityViewModelFactory
+            }
+        }.launch(
+            IdentityVerificationSheetContract().createIntent(
+                context = ApplicationProvider.getApplicationContext(),
+                input = ARGS
+            )
+        ).onActivity {
+            verify(mockIdentityViewModel).retrieveAndBufferVerificationPage()
+            assertThat(it.supportFragmentManager.fragments.size).isEqualTo(1)
+            it.launchFallbackUrl("fallback")
+        }.recreate().onActivity {
+            assertThat(it.supportFragmentManager.fragments.size).isEqualTo(0)
+        }
+    }
+
+    @Test
+    fun `when activity is recreated without launchFallbackUrl fragment is recreated`() {
         injectableActivityScenario<IdentityActivity> {
             injectActivity {
                 viewModelFactory = mockIdentityViewModelFactory
@@ -354,7 +374,7 @@ internal class IdentityActivityTest {
             verify(mockIdentityViewModel).retrieveAndBufferVerificationPage()
             assertThat(it.supportFragmentManager.fragments.size).isEqualTo(1)
         }.recreate().onActivity {
-            assertThat(it.supportFragmentManager.fragments.size).isEqualTo(0)
+            assertThat(it.supportFragmentManager.fragments.size).isEqualTo(1)
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Instead of save the boolean on `onSaveInstanceState`, we should only turn on the boolean when `launchFallbackUrl` is called. This would correctly recover the fragment status when the app is brought to background and brought to front

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Recover fragment status

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
