### PR TITLE
Restore selected payment method when user returns to Link

### DIFF
--- a/link/api/link.api
+++ b/link/api/link.api
@@ -18,8 +18,8 @@ public final class com/stripe/android/link/LinkActivityContract$Args : com/strip
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/link/LinkActivityContract$Args$Companion;
-	public final fun copy (Lcom/stripe/android/model/StripeIntent;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/link/LinkActivityContract$Args$InjectionParams;)Lcom/stripe/android/link/LinkActivityContract$Args;
-	public static synthetic fun copy$default (Lcom/stripe/android/link/LinkActivityContract$Args;Lcom/stripe/android/model/StripeIntent;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/link/LinkActivityContract$Args$InjectionParams;ILjava/lang/Object;)Lcom/stripe/android/link/LinkActivityContract$Args;
+	public final fun copy (Lcom/stripe/android/model/StripeIntent;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/link/LinkPaymentDetails;Lcom/stripe/android/link/LinkActivityContract$Args$InjectionParams;)Lcom/stripe/android/link/LinkActivityContract$Args;
+	public static synthetic fun copy$default (Lcom/stripe/android/link/LinkActivityContract$Args;Lcom/stripe/android/model/StripeIntent;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/link/LinkPaymentDetails;Lcom/stripe/android/link/LinkActivityContract$Args$InjectionParams;ILjava/lang/Object;)Lcom/stripe/android/link/LinkActivityContract$Args;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -121,21 +121,11 @@ public final class com/stripe/android/link/LinkActivityViewModel_Factory_Members
 	public static fun injectViewModel (Lcom/stripe/android/link/LinkActivityViewModel$Factory;Lcom/stripe/android/link/LinkActivityViewModel;)V
 }
 
-public final class com/stripe/android/link/LinkPaymentDetails : android/os/Parcelable {
+public abstract class com/stripe/android/link/LinkPaymentDetails : android/os/Parcelable {
 	public static final field $stable I
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (Lcom/stripe/android/model/ConsumerPaymentDetails$PaymentDetails;Lcom/stripe/android/model/PaymentMethodCreateParams;)V
-	public final fun component1 ()Lcom/stripe/android/model/ConsumerPaymentDetails$PaymentDetails;
-	public final fun component2 ()Lcom/stripe/android/model/PaymentMethodCreateParams;
-	public final fun copy (Lcom/stripe/android/model/ConsumerPaymentDetails$PaymentDetails;Lcom/stripe/android/model/PaymentMethodCreateParams;)Lcom/stripe/android/link/LinkPaymentDetails;
-	public static synthetic fun copy$default (Lcom/stripe/android/link/LinkPaymentDetails;Lcom/stripe/android/model/ConsumerPaymentDetails$PaymentDetails;Lcom/stripe/android/model/PaymentMethodCreateParams;ILjava/lang/Object;)Lcom/stripe/android/link/LinkPaymentDetails;
-	public fun describeContents ()I
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getPaymentDetails ()Lcom/stripe/android/model/ConsumerPaymentDetails$PaymentDetails;
-	public final fun getPaymentMethodCreateParams ()Lcom/stripe/android/model/PaymentMethodCreateParams;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
+	public synthetic fun <init> (Lcom/stripe/android/model/ConsumerPaymentDetails$PaymentDetails;Lcom/stripe/android/model/PaymentMethodCreateParams;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getPaymentDetails ()Lcom/stripe/android/model/ConsumerPaymentDetails$PaymentDetails;
+	public fun getPaymentMethodCreateParams ()Lcom/stripe/android/model/PaymentMethodCreateParams;
 }
 
 public final class com/stripe/android/link/LinkPaymentLauncher_Factory {

--- a/link/build.gradle
+++ b/link/build.gradle
@@ -105,7 +105,8 @@ android {
     kotlinOptions {
         freeCompilerArgs = [
                 "-Xuse-experimental=androidx.compose.ui.ExperimentalComposeUiApi",
-                "-Xuse-experimental=kotlinx.coroutines.FlowPreview"
+                "-Xuse-experimental=kotlinx.coroutines.FlowPreview",
+                "-Xopt-in=kotlin.RequiresOptIn"
         ]
         jvmTarget = "1.8"
     }

--- a/link/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -167,11 +167,21 @@ internal class LinkActivity : ComponentActivity() {
                                 }
                             }
 
-                            composable(LinkScreen.PaymentMethod.route) {
+                            composable(
+                                LinkScreen.PaymentMethod.route,
+                                arguments = listOf(
+                                    navArgument(LinkScreen.PaymentMethod.loadArg) {
+                                        type = NavType.BoolType
+                                    }
+                                )
+                            ) { backStackEntry ->
+                                val loadFromArgs = backStackEntry.arguments
+                                    ?.getBoolean(LinkScreen.PaymentMethod.loadArg) ?: false
                                 linkAccount?.let { account ->
                                     PaymentMethodBody(
                                         account,
-                                        viewModel.injector
+                                        viewModel.injector,
+                                        loadFromArgs
                                     )
                                 }
                             }

--- a/link/src/main/java/com/stripe/android/link/LinkActivityContract.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivityContract.kt
@@ -31,6 +31,7 @@ class LinkActivityContract :
      * @param merchantName The customer-facing business name.
      * @param customerEmail Email of the customer, used to pre-fill the form.
      * @param customerPhone Phone number of the customer, used to pre-fill the form.
+     * @param selectedPaymentDetails The payment method previously selected by the user.
      * @param injectionParams Parameters needed to perform dependency injection.
      *                        If null, a new dependency graph will be created.
      */
@@ -41,6 +42,7 @@ class LinkActivityContract :
         internal val merchantName: String,
         internal val customerEmail: String? = null,
         internal val customerPhone: String? = null,
+        internal val selectedPaymentDetails: LinkPaymentDetails? = null,
         internal val injectionParams: InjectionParams? = null
     ) : ActivityStarter.Args {
 

--- a/link/src/main/java/com/stripe/android/link/LinkPaymentDetails.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkPaymentDetails.kt
@@ -1,8 +1,10 @@
 package com.stripe.android.link
 
 import android.os.Parcelable
+import com.stripe.android.link.ui.forms.FormController
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.ui.core.forms.convertToFormValuesMap
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -13,8 +15,36 @@ import kotlinx.parcelize.Parcelize
  * @param paymentMethodCreateParams The [PaymentMethodCreateParams] to be used to confirm
  *                                  the Stripe Intent.
  */
-@Parcelize
-data class LinkPaymentDetails(
-    val paymentDetails: ConsumerPaymentDetails.PaymentDetails,
-    val paymentMethodCreateParams: PaymentMethodCreateParams
-) : Parcelable
+sealed class LinkPaymentDetails(
+    open val paymentDetails: ConsumerPaymentDetails.PaymentDetails,
+    open val paymentMethodCreateParams: PaymentMethodCreateParams
+) : Parcelable {
+
+    /**
+     * A [ConsumerPaymentDetails.PaymentDetails] that is already saved to the consumer's account.
+     */
+    @Parcelize
+    internal class Saved(
+        override val paymentDetails: ConsumerPaymentDetails.PaymentDetails,
+        override val paymentMethodCreateParams: PaymentMethodCreateParams
+    ) : LinkPaymentDetails(paymentDetails, paymentMethodCreateParams)
+
+    /**
+     * A new [ConsumerPaymentDetails.PaymentDetails], whose data was just collected from the user.
+     * Must hold the original [PaymentMethodCreateParams] too in case we need to populate the form
+     * fields with the user-entered values.
+     */
+    @Parcelize
+    internal class New(
+        override val paymentDetails: ConsumerPaymentDetails.PaymentDetails,
+        override val paymentMethodCreateParams: PaymentMethodCreateParams,
+        private val originalParams: PaymentMethodCreateParams
+    ) : LinkPaymentDetails(paymentDetails, paymentMethodCreateParams) {
+
+        /**
+         * Build a flat map of the values entered by the user when creating this payment method,
+         * in a format that can be used to set the initial values in the [FormController].
+         */
+        fun buildFormValues() = convertToFormValuesMap(originalParams.toParamMap())
+    }
+}

--- a/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
@@ -112,14 +112,17 @@ class LinkPaymentLauncher @AssistedInject internal constructor(
      * @param stripeIntent the PaymentIntent or SetupIntent.
      * @param completePayment whether the payment should be completed, or the selected payment
      *  method should be returned as a result.
+     * @param selectedPaymentDetails the payment method previously selected by the user, if they are
+     *  returning to Link. It will be the initially selected value.
      * @param coroutineScope the coroutine scope used to collect the account status flow.
      */
     suspend fun setup(
         stripeIntent: StripeIntent,
         completePayment: Boolean,
+        selectedPaymentDetails: LinkPaymentDetails?,
         coroutineScope: CoroutineScope
     ): AccountStatus {
-        val component = setupDependencies(stripeIntent, completePayment)
+        val component = setupDependencies(stripeIntent, completePayment, selectedPaymentDetails)
         accountStatus = component.linkAccountManager.accountStatus.stateIn(coroutineScope)
         linkAccountManager = component.linkAccountManager
         return accountStatus.value
@@ -152,13 +155,14 @@ class LinkPaymentLauncher @AssistedInject internal constructor(
         paymentMethodCreateParams: PaymentMethodCreateParams
     ): Result<LinkPaymentDetails> =
         linkAccountManager.createPaymentDetails(
-            SupportedPaymentMethod.Card(),
+            SupportedPaymentMethod.Card,
             paymentMethodCreateParams
         )
 
     private fun setupDependencies(
         stripeIntent: StripeIntent,
-        completePayment: Boolean
+        completePayment: Boolean,
+        selectedPaymentDetails: LinkPaymentDetails?
     ): LinkPaymentLauncherComponent {
         val args = LinkActivityContract.Args(
             stripeIntent,
@@ -166,6 +170,7 @@ class LinkPaymentLauncher @AssistedInject internal constructor(
             merchantName,
             customerEmail,
             customerPhone,
+            selectedPaymentDetails,
             LinkActivityContract.Args.InjectionParams(
                 injectorKey,
                 productUsage,

--- a/link/src/main/java/com/stripe/android/link/LinkScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkScreen.kt
@@ -12,7 +12,16 @@ internal sealed class LinkScreen(
     object Loading : LinkScreen("Loading")
     object Verification : LinkScreen("Verification")
     object Wallet : LinkScreen("Wallet")
-    object PaymentMethod : LinkScreen("PaymentMethod")
+
+    class PaymentMethod(loadFromArgs: Boolean = false) :
+        LinkScreen("PaymentMethod?$loadArg=$loadFromArgs") {
+        override val route = super.route
+
+        companion object {
+            const val loadArg = "loadFromArgs"
+            const val route = "PaymentMethod?$loadArg={$loadArg}"
+        }
+    }
 
     class CardEdit(paymentDetailsId: String) :
         LinkScreen("CardEdit?$idArg=${paymentDetailsId.urlEncode()}") {

--- a/link/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
+++ b/link/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
@@ -9,7 +9,6 @@ import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.repositories.LinkRepository
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.link.ui.paymentmethod.SupportedPaymentMethod
-import com.stripe.android.model.ConsumerPaymentDetailsCreateParams
 import com.stripe.android.model.ConsumerPaymentDetailsUpdateParams
 import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -193,9 +192,10 @@ internal class LinkAccountManager @Inject constructor(
     ): Result<LinkPaymentDetails> =
         linkAccount.value?.let { account ->
             createPaymentDetails(
-                paymentMethod.createParams(paymentMethodCreateParams, account.email),
-                args.stripeIntent,
-                paymentMethod.extraConfirmationParams(paymentMethodCreateParams)
+                paymentMethod,
+                paymentMethodCreateParams,
+                account.email,
+                args.stripeIntent
             )
         } ?: Result.failure(
             IllegalStateException("A non-null Link account is needed to create payment details")
@@ -205,14 +205,16 @@ internal class LinkAccountManager @Inject constructor(
      * Create a new payment method in the signed in consumer account.
      */
     suspend fun createPaymentDetails(
-        paymentDetails: ConsumerPaymentDetailsCreateParams,
-        stripeIntent: StripeIntent,
-        extraConfirmationParams: Map<String, Any>?
+        paymentMethod: SupportedPaymentMethod,
+        paymentMethodCreateParams: PaymentMethodCreateParams,
+        userEmail: String,
+        stripeIntent: StripeIntent
     ) = retryingOnAuthError { clientSecret ->
         linkRepository.createPaymentDetails(
-            paymentDetails,
+            paymentMethod,
+            paymentMethodCreateParams,
+            userEmail,
             stripeIntent,
-            extraConfirmationParams,
             clientSecret,
             consumerPublishableKey
         )

--- a/link/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
+++ b/link/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
@@ -1,11 +1,12 @@
 package com.stripe.android.link.repositories
 
 import com.stripe.android.link.LinkPaymentDetails
+import com.stripe.android.link.ui.paymentmethod.SupportedPaymentMethod
 import com.stripe.android.model.ConsumerPaymentDetails
-import com.stripe.android.model.ConsumerPaymentDetailsCreateParams
 import com.stripe.android.model.ConsumerPaymentDetailsUpdateParams
 import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.ConsumerSessionLookup
+import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.StripeIntent
 
 /**
@@ -71,9 +72,10 @@ internal interface LinkRepository {
      * Create a new payment method in the consumer account.
      */
     suspend fun createPaymentDetails(
-        paymentDetails: ConsumerPaymentDetailsCreateParams,
+        paymentMethod: SupportedPaymentMethod,
+        paymentMethodCreateParams: PaymentMethodCreateParams,
+        userEmail: String,
         stripeIntent: StripeIntent,
-        extraConfirmationParams: Map<String, Any>? = null,
         consumerSessionClientSecret: String,
         consumerPublishableKey: String?
     ): Result<LinkPaymentDetails>

--- a/link/src/main/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreen.kt
@@ -1,15 +1,20 @@
 package com.stripe.android.link.ui.paymentmethod
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -52,33 +57,52 @@ private fun PaymentMethodBodyPreview() {
 @Composable
 internal fun PaymentMethodBody(
     linkAccount: LinkAccount,
-    injector: NonFallbackInjector
+    injector: NonFallbackInjector,
+    loadFromArgs: Boolean
 ) {
     val viewModel: PaymentMethodViewModel = viewModel(
-        factory = PaymentMethodViewModel.Factory(linkAccount, injector)
+        factory = PaymentMethodViewModel.Factory(linkAccount, injector, loadFromArgs)
     )
 
-    val formValues by viewModel.formController.completeFormValues.collectAsState(null)
-    val isProcessing by viewModel.isProcessing.collectAsState()
-    val errorMessage by viewModel.errorMessage.collectAsState()
+    val formController by viewModel.formController.collectAsState()
 
-    PaymentMethodBody(
-        isProcessing = isProcessing,
-        primaryButtonLabel = primaryButtonLabel(viewModel.args, LocalContext.current.resources),
-        primaryButtonEnabled = formValues != null,
-        secondaryButtonLabel = stringResource(id = viewModel.secondaryButtonLabel),
-        errorMessage = errorMessage,
-        onPrimaryButtonClick = {
-            formValues?.let {
-                viewModel.startPayment(it)
+    if (formController == null) {
+        Box(
+            modifier = Modifier
+                .fillMaxHeight()
+                .fillMaxWidth(),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator()
+        }
+    } else {
+        formController?.let {
+            val formValues by it.completeFormValues.collectAsState(null)
+            val isProcessing by viewModel.isProcessing.collectAsState()
+            val errorMessage by viewModel.errorMessage.collectAsState()
+
+            PaymentMethodBody(
+                isProcessing = isProcessing,
+                primaryButtonLabel = primaryButtonLabel(
+                    viewModel.args,
+                    LocalContext.current.resources
+                ),
+                primaryButtonEnabled = formValues != null,
+                secondaryButtonLabel = stringResource(id = viewModel.secondaryButtonLabel),
+                errorMessage = errorMessage,
+                onPrimaryButtonClick = {
+                    formValues?.let {
+                        viewModel.startPayment(it)
+                    }
+                },
+                onSecondaryButtonClick = viewModel::onSecondaryButtonClick
+            ) {
+                Form(
+                    it,
+                    viewModel.isEnabled
+                )
             }
-        },
-        onSecondaryButtonClick = viewModel::onSecondaryButtonClick
-    ) {
-        Form(
-            viewModel.formController,
-            viewModel.isEnabled
-        )
+        }
     }
 }
 

--- a/link/src/main/java/com/stripe/android/link/ui/paymentmethod/SupportedPaymentMethod.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/paymentmethod/SupportedPaymentMethod.kt
@@ -35,7 +35,7 @@ internal sealed class SupportedPaymentMethod(
         Map<String, Any>? = null
 
     @Parcelize
-    class Card : SupportedPaymentMethod(
+    object Card : SupportedPaymentMethod(
         PaymentMethod.Type.Card,
         LinkCardForm.items
     ) {

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -86,6 +86,7 @@ private fun WalletBodyPreview() {
                         "4444"
                     )
                 ),
+                initiallySelectedId = null,
                 primaryButtonLabel = "Pay $10.99",
                 errorMessage = null,
                 onAddNewPaymentMethodClick = {},
@@ -119,6 +120,7 @@ internal fun WalletBody(
     WalletBody(
         isProcessing = isProcessing,
         paymentDetails = paymentDetails,
+        initiallySelectedId = viewModel.initiallySelectedId,
         primaryButtonLabel = primaryButtonLabel(viewModel.args, LocalContext.current.resources),
         errorMessage = errorMessage,
         onAddNewPaymentMethodClick = viewModel::addNewPaymentMethod,
@@ -134,6 +136,7 @@ internal fun WalletBody(
 internal fun WalletBody(
     isProcessing: Boolean,
     paymentDetails: List<ConsumerPaymentDetails.PaymentDetails>,
+    initiallySelectedId: String?,
     primaryButtonLabel: String,
     errorMessage: ErrorMessage?,
     onAddNewPaymentMethodClick: () -> Unit,
@@ -177,7 +180,7 @@ internal fun WalletBody(
             Spacer(modifier = Modifier.height(12.dp))
 
             var selectedItemId by rememberSaveable {
-                mutableStateOf(getDefaultSelectedCard(paymentDetails))
+                mutableStateOf(initiallySelectedId ?: getDefaultSelectedCard(paymentDetails))
             }
 
             // Update selected item if it's not on the list anymore

--- a/link/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
@@ -27,6 +27,7 @@ class LinkActivityContractTest {
             "Merchant, Inc",
             "customer@email.com",
             "1234567890",
+            null,
             injectionParams
         )
 

--- a/link/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -38,6 +38,7 @@ class LinkActivityViewModelTest {
         MERCHANT_NAME,
         CUSTOMER_EMAIL,
         CUSTOMER_PHONE,
+        null,
         LinkActivityContract.Args.InjectionParams(
             INJECTOR_KEY,
             setOf(PRODUCT_USAGE),

--- a/link/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
@@ -49,7 +49,7 @@ class LinkPaymentLauncherTest {
         runTest {
             launch {
                 val stripeIntent = StripeIntentFixtures.PI_SUCCEEDED
-                linkPaymentLauncher.setup(stripeIntent, true, this)
+                linkPaymentLauncher.setup(stripeIntent, true, null, this)
                 linkPaymentLauncher.present(mockHostActivityLauncher)
 
                 verify(mockHostActivityLauncher).launch(

--- a/link/src/test/java/com/stripe/android/link/account/LinkAccountManagerTest.kt
+++ b/link/src/test/java/com/stripe/android/link/account/LinkAccountManagerTest.kt
@@ -346,6 +346,7 @@ class LinkAccountManagerTest {
                 anyOrNull(),
                 anyOrNull(),
                 anyOrNull(),
+                anyOrNull(),
                 anyOrNull()
             )
         ).thenReturn(
@@ -353,10 +354,12 @@ class LinkAccountManagerTest {
             Result.success(mock())
         )
 
-        accountManager.createPaymentDetails(mock(), mock(), mock())
+        accountManager.createPaymentDetails(mock(), mock(), "", mock())
 
         verify(linkRepository, times(2))
-            .createPaymentDetails(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull())
+            .createPaymentDetails(
+                anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()
+            )
         verify(linkRepository).lookupConsumer(anyOrNull(), anyOrNull())
 
         assertThat(accountManager.linkAccount.value).isNotNull()
@@ -374,6 +377,7 @@ class LinkAccountManagerTest {
                 anyOrNull(),
                 anyOrNull(),
                 anyOrNull(),
+                anyOrNull(),
                 anyOrNull()
             )
         ).thenReturn(
@@ -381,10 +385,12 @@ class LinkAccountManagerTest {
             Result.success(mock())
         )
 
-        accountManager.createPaymentDetails(mock(), mock(), mock())
+        accountManager.createPaymentDetails(mock(), mock(), "", mock())
 
         verify(linkRepository)
-            .createPaymentDetails(anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull())
+            .createPaymentDetails(
+                anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()
+            )
         verify(linkRepository, times(0)).lookupConsumer(anyOrNull(), anyOrNull())
     }
 

--- a/link/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModelTest.kt
@@ -23,9 +23,9 @@ import com.stripe.android.link.model.PaymentDetailsFixtures
 import com.stripe.android.link.model.StripeIntentFixtures
 import com.stripe.android.link.ui.ErrorMessage
 import com.stripe.android.model.ConfirmStripeIntentParams
-import com.stripe.android.model.ConsumerPaymentDetailsCreateParams
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.payments.paymentlauncher.PaymentResult
+import com.stripe.android.ui.core.FieldValuesToParamsMapConverter
 import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.ui.core.forms.FormFieldEntry
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -33,6 +33,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argWhere
@@ -67,7 +68,7 @@ class PaymentMethodViewModelTest {
     private val formControllerSubcomponent = mock<FormControllerSubcomponent>().apply {
         whenever(formController).thenReturn(mock())
     }
-    private val formControllerProvider = Provider {
+    private val formControllerSubcomponentBuilder =
         mock<FormControllerSubcomponent.Builder>().apply {
             whenever(formSpec(anyOrNull())).thenReturn(this)
             whenever(initialValues(anyOrNull())).thenReturn(this)
@@ -75,7 +76,7 @@ class PaymentMethodViewModelTest {
             whenever(viewModelScope(anyOrNull())).thenReturn(this)
             whenever(build()).thenReturn(formControllerSubcomponent)
         }
-    }
+    private val formControllerProvider = Provider { formControllerSubcomponentBuilder }
 
     @Before
     fun before() {
@@ -86,13 +87,20 @@ class PaymentMethodViewModelTest {
 
     @Test
     fun `startPayment creates PaymentDetails`() = runTest {
-        whenever(linkAccountManager.createPaymentDetails(anyOrNull(), anyOrNull(), anyOrNull()))
-            .thenReturn(Result.success(createLinkPaymentDetails()))
+        whenever(
+            linkAccountManager.createPaymentDetails(
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull()
+            )
+        ).thenReturn(Result.success(createLinkPaymentDetails()))
 
         createViewModel().startPayment(cardFormFieldValues)
 
-        val paramsCaptor = argumentCaptor<ConsumerPaymentDetailsCreateParams>()
+        val paramsCaptor = argumentCaptor<PaymentMethodCreateParams>()
         verify(linkAccountManager).createPaymentDetails(
+            any(),
             paramsCaptor.capture(),
             any(),
             anyOrNull()
@@ -101,15 +109,17 @@ class PaymentMethodViewModelTest {
         assertThat(paramsCaptor.firstValue.toParamMap()).isEqualTo(
             mapOf(
                 "type" to "card",
-                "billing_email_address" to "email@stripe.com",
                 "card" to mapOf(
                     "number" to "5555555555554444",
                     "exp_month" to "12",
-                    "exp_year" to "2050"
+                    "exp_year" to "2050",
+                    "cvc" to "123"
                 ),
-                "billing_address" to mapOf(
-                    "country_code" to "US",
-                    "postal_code" to "12345"
+                "billing_details" to mapOf(
+                    "address" to mapOf(
+                        "country" to "US",
+                        "postal_code" to "12345"
+                    )
                 )
             )
         )
@@ -120,7 +130,12 @@ class PaymentMethodViewModelTest {
         runTest {
             val value = createLinkPaymentDetails()
             whenever(
-                linkAccountManager.createPaymentDetails(anyOrNull(), anyOrNull(), anyOrNull())
+                linkAccountManager.createPaymentDetails(
+                    anyOrNull(),
+                    anyOrNull(),
+                    anyOrNull(),
+                    anyOrNull()
+                )
             ).thenReturn(Result.success(value))
 
             createViewModel().startPayment(cardFormFieldValues)
@@ -163,7 +178,12 @@ class PaymentMethodViewModelTest {
 
             val linkPaymentDetails = createLinkPaymentDetails()
             whenever(
-                linkAccountManager.createPaymentDetails(anyOrNull(), anyOrNull(), anyOrNull())
+                linkAccountManager.createPaymentDetails(
+                    anyOrNull(),
+                    anyOrNull(),
+                    anyOrNull(),
+                    anyOrNull()
+                )
             ).thenReturn(Result.success(linkPaymentDetails))
 
             createViewModel().startPayment(cardFormFieldValues)
@@ -179,7 +199,12 @@ class PaymentMethodViewModelTest {
     @Test
     fun `startPayment dismisses Link on success`() = runTest {
         whenever(
-            linkAccountManager.createPaymentDetails(anyOrNull(), anyOrNull(), anyOrNull())
+            linkAccountManager.createPaymentDetails(
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull()
+            )
         ).thenReturn(Result.success(createLinkPaymentDetails()))
 
         var callback: PaymentConfirmationCallback? = null
@@ -203,7 +228,12 @@ class PaymentMethodViewModelTest {
     @Test
     fun `startPayment starts processing`() = runTest {
         whenever(
-            linkAccountManager.createPaymentDetails(anyOrNull(), anyOrNull(), anyOrNull())
+            linkAccountManager.createPaymentDetails(
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull()
+            )
         ).thenReturn(Result.success(createLinkPaymentDetails()))
 
         val viewModel = createViewModel()
@@ -221,7 +251,12 @@ class PaymentMethodViewModelTest {
     @Test
     fun `startPayment stops processing on error`() = runTest {
         whenever(
-            linkAccountManager.createPaymentDetails(anyOrNull(), anyOrNull(), anyOrNull())
+            linkAccountManager.createPaymentDetails(
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull()
+            )
         ).thenReturn(Result.success(createLinkPaymentDetails()))
 
         var callback: PaymentConfirmationCallback? = null
@@ -253,7 +288,12 @@ class PaymentMethodViewModelTest {
     fun `when startPayment fails then an error message is shown`() = runTest {
         val errorMessage = "Error message"
         whenever(
-            linkAccountManager.createPaymentDetails(anyOrNull(), anyOrNull(), anyOrNull())
+            linkAccountManager.createPaymentDetails(
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull()
+            )
         ).thenReturn(Result.failure(RuntimeException(errorMessage)))
 
         val viewModel = createViewModel()
@@ -261,6 +301,27 @@ class PaymentMethodViewModelTest {
         viewModel.startPayment(cardFormFieldValues)
 
         assertThat(viewModel.errorMessage.value).isEqualTo(ErrorMessage.Raw(errorMessage))
+    }
+
+    @Test
+    fun `when loading from arguments fails then form is prefilled`() = runTest {
+        whenever(args.selectedPaymentDetails).thenReturn(createLinkPaymentDetails())
+        createViewModel(true)
+
+        val initialValuesCaptor: KArgumentCaptor<Map<IdentifierSpec, String?>> = argumentCaptor()
+        verify(formControllerSubcomponentBuilder).initialValues(initialValuesCaptor.capture())
+
+        assertThat(initialValuesCaptor.firstValue).containsAtLeastEntriesIn(
+            mapOf(
+                IdentifierSpec.get("type") to "card",
+                IdentifierSpec.CardNumber to "5555555555554444",
+                IdentifierSpec.CardCvc to "123",
+                IdentifierSpec.CardExpMonth to "12",
+                IdentifierSpec.CardExpYear to "2050",
+                IdentifierSpec.Country to "US",
+                IdentifierSpec.PostalCode to "12345"
+            )
+        )
     }
 
     @Test
@@ -323,14 +384,15 @@ class PaymentMethodViewModelTest {
 
         val factory = PaymentMethodViewModel.Factory(
             mock(),
-            injector
+            injector,
+            false
         )
         val factorySpy = spy(factory)
         val createdViewModel = factorySpy.create(PaymentMethodViewModel::class.java)
         assertThat(createdViewModel).isEqualTo(vmToBeReturned)
     }
 
-    private fun createViewModel() =
+    private fun createViewModel(loadFromArgs: Boolean = false) =
         PaymentMethodViewModel(
             args,
             linkAccount,
@@ -339,16 +401,21 @@ class PaymentMethodViewModelTest {
             confirmationManager,
             logger,
             formControllerProvider
-        )
+        ).apply { init(loadFromArgs) }
 
     private fun createLinkPaymentDetails() =
         PaymentDetailsFixtures.CONSUMER_SINGLE_PAYMENT_DETAILS.paymentDetails.first().let {
-            LinkPaymentDetails(
+            LinkPaymentDetails.New(
                 it,
                 PaymentMethodCreateParams.createLink(
                     it.id,
                     CLIENT_SECRET,
                     mapOf("card" to mapOf("cvc" to "123"))
+                ),
+                FieldValuesToParamsMapConverter.transformToPaymentMethodCreateParams(
+                    cardFormFieldValues,
+                    "card",
+                    false
                 )
             )
         }

--- a/link/src/test/java/com/stripe/android/link/ui/signup/SignUpViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/signup/SignUpViewModelTest.kt
@@ -51,6 +51,7 @@ class SignUpViewModelTest {
         MERCHANT_NAME,
         CUSTOMER_EMAIL,
         CUSTOMER_PHONE,
+        null,
         LinkActivityContract.Args.InjectionParams(
             INJECTOR_KEY,
             setOf(PRODUCT_USAGE),

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -582,6 +582,10 @@ public final class com/stripe/android/ui/core/forms/TransformSpecToElements {
 	public final fun transform (Ljava/util/List;)Ljava/util/List;
 }
 
+public final class com/stripe/android/ui/core/forms/UtilsKt {
+	public static final fun convertToFormValuesMap (Ljava/util/Map;)Ljava/util/Map;
+}
+
 public final class com/stripe/android/ui/core/forms/resources/AsyncResourceRepository_Factory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/ui/core/forms/resources/AsyncResourceRepository_Factory;

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/Utils.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/Utils.kt
@@ -1,0 +1,38 @@
+package com.stripe.android.ui.core.forms
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.ui.core.elements.IdentifierSpec
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
+fun convertToFormValuesMap(paramMap: Map<String, Any?>): Map<IdentifierSpec, String?> {
+    val mutableMap = mutableMapOf<IdentifierSpec, String?>()
+    addPath(paramMap, "", mutableMap)
+    return mutableMap
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun addPath(
+    paramMap: Map<String, Any?>,
+    path: String,
+    output: MutableMap<IdentifierSpec, String?>
+) {
+    for (entry in paramMap.entries) {
+        when (entry.value) {
+            null -> {
+                output[IdentifierSpec.get(addPathKey(path, entry.key))] = null
+            }
+            is String -> {
+                output[IdentifierSpec.get(addPathKey(path, entry.key))] = entry.value as String
+            }
+            is Map<*, *> -> {
+                addPath(entry.value as Map<String, Any>, addPathKey(path, entry.key), output)
+            }
+        }
+    }
+}
+
+private fun addPathKey(original: String, add: String) = if (original.isEmpty()) {
+    add
+} else {
+    "$original[$add]"
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
@@ -187,7 +187,7 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
                 merchantName = sheetViewModel.merchantName,
                 amount = sheetViewModel.amount.value,
                 injectorKey = sheetViewModel.injectorKey,
-                newLpm = sheetViewModel.newLpm,
+                newLpm = sheetViewModel.newPaymentSelection,
                 isShowingLinkInlineSignup = showLinkInlineSignup
             )
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -71,7 +71,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
 
     // Only used to determine if we should skip the list and go to the add card view.
     // and how to populate that view.
-    override var newLpm = args.newLpm
+    override var newPaymentSelection = args.newLpm
 
     // This is used in the case where the last card was new and not saved. In this scenario
     // when the payment options is opened it should jump to the add card, but if the user
@@ -79,7 +79,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
     private var hasTransitionToUnsavedCard = false
     private val shouldTransitionToUnsavedCard: Boolean
         get() =
-            !hasTransitionToUnsavedCard && newLpm != null
+            !hasTransitionToUnsavedCard && newPaymentSelection != null
 
     init {
         savedStateHandle[SAVE_GOOGLE_PAY_READY] = args.isGooglePayReady
@@ -164,7 +164,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
     override fun onLinkPaymentDetailsCollected(linkPaymentDetails: LinkPaymentDetails?) {
         linkPaymentDetails?.let {
             // Link PaymentDetails was created successfully, use it to confirm the Stripe Intent.
-            updateSelection(it.convertToPaymentSelection())
+            updateSelection(PaymentSelection.New.Link(it))
             onUserSelection()
         } ?: run {
             // Creating Link PaymentDetails failed, fallback to regular checkout.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -145,7 +145,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     internal val isProcessingPaymentIntent
         get() = args.clientSecret is PaymentIntentClientSecret
 
-    override var newLpm: PaymentSelection.New? = null
+    override var newPaymentSelection: PaymentSelection.New? = null
 
     @VisibleForTesting
     internal var googlePayPaymentMethodLauncher: GooglePayPaymentMethodLauncher? = null
@@ -410,7 +410,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     override fun onLinkPaymentDetailsCollected(linkPaymentDetails: LinkPaymentDetails?) {
         linkPaymentDetails?.let {
             // Link PaymentDetails was created successfully, use it to confirm the Stripe Intent.
-            updateSelection(it.convertToPaymentSelection())
+            updateSelection(PaymentSelection.New.Link(it))
             checkout(CheckoutIdentifier.SheetBottomBuy)
         } ?: run {
             // Link PaymentDetails creationg failed, fallback to regular checkout.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.model
 import android.os.Parcelable
 import androidx.annotation.DrawableRes
 import androidx.annotation.RestrictTo
+import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.PaymentMethod
@@ -65,12 +66,15 @@ sealed class PaymentSelection : Parcelable {
 
         @Parcelize
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        data class Link(
-            val paymentDetails: ConsumerPaymentDetails.PaymentDetails,
-            override val paymentMethodCreateParams: PaymentMethodCreateParams
-        ) : New() {
+        data class Link(val linkPaymentDetails: LinkPaymentDetails) : New() {
             @IgnoredOnParcel
             override val customerRequestedSave = CustomerRequestedSave.NoRequest
+
+            @IgnoredOnParcel
+            private val paymentDetails = linkPaymentDetails.paymentDetails
+
+            @IgnoredOnParcel
+            override val paymentMethodCreateParams = linkPaymentDetails.paymentMethodCreateParams
 
             @IgnoredOnParcel
             @DrawableRes

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormFragmentArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormFragmentArguments.kt
@@ -7,6 +7,7 @@ import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.elements.IdentifierSpec
+import com.stripe.android.ui.core.forms.convertToFormValuesMap
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -22,11 +23,9 @@ internal data class FormFragmentArguments(
 ) : Parcelable
 
 internal fun FormFragmentArguments.getInitialValuesMap(): Map<IdentifierSpec, String?> {
-
-    list.clear()
-    initialPaymentMethodCreateParams?.let {
-        addPath(it.toParamMap(), "")
-    }
+    val initialValues = initialPaymentMethodCreateParams?.let {
+        convertToFormValuesMap(it.toParamMap())
+    } ?: emptyMap()
 
     return mapOf(
         IdentifierSpec.Name to this.billingDetails?.name,
@@ -38,28 +37,5 @@ internal fun FormFragmentArguments.getInitialValuesMap(): Map<IdentifierSpec, St
         IdentifierSpec.State to this.billingDetails?.address?.state,
         IdentifierSpec.Country to this.billingDetails?.address?.country,
         IdentifierSpec.PostalCode to this.billingDetails?.address?.postalCode
-    ).plus(list.toMap())
-}
-
-private val list = mutableListOf<Pair<IdentifierSpec, String?>>()
-private fun addPath(map: Map<String, Any?>, path: String) {
-    for (entry in map.entries) {
-        when (entry.value) {
-            null -> {
-                list.add(IdentifierSpec.get(addPathKey(path, entry.key)) to null)
-            }
-            is String -> {
-                list.add(IdentifierSpec.get(addPathKey(path, entry.key)) to entry.value as String)
-            }
-            is Map<*, *> -> {
-                addPath(entry.value as Map<String, Any>, addPathKey(path, entry.key))
-            }
-        }
-    }
-}
-
-private fun addPathKey(original: String, add: String) = if (original.isEmpty()) {
-    add
-} else {
-    "$original[$add]"
+    ).plus(initialValues)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormFragment.kt
@@ -139,7 +139,7 @@ internal class USBankAccountFormFragment : Fragment() {
                     sheetViewModel is PaymentSheetViewModel,
                     clientSecret,
                     sheetViewModel?.usBankAccountSavedScreenState,
-                    (sheetViewModel?.newLpm as? PaymentSelection.New.USBankAccount)
+                    (sheetViewModel?.newPaymentSelection as? PaymentSelection.New.USBankAccount)
                 )
             },
             this


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Receive the previously selected `LinkPaymentDetails` during setup, and properly select it when the user returns to Link in the custom flow.
Make the `PaymentMethod` screen receive a parameter determining if it should show the previously selected payment method, fetched from the arguments.
Create two subclasses of `LinkPaymentDetails`, representing saved and new payment methods. A new payment method must hold the data entered by the user so the form can be pre-filled with those values when the user returns.
Move the logic that creates a map used to prefill the forms based on the params map into `payments-ui-core` so that Link also can use it.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Load previously selected payment method when user returns to Link in the custom flow.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
