### PR TITLE
Fallback in case `elements/sessions` throws exception.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/StripeIntentRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/StripeIntentRepository.kt
@@ -54,11 +54,13 @@ internal sealed class StripeIntentRepository {
                 is PaymentIntentClientSecret -> {
                     requireNotNull(
                         locale?.let {
-                            stripeRepository.retrievePaymentIntentWithOrderedPaymentMethods(
-                                clientSecret.value,
-                                requestOptions,
-                                it
-                            )
+                            runCatching {
+                                stripeRepository.retrievePaymentIntentWithOrderedPaymentMethods(
+                                    clientSecret.value,
+                                    requestOptions,
+                                    it
+                                )
+                            }.getOrNull()
                         } ?: stripeRepository.retrievePaymentIntent(
                             clientSecret.value,
                             requestOptions,
@@ -71,11 +73,13 @@ internal sealed class StripeIntentRepository {
                 is SetupIntentClientSecret -> {
                     requireNotNull(
                         locale?.let {
-                            stripeRepository.retrieveSetupIntentWithOrderedPaymentMethods(
-                                clientSecret.value,
-                                requestOptions,
-                                locale
-                            )
+                            runCatching {
+                                stripeRepository.retrieveSetupIntentWithOrderedPaymentMethods(
+                                    clientSecret.value,
+                                    requestOptions,
+                                    locale
+                                )
+                            }.getOrNull()
                         } ?: stripeRepository.retrieveSetupIntent(
                             clientSecret.value,
                             requestOptions,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/StripeIntentRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/StripeIntentRepositoryTest.kt
@@ -19,6 +19,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
+import java.lang.RuntimeException
 import java.util.Locale
 import kotlin.test.Test
 
@@ -58,6 +59,26 @@ internal class StripeIntentRepositoryTest {
                 stripeRepository
                     .retrievePaymentIntentWithOrderedPaymentMethods(any(), any(), any())
             ).thenReturn(null)
+
+            whenever(stripeRepository.retrievePaymentIntent(any(), any(), any()))
+                .thenReturn(PaymentIntentFixtures.PI_WITH_SHIPPING)
+
+            val paymentIntent =
+                createRepository(Locale.ITALY).get(PaymentIntentClientSecret("client_secret"))
+
+            verify(stripeRepository)
+                .retrievePaymentIntentWithOrderedPaymentMethods(any(), any(), any())
+            verify(stripeRepository).retrievePaymentIntent(any(), any(), any())
+            assertThat(paymentIntent).isEqualTo(PaymentIntentFixtures.PI_WITH_SHIPPING)
+        }
+
+    @Test
+    fun `get with locale when ordered payment methods fails with exception should fallback to retrievePaymentIntent()`() =
+        runTest {
+            whenever(
+                stripeRepository
+                    .retrievePaymentIntentWithOrderedPaymentMethods(any(), any(), any())
+            ).thenThrow(RuntimeException())
 
             whenever(stripeRepository.retrievePaymentIntent(any(), any(), any()))
                 .thenReturn(PaymentIntentFixtures.PI_WITH_SHIPPING)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
On PaymentSheet, if `elements/sessions` call returns null we fallback to fetching the payment intent using `payment_intents/$id`. Update this logic to fallback also if the first call throws an exception.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fallback if elements service is down.
https://jira.corp.stripe.com/browse/PWE-345

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
