### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ This release contains several bug fixes for Payments and PaymentSheet, deprecate
 * [FIXED][5079](https://github.com/stripe/stripe-android/pull/5079) Add 3ds2 url to list of completion URLs so callbacks work correctly.
 * [FIXED][5094](https://github.com/stripe/stripe-android/pull/5094) Use correct cvc icon in card form view.
 
+### CardScan
+* [FIXED] [5075](https://github.com/stripe/stripe-android/pull/5075) Prevent a crash when the fragment is detached.
+
 ## 20.4.0 - 2022-05-23
 This release adds [appearance customization APIs](https://github.com/stripe/stripe-android/blob/master/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt#L186) to payment sheet and enables Affirm and AU BECS direct debit as payment methods within Payment Sheet.
 
@@ -81,9 +84,6 @@ This release includes several Payments and PaymentSheet bug fixes.
 ### PaymentSheet
 * [FIXED] [4861](https://github.com/stripe/stripe-android/pull/4861) Remove font resource to save space and default to system default
 * [CHANGED] [4855](https://github.com/stripe/stripe-android/pull/4855) Remove force portrait mode in PaymentLauncher.
-
-### CardScan
-* [FIXED] [5075](https://github.com/stripe/stripe-android/pull/5075) Prevent a crash when the fragment is detached.
 
 ## 20.0.1 - 2022-04-11
 This release includes several PaymentSheet bug fixes.


### PR DESCRIPTION
A semantic merge caused a changelog entry to get into the wrong release.

# Summary
Fix the placement of a StripeCardScan entry in the changelog

# Motivation
PR 5075 was in the wrong release in the changelog. This was likely because it was based on an older commit.

