### PR TITLE
[Identity] finish status tracking analytics

### DIFF
--- a/identity/build.gradle
+++ b/identity/build.gradle
@@ -91,6 +91,9 @@ android {
     testOptions {
         unitTests {
             includeAndroidResources = true
+            all {
+                maxHeapSize = "1024m"
+            }
         }
     }
 

--- a/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
@@ -89,7 +89,7 @@ internal class IdentityActivity :
                     finishWithResult(
                         if (it.submitted) {
                             identityViewModel.sendAnalyticsRequest(
-                                identityViewModel.identityAnalyticsRequestFactory.verificationSucceed(
+                                identityViewModel.identityAnalyticsRequestFactory.verificationSucceeded(
                                     isFromFallbackUrl = true
                                 )
                             )

--- a/identity/src/main/java/com/stripe/android/identity/analytics/AnalyticsState.kt
+++ b/identity/src/main/java/com/stripe/android/identity/analytics/AnalyticsState.kt
@@ -1,0 +1,17 @@
+package com.stripe.android.identity.analytics
+
+import com.stripe.android.identity.networking.models.DocumentUploadParam
+import com.stripe.android.identity.states.IdentityScanState
+
+internal data class AnalyticsState(
+    val scanType: IdentityScanState.ScanType? = null,
+    val requireSelfie: Boolean? = null,
+    val docFrontRetryTimes: Int? = null,
+    val docBackRetryTimes: Int? = null,
+    val selfieRetryTimes: Int? = null,
+    val docFrontUploadType: DocumentUploadParam.UploadMethod? = null,
+    val docBackUploadType: DocumentUploadParam.UploadMethod? = null,
+    val docFrontModelScore: Float? = null,
+    val docBackModelScore: Float? = null,
+    val selfieModelScore: Float? = null
+)

--- a/identity/src/main/java/com/stripe/android/identity/analytics/IdentityAnalyticsRequestFactory.kt
+++ b/identity/src/main/java/com/stripe/android/identity/analytics/IdentityAnalyticsRequestFactory.kt
@@ -36,7 +36,7 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
         )
     )
 
-    fun verificationSucceed(
+    fun verificationSucceeded(
         isFromFallbackUrl: Boolean,
         scanType: IdentityScanState.ScanType? = null,
         requireSelfie: Boolean? = null,
@@ -47,9 +47,9 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
         docBackUploadType: DocumentUploadParam.UploadMethod? = null,
         docFrontModelScore: Float? = null,
         docBackModelScore: Float? = null,
-        selfieModelScore: Float? = null,
+        selfieModelScore: Float? = null
     ) = requestFactory.createRequestR(
-        eventName = EVENT_VERIFICATION_SUCCEED,
+        eventName = EVENT_VERIFICATION_SUCCEEDED,
         additionalParams =
         mapOf(
             PARAM_FROM_FALLBACK_URL to isFromFallbackUrl,
@@ -157,26 +157,19 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
 
     fun documentTimeout(
         scanType: IdentityScanState.ScanType,
-        count: Int
     ) = requestFactory.createRequestR(
         eventName = EVENT_DOCUMENT_TIMEOUT,
         additionalParams = mapOf(
             PARAM_VERIFICATION_SESSION to args.verificationSessionId,
             PARAM_SCAN_TYPE to scanType.toParam(),
-            PARAM_SIDE to scanType.toSide(),
-            PARAM_COUNT to count
+            PARAM_SIDE to scanType.toSide()
         )
     )
 
-    fun selfieTimeout(
-        scanType: IdentityScanState.ScanType,
-        count: Int
-    ) = requestFactory.createRequestR(
+    fun selfieTimeout() = requestFactory.createRequestR(
         eventName = EVENT_SELFIE_TIMEOUT,
         additionalParams = mapOf(
             PARAM_VERIFICATION_SESSION to args.verificationSessionId,
-            PARAM_SCAN_TYPE to scanType.toParam(),
-            PARAM_COUNT to count
         )
     )
 
@@ -215,7 +208,7 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
 
         const val EVENT_SHEET_PRESENTED = "sheet_presented"
         const val EVENT_SHEET_CLOSED = "sheet_closed"
-        const val EVENT_VERIFICATION_SUCCEED = "verification_succeed"
+        const val EVENT_VERIFICATION_SUCCEEDED = "verification_succeeded"
         const val EVENT_VERIFICATION_FAILED = "verification_failed"
         const val EVENT_VERIFICATION_CANCELED = "verification_canceled"
         const val EVENT_SCREEN_PRESENTED = "screen_presented"
@@ -243,7 +236,6 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
         const val PARAM_EXCEPTION = "exception"
         const val PARAM_STACKTRACE = "stacktrace"
         const val PARAM_SCREEN_NAME = "screen_name"
-        const val PARAM_COUNT = "count"
         const val PARAM_SIDE = "side"
 
         const val SCREEN_NAME_CONSENT = "consent"

--- a/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
@@ -67,6 +67,11 @@ internal class ConsentFragment(
         identityViewModel.observeForVerificationPage(
             viewLifecycleOwner,
             onSuccess = { verificationPage ->
+                identityViewModel.updateAnalyticsState { oldState ->
+                    oldState.copy(
+                        requireSelfie = verificationPage.requireSelfie()
+                    )
+                }
                 if (verificationPage.isUnsupportedClient()) {
                     Log.e(TAG, "Unsupported client, launching fallback url")
                     fallbackUrlLauncher.launchFallbackUrl(verificationPage.fallbackUrl)

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
@@ -18,10 +18,14 @@ import com.stripe.android.camera.scanui.CameraView
 import com.stripe.android.camera.scanui.util.asRect
 import com.stripe.android.core.exception.InvalidResponseException
 import com.stripe.android.identity.R
+import com.stripe.android.identity.ml.FaceDetectorOutput
+import com.stripe.android.identity.ml.IDDetectorOutput
 import com.stripe.android.identity.navigation.CouldNotCaptureFragment.Companion.ARG_COULD_NOT_CAPTURE_SCAN_TYPE
 import com.stripe.android.identity.navigation.CouldNotCaptureFragment.Companion.ARG_REQUIRE_LIVE_CAPTURE
 import com.stripe.android.identity.networking.Status
 import com.stripe.android.identity.states.IdentityScanState
+import com.stripe.android.identity.states.IdentityScanState.Companion.isBack
+import com.stripe.android.identity.states.IdentityScanState.Companion.isFront
 import com.stripe.android.identity.utils.navigateToDefaultErrorFragment
 import com.stripe.android.identity.viewmodel.CameraViewModel
 import com.stripe.android.identity.viewmodel.IdentityScanViewModel
@@ -68,12 +72,44 @@ internal abstract class IdentityCameraScanFragment(
                 viewLifecycleOwner,
                 onSuccess = { verificationPage ->
                     if (finalResult.identityState is IdentityScanState.Finished) {
+                        when (finalResult.result) {
+                            is FaceDetectorOutput -> {
+                                identityViewModel.updateAnalyticsState { oldState ->
+                                    oldState.copy(selfieModelScore = finalResult.result.resultScore)
+                                }
+                            }
+                            is IDDetectorOutput -> {
+                                if (finalResult.identityState.type.isFront()) {
+                                    identityViewModel.updateAnalyticsState { oldState ->
+                                        oldState.copy(docFrontModelScore = finalResult.result.resultScore)
+                                    }
+                                } else if (finalResult.identityState.type.isBack()) {
+                                    identityViewModel.updateAnalyticsState { oldState ->
+                                        oldState.copy(docBackModelScore = finalResult.result.resultScore)
+                                    }
+                                }
+                            }
+                        }
                         identityViewModel.uploadScanResult(
                             finalResult,
                             verificationPage,
                             identityScanViewModel.targetScanType
                         )
                     } else if (finalResult.identityState is IdentityScanState.TimeOut) {
+                        when (finalResult.result) {
+                            is FaceDetectorOutput -> {
+                                identityViewModel.sendAnalyticsRequest(
+                                    identityViewModel.identityAnalyticsRequestFactory.selfieTimeout()
+                                )
+                            }
+                            is IDDetectorOutput -> {
+                                identityViewModel.sendAnalyticsRequest(
+                                    identityViewModel.identityAnalyticsRequestFactory.documentTimeout(
+                                        scanType = finalResult.identityState.type
+                                    )
+                                )
+                            }
+                        }
                         findNavController().navigate(
                             R.id.action_global_couldNotCaptureFragment,
                             bundleOf(
@@ -136,6 +172,46 @@ internal abstract class IdentityCameraScanFragment(
      * Start scanning for the required scan type.
      */
     protected fun startScanning(scanType: IdentityScanState.ScanType) {
+        identityViewModel.updateAnalyticsState { oldState ->
+            when (scanType) {
+                IdentityScanState.ScanType.ID_FRONT -> {
+                    oldState.copy(
+                        docFrontRetryTimes =
+                        oldState.docFrontRetryTimes?.let { it + 1 } ?: 0
+                    )
+                }
+                IdentityScanState.ScanType.ID_BACK -> {
+                    oldState.copy(
+                        docFrontRetryTimes =
+                        oldState.docFrontRetryTimes?.let { it + 1 } ?: 0
+                    )
+                }
+                IdentityScanState.ScanType.DL_FRONT -> {
+                    oldState.copy(
+                        docFrontRetryTimes =
+                        oldState.docFrontRetryTimes?.let { it + 1 } ?: 0
+                    )
+                }
+                IdentityScanState.ScanType.DL_BACK -> {
+                    oldState.copy(
+                        docFrontRetryTimes =
+                        oldState.docFrontRetryTimes?.let { it + 1 } ?: 0
+                    )
+                }
+                IdentityScanState.ScanType.PASSPORT -> {
+                    oldState.copy(
+                        docFrontRetryTimes =
+                        oldState.docFrontRetryTimes?.let { it + 1 } ?: 0
+                    )
+                }
+                IdentityScanState.ScanType.SELFIE -> {
+                    oldState.copy(
+                        selfieRetryTimes =
+                        oldState.selfieRetryTimes?.let { it + 1 } ?: 0
+                    )
+                }
+            }
+        }
         identityScanViewModel.targetScanType = scanType
         resetUI()
         cameraAdapter.bindToLifecycle(this)

--- a/identity/src/main/java/com/stripe/android/identity/states/IdentityScanState.kt
+++ b/identity/src/main/java/com/stripe/android/identity/states/IdentityScanState.kt
@@ -125,4 +125,12 @@ internal sealed class IdentityScanState(
             analyzerOutput: AnalyzerOutput
         ) = this
     }
+
+    internal companion object {
+        fun ScanType.isFront() =
+            this == ScanType.ID_FRONT || this == ScanType.DL_FRONT || this == ScanType.PASSPORT
+
+        fun ScanType.isBack() =
+            this == ScanType.ID_BACK || this == ScanType.DL_BACK
+    }
 }

--- a/identity/src/test/java/com/stripe/android/identity/navigation/ConfirmationFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/ConfirmationFragmentTest.kt
@@ -102,6 +102,7 @@ class ConfirmationFragmentTest {
             setUpSuccessVerificationPage()
             binding.kontinue.callOnClick()
 
+            verify(mockIdentityViewModel).sendSucceededAnalyticsRequestForNative()
             verify(mockVerificationFlowFinishable).finishWithResult(
                 eq(IdentityVerificationSheet.VerificationFlowResult.Completed)
             )

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IdentityCameraScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IdentityCameraScanFragmentTest.kt
@@ -1,0 +1,292 @@
+package com.stripe.android.identity.navigation
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.lifecycle.MediatorLiveData
+import androidx.lifecycle.ViewModelProvider
+import androidx.navigation.Navigation
+import androidx.navigation.testing.TestNavHostController
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.camera.Camera1Adapter
+import com.stripe.android.identity.R
+import com.stripe.android.identity.SUCCESS_VERIFICATION_PAGE_NOT_REQUIRE_LIVE_CAPTURE
+import com.stripe.android.identity.analytics.AnalyticsState
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
+import com.stripe.android.identity.camera.IdentityAggregator
+import com.stripe.android.identity.camera.IdentityScanFlow
+import com.stripe.android.identity.ml.Category
+import com.stripe.android.identity.ml.FaceDetectorOutput
+import com.stripe.android.identity.ml.IDDetectorOutput
+import com.stripe.android.identity.networking.Resource
+import com.stripe.android.identity.networking.models.VerificationPage
+import com.stripe.android.identity.states.IdentityScanState
+import com.stripe.android.identity.utils.SingleLiveEvent
+import com.stripe.android.identity.viewModelFactoryFor
+import com.stripe.android.identity.viewmodel.IdentityScanViewModel
+import com.stripe.android.identity.viewmodel.IdentityViewModel
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import org.mockito.kotlin.KArgumentCaptor
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class IdentityCameraScanFragmentTest {
+    @get:Rule
+    var rule: TestRule = InstantTaskExecutorRule()
+
+    private val finalResultLiveData = SingleLiveEvent<IdentityAggregator.FinalResult>()
+    private val displayStateChanged = SingleLiveEvent<Pair<IdentityScanState, IdentityScanState?>>()
+    private val mockScanFlow = mock<IdentityScanFlow>()
+
+    private val mockIdentityScanViewModel = mock<IdentityScanViewModel>().also {
+        whenever(it.identityScanFlow).thenReturn(mockScanFlow)
+        whenever(it.finalResult).thenReturn(finalResultLiveData)
+        whenever(it.displayStateChanged).thenReturn(displayStateChanged)
+        whenever(it.targetScanType).thenReturn(IdentityScanState.ScanType.ID_FRONT)
+    }
+
+    private val mockPageAndModel = MediatorLiveData<Resource<IdentityViewModel.PageAndModelFiles>>()
+    private val mockIdentityAnalyticsRequestFactory = mock<IdentityAnalyticsRequestFactory>()
+    private val mockIdentityViewModel = mock<IdentityViewModel>().also {
+        whenever(it.pageAndModelFiles).thenReturn(mockPageAndModel)
+        whenever(it.identityAnalyticsRequestFactory).thenReturn(mockIdentityAnalyticsRequestFactory)
+    }
+
+    @Test
+    fun `when document front finished result is posted send analytics`() {
+        launchTestFragmentWithFinalResult(FINISHED_RESULT_ID_FRONT) {
+            val updateBlockCaptor: KArgumentCaptor<(AnalyticsState) -> AnalyticsState> =
+                argumentCaptor()
+            verify(mockIdentityViewModel).updateAnalyticsState(
+                updateBlockCaptor.capture()
+            )
+            val newState = updateBlockCaptor.firstValue(AnalyticsState())
+
+            assertThat(newState.docFrontModelScore).isEqualTo(DOC_FRONT_SCORE)
+        }
+    }
+
+    @Test
+    fun `when document back finished result is posted send analytics`() {
+        launchTestFragmentWithFinalResult(FINISHED_RESULT_ID_BACK) {
+            val updateBlockCaptor: KArgumentCaptor<(AnalyticsState) -> AnalyticsState> =
+                argumentCaptor()
+            verify(mockIdentityViewModel).updateAnalyticsState(
+                updateBlockCaptor.capture()
+            )
+            val newState = updateBlockCaptor.firstValue(AnalyticsState())
+
+            assertThat(newState.docBackModelScore).isEqualTo(DOC_BACK_SCORE)
+        }
+    }
+
+    @Test
+    fun `when selfie finished result is posted send analytics`() {
+        launchTestFragmentWithFinalResult(FINISHED_RESULT_SELFIE) {
+            val updateBlockCaptor: KArgumentCaptor<(AnalyticsState) -> AnalyticsState> =
+                argumentCaptor()
+            verify(mockIdentityViewModel).updateAnalyticsState(
+                updateBlockCaptor.capture()
+            )
+            val newState = updateBlockCaptor.firstValue(AnalyticsState())
+
+            assertThat(newState.selfieModelScore).isEqualTo(SELFIE_SCORE)
+        }
+    }
+
+    @Test
+    fun `when document front timeout result is posted send analytics`() {
+        launchTestFragmentWithFinalResult(TIMEOUT_RESULT_ID_FRONT) {
+            verify(mockIdentityAnalyticsRequestFactory).documentTimeout(
+                scanType = eq(IdentityScanState.ScanType.ID_FRONT)
+            )
+
+            verify(mockIdentityViewModel).sendAnalyticsRequest(anyOrNull())
+        }
+    }
+
+    @Test
+    fun `when document back timeout result is posted send analytics`() {
+        launchTestFragmentWithFinalResult(TIMEOUT_RESULT_ID_BACK) {
+            verify(mockIdentityAnalyticsRequestFactory).documentTimeout(
+                scanType = eq(IdentityScanState.ScanType.ID_BACK)
+            )
+
+            verify(mockIdentityViewModel).sendAnalyticsRequest(anyOrNull())
+        }
+    }
+
+    @Test
+    fun `when selfie timeout result is posted send analytics`() {
+        launchTestFragmentWithFinalResult(TIMEOUT_RESULT_SELFIE) {
+            verify(mockIdentityAnalyticsRequestFactory).selfieTimeout()
+
+            verify(mockIdentityViewModel).sendAnalyticsRequest(anyOrNull())
+        }
+    }
+
+    private fun launchTestFragmentWithFinalResult(
+        finalResult: IdentityAggregator.FinalResult,
+        testBlock: () -> Unit
+    ) =
+        launchFragmentInContainer(
+            themeResId = R.style.Theme_MaterialComponents
+        ) {
+            TestFragment(
+                viewModelFactoryFor(mockIdentityScanViewModel),
+                viewModelFactoryFor(mockIdentityViewModel)
+            )
+        }.onFragment {
+            val navController = TestNavHostController(
+                ApplicationProvider.getApplicationContext()
+            )
+            navController.setGraph(
+                R.navigation.identity_nav_graph
+            )
+            navController.setCurrentDestination(R.id.IDScanFragment)
+            Navigation.setViewNavController(
+                it.requireView(),
+                navController
+            )
+
+            finalResultLiveData.postValue(
+                finalResult
+            )
+
+            val successCaptor: KArgumentCaptor<(VerificationPage) -> Unit> = argumentCaptor()
+            verify(mockIdentityViewModel).observeForVerificationPage(
+                any(),
+                successCaptor.capture(),
+                any()
+            )
+            successCaptor.firstValue(SUCCESS_VERIFICATION_PAGE_NOT_REQUIRE_LIVE_CAPTURE)
+
+            testBlock()
+        }
+
+    internal class TestFragment(
+        identityScanViewModelFactory: ViewModelProvider.Factory,
+        identityViewModelFactory: ViewModelProvider.Factory,
+    ) : IdentityCameraScanFragment(
+        identityScanViewModelFactory, identityViewModelFactory
+    ) {
+        override val fragmentId = 0
+
+        override fun onCameraReady() {}
+
+        override fun createCameraAdapter() = mock<Camera1Adapter>()
+
+        override fun updateUI(identityScanState: IdentityScanState) {
+        }
+
+        override fun onCreateView(
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?
+        ): View {
+            return View(ApplicationProvider.getApplicationContext())
+        }
+
+        override fun resetUI() {
+        }
+    }
+
+    private companion object {
+        const val DOC_FRONT_SCORE = 0.12f
+        const val DOC_BACK_SCORE = 0.23f
+        const val SELFIE_SCORE = 0.34f
+        val FINISHED_RESULT_ID_FRONT = IdentityAggregator.FinalResult(
+            frame = mock(),
+            result = IDDetectorOutput(
+                boundingBox = mock(),
+                category = Category.ID_FRONT,
+                resultScore = DOC_FRONT_SCORE,
+                allScores = mock()
+            ),
+            identityState = IdentityScanState.Finished(
+                type = IdentityScanState.ScanType.ID_FRONT,
+                transitioner = mock()
+            )
+        )
+
+        val FINISHED_RESULT_ID_BACK = IdentityAggregator.FinalResult(
+            frame = mock(),
+            result = IDDetectorOutput(
+                boundingBox = mock(),
+                category = Category.ID_BACK,
+                resultScore = DOC_BACK_SCORE,
+                allScores = mock()
+            ),
+            identityState = IdentityScanState.Finished(
+                type = IdentityScanState.ScanType.ID_BACK,
+                transitioner = mock()
+            )
+        )
+
+        val FINISHED_RESULT_SELFIE = IdentityAggregator.FinalResult(
+            frame = mock(),
+            result = FaceDetectorOutput(
+                boundingBox = mock(),
+                resultScore = SELFIE_SCORE,
+            ),
+            identityState = IdentityScanState.Finished(
+                type = IdentityScanState.ScanType.SELFIE,
+                transitioner = mock()
+            )
+        )
+
+        val TIMEOUT_RESULT_ID_FRONT = IdentityAggregator.FinalResult(
+            frame = mock(),
+            result = IDDetectorOutput(
+                boundingBox = mock(),
+                category = Category.ID_FRONT,
+                resultScore = DOC_FRONT_SCORE,
+                allScores = mock()
+            ),
+            identityState = IdentityScanState.TimeOut(
+                type = IdentityScanState.ScanType.ID_FRONT,
+                transitioner = mock()
+            )
+        )
+
+        val TIMEOUT_RESULT_ID_BACK = IdentityAggregator.FinalResult(
+            frame = mock(),
+            result = IDDetectorOutput(
+                boundingBox = mock(),
+                category = Category.ID_BACK,
+                resultScore = DOC_BACK_SCORE,
+                allScores = mock()
+            ),
+            identityState = IdentityScanState.TimeOut(
+                type = IdentityScanState.ScanType.ID_BACK,
+                transitioner = mock()
+            )
+        )
+
+        val TIMEOUT_RESULT_SELFIE = IdentityAggregator.FinalResult(
+            frame = mock(),
+            result = FaceDetectorOutput(
+                boundingBox = mock(),
+                resultScore = SELFIE_SCORE,
+            ),
+            identityState = IdentityScanState.TimeOut(
+                type = IdentityScanState.ScanType.SELFIE,
+                transitioner = mock()
+            )
+        )
+    }
+}

--- a/identity/src/test/java/com/stripe/android/identity/viewmodel/IdentityViewModelTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/viewmodel/IdentityViewModelTest.kt
@@ -220,6 +220,56 @@ internal class IdentityViewModelTest {
             )
         }
 
+    @Test
+    fun verifyAnalyticsState() {
+        // initialized with all null
+        assertThat(viewModel.analyticsState.value.scanType).isNull()
+        assertThat(viewModel.analyticsState.value.requireSelfie).isNull()
+        assertThat(viewModel.analyticsState.value.docFrontUploadType).isNull()
+
+        viewModel.updateAnalyticsState { oldState ->
+            oldState.copy(
+                scanType = IdentityScanState.ScanType.ID_FRONT
+            )
+        }
+
+        assertThat(viewModel.analyticsState.value.scanType).isEqualTo(
+            IdentityScanState.ScanType.ID_FRONT
+        )
+        assertThat(viewModel.analyticsState.value.requireSelfie).isNull()
+        assertThat(viewModel.analyticsState.value.docFrontUploadType).isNull()
+
+        viewModel.updateAnalyticsState { oldState ->
+            oldState.copy(
+                requireSelfie = false
+            )
+        }
+
+        assertThat(viewModel.analyticsState.value.scanType).isEqualTo(
+            IdentityScanState.ScanType.ID_FRONT
+        )
+        assertThat(viewModel.analyticsState.value.requireSelfie).isEqualTo(
+            false
+        )
+        assertThat(viewModel.analyticsState.value.docFrontUploadType).isNull()
+
+        viewModel.updateAnalyticsState { oldState ->
+            oldState.copy(
+                docFrontUploadType = DocumentUploadParam.UploadMethod.MANUALCAPTURE
+            )
+        }
+
+        assertThat(viewModel.analyticsState.value.scanType).isEqualTo(
+            IdentityScanState.ScanType.ID_FRONT
+        )
+        assertThat(viewModel.analyticsState.value.requireSelfie).isEqualTo(
+            false
+        )
+        assertThat(viewModel.analyticsState.value.docFrontUploadType).isEqualTo(
+            DocumentUploadParam.UploadMethod.MANUALCAPTURE
+        )
+    }
+
     private fun testUploadManualSuccessResult(isFront: Boolean) {
         mockUploadSuccess()
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add `StateFlow<AnalyticsState>` in `IdentityViewModel` to aggregate the status across the verification session and report them, which enables us to report`verfication_succeeded`, `document_timeout` and `selfie_timeout` metrics. 

Please see more details in [this](https://docs.google.com/document/d/1LyVYV4mLaozxjJu-wkMojDdAkV8NajQ_E8NVNAQAGK4/edit#bookmark=id.gxdz3g2cbq1j) internal doc.


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
analytics for Identity

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
