### PR TITLE
OTP element UI fixes

### DIFF
--- a/link/src/main/java/com/stripe/android/link/theme/Color.kt
+++ b/link/src/main/java/com/stripe/android/link/theme/Color.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.PaymentsThemeDefaults
+import com.stripe.android.ui.core.elements.OTPElementColors
 
 private val LinkTeal = Color(0xFF33DDB3)
 private val ActionGreen = Color(0xFF05A87F)
@@ -26,6 +27,7 @@ private val LightFill = Color(0xFFF6F8FA)
 private val LightCloseButton = Color(0xFF30313D)
 private val LightLinkLogo = Color(0xFF1D3944)
 private val LightSecondaryButtonLabel = Color(0xFF1D3944)
+private val LightOtpPlaceholder = Color(0xFFEBEEF1)
 
 private val DarkComponentBackground = Color(0x2E747480)
 private val DarkComponentBorder = Color(0x5C787880)
@@ -38,11 +40,13 @@ private val DarkFill = Color(0x33787880)
 private val DarkCloseButton = Color(0x99EBEBF5)
 private val DarkLinkLogo = Color.White
 private val DarkSecondaryButtonLabel = ActionGreen
+private val DarkOtpPlaceholder = Color(0x61FFFFFF)
 
 internal data class LinkColors(
     val componentBackground: Color,
     val componentBorder: Color,
     val componentDivider: Color,
+    val clickableHyperlink: Color,
     val buttonLabel: Color,
     val dialogButtonLabel: Color,
     val disabledText: Color,
@@ -51,6 +55,7 @@ internal data class LinkColors(
     val errorText: Color,
     val errorComponentBackground: Color,
     val secondaryButtonLabel: Color,
+    val otpElementColors: OTPElementColors,
     val materialColors: Colors
 )
 
@@ -82,6 +87,7 @@ internal object LinkThemeConfig {
         componentBackground = LightComponentBackground,
         componentBorder = LightComponentBorder,
         componentDivider = LightComponentDivider,
+        clickableHyperlink = ActionGreen,
         buttonLabel = ButtonLabel,
         dialogButtonLabel = ActionGreen,
         disabledText = LightTextDisabled,
@@ -90,6 +96,10 @@ internal object LinkThemeConfig {
         errorText = ErrorText,
         errorComponentBackground = ErrorBackground,
         secondaryButtonLabel = LightSecondaryButtonLabel,
+        otpElementColors = OTPElementColors(
+            selectedBorder = LinkTeal,
+            placeholder = LightOtpPlaceholder
+        ),
         materialColors = lightColors(
             primary = LinkTeal,
             secondary = LightFill,
@@ -104,6 +114,7 @@ internal object LinkThemeConfig {
         componentBackground = DarkComponentBackground,
         componentBorder = DarkComponentBorder,
         componentDivider = DarkComponentDivider,
+        clickableHyperlink = ActionGreen,
         buttonLabel = ButtonLabel,
         dialogButtonLabel = ActionGreen,
         disabledText = DarkTextDisabled,
@@ -112,6 +123,10 @@ internal object LinkThemeConfig {
         errorText = ErrorText,
         errorComponentBackground = ErrorBackground,
         secondaryButtonLabel = DarkSecondaryButtonLabel,
+        otpElementColors = OTPElementColors(
+            selectedBorder = LinkTeal,
+            placeholder = DarkOtpPlaceholder
+        ),
         materialColors = darkColors(
             primary = LinkTeal,
             secondary = DarkFill,

--- a/link/src/main/java/com/stripe/android/link/theme/Type.kt
+++ b/link/src/main/java/com/stripe/android/link/theme/Type.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.unit.sp
 internal val Typography = Typography(
     h2 = TextStyle(
         fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Bold,
+        fontWeight = FontWeight.SemiBold,
         fontSize = 24.sp,
         lineHeight = 32.sp
     ),

--- a/link/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -88,6 +89,7 @@ internal fun SignUpBody(
     )
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 internal fun SignUpBody(
     merchantName: String,

--- a/link/src/main/java/com/stripe/android/link/ui/verification/VerificationScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/verification/VerificationScreen.kt
@@ -20,14 +20,13 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -80,6 +79,7 @@ internal fun VerificationBodyFullFlow(
     )
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 internal fun VerificationBody(
     @StringRes headerStringResId: Int,
@@ -165,7 +165,8 @@ internal fun VerificationBody(
             OTPElementUI(
                 enabled = !isProcessing,
                 element = otpElement,
-                modifier = Modifier.padding(vertical = 10.dp)
+                modifier = Modifier.padding(vertical = 10.dp),
+                colors = MaterialTheme.linkColors.otpElementColors
             )
         }
         if (showChangeEmailMessage) {
@@ -188,9 +189,8 @@ internal fun VerificationBody(
                             enabled = !isProcessing,
                             onClick = onChangeEmailClick
                         ),
-                    style = MaterialTheme.typography.body2
-                        .merge(TextStyle(textDecoration = TextDecoration.Underline)),
-                    color = MaterialTheme.colors.onSecondary
+                    style = MaterialTheme.typography.body2,
+                    color = MaterialTheme.linkColors.clickableHyperlink
                 )
             }
         }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormUI.kt
@@ -73,9 +73,7 @@ fun FormUI(
                             enabled, element.controller, hiddenIdentifiers
                         )
                         is BsbElement -> BsbElementUI(enabled, element, lastTextFieldIdentifier)
-                        is OTPElement -> DefaultPaymentsTheme {
-                            OTPElementUI(enabled, element)
-                        }
+                        is OTPElement -> OTPElementUI(enabled, element)
                         is EmptyFormElement -> {}
                     }
                 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/PaymentsTheme.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/PaymentsTheme.kt
@@ -353,11 +353,18 @@ val MaterialTheme.paymentsShapes: PaymentsShapes
 
 @Composable
 @ReadOnlyComposable
-fun MaterialTheme.getBorderStroke(isSelected: Boolean): BorderStroke {
-    val width = if (isSelected) paymentsShapes.borderStrokeWidthSelected else paymentsShapes.borderStrokeWidth
-    val color = if (isSelected) paymentsColors.materialColors.primary else paymentsColors.componentBorder
-    return BorderStroke(width.dp, color)
-}
+internal fun MaterialTheme.getBorderStrokeWidth(isSelected: Boolean) =
+    if (isSelected) paymentsShapes.borderStrokeWidthSelected.dp else paymentsShapes.borderStrokeWidth.dp
+
+@Composable
+@ReadOnlyComposable
+internal fun MaterialTheme.getBorderStrokeColor(isSelected: Boolean) =
+    if (isSelected) paymentsColors.materialColors.primary else paymentsColors.componentBorder
+
+@Composable
+@ReadOnlyComposable
+fun MaterialTheme.getBorderStroke(isSelected: Boolean): BorderStroke =
+    BorderStroke(getBorderStrokeWidth(isSelected), getBorderStrokeColor(isSelected))
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 object PaymentsTheme {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPElementUI.kt
@@ -2,14 +2,21 @@ package com.stripe.android.ui.core.elements
 
 import android.view.KeyEvent
 import androidx.annotation.RestrictTo
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.LocalContentColor
-import androidx.compose.material.LocalTextStyle
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
@@ -26,6 +33,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
@@ -35,16 +43,23 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.stripe.android.ui.core.getBorderStrokeWidth
+import com.stripe.android.ui.core.paymentsColors
 
-@OptIn(ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalMaterialApi::class)
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun OTPElementUI(
     enabled: Boolean,
     element: OTPElement,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    colors: OTPElementColors = OTPElementColors(
+        selectedBorder = MaterialTheme.colors.primary,
+        placeholder = MaterialTheme.paymentsColors.placeholderText
+    )
 ) {
     val focusManager = LocalFocusManager.current
     val focusRequester = remember { FocusRequester() }
@@ -57,19 +72,34 @@ fun OTPElementUI(
         var focusedElementIndex by remember { mutableStateOf(-1) }
 
         (0 until element.controller.otpLength).map { index ->
+            val isSelected = focusedElementIndex == index
+
+            // Add extra spacing in the middle
+            if (index == element.controller.otpLength / 2) {
+                Spacer(modifier = Modifier.width(12.dp))
+            }
+
             SectionCard(
                 modifier = Modifier
                     .weight(1f)
-                    .padding(horizontal = 2.dp)
+                    .padding(horizontal = 4.dp),
+                border = BorderStroke(
+                    width = MaterialTheme.getBorderStrokeWidth(isSelected),
+                    color = if (isSelected) {
+                        colors.selectedBorder
+                    } else {
+                        MaterialTheme.paymentsColors.componentBorder
+                    }
+                )
             ) {
                 val value by element.controller.fieldValues[index].collectAsState("")
 
                 var textFieldModifier = Modifier
-                    .padding(0.dp)
+                    .height(56.dp)
                     .onFocusChanged { focusState ->
                         if (focusState.isFocused) {
                             focusedElementIndex = index
-                        } else if (!focusState.isFocused && focusedElementIndex == index) {
+                        } else if (!focusState.isFocused && isSelected) {
                             focusedElementIndex = -1
                         }
                     }
@@ -94,10 +124,12 @@ fun OTPElementUI(
                     textFieldModifier = textFieldModifier.focusRequester(focusRequester)
                 }
 
-                androidx.compose.material.TextField(
+                // Need to use BasicTextField instead of TextField to be able to customize the
+                // internal contentPadding
+                BasicTextField(
                     value = TextFieldValue(
                         text = value,
-                        selection = if (focusedElementIndex == index) {
+                        selection = if (isSelected) {
                             TextRange(value.length)
                         } else {
                             TextRange.Zero
@@ -111,7 +143,11 @@ fun OTPElementUI(
                     },
                     modifier = textFieldModifier,
                     enabled = enabled,
-                    textStyle = LocalTextStyle.current.copy(textAlign = TextAlign.Center),
+                    textStyle = MaterialTheme.typography.h2.copy(
+                        color = MaterialTheme.paymentsColors.onComponent,
+                        textAlign = TextAlign.Center
+                    ),
+                    cursorBrush = SolidColor(MaterialTheme.paymentsColors.textCursor),
                     keyboardOptions = KeyboardOptions(
                         keyboardType = element.controller.keyboardType
                     ),
@@ -124,20 +160,39 @@ fun OTPElementUI(
                         }
                     ),
                     singleLine = true,
-                    placeholder = {
-                        Text(
-                            modifier = Modifier.fillMaxWidth(),
-                            text = if (focusedElementIndex != index) "●" else "",
-                            textAlign = TextAlign.Center
+                    decorationBox = @Composable { innerTextField ->
+                        TextFieldDefaults.TextFieldDecorationBox(
+                            value = value,
+                            visualTransformation = VisualTransformation.None,
+                            innerTextField = innerTextField,
+                            placeholder = {
+                                Text(
+                                    text = if (!isSelected) "●" else "",
+                                    modifier = Modifier.fillMaxWidth(),
+                                    textAlign = TextAlign.Center
+                                )
+                            },
+                            singleLine = true,
+                            enabled = enabled,
+                            interactionSource = remember { MutableInteractionSource() },
+                            colors = TextFieldDefaults.textFieldColors(
+                                textColor = MaterialTheme.paymentsColors.onComponent,
+                                backgroundColor = Color.Transparent,
+                                cursorColor = MaterialTheme.paymentsColors.textCursor,
+                                focusedIndicatorColor = Color.Transparent,
+                                disabledIndicatorColor = Color.Transparent,
+                                unfocusedIndicatorColor = Color.Transparent,
+                                placeholderColor = colors.placeholder,
+                                disabledPlaceholderColor = colors.placeholder
+                            ),
+                            contentPadding = PaddingValues(
+                                TextFieldPadding,
+                                TextFieldPadding,
+                                TextFieldPadding,
+                                TextFieldPadding
+                            )
                         )
-                    },
-                    colors = TextFieldDefaults.textFieldColors(
-                        backgroundColor = Color.Transparent,
-                        cursorColor = LocalContentColor.current,
-                        focusedIndicatorColor = Color.Transparent,
-                        disabledIndicatorColor = Color.Transparent,
-                        unfocusedIndicatorColor = Color.Transparent,
-                    )
+                    }
                 )
             }
         }
@@ -148,3 +203,11 @@ fun OTPElementUI(
         }
     }
 }
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class OTPElementColors(
+    val selectedBorder: Color,
+    val placeholder: Color
+)
+
+private val TextFieldPadding = 12.dp

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionUI.kt
@@ -2,6 +2,7 @@ package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
 import androidx.annotation.StringRes
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Card
@@ -62,10 +63,11 @@ internal fun SectionTitle(@StringRes titleText: Int?) {
 fun SectionCard(
     modifier: Modifier = Modifier,
     isSelected: Boolean = false,
+    border: BorderStroke = MaterialTheme.getBorderStroke(isSelected),
     content: @Composable () -> Unit
 ) {
     Card(
-        border = MaterialTheme.getBorderStroke(isSelected),
+        border = border,
         // TODO(skyler-stripe): this will change when we add shadow configurations.
         elevation = if (isSelected) 1.5.dp else 0.dp,
         backgroundColor = MaterialTheme.paymentsColors.component,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fixes for Link OTP UI.
- Create an `OTPElementColors` that can be passed into `OTPElementUI` to customize its appearance. Using this colors object, similar to `TextFieldColors`, because the OTP element uses a couple of specific colors that don't fit the more general `PaymentsTheme` approach.
- Use a `BasicTextField` for the OTP fields instead of `TextField` so that the padding can be customized. Using `TextField` you can't customize the 16.dp padding, which makes the numbers entered only partially visible.
- Update hyperlink text color on `VerificationScreen`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix UI for OTP element.
https://jira.corp.stripe.com/browse/MOBILESDK-835

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
