### PR TITLE
Updates Accompanist to 0.24.11-rc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ ext {
 
     kotlinCoroutinesVersion = '1.6.1'
     kotlinSerializationVersion = '1.3.3'
-    flowlayoutVersion = '0.23.1'
+    accompanistVersion = '0.24.11-rc'
     ktlintVersion = '0.45.2'
     // material 1.6 causes paymentsheet to not render correctly.
     // see here: https://github.com/material-components/material-components-android/issues/2702

--- a/link/build.gradle
+++ b/link/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation "androidx.navigation:navigation-compose:$androidxNavigationVersion"
     // Integration with observables
     implementation "androidx.compose.runtime:runtime-livedata:$androidxComposeVersion"
-    implementation "com.google.accompanist:accompanist-flowlayout:$flowlayoutVersion"
+    implementation "com.google.accompanist:accompanist-flowlayout:$accompanistVersion"
     implementation "androidx.compose.ui:ui-tooling-preview:$androidxComposeVersion"
 
     testImplementation project(':payments-core')

--- a/payments-ui-core/build.gradle
+++ b/payments-ui-core/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     implementation "androidx.activity:activity-compose:$androidxActivityVersion"
     // Integration with observables
     implementation "androidx.compose.runtime:runtime-livedata:$androidxComposeVersion"
-    implementation "com.google.accompanist:accompanist-flowlayout:$flowlayoutVersion"
+    implementation "com.google.accompanist:accompanist-flowlayout:$accompanistVersion"
     // Tooling support (Previews, etc.)
     debugImplementation "androidx.compose.ui:ui-tooling:$androidxComposeVersion"
 

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout-compose:$androidxConstraintlayoutComposeVersion"
     // Integration with observables
     implementation "androidx.compose.runtime:runtime-livedata:$androidxComposeVersion"
-    implementation "com.google.accompanist:accompanist-flowlayout:$flowlayoutVersion"
+    implementation "com.google.accompanist:accompanist-flowlayout:$accompanistVersion"
     // Tooling support (Previews, etc.)
     debugImplementation "androidx.compose.ui:ui-tooling:$androidxComposeVersion"
 


### PR DESCRIPTION
# Summary

- Updates Accompanist to work with Compose 1.2
- Renames version variable to `accompanistVersions` (Accompanist libs all share the same versioning)

<img width="757" alt="image" src="https://user-images.githubusercontent.com/99293320/174400436-de1d5c5c-9182-42cd-9faa-417ed6e1277c.png">