### PR TITLE
Fix Link instrumentation tests

### DIFF
--- a/link/src/androidTest/java/com/stripe/android/link/ui/cardedit/CardEditScreenTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/cardedit/CardEditScreenTest.kt
@@ -1,18 +1,14 @@
 package com.stripe.android.link.ui.cardedit
 
-import android.content.Intent
+import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasParent
 import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
-import com.stripe.android.link.LinkActivity
-import com.stripe.android.link.LinkActivityContract
-import com.stripe.android.link.StripeIntentFixtures
-import com.stripe.android.link.createAndroidIntentComposeRule
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.link.ui.ErrorMessage
 import org.junit.Rule
@@ -22,19 +18,7 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 internal class CardEditScreenTest {
     @get:Rule
-    val composeTestRule = createAndroidIntentComposeRule<LinkActivity> {
-        PaymentConfiguration.init(it, "publishable_key")
-        Intent(it, LinkActivity::class.java).apply {
-            putExtra(
-                LinkActivityContract.EXTRA_ARGS,
-                LinkActivityContract.Args(
-                    StripeIntentFixtures.PI_SUCCEEDED,
-                    true,
-                    "Merchant, Inc"
-                )
-            )
-        }
-    }
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
     fun when_default_show_default_label() {

--- a/link/src/androidTest/java/com/stripe/android/link/ui/inline/LinkInlineSignupViewTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/inline/LinkInlineSignupViewTest.kt
@@ -1,17 +1,13 @@
 package com.stripe.android.link.ui.inline
 
-import android.content.Intent
+import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
-import com.stripe.android.link.LinkActivity
-import com.stripe.android.link.LinkActivityContract
-import com.stripe.android.link.StripeIntentFixtures
-import com.stripe.android.link.createAndroidIntentComposeRule
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.link.ui.progressIndicatorTestTag
 import com.stripe.android.link.ui.signup.SignUpState
@@ -24,19 +20,7 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 internal class LinkInlineSignupViewTest {
     @get:Rule
-    val composeTestRule = createAndroidIntentComposeRule<LinkActivity> {
-        PaymentConfiguration.init(it, "publishable_key")
-        Intent(it, LinkActivity::class.java).apply {
-            putExtra(
-                LinkActivityContract.EXTRA_ARGS,
-                LinkActivityContract.Args(
-                    StripeIntentFixtures.PI_SUCCEEDED,
-                    true,
-                    "Merchant, Inc"
-                )
-            )
-        }
-    }
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
     fun clicking_on_checkbox_triggers_callback() {

--- a/link/src/androidTest/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreenTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreenTest.kt
@@ -1,16 +1,12 @@
 package com.stripe.android.link.ui.paymentmethod
 
-import android.content.Intent
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
-import com.stripe.android.link.LinkActivity
-import com.stripe.android.link.LinkActivityContract
-import com.stripe.android.link.StripeIntentFixtures
-import com.stripe.android.link.createAndroidIntentComposeRule
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.link.ui.ErrorMessage
 import com.stripe.android.link.ui.progressIndicatorTestTag
@@ -21,19 +17,7 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 internal class PaymentMethodScreenTest {
     @get:Rule
-    val composeTestRule = createAndroidIntentComposeRule<LinkActivity> {
-        PaymentConfiguration.init(it, "publishable_key")
-        Intent(it, LinkActivity::class.java).apply {
-            putExtra(
-                LinkActivityContract.EXTRA_ARGS,
-                LinkActivityContract.Args(
-                    StripeIntentFixtures.PI_SUCCEEDED,
-                    true,
-                    "Merchant, Inc"
-                )
-            )
-        }
-    }
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     private val primaryButtonLabel = "Pay $10.99"
     private val secondaryButtonLabel = "Cancel"

--- a/link/src/androidTest/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
@@ -1,17 +1,13 @@
 package com.stripe.android.link.ui.signup
 
-import android.content.Intent
+import androidx.activity.ComponentActivity
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.stripe.android.PaymentConfiguration
-import com.stripe.android.link.LinkActivity
-import com.stripe.android.link.LinkActivityContract
-import com.stripe.android.link.StripeIntentFixtures
-import com.stripe.android.link.createAndroidIntentComposeRule
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.link.ui.ErrorMessage
 import com.stripe.android.link.ui.progressIndicatorTestTag
@@ -25,19 +21,7 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 internal class SignUpScreenTest {
     @get:Rule
-    val composeTestRule = createAndroidIntentComposeRule<LinkActivity> {
-        PaymentConfiguration.init(it, "publishable_key")
-        Intent(it, LinkActivity::class.java).apply {
-            putExtra(
-                LinkActivityContract.EXTRA_ARGS,
-                LinkActivityContract.Args(
-                    StripeIntentFixtures.PI_SUCCEEDED,
-                    merchantName = "Merchant, Inc",
-                    completePayment = false
-                )
-            )
-        }
-    }
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
     fun status_inputting_email_shows_only_email_field() {

--- a/link/src/androidTest/java/com/stripe/android/link/ui/verification/VerificationScreenTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/verification/VerificationScreenTest.kt
@@ -109,6 +109,8 @@ internal class VerificationScreenTest {
 
         assertThat(otpValue?.isComplete).isTrue()
         assertThat(otpValue?.value).isEqualTo("123")
+
+        composeTestRule.waitForIdle()
     }
 
     @Test
@@ -125,6 +127,8 @@ internal class VerificationScreenTest {
 
         assertThat(otpValue?.isComplete).isTrue()
         assertThat(otpValue?.value).isEqualTo("123456")
+
+        composeTestRule.waitForIdle()
     }
 
     @Test

--- a/link/src/androidTest/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.link.ui.wallet
 
-import android.content.Intent
+import androidx.activity.ComponentActivity
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -21,6 +21,7 @@ import androidx.compose.ui.test.filter
 import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -29,11 +30,6 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.unit.dp
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
-import com.stripe.android.link.LinkActivity
-import com.stripe.android.link.LinkActivityContract
-import com.stripe.android.link.StripeIntentFixtures
-import com.stripe.android.link.createAndroidIntentComposeRule
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.link.ui.BottomSheetContent
 import com.stripe.android.link.ui.ErrorMessage
@@ -49,19 +45,7 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 internal class WalletScreenTest {
     @get:Rule
-    val composeTestRule = createAndroidIntentComposeRule<LinkActivity> {
-        PaymentConfiguration.init(it, "publishable_key")
-        Intent(it, LinkActivity::class.java).apply {
-            putExtra(
-                LinkActivityContract.EXTRA_ARGS,
-                LinkActivityContract.Args(
-                    StripeIntentFixtures.PI_SUCCEEDED,
-                    true,
-                    "Merchant, Inc"
-                )
-            )
-        }
-    }
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     private val primaryButtonLabel = "Pay $10.99"
     private val paymentDetails = listOf(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
- Using `LinkActivity` was causing failures after upgrading to compose 1.2.0-rc1 due to calling `setContent` twice.
- Add call to `composeTestRule.waitForIdle()` on `VerificationScreenTest` to fix flaky `java.lang.IllegalStateException: LayoutCoordinate operations are only valid when isAttached is true` (https://issuetracker.google.com/issues/215116019).

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix instrumentation tests.
