### PR TITLE
[stripe-core] rename createRequestR to createRequest

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/analytics/IdentityAnalyticsRequestFactory.kt
+++ b/identity/src/main/java/com/stripe/android/identity/analytics/IdentityAnalyticsRequestFactory.kt
@@ -21,14 +21,14 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
         origin = ORIGIN
     )
 
-    fun sheetPresented() = requestFactory.createRequestR(
+    fun sheetPresented() = requestFactory.createRequest(
         EVENT_SHEET_PRESENTED,
         additionalParams = mapOf(
             PARAM_VERIFICATION_SESSION to args.verificationSessionId
         )
     )
 
-    fun sheetClosed(sessionResult: String) = requestFactory.createRequestR(
+    fun sheetClosed(sessionResult: String) = requestFactory.createRequest(
         eventName = EVENT_SHEET_CLOSED,
         additionalParams = mapOf(
             PARAM_VERIFICATION_SESSION to args.verificationSessionId,
@@ -48,7 +48,7 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
         docFrontModelScore: Float? = null,
         docBackModelScore: Float? = null,
         selfieModelScore: Float? = null
-    ) = requestFactory.createRequestR(
+    ) = requestFactory.createRequest(
         eventName = EVENT_VERIFICATION_SUCCEEDED,
         additionalParams =
         mapOf(
@@ -72,7 +72,7 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
         lastScreenName: String? = null,
         scanType: IdentityScanState.ScanType? = null,
         requireSelfie: Boolean? = null
-    ) = requestFactory.createRequestR(
+    ) = requestFactory.createRequest(
         eventName = EVENT_VERIFICATION_CANCELED,
         additionalParams =
         mapOf(
@@ -91,7 +91,7 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
         docFrontUploadType: DocumentUploadParam.UploadMethod? = null,
         docBackUploadType: DocumentUploadParam.UploadMethod? = null,
         throwable: Throwable
-    ) = requestFactory.createRequestR(
+    ) = requestFactory.createRequest(
         eventName = EVENT_VERIFICATION_FAILED,
         additionalParams =
         mapOf(
@@ -111,7 +111,7 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
     fun screenPresented(
         scanType: IdentityScanState.ScanType? = null,
         screenName: String
-    ) = requestFactory.createRequestR(
+    ) = requestFactory.createRequest(
         eventName = EVENT_SCREEN_PRESENTED,
         additionalParams = mapOf(
             PARAM_VERIFICATION_SESSION to args.verificationSessionId,
@@ -123,7 +123,7 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
     fun cameraError(
         scanType: IdentityScanState.ScanType,
         throwable: Throwable
-    ) = requestFactory.createRequestR(
+    ) = requestFactory.createRequest(
         eventName = EVENT_CAMERA_ERROR,
         additionalParams = mapOf(
             PARAM_VERIFICATION_SESSION to args.verificationSessionId,
@@ -137,7 +137,7 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
 
     fun cameraPermissionDenied(
         scanType: IdentityScanState.ScanType
-    ) = requestFactory.createRequestR(
+    ) = requestFactory.createRequest(
         eventName = EVENT_CAMERA_PERMISSION_DENIED,
         additionalParams = mapOf(
             PARAM_VERIFICATION_SESSION to args.verificationSessionId,
@@ -147,7 +147,7 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
 
     fun cameraPermissionGranted(
         scanType: IdentityScanState.ScanType
-    ) = requestFactory.createRequestR(
+    ) = requestFactory.createRequest(
         eventName = EVENT_CAMERA_PERMISSION_GRANTED,
         additionalParams = mapOf(
             PARAM_VERIFICATION_SESSION to args.verificationSessionId,
@@ -157,7 +157,7 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
 
     fun documentTimeout(
         scanType: IdentityScanState.ScanType
-    ) = requestFactory.createRequestR(
+    ) = requestFactory.createRequest(
         eventName = EVENT_DOCUMENT_TIMEOUT,
         additionalParams = mapOf(
             PARAM_VERIFICATION_SESSION to args.verificationSessionId,
@@ -166,7 +166,7 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
         )
     )
 
-    fun selfieTimeout() = requestFactory.createRequestR(
+    fun selfieTimeout() = requestFactory.createRequest(
         eventName = EVENT_SELFIE_TIMEOUT,
         additionalParams = mapOf(
             PARAM_VERIFICATION_SESSION to args.verificationSessionId

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2.kt
@@ -22,7 +22,7 @@ import java.util.UUID
  *   [HEADER_USER_AGENT] - Used for parsing client info, needs to conform the format starting with "Stripe/v1"
  *
  * It sets four params required r.stripe.com -
- *   [PARAM_EVENT_ID] - A string identifying the client making the request, set from analytics server
+ *   [PARAM_CLIENT_ID] - A string identifying the client making the request, set from analytics server
  *   [PARAM_CREATED] - Timestamp when the event was created in seconds
  *   [PARAM_EVENT_NAME] - An identifying name for this type of event
  *   [PARAM_EVENT_ID] - UUID used to deduplicate events

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2Factory.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2Factory.kt
@@ -32,7 +32,7 @@ class AnalyticsRequestV2Factory(
      *
      * @param includeSDKParams - whether to include default SDK params.
      */
-    fun createRequestR(
+    fun createRequest(
         eventName: String,
         additionalParams: Map<String, Any?> = mapOf(),
         includeSDKParams: Boolean = true

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestV2FactoryTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestV2FactoryTest.kt
@@ -36,23 +36,23 @@ class AnalyticsRequestV2FactoryTest {
 
     @Test
     fun `verify clientId and origin`() {
-        val requestR = factory.createRequestR(
+        val request = factory.createRequest(
             "EVENT_NAME",
             includeSDKParams = true
         )
 
-        assertThat(requestR.postParameters.toMap()[PARAM_CLIENT_ID]).isEqualTo(CLIENT_ID)
-        assertThat(requestR.headers[AnalyticsRequestV2.HEADER_ORIGIN]).isEqualTo(ORIGIN)
+        assertThat(request.postParameters.toMap()[PARAM_CLIENT_ID]).isEqualTo(CLIENT_ID)
+        assertThat(request.headers[AnalyticsRequestV2.HEADER_ORIGIN]).isEqualTo(ORIGIN)
     }
 
     @Test
     fun `verify SDKParams are included`() {
-        val requestR = factory.createRequestR(
+        val request = factory.createRequest(
             "EVENT_NAME",
             includeSDKParams = true
         )
 
-        requestR.postParameters.toMap().let { paramsMap ->
+        request.postParameters.toMap().let { paramsMap ->
             sdkParamKeys.forEach {
                 assertThat(paramsMap).containsKey(it)
             }
@@ -61,12 +61,12 @@ class AnalyticsRequestV2FactoryTest {
 
     @Test
     fun `SDKParams are not included`() {
-        val requestR = factory.createRequestR(
+        val request = factory.createRequest(
             "EVENT_NAME",
             includeSDKParams = false
         )
 
-        requestR.postParameters.toMap().let { paramsMap ->
+        request.postParameters.toMap().let { paramsMap ->
             sdkParamKeys.forEach {
                 assertThat(paramsMap).doesNotContainKey(it)
             }
@@ -86,7 +86,7 @@ class AnalyticsRequestV2FactoryTest {
             "nestedParam2" to "nestedValue2"
         )
 
-        val requestR = factory.createRequestR(
+        val request = factory.createRequest(
             "EVENT_NAME",
             additionalParams = mapOf(
                 additionalParam1 to additionalValue1,
@@ -96,7 +96,7 @@ class AnalyticsRequestV2FactoryTest {
             includeSDKParams = true
         )
 
-        requestR.postParameters.toMap().let { paramsMap ->
+        request.postParameters.toMap().let { paramsMap ->
             assertThat(paramsMap[additionalParam1]).isEqualTo(additionalValue1)
             assertThat(paramsMap[additionalParam2]).isEqualTo(additionalValue2)
             assertThat(paramsMap[additionalParam3]).isEqualTo(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
The request was called `AnalyticsRueqestR`(for `r.stripe.com`) and was renamed to `AnalyticsRequestV2`. Rename the factory method accordingly.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Analytics to r.stripe.com

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
