### PR TITLE
Fix browserstack tests and improve runtime speed.

### DIFF
--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestHardCodedLpms.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestHardCodedLpms.kt
@@ -79,6 +79,7 @@ class TestHardCodedLpms {
     fun testCard() {
         testDriver.confirmNewOrGuestComplete(
             newUser.copy(
+                customer = Customer.New,
                 billing = Billing.On,
                 paymentMethod = LpmRepository.HardcodedCard,
                 authorizationAction = null,

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -5,6 +5,7 @@ import android.app.Application
 import android.content.Intent
 import android.graphics.Bitmap
 import android.os.Bundle
+import android.util.Log
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
@@ -20,6 +21,7 @@ import com.stripe.android.paymentsheet.example.playground.activity.PaymentSheetP
 import com.stripe.android.test.core.ui.BrowserUI
 import com.stripe.android.test.core.ui.EspressoText
 import com.stripe.android.test.core.ui.Selectors
+import com.stripe.android.test.core.ui.UiAutomatorText
 import org.junit.Assume
 import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
@@ -296,7 +298,18 @@ class PlaygroundTestDriver(
 
                 blockUntilAuthorizationPageLoaded()
 
-                authorizeAction.click()
+                if(authorizeAction.exists()){
+                    authorizeAction.click()
+                }
+                // Failure isn't showing the same way each time.
+                else if(!authorizeAction.exists() && (testParameters.authorizationAction == AuthorizeAction.Fail)){
+                    object : UiAutomatorText(
+                        label = AuthorizeAction.Fail.text,
+                        className = "android.widget.TextView",
+                        device = device
+                    ) {}.click()
+                    Log.e("Stripe", "Fail authorization was a text view not a button this time")
+                }
 
                 when (testParameters.authorizationAction) {
                     AuthorizeAction.Authorize -> {}

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -310,6 +310,15 @@ class PlaygroundTestDriver(
                     ) {}.click()
                     Log.e("Stripe", "Fail authorization was a text view not a button this time")
                 }
+                // Failure isn't showing the same way each time.
+                else if(!authorizeAction.exists() && (testParameters.authorizationAction == AuthorizeAction.Authorize)){
+                    object : UiAutomatorText(
+                        label = AuthorizeAction.Authorize.text,
+                        className = "android.widget.TextView",
+                        device = device
+                    ) {}.click()
+                    Log.e("Stripe", "Authorization was a text view not a button this time")
+                }
 
                 when (testParameters.authorizationAction) {
                     AuthorizeAction.Authorize -> {}

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -301,23 +301,14 @@ class PlaygroundTestDriver(
                 if(authorizeAction.exists()){
                     authorizeAction.click()
                 }
-                // Failure isn't showing the same way each time.
-                else if(!authorizeAction.exists() && (testParameters.authorizationAction == AuthorizeAction.Fail)){
+                // Buttons aren't showing the same way each time in the web page.
+                else if(!authorizeAction.exists()){
                     object : UiAutomatorText(
-                        label = AuthorizeAction.Fail.text,
+                        label = requireNotNull(testParameters.authorizationAction).text,
                         className = "android.widget.TextView",
                         device = device
                     ) {}.click()
                     Log.e("Stripe", "Fail authorization was a text view not a button this time")
-                }
-                // Failure isn't showing the same way each time.
-                else if(!authorizeAction.exists() && (testParameters.authorizationAction == AuthorizeAction.Authorize)){
-                    object : UiAutomatorText(
-                        label = AuthorizeAction.Authorize.text,
-                        className = "android.widget.TextView",
-                        device = device
-                    ) {}.click()
-                    Log.e("Stripe", "Authorization was a text view not a button this time")
                 }
 
                 when (testParameters.authorizationAction) {

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/PaymentSelection.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/PaymentSelection.kt
@@ -5,10 +5,9 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performScrollToNode
 import androidx.test.platform.app.InstrumentationRegistry
 import com.stripe.android.paymentsheet.TEST_TAG_LIST
@@ -16,6 +15,12 @@ import com.stripe.android.paymentsheet.TEST_TAG_LIST
 class PaymentSelection(val composeTestRule: ComposeTestRule, @StringRes val label: Int) {
     fun click() {
         val resource = InstrumentationRegistry.getInstrumentation().targetContext.resources
+
+        composeTestRule.waitUntil(5000) {
+            composeTestRule
+                .onAllNodesWithTag(TEST_TAG_LIST)
+                .fetchSemanticsNodes().size == 1
+        }
         composeTestRule.onNodeWithTag(TEST_TAG_LIST, true)
             .performScrollToNode(hasText(resource.getString(label)))
         composeTestRule.waitForIdle()

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/Selectors.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/Selectors.kt
@@ -209,7 +209,7 @@ class Selectors(
         AuthorizeAction.Fail -> {
             object : UiAutomatorText(
                 label = testParameters.authorizationAction.text,
-                className = "android.widget.TextView",
+                className = "android.widget.Button",
                 device = device
             ) {}
         }

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/Selectors.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/Selectors.kt
@@ -209,7 +209,7 @@ class Selectors(
         AuthorizeAction.Fail -> {
             object : UiAutomatorText(
                 label = testParameters.authorizationAction.text,
-                className = "android.widget.Button",
+                className = "android.widget.TextView",
                 device = device
             ) {}
         }

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/UiAutomatorText.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/UiAutomatorText.kt
@@ -19,7 +19,9 @@ open class UiAutomatorText(
 
     open fun click() {
         if (!exists()) {
-            scroll()
+            if (!exists()) {
+                scroll()
+            }
         }
         if (!exists()) {
             throw InvalidParameterException("Text button not found: $label $className")

--- a/scripts/browserstack.py
+++ b/scripts/browserstack.py
@@ -119,7 +119,7 @@ def executeTests(appUrl, testUrl):
     # firefox doesn't work on this samsung: Samsung Galaxy S9 Plus-9.0"]
     response = requests.post(url, json={
          "app": appUrl,
-         "devices": ["Samsung Galaxy S22-12.0"],
+         "devices": ["Google Pixel 3-9.0"],
          "testSuite": testUrl,
          "networkLogs": True,
          "deviceLogs": True,

--- a/scripts/browserstack.py
+++ b/scripts/browserstack.py
@@ -129,7 +129,7 @@ def executeTests(appUrl, testUrl):
          "enableSpoonFramework": False,
          "project": "Mobile Payments",
          "shards": {
-            "numberOfShards": 3,
+            "numberOfShards": 4,
             "mapping": [
                 {
                    "name": "Shard 1",
@@ -144,7 +144,12 @@ def executeTests(appUrl, testUrl):
                 {
                    "name": "Shard 3",
                    "strategy": "class",
-                   "values": ["com.stripe.android.TestHardCodedLpms", "com.stripe.android.TestMultiStepFieldsReloaded"]
+                   "values": ["com.stripe.android.TestHardCodedLpms"]
+                },
+                {
+                   "name": "Shard 4",
+                   "strategy": "class",
+                   "values": ["com.stripe.android.TestMultiStepFieldsReloaded"]
                 },
             ]
          }

--- a/scripts/browserstack.py
+++ b/scripts/browserstack.py
@@ -119,7 +119,7 @@ def executeTests(appUrl, testUrl):
     # firefox doesn't work on this samsung: Samsung Galaxy S9 Plus-9.0"]
     response = requests.post(url, json={
          "app": appUrl,
-         "devices": ["Google Pixel 3-9.0"],
+         "devices": ["Samsung Galaxy S22-12.0"],
          "testSuite": testUrl,
          "networkLogs": True,
          "deviceLogs": True,
@@ -127,7 +127,27 @@ def executeTests(appUrl, testUrl):
 #          "language": "en_US",
          "locale": "en_US",
          "enableSpoonFramework": False,
-         "project": "Mobile Payments"
+         "project": "Mobile Payments",
+         "shards": {
+            "numberOfShards": 3,
+            "mapping": [
+                {
+                   "name": "Shard 1",
+                   "strategy": "class",
+                   "values": ["com.stripe.android.TestAuthorization", "com.stripe.android.TestBrowsers", "com.stripe.android.TestCustomers"]
+                },
+                {
+                   "name": "Shard 2",
+                   "strategy": "class",
+                   "values": ["com.stripe.android.TestFieldPopulation", "com.stripe.android.TestGooglePay"]
+                },
+                {
+                   "name": "Shard 3",
+                   "strategy": "class",
+                   "values": ["com.stripe.android.TestHardCodedLpms", "com.stripe.android.TestMultiStepFieldsReloaded"]
+                },
+            ]
+         }
       }, auth=(user, authKey))
     jsonResponse = response.json()
 


### PR DESCRIPTION
# Summary
* Add sharding and specify specific test cases to improve build time.
* Select the class names of tests to run and which shard to run them on.  This has the effect of not running the Screenshot tests again on browerstack.
* Effect of the above changes means the tests run in 10m down from 24m

# Motivation
RUN_MOBILESDK-1154

# Testing
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified
https://app-automate.browserstack.com/dashboard/v2/builds/4a3f68a0917fac41f0f3e18334a3fd68a4692b23

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
