### PR TITLE
[stripe-core] Encode nested map params for analytics request

### DIFF
--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2.kt
@@ -44,8 +44,8 @@ class AnalyticsRequestV2(
     // E.g for a nested map with value {"key", {"nestedKey1" -> "value1", "nestedKey2" -> "value2"}}
     // The params are encoded as a prettified json format sorted by key as follows
     // key="{
-    //    "nestedKey1": "value1",
-    //    "nestedKey2": "value2"
+    //   "nestedKey1": "value1",
+    //   "nestedKey2": "value2"
     // }"
     // As opposed to
     // key[nestedKey1]="value1"&key[nestedKey2]="value2"
@@ -110,16 +110,16 @@ class AnalyticsRequestV2(
                 }
             if (encodedValue.isNotBlank()) {
                 if (first) {
-                    stringBuilder.append(TAB.repeat(level)).append("$TAB\"$key\": $encodedValue")
+                    stringBuilder.append(INDENTATION.repeat(level)).append("$INDENTATION\"$key\": $encodedValue")
                     first = false
                 } else {
-                    stringBuilder.appendLine(",").append(TAB.repeat(level))
-                        .append("$TAB\"$key\": $encodedValue")
+                    stringBuilder.appendLine(",").append(INDENTATION.repeat(level))
+                        .append("$INDENTATION\"$key\": $encodedValue")
                 }
             }
         }
         stringBuilder.appendLine()
-        stringBuilder.append(TAB.repeat(level)).append("}")
+        stringBuilder.append(INDENTATION.repeat(level)).append("}")
         return stringBuilder.toString()
     }
 
@@ -163,6 +163,6 @@ class AnalyticsRequestV2(
         internal const val PARAM_EVENT_NAME = "event_name"
         internal const val PARAM_EVENT_ID = "event_id"
 
-        private const val TAB = "   "
+        private const val INDENTATION = "  "
     }
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestV2.kt
@@ -3,6 +3,7 @@ package com.stripe.android.core.networking
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.core.networking.AnalyticsRequestV2.Companion.HEADER_ORIGIN
+import com.stripe.android.core.networking.AnalyticsRequestV2.Companion.PARAM_CLIENT_ID
 import com.stripe.android.core.networking.AnalyticsRequestV2.Companion.PARAM_CREATED
 import com.stripe.android.core.networking.AnalyticsRequestV2.Companion.PARAM_EVENT_ID
 import com.stripe.android.core.networking.AnalyticsRequestV2.Companion.PARAM_EVENT_NAME
@@ -40,7 +41,6 @@ class AnalyticsRequestV2(
 ) : StripeRequest() {
     // Note: nested params are calculated as a json string, which is different from other requests
     // that uses form encoding.
-    // There are at most two levels of nest params for AnalyticsRequestV2.
     // E.g for a nested map with value {"key", {"nestedKey1" -> "value1", "nestedKey2" -> "value2"}}
     // The params are encoded as a prettified json format sorted by key as follows
     // key="{
@@ -93,22 +93,33 @@ class AnalyticsRequestV2(
         }
     }
 
-    private fun encodeMapParam(map: Map<*, *>): String {
+    private fun encodeMapParam(map: Map<*, *>, level: Int = 0): String {
         val stringBuilder = StringBuilder()
         var first = true
         stringBuilder.appendLine("{")
         map.toSortedMap { key1, key2 ->
             key1.toString().compareTo(key2.toString())
         }.forEach { (key, value) ->
-            if (first) {
-                stringBuilder.append("  \"$key\": \"$value\"")
-                first = false
-            } else {
-                stringBuilder.appendLine(",").append("  \"$key\": \"$value\"")
+            val encodedValue =
+                when (value) {
+                    is Map<*, *> -> {
+                        encodeMapParam(value, level + 1)
+                    }
+                    null -> ""
+                    else -> "\"$value\""
+                }
+            if (encodedValue.isNotBlank()) {
+                if (first) {
+                    stringBuilder.append(TAB.repeat(level)).append("$TAB\"$key\": $encodedValue")
+                    first = false
+                } else {
+                    stringBuilder.appendLine(",").append(TAB.repeat(level))
+                        .append("$TAB\"$key\": $encodedValue")
+                }
             }
         }
         stringBuilder.appendLine()
-        stringBuilder.append("}")
+        stringBuilder.append(TAB.repeat(level)).append("}")
         return stringBuilder.toString()
     }
 
@@ -151,5 +162,7 @@ class AnalyticsRequestV2(
         internal const val PARAM_CREATED = "created"
         internal const val PARAM_EVENT_NAME = "event_name"
         internal const val PARAM_EVENT_ID = "event_id"
+
+        private const val TAB = "   "
     }
 }

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestV2FactoryTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestV2FactoryTest.kt
@@ -110,20 +110,20 @@ class AnalyticsRequestV2FactoryTest {
                 URLEncoder.encode(
                     """
                     {
-                       "nestedParam1": "nestedValue1",
-                       "nestedParam2": "nestedValue2",
-                       "nestedParam3": "nestedValue3",
-                       "nestedParam4": {
-                          "nestedLv2Param1": "nestedLv2Value1",
-                          "nestedLv2Param2": "nestedLv2Value2",
-                          "nestedLv2Param3": "nestedLv2Value3",
-                          "nestedLv2Param5": ""
-                       },
-                       "nestedParam5": {
-                          "nestedLv2Param6": {
-                             "nestedLvl3Param1": "nestedLvl3Param2"
-                          }
-                       }
+                      "nestedParam1": "nestedValue1",
+                      "nestedParam2": "nestedValue2",
+                      "nestedParam3": "nestedValue3",
+                      "nestedParam4": {
+                        "nestedLv2Param1": "nestedLv2Value1",
+                        "nestedLv2Param2": "nestedLv2Value2",
+                        "nestedLv2Param3": "nestedLv2Value3",
+                        "nestedLv2Param5": ""
+                      },
+                      "nestedParam5": {
+                        "nestedLv2Param6": {
+                          "nestedLvl3Param1": "nestedLvl3Param2"
+                        }
+                      }
                     }
                     """.trimIndent(),
                     Charsets.UTF_8.name()

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestV2FactoryTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestV2FactoryTest.kt
@@ -75,42 +75,62 @@ class AnalyticsRequestV2FactoryTest {
 
     @Test
     fun `verify additionalParams`() {
-        val additionalParam1 = "param1"
-        val additionalValue1 = "value1"
-        val additionalParam2 = "param2"
-        val additionalValue2 = "value2"
-        val additionalParam3 = "param3"
-        val additionalValue3 = mapOf(
-            "nestedParam1" to "nestedValue1",
-            "nestedParam3" to "nestedValue3",
-            "nestedParam2" to "nestedValue2"
-        )
-
         val request = factory.createRequest(
             "EVENT_NAME",
             additionalParams = mapOf(
-                additionalParam1 to additionalValue1,
-                additionalParam2 to additionalValue2,
-                additionalParam3 to additionalValue3
+                "param1" to "value1",
+                "param2" to "value2",
+                "param3" to mapOf(
+                    "nestedParam1" to "nestedValue1",
+                    "nestedParam3" to "nestedValue3",
+                    "nestedParam2" to "nestedValue2",
+                    "nestedParam4" to mapOf(
+                        "nestedLv2Param1" to "nestedLv2Value1",
+                        "nestedLv2Param3" to "nestedLv2Value3",
+                        "nestedLv2Param2" to "nestedLv2Value2",
+                        "nestedLv2Param4" to null,
+                        "nestedLv2Param5" to "",
+                    ),
+                    "nestedParam5" to mapOf(
+                        "nestedLv2Param6" to mapOf(
+                            "nestedLvl3Param1" to "nestedLvl3Param2"
+                        )
+                    ),
+                ),
+                "param4" to null,
+                "param5" to "",
             ),
             includeSDKParams = true
         )
 
         request.postParameters.toMap().let { paramsMap ->
-            assertThat(paramsMap[additionalParam1]).isEqualTo(additionalValue1)
-            assertThat(paramsMap[additionalParam2]).isEqualTo(additionalValue2)
-            assertThat(paramsMap[additionalParam3]).isEqualTo(
+            assertThat(paramsMap["param1"]).isEqualTo("value1")
+            assertThat(paramsMap["param2"]).isEqualTo("value2")
+            assertThat(paramsMap["param3"]).isEqualTo(
                 URLEncoder.encode(
                     """
                     {
-                      "nestedParam1": "nestedValue1",
-                      "nestedParam2": "nestedValue2",
-                      "nestedParam3": "nestedValue3"
+                       "nestedParam1": "nestedValue1",
+                       "nestedParam2": "nestedValue2",
+                       "nestedParam3": "nestedValue3",
+                       "nestedParam4": {
+                          "nestedLv2Param1": "nestedLv2Value1",
+                          "nestedLv2Param2": "nestedLv2Value2",
+                          "nestedLv2Param3": "nestedLv2Value3",
+                          "nestedLv2Param5": ""
+                       },
+                       "nestedParam5": {
+                          "nestedLv2Param6": {
+                             "nestedLvl3Param1": "nestedLvl3Param2"
+                          }
+                       }
                     }
                     """.trimIndent(),
                     Charsets.UTF_8.name()
                 )
             )
+            assertThat(paramsMap.containsKey("param4")).isFalse()
+            assertThat(paramsMap["param5"]).isEqualTo("")
         }
     }
 

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestV2FactoryTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/AnalyticsRequestV2FactoryTest.kt
@@ -89,16 +89,16 @@ class AnalyticsRequestV2FactoryTest {
                         "nestedLv2Param3" to "nestedLv2Value3",
                         "nestedLv2Param2" to "nestedLv2Value2",
                         "nestedLv2Param4" to null,
-                        "nestedLv2Param5" to "",
+                        "nestedLv2Param5" to ""
                     ),
                     "nestedParam5" to mapOf(
                         "nestedLv2Param6" to mapOf(
                             "nestedLvl3Param1" to "nestedLvl3Param2"
                         )
-                    ),
+                    )
                 ),
                 "param4" to null,
-                "param5" to "",
+                "param5" to ""
             ),
             includeSDKParams = true
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Encode the params map recursively and remove null values.
An input map of the following 
```
mapOf(
    "nestedParam1" to "nestedValue1",
    "nestedParam3" to "nestedValue3",
    "nestedParam2" to "nestedValue2",
    "nestedParam4" to mapOf(
        "nestedLv2Param1" to "nestedLv2Value1",
        "nestedLv2Param3" to "nestedLv2Value3",
        "nestedLv2Param2" to "nestedLv2Value2",
        "nestedLv2Param4" to null,
        "nestedLv2Param5" to "",
    ),
    "nestedParam5" to mapOf(
        "nestedLv2Param6" to mapOf(
            "nestedLvl3Param1" to "nestedLvl3Param2"
        )
    ),
)
```
will be encoded as 
```
{
   "nestedParam1": "nestedValue1",
   "nestedParam2": "nestedValue2",
   "nestedParam3": "nestedValue3",
   "nestedParam4": {
      "nestedLv2Param1": "nestedLv2Value1",
      "nestedLv2Param2": "nestedLv2Value2",
      "nestedLv2Param3": "nestedLv2Value3",
      "nestedLv2Param5": ""
   },
   "nestedParam5": {
      "nestedLv2Param6": {
         "nestedLvl3Param1": "nestedLvl3Param2"
      }
   }
}
```

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Send correct params to analytics server

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
