### PR TITLE
[Identity] Wrap additional params in a nested map entry with event_metadata

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/analytics/IdentityAnalyticsRequestFactory.kt
+++ b/identity/src/main/java/com/stripe/android/identity/analytics/IdentityAnalyticsRequestFactory.kt
@@ -21,17 +21,20 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
         origin = ORIGIN
     )
 
+    private fun additionalParamWithEventMetadata(vararg pairs: Pair<String, *>) =
+        mapOf(
+            PARAM_VERIFICATION_SESSION to args.verificationSessionId,
+            PARAM_EVENT_META_DATA to mapOf(*pairs)
+        )
+
     fun sheetPresented() = requestFactory.createRequest(
         EVENT_SHEET_PRESENTED,
-        additionalParams = mapOf(
-            PARAM_VERIFICATION_SESSION to args.verificationSessionId
-        )
+        additionalParams = additionalParamWithEventMetadata()
     )
 
     fun sheetClosed(sessionResult: String) = requestFactory.createRequest(
         eventName = EVENT_SHEET_CLOSED,
-        additionalParams = mapOf(
-            PARAM_VERIFICATION_SESSION to args.verificationSessionId,
+        additionalParams = additionalParamWithEventMetadata(
             PARAM_SESSION_RESULT to sessionResult
         )
     )
@@ -50,10 +53,8 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
         selfieModelScore: Float? = null
     ) = requestFactory.createRequest(
         eventName = EVENT_VERIFICATION_SUCCEEDED,
-        additionalParams =
-        mapOf(
+        additionalParams = additionalParamWithEventMetadata(
             PARAM_FROM_FALLBACK_URL to isFromFallbackUrl,
-            PARAM_VERIFICATION_SESSION to args.verificationSessionId,
             PARAM_SCAN_TYPE to scanType?.toParam(),
             PARAM_REQUIRE_SELFIE to requireSelfie,
             PARAM_DOC_FRONT_RETRY_TIMES to docFrontRetryTimes,
@@ -74,10 +75,8 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
         requireSelfie: Boolean? = null
     ) = requestFactory.createRequest(
         eventName = EVENT_VERIFICATION_CANCELED,
-        additionalParams =
-        mapOf(
+        additionalParams = additionalParamWithEventMetadata(
             PARAM_FROM_FALLBACK_URL to isFromFallbackUrl,
-            PARAM_VERIFICATION_SESSION to args.verificationSessionId,
             PARAM_SCAN_TYPE to scanType?.toParam(),
             PARAM_REQUIRE_SELFIE to requireSelfie,
             PARAM_LAST_SCREEN_NAME to lastScreenName
@@ -93,10 +92,8 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
         throwable: Throwable
     ) = requestFactory.createRequest(
         eventName = EVENT_VERIFICATION_FAILED,
-        additionalParams =
-        mapOf(
+        additionalParams = additionalParamWithEventMetadata(
             PARAM_FROM_FALLBACK_URL to isFromFallbackUrl,
-            PARAM_VERIFICATION_SESSION to args.verificationSessionId,
             PARAM_SCAN_TYPE to scanType?.toParam(),
             PARAM_REQUIRE_SELFIE to requireSelfie,
             PARAM_DOC_FRONT_UPLOAD_TYPE to docFrontUploadType?.name,
@@ -113,8 +110,7 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
         screenName: String
     ) = requestFactory.createRequest(
         eventName = EVENT_SCREEN_PRESENTED,
-        additionalParams = mapOf(
-            PARAM_VERIFICATION_SESSION to args.verificationSessionId,
+        additionalParams = additionalParamWithEventMetadata(
             PARAM_SCAN_TYPE to scanType?.toParam(),
             PARAM_SCREEN_NAME to screenName
         )
@@ -125,8 +121,7 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
         throwable: Throwable
     ) = requestFactory.createRequest(
         eventName = EVENT_CAMERA_ERROR,
-        additionalParams = mapOf(
-            PARAM_VERIFICATION_SESSION to args.verificationSessionId,
+        additionalParams = additionalParamWithEventMetadata(
             PARAM_SCAN_TYPE to scanType.toParam(),
             PARAM_ERROR to mapOf(
                 PARAM_EXCEPTION to throwable.javaClass.name,
@@ -139,8 +134,7 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
         scanType: IdentityScanState.ScanType
     ) = requestFactory.createRequest(
         eventName = EVENT_CAMERA_PERMISSION_DENIED,
-        additionalParams = mapOf(
-            PARAM_VERIFICATION_SESSION to args.verificationSessionId,
+        additionalParams = additionalParamWithEventMetadata(
             PARAM_SCAN_TYPE to scanType.toParam()
         )
     )
@@ -149,8 +143,7 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
         scanType: IdentityScanState.ScanType
     ) = requestFactory.createRequest(
         eventName = EVENT_CAMERA_PERMISSION_GRANTED,
-        additionalParams = mapOf(
-            PARAM_VERIFICATION_SESSION to args.verificationSessionId,
+        additionalParams = additionalParamWithEventMetadata(
             PARAM_SCAN_TYPE to scanType.toParam()
         )
     )
@@ -159,8 +152,7 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
         scanType: IdentityScanState.ScanType
     ) = requestFactory.createRequest(
         eventName = EVENT_DOCUMENT_TIMEOUT,
-        additionalParams = mapOf(
-            PARAM_VERIFICATION_SESSION to args.verificationSessionId,
+        additionalParams = additionalParamWithEventMetadata(
             PARAM_SCAN_TYPE to scanType.toParam(),
             PARAM_SIDE to scanType.toSide()
         )
@@ -168,28 +160,27 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
 
     fun selfieTimeout() = requestFactory.createRequest(
         eventName = EVENT_SELFIE_TIMEOUT,
-        additionalParams = mapOf(
-            PARAM_VERIFICATION_SESSION to args.verificationSessionId
-        )
+        additionalParams = additionalParamWithEventMetadata()
     )
 
     fun averageFps(type: String, value: Int) = requestFactory.createRequest(
         eventName = EVENT_AVERAGE_FPS,
-        additionalParams = mapOf(
+        additionalParams = additionalParamWithEventMetadata(
             PARAM_TYPE to type,
             PARAM_VALUE to value
         )
     )
 
-    fun modelPerformance(mlModel: String, preprocess: Long, inference: Long, frames: Int) = requestFactory.createRequest(
-        eventName = EVENT_MODEL_PERFORMANCE,
-        additionalParams = mapOf(
-            PARAM_PREPROCESS to preprocess,
-            PARAM_INFERENCE to inference,
-            PARAM_ML_MODEL to mlModel,
-            PARAM_FRAMES to frames
+    fun modelPerformance(mlModel: String, preprocess: Long, inference: Long, frames: Int) =
+        requestFactory.createRequest(
+            eventName = EVENT_MODEL_PERFORMANCE,
+            additionalParams = additionalParamWithEventMetadata(
+                PARAM_PREPROCESS to preprocess,
+                PARAM_INFERENCE to inference,
+                PARAM_ML_MODEL to mlModel,
+                PARAM_FRAMES to frames
+            )
         )
-    )
 
     private fun IdentityScanState.ScanType.toParam(): String =
         when (this) {
@@ -238,6 +229,7 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
         const val EVENT_AVERAGE_FPS = "average_fps"
         const val EVENT_MODEL_PERFORMANCE = "model_performance"
 
+        const val PARAM_EVENT_META_DATA = "event_metadata"
         const val PARAM_FROM_FALLBACK_URL = "from_fallback_url"
         const val PARAM_VERIFICATION_SESSION = "verification_session"
         const val PARAM_SESSION_RESULT = "session_result"

--- a/identity/src/test/java/com/stripe/android/identity/navigation/CameraPermissionDeniedFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/CameraPermissionDeniedFragmentTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.camera.AppSettingsOpenable
 import com.stripe.android.identity.R
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.EVENT_SCREEN_PRESENTED
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_EVENT_META_DATA
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_SCREEN_NAME
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_ERROR
 import com.stripe.android.identity.databinding.BaseErrorFragmentBinding
@@ -138,7 +139,7 @@ class CameraPermissionDeniedFragmentTest {
             verify(mockIdentityViewModel).sendAnalyticsRequest(
                 argThat {
                     eventName == EVENT_SCREEN_PRESENTED &&
-                        params[PARAM_SCREEN_NAME] == SCREEN_NAME_ERROR
+                        (params[PARAM_EVENT_META_DATA] as Map<*, *>)[PARAM_SCREEN_NAME] == SCREEN_NAME_ERROR
                 }
             )
         }

--- a/identity/src/test/java/com/stripe/android/identity/navigation/ConfirmationFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/ConfirmationFragmentTest.kt
@@ -10,6 +10,7 @@ import com.stripe.android.identity.R
 import com.stripe.android.identity.VerificationFlowFinishable
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.EVENT_SCREEN_PRESENTED
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_EVENT_META_DATA
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_SCREEN_NAME
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_CONFIRMATION
 import com.stripe.android.identity.databinding.ConfirmationFragmentBinding
@@ -87,7 +88,7 @@ class ConfirmationFragmentTest {
             verify(mockIdentityViewModel).sendAnalyticsRequest(
                 argThat {
                     eventName == EVENT_SCREEN_PRESENTED &&
-                        params[PARAM_SCREEN_NAME] == SCREEN_NAME_CONFIRMATION
+                        (params[PARAM_EVENT_META_DATA] as Map<*, *>)[PARAM_SCREEN_NAME] == SCREEN_NAME_CONFIRMATION
                 }
             )
             assertThat(binding.titleText.text).isEqualTo(CONFIRMATION_TITLE)

--- a/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
@@ -17,6 +17,7 @@ import com.stripe.android.identity.IdentityVerificationSheetContract
 import com.stripe.android.identity.R
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.EVENT_SCREEN_PRESENTED
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_EVENT_META_DATA
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_SCREEN_NAME
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_CONSENT
 import com.stripe.android.identity.databinding.ConsentFragmentBinding
@@ -223,7 +224,7 @@ internal class ConsentFragmentTest {
             verify(mockIdentityViewModel).sendAnalyticsRequest(
                 argThat {
                     eventName == EVENT_SCREEN_PRESENTED &&
-                        params[PARAM_SCREEN_NAME] == SCREEN_NAME_CONSENT
+                        (params[PARAM_EVENT_META_DATA] as Map<*, *>)[PARAM_SCREEN_NAME] == SCREEN_NAME_CONSENT
                 }
             )
             verify(

--- a/identity/src/test/java/com/stripe/android/identity/navigation/CouldNotCaptureFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/CouldNotCaptureFragmentTest.kt
@@ -12,6 +12,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.identity.R
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.EVENT_SCREEN_PRESENTED
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_EVENT_META_DATA
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_SCREEN_NAME
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_ERROR
 import com.stripe.android.identity.databinding.BaseErrorFragmentBinding
@@ -199,7 +200,7 @@ internal class CouldNotCaptureFragmentTest {
         verify(mockIdentityViewModel).sendAnalyticsRequest(
             argThat {
                 eventName == EVENT_SCREEN_PRESENTED &&
-                    params[PARAM_SCREEN_NAME] == SCREEN_NAME_ERROR
+                    (params[PARAM_EVENT_META_DATA] as Map<*, *>)[PARAM_SCREEN_NAME] == SCREEN_NAME_ERROR
             }
         )
 

--- a/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.EVENT_CAMERA_PERMISSION_DENIED
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.EVENT_CAMERA_PERMISSION_GRANTED
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.EVENT_SCREEN_PRESENTED
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_EVENT_META_DATA
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_SCREEN_NAME
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_DOC_SELECT
 import com.stripe.android.identity.databinding.DocSelectionFragmentBinding
@@ -113,7 +114,7 @@ internal class DocSelectionFragmentTest {
             verify(mockIdentityViewModel).sendAnalyticsRequest(
                 argThat {
                     eventName == EVENT_SCREEN_PRESENTED &&
-                        params[PARAM_SCREEN_NAME] == SCREEN_NAME_DOC_SELECT
+                        (params[PARAM_EVENT_META_DATA] as Map<*, *>)[PARAM_SCREEN_NAME] == SCREEN_NAME_DOC_SELECT
                 }
             )
             assertThat(binding.title.text).isEqualTo(DOCUMENT_SELECT_TITLE)

--- a/identity/src/test/java/com/stripe/android/identity/navigation/DriverLicenseScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/DriverLicenseScanFragmentTest.kt
@@ -21,6 +21,7 @@ import com.stripe.android.identity.SUCCESS_VERIFICATION_PAGE_NOT_REQUIRE_LIVE_CA
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.DRIVER_LICENSE
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.EVENT_SCREEN_PRESENTED
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_EVENT_META_DATA
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_SCAN_TYPE
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_SCREEN_NAME
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_LIVE_CAPTURE
@@ -125,8 +126,8 @@ internal class DriverLicenseScanFragmentTest {
             verify(mockIdentityViewModel).sendAnalyticsRequest(
                 argThat {
                     eventName == EVENT_SCREEN_PRESENTED &&
-                        params[PARAM_SCREEN_NAME] == SCREEN_NAME_LIVE_CAPTURE &&
-                        params[PARAM_SCAN_TYPE] == DRIVER_LICENSE
+                        (params[PARAM_EVENT_META_DATA] as Map<*, *>)[PARAM_SCREEN_NAME] == SCREEN_NAME_LIVE_CAPTURE &&
+                        (params[PARAM_EVENT_META_DATA] as Map<*, *>)[PARAM_SCAN_TYPE] == DRIVER_LICENSE
                 }
             )
         }

--- a/identity/src/test/java/com/stripe/android/identity/navigation/ErrorFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/ErrorFragmentTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.identity.R
 import com.stripe.android.identity.VerificationFlowFinishable
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.EVENT_SCREEN_PRESENTED
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_EVENT_META_DATA
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_SCREEN_NAME
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_ERROR
 import com.stripe.android.identity.databinding.BaseErrorFragmentBinding
@@ -44,7 +45,7 @@ class ErrorFragmentTest {
             verify(mockIdentityViewModel).sendAnalyticsRequest(
                 argThat {
                     eventName == EVENT_SCREEN_PRESENTED &&
-                        params[PARAM_SCREEN_NAME] == SCREEN_NAME_ERROR
+                        (params[PARAM_EVENT_META_DATA] as Map<*, *>)[PARAM_SCREEN_NAME] == SCREEN_NAME_ERROR
                 }
             )
 

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IDScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IDScanFragmentTest.kt
@@ -22,6 +22,7 @@ import com.stripe.android.identity.analytics.FPSTracker
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.EVENT_SCREEN_PRESENTED
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.ID
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_EVENT_META_DATA
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_SCAN_TYPE
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_SCREEN_NAME
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_LIVE_CAPTURE
@@ -129,8 +130,8 @@ internal class IDScanFragmentTest {
             verify(mockIdentityViewModel).sendAnalyticsRequest(
                 argThat {
                     eventName == EVENT_SCREEN_PRESENTED &&
-                        params[PARAM_SCREEN_NAME] == SCREEN_NAME_LIVE_CAPTURE &&
-                        params[PARAM_SCAN_TYPE] == ID
+                        (params[PARAM_EVENT_META_DATA] as Map<*, *>)[PARAM_SCREEN_NAME] == SCREEN_NAME_LIVE_CAPTURE &&
+                        (params[PARAM_EVENT_META_DATA] as Map<*, *>)[PARAM_SCAN_TYPE] == ID
                 }
             )
             verify(mockFPSTracker).start()

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IdentityUploadFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IdentityUploadFragmentTest.kt
@@ -25,8 +25,11 @@ import com.stripe.android.identity.CORRECT_WITH_SUBMITTED_SUCCESS_VERIFICATION_P
 import com.stripe.android.identity.R
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.EVENT_SCREEN_PRESENTED
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.ID
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_EVENT_META_DATA
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_SCAN_TYPE
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_SCREEN_NAME
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_FILE_UPLOAD
 import com.stripe.android.identity.databinding.IdentityUploadFragmentBinding
 import com.stripe.android.identity.networking.DocumentUploadState
 import com.stripe.android.identity.networking.Resource
@@ -612,8 +615,8 @@ class IdentityUploadFragmentTest {
             verify(identityViewModel).sendAnalyticsRequest(
                 argThat {
                     eventName == EVENT_SCREEN_PRESENTED &&
-                        params[PARAM_SCREEN_NAME] == IdentityAnalyticsRequestFactory.SCREEN_NAME_FILE_UPLOAD &&
-                        params[PARAM_SCAN_TYPE] == IdentityAnalyticsRequestFactory.ID // from frontScanType = IdentityScanState.ScanType.ID_FRONT
+                        (params[PARAM_EVENT_META_DATA] as Map<*, *>)[PARAM_SCREEN_NAME] == SCREEN_NAME_FILE_UPLOAD &&
+                        (params[PARAM_EVENT_META_DATA] as Map<*, *>)[PARAM_SCAN_TYPE] == ID // from frontScanType = IdentityScanState.ScanType.ID_FRONT
                 }
             )
         }

--- a/identity/src/test/java/com/stripe/android/identity/navigation/PassportScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/PassportScanFragmentTest.kt
@@ -18,6 +18,7 @@ import com.stripe.android.identity.R
 import com.stripe.android.identity.SUCCESS_VERIFICATION_PAGE_NOT_REQUIRE_LIVE_CAPTURE
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.EVENT_SCREEN_PRESENTED
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_EVENT_META_DATA
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_SCAN_TYPE
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_SCREEN_NAME
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PASSPORT
@@ -121,8 +122,8 @@ class PassportScanFragmentTest {
             verify(mockIdentityViewModel).sendAnalyticsRequest(
                 argThat {
                     eventName == EVENT_SCREEN_PRESENTED &&
-                        params[PARAM_SCREEN_NAME] == SCREEN_NAME_LIVE_CAPTURE &&
-                        params[PARAM_SCAN_TYPE] == PASSPORT
+                        (params[PARAM_EVENT_META_DATA] as Map<*, *>)[PARAM_SCREEN_NAME] == SCREEN_NAME_LIVE_CAPTURE &&
+                        (params[PARAM_EVENT_META_DATA] as Map<*, *>)[PARAM_SCAN_TYPE] == PASSPORT
                 }
             )
         }

--- a/identity/src/test/java/com/stripe/android/identity/navigation/SelfieFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/SelfieFragmentTest.kt
@@ -18,6 +18,7 @@ import com.stripe.android.identity.R
 import com.stripe.android.identity.analytics.FPSTracker
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.EVENT_SCREEN_PRESENTED
+import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_EVENT_META_DATA
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.PARAM_SCREEN_NAME
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_SELFIE
 import com.stripe.android.identity.camera.IdentityAggregator
@@ -119,7 +120,7 @@ internal class SelfieFragmentTest {
             verify(mockIdentityViewModel).sendAnalyticsRequest(
                 argThat {
                     eventName == EVENT_SCREEN_PRESENTED &&
-                        params[PARAM_SCREEN_NAME] == SCREEN_NAME_SELFIE
+                        (params[PARAM_EVENT_META_DATA] as Map<*, *>)[PARAM_SCREEN_NAME] == SCREEN_NAME_SELFIE
                 }
             )
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
When sending custom [additional properties](https://docs.google.com/document/d/1LyVYV4mLaozxjJu-wkMojDdAkV8NajQ_E8NVNAQAGK4/edit#bookmark=id.chfeax1mc30i) params `{"p1"="v1", "p2"="v2"}`, instead of directly encoding them as column names, they should be added as the value of key `event_metadata`
```
"event_metadata":  "{
  "p1"="v1", 
  "p2"="v2"
}"
```

#5209 ensures if "v1" is a map, it's encoded recursively

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Send correct analytics param

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
