### PR TITLE
Fix `stripecardscan-tflite` build for Jitpack

### DIFF
--- a/stripecardscan-tflite/build.gradle
+++ b/stripecardscan-tflite/build.gradle
@@ -1,6 +1,10 @@
 configurations.maybeCreate("default")
 artifacts.add("default", file('tensorflow-lite-all-models.aar'))
 
+if (System.getenv("JITPACK")) {
+    group='com.github.stripe.stripe-android'
+}
+
 ext {
     artifactId = "stripecardscan-tflite"
     artifactName = "stripecardscan-tflite"


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Need to set the group otherwise the dependency is not found.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix building on Jitpack
