### PR TITLE
E2E tests should always set merchant country.

### DIFF
--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestAuthorization.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestAuthorization.kt
@@ -67,6 +67,7 @@ class TestAuthorization {
         saveForFutureUseCheckboxVisible = false,
         useBrowser = Browser.Chrome,
         authorizationAction = AuthorizeAction.Authorize,
+        merchantCountryCode = "GB",
     )
 
     @Test

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestBrowsers.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestBrowsers.kt
@@ -73,6 +73,7 @@ class TestBrowsers {
         saveForFutureUseCheckboxVisible = false,
         useBrowser = Browser.Chrome,
         authorizationAction = AuthorizeAction.Authorize,
+        merchantCountryCode = "GB",
     )
 
     @Test

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestCustomers.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestCustomers.kt
@@ -66,6 +66,7 @@ class TestCustomers {
         saveForFutureUseCheckboxVisible = false,
         useBrowser = Browser.Chrome,
         authorizationAction = AuthorizeAction.Authorize,
+        merchantCountryCode = "GB",
     )
 
     @Test

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestFieldPopulation.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestFieldPopulation.kt
@@ -67,6 +67,7 @@ class TestFieldPopulation {
         saveForFutureUseCheckboxVisible = false,
         useBrowser = null,
         authorizationAction = null,
+        merchantCountryCode = "GB",
     )
 
     private val card = TestParameters(
@@ -74,6 +75,7 @@ class TestFieldPopulation {
         customer = Customer.New,
         googlePayState = GooglePayState.On,
         currency = Currency.EUR,
+        merchantCountryCode = "GB",
         intentType = IntentType.Pay,
         billing = Billing.On,
         shipping = Shipping.Off,

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestGooglePay.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestGooglePay.kt
@@ -71,6 +71,7 @@ class TestGooglePay {
         saveForFutureUseCheckboxVisible = false,
         useBrowser = Browser.Chrome,
         authorizationAction = AuthorizeAction.Authorize,
+        merchantCountryCode = "GB",
     )
 
     @Test
@@ -89,6 +90,7 @@ class TestGooglePay {
             testParameters.copy(
                 paymentMethod = LpmRepository.HardcodedCard,
                 currency = Currency.USD,
+                merchantCountryCode = "US",
                 intentType = IntentType.Setup, // This means only card will show
             ),
             R.string.stripe_paymentsheet_or_pay_using

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestHardCodedLpms.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestHardCodedLpms.kt
@@ -72,7 +72,8 @@ class TestHardCodedLpms {
         saveForFutureUseCheckboxVisible = false,
         useBrowser = null,
         authorizationAction = AuthorizeAction.Authorize,
-        takeScreenshotOnLpmLoad = true
+        takeScreenshotOnLpmLoad = true,
+        merchantCountryCode = "GB"
     )
 
     @Test
@@ -163,6 +164,7 @@ class TestHardCodedLpms {
             newUser.copy(
                 paymentMethod = lpmRepository.fromCode("afterpay_clearpay")!!,
                 authorizationAction = AuthorizeAction.Authorize,
+                merchantCountryCode = "US",
                 currency = Currency.USD,
                 shipping = Shipping.On
             )
@@ -176,6 +178,7 @@ class TestHardCodedLpms {
                 paymentMethod = lpmRepository.fromCode("sofort")!!,
                 authorizationAction = AuthorizeAction.Authorize,
                 currency = Currency.EUR,
+                merchantCountryCode = "GB",
                 delayed = DelayedPMs.On,
                 automatic = Automatic.Off
             )
@@ -188,6 +191,7 @@ class TestHardCodedLpms {
             newUser.copy(
                 paymentMethod = lpmRepository.fromCode("affirm")!!,
                 authorizationAction = AuthorizeAction.Authorize,
+                merchantCountryCode = "US",
                 currency = Currency.USD,
                 shipping = Shipping.On,
                 automatic = Automatic.Off
@@ -216,7 +220,8 @@ class TestHardCodedLpms {
             newUser.copy(
                 paymentMethod = lpmRepository.fromCode("klarna")!!,
                 authorizationAction = AuthorizeAction.Authorize,
-                currency = Currency.USD
+                currency = Currency.USD,
+                merchantCountryCode = "US",
             )
         )
     }
@@ -228,6 +233,7 @@ class TestHardCodedLpms {
                 paymentMethod = lpmRepository.fromCode("paypal")!!,
                 authorizationAction = AuthorizeAction.Authorize,
                 currency = Currency.GBP,
+                merchantCountryCode = "GB",
                 automatic = Automatic.Off
             )
         )

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestMultiStepFieldsReloaded.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestMultiStepFieldsReloaded.kt
@@ -58,6 +58,7 @@ class TestMultiStepFieldsReloaded {
         saveForFutureUseCheckboxVisible = false,
         useBrowser = null,
         authorizationAction = AuthorizeAction.Authorize,
+        merchantCountryCode = "GB",
     )
 
     @Before
@@ -153,6 +154,7 @@ class TestMultiStepFieldsReloaded {
         testDriver.confirmCustom(
             newUser.copy(
                 paymentMethod = lpmRepository.fromCode("afterpay_clearpay")!!,
+                merchantCountryCode = "US",
                 currency = Currency.USD,
                 shipping = Shipping.On
             )
@@ -164,6 +166,7 @@ class TestMultiStepFieldsReloaded {
         testDriver.confirmCustom(
             newUser.copy(
                 paymentMethod = lpmRepository.fromCode("affirm")!!,
+                merchantCountryCode = "US",
                 currency = Currency.USD,
             )
         )
@@ -175,6 +178,7 @@ class TestMultiStepFieldsReloaded {
             newUser.copy(
                 paymentMethod = lpmRepository.fromCode("au_becs_debit")!!,
                 delayed = DelayedPMs.On,
+                merchantCountryCode = "AU",
                 currency = Currency.AUD,
             )
         )

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/screenshot/TestPaymentSheetScreenshots.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/screenshot/TestPaymentSheetScreenshots.kt
@@ -63,7 +63,8 @@ class TestPaymentSheetScreenshots {
         useBrowser = null,
         authorizationAction = null,
         takeScreenshotOnLpmLoad = true,
-        snapshotReturningCustomer = true
+        snapshotReturningCustomer = true,
+        merchantCountryCode = "GB",
     )
 
     private val colors = PaymentSheet.Colors(

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/TestParameters.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/TestParameters.kt
@@ -24,12 +24,7 @@ data class TestParameters(
     val forceDarkMode: Boolean? = null,
     val appearance: PaymentSheet.Appearance = PaymentSheet.Appearance(),
     val snapshotReturningCustomer: Boolean = false,
-    val merchantCountryCode: String = when (currency) {
-        Currency.EUR -> "GB"
-        Currency.AUD -> "AU"
-        Currency.GBP -> "GB"
-        Currency.USD -> "US"
-    }
+    val merchantCountryCode: String
 )
 
 /**


### PR DESCRIPTION
# Summary
Updated the tests to always include the merchant country required.  As things are now saved the defaults are not used and this impacted some of the tests.

# Motivation
Failing browserstack tests: https://app-automate.browserstack.com/dashboard/v2/builds/2db9f092f5a044853e2fb487f288c8aa7030e0f9

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
