### PR TITLE
Call out compileSdkVersion upgrade on CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 ## 20.6.2 - 2022-06-23
 This release contains several bug fixes for Payments, reduces the size of StripeCardScan, and adds new `rememberFinancialConnections` features for Financial Connections.
 
+* [CHANGED] [5162](https://github.com/stripe/stripe-android/pull/5162) Upgrade `compileSdkVersion` to 32, Kotlin version to 1.6.21, Android Gradle plugin to 7.2.1.
+
 ### Financial Connections
 * [ADDED][5117](https://github.com/stripe/stripe-android/pull/5117) Adds rememberFinancialConnectionsSheet and rememberFinancialConnectionsSheetForToken.
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Version was upgraded and requires users to upgrade their compileSdkVersion too.
Also updated the release description https://github.com/stripe/stripe-android/releases/tag/v20.6.2.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Inform users of upgrade.

