### PR TITLE
Persist GooglePayLauncherViewModel state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 ## X.X.X
 
 ### PaymentSheet
-* [Fixed][5215](https://github.com/stripe/stripe-android/pull/5215) Fix issue with us_bank_account appearing in payment sheet when Financial Connections SDK is not available
+* [Fixed] [5215](https://github.com/stripe/stripe-android/pull/5215) Fix issue with us_bank_account appearing in payment sheet when Financial Connections SDK is not available
+
+### Payments
+* [FIXED] [5226](https://github.com/stripe/stripe-android/pull/5226) Persist `GooglePayLauncherViewModel` state across process death
 
 ## 20.6.2 - 2022-06-23
 This release contains several bug fixes for Payments, reduces the size of StripeCardScan, and adds new `rememberFinancialConnections` features for Financial Connections.

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherActivity.kt
@@ -35,7 +35,8 @@ internal class GooglePayLauncherActivity : AppCompatActivity() {
     private val viewModel: GooglePayLauncherViewModel by viewModels {
         GooglePayLauncherViewModel.Factory(
             application,
-            args
+            args,
+            this
         )
     }
 
@@ -68,14 +69,13 @@ internal class GooglePayLauncherActivity : AppCompatActivity() {
         }
 
         if (!viewModel.hasLaunched) {
-            viewModel.hasLaunched = true
-
             lifecycleScope.launch {
                 runCatching {
                     viewModel.createLoadPaymentDataTask()
                 }.fold(
                     onSuccess = {
                         payWithGoogle(it)
+                        viewModel.hasLaunched = true
                     },
                     onFailure = {
                         viewModel.updateResult(

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.launch
 import org.json.JSONObject
 import kotlin.coroutines.CoroutineContext
 
+@Suppress("LongParameterList")
 internal class GooglePayLauncherViewModel(
     private val paymentsClient: PaymentsClient,
     private val requestOptions: ApiRequest.Options,

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
@@ -290,6 +290,7 @@ internal class GooglePayLauncherViewModel(
     }
 
     companion object {
-        private const val HAS_LAUNCHED_KEY = "has_launched"
+        @VisibleForTesting
+        const val HAS_LAUNCHED_KEY = "has_launched"
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
@@ -2,12 +2,15 @@ package com.stripe.android.googlepaylauncher
 
 import android.app.Application
 import android.content.Intent
+import android.os.Bundle
 import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.AbstractSavedStateViewModelFactory
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.viewModelScope
+import androidx.savedstate.SavedStateRegistryOwner
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.wallet.PaymentData
 import com.google.android.gms.wallet.PaymentDataRequest
@@ -42,9 +45,17 @@ internal class GooglePayLauncherViewModel(
     private val stripeRepository: StripeRepository,
     private val paymentController: PaymentController,
     private val googlePayJsonFactory: GooglePayJsonFactory,
-    private val googlePayRepository: GooglePayRepository
+    private val googlePayRepository: GooglePayRepository,
+    private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
-    var hasLaunched: Boolean = false
+    /**
+     * [hasLaunched] indicates whether Google Pay has already been launched, and must be persisted
+     * across process death in case the Activity and ViewModel are destroyed while the user is
+     * interacting with Google Pay.
+     */
+    var hasLaunched: Boolean
+        get() = savedStateHandle.get<Boolean>(HAS_LAUNCHED_KEY) == true
+        set(value) = savedStateHandle.set(HAS_LAUNCHED_KEY, value)
 
     private val _googleResult = MutableLiveData<GooglePayLauncher.Result>()
     internal val googlePayResult = _googleResult.distinctUntilChanged()
@@ -209,11 +220,17 @@ internal class GooglePayLauncherViewModel(
     internal class Factory(
         private val application: Application,
         private val args: GooglePayLauncherContract.Args,
+        owner: SavedStateRegistryOwner,
         private val enableLogging: Boolean = false,
-        private val workContext: CoroutineContext = Dispatchers.IO
-    ) : ViewModelProvider.Factory {
+        private val workContext: CoroutineContext = Dispatchers.IO,
+        defaultArgs: Bundle? = null
+    ) : AbstractSavedStateViewModelFactory(owner, defaultArgs) {
         @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        override fun <T : ViewModel> create(
+            key: String,
+            modelClass: Class<T>,
+            handle: SavedStateHandle
+        ): T {
             val googlePayEnvironment = args.config.environment
             val logger = Logger.getInstance(enableLogging)
 
@@ -265,8 +282,13 @@ internal class GooglePayLauncherViewModel(
                     googlePayConfig = GooglePayConfig(publishableKey, stripeAccountId),
                     isJcbEnabled = args.config.isJcbEnabled
                 ),
-                googlePayRepository
+                googlePayRepository,
+                handle
             ) as T
         }
+    }
+
+    companion object {
+        private const val HAS_LAUNCHED_KEY = "has_launched"
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.googlepaylauncher
 
 import android.content.Intent
+import androidx.lifecycle.SavedStateHandle
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.wallet.PaymentData
 import com.google.android.gms.wallet.PaymentsClient
@@ -14,6 +15,7 @@ import com.stripe.android.SetupIntentResult
 import com.stripe.android.StripePaymentController
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.googlepaylauncher.GooglePayLauncherViewModel.Companion.HAS_LAUNCHED_KEY
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
@@ -42,6 +44,7 @@ import kotlin.test.assertFailsWith
 @RunWith(RobolectricTestRunner::class)
 class GooglePayLauncherViewModelTest {
     private val stripeRepository = FakeStripeRepository()
+    private val savedStateHandle = SavedStateHandle()
     private val googlePayJsonFactory = GooglePayJsonFactory(
         googlePayConfig = GooglePayConfig(
             ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
@@ -122,6 +125,17 @@ class GooglePayLauncherViewModelTest {
                     checkoutOption = GooglePayJsonFactory.TransactionInfo.CheckoutOption.Default
                 )
             )
+    }
+
+    @Test
+    fun `hasLaunched is stored in savedStateHandle`() {
+        val viewModel = createViewModel()
+
+        assertThat(viewModel.hasLaunched).isFalse()
+
+        viewModel.hasLaunched = true
+
+        assertThat(savedStateHandle.get<Boolean>(HAS_LAUNCHED_KEY)).isTrue()
     }
 
     @Test
@@ -218,7 +232,8 @@ class GooglePayLauncherViewModelTest {
         stripeRepository,
         paymentController,
         googlePayJsonFactory,
-        googlePayRepository
+        googlePayRepository,
+        savedStateHandle
     )
 
     private class FakePaymentController : AbsPaymentController() {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Persist `GooglePayLauncherViewModel` state across process death.
`GooglePayLauncherViewModel.hasLaunched` was kept in memory, so if the ViewModel was destroyed and recreated, it would launch Google Pay again. This is already fixed in [`GooglePayPaymentMethodLauncherViewModel`](https://github.com/stripe/stripe-android/blob/master/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt). 
Also fix the example `GooglePayLauncherIntegrationActivity` which would request a new Payment Intent when the activity is recreated.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix #5193 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

Hard to test killing and restoring process, probably a good candidate for the instrumentation tests.
