### PR TITLE
Only finish consent fragment tracking when the UI is correctly bound

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
@@ -81,6 +81,10 @@ internal class ConsentFragment(
                         verificationPage.biometricConsent,
                         verificationPage.requireSelfie()
                     )
+
+                    lifecycleScope.launch(identityViewModel.workContext) {
+                        identityViewModel.screenTracker.screenTransitionFinish(SCREEN_NAME_CONSENT)
+                    }
                 } else {
                     navigateToDocSelection()
                 }
@@ -94,9 +98,6 @@ internal class ConsentFragment(
             }
         )
 
-        lifecycleScope.launch(identityViewModel.workContext) {
-            identityViewModel.screenTracker.screenTransitionFinish(SCREEN_NAME_CONSENT)
-        }
         identityViewModel.sendAnalyticsRequest(
             identityViewModel.identityAnalyticsRequestFactory.screenPresented(
                 screenName = SCREEN_NAME_CONSENT

--- a/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
@@ -234,6 +234,10 @@ internal class ConsentFragmentTest {
         launchConsentFragment { binding, _, _ ->
             setUpSuccessVerificationPage()
 
+            runBlocking {
+                verify(mockScreenTracker).screenTransitionFinish(eq(SCREEN_NAME_CONSENT))
+            }
+
             verify(mockIdentityViewModel).sendAnalyticsRequest(
                 argThat {
                     eventName == EVENT_SCREEN_PRESENTED &&
@@ -445,9 +449,6 @@ internal class ConsentFragmentTest {
             it.requireView(),
             navController
         )
-        runBlocking {
-            verify(mockScreenTracker).screenTransitionFinish(eq(SCREEN_NAME_CONSENT))
-        }
         testBlock(ConsentFragmentBinding.bind(it.requireView()), navController, it)
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
It's possible the `ConsentFragment` is skipped due to client not supported or consent is granted. This change makes it only track the finish event when the UI is correctly bound when consent is missing.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
analytics

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
