### PR TITLE
[Identity] Clear back stack when navigate from CouldNotCaptureFragment

### DIFF
--- a/identity/res/navigation/identity_nav_graph.xml
+++ b/identity/res/navigation/identity_nav_graph.xml
@@ -140,25 +140,39 @@
             app:argType="com.stripe.android.identity.states.IdentityScanState$ScanType" />
         <action
             android:id="@+id/action_couldNotCaptureFragment_to_passportUploadFragment"
-            app:destination="@id/passportUploadFragment" />
+            app:destination="@id/passportUploadFragment"
+            app:popUpTo="@id/docSelectionFragment"
+            app:popUpToInclusive="false" />
         <action
             android:id="@+id/action_couldNotCaptureFragment_to_IDUploadFragment"
-            app:destination="@id/IDUploadFragment" />
+            app:destination="@id/IDUploadFragment"
+            app:popUpTo="@id/docSelectionFragment"
+            app:popUpToInclusive="false" />
         <action
             android:id="@+id/action_couldNotCaptureFragment_to_driverLicenseUploadFragment"
-            app:destination="@id/driverLicenseUploadFragment" />
+            app:destination="@id/driverLicenseUploadFragment"
+            app:popUpTo="@id/docSelectionFragment"
+            app:popUpToInclusive="false" />
         <action
             android:id="@+id/action_couldNotCaptureFragment_to_passportScanFragment"
-            app:destination="@id/passportScanFragment" />
+            app:destination="@id/passportScanFragment"
+            app:popUpTo="@id/docSelectionFragment"
+            app:popUpToInclusive="false" />
         <action
             android:id="@+id/action_couldNotCaptureFragment_to_IDScanFragment"
-            app:destination="@id/IDScanFragment" />
+            app:destination="@id/IDScanFragment"
+            app:popUpTo="@id/docSelectionFragment"
+            app:popUpToInclusive="false" />
         <action
             android:id="@+id/action_couldNotCaptureFragment_to_driverLicenseScanFragment"
-            app:destination="@id/driverLicenseScanFragment" />
+            app:destination="@id/driverLicenseScanFragment"
+            app:popUpTo="@id/docSelectionFragment"
+            app:popUpToInclusive="false" />
         <action
             android:id="@+id/action_couldNotCaptureFragment_to_selfieFragment"
-            app:destination="@id/selfieFragment" />
+            app:destination="@id/selfieFragment"
+            app:popUpTo="@id/docSelectionFragment"
+            app:popUpToInclusive="false" />
     </fragment>
     <fragment
         android:id="@+id/selfieFragment"


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
When navigating from `CouldNotCaptureFragment`, always clear back stack all the way up to `DocSelectFragment`, so that when back is clicked, we always return to `DocSelectFragment`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
clear back stack

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
