### PR TITLE
Add places client proxy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,8 @@ ext {
     materialVersion = '1.5.0'
     daggerVersion = '2.42'
     playServicesWalletVersion = '19.1.0'
+    placesVersion = '2.6.0'
+    playServicesVersion = '1.6.3'
 
     androidTestVersion = '1.4.0'
     androidTestJunitVersion = '1.1.3'

--- a/payments-ui-core/build.gradle
+++ b/payments-ui-core/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation project(":stripe-core")
     implementation project(":payments-core")
     compileOnly project(":stripecardscan")
+    compileOnly "com.google.android.libraries.places:places:$placesVersion"
 
     implementation 'androidx.constraintlayout:constraintlayout-compose:1.0.1'
     implementation "androidx.core:core-ktx:$androidxCoreVersion"
@@ -50,6 +51,8 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinSerializationVersion"
 
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-play-services:$playServicesVersion"
+
     testImplementation "junit:junit:$junitVersion"
     testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
     testImplementation "org.mockito:mockito-inline:$mockitoCoreVersion"
@@ -64,6 +67,7 @@ dependencies {
     testImplementation "androidx.test.ext:junit-ktx:$androidTestJunitVersion"
     testImplementation "androidx.arch.core:core-testing:$androidxArchCoreVersion"
     testImplementation "androidx.fragment:fragment-testing:$androidxFragmentVersion"
+    testImplementation "com.google.android.libraries.places:places:$placesVersion"
     testImplementation project(':stripecardscan')
 
     ktlint "com.pinterest:ktlint:$ktlintVersion"

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy.kt
@@ -1,0 +1,182 @@
+package com.stripe.android.ui.core.elements.autocomplete
+
+import android.content.Context
+import android.graphics.Typeface
+import android.text.style.StyleSpan
+import com.google.android.libraries.places.api.Places
+import com.google.android.libraries.places.api.model.AutocompleteSessionToken
+import com.google.android.libraries.places.api.model.TypeFilter
+import com.google.android.libraries.places.api.net.FetchPlaceRequest
+import com.google.android.libraries.places.api.net.FindAutocompletePredictionsRequest
+import com.google.android.libraries.places.api.net.PlacesClient
+import com.stripe.android.BuildConfig
+import com.stripe.android.ui.core.R
+import com.stripe.android.ui.core.elements.autocomplete.model.AddressComponent
+import com.stripe.android.ui.core.elements.autocomplete.model.AutocompletePrediction
+import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
+import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
+import com.stripe.android.ui.core.elements.autocomplete.model.Place
+import kotlinx.coroutines.tasks.await
+
+internal interface PlacesClientProxy {
+    suspend fun findAutocompletePredictions(
+        query: String?,
+        country: String,
+        limit: Int
+    ): Result<FindAutocompletePredictionsResponse>
+
+    suspend fun fetchPlace(
+        placeId: String
+    ): Result<FetchPlaceResponse>
+
+    companion object {
+        fun create(
+            context: Context,
+            googlePlacesApiKey: String,
+            isPlacesAvailable: IsPlacesAvailable = DefaultIsPlacesAvailable(),
+            clientFactory: (Context) -> PlacesClient = { Places.createClient(context) },
+            initializer: () -> Unit = { Places.initialize(context, googlePlacesApiKey) }
+        ): PlacesClientProxy {
+            return if (isPlacesAvailable()) {
+                initializer()
+                DefaultPlacesClientProxy(
+                    clientFactory(context)
+                )
+            } else {
+                UnsupportedPlacesClientProxy()
+            }
+        }
+
+        fun getPlacesPoweredByGoogleDrawable(
+            isSystemDarkTheme: Boolean,
+            isPlacesAvailable: IsPlacesAvailable = DefaultIsPlacesAvailable()
+        ): Int? {
+            return if (isPlacesAvailable()) {
+                if (isSystemDarkTheme) {
+                    R.drawable.places_powered_by_google_dark
+                } else {
+                    R.drawable.places_powered_by_google_light
+                }
+            } else {
+                if (BuildConfig.DEBUG) {
+                    throw IllegalStateException(
+                        "Missing Google Places dependency, please add it to your apps build.gradle"
+                    )
+                }
+                null
+            }
+        }
+    }
+}
+
+internal class DefaultPlacesClientProxy(
+    private val client: PlacesClient
+) : PlacesClientProxy {
+    private val token = AutocompleteSessionToken.newInstance()
+
+    override suspend fun findAutocompletePredictions(
+        query: String?,
+        country: String,
+        limit: Int
+    ): Result<FindAutocompletePredictionsResponse> {
+        return try {
+            val response = client.findAutocompletePredictions(
+                FindAutocompletePredictionsRequest
+                    .builder()
+                    .setSessionToken(token)
+                    .setQuery(query)
+                    .setCountry(country)
+                    .setTypeFilter(TypeFilter.ADDRESS)
+                    .build()
+            ).await()
+            Result.success(
+                FindAutocompletePredictionsResponse(
+                    autocompletePredictions = response.autocompletePredictions.map {
+                        AutocompletePrediction(
+                            primaryText = it.getPrimaryText(StyleSpan(Typeface.BOLD)),
+                            secondaryText = it.getSecondaryText(StyleSpan(Typeface.BOLD)),
+                            placeId = it.placeId
+                        )
+                    }.take(limit ?: response.autocompletePredictions.size)
+                )
+            )
+        } catch (e: Exception) {
+            Result.failure(
+                Exception("Could not find autocomplete predictions: ${e.message}")
+            )
+        }
+    }
+
+    override suspend fun fetchPlace(
+        placeId: String
+    ): Result<FetchPlaceResponse> {
+        return try {
+            val response = client.fetchPlace(
+                FetchPlaceRequest.newInstance(
+                    placeId,
+                    listOf(
+                        com.google.android.libraries.places.api.model.Place.Field.ADDRESS_COMPONENTS
+                    )
+                )
+            ).await()
+            Result.success(
+                FetchPlaceResponse(
+                    Place(
+                        response.place.addressComponents?.asList()?.map {
+                            AddressComponent(
+                                shortName = it.shortName,
+                                longName = it.name,
+                                types = it.types
+                            )
+                        }
+                    )
+                )
+            )
+        } catch (e: Exception) {
+            Result.failure(
+                Exception("Could not fetch place: ${e.message}")
+            )
+        }
+    }
+}
+
+internal class UnsupportedPlacesClientProxy : PlacesClientProxy {
+    override suspend fun findAutocompletePredictions(
+        query: String?,
+        country: String,
+        limit: Int
+    ): Result<FindAutocompletePredictionsResponse> {
+        val exception = IllegalStateException(
+            "Missing Google Places dependency, please add it to your apps build.gradle"
+        )
+        if (BuildConfig.DEBUG) {
+            throw exception
+        }
+        return Result.failure(exception)
+    }
+
+    override suspend fun fetchPlace(placeId: String): Result<FetchPlaceResponse> {
+        val exception = IllegalStateException(
+            "Missing Google Places dependency, please add it to your apps build.gradle"
+        )
+        if (BuildConfig.DEBUG) {
+            throw exception
+        }
+        return Result.failure(exception)
+    }
+}
+
+internal interface IsPlacesAvailable {
+    operator fun invoke(): Boolean
+}
+
+internal class DefaultIsPlacesAvailable : IsPlacesAvailable {
+    override fun invoke(): Boolean {
+        return try {
+            Class.forName("com.google.android.libraries.places.api.Places")
+            true
+        } catch (_: Exception) {
+            false
+        }
+    }
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/model/Place.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/model/Place.kt
@@ -1,0 +1,50 @@
+package com.stripe.android.ui.core.elements.autocomplete.model
+
+import android.text.SpannableString
+
+internal data class FindAutocompletePredictionsResponse(
+    val autocompletePredictions: List<AutocompletePrediction>
+)
+
+internal data class AutocompletePrediction(
+    val primaryText: SpannableString,
+    val secondaryText: SpannableString,
+    val placeId: String
+)
+
+internal data class FetchPlaceResponse(
+    val place: Place
+)
+
+internal data class Place(
+    val addressComponents: List<AddressComponent>?
+) {
+    enum class Type(val value: String) {
+        ADMINISTRATIVE_AREA_LEVEL_1("administrative_area_level_1"),
+        ADMINISTRATIVE_AREA_LEVEL_2("administrative_area_level_2"),
+        ADMINISTRATIVE_AREA_LEVEL_3("administrative_area_level_3"),
+        ADMINISTRATIVE_AREA_LEVEL_4("administrative_area_level_4"),
+        COUNTRY("country"),
+        LOCALITY("locality"),
+        NEIGHBORHOOD("neighborhood"),
+        POSTAL_TOWN("postal_town"),
+        POSTAL_CODE("postal_code"),
+        PREMISE("premise"),
+        ROUTE("route"),
+        STREET_NUMBER("street_number"),
+        SUBLOCALITY("sublocality"),
+        SUBLOCALITY_LEVEL_2("sublocality_level_2"),
+        SUBLOCALITY_LEVEL_3("sublocality_level_3"),
+        SUBLOCALITY_LEVEL_4("sublocality_level_4"),
+    }
+}
+
+internal data class AddressComponent(
+    val shortName: String?,
+    val longName: String,
+    val types: List<String>
+) {
+    fun contains(type: Place.Type): Boolean {
+        return types.contains(type.value)
+    }
+}

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxyTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxyTest.kt
@@ -1,0 +1,214 @@
+package com.stripe.android.ui.core.elements.autocomplete
+
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
+import com.google.android.libraries.places.api.model.AutocompletePrediction
+import com.google.android.libraries.places.api.model.Place
+import com.google.android.libraries.places.api.net.FetchPhotoRequest
+import com.google.android.libraries.places.api.net.FetchPhotoResponse
+import com.google.android.libraries.places.api.net.FetchPlaceRequest
+import com.google.android.libraries.places.api.net.FetchPlaceResponse
+import com.google.android.libraries.places.api.net.FindAutocompletePredictionsRequest
+import com.google.android.libraries.places.api.net.FindAutocompletePredictionsResponse
+import com.google.android.libraries.places.api.net.FindCurrentPlaceRequest
+import com.google.android.libraries.places.api.net.FindCurrentPlaceResponse
+import com.google.android.libraries.places.api.net.PlacesClient
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+class PlacesClientProxyTest {
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `create returns default client when google places available`() {
+        val client = PlacesClientProxy.create(
+            context = mock(),
+            googlePlacesApiKey = "abc123",
+            isPlacesAvailable = object : IsPlacesAvailable {
+                override fun invoke(): Boolean {
+                    return true
+                }
+            },
+            clientFactory = { mock() },
+            initializer = { /* no-op */ }
+        )
+
+        assertThat(client).isInstanceOf(DefaultPlacesClientProxy::class.java)
+    }
+
+    @Test
+    fun `create returns unsupported client when google places not available`() {
+        val client = PlacesClientProxy.create(
+            context = mock(),
+            googlePlacesApiKey = "abc123",
+            isPlacesAvailable = object : IsPlacesAvailable {
+                override fun invoke(): Boolean {
+                    return false
+                }
+            },
+            clientFactory = { mock() },
+            initializer = { /* no-op */ }
+        )
+
+        assertThat(client).isInstanceOf(UnsupportedPlacesClientProxy::class.java)
+    }
+
+    @Test
+    fun `findAutocompletePredictions returns results with limit`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val client = createGooglePlacesClient(
+                onFindAutocompletePredictions = {
+                    Tasks.forResult(
+                        FindAutocompletePredictionsResponse.newInstance(
+                            listOf(
+                                AutocompletePrediction.builder("1").build(),
+                                AutocompletePrediction.builder("2").build(),
+                                AutocompletePrediction.builder("3").build(),
+                                AutocompletePrediction.builder("4").build(),
+                                AutocompletePrediction.builder("5").build()
+                            )
+                        )
+                    )
+                }
+            )
+            val proxy = PlacesClientProxy.create(
+                context = mock(),
+                googlePlacesApiKey = "abc123",
+                isPlacesAvailable = object : IsPlacesAvailable {
+                    override fun invoke(): Boolean {
+                        return true
+                    }
+                },
+                clientFactory = { client },
+                initializer = { /* no-op */ }
+            )
+
+            val predictions = proxy.findAutocompletePredictions(
+                "some query",
+                "country",
+                3
+            )
+
+            runCurrent()
+
+            assertThat(predictions.getOrNull()?.autocompletePredictions?.size)
+                .isEqualTo(3)
+        }
+
+    @Test
+    fun `fetchPlace returns place`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val client = createGooglePlacesClient(
+                onFetchPlace = {
+                    Tasks.forResult(
+                        FetchPlaceResponse.newInstance(
+                            Place.builder().build()
+                        )
+                    )
+                }
+            )
+            val proxy = PlacesClientProxy.create(
+                context = mock(),
+                googlePlacesApiKey = "abc123",
+                isPlacesAvailable = object : IsPlacesAvailable {
+                    override fun invoke(): Boolean {
+                        return true
+                    }
+                },
+                clientFactory = { client },
+                initializer = { /* no-op */ }
+            )
+
+            val place = proxy.fetchPlace(
+                "placeId"
+            )
+
+            runCurrent()
+
+            assertThat(place.getOrNull()?.place)
+                .isNotNull()
+        }
+
+    @Test
+    fun `getPlacesPoweredByGoogleDrawable returns drawable when places is available`() {
+        val drawable = PlacesClientProxy.getPlacesPoweredByGoogleDrawable(
+            isSystemDarkTheme = true,
+            isPlacesAvailable = object : IsPlacesAvailable {
+                override fun invoke(): Boolean {
+                    return true
+                }
+            }
+        )
+        assertThat(drawable).isNotNull()
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `getPlacesPoweredByGoogleDrawable returns null when places is not available`() {
+        PlacesClientProxy.getPlacesPoweredByGoogleDrawable(
+            isSystemDarkTheme = true,
+            isPlacesAvailable = object : IsPlacesAvailable {
+                override fun invoke(): Boolean {
+                    return false
+                }
+            }
+        )
+    }
+
+    private fun createGooglePlacesClient(
+        onFetchPlace: () -> Task<FetchPlaceResponse> = {
+            Tasks.forCanceled()
+        },
+        onFindAutocompletePredictions: () -> Task<FindAutocompletePredictionsResponse> = {
+            Tasks.forCanceled()
+        }
+    ): PlacesClient {
+        val client = object : PlacesClient {
+            override fun fetchPhoto(
+                p0: FetchPhotoRequest
+            ): Task<FetchPhotoResponse> {
+                return Tasks.forCanceled()
+            }
+
+            override fun fetchPlace(
+                p0: FetchPlaceRequest
+            ): Task<FetchPlaceResponse> {
+                return onFetchPlace()
+            }
+
+            override fun findAutocompletePredictions(
+                p0: FindAutocompletePredictionsRequest
+            ): Task<FindAutocompletePredictionsResponse> {
+                return onFindAutocompletePredictions()
+            }
+
+            override fun findCurrentPlace(
+                p0: FindCurrentPlaceRequest
+            ): Task<FindCurrentPlaceResponse> {
+                return Tasks.forCanceled()
+            }
+        }
+        return client
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

- Add Google Places SDK compileOnly gradle dependency
- Add Google Places client proxy used for the autocomplete address element
- Add dependency on `org.jetbrains.kotlinx:kotlinx-coroutines-play-services` which is a utility to convert Executors into coroutines

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Shipping Address Element. Merchants will have the ability to use the Google Places SDK in their app if they want autocomplete address features for the new Shipping Address Element.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified
