### PR TITLE
Add Google to Stripe Address transformer

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/model/Place.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/model/Place.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.ui.core.elements.autocomplete.model
 
 import android.text.SpannableString
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
 internal data class FindAutocompletePredictionsResponse(
     val autocompletePredictions: List<AutocompletePrediction>
@@ -16,8 +18,9 @@ internal data class FetchPlaceResponse(
     val place: Place
 )
 
+@Serializable
 internal data class Place(
-    val addressComponents: List<AddressComponent>?
+    @SerialName("address_components") val addressComponents: List<AddressComponent>?
 ) {
     enum class Type(val value: String) {
         ADMINISTRATIVE_AREA_LEVEL_1("administrative_area_level_1"),
@@ -33,16 +36,18 @@ internal data class Place(
         ROUTE("route"),
         STREET_NUMBER("street_number"),
         SUBLOCALITY("sublocality"),
+        SUBLOCALITY_LEVEL_1("sublocality_level_1"),
         SUBLOCALITY_LEVEL_2("sublocality_level_2"),
         SUBLOCALITY_LEVEL_3("sublocality_level_3"),
         SUBLOCALITY_LEVEL_4("sublocality_level_4"),
     }
 }
 
+@Serializable
 internal data class AddressComponent(
-    val shortName: String?,
-    val longName: String,
-    val types: List<String>
+    @SerialName("short_name") val shortName: String?,
+    @SerialName("long_name") val longName: String,
+    @SerialName("types") val types: List<String>
 ) {
     fun contains(type: Place.Type): Boolean {
         return types.contains(type.value)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/model/TransformGoogleToStripeAddress.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/model/TransformGoogleToStripeAddress.kt
@@ -1,0 +1,259 @@
+package com.stripe.android.ui.core.elements.autocomplete.model
+
+import android.content.Context
+import android.os.Build
+import java.util.Locale
+
+// Largely duplicated from
+// https://git.corp.stripe.com/stripe-internal/stripe-js-v3/blob/1c111621/src/elements/inner/autocomplete_suggestions/utils/transformGoogleToStripeAddress.ts#L248-L325
+
+internal data class AddressLine1(
+    var streetNumber: String? = null,
+    var route: String? = null,
+    var subLocalityLevel2: String? = null,
+    var subLocalityLevel3: String? = null,
+    var subLocalityLevel4: String? = null
+)
+
+internal data class Address(
+    var locality: String? = null,
+    var country: String? = null,
+    var addressLine1: String? = null,
+    var addressLine2: String? = null,
+    var administrativeArea: String? = null,
+    var dependentLocality: String? = null,
+    var postalCode: String? = null
+)
+
+// These countries will have address line 1 that takes the format
+// of "King Street 123" instead of "123 King Street"
+// Reference for country formats:
+// https://docs.google.com/spreadsheets/d/1tIZO0-Iqvs_8CA9UL3S9qYvoTzjPdrHZr-hdetz6Uuo/edit#gid=696373988
+internal val STREET_NAME_FIRST_COUNTRIES = listOf(
+    "BE",
+    "BR",
+    "CH",
+    "ES",
+    "ID",
+    "IT",
+    "MX",
+    "NL",
+    "NO",
+    "PL",
+    "RU",
+    "SE"
+)
+
+internal fun Place.filter(type: Place.Type): AddressComponent? {
+    return addressComponents?.find { it.types.contains(type.value) }
+}
+
+internal fun composeAddressLine1(
+    context: Context,
+    addressLine1: AddressLine1,
+    address: Address
+): String {
+    val streetNumber = addressLine1.streetNumber
+    val streetName = addressLine1.route
+    val locality = address.locality
+    val countryCode = address.country
+
+    return if (countryCode == "JP") {
+        val premise = address.addressLine2
+        composeJapaneseAddressLine1(context, addressLine1, locality, premise)
+    } else if (streetNumber != null || streetName != null) {
+        // Depending on the country we'll want either
+        // "123 King Street" or "King Street 123"
+        return if (STREET_NAME_FIRST_COUNTRIES.contains(countryCode)) {
+            "$streetName $streetNumber".trim()
+        } else {
+            "$streetNumber $streetName".trim()
+        }
+    } else {
+        ""
+    }
+}
+
+internal fun composeJapaneseAddressLine1(
+    context: Context,
+    addressLine1: AddressLine1,
+    localityComponent: String?,
+    premiseComponent: String?
+): String {
+    val districtBlockNumberAllExist =
+        addressLine1.subLocalityLevel2 != null &&
+            addressLine1.subLocalityLevel3 != null &&
+            addressLine1.subLocalityLevel4 != null
+    val district = addressLine1.subLocalityLevel3
+    val block = addressLine1.subLocalityLevel4
+    val buildingNumber = premiseComponent ?: ""
+    val locality = localityComponent ?: ""
+    val municipality = addressLine1.subLocalityLevel2
+
+    val composite: String
+
+    val locale = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        context.resources.configuration.locales.get(0)
+    } else {
+        context.resources.configuration.locale
+    }
+
+    if (locale == Locale.JAPANESE) {
+        // In Japanese, address line 1 components should be in this order:
+        // `{locality}{municipality}{district}{block}-{buildingNumber}`
+        val districtBlockNumber = if (districtBlockNumberAllExist) {
+            "$district$block-$buildingNumber"
+        } else {
+            ""
+        }
+        composite = "$locality$municipality$districtBlockNumber"
+    } else {
+        // In Latin script, address line 1 components should be in this order:
+        // `{district}-{block}-{buildingNumber} {municipality} {locality}`
+        val districtBlockNumber = if (districtBlockNumberAllExist) {
+            "$district-$block-$buildingNumber"
+        } else {
+            ""
+        }
+        composite = "$districtBlockNumber $municipality $locality"
+    }
+
+    return composite
+}
+
+internal fun Address.combineDependentLocalityWithLine2(): Address {
+    val newAddress = copy()
+    if (dependentLocality != null) {
+        newAddress.addressLine2 = if (addressLine2 != null) {
+            "$addressLine2, $dependentLocality"
+        } else {
+            dependentLocality
+        }
+    }
+    return newAddress
+}
+
+internal fun Address.modifyStripeAddressByCountry(place: Place): Address {
+    val administrativeAreaLevel2 = place.filter(Place.Type.ADMINISTRATIVE_AREA_LEVEL_2)?.shortName
+    val administrativeAreaLevel1 = place.filter(Place.Type.ADMINISTRATIVE_AREA_LEVEL_1)?.longName
+    var newAddress = copy()
+    when (country) {
+        "IE" -> {
+            if (administrativeAreaLevel1 != null) {
+                newAddress.administrativeArea = administrativeAreaLevel1
+                newAddress = newAddress.combineDependentLocalityWithLine2()
+            }
+        }
+        // For Japanese addresses, the "premise" is the building number and not
+        // address line 2, so clear addressLine2 if it exists
+        "JP" -> {
+            newAddress.addressLine2 = null
+        }
+        // Turkish districts correspond to the "locality" field in
+        // the address form, and districts are in "administrative_area_level_2"
+        // Brazilian addresses have the locality in "administrative_area_level_2"
+        "TR", "BR" -> {
+            if (locality == null && administrativeAreaLevel2 != null) {
+                newAddress.locality = administrativeAreaLevel2
+            }
+            newAddress = newAddress.combineDependentLocalityWithLine2()
+        }
+        // Most countries contain the province in "administrative_area_level_1"
+        // However, Spanish and Italian provinces are in
+        // "administrative_area_level_2" and "administrative_area_level_1"
+        // contains the region (eg. the autonomous community, like Basque), which
+        // isn't used in mailing addresses.
+        "ES", "IT" -> {
+            if (administrativeAreaLevel2 != null) {
+                newAddress.administrativeArea = administrativeAreaLevel2
+            }
+        }
+        "MX", "MY", "PH", "ZA" -> {
+            newAddress = newAddress.combineDependentLocalityWithLine2()
+        }
+    }
+
+    return newAddress
+}
+
+internal fun Place.transformGoogleToStripeAddress(
+    context: Context
+): com.stripe.android.model.Address {
+    var address = Address()
+    val addressLine1 = AddressLine1()
+
+    addressComponents?.forEach { field ->
+        when (field.types[0]) {
+            Place.Type.STREET_NUMBER.value -> {
+                addressLine1.streetNumber = field.longName
+            }
+            Place.Type.ROUTE.value -> {
+                addressLine1.route = field.longName
+            }
+            Place.Type.PREMISE.value -> {
+                address.addressLine2 = field.longName
+            }
+            Place.Type.LOCALITY.value,
+            Place.Type.SUBLOCALITY.value,
+            Place.Type.POSTAL_TOWN.value -> {
+                address.locality = field.longName
+            }
+            Place.Type.ADMINISTRATIVE_AREA_LEVEL_1.value -> {
+                address.administrativeArea = field.shortName
+            }
+            Place.Type.ADMINISTRATIVE_AREA_LEVEL_3.value -> {
+                if (address.locality == null) {
+                    address.locality = field.longName
+                }
+            }
+            Place.Type.ADMINISTRATIVE_AREA_LEVEL_2.value -> {
+                if (address.administrativeArea == null && address.dependentLocality == null) {
+                    address.dependentLocality = field.longName
+                } else {
+                    address.administrativeArea = field.shortName
+                }
+            }
+            Place.Type.NEIGHBORHOOD.value -> {
+                if (address.locality == null) {
+                    address.locality = field.longName
+                } else {
+                    address.dependentLocality = field.longName
+                }
+            }
+            Place.Type.POSTAL_CODE.value -> {
+                address.postalCode = field.longName
+            }
+            Place.Type.COUNTRY.value -> {
+                address.country = field.shortName
+            }
+            Place.Type.SUBLOCALITY_LEVEL_1.value -> {
+                if (address.locality == null) {
+                    address.dependentLocality = field.longName
+                } else {
+                    address.locality = field.longName
+                }
+            }
+            Place.Type.SUBLOCALITY_LEVEL_2.value -> {
+                addressLine1.subLocalityLevel2 = field.longName
+            }
+            Place.Type.SUBLOCALITY_LEVEL_3.value -> {
+                addressLine1.subLocalityLevel3 = field.longName
+            }
+            Place.Type.SUBLOCALITY_LEVEL_4.value -> {
+                addressLine1.subLocalityLevel4 = field.longName
+            }
+        }
+    }
+
+    address.addressLine1 = composeAddressLine1(context, addressLine1, address)
+    address = address.modifyStripeAddressByCountry(this)
+
+    return com.stripe.android.model.Address.Builder()
+        .setLine1(address.addressLine1)
+        .setLine2(address.addressLine2)
+        .setCity(address.locality)
+        .setState(address.administrativeArea)
+        .setCountry(address.country)
+        .setPostalCode(address.postalCode)
+        .build()
+}

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/autocomplete/model/TransformGoogleToStripeAddressTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/autocomplete/model/TransformGoogleToStripeAddressTest.kt
@@ -1,0 +1,348 @@
+package com.stripe.android.ui.core.elements.autocomplete.model
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.Address
+import kotlinx.serialization.json.Json
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class TransformGoogleToStripeAddressTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Test
+    fun `test US address without sublocality`() {
+        val place = parseJson(
+            """
+                {
+                    "address_components": [
+                        {
+                            "long_name" : "123",
+                            "short_name" : "123",
+                            "types" : [ "street_number" ]
+                        },
+                        {
+                            "long_name" : "South Main Street",
+                            "short_name" : "South Main St",
+                            "types" : [ "route" ]
+                        },
+                        {
+                            "long_name" : "Pioneer Square",
+                            "short_name" : "Pioneer Square",
+                            "types" : [ "neighborhood", "political" ]
+                        },
+                        {
+                            "long_name" : "Seattle",
+                            "short_name" : "Seattle",
+                            "types" : [ "locality", "political" ]
+                        },
+                        {
+                            "long_name" : "King County",
+                            "short_name" : "King County",
+                            "types" : [ "administrative_area_level_2", "political" ]
+                        },
+                        {
+                            "long_name" : "Washington",
+                            "short_name" : "WA",
+                            "types" : [ "administrative_area_level_1", "political" ]
+                        },
+                        {
+                            "long_name" : "United States",
+                            "short_name" : "US",
+                            "types" : [ "country", "political" ]
+                        },
+                        {
+                            "long_name" : "98104",
+                            "short_name" : "98104",
+                            "types" : [ "postal_code" ]
+                        }
+                    ]
+                }
+            """.trimIndent()
+        )
+
+        val stripeAddress = place.transformGoogleToStripeAddress(context)
+
+        assertThat(stripeAddress).isEqualTo(
+            Address(
+                city = "Seattle",
+                country = "US",
+                line1 = "123 South Main Street",
+                line2 = null,
+                postalCode = "98104",
+                state = "WA"
+            )
+        )
+    }
+
+    @Test
+    fun `test US address with sublocality`() {
+        val place = parseJson(
+            """
+                {
+                    "address_components": [
+                        {
+                            "long_name" : "123",
+                            "short_name" : "123",
+                            "types" : [ "street_number" ]
+                        },
+                        {
+                            "long_name" : "East Broadway",
+                            "short_name" : "E Broadway",
+                            "types" : [ "route" ]
+                        },
+                        {
+                            "long_name" : "Manhattan",
+                            "short_name" : "Manhattan",
+                            "types" : [ "sublocality_level_1", "sublocality", "political" ]
+                        },
+                        {
+                            "long_name" : "New York",
+                            "short_name" : "New York",
+                            "types" : [ "locality", "political" ]
+                        },
+                        {
+                            "long_name" : "New York County",
+                            "short_name" : "New York County",
+                            "types" : [ "administrative_area_level_2", "political" ]
+                        },
+                        {
+                            "long_name" : "New York",
+                            "short_name" : "NY",
+                            "types" : [ "administrative_area_level_1", "political" ]
+                        },
+                        {
+                            "long_name" : "United States",
+                            "short_name" : "US",
+                            "types" : [ "country", "political" ]
+                        },
+                        {
+                            "long_name" : "10002",
+                            "short_name" : "10002",
+                            "types" : [ "postal_code" ]
+                        }
+                    ]
+                }
+            """.trimIndent()
+        )
+
+        val stripeAddress = place.transformGoogleToStripeAddress(context)
+
+        assertThat(stripeAddress).isEqualTo(
+            Address(
+                city = "New York",
+                country = "US",
+                line1 = "123 East Broadway",
+                line2 = null,
+                postalCode = "10002",
+                state = "NY"
+            )
+        )
+    }
+
+    @Test
+    fun `test should make dependent locality line 2 - BR`() {
+        val place = parseJson(
+            """
+                {
+                    "address_components": [
+                        {
+                            "long_name": "512",
+                            "short_name": "512",
+                            "types": ["street_number"]
+                        },
+                        {
+                            "long_name": "Rua Borges Lagoa",
+                            "short_name": "R. Borges Lagoa",
+                            "types": ["route"]
+                        },
+                        {
+                            "long_name": "Vila Clementino",
+                            "short_name": "Vila Clementino",
+                            "types": ["sublocality_level_1", "sublocality", "political"]
+                        },
+                        {
+                            "long_name": "São Paulo",
+                            "short_name": "São Paulo",
+                            "types": ["administrative_area_level_2", "political"]
+                        },
+                        {
+                            "long_name": "São Paulo",
+                            "short_name": "SP",
+                            "types": ["administrative_area_level_1", "political"]
+                        },
+                        {
+                            "long_name": "Brazil",
+                            "short_name": "BR",
+                            "types": ["country", "political"]
+                        },
+                        {
+                            "long_name": "04038-000",
+                            "short_name": "04038-000",
+                            "types": ["postal_code"]
+                        }
+                    ]
+                }
+            """.trimIndent()
+        )
+
+        val stripeAddress = place.transformGoogleToStripeAddress(context)
+
+        assertThat(stripeAddress).isEqualTo(
+            Address(
+                city = "São Paulo",
+                country = "BR",
+                line1 = "Rua Borges Lagoa 512",
+                line2 = "Vila Clementino",
+                postalCode = "04038-000",
+                state = "SP"
+            )
+        )
+    }
+
+    @Test
+    fun `test should not combine dependent locality - US`() {
+        val place = parseJson(
+            """
+                {
+                    "address_components": [
+                        {
+                            "long_name": "1231",
+                            "short_name": "1231",
+                            "types": ["street_number"]
+                        },
+                        {
+                            "long_name": "116th Avenue Northeast",
+                            "short_name": "116th Ave NE",
+                            "types": ["route"]
+                        },
+                        {
+                            "long_name": "Wilburton",
+                            "short_name": "Wilburton",
+                            "types": ["neighborhood", "political"]
+                        },
+                        {
+                            "long_name": "Bellevue",
+                            "short_name": "Bellevue",
+                            "types": ["locality", "political"]
+                        },
+                        {
+                            "long_name": "King County",
+                            "short_name": "King County",
+                            "types": ["administrative_area_level_2", "political"]
+                        },
+                        {
+                            "long_name": "Washington",
+                            "short_name": "WA",
+                            "types": ["administrative_area_level_1", "political"]
+                        },
+                        {
+                            "long_name": "United States",
+                            "short_name": "US",
+                            "types": ["country", "political"]
+                        },
+                        {
+                            "long_name": "98004",
+                            "short_name": "98004",
+                            "types": ["postal_code"]
+                        },
+                        {
+                            "long_name": "3804",
+                            "short_name": "3804",
+                            "types": ["postal_code_suffix"]
+                        }
+                    ]
+                }
+            """.trimIndent()
+        )
+
+        val stripeAddress = place.transformGoogleToStripeAddress(context)
+
+        assertThat(stripeAddress).isEqualTo(
+            Address(
+                city = "Bellevue",
+                country = "US",
+                line1 = "1231 116th Avenue Northeast",
+                line2 = null,
+                postalCode = "98004",
+                state = "WA"
+            )
+        )
+    }
+
+    @Test
+    fun `test JP address`() {
+        val place = parseJson(
+            """
+                {
+                    "address_components": [
+                        {
+                            "long_name" : "1",
+                            "short_name" : "1",
+                            "types" : [ "premise" ]
+                        },
+                        {
+                            "long_name" : "6",
+                            "short_name" : "6",
+                            "types" : [ "sublocality_level_4", "sublocality", "political" ]
+                        },
+                        {
+                            "long_name" : "3-chōme",
+                            "short_name" : "3-chōme",
+                            "types" : [ "sublocality_level_3", "sublocality", "political" ]
+                        },
+                        {
+                            "long_name" : "Kameido",
+                            "short_name" : "Kameido",
+                            "types" : [ "sublocality_level_2", "sublocality", "political" ]
+                        },
+                        {
+                            "long_name" : "Koto City",
+                            "short_name" : "Koto City",
+                            "types" : [ "locality", "political" ]
+                        },
+                        {
+                            "long_name" : "Tokyo",
+                            "short_name" : "Tokyo",
+                            "types" : [ "administrative_area_level_1", "political" ]
+                        },
+                        {
+                            "long_name" : "Japan",
+                            "short_name" : "JP",
+                            "types" : [ "country", "political" ]
+                        },
+                        {
+                            "long_name" : "136-0071",
+                            "short_name" : "136-0071",
+                            "types" : [ "postal_code" ]
+                        }
+                    ]
+                }
+            """.trimIndent()
+        )
+
+        val stripeAddress = place.transformGoogleToStripeAddress(context)
+
+        assertThat(stripeAddress).isEqualTo(
+            Address(
+                city = "Koto City",
+                country = "JP",
+                line1 = "3-chōme-6-1 Kameido Koto City",
+                line2 = null,
+                postalCode = "136-0071",
+                state = "Tokyo"
+            )
+        )
+    }
+
+    private fun parseJson(json: String): Place {
+        return Json.decodeFromString(
+            Place.serializer(),
+            json
+        )
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

- Add Google to Stripe Address transformer
- Adapted from https://git.corp.stripe.com/stripe-internal/stripe-js-v3/blob/1c111621/src/elements/inner/autocomplete_suggestions/utils/transformGoogleToStripeAddress.ts#L132

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Make sure that Google Places addresses can be tranformed into Stripe Addresses

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified
