### PR TITLE
Add onClick to trailing icon

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/Html.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/Html.kt
@@ -122,10 +122,11 @@ fun Html(
  * @return the string data associated with the resource
  */
 @Composable
-private fun annotatedStringResource(
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun annotatedStringResource(
     text: String,
-    imageGetter: Map<String, EmbeddableImage>,
-    urlSpanStyle: SpanStyle
+    imageGetter: Map<String, EmbeddableImage> = emptyMap(),
+    urlSpanStyle: SpanStyle = SpanStyle(textDecoration = TextDecoration.Underline)
 ): AnnotatedString {
     val spanned = remember(text) {
         HtmlCompat.fromHtml(text, HtmlCompat.FROM_HTML_MODE_LEGACY)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SimpleTextFieldConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SimpleTextFieldConfig.kt
@@ -11,11 +11,11 @@ import kotlinx.coroutines.flow.MutableStateFlow
 class SimpleTextFieldConfig(
     @StringRes override val label: Int,
     override val capitalization: KeyboardCapitalization = KeyboardCapitalization.Words,
-    override val keyboard: KeyboardType = KeyboardType.Text
+    override val keyboard: KeyboardType = KeyboardType.Text,
+    override val trailingIcon: MutableStateFlow<TextFieldIcon?> = MutableStateFlow(null)
 ) : TextFieldConfig {
     override val debugLabel: String = "generic_text"
     override val visualTransformation: VisualTransformation? = null
-    override val trailingIcon: MutableStateFlow<TextFieldIcon?> = MutableStateFlow(null)
     override val loading: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
     override fun determineState(input: String): TextFieldState = object : TextFieldState {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldController.kt
@@ -49,7 +49,8 @@ sealed class TextFieldIcon {
         val contentDescription: Int? = null,
 
         /** If it is an icon that should be tinted to match the text the value should be true */
-        val isTintable: Boolean
+        val isTintable: Boolean,
+        val onClick: (() -> Unit)? = null
     ) : TextFieldIcon()
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
@@ -5,6 +5,7 @@ import androidx.annotation.RestrictTo
 import androidx.annotation.StringRes
 import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -270,6 +271,9 @@ internal fun TrailingIcon(
             painter = painterResource(id = trailingIcon.idRes),
             contentDescription = trailingIcon.contentDescription?.let {
                 stringResource(trailingIcon.contentDescription)
+            },
+            modifier = Modifier.clickable {
+                trailingIcon.onClick?.invoke()
             }
         )
     } else {
@@ -277,6 +281,9 @@ internal fun TrailingIcon(
             painter = painterResource(id = trailingIcon.idRes),
             contentDescription = trailingIcon.contentDescription?.let {
                 stringResource(trailingIcon.contentDescription)
+            },
+            modifier = Modifier.clickable {
+                trailingIcon.onClick?.invoke()
             }
         )
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

- Add `onClick` to TrailingIcon
- Expose `annotatedStringResource`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Needed for `AutocompleteTextField` for shipping address element

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
