### PR TITLE
Reenable browserstack instrumentation test failure jira tickets

### DIFF
--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -70,10 +70,10 @@ jobs:
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
         run: python scripts/browserstack.py --test --apk paymentsheet-example/build/outputs/apk/debug/paymentsheet-example-debug.apk --espresso paymentsheet-example/build/outputs/apk/androidTest/debug/paymentsheet-example-debug-androidTest.apk
 
-#      - name: Notify failure endpoint
-#        id: notifyFailureEndpoint
-#        if: failure()
-#        run: ./scripts/notify_failure_enpiont.rb ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT }} ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT_HMAC_KEY }} ${{ github.run_id }}
+      - name: Notify failure endpoint
+        id: notifyFailureEndpoint
+        if: failure()
+        run: ./scripts/notify_failure_enpiont.rb ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT }} ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT_HMAC_KEY }} ${{ github.run_id }}
 
   screenshot-regression-tests:
     runs-on: macos-latest


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Turning the reporting back on. I will merge this after the long weekend assuming the tests continue to pass.


