### PR TITLE
[Identity] Make error screen and Selfie screen scrollable

### DIFF
--- a/identity/api/identity.api
+++ b/identity/api/identity.api
@@ -282,7 +282,8 @@ public final class com/stripe/android/identity/databinding/SelfieScanFragmentBin
 	public final field headerTitle Landroid/widget/TextView;
 	public final field kontinue Lcom/stripe/android/identity/ui/LoadingButton;
 	public final field message Landroid/widget/TextView;
-	public final field resultView Landroid/widget/LinearLayout;
+	public final field padding Landroid/view/View;
+	public final field resultView Landroid/widget/ScrollView;
 	public final field scanningView Lcom/google/android/material/card/MaterialCardView;
 	public static fun bind (Landroid/view/View;)Lcom/stripe/android/identity/databinding/SelfieScanFragmentBinding;
 	public synthetic fun getRoot ()Landroid/view/View;

--- a/identity/res/layout/base_error_fragment.xml
+++ b/identity/res/layout/base_error_fragment.xml
@@ -18,14 +18,13 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:layout_marginTop="180dp"
-            android:gravity="center">
+            android:orientation="vertical">
 
             <ImageView
                 android:layout_gravity="center_horizontal"
                 android:layout_width="92dp"
                 android:layout_height="92dp"
+                android:layout_marginTop="180dp"
                 android:src="@drawable/ic_exclamation"
                 android:layout_marginBottom="26dp"
                 app:tint="@color/error_exclamation_color" />

--- a/identity/res/layout/selfie_scan_fragment.xml
+++ b/identity/res/layout/selfie_scan_fragment.xml
@@ -71,32 +71,38 @@
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 
-    <LinearLayout
+    <ScrollView
         android:id="@+id/result_view"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
         android:visibility="gone"
-        android:orientation="vertical">
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/captured_images"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
-
-        <CheckBox
-            android:id="@+id/allow_image_collection"
+        android:layout_weight="1">
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/page_horizontal_margin"
-            android:layout_marginEnd="@dimen/page_horizontal_margin"
-            android:layout_marginTop="20dp" />
-    </LinearLayout>
+            android:orientation="vertical">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/captured_images"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+
+            <CheckBox
+                android:id="@+id/allow_image_collection"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/page_horizontal_margin"
+                android:layout_marginEnd="@dimen/page_horizontal_margin"
+                android:layout_marginTop="20dp" />
+        </LinearLayout>
+    </ScrollView>
 
     <View
         android:layout_width="match_parent"
         android:layout_height="0dp"
+        android:id="@+id/padding"
         android:layout_weight="1" />
 
     <com.stripe.android.identity.ui.LoadingButton

--- a/identity/src/main/java/com/stripe/android/identity/navigation/SelfieFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/SelfieFragment.kt
@@ -9,7 +9,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.CheckBox
-import android.widget.LinearLayout
+import android.widget.ScrollView
 import android.widget.TextView
 import androidx.annotation.VisibleForTesting
 import androidx.cardview.widget.CardView
@@ -53,7 +53,8 @@ internal class SelfieFragment(
     private lateinit var messageView: TextView
     private lateinit var flashMask: View
     private lateinit var scanningView: CardView
-    private lateinit var resultView: LinearLayout
+    private lateinit var resultView: ScrollView
+    private lateinit var padding: View
     private lateinit var capturedImages: RecyclerView
     private lateinit var allowImageCollection: CheckBox
 
@@ -74,6 +75,7 @@ internal class SelfieFragment(
         flashMask = binding.flashMask
         scanningView = binding.scanningView
         resultView = binding.resultView
+        padding = binding.padding
         capturedImages = binding.capturedImages
         allowImageCollection = binding.allowImageCollection
         capturedImages.adapter = selfieResultAdapter
@@ -164,6 +166,7 @@ internal class SelfieFragment(
                 binding.message.text = requireContext().getText(R.string.selfie_capture_complete)
             }
             is IdentityScanState.Finished -> {
+                binding.message.text = requireContext().getText(R.string.selfie_capture_complete)
                 toggleResultViewWithResult(
                     (identityScanState.transitioner as FaceDetectorTransitioner)
                         .filteredFrames.map { it.first.cameraPreviewImage.image.mirrorHorizontally() }
@@ -177,6 +180,7 @@ internal class SelfieFragment(
 
     override fun resetUI() {
         scanningView.visibility = View.VISIBLE
+        padding.visibility = View.VISIBLE
         resultView.visibility = View.GONE
         continueButton.isEnabled = false
         messageView.text = requireContext().getText(R.string.position_selfie)
@@ -258,6 +262,7 @@ internal class SelfieFragment(
     private fun toggleResultViewWithResult(resultList: List<Bitmap>) {
         scanningView.visibility = View.GONE
         resultView.visibility = View.VISIBLE
+        padding.visibility = View.GONE
         continueButton.isEnabled = true
         selfieResultAdapter.submitList(resultList)
     }

--- a/identity/src/test/java/com/stripe/android/identity/navigation/SelfieFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/SelfieFragmentTest.kt
@@ -158,6 +158,7 @@ internal class SelfieFragmentTest {
             verify(mockIdentityViewModel).resetSelfieUploadedState()
             assertThat(binding.scanningView.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.resultView.visibility).isEqualTo(View.GONE)
+            assertThat(binding.padding.visibility).isEqualTo(View.VISIBLE)
             assertThat(binding.kontinue.isEnabled).isEqualTo(false)
             assertThat(binding.allowImageCollection.text.toString()).isEqualTo(CONSENT_TEXT)
         }
@@ -197,6 +198,7 @@ internal class SelfieFragmentTest {
 
             assertThat(binding.scanningView.visibility).isEqualTo(View.GONE)
             assertThat(binding.resultView.visibility).isEqualTo(View.VISIBLE)
+            assertThat(binding.padding.visibility).isEqualTo(View.GONE)
             assertThat(binding.kontinue.isEnabled).isEqualTo(true)
             assertThat(fragment.selfieResultAdapter.itemCount).isEqualTo(FILTERED_FRAMES.size)
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Make the screens scrollable when font and size are set to largest for accessibility

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Better accessibility support 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified



# Screenshots
(Selfies deliberately  masked for privacy)
| Before  | After |
| ------------- | ------------- |
| ![errorAfter](https://user-images.githubusercontent.com/79880926/177066066-b54abdd4-3310-4ce8-a675-2aebca60382f.png) | ![errorBefore](https://user-images.githubusercontent.com/79880926/177066061-b0c2888b-e7e3-4262-a0a2-28799c8772fc.png) |
| ![selfieBefore](https://user-images.githubusercontent.com/79880926/177066067-537c3013-6f55-4388-9e69-5df2a9b9f836.png) | ![selfieAfter](https://user-images.githubusercontent.com/79880926/177066064-951f7910-07c2-443c-94e3-38312bef221f.png) |


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
