### PR TITLE
Add one line address element

### DIFF
--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -77,6 +77,9 @@ public final class com/stripe/android/ui/core/databinding/ActivityCardScanBindin
 	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/ui/core/databinding/ActivityCardScanBinding;
 }
 
+public final class com/stripe/android/ui/core/elements/AddressElement$Companion {
+}
+
 public final class com/stripe/android/ui/core/elements/AddressSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/AddressSpec$$serializer;

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -94,30 +94,31 @@ public final class com/stripe/android/ui/core/elements/AddressSpec$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/stripe/android/ui/core/elements/AddressType : java/lang/Enum {
-	public static final field Companion Lcom/stripe/android/ui/core/elements/AddressType$Companion;
-	public static final field Normal Lcom/stripe/android/ui/core/elements/AddressType;
-	public static final field ShippingCondensed Lcom/stripe/android/ui/core/elements/AddressType;
-	public static final field ShippingExpanded Lcom/stripe/android/ui/core/elements/AddressType;
-	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/ui/core/elements/AddressType;
-	public static fun values ()[Lcom/stripe/android/ui/core/elements/AddressType;
+public final class com/stripe/android/ui/core/elements/AddressTextFieldUIKt {
 }
 
-public final class com/stripe/android/ui/core/elements/AddressType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public final class com/stripe/android/ui/core/elements/AddressType$Normal : com/stripe/android/ui/core/elements/AddressType {
 	public static final field $stable I
-	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/AddressType$$serializer;
-	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/ui/core/elements/AddressType;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/ui/core/elements/AddressType;)V
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/AddressType$Normal;
 }
 
-public final class com/stripe/android/ui/core/elements/AddressType$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+public final class com/stripe/android/ui/core/elements/AddressType$ShippingCondensed : com/stripe/android/ui/core/elements/AddressType {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlin/jvm/functions/Function0;
+	public final fun copy (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Lcom/stripe/android/ui/core/elements/AddressType$ShippingCondensed;
+	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/AddressType$ShippingCondensed;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/AddressType$ShippingCondensed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGoogleApiKey ()Ljava/lang/String;
+	public final fun getOnNavigation ()Lkotlin/jvm/functions/Function0;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/ui/core/elements/AddressType$ShippingExpanded : com/stripe/android/ui/core/elements/AddressType {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/AddressType$ShippingExpanded;
 }
 
 public final class com/stripe/android/ui/core/elements/AffirmElementUIKt {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormController.kt
@@ -42,8 +42,8 @@ class FormController @Inject constructor(
             val delayedElements = MutableStateFlow<List<FormElement>?>(null)
             viewModelScope.launch {
                 resourceRepository.waitUntilLoaded()
-                delayedElements.value =
-                    transformSpecToElement.transform(formSpec.items)
+                delayedElements.value = transformSpecToElement
+                    .transform(formSpec.items)
             }
             this.elements = delayedElements
         }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressElement.kt
@@ -24,11 +24,6 @@ open class AddressElement constructor(
     )
 ) : SectionMultiFieldElement(_identifier) {
 
-    private val autocompleteSupportedCountries = setOf(
-        "AU", "BE", "BR", "CA", "CH", "DE", "ES", "FR", "GB", "IE", "IN", "IT", "JP", "MX", "MY",
-        "NO", "NL", "PH", "PL", "RU", "SE", "SG", "TR", "US", "ZA"
-    )
-
     @VisibleForTesting
     val countryElement = CountryElement(
         IdentifierSpec.Country,
@@ -132,5 +127,12 @@ open class AddressElement constructor(
 
     override fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>) {
         this.rawValuesMap = rawValuesMap
+    }
+
+    companion object {
+        private val autocompleteSupportedCountries = setOf(
+            "AU", "BE", "BR", "CA", "CH", "DE", "ES", "FR", "GB", "IE", "IN", "IT", "JP", "MX", "MY",
+            "NO", "NL", "PH", "PL", "RU", "SE", "SG", "TR", "US", "ZA"
+        )
     }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
@@ -5,6 +5,7 @@ import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.address.AddressFieldElementRepository
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 
 @Serializable
 enum class DisplayField {
@@ -12,16 +13,14 @@ enum class DisplayField {
     Country
 }
 
-@Serializable
-enum class AddressType {
-    @SerialName("shipping_condensed")
-    ShippingCondensed,
-
-    @SerialName("shipping_expanded")
-    ShippingExpanded,
-
-    @SerialName("normal")
-    Normal
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
+sealed class AddressType {
+    data class ShippingCondensed(
+        val googleApiKey: String?,
+        val onNavigation: () -> Unit
+    ) : AddressType()
+    object ShippingExpanded : AddressType()
+    object Normal : AddressType()
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
@@ -39,7 +38,10 @@ data class AddressSpec(
     @SerialName("show_label")
     val showLabel: Boolean = true,
 
-    @SerialName("address_type")
+    /**
+     * This field is not deserialized, this field is used for the Address Element
+     */
+    @Transient
     val type: AddressType = AddressType.Normal
 ) : FormItemSpec() {
     fun transform(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressTextFieldController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressTextFieldController.kt
@@ -1,0 +1,98 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.annotation.RestrictTo
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.VisualTransformation
+import com.stripe.android.ui.core.forms.FormFieldEntry
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class AddressTextFieldController(
+    private val config: TextFieldConfig,
+    private val onNavigation: (() -> Unit)? = null,
+    initialValue: String? = null
+) : TextFieldController, InputController, SectionFieldErrorController {
+
+    init {
+        initialValue?.let { onRawValueChange(it) }
+    }
+
+    override val trailingIcon: Flow<TextFieldIcon?> = config.trailingIcon
+    override val capitalization: KeyboardCapitalization = config.capitalization
+    override val keyboardType: KeyboardType = config.keyboard
+    override val visualTransformation =
+        config.visualTransformation ?: VisualTransformation.None
+    override val showOptionalLabel: Boolean = false
+
+    override val label: Flow<Int> = MutableStateFlow(config.label)
+    override val debugLabel = config.debugLabel
+
+    /** This is all the information that can be observed on the element */
+    private val _fieldValue = MutableStateFlow("")
+    override val fieldValue: Flow<String> = _fieldValue
+
+    override val rawFieldValue: Flow<String> = _fieldValue.map { config.convertToRaw(it) }
+
+    override val contentDescription: Flow<String> = _fieldValue
+
+    private val _fieldState = MutableStateFlow<TextFieldState>(TextFieldStateConstants.Error.Blank)
+    override val fieldState: Flow<TextFieldState> = _fieldState
+
+    override val loading: Flow<Boolean> = config.loading
+
+    private val _hasFocus = MutableStateFlow(false)
+
+    override val visibleError: Flow<Boolean> =
+        combine(_fieldState, _hasFocus) { fieldState, hasFocus ->
+            fieldState.shouldShowError(hasFocus)
+        }
+
+    /**
+     * An error must be emitted if it is visible or not visible.
+     **/
+    override val error: Flow<FieldError?> = visibleError.map { visibleError ->
+        _fieldState.value.getError()?.takeIf { visibleError }
+    }
+
+    override val isComplete: Flow<Boolean> = _fieldState.map {
+        it.isValid() || (!it.isValid() && showOptionalLabel && it.isBlank())
+    }
+
+    /**
+     * This is called when the value changed to is a display value.
+     */
+    override fun onValueChange(displayFormatted: String): TextFieldState? {
+        val originalTextStateValue = _fieldState.value
+        _fieldValue.value = config.filter(displayFormatted)
+
+        // Should be filtered value
+        _fieldState.value = config.determineState(_fieldValue.value)
+
+        return if (_fieldState.value != originalTextStateValue) {
+            _fieldState.value
+        } else {
+            null
+        }
+    }
+
+    override fun onFocusChange(newHasFocus: Boolean) {
+        _hasFocus.value = newHasFocus
+    }
+
+    override val formFieldValue: Flow<FormFieldEntry> =
+        combine(isComplete, rawFieldValue) { complete, value ->
+            FormFieldEntry(value, complete)
+        }
+
+    override fun onRawValueChange(rawValue: String) {
+        onValueChange(config.convertFromRaw(rawValue))
+    }
+
+    fun launchAutocompleteScreen() {
+        onNavigation?.invoke()
+    }
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressTextFieldElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressTextFieldElement.kt
@@ -1,0 +1,14 @@
+package com.stripe.android.ui.core.elements
+
+internal class AddressTextFieldElement(
+    override val identifier: IdentifierSpec,
+    config: TextFieldConfig,
+    onNavigation: (() -> Unit)? = null
+) : SectionSingleFieldElement(identifier) {
+
+    override val controller: AddressTextFieldController =
+        AddressTextFieldController(
+            config,
+            onNavigation
+        )
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressTextFieldUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressTextFieldUI.kt
@@ -9,14 +9,17 @@ import androidx.compose.ui.text.input.ImeAction
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun AddressTextFieldUI(
-    controller: AddressTextFieldController
+    controller: AddressTextFieldController,
+    onClick: () -> Unit = {
+        controller.launchAutocompleteScreen()
+    }
 ) {
     TextField(
         textFieldController = controller,
         imeAction = ImeAction.Next,
         enabled = false,
         modifier = Modifier.clickable {
-            controller.launchAutocompleteScreen()
+            onClick()
         }
     )
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressTextFieldUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressTextFieldUI.kt
@@ -1,0 +1,22 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.annotation.RestrictTo
+import androidx.compose.foundation.clickable
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+
+@Composable
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun AddressTextFieldUI(
+    controller: AddressTextFieldController
+) {
+    TextField(
+        textFieldController = controller,
+        imeAction = ImeAction.Next,
+        enabled = false,
+        modifier = Modifier.clickable {
+            controller.launchAutocompleteScreen()
+        }
+    )
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionFieldElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionFieldElementUI.kt
@@ -17,6 +17,9 @@ internal fun SectionFieldElementUI(
 ) {
     if (hiddenIdentifiers?.contains(field.identifier) == false) {
         when (val controller = field.sectionFieldErrorController()) {
+            is AddressTextFieldController -> {
+                AddressTextFieldUI(controller)
+            }
             is TextFieldController -> {
                 TextField(
                     textFieldController = controller,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy.kt
@@ -173,7 +173,8 @@ interface IsPlacesAvailable {
     operator fun invoke(): Boolean
 }
 
-internal class DefaultIsPlacesAvailable : IsPlacesAvailable {
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class DefaultIsPlacesAvailable : IsPlacesAvailable {
     override fun invoke(): Boolean {
         return try {
             Class.forName("com.google.android.libraries.places.api.Places")

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/TransformSpecToElements.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/TransformSpecToElements.kt
@@ -48,9 +48,7 @@ class TransformSpecToElements(
     private val context: Context,
     private val viewOnlyFields: Set<IdentifierSpec> = emptySet()
 ) {
-    fun transform(
-        list: List<FormItemSpec>
-    ): List<FormElement> =
+    fun transform(list: List<FormItemSpec>): List<FormElement> =
         list.map {
             when (it) {
                 is SaveForFutureUseSpec -> it.transform(

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressElementTest.kt
@@ -143,7 +143,7 @@ class AddressElementTest {
             IdentifierSpec.Generic("address"),
             addressFieldElementRepository,
             countryDropdownFieldController = countryDropdownFieldController,
-            addressType = AddressType.ShippingCondensed
+            addressType = AddressType.ShippingCondensed(null) { }
         )
 
         val identifierSpecs = addressElement.fields.first().map {
@@ -206,13 +206,28 @@ class AddressElementTest {
             IdentifierSpec.Generic("address"),
             addressFieldElementRepository,
             countryDropdownFieldController = countryDropdownFieldController,
-            addressType = AddressType.ShippingCondensed
+            addressType = AddressType.ShippingCondensed("some key") { }
         )
 
         val identifierSpecs = addressElement.fields.first().map {
             it.identifier
         }
         assertThat(identifierSpecs.contains(IdentifierSpec.OneLineAddress)).isTrue()
+    }
+
+    @Test
+    fun `when google api key not supplied, condensed shipping address element is not one line address element`() = runTest {
+        val addressElement = AddressElement(
+            IdentifierSpec.Generic("address"),
+            addressFieldElementRepository,
+            countryDropdownFieldController = countryDropdownFieldController,
+            addressType = AddressType.ShippingCondensed(null) { }
+        )
+
+        val identifierSpecs = addressElement.fields.first().map {
+            it.identifier
+        }
+        assertThat(identifierSpecs.contains(IdentifierSpec.OneLineAddress)).isFalse()
     }
 
     @Test

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AddressTextFieldUITest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AddressTextFieldUITest.kt
@@ -1,0 +1,49 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth
+import com.stripe.android.R
+import com.stripe.android.ui.core.DefaultPaymentsTheme
+import com.stripe.android.ui.core.elements.AddressTextFieldController
+import com.stripe.android.ui.core.elements.AddressTextFieldUI
+import com.stripe.android.ui.core.elements.SimpleTextFieldConfig
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AddressTextFieldUITest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun clicking_address_should_trigger_on_cick() {
+        var count = 0
+        setContent {
+            count++
+        }
+
+        composeTestRule.onNodeWithText("Address").performClick()
+
+        Truth.assertThat(count).isEqualTo(1)
+    }
+
+    private fun setContent(
+        onClick: () -> Unit
+    ) {
+        composeTestRule.setContent {
+            DefaultPaymentsTheme {
+                AddressTextFieldUI(
+                    controller = AddressTextFieldController(
+                        SimpleTextFieldConfig(label = R.string.address_label_address)
+                    ),
+                    onClick = onClick
+                )
+            }
+        }
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreenTest.kt
@@ -22,13 +22,13 @@ class InputAddressScreenTest {
     @Test
     fun no_shipping_address_set_should_show_expand_button() {
         setContent()
-        composeTestRule.onNodeWithText("Enter manually").assertExists()
+        composeTestRule.onNodeWithText("Enter address manually").assertExists()
     }
 
     @Test
     fun shipping_address_set_should_not_show_expand_button() {
         setContent(ShippingAddress(name = "skyler"))
-        composeTestRule.onNodeWithText("Enter manually").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Enter address manually").assertDoesNotExist()
     }
 
     @Test
@@ -59,7 +59,7 @@ class InputAddressScreenTest {
     fun clicking_enter_manually_triggers_callback() {
         var counter = 0
         setContent(onEnterManuallyCallback = { counter++ })
-        composeTestRule.onNodeWithText("Enter Manually").performClick()
+        composeTestRule.onNodeWithText("Enter address manually").performClick()
         Truth.assertThat(counter).isEqualTo(1)
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivity.kt
@@ -9,6 +9,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetValue
@@ -104,7 +105,7 @@ internal class AddressElementActivity : ComponentActivity() {
                     }
                 },
                 content = {},
-                modifier = Modifier.navigationBarsPadding()
+                modifier = Modifier.navigationBarsPadding().systemBarsPadding()
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
@@ -69,9 +69,9 @@ internal class AutocompleteViewModel @Inject constructor(
     fun initialize(
         clientProvider: () -> PlacesClientProxy? = {
             // TODO: Update the PaymentSheet Configuration to include api key
-//            args.config?.googlePlacesApiKey?.let {
-//                PlacesClientProxy.create(getApplication(), it)
-//            }
+            // args.config?.googlePlacesApiKey?.let {
+            //     PlacesClientProxy.create(getApplication(), it)
+            // }
             PlacesClientProxy.create(getApplication(), "")
         }
     ) {
@@ -198,32 +198,5 @@ internal class AutocompleteViewModel @Inject constructor(
         const val SEARCH_DEBOUNCE_MS = 1000L
         const val MAX_DISPLAYED_RESULTS = 4
         const val MIN_CHARS_AUTOCOMPLETE = 3
-        val autocompleteSupportedCountries = setOf(
-            "AU",
-            "BE",
-            "BR",
-            "CA",
-            "CH",
-            "DE",
-            "ES",
-            "FR",
-            "GB",
-            "IE",
-            "IN",
-            "IT",
-            "JP",
-            "MX",
-            "MY",
-            "NO",
-            "NL",
-            "PH",
-            "PL",
-            "RU",
-            "SE",
-            "SG",
-            "TR",
-            "US",
-            "ZA"
-        )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
@@ -33,7 +33,7 @@ internal fun InputAddressScreen(
     onEnterManuallyClick: () -> Unit,
     formContent: @Composable ColumnScope.() -> Unit
 ) {
-    Column {
+    Column(modifier = Modifier.fillMaxHeight()) {
         AddressOptionsAppBar(
             isRootScreen = true,
             onButtonClick = { onCloseClick() }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -14,7 +14,6 @@ import com.stripe.android.ui.core.injection.FormControllerSubcomponent
 import com.stripe.android.ui.core.injection.NonFallbackInjector
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Provider
@@ -24,14 +23,14 @@ internal class InputAddressViewModel @Inject constructor(
     val navigator: AddressElementNavigator,
     formControllerProvider: Provider<FormControllerSubcomponent.Builder>
 ) : ViewModel() {
-    val _collectedAddress = MutableStateFlow<ShippingAddress?>(null)
+    private val _collectedAddress = MutableStateFlow<ShippingAddress?>(null)
     val collectedAddress: StateFlow<ShippingAddress?> = _collectedAddress
 
-    val _formController = MutableStateFlow<FormController?>(null)
-    val formController = _formController
+    private val _formController = MutableStateFlow<FormController?>(null)
+    val formController: StateFlow<FormController?> = _formController
 
-    val _formEnabled = MutableStateFlow(true)
-    val formEnabled = _formEnabled
+    private val _formEnabled = MutableStateFlow(true)
+    val formEnabled: StateFlow<Boolean> = _formEnabled
 
     init {
         viewModelScope.launch {
@@ -73,25 +72,29 @@ internal class InputAddressViewModel @Inject constructor(
                     .viewModelScope(viewModelScope)
                     .stripeIntent(args.stripeIntent)
                     .merchantName(args.config?.merchantDisplayName ?: "")
-                    .formSpec(buildFormSpec(shippingAddress != null))
+                    .formSpec(buildFormSpec(shippingAddress == null))
                     .initialValues(initialValues)
                     .build().formController
             }
         }
     }
 
-    private fun buildFormSpec(expandedForm: Boolean): LayoutSpec {
+    private fun buildFormSpec(condensedForm: Boolean): LayoutSpec {
         return LayoutSpec(
             listOf(
-                if (expandedForm) {
+                if (condensedForm) {
                     AddressSpec(
                         showLabel = false,
-                        type = AddressType.ShippingExpanded
+                        type = AddressType.ShippingCondensed(
+                            googleApiKey = "" // args.config?.googlePlacesApiKey
+                        ) {
+                            navigator.navigateTo(AddressElementScreen.Autocomplete)
+                        }
                     )
                 } else {
                     AddressSpec(
                         showLabel = false,
-                        type = AddressType.ShippingCondensed
+                        type = AddressType.ShippingExpanded
                     )
                 }
             )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Add one line address element that will launch an autocomplete screen to capture address from google places sdk.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Shipping Address Element

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots

https://user-images.githubusercontent.com/99316447/178067266-bb62f68b-d1bb-47de-9918-83aa5fdff452.mov

