### PR TITLE
BANKCON-4486 Remember entire FinancialConnectionsSheet object

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetCompose.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetCompose.kt
@@ -15,6 +15,9 @@ import com.stripe.android.financialconnections.launcher.FinancialConnectionsShee
  * This API uses Compose specific API [rememberLauncherForActivityResult] to register a
  * [androidx.activity.result.ActivityResultLauncher] into the current activity,
  * so it should be called as part of Compose initialization path.
+ *
+ * The created FinancialConnectionsSheet is remembered across recompositions. 
+ * Recomposition will always return the value produced by composition.
  */
 @Composable
 fun rememberFinancialConnectionsSheet(
@@ -39,6 +42,9 @@ fun rememberFinancialConnectionsSheet(
  * This API uses Compose specific API [rememberLauncherForActivityResult] to register a
  * [androidx.activity.result.ActivityResultLauncher] into the current activity,
  * so it should be called as part of Compose initialization path.
+ *
+ * The created FinancialConnectionsSheet is remembered across recompositions. 
+ * Recomposition will always return the value produced by composition.
  */
 @Composable
 fun rememberFinancialConnectionsSheetForToken(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetCompose.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetCompose.kt
@@ -2,6 +2,7 @@ package com.stripe.android.financialconnections
 
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetForDataContract
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetForDataLauncher
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetForTokenContract
@@ -18,13 +19,18 @@ import com.stripe.android.financialconnections.launcher.FinancialConnectionsShee
 @Composable
 fun rememberFinancialConnectionsSheet(
     callback: (FinancialConnectionsSheetResult) -> Unit
-): FinancialConnectionsSheet = FinancialConnectionsSheet(
-    FinancialConnectionsSheetForDataLauncher(
-        rememberLauncherForActivityResult(
-            FinancialConnectionsSheetForDataContract()
-        ) { callback(it) }
-    )
-)
+): FinancialConnectionsSheet {
+    val activityResultLauncher = rememberLauncherForActivityResult(
+        FinancialConnectionsSheetForDataContract()
+    ) { callback(it) }
+    return remember {
+        FinancialConnectionsSheet(
+            FinancialConnectionsSheetForDataLauncher(
+                activityResultLauncher
+            )
+        )
+    }
+}
 
 /**
  * Register a request to launch an instance of [FinancialConnectionsSheet]
@@ -37,10 +43,15 @@ fun rememberFinancialConnectionsSheet(
 @Composable
 fun rememberFinancialConnectionsSheetForToken(
     callback: (FinancialConnectionsSheetForTokenResult) -> Unit
-): FinancialConnectionsSheet = FinancialConnectionsSheet(
-    FinancialConnectionsSheetForTokenLauncher(
-        rememberLauncherForActivityResult(
-            FinancialConnectionsSheetForTokenContract()
-        ) { callback(it) }
-    )
-)
+): FinancialConnectionsSheet {
+    val activityResultLauncher = rememberLauncherForActivityResult(
+        FinancialConnectionsSheetForTokenContract()
+    ) { callback(it) }
+    return remember {
+        FinancialConnectionsSheet(
+            FinancialConnectionsSheetForTokenLauncher(
+                activityResultLauncher
+            )
+        )
+    }
+}

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetCompose.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetCompose.kt
@@ -16,7 +16,7 @@ import com.stripe.android.financialconnections.launcher.FinancialConnectionsShee
  * [androidx.activity.result.ActivityResultLauncher] into the current activity,
  * so it should be called as part of Compose initialization path.
  *
- * The created FinancialConnectionsSheet is remembered across recompositions. 
+ * The created FinancialConnectionsSheet is remembered across recompositions.
  * Recomposition will always return the value produced by composition.
  */
 @Composable
@@ -43,7 +43,7 @@ fun rememberFinancialConnectionsSheet(
  * [androidx.activity.result.ActivityResultLauncher] into the current activity,
  * so it should be called as part of Compose initialization path.
  *
- * The created FinancialConnectionsSheet is remembered across recompositions. 
+ * The created FinancialConnectionsSheet is remembered across recompositions.
  * Recomposition will always return the value produced by composition.
  */
 @Composable


### PR DESCRIPTION
# Summary
- Remembers entire FinancialConnectionsSheet object so that it persists across recompositions (thanks @brnunes-stripe) 
