### PR TITLE
Parse `extra_fields` from Stripe API Error object

### DIFF
--- a/stripe-core/api/stripe-core.api
+++ b/stripe-core/api/stripe-core.api
@@ -55,8 +55,8 @@ public final class com/stripe/android/core/StripeError : com/stripe/android/core
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/core/StripeError;
-	public static synthetic fun copy$default (Lcom/stripe/android/core/StripeError;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/core/StripeError;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lcom/stripe/android/core/StripeError;
+	public static synthetic fun copy$default (Lcom/stripe/android/core/StripeError;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lcom/stripe/android/core/StripeError;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCharge ()Ljava/lang/String;

--- a/stripe-core/src/main/java/com/stripe/android/core/StripeError.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/StripeError.kt
@@ -2,6 +2,7 @@ package com.stripe.android.core
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeModel
+import com.stripe.android.core.model.parsers.ExtraFields
 import kotlinx.parcelize.Parcelize
 import java.io.Serializable
 
@@ -80,5 +81,15 @@ constructor(
      *
      * [doc_url](https://stripe.com/docs/api/errors#errors-doc_url)
      */
-    val docUrl: String? = null
+    val docUrl: String? = null,
+
+    /**
+     * Internal list of extra fields related to the error.
+     */
+    internal val extraFields: ExtraFields? = null
 ) : StripeModel, Serializable
+
+@Parcelize
+internal data class ExtraFields(
+    val value: Map<String, String>
+) : StripeModel

--- a/stripe-core/src/main/java/com/stripe/android/core/StripeError.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/StripeError.kt
@@ -2,7 +2,6 @@ package com.stripe.android.core
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeModel
-import com.stripe.android.core.model.parsers.ExtraFields
 import kotlinx.parcelize.Parcelize
 import java.io.Serializable
 

--- a/stripe-core/src/main/java/com/stripe/android/core/StripeError.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/StripeError.kt
@@ -85,11 +85,7 @@ constructor(
 
     /**
      * Internal list of extra fields related to the error.
+     * Note - value type is ignored and always parsed as string (true -> "true")
      */
-    internal val extraFields: ExtraFields? = null
+    internal val extraFields: Map<String, String>? = null
 ) : StripeModel, Serializable
-
-@Parcelize
-internal data class ExtraFields(
-    val value: Map<String, String>
-) : StripeModel

--- a/stripe-core/src/main/java/com/stripe/android/core/model/parsers/StripeErrorJsonParser.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/model/parsers/StripeErrorJsonParser.kt
@@ -23,7 +23,7 @@ class StripeErrorJsonParser : ModelJsonParser<StripeError> {
                     extraFields = errorObject
                         .optJSONObject(FIELD_EXTRA_FIELDS)?.let { extraFieldsJson ->
                             extraFieldsJson.keys().asSequence()
-                                .map { key -> key to json.getString(key) }
+                                .map { key -> key to extraFieldsJson.getString(key) }
                                 .toMap()
                         }
                 )

--- a/stripe-core/src/main/java/com/stripe/android/core/model/parsers/StripeErrorJsonParser.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/model/parsers/StripeErrorJsonParser.kt
@@ -28,11 +28,7 @@ class StripeErrorJsonParser : ModelJsonParser<StripeError> {
                         }
                 )
             }
-        }
-            .onFailure {
-                it
-            }
-            .getOrDefault(
+        }.getOrDefault(
             StripeError(
                 message = MALFORMED_RESPONSE_MESSAGE
             )

--- a/stripe-core/src/main/java/com/stripe/android/core/model/parsers/StripeErrorJsonParser.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/model/parsers/StripeErrorJsonParser.kt
@@ -23,7 +23,11 @@ class StripeErrorJsonParser : ModelJsonParser<StripeError> {
                     type = optString(errorObject, FIELD_TYPE),
                     docUrl = optString(errorObject, FIELD_DOC_URL),
                     extraFields = errorObject
-                        .optJSONObject(FIELD_EXTRA_FIELDS)?.let { ExtraFieldsParser().parse(it) }
+                        .optJSONObject(FIELD_EXTRA_FIELDS)?.let { extraFieldsJson ->
+                            extraFieldsJson.keys().asSequence()
+                                .map { key -> key to json.getString(key) }
+                                .toMap()
+                        }
                 )
             }
         }.getOrDefault(
@@ -51,16 +55,3 @@ class StripeErrorJsonParser : ModelJsonParser<StripeError> {
     }
 }
 
-private class ExtraFieldsParser : ModelJsonParser<ExtraFields> {
-    override fun parse(json: JSONObject): ExtraFields {
-        return runCatching {
-            ExtraFields(
-                json.keys().asSequence().map { key -> key to json.getString(key) }.toMap()
-            )
-        }.getOrDefault(
-            ExtraFields(
-                emptyMap()
-            )
-        )
-    }
-}

--- a/stripe-core/src/main/java/com/stripe/android/core/model/parsers/StripeErrorJsonParser.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/model/parsers/StripeErrorJsonParser.kt
@@ -23,12 +23,16 @@ class StripeErrorJsonParser : ModelJsonParser<StripeError> {
                     extraFields = errorObject
                         .optJSONObject(FIELD_EXTRA_FIELDS)?.let { extraFieldsJson ->
                             extraFieldsJson.keys().asSequence()
-                                .map { key -> key to extraFieldsJson.getString(key) }
+                                .map { key -> key to extraFieldsJson.get(key).toString() }
                                 .toMap()
                         }
                 )
             }
-        }.getOrDefault(
+        }
+            .onFailure {
+                it
+            }
+            .getOrDefault(
             StripeError(
                 message = MALFORMED_RESPONSE_MESSAGE
             )

--- a/stripe-core/src/main/java/com/stripe/android/core/model/parsers/StripeErrorJsonParser.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/model/parsers/StripeErrorJsonParser.kt
@@ -4,8 +4,6 @@ import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.model.StripeJsonUtils.optString
-import com.stripe.android.core.model.StripeModel
-import kotlinx.parcelize.Parcelize
 import org.json.JSONObject
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -54,4 +52,3 @@ class StripeErrorJsonParser : ModelJsonParser<StripeError> {
         private const val FIELD_TYPE = "type"
     }
 }
-

--- a/stripe-core/src/test/java/com/stripe/android/core/model/parsers/StripeErrorJsonParserTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/model/parsers/StripeErrorJsonParserTest.kt
@@ -90,7 +90,11 @@ class StripeErrorJsonParserTest {
                     "decline_code": "card_declined",
                     "message": "Your card was declined.",
                     "type": "invalid_request_error",
-                    "extra_fields": { "test_number": 1, "test_boolean": true, "test_string": "hola" }
+                    "extra_fields": {
+                        "test_number": 1, 
+                        "test_boolean": true,
+                        "test_string": "hola" 
+                    }
                 }
             }
             """.trimIndent()

--- a/stripe-core/src/test/java/com/stripe/android/core/model/parsers/StripeErrorJsonParserTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/model/parsers/StripeErrorJsonParserTest.kt
@@ -41,7 +41,12 @@ class StripeErrorJsonParserTest {
             charge = "charge_value",
             message = "Your card was declined.",
             declineCode = "card_declined",
-            type = "invalid_request_error"
+            type = "invalid_request_error",
+            extraFields = mapOf(
+                "test_number" to "1"
+                "test_boolean" to "true",
+                "test_string" to "hola"
+            )
         )
         assertThat(StripeErrorJsonParser().parse(RAW_ERROR_WITH_ALL_FIELDS))
             .isEqualTo(expected)
@@ -84,7 +89,8 @@ class StripeErrorJsonParserTest {
                     "charge": "charge_value",
                     "decline_code": "card_declined",
                     "message": "Your card was declined.",
-                    "type": "invalid_request_error"
+                    "type": "invalid_request_error",
+                    "extra_fields": { "test_number": 1, "test_boolean": true, "test_string": "hola" }
                 }
             }
             """.trimIndent()

--- a/stripe-core/src/test/java/com/stripe/android/core/model/parsers/StripeErrorJsonParserTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/model/parsers/StripeErrorJsonParserTest.kt
@@ -43,7 +43,7 @@ class StripeErrorJsonParserTest {
             declineCode = "card_declined",
             type = "invalid_request_error",
             extraFields = mapOf(
-                "test_number" to "1"
+                "test_number" to "1",
                 "test_boolean" to "true",
                 "test_string" to "hola"
             )


### PR DESCRIPTION
# Summary
- The stripe error response can include a dynamic list of extra fields.
- Adds support to parse this list of extra fields into a dynamic 

Sample error response with extra fields:

<img width="864" alt="image" src="https://user-images.githubusercontent.com/99293320/178807605-e5c71695-f0d4-4dbd-bd8e-fbb59e85809b.png">
