### PR TITLE
Add ability to pass country from input screen to autocomplete screen

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -803,11 +803,11 @@ public final class com/stripe/android/paymentsheet/addresselement/AutocompleteSc
 }
 
 public final class com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/addresselement/AutocompleteViewModel_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/addresselement/AutocompleteViewModel_Factory;
 	public fun get ()Lcom/stripe/android/paymentsheet/addresselement/AutocompleteViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/paymentsheet/addresselement/AddressElementActivityContract$Args;Lcom/stripe/android/paymentsheet/addresselement/AddressElementNavigator;Landroid/app/Application;)Lcom/stripe/android/paymentsheet/addresselement/AutocompleteViewModel;
+	public static fun newInstance (Lcom/stripe/android/paymentsheet/addresselement/AddressElementActivityContract$Args;Lcom/stripe/android/paymentsheet/addresselement/AddressElementNavigator;Lcom/stripe/android/paymentsheet/addresselement/AutocompleteViewModel$Args;Landroid/app/Application;)Lcom/stripe/android/paymentsheet/addresselement/AutocompleteViewModel;
 }
 
 public final class com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel_Factory_MembersInjector : dagger/MembersInjector {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
@@ -135,6 +135,9 @@ class AutocompleteScreenTest {
                     viewModel = AutocompleteViewModel(
                         args,
                         AddressElementNavigator(),
+                        AutocompleteViewModel.Args(
+                            "US"
+                        ),
                         application
                     ).apply {
                         initialize {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivity.kt
@@ -21,8 +21,9 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.navArgument
 import com.google.accompanist.navigation.animation.composable
 import com.google.accompanist.navigation.animation.AnimatedNavHost
 import com.google.accompanist.navigation.animation.rememberAnimatedNavController
@@ -97,8 +98,23 @@ internal class AddressElementActivity : ComponentActivity() {
                                 composable(AddressElementScreen.InputAddress.route) {
                                     InputAddressScreen(viewModel.injector)
                                 }
-                                composable(AddressElementScreen.Autocomplete.route) {
-                                    AutocompleteScreen(viewModel.injector)
+                                composable(
+                                    AddressElementScreen.Autocomplete.route,
+                                    arguments = listOf(
+                                        navArgument(AddressElementScreen.Autocomplete.countryArg) {
+                                            type = NavType.StringType
+                                        }
+                                    )
+                                ) { backStackEntry ->
+                                    val country = backStackEntry
+                                        .arguments
+                                        ?.getString(
+                                            AddressElementScreen.Autocomplete.countryArg
+                                        )
+                                    AutocompleteScreen(
+                                        viewModel.injector,
+                                        country
+                                    )
                                 }
                             }
                         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivityContract.kt
@@ -36,7 +36,8 @@ internal class AddressElementActivityContract :
     data class Args internal constructor(
         internal val stripeIntent: StripeIntent,
         internal val config: PaymentSheet.Configuration?,
-        internal val injectionParams: InjectionParams? = null
+        internal val injectionParams: InjectionParams? = null,
+        internal val googlePlacesApiKey: String? = null
     ) : ActivityStarter.Args {
 
         companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementScreen.kt
@@ -6,6 +6,16 @@ package com.stripe.android.paymentsheet.addresselement
 internal sealed class AddressElementScreen(
     open val route: String
 ) {
-    object Autocomplete : AddressElementScreen("AutoComplete")
+    class Autocomplete(
+        val country: String
+    ) : AddressElementScreen(
+        "Autocomplete?$countryArg=$country"
+    ) {
+        companion object {
+            const val countryArg = "country"
+            const val route = "Autocomplete?$countryArg={$countryArg}"
+        }
+    }
+
     object InputAddress : AddressElementScreen("InputAddress")
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreen.kt
@@ -22,10 +22,14 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
@@ -46,12 +50,18 @@ import com.stripe.android.ui.core.paymentsColors
 const val TEST_TAG_ATTRIBUTION_DRAWABLE = "AutocompleteAttributionDrawable"
 
 @Composable
-internal fun AutocompleteScreen(injector: NonFallbackInjector) {
+internal fun AutocompleteScreen(
+    injector: NonFallbackInjector,
+    country: String?
+) {
     val application = LocalContext.current.applicationContext as Application
     val viewModel: AutocompleteViewModel =
         viewModel<AutocompleteViewModel>(
             factory = AutocompleteViewModel.Factory(
-                injector
+                injector,
+                AutocompleteViewModel.Args(
+                    country = country
+                )
             ) { application }
         ).also {
             it.initialize()
@@ -67,7 +77,7 @@ internal fun AutocompleteScreenUI(viewModel: AutocompleteViewModel) {
     val query = viewModel.textFieldController.fieldValue.collectAsState(initial = "")
     val attributionDrawable =
         PlacesClientProxy.getPlacesPoweredByGoogleDrawable(isSystemInDarkTheme())
-
+    val focusRequester = remember { FocusRequester() }
     Scaffold(
         bottomBar = {
             Row(
@@ -112,8 +122,13 @@ internal fun AutocompleteScreenUI(viewModel: AutocompleteViewModel) {
                         textFieldController = viewModel.textFieldController,
                         imeAction = ImeAction.Done,
                         enabled = true,
-                        modifier = Modifier.fillMaxWidth()
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .focusRequester(focusRequester)
                     )
+                    SideEffect {
+                        focusRequester.requestFocus()
+                    }
                 }
                 if (loading) {
                     Row(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -14,6 +14,7 @@ import com.stripe.android.ui.core.injection.FormControllerSubcomponent
 import com.stripe.android.ui.core.injection.NonFallbackInjector
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Provider
@@ -86,9 +87,24 @@ internal class InputAddressViewModel @Inject constructor(
                     AddressSpec(
                         showLabel = false,
                         type = AddressType.ShippingCondensed(
-                            googleApiKey = "" // args.config?.googlePlacesApiKey
+                            googleApiKey = args.googlePlacesApiKey
                         ) {
-                            navigator.navigateTo(AddressElementScreen.Autocomplete)
+                            viewModelScope.launch {
+                                val country = _formController
+                                    .value
+                                    ?.formValues
+                                    ?.stateIn(viewModelScope)
+                                    ?.value
+                                    ?.get(IdentifierSpec.Country)
+                                    ?.value
+                                country?.let {
+                                    navigator.navigateTo(
+                                        AddressElementScreen.Autocomplete(
+                                            country = country
+                                        )
+                                    )
+                                }
+                            }
                         }
                     )
                 } else {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -275,7 +275,8 @@ internal class DefaultFlowController @Inject internal constructor(
                     injectorKey = injectorKey,
                     productUsage = productUsage,
                     enableLogging = enableLogging
-                )
+                ),
+                googlePlacesApiKey = ""
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
@@ -13,7 +13,7 @@ import javax.inject.Singleton
     subcomponents = [
         AddressElementViewModelSubcomponent::class,
         InputAddressViewModelSubcomponent::class,
-        AutoCompleteViewModelSubcomponent::class,
+        AutocompleteViewModelSubcomponent::class,
         FormControllerSubcomponent::class
     ]
 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AutocompleteViewModelSubcomponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AutocompleteViewModelSubcomponent.kt
@@ -6,7 +6,7 @@ import dagger.BindsInstance
 import dagger.Subcomponent
 
 @Subcomponent
-internal interface AutoCompleteViewModelSubcomponent {
+internal interface AutocompleteViewModelSubcomponent {
     val autoCompleteViewModel: AutocompleteViewModel
 
     @Subcomponent.Builder
@@ -14,6 +14,9 @@ internal interface AutoCompleteViewModelSubcomponent {
         @BindsInstance
         fun application(application: Application): Builder
 
-        fun build(): AutoCompleteViewModelSubcomponent
+        @BindsInstance
+        fun configuration(configuration: AutocompleteViewModel.Args): Builder
+
+        fun build(): AutocompleteViewModelSubcomponent
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModelTest.kt
@@ -44,6 +44,9 @@ class AutocompleteViewModelTest {
         AutocompleteViewModel(
             args,
             navigator,
+            AutocompleteViewModel.Args(
+                "US"
+            ),
             application
         ).apply {
             initialize {


### PR DESCRIPTION
# Summary

Add ability to pass the country from `InputAddressScreen` to `AutocompleteScreen`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Address Element Alpha

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots

https://user-images.githubusercontent.com/99316447/179624931-39cf171f-5323-4799-9535-d939aa946554.mov
