### PR TITLE
Add dynamic colors for manual address button

### DIFF
--- a/payments-ui-core/res/values/colors.xml
+++ b/payments-ui-core/res/values/colors.xml
@@ -49,6 +49,4 @@
 
     <!-- CardFormView -->
 
-    <color name="stripe_paymentsheet_shipping_address_background">#1A1A1A0D</color>
-
 </resources>

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/PaymentsTheme.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/PaymentsTheme.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.ColorUtils
+import java.lang.Float.max
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class PaymentsColors(
@@ -493,4 +494,27 @@ fun PrimaryButtonStyle.getComposeTextStyle(): TextStyle {
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun Context.getRawValueFromDimenResource(resource: Int): Float {
     return resources.getDimension(resource) / resources.displayMetrics.density
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun Color.lighten(amount: Float): Color {
+    return modifyBrightness {
+        max(it + amount, 1f)
+    }
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun Color.darken(amount: Float): Color {
+    return modifyBrightness {
+        max(it - amount, 0f)
+    }
+}
+
+private fun Color.modifyBrightness(transform: (Float) -> Float): Color {
+    val hsl = FloatArray(3)
+    ColorUtils.colorToHSL(this.toArgb(), hsl)
+    val hue = hsl[0]
+    val saturation = hsl[1]
+    val lightness = hsl[2]
+    return Color.hsl(hue, saturation, transform(lightness))
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.Surface
@@ -88,7 +89,8 @@ internal class AddressElementActivity : ComponentActivity() {
                 sheetContent = {
                     PaymentsTheme {
                         Surface(
-                            Modifier.fillMaxWidth()
+                            color = MaterialTheme.colors.background,
+                            modifier = Modifier.fillMaxWidth()
                         ) {
                             AnimatedNavHost(
                                 navController,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -36,6 +35,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.ui.AddressOptionsAppBar
+import com.stripe.android.ui.core.darken
 import com.stripe.android.ui.core.elements.TextFieldSection
 import com.stripe.android.ui.core.elements.annotatedStringResource
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
@@ -70,15 +70,16 @@ internal fun AutocompleteScreenUI(viewModel: AutocompleteViewModel) {
 
     Scaffold(
         bottomBar = {
+            val background = if (isSystemInDarkTheme()) {
+                MaterialTheme.paymentsColors.component
+            } else {
+                MaterialTheme.paymentsColors.materialColors.surface.darken(0.07f)
+            }
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.Center,
                 modifier = Modifier
-                    .background(
-                        color = colorResource(
-                            id = R.color.stripe_paymentsheet_shipping_address_background
-                        )
-                    )
+                    .background(color = background)
                     .fillMaxWidth()
                     .imePadding()
                     .navigationBarsPadding()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

- Add dynamic colors for manual address button in address element
- Update input address screen background color to match designs (it uses background now)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Shipping Address Element alpha

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

<img src="https://user-images.githubusercontent.com/99316447/179829095-a9783d1a-3aa8-42ee-a9a7-b7a0764aefc3.png" height=400/>

<img src="https://user-images.githubusercontent.com/99316447/179828868-f37c7130-b1ad-4fb7-90d6-9d87b4c55530.png" height=400/>

<img src="https://user-images.githubusercontent.com/99316447/179828877-42e48578-0d60-470e-83c3-b10267ae2bd6.png" height=400/>

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
