### PR TITLE
[stripe-core] add PluginDetector to check if the SDK is integrated native or through a plugin

### DIFF
--- a/stripe-core/src/main/java/com/stripe/android/core/utils/PluginDetector.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/PluginDetector.kt
@@ -1,0 +1,23 @@
+package com.stripe.android.core.utils
+
+internal object PluginDetector {
+    var pluginType: String? =
+        PluginType.values().firstOrNull {
+            isPlugin(it.className)
+        }?.pluginName
+
+    private fun isPlugin(className: String): Boolean = try {
+        Class.forName(className)
+        true
+    } catch (e: Exception) {
+        false
+    }
+
+    enum class PluginType(
+        val className: String,
+        val pluginName: String
+    ) {
+        ReactNative("com.facebook.proguard.annotations.DoNotStrip", "react-native"),
+        Flutter("io.flutter.embedding.android.FlutterActivity", "flutter")
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Use reflection to check if the SDK is used through a plugin or natively

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
detect plugin

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

manually verified on react native

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
