### PR TITLE
[stripe-core] add PluginDetector to check if the SDK is integrated native or through a plugin

### DIFF
--- a/stripe-core/src/main/java/com/stripe/android/core/utils/PluginDetector.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/PluginDetector.kt
@@ -23,7 +23,7 @@ object PluginDetector {
         Class.forName(className)
         true
     } catch (e: ClassNotFoundException) {
-        Log.d(TAG, "$className not found.")
+        Log.d(TAG, "$className not found: $e")
         false
     }
 

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/PluginDetector.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/PluginDetector.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.core.utils
 
+import android.util.Log
 import androidx.annotation.RestrictTo
 
 /**
@@ -7,8 +8,10 @@ import androidx.annotation.RestrictTo
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 object PluginDetector {
+    private val TAG = PluginDetector::class.java.simpleName
+
     /**
-     * Loop through all possible [PluginType]s and found the first one that exists in class path,
+     * Loop through all possible [PluginType]s and find the first one that exists in class path,
      * return null if none of the class is found.
      */
     val pluginType: String? =
@@ -19,7 +22,8 @@ object PluginDetector {
     private fun isPlugin(className: String): Boolean = try {
         Class.forName(className)
         true
-    } catch (e: Exception) {
+    } catch (e: ClassNotFoundException) {
+        Log.d(TAG, "$className not found.")
         false
     }
 

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/PluginDetector.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/PluginDetector.kt
@@ -23,6 +23,7 @@ object PluginDetector {
         false
     }
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     enum class PluginType(
         val className: String,
         val pluginName: String

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/PluginDetector.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/PluginDetector.kt
@@ -1,0 +1,35 @@
+package com.stripe.android.core.utils
+
+import androidx.annotation.RestrictTo
+
+/**
+ * A detector using reflection to check which plugin the SDK is being used from.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+object PluginDetector {
+    /**
+     * Loop through all possible [PluginType]s and found the first one that exists in class path,
+     * return null if none of the class is found.
+     */
+    val pluginType: String? =
+        PluginType.values().firstOrNull {
+            isPlugin(it.className)
+        }?.pluginName
+
+    private fun isPlugin(className: String): Boolean = try {
+        Class.forName(className)
+        true
+    } catch (e: Exception) {
+        false
+    }
+
+    enum class PluginType(
+        val className: String,
+        val pluginName: String
+    ) {
+        ReactNative("com.facebook.proguard.annotations.DoNotStrip", "react-native"),
+        Flutter("io.flutter.embedding.engine.FlutterEngine", "flutter"),
+        Cordova("org.apache.cordova.CordovaActivity", "cordova"),
+        Unity("com.unity3d.player.UnityPlayerActivity", "unity")
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Use reflection to check if the SDK is used through a plugin. Inspired from stripe-ios's [PluginDetector](https://github.com/stripe/stripe-ios/blob/67f49e842d23e1c9e73255c8c2b19bf0976ac274/StripeCore/StripeCore/Source/Analytics/PluginDetector.swift)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
detect plugin


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

manually verified on react native and flutter, two of the most popular platforms

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
