### PR TITLE
Add allowed countries filter

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -104,20 +104,12 @@ internal class InputAddressViewModel @Inject constructor(
                         }
                     }
                 }
-            ).apply {
-                args.config?.allowedCountries?.let {
-                    (allowedCountryCodes as? MutableSet<String>)?.retainAll(it)
-                }
-            }
+            )
         } else {
             AddressSpec(
                 showLabel = false,
                 type = AddressType.ShippingExpanded
-            ).apply {
-                args.config?.allowedCountries?.let {
-                    (allowedCountryCodes as? MutableSet<String>)?.retainAll(it)
-                }
-            }
+            )
         }
 
         val addressSpecWithAllowedCountries = args.config?.allowedCountries?.run {
@@ -129,6 +121,20 @@ internal class InputAddressViewModel @Inject constructor(
                 addressSpecWithAllowedCountries ?: addressSpec
             )
         )
+    }
+
+    fun expandAddressForm() {
+        viewModelScope.launch {
+            formController.value?.let { controller ->
+                controller.formValues.collect {
+                    _collectedAddress.value = AddressDetails(
+                        name = it[IdentifierSpec.Name]?.value,
+                        phoneNumber = it[IdentifierSpec.Phone]?.value,
+                        country = it[IdentifierSpec.Country]?.value
+                    )
+                }
+            }
+        }
     }
 
     fun clickPrimaryButton() {


### PR DESCRIPTION
# Summary

Use the `allowedCountries` coming from `AddressLauncher.Configuration` to filter out the counties in the country picker.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Address Element Alpha

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

<img src="https://user-images.githubusercontent.com/99316447/180084796-2a964845-4c8c-4c1d-9498-76a81d079cf2.png" height=400/>

