### PR TITLE
Use default address if passed by the merchant

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -24,7 +24,7 @@ internal class InputAddressViewModel @Inject constructor(
     val navigator: AddressElementNavigator,
     formControllerProvider: Provider<FormControllerSubcomponent.Builder>
 ) : ViewModel() {
-    private val _collectedAddress = MutableStateFlow<AddressDetails?>(null)
+    private val _collectedAddress = MutableStateFlow<AddressDetails?>(args.config?.defaultValues)
     val collectedAddress: StateFlow<AddressDetails?> = _collectedAddress
 
     private val _formController = MutableStateFlow<FormController?>(null)
@@ -115,20 +115,6 @@ internal class InputAddressViewModel @Inject constructor(
                 }
             )
         )
-    }
-
-    fun expandAddressForm() {
-        viewModelScope.launch {
-            formController.value?.let { controller ->
-                controller.formValues.collect {
-                    _collectedAddress.value = AddressDetails(
-                        name = it[IdentifierSpec.Name]?.value,
-                        phoneNumber = it[IdentifierSpec.Phone]?.value,
-                        country = it[IdentifierSpec.Country]?.value
-                    )
-                }
-            }
-        }
     }
 
     fun clickPrimaryButton() {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -17,15 +17,21 @@ import javax.inject.Provider
 @ExperimentalCoroutinesApi
 class InputAddressViewModelTest {
     private val args = mock<AddressElementActivityContract.Args>()
+    private val config = mock<AddressLauncher.Configuration>()
     private val navigator = mock<AddressElementNavigator>()
     private val formcontrollerProvider = mock<Provider<FormControllerSubcomponent.Builder>>()
 
-    private fun createViewModel() =
-        InputAddressViewModel(
+    private fun createViewModel(defaultAddress: AddressDetails? = null): InputAddressViewModel {
+        defaultAddress?.let {
+            whenever(config.defaultValues).thenReturn(defaultAddress)
+        }
+        whenever(args.config).thenReturn(config)
+        return InputAddressViewModel(
             args,
             navigator,
             formcontrollerProvider
         )
+    }
 
     @Test
     fun `no autocomplete address passed has an empty address to start`() = runTest {
@@ -43,6 +49,14 @@ class InputAddressViewModelTest {
         whenever(navigator.getResultFlow<AddressDetails?>(any())).thenReturn(flow)
 
         val viewModel = createViewModel()
+        assertThat(viewModel.collectedAddress.value).isEqualTo(expectedAddress)
+    }
+
+    @Test
+    fun `default address from merchant is parsed`() = runTest {
+        val expectedAddress = AddressDetails(name = "skyler", company = "stripe")
+
+        val viewModel = createViewModel(expectedAddress)
         assertThat(viewModel.collectedAddress.value).isEqualTo(expectedAddress)
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* If a merchant passes in a default address, it should be used to fill in the form. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
* The API didn't do anything before this PR 😢 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

https://user-images.githubusercontent.com/89166418/180097182-13829567-0418-45bd-927a-6ad30f65f5c0.mp4

* need to fix the long loading spinner on the form. 