### PR TITLE
Use merchant config to get Address Element button text

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
@@ -12,8 +12,6 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTextInput
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.stripe.android.model.parsers.PaymentIntentJsonParser
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.ui.core.DefaultPaymentsTheme
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.ui.core.elements.autocomplete.model.AddressComponent
@@ -21,7 +19,6 @@ import com.stripe.android.ui.core.elements.autocomplete.model.AutocompletePredic
 import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.Place
-import org.json.JSONObject
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -32,52 +29,9 @@ class AutocompleteScreenTest {
     @get:Rule
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
-    private val paymentIntent = requireNotNull(
-        PaymentIntentJsonParser().parse(
-            JSONObject(
-                """
-                {
-                    "id": "pi_1IRg6VCRMbs6F",
-                    "object": "payment_intent",
-                    "amount": 1099,
-                    "canceled_at": null,
-                    "cancellation_reason": null,
-                    "capture_method": "automatic",
-                    "client_secret": "pi_1IRg6VCRMbs6F_secret_7oH5g4v8GaCrHfsGYS6kiSnwF",
-                    "confirmation_method": "automatic",
-                    "created": 1614960135,
-                    "currency": "usd",
-                    "description": "Example PaymentIntent",
-                    "last_payment_error": null,
-                    "livemode": false,
-                    "next_action": null,
-                    "payment_method": "pm_1IJs3ZCRMbs",
-                    "payment_method_types": ["card"],
-                    "receipt_email": null,
-                    "setup_future_usage": null,
-                    "shipping": null,
-                    "source": null,
-                    "status": "succeeded"
-                }
-                """.trimIndent()
-            )
-        )
-    )
-
     private val args = AddressElementActivityContract.Args(
-        paymentIntent,
-        PaymentSheet.Configuration(
-            merchantDisplayName = "Merchant, Inc.",
-            customer = PaymentSheet.CustomerConfiguration(
-                "customer_id",
-                "ephemeral_key"
-            )
-        ),
-        AddressElementActivityContract.Args.InjectionParams(
-            "injectorKey",
-            setOf("Product Usage"),
-            true
-        )
+        AddressLauncher.Configuration(),
+        "injectorKey"
     )
     private val application = ApplicationProvider.getApplicationContext<Application>()
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreenTest.kt
@@ -54,6 +54,7 @@ class InputAddressScreenTest {
             DefaultPaymentsTheme {
                 InputAddressScreen(
                     primaryButtonEnabled = primaryButtonEnabled,
+                    primaryButtonText = "Save Address",
                     onPrimaryButtonClick = primaryButtonCallback,
                     onCloseClick = onCloseCallback,
                     formContent = {}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/screenshot/AddressElementPrimaryButtonScreenshot.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/screenshot/AddressElementPrimaryButtonScreenshot.kt
@@ -23,7 +23,7 @@ class AddressElementPrimaryButtonScreenshot : ScreenshotTest {
                 colors = PaymentsThemeDefaults.colorsLight
             ) {
                 Surface(color = colors.materialColors.surface) {
-                    AddressElementPrimaryButton(isEnabled = true) {
+                    AddressElementPrimaryButton(isEnabled = true, BUTTON_TEXT) {
                     }
                 }
             }
@@ -39,7 +39,7 @@ class AddressElementPrimaryButtonScreenshot : ScreenshotTest {
                 colors = PaymentsThemeDefaults.colorsDark
             ) {
                 Surface(color = colors.materialColors.surface) {
-                    AddressElementPrimaryButton(isEnabled = true) {
+                    AddressElementPrimaryButton(isEnabled = true, BUTTON_TEXT) {
                     }
                 }
             }
@@ -55,7 +55,7 @@ class AddressElementPrimaryButtonScreenshot : ScreenshotTest {
                 colors = PaymentsThemeDefaults.colorsLight
             ) {
                 Surface(color = colors.materialColors.surface) {
-                    AddressElementPrimaryButton(isEnabled = false) {}
+                    AddressElementPrimaryButton(isEnabled = false, BUTTON_TEXT) {}
                 }
             }
         }
@@ -70,10 +70,14 @@ class AddressElementPrimaryButtonScreenshot : ScreenshotTest {
                 colors = PaymentsThemeDefaults.colorsDark
             ) {
                 Surface(color = colors.materialColors.surface) {
-                    AddressElementPrimaryButton(isEnabled = false) {}
+                    AddressElementPrimaryButton(isEnabled = false, BUTTON_TEXT) {}
                 }
             }
         }
         compareScreenshot(composeTestRule)
+    }
+
+    companion object {
+        const val BUTTON_TEXT = "Save Address"
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementPrimaryButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementPrimaryButton.kt
@@ -16,9 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.stripe.android.paymentsheet.R
 import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.getBackgroundColor
 import com.stripe.android.ui.core.getOnBackgroundColor
@@ -26,6 +24,7 @@ import com.stripe.android.ui.core.getOnBackgroundColor
 @Composable
 internal fun AddressElementPrimaryButton(
     isEnabled: Boolean,
+    text: String,
     onButtonClick: () -> Unit
 ) {
     val context = LocalContext.current
@@ -53,9 +52,7 @@ internal fun AddressElementPrimaryButton(
                 )
             ) {
                 Text(
-                    text = stringResource(
-                        R.string.stripe_paymentsheet_address_element_primary_button
-                    ),
+                    text = text,
                     color = onBackground.copy(alpha = LocalContentAlpha.current)
                 )
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
@@ -25,6 +25,7 @@ import com.stripe.android.ui.core.injection.NonFallbackInjector
 @Composable
 internal fun InputAddressScreen(
     primaryButtonEnabled: Boolean,
+    primaryButtonText: String,
     onPrimaryButtonClick: () -> Unit,
     onCloseClick: () -> Unit,
     formContent: @Composable ColumnScope.() -> Unit
@@ -44,7 +45,10 @@ internal fun InputAddressScreen(
                 modifier = Modifier.padding(bottom = 8.dp)
             )
             formContent()
-            AddressElementPrimaryButton(isEnabled = primaryButtonEnabled) {
+            AddressElementPrimaryButton(
+                isEnabled = primaryButtonEnabled,
+                text = primaryButtonText
+            ) {
                 onPrimaryButtonClick()
             }
         }
@@ -74,9 +78,12 @@ internal fun InputAddressScreen(
     } else {
         formController?.let {
             val completeValues by it.completeFormValues.collectAsState(null)
-
+            val buttonText = viewModel.args.config?.buttonTitle ?: stringResource(
+                R.string.stripe_paymentsheet_address_element_primary_button
+            )
             InputAddressScreen(
                 primaryButtonEnabled = completeValues != null,
+                primaryButtonText = buttonText,
                 onPrimaryButtonClick = { viewModel.clickPrimaryButton() },
                 onCloseClick = { viewModel.navigator.dismiss() },
                 formContent = {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* adds ability to set label of the Address Element's primary button
* Parses merchant's config to get the label
* Fixes broken android tests.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
* Currently the API does nothing! 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
![Screenshot_20220720_161143](https://user-images.githubusercontent.com/89166418/180099437-dbc26fe2-a1f0-4fdd-a288-ee5975d49ec6.png)
