### PR TITLE
Fix OXXO so that processing is a terminal state.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
 ## X.X.X
+### Payments
+[Fixed][5308](https://github.com/stripe/stripe-android/pull/5308) OXXO so that processing is considered a successful terminal state, similar to Konbini and Boleto.
 
 ## 20.7.0 - 2022-07-06
 * This release adds additional support for Afterpay/Clearpay in PaymentSheet.

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -263,7 +263,7 @@ constructor(
             isReusable = false,
             isVoucher = true,
             requiresMandate = false,
-            hasDelayedSettlement = false
+            hasDelayedSettlement = true
         ),
         Alipay(
             "alipay",

--- a/payments-core/src/test/java/com/stripe/android/PaymentIntentResultTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentIntentResultTest.kt
@@ -48,11 +48,11 @@ class PaymentIntentResultTest {
             created = 500L,
             amount = 1000L,
             clientSecret = "secret",
-            paymentMethod = PaymentMethodFixtures.US_BANK_ACCOUNT_PAYMENT_METHOD,
+            paymentMethod = PaymentMethodFixtures.OXXO_PAYMENT_METHOD,
             isLiveMode = false,
             id = "pi_12345",
             currency = "usd",
-            paymentMethodTypes = listOf(PaymentMethod.Type.USBankAccount.code),
+            paymentMethodTypes = listOf(PaymentMethod.Type.Oxxo.code),
             status = StripeIntent.Status.Processing,
             unactivatedPaymentMethods = emptyList(),
             nextActionData = StripeIntent.NextActionData.DisplayOxxoDetails()

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentMethodFixtures.kt
@@ -109,6 +109,14 @@ internal object PaymentMethodFixtures {
         )
     )
 
+    val OXXO_PAYMENT_METHOD = PaymentMethod(
+        id = "pm_1IcuwoL32KlRot01",
+        billingDetails = BILLING_DETAILS,
+        created = 1617638802,
+        liveMode = false,
+        type = PaymentMethod.Type.Oxxo
+    )
+
     val SEPA_DEBIT_JSON = JSONObject(
         """
         {


### PR DESCRIPTION
# Summary
Fix OXXO so that processing is considered a successful terminal state, similar to Konbini and Boleto


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
[Fixed] OXXO so that processing is considered a successful terminal state, similar to Konbini and Boleto.
