### PR TITLE
Fix errors in instrumentation tests

### DIFF
--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestAuthorization.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestAuthorization.kt
@@ -100,7 +100,9 @@ class TestAuthorization {
 
     companion object {
         private val lpmRepository = LpmRepository(
-            InstrumentationRegistry.getInstrumentation().targetContext.resources
+            LpmRepository.LpmRepositoryArguments(
+                InstrumentationRegistry.getInstrumentation().targetContext.resources
+            )
         )
     }
 }

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestAuthorization.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestAuthorization.kt
@@ -103,6 +103,8 @@ class TestAuthorization {
             LpmRepository.LpmRepositoryArguments(
                 InstrumentationRegistry.getInstrumentation().targetContext.resources
             )
-        )
+        ).apply {
+            forceUpdate(LpmRepository.exposedPaymentMethods, null)
+        }
     }
 }

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestBrowsers.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestBrowsers.kt
@@ -106,7 +106,9 @@ class TestBrowsers {
 
     companion object {
         private val lpmRepository = LpmRepository(
-            InstrumentationRegistry.getInstrumentation().targetContext.resources
+            LpmRepository.LpmRepositoryArguments(
+                InstrumentationRegistry.getInstrumentation().targetContext.resources
+            )
         )
     }
 }

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestBrowsers.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestBrowsers.kt
@@ -109,6 +109,8 @@ class TestBrowsers {
             LpmRepository.LpmRepositoryArguments(
                 InstrumentationRegistry.getInstrumentation().targetContext.resources
             )
-        )
+        ).apply {
+            forceUpdate(LpmRepository.exposedPaymentMethods, null)
+        }
     }
 }

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestCustomers.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestCustomers.kt
@@ -8,12 +8,12 @@ import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.Automatic
 import com.stripe.android.test.core.Billing
 import com.stripe.android.test.core.Browser
-import com.stripe.android.test.core.IntentType
 import com.stripe.android.test.core.Currency
 import com.stripe.android.test.core.Customer
 import com.stripe.android.test.core.DelayedPMs
 import com.stripe.android.test.core.GooglePayState
 import com.stripe.android.test.core.INDIVIDUAL_TEST_TIMEOUT_SECONDS
+import com.stripe.android.test.core.IntentType
 import com.stripe.android.test.core.MyScreenCaptureProcessor
 import com.stripe.android.test.core.PlaygroundTestDriver
 import com.stripe.android.test.core.Shipping
@@ -89,7 +89,9 @@ class TestCustomers {
 
     companion object {
         private val lpmRepository = LpmRepository(
-            InstrumentationRegistry.getInstrumentation().targetContext.resources
+            LpmRepository.LpmRepositoryArguments(
+                InstrumentationRegistry.getInstrumentation().targetContext.resources
+            )
         )
     }
 }

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestCustomers.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestCustomers.kt
@@ -92,6 +92,8 @@ class TestCustomers {
             LpmRepository.LpmRepositoryArguments(
                 InstrumentationRegistry.getInstrumentation().targetContext.resources
             )
-        )
+        ).apply {
+            forceUpdate(LpmRepository.exposedPaymentMethods, null)
+        }
     }
 }

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestFieldPopulation.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestFieldPopulation.kt
@@ -142,6 +142,8 @@ class TestFieldPopulation {
             LpmRepository.LpmRepositoryArguments(
                 InstrumentationRegistry.getInstrumentation().targetContext.resources
             )
-        )
+        ).apply {
+            forceUpdate(LpmRepository.exposedPaymentMethods, null)
+        }
     }
 }

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestFieldPopulation.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestFieldPopulation.kt
@@ -139,7 +139,9 @@ class TestFieldPopulation {
 
     companion object {
         private val lpmRepository = LpmRepository(
-            InstrumentationRegistry.getInstrumentation().targetContext.resources
+            LpmRepository.LpmRepositoryArguments(
+                InstrumentationRegistry.getInstrumentation().targetContext.resources
+            )
         )
     }
 }

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestGooglePay.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestGooglePay.kt
@@ -136,6 +136,8 @@ class TestGooglePay {
             LpmRepository.LpmRepositoryArguments(
                 InstrumentationRegistry.getInstrumentation().targetContext.resources
             )
-        )
+        ).apply {
+            forceUpdate(LpmRepository.exposedPaymentMethods, null)
+        }
     }
 }

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestGooglePay.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestGooglePay.kt
@@ -7,7 +7,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import com.stripe.android.paymentsheet.R
-import com.stripe.android.ui.core.forms.resources.LpmRepository.SupportedPaymentMethod
 import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.Automatic
 import com.stripe.android.test.core.Billing
@@ -125,16 +124,18 @@ class TestGooglePay {
 
             selectors.getGoogleDividerText()
                 .assertTextEquals(
-                selectors.getResourceString(expectedText),
+                    selectors.getResourceString(expectedText),
                     includeEditableText = false
-            )
+                )
             testDriver.teardown()
         }
     }
 
     companion object {
         private val lpmRepository = LpmRepository(
-            InstrumentationRegistry.getInstrumentation().targetContext.resources
+            LpmRepository.LpmRepositoryArguments(
+                InstrumentationRegistry.getInstrumentation().targetContext.resources
+            )
         )
     }
 }

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestHardCodedLpms.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestHardCodedLpms.kt
@@ -52,10 +52,7 @@ class TestHardCodedLpms {
                 InstrumentationRegistry.getInstrumentation().targetContext.resources
             )
         ).apply {
-            forceUpdate(
-                LpmRepository.exposedPaymentMethods,
-                null
-            )
+            forceUpdate(LpmRepository.exposedPaymentMethods, null)
         }
     }
 

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestMultiStepFieldsReloaded.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestMultiStepFieldsReloaded.kt
@@ -210,6 +210,8 @@ class TestMultiStepFieldsReloaded {
             LpmRepository.LpmRepositoryArguments(
                 InstrumentationRegistry.getInstrumentation().targetContext.resources
             )
-        )
+        ).apply {
+            forceUpdate(LpmRepository.exposedPaymentMethods, null)
+        }
     }
 }

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestMultiStepFieldsReloaded.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestMultiStepFieldsReloaded.kt
@@ -207,7 +207,9 @@ class TestMultiStepFieldsReloaded {
         // their files in the same directory.
         private val screenshotProcessor = MyScreenCaptureProcessor()
         private val lpmRepository = LpmRepository(
-            InstrumentationRegistry.getInstrumentation().targetContext.resources
+            LpmRepository.LpmRepositoryArguments(
+                InstrumentationRegistry.getInstrumentation().targetContext.resources
+            )
         )
     }
 }

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/screenshot/TestPaymentSheetScreenshots.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/screenshot/TestPaymentSheetScreenshots.kt
@@ -252,7 +252,9 @@ class TestPaymentSheetScreenshots {
 
     companion object {
         private val lpmRepository = LpmRepository(
-            InstrumentationRegistry.getInstrumentation().targetContext.resources
+            LpmRepository.LpmRepositoryArguments(
+                InstrumentationRegistry.getInstrumentation().targetContext.resources
+            )
         )
     }
 }

--- a/scripts/browserstack.py
+++ b/scripts/browserstack.py
@@ -140,6 +140,7 @@ def executeTests(appUrl, testUrl):
          "networkLogs": True,
          "deviceLogs": True,
          "video": True,
+         "acceptInsecureCerts": True,
 #          "language": "en_US",
          "locale": "en_US",
          "enableSpoonFramework": False,


### PR DESCRIPTION
# Summary
The browserstack builds were failing because of certificates so that was turned off in the browserstack script.  Also there was a compile error in the instrumentation tests that needed to be fixed.
