### PR TITLE
Hide trailing icon if textfield is empty

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModelTest.kt
@@ -210,4 +210,17 @@ class AutocompleteViewModelTest {
 
         assertThat(viewModel.predictions.value?.size).isEqualTo(null)
     }
+
+    @Test
+    fun `when address is empty trailing icon is null`() = runTest(UnconfinedTestDispatcher()) {
+        val viewModel = createViewModel()
+
+        viewModel.textFieldController.onRawValueChange("")
+
+        assertThat(viewModel.textFieldController.trailingIcon.stateIn(viewModel.viewModelScope).value).isNull()
+
+        viewModel.textFieldController.onRawValueChange("a")
+
+        assertThat(viewModel.textFieldController.trailingIcon.stateIn(viewModel.viewModelScope).value).isNotNull()
+    }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Hide trailing icon in autocomplete screen if textfield is empty

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Address Element Alpha

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

<img src="https://user-images.githubusercontent.com/99316447/180308208-351ab0ff-1abd-4b71-8514-af034dfba81b.gif" height=400 />

