### PR TITLE
Parse appearance config from merchant in Address Element

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivity.kt
@@ -28,6 +28,7 @@ import androidx.navigation.navArgument
 import com.google.accompanist.navigation.animation.composable
 import com.google.accompanist.navigation.animation.AnimatedNavHost
 import com.google.accompanist.navigation.animation.rememberAnimatedNavController
+import com.stripe.android.paymentsheet.parseAppearance
 import com.stripe.android.ui.core.PaymentsTheme
 import kotlinx.coroutines.launch
 
@@ -54,6 +55,7 @@ internal class AddressElementActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         WindowCompat.setDecorFitsSystemWindows(window, false)
+        starterArgs.config?.appearance?.parseAppearance()
 
         // set a default result in case the user closes the sheet manually
         setResult()
@@ -90,7 +92,7 @@ internal class AddressElementActivity : ComponentActivity() {
                 sheetContent = {
                     PaymentsTheme {
                         Surface(
-                            color = MaterialTheme.colors.background,
+                            color = MaterialTheme.colors.surface,
                             modifier = Modifier.fillMaxWidth()
                         ) {
                             AnimatedNavHost(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementPrimaryButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementPrimaryButton.kt
@@ -1,13 +1,14 @@
 package com.stripe.android.paymentsheet.addresselement
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.LocalContentAlpha
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
@@ -16,9 +17,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.getBackgroundColor
+import com.stripe.android.ui.core.getBorderStrokeColor
 import com.stripe.android.ui.core.getOnBackgroundColor
 
 @Composable
@@ -27,9 +32,24 @@ internal fun AddressElementPrimaryButton(
     text: String,
     onButtonClick: () -> Unit
 ) {
+    // We need to use PaymentsTheme.primaryButtonStyle instead of MaterialTheme
+    // because of the rules API for primary button.
     val context = LocalContext.current
     val background = Color(PaymentsTheme.primaryButtonStyle.getBackgroundColor(context))
     val onBackground = Color(PaymentsTheme.primaryButtonStyle.getOnBackgroundColor(context))
+    val borderStroke = BorderStroke(
+        PaymentsTheme.primaryButtonStyle.shape.borderStrokeWidth.dp,
+        Color(PaymentsTheme.primaryButtonStyle.getBorderStrokeColor(context))
+    )
+    val shape = RoundedCornerShape(
+        PaymentsTheme.primaryButtonStyle.shape.cornerRadius
+    )
+    val fontFamily = PaymentsTheme.primaryButtonStyle.typography.fontFamily
+    val textStyle = TextStyle(
+        fontFamily = if (fontFamily != null) FontFamily(Font(fontFamily)) else FontFamily.Default,
+        fontSize = PaymentsTheme.primaryButtonStyle.typography.fontSize
+    )
+
     CompositionLocalProvider(
         LocalContentAlpha provides if (isEnabled) ContentAlpha.high else ContentAlpha.disabled
     ) {
@@ -45,7 +65,8 @@ internal fun AddressElementPrimaryButton(
                     .fillMaxWidth()
                     .height(44.dp),
                 enabled = isEnabled,
-                shape = MaterialTheme.shapes.medium,
+                shape = shape,
+                border = borderStroke,
                 colors = ButtonDefaults.buttonColors(
                     backgroundColor = background,
                     disabledBackgroundColor = background
@@ -53,7 +74,8 @@ internal fun AddressElementPrimaryButton(
             ) {
                 Text(
                     text = text,
-                    color = onBackground.copy(alpha = LocalContentAlpha.current)
+                    color = onBackground.copy(alpha = LocalContentAlpha.current),
+                    style = textStyle
                 )
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreen.kt
@@ -107,6 +107,7 @@ internal fun AutocompleteScreenUI(viewModel: AutocompleteViewModel) {
                 .fillMaxHeight()
                 .systemBarsPadding()
                 .padding(paddingValues)
+                .background(MaterialTheme.colors.surface)
         ) {
             Column(
                 modifier = Modifier.fillMaxWidth()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.addresselement
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -30,7 +31,11 @@ internal fun InputAddressScreen(
     onCloseClick: () -> Unit,
     formContent: @Composable ColumnScope.() -> Unit
 ) {
-    Column(modifier = Modifier.fillMaxHeight()) {
+    Column(
+        modifier = Modifier
+            .fillMaxHeight()
+            .background(MaterialTheme.colors.surface)
+    ) {
         AddressOptionsAppBar(
             isRootScreen = true,
             onButtonClick = { onCloseClick() }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddressOptionsAppBar.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddressOptionsAppBar.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.ui.core.paymentsColors
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -38,7 +39,7 @@ fun AddressOptionsAppBar(
                     if (isRootScreen) R.string.stripe_paymentsheet_close
                     else R.string.stripe_paymentsheet_back
                 ),
-                tint = MaterialTheme.colors.onSurface
+                tint = MaterialTheme.paymentsColors.appBarIcon
             )
         }
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Make address element activity parse the merchant's appearance config
* Make address element's primary button adhere to the config
* All screens have the correct surface background. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
* Making the APIs work!
* UX feedback.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified


# Screenshots
| Input Address | Autocomplete |
| ------------- | ------------- |
|![InputAddress](https://user-images.githubusercontent.com/89166418/180327122-51570fa0-bae0-4241-a03c-41e7130f48f3.png)|![Autocomplete](https://user-images.githubusercontent.com/89166418/180327127-dfa7bd06-feb0-4392-b9dd-36d8f72cfa3a.png)|

