### PR TITLE
Fix go back

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreen.kt
@@ -113,7 +113,7 @@ internal fun AutocompleteScreenUI(viewModel: AutocompleteViewModel) {
                 modifier = Modifier.fillMaxWidth()
             ) {
                 AddressOptionsAppBar(false) {
-                    viewModel.setResultAndGoBack()
+                    viewModel.onBackPressed()
                 }
                 Box(
                     modifier = Modifier

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
@@ -143,21 +143,39 @@ internal class AutocompleteViewModel @Inject constructor(
         }
     }
 
-    fun onEnterAddressManually() {
-        setResultAndGoBack()
+    fun onBackPressed() {
+        val result = if (queryFlow.value.isNotBlank()) {
+            AddressDetails(
+                line1 = queryFlow.value
+            )
+        } else {
+            null
+        }
+        setResultAndGoBack(result)
     }
 
-    fun setResultAndGoBack() {
-        addressResult.value?.fold(
-            onSuccess = {
-                navigator.setResult(AddressDetails.KEY, it)
-            },
-            onFailure = {
-                navigator.setResult(AddressDetails.KEY, null)
-            }
-        ) ?: run {
-            navigator.setResult(AddressDetails.KEY, AddressDetails())
+    fun onEnterAddressManually() {
+        setResultAndGoBack(
+            AddressDetails(
+                line1 = queryFlow.value
+            )
+        )
+    }
+
+    private fun setResultAndGoBack(addressDetails: AddressDetails? = null) {
+        if (addressDetails != null) {
+            navigator.setResult(AddressDetails.KEY, addressDetails)
+        } else {
+            addressResult.value?.fold(
+                onSuccess = {
+                    navigator.setResult(AddressDetails.KEY, it)
+                },
+                onFailure = {
+                    navigator.setResult(AddressDetails.KEY, null)
+                }
+            )
         }
+
         navigator.onBack()
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Fix an issue where going back from the autocomplete screen shows the multi-line address form instead of the one-line form.

Flows:
- Autocomplete screen > no changes > on back > one-line form
- Autocomplete screen > no changes > Enter address manually > multi-line form with empty fields
- Autocomplete screen > type something > on back > multi-line form with query in line 1
- Autocomplete screen > type something > Enter address manually > multi-line form with query in line 1

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Address Element Alpha

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots

https://user-images.githubusercontent.com/99316447/180871362-a1d2f8cd-6ab5-4b5a-b94d-f6fc7905586e.mov


