### PR TITLE
Add phone number api to address element

### DIFF
--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -102,26 +102,44 @@ public final class com/stripe/android/ui/core/elements/AddressTextFieldUIKt {
 
 public final class com/stripe/android/ui/core/elements/AddressType$Normal : com/stripe/android/ui/core/elements/AddressType {
 	public static final field $stable I
-	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/AddressType$Normal;
+	public fun <init> ()V
+	public fun <init> (Lcom/stripe/android/ui/core/elements/PhoneNumberState;)V
+	public synthetic fun <init> (Lcom/stripe/android/ui/core/elements/PhoneNumberState;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/stripe/android/ui/core/elements/PhoneNumberState;
+	public final fun copy (Lcom/stripe/android/ui/core/elements/PhoneNumberState;)Lcom/stripe/android/ui/core/elements/AddressType$Normal;
+	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/AddressType$Normal;Lcom/stripe/android/ui/core/elements/PhoneNumberState;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/AddressType$Normal;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getPhoneNumberState ()Lcom/stripe/android/ui/core/elements/PhoneNumberState;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/stripe/android/ui/core/elements/AddressType$ShippingCondensed : com/stripe/android/ui/core/elements/AddressType {
 	public static final field $stable I
-	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/ui/core/elements/PhoneNumberState;Lkotlin/jvm/functions/Function0;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Lkotlin/jvm/functions/Function0;
-	public final fun copy (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Lcom/stripe/android/ui/core/elements/AddressType$ShippingCondensed;
-	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/AddressType$ShippingCondensed;Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/AddressType$ShippingCondensed;
+	public final fun component2 ()Lcom/stripe/android/ui/core/elements/PhoneNumberState;
+	public final fun component3 ()Lkotlin/jvm/functions/Function0;
+	public final fun copy (Ljava/lang/String;Lcom/stripe/android/ui/core/elements/PhoneNumberState;Lkotlin/jvm/functions/Function0;)Lcom/stripe/android/ui/core/elements/AddressType$ShippingCondensed;
+	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/AddressType$ShippingCondensed;Ljava/lang/String;Lcom/stripe/android/ui/core/elements/PhoneNumberState;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/AddressType$ShippingCondensed;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getGoogleApiKey ()Ljava/lang/String;
 	public final fun getOnNavigation ()Lkotlin/jvm/functions/Function0;
+	public fun getPhoneNumberState ()Lcom/stripe/android/ui/core/elements/PhoneNumberState;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/stripe/android/ui/core/elements/AddressType$ShippingExpanded : com/stripe/android/ui/core/elements/AddressType {
 	public static final field $stable I
-	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/AddressType$ShippingExpanded;
+	public fun <init> (Lcom/stripe/android/ui/core/elements/PhoneNumberState;)V
+	public final fun component1 ()Lcom/stripe/android/ui/core/elements/PhoneNumberState;
+	public final fun copy (Lcom/stripe/android/ui/core/elements/PhoneNumberState;)Lcom/stripe/android/ui/core/elements/AddressType$ShippingExpanded;
+	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/AddressType$ShippingExpanded;Lcom/stripe/android/ui/core/elements/PhoneNumberState;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/AddressType$ShippingExpanded;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getPhoneNumberState ()Lcom/stripe/android/ui/core/elements/PhoneNumberState;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/stripe/android/ui/core/elements/AffirmElementUIKt {
@@ -523,6 +541,32 @@ public final class com/stripe/android/ui/core/elements/PhoneNumberController$Com
 }
 
 public final class com/stripe/android/ui/core/elements/PhoneNumberElementUIKt {
+}
+
+public final class com/stripe/android/ui/core/elements/PhoneNumberState : java/lang/Enum {
+	public static final field Companion Lcom/stripe/android/ui/core/elements/PhoneNumberState$Companion;
+	public static final field HIDDEN Lcom/stripe/android/ui/core/elements/PhoneNumberState;
+	public static final field OPTIONAL Lcom/stripe/android/ui/core/elements/PhoneNumberState;
+	public static final field REQUIRED Lcom/stripe/android/ui/core/elements/PhoneNumberState;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/ui/core/elements/PhoneNumberState;
+	public static fun values ()[Lcom/stripe/android/ui/core/elements/PhoneNumberState;
+}
+
+public final class com/stripe/android/ui/core/elements/PhoneNumberState$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/PhoneNumberState$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/ui/core/elements/PhoneNumberState;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/ui/core/elements/PhoneNumberState;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/ui/core/elements/PhoneNumberState$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/stripe/android/ui/core/elements/SaveForFutureUseElementUIKt {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
@@ -15,12 +15,34 @@ enum class DisplayField {
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 sealed class AddressType {
+    abstract val phoneNumberState: PhoneNumberState
+
     data class ShippingCondensed(
         val googleApiKey: String?,
+        override val phoneNumberState: PhoneNumberState,
         val onNavigation: () -> Unit
     ) : AddressType()
-    object ShippingExpanded : AddressType()
-    object Normal : AddressType()
+
+    data class ShippingExpanded(
+        override val phoneNumberState: PhoneNumberState
+    ) : AddressType()
+
+    data class Normal(
+        override val phoneNumberState: PhoneNumberState =
+            PhoneNumberState.HIDDEN
+    ) : AddressType()
+}
+
+@Serializable
+enum class PhoneNumberState {
+    @SerialName("hidden")
+    HIDDEN,
+
+    @SerialName("optional")
+    OPTIONAL,
+
+    @SerialName("required")
+    REQUIRED
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
@@ -42,7 +64,7 @@ data class AddressSpec(
      * This field is not deserialized, this field is used for the Address Element
      */
     @Transient
-    val type: AddressType = AddressType.Normal
+    val type: AddressType = AddressType.Normal()
 ) : FormItemSpec() {
     fun transform(
         initialValues: Map<IdentifierSpec, String?>,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingAddressElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingAddressElement.kt
@@ -25,7 +25,7 @@ class CardBillingAddressElement(
     identifier,
     addressFieldRepository,
     rawValuesMap,
-    AddressType.Normal,
+    AddressType.Normal(),
     countryCodes,
     countryDropdownFieldController
 ) {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PhoneNumberController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PhoneNumberController.kt
@@ -14,7 +14,8 @@ import kotlinx.coroutines.flow.map
 class PhoneNumberController internal constructor(
     val initialPhoneNumber: String = "",
     initiallySelectedCountryCode: String? = null,
-    overrideCountryCodes: Set<String> = emptySet()
+    overrideCountryCodes: Set<String> = emptySet(),
+    override val showOptionalLabel: Boolean = false
 ) : InputController {
     override val label = flowOf(R.string.address_label_phone_number)
 
@@ -54,10 +55,9 @@ class PhoneNumberController internal constructor(
     override val rawFieldValue = combine(fieldValue, phoneNumberFormatter) { value, formatter ->
         formatter.toE164Format(value)
     }
-    override val isComplete = fieldValue.map { it.isNotBlank() }
-    override val showOptionalLabel = false
-    override val formFieldValue = fieldValue.map {
-        FormFieldEntry(it, it.isNotBlank())
+    override val isComplete = fieldValue.map { it.isNotBlank() || showOptionalLabel }
+    override val formFieldValue = fieldValue.combine(isComplete) { fieldValue, isComplete ->
+        FormFieldEntry(fieldValue, isComplete)
     }
 
     override val error: Flow<FieldError?> = flowOf(null)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PhoneNumberElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PhoneNumberElementUI.kt
@@ -73,7 +73,16 @@ internal fun PhoneNumberElementUI(
             .focusRequester(focusRequester),
         enabled = enabled,
         label = {
-            FormLabel(text = stringResource(label))
+            FormLabel(
+                text = if (controller.showOptionalLabel) {
+                    stringResource(
+                        R.string.form_label_optional,
+                        stringResource(label)
+                    )
+                } else {
+                    stringResource(label)
+                }
+            )
         },
         placeholder = {
             Text(text = placeholder)

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressElementTest.kt
@@ -138,12 +138,12 @@ class AddressElementTest {
     }
 
     @Test
-    fun `condensed shipping address element should have name and phone number fields`() = runTest {
+    fun `condensed shipping address element should have name and phone number fields when required`() = runTest {
         val addressElement = AddressElement(
             IdentifierSpec.Generic("address"),
             addressFieldElementRepository,
             countryDropdownFieldController = countryDropdownFieldController,
-            addressType = AddressType.ShippingCondensed(null) { }
+            addressType = AddressType.ShippingCondensed(null, PhoneNumberState.REQUIRED) { }
         )
 
         val identifierSpecs = addressElement.fields.first().map {
@@ -154,18 +154,84 @@ class AddressElementTest {
     }
 
     @Test
-    fun `expanded shipping address element should have name and phone number fields`() = runTest {
+    fun `hidden phone number field is not shown`() = runTest {
         val addressElement = AddressElement(
             IdentifierSpec.Generic("address"),
             addressFieldElementRepository,
             countryDropdownFieldController = countryDropdownFieldController,
-            addressType = AddressType.ShippingExpanded
+            addressType = AddressType.ShippingCondensed(null, PhoneNumberState.HIDDEN) { }
+        )
+
+        val identifierSpecs = addressElement.fields.first().map {
+            it.identifier
+        }
+        assertThat(identifierSpecs.contains(IdentifierSpec.Phone)).isFalse()
+    }
+
+    @Test
+    fun `optional phone number field is shown`() = runTest {
+        val addressElement = AddressElement(
+            IdentifierSpec.Generic("address"),
+            addressFieldElementRepository,
+            countryDropdownFieldController = countryDropdownFieldController,
+            addressType = AddressType.ShippingCondensed(null, PhoneNumberState.OPTIONAL) { }
+        )
+
+        val identifierSpecs = addressElement.fields.first().map {
+            it.identifier
+        }
+        assertThat(identifierSpecs.contains(IdentifierSpec.Phone)).isTrue()
+    }
+
+    @Test
+    fun `expanded shipping address element should have name and phone number fields when required`() = runTest {
+        val addressElement = AddressElement(
+            IdentifierSpec.Generic("address"),
+            addressFieldElementRepository,
+            countryDropdownFieldController = countryDropdownFieldController,
+            addressType = AddressType.ShippingExpanded(
+                PhoneNumberState.REQUIRED
+            )
         )
 
         val identifierSpecs = addressElement.fields.first().map {
             it.identifier
         }
         assertThat(identifierSpecs.contains(IdentifierSpec.Name)).isTrue()
+        assertThat(identifierSpecs.contains(IdentifierSpec.Phone)).isTrue()
+    }
+
+    @Test
+    fun `expanded shipping address element should hide phone number when state is hidden`() = runTest {
+        val addressElement = AddressElement(
+            IdentifierSpec.Generic("address"),
+            addressFieldElementRepository,
+            countryDropdownFieldController = countryDropdownFieldController,
+            addressType = AddressType.ShippingExpanded(
+                PhoneNumberState.HIDDEN
+            )
+        )
+
+        val identifierSpecs = addressElement.fields.first().map {
+            it.identifier
+        }
+        assertThat(identifierSpecs.contains(IdentifierSpec.Phone)).isFalse()
+    }
+
+    @Test
+    fun `expanded shipping address element should show phone number when state is optional`() = runTest {
+        val addressElement = AddressElement(
+            IdentifierSpec.Generic("address"),
+            addressFieldElementRepository,
+            countryDropdownFieldController = countryDropdownFieldController,
+            addressType = AddressType.ShippingExpanded(
+                PhoneNumberState.OPTIONAL
+            )
+        )
+
+        val identifierSpecs = addressElement.fields.first().map {
+            it.identifier
+        }
         assertThat(identifierSpecs.contains(IdentifierSpec.Phone)).isTrue()
     }
 
@@ -175,7 +241,7 @@ class AddressElementTest {
             IdentifierSpec.Generic("address"),
             addressFieldElementRepository,
             countryDropdownFieldController = countryDropdownFieldController,
-            addressType = AddressType.Normal
+            addressType = AddressType.Normal()
         )
 
         val identifierSpecs = addressElement.fields.first().map {
@@ -191,7 +257,7 @@ class AddressElementTest {
             IdentifierSpec.Generic("address"),
             addressFieldElementRepository,
             countryDropdownFieldController = countryDropdownFieldController,
-            addressType = AddressType.Normal
+            addressType = AddressType.Normal()
         )
 
         val identifierSpecs = addressElement.fields.first().map {
@@ -206,7 +272,10 @@ class AddressElementTest {
             IdentifierSpec.Generic("address"),
             addressFieldElementRepository,
             countryDropdownFieldController = countryDropdownFieldController,
-            addressType = AddressType.ShippingCondensed("some key") { }
+            addressType = AddressType.ShippingCondensed(
+                "some key",
+                PhoneNumberState.OPTIONAL
+            ) { }
         )
 
         val identifierSpecs = addressElement.fields.first().map {
@@ -221,7 +290,10 @@ class AddressElementTest {
             IdentifierSpec.Generic("address"),
             addressFieldElementRepository,
             countryDropdownFieldController = countryDropdownFieldController,
-            addressType = AddressType.ShippingCondensed(null) { }
+            addressType = AddressType.ShippingCondensed(
+                null,
+                PhoneNumberState.OPTIONAL
+            ) { }
         )
 
         val identifierSpecs = addressElement.fields.first().map {
@@ -236,7 +308,9 @@ class AddressElementTest {
             IdentifierSpec.Generic("address"),
             addressFieldElementRepository,
             countryDropdownFieldController = countryDropdownFieldController,
-            addressType = AddressType.ShippingExpanded
+            addressType = AddressType.ShippingExpanded(
+                PhoneNumberState.OPTIONAL
+            )
         )
 
         val identifierSpecs = addressElement.fields.first().map {

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PhoneNumberControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PhoneNumberControllerTest.kt
@@ -52,6 +52,25 @@ internal class PhoneNumberControllerTest {
     }
 
     @Test
+    fun `any input is marked complete if field is optional`() {
+        val phoneNumberController = PhoneNumberController(showOptionalLabel = true)
+
+        val isComplete = mutableListOf<Boolean>()
+        phoneNumberController.isComplete.asLiveData().observeForever {
+            isComplete.add(it)
+        }
+        assertThat(isComplete.last()).isTrue()
+
+        phoneNumberController.onValueChange("1")
+        idleLooper()
+        assertThat(isComplete.last()).isTrue()
+
+        phoneNumberController.onValueChange("")
+        idleLooper()
+        assertThat(isComplete.last()).isTrue()
+    }
+
+    @Test
     fun `when initial number is in E164 format then initial country is set`() {
         val phoneNumberController = PhoneNumberController.createPhoneNumberController(
             initialValue = "+491234567890"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
@@ -92,7 +92,7 @@ internal class AddressLauncher internal constructor(
          * Configuration for the field that collects a phone number.
          * Defaults to HIDDEN
          */
-        val phone: AdditionalFieldsConfiguration = AdditionalFieldsConfiguration.HIDDEN,
+        val phone: AdditionalFieldsConfiguration = AdditionalFieldsConfiguration.OPTIONAL,
 
         /**
          * Configuration for a "Remember this shipping destination" checkbox.
@@ -114,7 +114,7 @@ internal class AddressLauncher internal constructor(
             var defaultValues: AddressDetails? = null
             var allowedCountries: Set<String> = emptySet()
             var buttonTitle: String? = null
-            var phone: AdditionalFieldsConfiguration = AdditionalFieldsConfiguration.HIDDEN
+            var phone: AdditionalFieldsConfiguration = AdditionalFieldsConfiguration.OPTIONAL
             var shouldShowCheckBox: Boolean = false
             var googlePlacesApiKey: String? = null
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Adds optional label config to `PhoneNumberElement`
* Adds ability to require, hide, or make optional the phone number field in the address element.
* Makes phone number customizable in the address launcher. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
* The API doesn't do anything prior to this change.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
![Screenshot_20220726_114354](https://user-images.githubusercontent.com/89166418/181086709-53b994ce-7feb-4ed4-b005-8f4901e7213c.png)

