### PR TITLE
Fix issue with persisting input values when moving to autocomplete screen

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -2,16 +2,23 @@ package com.stripe.android.paymentsheet.addresselement
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ui.core.injection.FormControllerSubcomponent
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import javax.inject.Provider
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 
 @RunWith(RobolectricTestRunner::class)
 @ExperimentalCoroutinesApi
@@ -19,7 +26,20 @@ class InputAddressViewModelTest {
     private val args = mock<AddressElementActivityContract.Args>()
     private val config = mock<AddressLauncher.Configuration>()
     private val navigator = mock<AddressElementNavigator>()
-    private val formcontrollerProvider = mock<Provider<FormControllerSubcomponent.Builder>>()
+    private val formControllerSubcomponent = mock<FormControllerSubcomponent>().apply {
+        whenever(formController).thenReturn(mock())
+    }
+    private val formControllerProvider = Provider {
+        mock<FormControllerSubcomponent.Builder>().apply {
+            whenever(formSpec(anyOrNull())).thenReturn(this)
+            whenever(initialValues(anyOrNull())).thenReturn(this)
+            whenever(viewOnlyFields(anyOrNull())).thenReturn(this)
+            whenever(viewModelScope(anyOrNull())).thenReturn(this)
+            whenever(merchantName(anyOrNull())).thenReturn(this)
+            whenever(stripeIntent(anyOrNull())).thenReturn(this)
+            whenever(build()).thenReturn(formControllerSubcomponent)
+        }
+    }
 
     private fun createViewModel(defaultAddress: AddressDetails? = null): InputAddressViewModel {
         defaultAddress?.let {
@@ -29,12 +49,22 @@ class InputAddressViewModelTest {
         return InputAddressViewModel(
             args,
             navigator,
-            formcontrollerProvider
+            formControllerProvider
         )
     }
 
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
     @Test
-    fun `no autocomplete address passed has an empty address to start`() = runTest {
+    fun `no autocomplete address passed has an empty address to start`() = runTest(UnconfinedTestDispatcher()) {
         val flow = MutableStateFlow<AddressDetails?>(null)
         whenever(navigator.getResultFlow<AddressDetails?>(any())).thenReturn(flow)
 
@@ -43,7 +73,7 @@ class InputAddressViewModelTest {
     }
 
     @Test
-    fun `autocomplete address passed is collected to start`() = runTest {
+    fun `autocomplete address passed is collected to start`() = runTest(UnconfinedTestDispatcher()) {
         val expectedAddress = AddressDetails(name = "skyler", company = "stripe")
         val flow = MutableStateFlow<AddressDetails?>(expectedAddress)
         whenever(navigator.getResultFlow<AddressDetails?>(any())).thenReturn(flow)
@@ -53,7 +83,7 @@ class InputAddressViewModelTest {
     }
 
     @Test
-    fun `default address from merchant is parsed`() = runTest {
+    fun `default address from merchant is parsed`() = runTest(UnconfinedTestDispatcher()) {
         val expectedAddress = AddressDetails(name = "skyler", company = "stripe")
 
         val viewModel = createViewModel(expectedAddress)


### PR DESCRIPTION
# Summary

Fix an issue when a user enters a name or phone number, the state is not persisted when moving to the autocomplete screen.

Also fix an issue with `InputAddressViewModelTest`s throwing coroutine exceptions

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Address Element Alpha

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

