### PR TITLE
Refactor async repository

### DIFF
--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -740,12 +740,19 @@ public final class com/stripe/android/ui/core/forms/TransformSpecToElements {
 	public final fun transform (Ljava/util/List;)Ljava/util/List;
 }
 
+public final class com/stripe/android/ui/core/forms/resources/AsyncResourceRepository$SurfaceType : java/lang/Enum {
+	public static final field Address Lcom/stripe/android/ui/core/forms/resources/AsyncResourceRepository$SurfaceType;
+	public static final field Payments Lcom/stripe/android/ui/core/forms/resources/AsyncResourceRepository$SurfaceType;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/ui/core/forms/resources/AsyncResourceRepository$SurfaceType;
+	public static fun values ()[Lcom/stripe/android/ui/core/forms/resources/AsyncResourceRepository$SurfaceType;
+}
+
 public final class com/stripe/android/ui/core/forms/resources/AsyncResourceRepository_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/ui/core/forms/resources/AsyncResourceRepository_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/ui/core/forms/resources/AsyncResourceRepository_Factory;
 	public fun get ()Lcom/stripe/android/ui/core/forms/resources/AsyncResourceRepository;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Landroid/content/res/Resources;Lkotlin/coroutines/CoroutineContext;Ljava/util/Locale;)Lcom/stripe/android/ui/core/forms/resources/AsyncResourceRepository;
+	public static fun newInstance (Landroid/content/res/Resources;Lkotlin/coroutines/CoroutineContext;Ljava/util/Locale;Lcom/stripe/android/ui/core/forms/resources/AsyncResourceRepository$SurfaceType;)Lcom/stripe/android/ui/core/forms/resources/AsyncResourceRepository;
 }
 
 public final class com/stripe/android/ui/core/forms/resources/LpmRepository$Companion {
@@ -783,6 +790,7 @@ public abstract class com/stripe/android/ui/core/forms/resources/injection/Resou
 
 public final class com/stripe/android/ui/core/forms/resources/injection/ResourceRepositoryModule$Companion {
 	public final fun provideResources (Landroid/content/Context;)Landroid/content/res/Resources;
+	public final fun providesSurfaceType ()Lcom/stripe/android/ui/core/forms/resources/AsyncResourceRepository$SurfaceType;
 }
 
 public final class com/stripe/android/ui/core/forms/resources/injection/ResourceRepositoryModule_Companion_ProvideResourcesFactory : dagger/internal/Factory {
@@ -791,6 +799,14 @@ public final class com/stripe/android/ui/core/forms/resources/injection/Resource
 	public fun get ()Landroid/content/res/Resources;
 	public synthetic fun get ()Ljava/lang/Object;
 	public static fun provideResources (Landroid/content/Context;)Landroid/content/res/Resources;
+}
+
+public final class com/stripe/android/ui/core/forms/resources/injection/ResourceRepositoryModule_Companion_ProvidesSurfaceTypeFactory : dagger/internal/Factory {
+	public fun <init> ()V
+	public static fun create ()Lcom/stripe/android/ui/core/forms/resources/injection/ResourceRepositoryModule_Companion_ProvidesSurfaceTypeFactory;
+	public fun get ()Lcom/stripe/android/ui/core/forms/resources/AsyncResourceRepository$SurfaceType;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun providesSurfaceType ()Lcom/stripe/android/ui/core/forms/resources/AsyncResourceRepository$SurfaceType;
 }
 
 public final class com/stripe/android/ui/core/injection/FormControllerModule$Companion {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelFactoryComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelFactoryComponent.kt
@@ -8,7 +8,6 @@ import com.stripe.android.paymentsheet.addresselement.AddressElementActivityCont
 import com.stripe.android.paymentsheet.addresselement.AddressElementViewModel
 import com.stripe.android.paymentsheet.addresselement.AutocompleteViewModel
 import com.stripe.android.paymentsheet.addresselement.InputAddressViewModel
-import com.stripe.android.ui.core.forms.resources.injection.ResourceRepositoryModule
 import com.stripe.android.ui.core.injection.FormControllerModule
 import dagger.BindsInstance
 import dagger.Component
@@ -21,7 +20,7 @@ import javax.inject.Singleton
         CoroutineContextModule::class,
         StripeRepositoryModule::class,
         LoggingModule::class,
-        ResourceRepositoryModule::class,
+        AddressLauncherResourceRepositoryModule::class,
         AddressElementViewModelModule::class,
         FormControllerModule::class
     ]

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressLauncherResourceRepositoryModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressLauncherResourceRepositoryModule.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.ui.core.forms.resources.injection
+package com.stripe.android.paymentsheet.injection
 
 import android.content.Context
 import android.content.res.Resources
@@ -10,7 +10,7 @@ import dagger.Provides
 import javax.inject.Singleton
 
 @Module
-abstract class ResourceRepositoryModule {
+abstract class AddressLauncherResourceRepositoryModule {
     @Binds
     abstract fun bindsResourceRepository(asyncResourceRepository: AsyncResourceRepository):
         ResourceRepository
@@ -26,7 +26,7 @@ abstract class ResourceRepositoryModule {
         @Provides
         @Singleton
         fun providesSurfaceType(): AsyncResourceRepository.SurfaceType {
-            return AsyncResourceRepository.SurfaceType.Payments
+            return AsyncResourceRepository.SurfaceType.Address
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/FormViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/FormViewModelModule.kt
@@ -22,5 +22,11 @@ internal abstract class FormViewModelModule {
         @Singleton
         fun provideLocale() =
             LocaleListCompat.getAdjustedDefault().takeUnless { it.isEmpty }?.get(0)
+
+        @Provides
+        @Singleton
+        fun providesSurfaceType(): AsyncResourceRepository.SurfaceType {
+            return AsyncResourceRepository.SurfaceType.Payments
+        }
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Refactor `AsyncResourceRepository` to take in a surface type. If the surface type is for payments, then load all of the LPM repository resources, otherwise do not load it.

This was needed because the Address Element depends on `AsyncResourceRepository` and it was trying to load `LpmRepository` without calling update and caused the Address Element screen to hang for 20 seconds.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Address Element Alpha

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

