### PR TITLE
add api to configure address element title

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
@@ -101,6 +101,11 @@ internal class AddressLauncher internal constructor(
         val shouldShowCheckBox: Boolean = false,
 
         /**
+         * Configuration for the title displayed at the top of the screen.
+         * Defaults to "Address"
+         */
+        val title: String? = null,
+        /**
          * Google Places api key used to provide autocomplete suggestions
          * When null, autocomplete is disabled.
          */
@@ -116,6 +121,7 @@ internal class AddressLauncher internal constructor(
             var buttonTitle: String? = null
             var phone: AdditionalFieldsConfiguration = AdditionalFieldsConfiguration.OPTIONAL
             var shouldShowCheckBox: Boolean = false
+            var title: String? = null
             var googlePlacesApiKey: String? = null
 
             fun appearance(appearance: PaymentSheet.Appearance) =
@@ -136,6 +142,9 @@ internal class AddressLauncher internal constructor(
             fun shouldShowCheckBox(shouldShowCheckBox: Boolean) =
                 apply { this.shouldShowCheckBox = shouldShowCheckBox }
 
+            fun title(title: String?) =
+                apply { this.title = title }
+
             fun googlePlacesApiKey(googlePlacesApiKey: String?) =
                 apply { this.googlePlacesApiKey = googlePlacesApiKey }
 
@@ -146,6 +155,7 @@ internal class AddressLauncher internal constructor(
                 buttonTitle,
                 phone,
                 shouldShowCheckBox,
+                title,
                 googlePlacesApiKey
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
@@ -27,6 +27,7 @@ import com.stripe.android.ui.core.injection.NonFallbackInjector
 internal fun InputAddressScreen(
     primaryButtonEnabled: Boolean,
     primaryButtonText: String,
+    title: String,
     onPrimaryButtonClick: () -> Unit,
     onCloseClick: () -> Unit,
     formContent: @Composable ColumnScope.() -> Unit
@@ -45,7 +46,7 @@ internal fun InputAddressScreen(
                 .padding(horizontal = 20.dp)
         ) {
             Text(
-                stringResource(R.string.stripe_paymentsheet_address_element_shipping_address),
+                title,
                 style = MaterialTheme.typography.h4,
                 modifier = Modifier.padding(bottom = 8.dp)
             )
@@ -83,9 +84,13 @@ internal fun InputAddressScreen(
             val buttonText = viewModel.args.config?.buttonTitle ?: stringResource(
                 R.string.stripe_paymentsheet_address_element_primary_button
             )
+            val titleText = viewModel.args.config?.title ?: stringResource(
+                R.string.stripe_paymentsheet_address_element_shipping_address
+            )
             InputAddressScreen(
                 primaryButtonEnabled = completeValues != null,
                 primaryButtonText = buttonText,
+                title = titleText,
                 onPrimaryButtonClick = { viewModel.clickPrimaryButton() },
                 onCloseClick = { viewModel.navigator.dismiss() },
                 formContent = {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Adds api to allow merchants to configure the title of their address element.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
* Address Element beta requirements. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
![Screenshot_20220728_162048](https://user-images.githubusercontent.com/89166418/181653343-23906eaa-0418-4577-825a-e728afdbc837.png)


