### PR TITLE
[BANKCON-4806] Poll for partner accounts after authorizing session

### DIFF
--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -395,6 +395,14 @@ public final class com/stripe/android/financialconnections/domain/NativeAuthFlow
 	public static fun newInstance ()Lcom/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator;
 }
 
+public final class com/stripe/android/financialconnections/domain/PollAuthorizationSessionAccounts_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/domain/PollAuthorizationSessionAccounts_Factory;
+	public fun get ()Lcom/stripe/android/financialconnections/domain/PollAuthorizationSessionAccounts;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Lcom/stripe/android/financialconnections/repository/FinancialConnectionsRepository;Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$Configuration;)Lcom/stripe/android/financialconnections/domain/PollAuthorizationSessionAccounts;
+}
+
 public final class com/stripe/android/financialconnections/domain/PollAuthorizationSessionOAuthResults_Factory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;)V
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/domain/PollAuthorizationSessionOAuthResults_Factory;
@@ -420,11 +428,18 @@ public final class com/stripe/android/financialconnections/domain/SearchInstitut
 }
 
 public final class com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel_Factory;
 	public fun get ()Lcom/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/financialconnections/features/accountpicker/AccountPickerState;)Lcom/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel;
+	public static fun newInstance (Lcom/stripe/android/financialconnections/features/accountpicker/AccountPickerState;Lcom/stripe/android/financialconnections/domain/PollAuthorizationSessionAccounts;)Lcom/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel;
+}
+
+public final class com/stripe/android/financialconnections/features/common/ComposableSingletons$ErrorContentKt {
+	public static final field INSTANCE Lcom/stripe/android/financialconnections/features/common/ComposableSingletons$ErrorContentKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class com/stripe/android/financialconnections/features/consent/ComposableSingletons$ConsentScreenKt {
@@ -442,13 +457,6 @@ public final class com/stripe/android/financialconnections/features/consent/Cons
 	public fun get ()Lcom/stripe/android/financialconnections/features/consent/ConsentViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
 	public static fun newInstance (Lcom/stripe/android/financialconnections/features/consent/ConsentState;Lcom/stripe/android/financialconnections/domain/AcceptConsent;Lcom/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator;Lcom/stripe/android/financialconnections/repository/FinancialConnectionsManifestRepository;Lcom/stripe/android/core/Logger;)Lcom/stripe/android/financialconnections/features/consent/ConsentViewModel;
-}
-
-public final class com/stripe/android/financialconnections/features/failure/ComposableSingletons$ErrorContentKt {
-	public static final field INSTANCE Lcom/stripe/android/financialconnections/features/failure/ComposableSingletons$ErrorContentKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function2;
-	public fun <init> ()V
-	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class com/stripe/android/financialconnections/features/institutionpicker/ComposableSingletons$InstitutionPickerScreenKt {

--- a/financial-connections/res/values/strings.xml
+++ b/financial-connections/res/values/strings.xml
@@ -35,6 +35,8 @@
     <string name="stripe_error_planned_downtime_title">%1$s is undergoing maintenance</string>
     <string name="stripe_error_planned_downtime_desc">Maintenance is scheduled to end at %1$s. Please select another bank or try again later.</string>
     <string name="stripe_error_cta_select_another_bank">Select another bank</string>
+    <string name="stripe_account_picker_loading_title">Retrieving accounts</string>
+    <string name="stripe_account_picker_loading_desc">Please wait while we retrieve your accounts</string>
     <string name="stripe_search">Search</string>
 </resources>
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/GoNext.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/GoNext.kt
@@ -14,6 +14,7 @@ import javax.inject.Inject
  *
  * @see [FinancialConnectionsSessionManifest.nextPane]
  * @see [FinancialConnectionsAuthorizationSession.nextPane]
+ * @see [com.stripe.android.financialconnections.model.PartnerAccountsList.nextPane]
  *
  */
 internal class GoNext @Inject constructor(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/GoNext.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/GoNext.kt
@@ -40,11 +40,12 @@ internal class GoNext @Inject constructor(
             NavigationDirections.consent.destination ->
                 manifest.nextPane.toNavigationCommand()
             /**
-             * after partner auth, auth completion receives an updated [FinancialConnectionsAuthorizationSession],
-             * source of truth for navigation.
+             * after partner auth, polling for accounts would determine the next step.
+             * To avoid polling in the auth step, navigate directly to account picker and poll there.
+             * If there's no account picker pane required, the account picker step will navigate to
+             * the actual next pane.
              */
-            NavigationDirections.partnerAuth.destination ->
-                authorizationSession!!.nextPane.toNavigationCommand()
+            NavigationDirections.partnerAuth.destination -> NavigationDirections.accountPicker
             else -> TODO()
         }
         logger.debug("Navigating to next pane: ${nextPane.destination}")

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/GoNext.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/GoNext.kt
@@ -40,12 +40,11 @@ internal class GoNext @Inject constructor(
             NavigationDirections.consent.destination ->
                 manifest.nextPane.toNavigationCommand()
             /**
-             * after partner auth, polling for accounts would determine the next step.
-             * To avoid polling in the auth step, navigate directly to account picker and poll there.
-             * If there's no account picker pane required, the account picker step will navigate to
-             * the actual next pane.
+             * Auth session authorization endpoint receives a
+             * fresh [FinancialConnectionsAuthorizationSession], source of truth for navigation.
              */
-            NavigationDirections.partnerAuth.destination -> NavigationDirections.accountPicker
+            NavigationDirections.partnerAuth.destination ->
+                authorizationSession!!.nextPane.toNavigationCommand()
             else -> TODO()
         }
         logger.debug("Navigating to next pane: ${nextPane.destination}")

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator.kt
@@ -33,7 +33,7 @@ internal class NativeAuthFlowCoordinator @Inject constructor() {
          * Request navigation to Next available Pane
          */
         data class RequestNextStep(
-            val currentStep: NavigationCommand
+            val currentStep: NavigationCommand,
         ) : Message
 
         object OpenWebAuthFlow : Message

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionAccounts.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionAccounts.kt
@@ -32,7 +32,7 @@ internal class PollAuthorizationSessionAccounts @Inject constructor(
         }
     }
 
-    companion object {
+    private companion object {
         private const val POLLING_TIME_MS = 2000L
         private const val MAX_TRIES = 10
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionAccounts.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionAccounts.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.financialconnections.domain
 
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
-import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.FinancialConnectionsAuthorizationSession
 import com.stripe.android.financialconnections.model.PartnerAccountsList
 import com.stripe.android.financialconnections.repository.FinancialConnectionsRepository
 import com.stripe.android.financialconnections.utils.retryOnException
@@ -19,7 +18,7 @@ internal class PollAuthorizationSessionAccounts @Inject constructor(
 ) {
 
     suspend operator fun invoke(
-        session: FinancialConnectionsAuthorizationSession,
+        sessionId: String,
     ): PartnerAccountsList {
         return retryOnException(
             times = MAX_TRIES,
@@ -28,7 +27,7 @@ internal class PollAuthorizationSessionAccounts @Inject constructor(
         ) {
             repository.postAuthorizationSessionAccounts(
                 clientSecret = configuration.financialConnectionsSessionClientSecret,
-                sessionId = session.id
+                sessionId = sessionId
             )
         }
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionAccounts.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionAccounts.kt
@@ -2,31 +2,31 @@ package com.stripe.android.financialconnections.domain
 
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.FinancialConnectionsAuthorizationSession
-import com.stripe.android.financialconnections.model.MixedOAuthParams
+import com.stripe.android.financialconnections.model.PartnerAccountsList
 import com.stripe.android.financialconnections.repository.FinancialConnectionsRepository
 import com.stripe.android.financialconnections.utils.retryOnException
 import com.stripe.android.financialconnections.utils.shouldRetry
 import javax.inject.Inject
 
 /**
- * Polls OAuth results from backend after user finishes authorization on web browser.
+ * Polls accounts from backend after authorization session completes.
  *
  * Will retry upon 202 backend responses every [POLLING_TIME_MS] up to [MAX_TRIES]
  */
-internal class PollAuthorizationSessionOAuthResults @Inject constructor(
+internal class PollAuthorizationSessionAccounts @Inject constructor(
     private val repository: FinancialConnectionsRepository,
     private val configuration: FinancialConnectionsSheet.Configuration
 ) {
 
     suspend operator fun invoke(
         session: FinancialConnectionsAuthorizationSession,
-    ): MixedOAuthParams {
+    ): PartnerAccountsList {
         return retryOnException(
             times = MAX_TRIES,
             delayMilliseconds = POLLING_TIME_MS,
             retryCondition = { exception -> exception.shouldRetry }
         ) {
-            repository.postAuthorizationSessionOAuthResults(
+            repository.postAuthorizationSessionAccounts(
                 clientSecret = configuration.financialConnectionsSessionClientSecret,
                 sessionId = session.id
             )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionOAuthResults.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionOAuthResults.kt
@@ -33,7 +33,7 @@ internal class PollAuthorizationSessionOAuthResults @Inject constructor(
         }
     }
 
-    companion object {
+    private companion object {
         private const val POLLING_TIME_MS = 2000L
         private const val MAX_TRIES = 10
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
@@ -1,21 +1,71 @@
 package com.stripe.android.financialconnections.features.accountpicker
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.airbnb.mvrx.Fail
+import com.airbnb.mvrx.Loading
+import com.airbnb.mvrx.Success
+import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.compose.collectAsState
+import com.airbnb.mvrx.compose.mavericksActivityViewModel
 import com.airbnb.mvrx.compose.mavericksViewModel
+import com.stripe.android.financialconnections.R
+import com.stripe.android.financialconnections.features.common.UnclassifiedErrorContent
+import com.stripe.android.financialconnections.features.institutionpicker.LoadingContent
+import com.stripe.android.financialconnections.model.PartnerAccountsList
+import com.stripe.android.financialconnections.presentation.FinancialConnectionsSheetNativeViewModel
+import com.stripe.android.financialconnections.ui.components.FinancialConnectionsScaffold
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
 
 @Composable
 internal fun AccountPickerScreen() {
+    // activity view model
+    val activityViewModel: FinancialConnectionsSheetNativeViewModel = mavericksActivityViewModel()
+    val authSessionId = activityViewModel.collectAsState { it.authorizationSession?.id }
+
     val viewModel: AccountPickerViewModel = mavericksViewModel()
     val state: State<AccountPickerState> = viewModel.collectAsState()
+    LaunchedEffect(authSessionId) {
+        authSessionId.value?.let { viewModel.onAuthSessionReceived(it) }
+    }
+    AccountPickerContent(state.value)
+}
+
+@Composable
+private fun AccountPickerContent(state: AccountPickerState) {
+    FinancialConnectionsScaffold {
+        when (val accounts = state.accounts) {
+            Uninitialized, is Loading -> LoadingContent(
+                R.string.stripe_picker_loading_title,
+                R.string.stripe_picker_loading_desc
+            )
+            is Success -> AccountPickerLoaded(accounts())
+            is Fail -> UnclassifiedErrorContent()
+        }
+    }
+}
+
+@Composable
+private fun AccountPickerLoaded(accounts: PartnerAccountsList) {
     Column {
         Text(
-            state.value.title,
-            style = FinancialConnectionsTheme.typography.heading
+            modifier = Modifier
+                .fillMaxWidth(),
+            text = stringResource(R.string.stripe_institutionpicker_pane_select_bank),
+            style = FinancialConnectionsTheme.typography.subtitle
         )
+        LazyColumn {
+            items(accounts.data, key = { it.id }) { account ->
+                Text(text = "${account.name} ****${account.displayableAccountNumbers}")
+            }
+        }
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
@@ -44,8 +44,8 @@ private fun AccountPickerContent(state: AccountPickerState) {
     FinancialConnectionsScaffold {
         when (val accounts = state.accounts) {
             Uninitialized, is Loading -> LoadingContent(
-                R.string.stripe_picker_loading_title,
-                R.string.stripe_picker_loading_desc
+                R.string.stripe_account_picker_loading_title,
+                R.string.stripe_account_picker_loading_desc
             )
             is Success -> AccountPickerLoaded(accounts())
             is Fail -> UnclassifiedErrorContent()

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
@@ -1,19 +1,25 @@
 package com.stripe.android.financialconnections.features.accountpicker
 
+import com.airbnb.mvrx.Async
 import com.airbnb.mvrx.MavericksState
 import com.airbnb.mvrx.MavericksViewModel
 import com.airbnb.mvrx.MavericksViewModelFactory
+import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.ViewModelContext
+import com.stripe.android.financialconnections.domain.PollAuthorizationSessionAccounts
+import com.stripe.android.financialconnections.model.PartnerAccountsList
 import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
 import javax.inject.Inject
 
 internal class AccountPickerViewModel @Inject constructor(
-    initialState: AccountPickerState
+    initialState: AccountPickerState,
+    private val pollAuthorizationSessionAccounts: PollAuthorizationSessionAccounts
 ) : MavericksViewModel<AccountPickerState>(initialState) {
 
-    init {
-        setState { copy(title = "Account picker - poll accounts from auth session") }
-        // TODO@carlosmuvi start polling
+    fun onAuthSessionReceived(authSessionId: String) {
+        suspend {
+            pollAuthorizationSessionAccounts(authSessionId)
+        }.execute { copy(accounts = it) }
     }
 
     companion object :
@@ -35,5 +41,5 @@ internal class AccountPickerViewModel @Inject constructor(
 }
 
 internal data class AccountPickerState(
-    val title: String = "",
+    val accounts: Async<PartnerAccountsList> = Uninitialized
 ) : MavericksState

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ErrorContent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ErrorContent.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.financialconnections.features.failure
+package com.stripe.android.financialconnections.features.common
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/LoadingContent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/LoadingContent.kt
@@ -1,0 +1,41 @@
+package com.stripe.android.financialconnections.features.institutionpicker
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
+
+@Composable
+internal fun LoadingContent(
+    @StringRes titleResId: Int,
+    @StringRes contentResId: Int
+) {
+    Column(
+        modifier = Modifier
+            .padding(horizontal = 16.dp)
+    ) {
+        CircularProgressIndicator(
+            color = FinancialConnectionsTheme.colors.textBrand,
+            modifier = Modifier
+                .size(36.dp)
+        )
+        Spacer(modifier = Modifier.size(16.dp))
+        Text(
+            text = stringResource(titleResId),
+            style = FinancialConnectionsTheme.typography.subtitle
+        )
+        Spacer(modifier = Modifier.size(16.dp))
+        Text(
+            text = stringResource(contentResId),
+            style = FinancialConnectionsTheme.typography.body
+        )
+    }
+}

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
@@ -51,9 +51,9 @@ import com.airbnb.mvrx.compose.mavericksViewModel
 import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.exception.InstitutionPlannedException
 import com.stripe.android.financialconnections.exception.InstitutionUnplannedException
-import com.stripe.android.financialconnections.features.failure.InstitutionPlannedDowntimeErrorContent
-import com.stripe.android.financialconnections.features.failure.InstitutionUnplannedDowntimeErrorContent
-import com.stripe.android.financialconnections.features.failure.UnclassifiedErrorContent
+import com.stripe.android.financialconnections.features.common.InstitutionPlannedDowntimeErrorContent
+import com.stripe.android.financialconnections.features.common.InstitutionUnplannedDowntimeErrorContent
+import com.stripe.android.financialconnections.features.common.UnclassifiedErrorContent
 import com.stripe.android.financialconnections.model.Institution
 import com.stripe.android.financialconnections.model.InstitutionResponse
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsOutlinedTextField
@@ -120,7 +120,10 @@ private fun InstitutionPickerContent(
                 )
             }
             is Loading -> {
-                LoadingContent()
+                LoadingContent(
+                    R.string.stripe_picker_loading_title,
+                    R.string.stripe_picker_loading_desc
+                )
             }
             is Fail -> {
                 InstitutionPickerErrorContent(
@@ -193,30 +196,6 @@ private fun LoadedContent(
                 onInstitutionSelected = onInstitutionSelected
             )
         }
-    }
-}
-
-@Composable
-private fun LoadingContent() {
-    Column(
-        modifier = Modifier
-            .padding(horizontal = 16.dp)
-    ) {
-        CircularProgressIndicator(
-            color = FinancialConnectionsTheme.colors.textBrand,
-            modifier = Modifier
-                .size(36.dp)
-        )
-        Spacer(modifier = Modifier.size(16.dp))
-        Text(
-            text = stringResource(R.string.stripe_picker_loading_title),
-            style = FinancialConnectionsTheme.typography.subtitle
-        )
-        Spacer(modifier = Modifier.size(16.dp))
-        Text(
-            text = stringResource(R.string.stripe_picker_loading_desc),
-            style = FinancialConnectionsTheme.typography.body
-        )
     }
 }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthScreen.kt
@@ -5,9 +5,16 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
+import com.airbnb.mvrx.Fail
+import com.airbnb.mvrx.Loading
+import com.airbnb.mvrx.Success
+import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.compose.collectAsState
 import com.airbnb.mvrx.compose.mavericksActivityViewModel
 import com.airbnb.mvrx.compose.mavericksViewModel
+import com.stripe.android.financialconnections.R
+import com.stripe.android.financialconnections.features.common.UnclassifiedErrorContent
+import com.stripe.android.financialconnections.features.institutionpicker.LoadingContent
 import com.stripe.android.financialconnections.presentation.FinancialConnectionsSheetNativeViewModel
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
 
@@ -29,10 +36,20 @@ internal fun PartnerAuthScreen() {
     LaunchedEffect(webAuthFlow.value) {
         viewModel.onWebAuthFlowFinished(webAuthFlow.value, authSession.value!!)
     }
-    Column {
-        Text(
-            state.value.title,
-            style = FinancialConnectionsTheme.typography.heading
+
+    when (webAuthFlow.value) {
+        Uninitialized, is Loading -> LoadingContent(
+            titleResId = R.string.stripe_picker_loading_title,
+            contentResId = R.string.stripe_picker_loading_desc
         )
+        is Success -> Column {
+            Text(
+                state.value.title,
+                style = FinancialConnectionsTheme.typography.heading
+            )
+        }
+        is Fail -> {
+            UnclassifiedErrorContent()
+        }
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthScreen.kt
@@ -1,7 +1,5 @@
 package com.stripe.android.financialconnections.features.partnerauth
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
@@ -16,7 +14,7 @@ import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.features.common.UnclassifiedErrorContent
 import com.stripe.android.financialconnections.features.institutionpicker.LoadingContent
 import com.stripe.android.financialconnections.presentation.FinancialConnectionsSheetNativeViewModel
-import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
+import com.stripe.android.financialconnections.ui.components.FinancialConnectionsScaffold
 
 @Composable
 internal fun PartnerAuthScreen() {
@@ -36,20 +34,21 @@ internal fun PartnerAuthScreen() {
     LaunchedEffect(webAuthFlow.value) {
         viewModel.onWebAuthFlowFinished(webAuthFlow.value, authSession.value!!)
     }
+    PartnerAuthScreenContent(state)
+}
 
-    when (webAuthFlow.value) {
-        Uninitialized, is Loading -> LoadingContent(
-            titleResId = R.string.stripe_picker_loading_title,
-            contentResId = R.string.stripe_picker_loading_desc
-        )
-        is Success -> Column {
-            Text(
-                state.value.title,
-                style = FinancialConnectionsTheme.typography.heading
+@Composable
+private fun PartnerAuthScreenContent(state: State<PartnerAuthState>) {
+    FinancialConnectionsScaffold {
+        when (state.value.authenticationStatus) {
+            Uninitialized, is Loading, is Success -> LoadingContent(
+                titleResId = R.string.stripe_picker_loading_title,
+                contentResId = R.string.stripe_picker_loading_desc
             )
-        }
-        is Fail -> {
-            UnclassifiedErrorContent()
+            is Fail -> {
+                // TODO@carlosmuvi translate error type to specific error screen.
+                UnclassifiedErrorContent()
+            }
         }
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
@@ -14,6 +14,7 @@ import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.domain.CompleteAuthorizationSession
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.UpdateAuthorizationSession
+import com.stripe.android.financialconnections.domain.PollAuthorizationSessionAccounts
 import com.stripe.android.financialconnections.domain.PollAuthorizationSessionOAuthResults
 import com.stripe.android.financialconnections.exception.WebAuthFlowCancelledException
 import com.stripe.android.financialconnections.exception.WebAuthFlowFailedException
@@ -30,6 +31,7 @@ internal class PartnerAuthViewModel @Inject constructor(
     val nativeAuthFlowCoordinator: NativeAuthFlowCoordinator,
     val repository: FinancialConnectionsRepository,
     val pollAuthorizationSessionOAuthResults: PollAuthorizationSessionOAuthResults,
+    val pollAuthorizationSessionAccounts: PollAuthorizationSessionAccounts,
     val logger: Logger
 ) : MavericksViewModel<PartnerAuthState>(PartnerAuthState()) {
 
@@ -76,7 +78,9 @@ internal class PartnerAuthViewModel @Inject constructor(
             )
             setState { copy(title = "Session authorized! Start polling accounts.") }
             nativeAuthFlowCoordinator().emit(UpdateAuthorizationSession(session))
-            // TODO@carlosmuvi start polling until accounts ready, then navigate to next pane.
+            val accounts = pollAuthorizationSessionAccounts(session = authSession)
+            setState { copy(title = "Polling completed! accounts: ${accounts.data.joinToString { it.name }}") }
+            // TODO@carlosmuvi update next step from accounts response, and navigate to next pane.
 //            nativeAuthFlowCoordinator().emit(
 //                RequestNextStep(currentStep = NavigationDirections.partnerAuth)
 //            )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
@@ -13,6 +13,7 @@ import com.stripe.android.core.Logger
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.domain.CompleteAuthorizationSession
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
+import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.RequestNextStep
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.UpdateAuthorizationSession
 import com.stripe.android.financialconnections.domain.PollAuthorizationSessionAccounts
 import com.stripe.android.financialconnections.domain.PollAuthorizationSessionOAuthResults
@@ -20,6 +21,7 @@ import com.stripe.android.financialconnections.exception.WebAuthFlowCancelledExc
 import com.stripe.android.financialconnections.exception.WebAuthFlowFailedException
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.FinancialConnectionsAuthorizationSession
 import com.stripe.android.financialconnections.model.MixedOAuthParams
+import com.stripe.android.financialconnections.navigation.NavigationDirections
 import com.stripe.android.financialconnections.repository.FinancialConnectionsRepository
 import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
 import kotlinx.coroutines.launch
@@ -80,10 +82,7 @@ internal class PartnerAuthViewModel @Inject constructor(
             nativeAuthFlowCoordinator().emit(UpdateAuthorizationSession(session))
             val accounts = pollAuthorizationSessionAccounts(session = authSession)
             setState { copy(title = "Polling completed! accounts: ${accounts.data.joinToString { it.name }}") }
-            // TODO@carlosmuvi update next step from accounts response, and navigate to next pane.
-//            nativeAuthFlowCoordinator().emit(
-//                RequestNextStep(currentStep = NavigationDirections.partnerAuth)
-//            )
+            nativeAuthFlowCoordinator().emit(RequestNextStep(currentStep = NavigationDirections.partnerAuth))
         }.onFailure {
             logger.error("failed authorizing session", it)
             setState { copy(title = "Failed authorizing session!") }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/NavigationCommand.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/NavigationCommand.kt
@@ -2,8 +2,6 @@ package com.stripe.android.financialconnections.navigation
 
 import android.util.Log
 import androidx.navigation.NamedNavArgument
-import androidx.navigation.NavController
-import androidx.navigation.NavOptionsBuilder
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/NavigationCommand.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/NavigationCommand.kt
@@ -2,6 +2,8 @@ package com.stripe.android.financialconnections.navigation
 
 import android.util.Log
 import androidx.navigation.NamedNavArgument
+import androidx.navigation.NavController
+import androidx.navigation.NavOptionsBuilder
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsRepository.kt
@@ -55,7 +55,7 @@ internal interface FinancialConnectionsRepository {
         publicToken: String? = null
     ): FinancialConnectionsSessionManifest.FinancialConnectionsAuthorizationSession
 
-    suspend fun getAuthorizationSessionAccounts(
+    suspend fun postAuthorizationSessionAccounts(
         clientSecret: String,
         sessionId: String
     ): PartnerAccountsList

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsRepositoryImpl.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsRepositoryImpl.kt
@@ -74,11 +74,11 @@ internal class FinancialConnectionsRepositoryImpl @Inject constructor(
         )
     }
 
-    override suspend fun getAuthorizationSessionAccounts(
+    override suspend fun postAuthorizationSessionAccounts(
         clientSecret: String,
         sessionId: String,
     ): PartnerAccountsList {
-        val request = apiRequestFactory.createGet(
+        val request = apiRequestFactory.createPost(
             url = accountsSessionUrl,
             options = options,
             params = mapOf(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
+import androidx.navigation.NavOptionsBuilder
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -108,8 +109,22 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), Ma
         LaunchedEffect(navigationManager.commands) {
             navigationManager.commands.collect { command ->
                 if (command.destination.isNotEmpty()) {
-                    navController.navigate(command.destination)
+                    navController.navigate(command.destination) {
+                        popUpAfterAuth(navController)
+                    }
                 }
+            }
+        }
+    }
+
+    /**
+     * Skips auth screens from back navigation.
+     */
+    private fun NavOptionsBuilder.popUpAfterAuth(navController: NavHostController) {
+        val destination: String = navController.currentBackStackEntry?.destination?.route ?: return
+        if (navController.currentDestination?.route == NavigationDirections.partnerAuth.destination) {
+            popUpTo(destination) {
+                inclusive = true
             }
         }
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/utils/Errors.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/utils/Errors.kt
@@ -23,7 +23,7 @@ internal suspend fun <T> retryOnException(
             } else {
                 throw exception
             }
-        } ?: requireNotNull(result.getOrNull())
+        } ?: return requireNotNull(result.getOrNull())
     }
     return block()
 }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/FakeFinancialConnectionsRepository.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/FakeFinancialConnectionsRepository.kt
@@ -43,7 +43,7 @@ internal class FakeFinancialConnectionsRepository : FinancialConnectionsReposito
         publicToken: String?
     ): FinancialConnectionsAuthorizationSession = postAuthorizationSessionProvider()
 
-    override suspend fun getAuthorizationSessionAccounts(
+    override suspend fun postAuthorizationSessionAccounts(
         clientSecret: String,
         sessionId: String
     ): PartnerAccountsList = getAuthorizationSessionAccounts()


### PR DESCRIPTION
# Summary
- After completing the session (`POST /authorize`), navigate to resulting AuthSession#NextPane.
- If nextPane is `ACCOUNT_PICKER`, navigate to account picker screen and start polling accounts. 

# Screenshots

https://user-images.githubusercontent.com/99293320/181806384-24066a27-b73b-4820-bad2-472496274272.mp4
