### PR TITLE
[stripe-core] change react native class for reflection

### DIFF
--- a/stripe-core/src/main/java/com/stripe/android/core/utils/PluginDetector.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/PluginDetector.kt
@@ -32,7 +32,7 @@ object PluginDetector {
         val className: String,
         val pluginName: String
     ) {
-        ReactNative("com.facebook.proguard.annotations.DoNotStrip", "react-native"),
+        ReactNative("com.facebook.react.bridge.NativeModule", "react-native"),
         Flutter("io.flutter.embedding.engine.FlutterEngine", "flutter"),
         Cordova("org.apache.cordova.CordovaActivity", "cordova"),
         Unity("com.unity3d.player.UnityPlayerActivity", "unity")


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Didn't notice the previous class path was a generic annotation used across facebook. The new class is [annotated](https://github.com/facebook/react-native/blob/6f7612252ba528f4fbabfe5c65b5bf775b776d28/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModule.java#L20) with `@DoNotStrip` and won't be proguarded.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Detect when the SDK is used from react native


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified - verified from native and react app

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
