### PR TITLE
fix address result not updating after autocomplete is edited

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
@@ -91,7 +91,7 @@ internal fun InputAddressScreen(
                 primaryButtonEnabled = completeValues != null,
                 primaryButtonText = buttonText,
                 title = titleText,
-                onPrimaryButtonClick = { viewModel.clickPrimaryButton() },
+                onPrimaryButtonClick = { viewModel.clickPrimaryButton(completeValues) },
                 onCloseClick = { viewModel.navigator.dismiss() },
                 formContent = {
                     FormUI(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -13,6 +13,7 @@ import com.stripe.android.ui.core.elements.AddressType
 import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.ui.core.elements.LayoutSpec
 import com.stripe.android.ui.core.elements.PhoneNumberState
+import com.stripe.android.ui.core.forms.FormFieldEntry
 import com.stripe.android.ui.core.injection.FormControllerSubcomponent
 import com.stripe.android.ui.core.injection.NonFallbackInjector
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -146,14 +147,20 @@ internal class InputAddressViewModel @Inject constructor(
         )
     }
 
-    fun clickPrimaryButton() {
+    fun clickPrimaryButton(completedFormValues: Map<IdentifierSpec, FormFieldEntry>?) {
         _formEnabled.value = false
-        viewModelScope.launch {
-            val address = getCurrentAddress()
-            address?.let {
-                dismissWithAddress(it)
-            }
-        }
+        dismissWithAddress(
+            AddressDetails(
+                name = completedFormValues?.get(IdentifierSpec.Name)?.value,
+                city = completedFormValues?.get(IdentifierSpec.City)?.value,
+                country = completedFormValues?.get(IdentifierSpec.Country)?.value,
+                line1 = completedFormValues?.get(IdentifierSpec.Line1)?.value,
+                line2 = completedFormValues?.get(IdentifierSpec.Line2)?.value,
+                postalCode = completedFormValues?.get(IdentifierSpec.PostalCode)?.value,
+                state = completedFormValues?.get(IdentifierSpec.State)?.value,
+                phoneNumber = completedFormValues?.get(IdentifierSpec.Phone)?.value
+            )
+        )
     }
 
     @VisibleForTesting


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* Fixes a bug where the user edits an address that was filled in by autocomplete but the originally autocomplete address is emitted instead of the edited one.

Steps to reproduce on `address-element-alpha` branch:
1. revert the bandaid `c0651aa85c15f63f6df76686478de027ff3e2166`
2. Open address element
3. Autocomplete an address (we'll call this address 1)
4. Edit the autocompleted address (we'll call this address 2)
5. press confirm button
6. Observe address 1 was emitted rather than address 2

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
* Previously we were [collecting an address from a flow](https://github.com/stripe/stripe-android/blob/master/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt#L152) to generate the final address we emit in our public api. This causes this flow to be recollected [here](https://github.com/stripe/stripe-android/blob/master/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressElement.kt#L57) which then causes the form to be repopulated with the initial values [here](https://github.com/stripe/stripe-android/blob/master/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressElement.kt#L68). Since we are [already collecting the completed form values](https://github.com/stripe/stripe-android/blob/master/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt#L83) to determine if our button is enabled, we can also just pass them along to the button's onClick to avoid collecting from the flow again. 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

