### PR TITLE
Send locale to Consumer sign up endpoint

### DIFF
--- a/link/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/link/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -72,6 +72,7 @@ internal class LinkApiRepository @Inject constructor(
                 email,
                 phone,
                 country,
+                locale ?: Locale.US,
                 authSessionCookie,
                 ApiRequest.Options(
                     publishableKeyProvider(),

--- a/link/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/link/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -72,7 +72,7 @@ internal class LinkApiRepository @Inject constructor(
                 email,
                 phone,
                 country,
-                locale ?: Locale.US,
+                locale,
                 authSessionCookie,
                 ApiRequest.Options(
                     publishableKeyProvider(),

--- a/link/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/link/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -96,6 +96,7 @@ class LinkApiRepositoryTest {
             eq(email),
             eq(phone),
             eq(country),
+            eq(Locale.US),
             eq(cookie),
             eq(ApiRequest.Options(PUBLISHABLE_KEY, STRIPE_ACCOUNT_ID))
         )
@@ -104,7 +105,7 @@ class LinkApiRepositoryTest {
     @Test
     fun `consumerSignUp returns successful result`() = runTest {
         val consumerSession = mock<ConsumerSession>()
-        whenever(stripeRepository.consumerSignUp(any(), any(), any(), anyOrNull(), any()))
+        whenever(stripeRepository.consumerSignUp(any(), any(), any(), any(), anyOrNull(), any()))
             .thenReturn(consumerSession)
 
         val result = linkRepository.consumerSignUp("email", "phone", "country", "cookie")
@@ -115,7 +116,7 @@ class LinkApiRepositoryTest {
 
     @Test
     fun `consumerSignUp catches exception and returns failure`() = runTest {
-        whenever(stripeRepository.consumerSignUp(any(), any(), any(), anyOrNull(), any()))
+        whenever(stripeRepository.consumerSignUp(any(), any(), any(), any(), anyOrNull(), any()))
             .thenThrow(RuntimeException("error"))
 
         val result = linkRepository.consumerSignUp("email", "phone", "country", "cookie")

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1202,6 +1202,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
         email: String,
         phoneNumber: String,
         country: String,
+        locale: Locale,
         authSessionCookie: String?,
         requestOptions: ApiRequest.Options
     ): ConsumerSession? {
@@ -1213,7 +1214,8 @@ class StripeApiRepository @JvmOverloads internal constructor(
                     "request_surface" to "android_payment_element",
                     "email_address" to email.lowercase(),
                     "phone_number" to phoneNumber,
-                    "country" to country
+                    "country" to country,
+                    "locale" to locale.toLanguageTag()
                 ).plus(
                     authSessionCookie?.let {
                         mapOf(

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1202,7 +1202,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
         email: String,
         phoneNumber: String,
         country: String,
-        locale: Locale,
+        locale: Locale?,
         authSessionCookie: String?,
         requestOptions: ApiRequest.Options
     ): ConsumerSession? {
@@ -1214,14 +1214,17 @@ class StripeApiRepository @JvmOverloads internal constructor(
                     "request_surface" to "android_payment_element",
                     "email_address" to email.lowercase(),
                     "phone_number" to phoneNumber,
-                    "country" to country,
-                    "locale" to locale.toLanguageTag()
+                    "country" to country
                 ).plus(
                     authSessionCookie?.let {
                         mapOf(
                             "cookies" to
                                 mapOf("verification_session_client_secrets" to listOf(it))
                         )
+                    } ?: emptyMap()
+                ).plus(
+                    locale?.let {
+                        mapOf("locale" to it.toLanguageTag())
                     } ?: emptyMap()
                 )
             ),

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -410,6 +410,7 @@ abstract class StripeRepository {
         email: String,
         phoneNumber: String,
         country: String,
+        locale: Locale,
         authSessionCookie: String?,
         requestOptions: ApiRequest.Options
     ): ConsumerSession?

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -406,11 +406,12 @@ abstract class StripeRepository {
     ): ConsumerSessionLookup?
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @Suppress("LongParameterList")
     abstract suspend fun consumerSignUp(
         email: String,
         phoneNumber: String,
         country: String,
-        locale: Locale,
+        locale: Locale?,
         authSessionCookie: String?,
         requestOptions: ApiRequest.Options
     ): ConsumerSession?

--- a/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
@@ -296,7 +296,7 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         email: String,
         phoneNumber: String,
         country: String,
-        locale: Locale,
+        locale: Locale?,
         authSessionCookie: String?,
         requestOptions: ApiRequest.Options
     ): ConsumerSession? {

--- a/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
@@ -296,6 +296,7 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         email: String,
         phoneNumber: String,
         country: String,
+        locale: Locale,
         authSessionCookie: String?,
         requestOptions: ApiRequest.Options
     ): ConsumerSession? {

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -1700,11 +1700,13 @@ internal class StripeApiRepositoryTest {
             val email = "email@example.com"
             val phoneNumber = "phone number"
             val country = "US"
+            val locale = Locale.US
             val cookie = "cookie1"
             create().consumerSignUp(
                 email,
                 phoneNumber,
                 country,
+                locale,
                 cookie,
                 DEFAULT_OPTIONS
             )
@@ -1714,6 +1716,7 @@ internal class StripeApiRepositoryTest {
             assertEquals(params["email_address"], email)
             assertEquals(params["phone_number"], phoneNumber)
             assertEquals(params["country"], country)
+            assertEquals(params["locale"], locale.toLanguageTag())
             val cookies = params["cookies"] as Map<*, *>
             val secret = cookies["verification_session_client_secrets"] as Collection<*>
             assertThat(secret).containsExactly(cookie)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Send missing parameter `locale` to Consumer sign up endpoint.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Send missing parameter.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
