### PR TITLE
Link UI Fixes

### DIFF
--- a/link/res/values-night/colors.xml
+++ b/link/res/values-night/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="link_window_background">#1C1C1E</color>
+</resources>

--- a/link/res/values/colors.xml
+++ b/link/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="link_window_background">#FFFFFF</color>
+</resources>

--- a/link/res/values/strings.xml
+++ b/link/res/values/strings.xml
@@ -6,7 +6,6 @@
     <string name="inline_sign_up_header">Save my info for secure 1-click checkout</string>
 
     <string name="sign_up_header">Secure 1-click checkout</string>
-    <string name="sign_up_header_new_user">Save your info for secure 1-click checkout</string>
     <string name="sign_up_message">Pay faster at %1$s and thousands of merchants.</string>
     <string name="sign_up_terms">By joining Link, you agree to the &lt;a href=\"https://link.co/terms\"&gt;Terms&lt;/a&gt; and &lt;a href=\"https://link.co/privacy\"&gt;Privacy Policy&lt;/a&gt;.</string>
     <string name="sign_up">Join Link</string>

--- a/link/res/values/themes.xml
+++ b/link/res/values/themes.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="LinkBaseTheme" parent="@style/Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowBackground">@color/link_window_background</item>
+        <item name="windowNoTitle">true</item>
+    </style>
+</resources>

--- a/link/src/androidTest/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
@@ -58,20 +58,10 @@ internal class SignUpScreenTest {
     }
 
     @Test
-    fun header_message_is_correct_before_collecting_email() {
+    fun header_message_is_correct() {
         setContent(SignUpState.InputtingEmail)
 
         composeTestRule.onNodeWithText("Secure 1-click checkout").assertExists()
-        composeTestRule.onNodeWithText("Save your info for secure 1-click checkout")
-            .assertDoesNotExist()
-    }
-
-    @Test
-    fun header_message_is_correct_when_collecting_phone_number() {
-        setContent(SignUpState.InputtingPhone)
-
-        composeTestRule.onNodeWithText("Secure 1-click checkout").assertDoesNotExist()
-        composeTestRule.onNodeWithText("Save your info for secure 1-click checkout").assertExists()
     }
 
     @Test

--- a/link/src/main/AndroidManifest.xml
+++ b/link/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <application>
         <activity
             android:name=".LinkActivity"
+            android:theme="@style/LinkBaseTheme"
             android:exported="false"
             android:label="@string/link" />
     </application>

--- a/link/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.rememberModalBottomSheetState
@@ -39,6 +40,7 @@ import androidx.navigation.navArgument
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.model.isOnRootScreen
 import com.stripe.android.link.theme.DefaultLinkTheme
+import com.stripe.android.link.theme.linkColors
 import com.stripe.android.link.ui.BottomSheetContent
 import com.stripe.android.link.ui.LinkAppBar
 import com.stripe.android.link.ui.cardedit.CardEditBody
@@ -95,7 +97,8 @@ internal class LinkActivity : ComponentActivity() {
                         Box(Modifier.defaultMinSize(minHeight = 1.dp)) {}
                     },
                     modifier = Modifier.fillMaxHeight(),
-                    sheetState = sheetState
+                    sheetState = sheetState,
+                    scrimColor = MaterialTheme.linkColors.sheetScrim
                 ) {
                     navController = rememberNavController()
 

--- a/link/src/main/java/com/stripe/android/link/theme/Color.kt
+++ b/link/src/main/java/com/stripe/android/link/theme/Color.kt
@@ -29,6 +29,8 @@ private val LightCloseButton = Color(0xFF30313D)
 private val LightLinkLogo = Color(0xFF1D3944)
 private val LightSecondaryButtonLabel = Color(0xFF1D3944)
 private val LightOtpPlaceholder = Color(0xFFEBEEF1)
+private val LightSheetScrim = Color(0x1F0A2348)
+private val LightProgressIndicator = Color(0xFF1D3944)
 
 private val DarkComponentBackground = Color(0x2E747480)
 private val DarkComponentBorder = Color(0x5C787880)
@@ -42,6 +44,8 @@ private val DarkCloseButton = Color(0x99EBEBF5)
 private val DarkLinkLogo = Color.White
 private val DarkSecondaryButtonLabel = ActionGreen
 private val DarkOtpPlaceholder = Color(0x61FFFFFF)
+private val DarkSheetScrim = Color(0x99000000)
+private val DarkProgressIndicator = LinkTeal
 
 internal data class LinkColors(
     val componentBackground: Color,
@@ -56,6 +60,8 @@ internal data class LinkColors(
     val errorText: Color,
     val errorComponentBackground: Color,
     val secondaryButtonLabel: Color,
+    val sheetScrim: Color,
+    val progressIndicator: Color,
     val otpElementColors: OTPElementColors,
     val materialColors: Colors
 )
@@ -97,6 +103,8 @@ internal object LinkThemeConfig {
         errorText = ErrorText,
         errorComponentBackground = ErrorBackground,
         secondaryButtonLabel = LightSecondaryButtonLabel,
+        sheetScrim = LightSheetScrim,
+        progressIndicator = LightProgressIndicator,
         otpElementColors = OTPElementColors(
             selectedBorder = LinkTeal,
             placeholder = LightOtpPlaceholder
@@ -124,6 +132,8 @@ internal object LinkThemeConfig {
         errorText = ErrorText,
         errorComponentBackground = ErrorBackground,
         secondaryButtonLabel = DarkSecondaryButtonLabel,
+        sheetScrim = DarkSheetScrim,
+        progressIndicator = DarkProgressIndicator,
         otpElementColors = OTPElementColors(
             selectedBorder = LinkTeal,
             placeholder = DarkOtpPlaceholder

--- a/link/src/main/java/com/stripe/android/link/ui/PrimaryButton.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/PrimaryButton.kt
@@ -103,6 +103,7 @@ internal fun PrimaryButton(
                     .fillMaxWidth()
                     .height(56.dp),
                 enabled = state == PrimaryButtonState.Enabled,
+                elevation = ButtonDefaults.elevation(0.dp, 0.dp, 0.dp, 0.dp, 0.dp),
                 shape = MaterialTheme.shapes.medium,
                 colors = ButtonDefaults.buttonColors(
                     backgroundColor = MaterialTheme.colors.primary,

--- a/link/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
@@ -104,13 +104,7 @@ internal fun SignUpBody(
 
     ScrollableTopLevelColumn {
         Text(
-            text = stringResource(
-                if (signUpState == SignUpState.InputtingPhone) {
-                    R.string.sign_up_header_new_user
-                } else {
-                    R.string.sign_up_header
-                }
-            ),
+            text = stringResource(R.string.sign_up_header),
             modifier = Modifier
                 .padding(vertical = 4.dp),
             textAlign = TextAlign.Center,
@@ -203,7 +197,7 @@ internal fun EmailCollectionSection(
                     .semantics {
                         testTag = progressIndicatorTestTag
                     },
-                color = MaterialTheme.linkColors.buttonLabel,
+                color = MaterialTheme.linkColors.progressIndicator,
                 strokeWidth = 2.dp
             )
         }

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -140,11 +140,11 @@ internal class WalletViewModel @Inject constructor(
         viewModelScope.launch {
             linkAccountManager.listPaymentDetails().fold(
                 onSuccess = { response ->
+                    setState(PrimaryButtonState.Enabled)
                     val hasSavedCards =
                         response.paymentDetails.filterIsInstance<ConsumerPaymentDetails.Card>()
                             .takeIf { it.isNotEmpty() }?.let {
                                 _paymentDetails.value = it
-                                setState(PrimaryButtonState.Enabled)
                                 true
                             } ?: false
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Multiple small fixes:
- Set a default theme with `android:windowBackground` for the LinkActivity, so that it doesn't inherit the host app's theme.
- Don't change header message in sign up screen.
- Fix scrim color in dark mode.
- Fix progress indicator color in dark mode.
- Always reset to enabled state on wallet screen after fetching payment details.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
UI fixes.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified