### PR TITLE
Fix url encoding

### DIFF
--- a/link/src/main/java/com/stripe/android/link/LinkScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkScreen.kt
@@ -44,5 +44,4 @@ internal sealed class LinkScreen(
     }
 }
 
-private fun String.urlEncode(): String =
-    URLEncoder.encode(this, StandardCharsets.UTF_8.toString())
+private fun String.urlEncode(): String = URLEncoder.encode(this, StandardCharsets.UTF_8.name())

--- a/link/src/test/java/com/stripe/android/link/LinkScreenTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkScreenTest.kt
@@ -1,0 +1,15 @@
+package com.stripe.android.link
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class LinkScreenTest {
+    @Test
+    fun `Parameter is URL encoded`() {
+        assertThat(LinkScreen.CardEdit("abc <>*/ ").route)
+            .isEqualTo("CardEdit?id=abc+%3C%3E*%2F+")
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
URL encoding was calling `Charset.toString` to get its value. On some Android versions this [returns the full class name](https://stackoverflow.com/questions/59988570/java-io-unsupportedencodingexception-java-nio-charset-charseticuutf-8). Should use `name()` instead.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix bug when URL encoding a String.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
Added test but couldn't really reproduce the issue in test environment.