### PR TITLE
Revert "Bump turbine from 0.8.0 to 0.9.0"

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -16,6 +16,6 @@ ext.libs = [
 ]
 
 ext.testLibs = [
-        turbine: "app.cash.turbine:turbine:0.9.0",
+        turbine: "app.cash.turbine:turbine:0.8.0",
         mavericks: "com.airbnb.android:mavericks-testing:$versions.mavericks"
 ]


### PR DESCRIPTION
Reverts stripe/stripe-android#5358

Causing CollectBankAccountViewModelTest to fail
https://github.com/stripe/stripe-android/runs/7699219072?check_suite_focus=true
https://github.com/cashapp/turbine/issues/134