### PR TITLE
Move AuthSession object from activity state to in-memory repository

### DIFF
--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -336,7 +336,7 @@ public final class com/stripe/android/financialconnections/domain/CompleteAuthor
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/domain/CompleteAuthorizationSession_Factory;
 	public fun get ()Lcom/stripe/android/financialconnections/domain/CompleteAuthorizationSession;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/financialconnections/repository/FinancialConnectionsRepository;Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$Configuration;)Lcom/stripe/android/financialconnections/domain/CompleteAuthorizationSession;
+	public static fun newInstance (Lcom/stripe/android/financialconnections/repository/FinancialConnectionsManifestRepository;Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$Configuration;)Lcom/stripe/android/financialconnections/domain/CompleteAuthorizationSession;
 }
 
 public final class com/stripe/android/financialconnections/domain/FetchFinancialConnectionsSessionForToken_Factory : dagger/internal/Factory {
@@ -408,7 +408,7 @@ public final class com/stripe/android/financialconnections/domain/PostAuthorizat
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/domain/PostAuthorizationSession_Factory;
 	public fun get ()Lcom/stripe/android/financialconnections/domain/PostAuthorizationSession;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/financialconnections/repository/FinancialConnectionsRepository;Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$Configuration;)Lcom/stripe/android/financialconnections/domain/PostAuthorizationSession;
+	public static fun newInstance (Lcom/stripe/android/financialconnections/repository/FinancialConnectionsManifestRepository;Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$Configuration;)Lcom/stripe/android/financialconnections/domain/PostAuthorizationSession;
 }
 
 public final class com/stripe/android/financialconnections/domain/SearchInstitutions_Factory : dagger/internal/Factory {
@@ -420,11 +420,11 @@ public final class com/stripe/android/financialconnections/domain/SearchInstitut
 }
 
 public final class com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel_Factory;
 	public fun get ()Lcom/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/financialconnections/features/accountpicker/AccountPickerState;Lcom/stripe/android/financialconnections/domain/PollAuthorizationSessionAccounts;)Lcom/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel;
+	public static fun newInstance (Lcom/stripe/android/financialconnections/features/accountpicker/AccountPickerState;Lcom/stripe/android/financialconnections/domain/GetManifest;Lcom/stripe/android/financialconnections/domain/PollAuthorizationSessionAccounts;)Lcom/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel;
 }
 
 public final class com/stripe/android/financialconnections/features/common/ComposableSingletons$ErrorContentKt {
@@ -469,11 +469,11 @@ public final class com/stripe/android/financialconnections/features/institutionp
 }
 
 public final class com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel_Factory;
 	public fun get ()Lcom/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/financialconnections/domain/CompleteAuthorizationSession;Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$Configuration;Lcom/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator;Lcom/stripe/android/financialconnections/repository/FinancialConnectionsRepository;Lcom/stripe/android/financialconnections/domain/PollAuthorizationSessionOAuthResults;Lcom/stripe/android/core/Logger;)Lcom/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel;
+	public static fun newInstance (Lcom/stripe/android/financialconnections/domain/CompleteAuthorizationSession;Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$Configuration;Lcom/stripe/android/financialconnections/domain/GetManifest;Lcom/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator;Lcom/stripe/android/financialconnections/repository/FinancialConnectionsRepository;Lcom/stripe/android/financialconnections/domain/PollAuthorizationSessionOAuthResults;Lcom/stripe/android/core/Logger;Lcom/stripe/android/financialconnections/features/partnerauth/PartnerAuthState;)Lcom/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel;
 }
 
 public final class com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetActivityArgs$ForData$Creator : android/os/Parcelable$Creator {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/CompleteAuthorizationSession.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/CompleteAuthorizationSession.kt
@@ -2,12 +2,12 @@ package com.stripe.android.financialconnections.domain
 
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
-import com.stripe.android.financialconnections.repository.FinancialConnectionsRepository
+import com.stripe.android.financialconnections.repository.FinancialConnectionsManifestRepository
 import javax.inject.Inject
 
 internal class CompleteAuthorizationSession @Inject constructor(
-    val repository: FinancialConnectionsRepository,
-    val configuration: FinancialConnectionsSheet.Configuration
+    private val repository: FinancialConnectionsManifestRepository,
+    private val configuration: FinancialConnectionsSheet.Configuration
 ) {
 
     suspend operator fun invoke(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/GoNext.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/GoNext.kt
@@ -25,7 +25,6 @@ internal class GoNext @Inject constructor(
     operator fun invoke(
         currentPane: NavigationCommand,
         manifest: FinancialConnectionsSessionManifest,
-        authorizationSession: FinancialConnectionsAuthorizationSession?
     ): NavigationCommand {
         val nextPane = when (currentPane.destination) {
             /**
@@ -33,7 +32,7 @@ internal class GoNext @Inject constructor(
              * after picking a bank, source of truth for navigation.
              */
             NavigationDirections.institutionPicker.destination ->
-                authorizationSession!!.nextPane.toNavigationCommand()
+                manifest.activeAuthSession!!.nextPane.toNavigationCommand()
             /**
              * Consent step receives a fresh [FinancialConnectionsSessionManifest]
              * after agreeing, source of truth for navigation.
@@ -45,7 +44,7 @@ internal class GoNext @Inject constructor(
              * fresh [FinancialConnectionsAuthorizationSession], source of truth for navigation.
              */
             NavigationDirections.partnerAuth.destination ->
-                authorizationSession!!.nextPane.toNavigationCommand()
+                manifest.activeAuthSession!!.nextPane.toNavigationCommand()
             else -> TODO()
         }
         logger.debug("Navigating to next pane: ${nextPane.destination}")

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.financialconnections.domain
 
-import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.FinancialConnectionsAuthorizationSession
 import com.stripe.android.financialconnections.navigation.NavigationCommand
 import kotlinx.coroutines.flow.MutableSharedFlow
 import javax.inject.Inject

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator.kt
@@ -23,13 +23,6 @@ internal class NativeAuthFlowCoordinator @Inject constructor() {
 
     internal sealed interface Message {
         /**
-         * Updates global [FinancialConnectionsAuthorizationSession] instance.
-         */
-        data class UpdateAuthorizationSession(
-            val authorizationSession: FinancialConnectionsAuthorizationSession
-        ) : Message
-
-        /**
          * Request navigation to Next available Pane
          */
         data class RequestNextStep(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PostAuthorizationSession.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PostAuthorizationSession.kt
@@ -7,7 +7,6 @@ import com.stripe.android.financialconnections.exception.InstitutionUnplannedExc
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.model.Institution
 import com.stripe.android.financialconnections.repository.FinancialConnectionsManifestRepository
-import com.stripe.android.financialconnections.repository.FinancialConnectionsRepository
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PostAuthorizationSession.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PostAuthorizationSession.kt
@@ -6,6 +6,7 @@ import com.stripe.android.financialconnections.exception.InstitutionPlannedExcep
 import com.stripe.android.financialconnections.exception.InstitutionUnplannedException
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.model.Institution
+import com.stripe.android.financialconnections.repository.FinancialConnectionsManifestRepository
 import com.stripe.android.financialconnections.repository.FinancialConnectionsRepository
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
@@ -15,7 +16,7 @@ import kotlin.time.Duration.Companion.seconds
  * an authorization session.
  */
 internal class PostAuthorizationSession @Inject constructor(
-    val repository: FinancialConnectionsRepository,
+    val repository: FinancialConnectionsManifestRepository,
     val configuration: FinancialConnectionsSheet.Configuration
 ) {
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -27,9 +26,6 @@ import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsThem
 
 @Composable
 internal fun AccountPickerScreen() {
-    // activity view model
-    val activityViewModel: FinancialConnectionsSheetNativeViewModel = mavericksActivityViewModel()
-
     val viewModel: AccountPickerViewModel = mavericksViewModel()
     val state: State<AccountPickerState> = viewModel.collectAsState()
     AccountPickerContent(state.value)

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
@@ -29,13 +29,9 @@ import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsThem
 internal fun AccountPickerScreen() {
     // activity view model
     val activityViewModel: FinancialConnectionsSheetNativeViewModel = mavericksActivityViewModel()
-    val authSessionId = activityViewModel.collectAsState { it.authorizationSession?.id }
 
     val viewModel: AccountPickerViewModel = mavericksViewModel()
     val state: State<AccountPickerState> = viewModel.collectAsState()
-    LaunchedEffect(authSessionId) {
-        authSessionId.value?.let { viewModel.onAuthSessionReceived(it) }
-    }
     AccountPickerContent(state.value)
 }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
@@ -14,13 +14,11 @@ import com.airbnb.mvrx.Loading
 import com.airbnb.mvrx.Success
 import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.compose.collectAsState
-import com.airbnb.mvrx.compose.mavericksActivityViewModel
 import com.airbnb.mvrx.compose.mavericksViewModel
 import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.features.common.UnclassifiedErrorContent
 import com.stripe.android.financialconnections.features.institutionpicker.LoadingContent
 import com.stripe.android.financialconnections.model.PartnerAccountsList
-import com.stripe.android.financialconnections.presentation.FinancialConnectionsSheetNativeViewModel
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsScaffold
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
@@ -6,6 +6,7 @@ import com.airbnb.mvrx.MavericksViewModel
 import com.airbnb.mvrx.MavericksViewModelFactory
 import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.ViewModelContext
+import com.stripe.android.financialconnections.domain.GetManifest
 import com.stripe.android.financialconnections.domain.PollAuthorizationSessionAccounts
 import com.stripe.android.financialconnections.model.PartnerAccountsList
 import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
@@ -13,12 +14,14 @@ import javax.inject.Inject
 
 internal class AccountPickerViewModel @Inject constructor(
     initialState: AccountPickerState,
+    private val getManifest: GetManifest,
     private val pollAuthorizationSessionAccounts: PollAuthorizationSessionAccounts
 ) : MavericksViewModel<AccountPickerState>(initialState) {
 
-    fun onAuthSessionReceived(authSessionId: String) {
+    init {
         suspend {
-            pollAuthorizationSessionAccounts(authSessionId)
+            val authSession = requireNotNull(getManifest().activeAuthSession)
+            pollAuthorizationSessionAccounts(authSession.id)
         }.execute { copy(accounts = it) }
     }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerViewModel.kt
@@ -11,7 +11,6 @@ import com.stripe.android.core.Logger
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.RequestNextStep
-import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.UpdateAuthorizationSession
 import com.stripe.android.financialconnections.domain.PostAuthorizationSession
 import com.stripe.android.financialconnections.domain.SearchInstitutions
 import com.stripe.android.financialconnections.model.Institution
@@ -70,9 +69,8 @@ internal class InstitutionPickerViewModel @Inject constructor(
         clearSearch()
         suspend {
             // api call
-            val session = postAuthorizationSession(institution)
+            postAuthorizationSession(institution)
             // navigate to next step
-            nativeAuthFlowCoordinator().emit(UpdateAuthorizationSession(session))
             nativeAuthFlowCoordinator().emit(RequestNextStep(currentStep = institutionPicker))
         }.execute {
             copy(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthScreen.kt
@@ -20,19 +20,18 @@ import com.stripe.android.financialconnections.ui.components.FinancialConnection
 internal fun PartnerAuthScreen() {
     // activity view model
     val activityViewModel: FinancialConnectionsSheetNativeViewModel = mavericksActivityViewModel()
-    val authSession = activityViewModel.collectAsState { it.authorizationSession }
     val webAuthFlow = activityViewModel.collectAsState { it.webAuthFlow }
 
     // step view model
     val viewModel: PartnerAuthViewModel = mavericksViewModel()
     val state: State<PartnerAuthState> = viewModel.collectAsState()
 
-    LaunchedEffect(authSession.value?.url) {
-        val url = authSession.value?.url
+    LaunchedEffect(state.value.url) {
+        val url = state.value.url
         if (url != null) activityViewModel.openPartnerAuthFlowInBrowser(url)
     }
     LaunchedEffect(webAuthFlow.value) {
-        viewModel.onWebAuthFlowFinished(webAuthFlow.value, authSession.value!!)
+        viewModel.onWebAuthFlowFinished(webAuthFlow.value)
     }
     PartnerAuthScreenContent(state)
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
@@ -26,6 +26,7 @@ import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativ
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+@Suppress("LongParameterList")
 internal class PartnerAuthViewModel @Inject constructor(
     val completeAuthorizationSession: CompleteAuthorizationSession,
     val configuration: FinancialConnectionsSheet.Configuration,
@@ -78,7 +79,7 @@ internal class PartnerAuthViewModel @Inject constructor(
         authSession: FinancialConnectionsAuthorizationSession
     ) {
         kotlin.runCatching {
-            val session = completeAuthorizationSession(
+            completeAuthorizationSession(
                 authorizationSessionId = authSession.id,
                 publicToken = oAuthParams.memberGuid
             )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
@@ -12,9 +12,9 @@ import com.airbnb.mvrx.ViewModelContext
 import com.stripe.android.core.Logger
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.domain.CompleteAuthorizationSession
+import com.stripe.android.financialconnections.domain.GetManifest
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.RequestNextStep
-import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.UpdateAuthorizationSession
 import com.stripe.android.financialconnections.domain.PollAuthorizationSessionOAuthResults
 import com.stripe.android.financialconnections.exception.WebAuthFlowCancelledException
 import com.stripe.android.financialconnections.exception.WebAuthFlowFailedException
@@ -29,17 +29,26 @@ import javax.inject.Inject
 internal class PartnerAuthViewModel @Inject constructor(
     val completeAuthorizationSession: CompleteAuthorizationSession,
     val configuration: FinancialConnectionsSheet.Configuration,
+    val getManifest: GetManifest,
     val nativeAuthFlowCoordinator: NativeAuthFlowCoordinator,
     val repository: FinancialConnectionsRepository,
     val pollAuthorizationSessionOAuthResults: PollAuthorizationSessionOAuthResults,
-    val logger: Logger
-) : MavericksViewModel<PartnerAuthState>(PartnerAuthState()) {
+    val logger: Logger,
+    initialState: PartnerAuthState
+) : MavericksViewModel<PartnerAuthState>(initialState) {
+
+    init {
+        viewModelScope.launch {
+            val authSession = getManifest().activeAuthSession!!
+            setState { copy(url = authSession.url) }
+        }
+    }
 
     fun onWebAuthFlowFinished(
-        webStatus: Async<String>,
-        authSession: FinancialConnectionsAuthorizationSession
+        webStatus: Async<String>
     ) {
         viewModelScope.launch {
+            val authSession = getManifest().activeAuthSession!!
             when (webStatus) {
                 is Uninitialized,
                 is Loading -> setState { copy(authenticationStatus = Loading()) }
@@ -74,7 +83,6 @@ internal class PartnerAuthViewModel @Inject constructor(
                 publicToken = oAuthParams.memberGuid
             )
             logger.debug("Session authorized!")
-            nativeAuthFlowCoordinator().emit(UpdateAuthorizationSession(session))
             nativeAuthFlowCoordinator().emit(RequestNextStep(currentStep = NavigationDirections.partnerAuth))
         }.onFailure {
             logger.error("failed authorizing session", it)
@@ -100,5 +108,6 @@ internal class PartnerAuthViewModel @Inject constructor(
 }
 
 internal data class PartnerAuthState(
+    val url: String? = null,
     val authenticationStatus: Async<String> = Uninitialized
 ) : MavericksState

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsSessionManifest.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsSessionManifest.kt
@@ -104,7 +104,7 @@ internal data class FinancialConnectionsSessionManifest(
     val accountholderIsLinkConsumer: Boolean? = null,
 
     @SerialName(value = "active_auth_session")
-    val activeAuthSession: String? = null,
+    val activeAuthSession: FinancialConnectionsAuthorizationSession? = null,
 
     @SerialName(value = "active_institution")
     val activeInstitution: FinancialConnectionsInstitution? = null,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
@@ -45,11 +45,7 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
                     is Message.RequestNextStep -> goNext(
                         currentPane = message.currentStep,
                         manifest = getManifest(),
-                        authorizationSession = awaitState().authorizationSession
                     )
-                    is Message.UpdateAuthorizationSession -> setState {
-                        copy(authorizationSession = message.authorizationSession)
-                    }
                     Message.OpenWebAuthFlow -> {
                         val manifest = getManifest()
                         setState {
@@ -126,7 +122,6 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
 
 internal data class FinancialConnectionsSheetNativeState(
     val webAuthFlow: Async<String>,
-    val authorizationSession: FinancialConnectionsAuthorizationSession?,
     val configuration: FinancialConnectionsSheet.Configuration,
     val viewEffect: FinancialConnectionsSheetNativeViewEffect?
 ) : MavericksState {
@@ -138,7 +133,6 @@ internal data class FinancialConnectionsSheetNativeState(
     constructor(args: FinancialConnectionsSheetNativeActivityArgs) : this(
         webAuthFlow = Uninitialized,
         configuration = args.configuration,
-        authorizationSession = null,
         viewEffect = null
     )
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
@@ -20,7 +20,6 @@ import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.
 import com.stripe.android.financialconnections.exception.WebAuthFlowCancelledException
 import com.stripe.android.financialconnections.exception.WebAuthFlowFailedException
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetNativeActivityArgs
-import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.FinancialConnectionsAuthorizationSession
 import com.stripe.android.financialconnections.presentation.FinancialConnectionsSheetNativeViewEffect.OpenUrl
 import kotlinx.coroutines.launch
 import javax.inject.Inject

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsManifestRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsManifestRepository.kt
@@ -8,6 +8,7 @@ import com.stripe.android.core.exception.InvalidRequestException
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
+import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.FinancialConnectionsAuthorizationSession
 import com.stripe.android.financialconnections.network.FinancialConnectionsRequestExecutor
 import com.stripe.android.financialconnections.network.NetworkConstants
 import kotlinx.coroutines.sync.Mutex
@@ -60,6 +61,29 @@ internal interface FinancialConnectionsManifestRepository {
         clientSecret: String
     ): FinancialConnectionsSessionManifest
 
+    @Throws(
+        AuthenticationException::class,
+        InvalidRequestException::class,
+        APIConnectionException::class,
+        APIException::class
+    )
+    suspend fun postAuthorizationSession(
+        clientSecret: String,
+        institutionId: String
+    ): FinancialConnectionsAuthorizationSession
+
+    @Throws(
+        AuthenticationException::class,
+        InvalidRequestException::class,
+        APIConnectionException::class,
+        APIException::class
+    )
+    suspend fun completeAuthorizationSession(
+        clientSecret: String,
+        sessionId: String,
+        publicToken: String? = null
+    ): FinancialConnectionsAuthorizationSession
+
     companion object {
         operator fun invoke(
             publishableKey: String,
@@ -105,7 +129,8 @@ private class FinancialConnectionsManifestRepositoryImpl(
                     url = getManifestUrl,
                     options = options,
                     params = mapOf(
-                        NetworkConstants.PARAMS_CLIENT_SECRET to configuration.financialConnectionsSessionClientSecret
+                        NetworkConstants.PARAMS_CLIENT_SECRET to configuration.financialConnectionsSessionClientSecret,
+                        "expand" to listOf("active_auth_session")
                     )
                 )
                 return requestExecutor.execute(
@@ -149,6 +174,59 @@ private class FinancialConnectionsManifestRepositoryImpl(
             financialConnectionsRequest,
             FinancialConnectionsSessionManifest.serializer()
         ).also { updateCachedManifest("consent acquired", it) }
+    }
+
+    override suspend fun postAuthorizationSession(
+        clientSecret: String,
+        institutionId: String
+    ): FinancialConnectionsAuthorizationSession {
+        val request = apiRequestFactory.createPost(
+            url = FinancialConnectionsRepositoryImpl.authorizationSessionUrl,
+            options = options,
+            params = mapOf(
+                NetworkConstants.PARAMS_CLIENT_SECRET to clientSecret,
+                "use_mobile_handoff" to false,
+                "institution" to institutionId
+            )
+        )
+        return requestExecutor.execute(
+            request,
+            FinancialConnectionsAuthorizationSession.serializer()
+        ).also {
+            updateCachedActiveAuthSession("postAuthorizationSession", it)
+        }
+    }
+
+    override suspend fun completeAuthorizationSession(
+        clientSecret: String,
+        sessionId: String,
+        publicToken: String?
+    ): FinancialConnectionsAuthorizationSession {
+        val request = apiRequestFactory.createPost(
+            url = FinancialConnectionsRepositoryImpl.authorizeSessionUrl,
+            options = options,
+            params = mapOf(
+                NetworkConstants.PARAMS_ID to sessionId,
+                NetworkConstants.PARAMS_CLIENT_SECRET to clientSecret,
+                "public_token" to publicToken
+            ).filter { it.value != null }
+        )
+        return requestExecutor.execute(
+            request,
+            FinancialConnectionsAuthorizationSession.serializer()
+        ).also {
+            updateCachedActiveAuthSession("completeAuthorizationSession", it)
+        }
+    }
+
+    private fun updateCachedActiveAuthSession(
+        source: String,
+        authSession: FinancialConnectionsAuthorizationSession
+    ) {
+        logger.debug("MANIFEST: updating local active auth session from $source")
+        cachedManifest = cachedManifest?.copy(
+            activeAuthSession = authSession
+        )
     }
 
     private fun updateCachedManifest(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsRepository.kt
@@ -32,29 +32,6 @@ internal interface FinancialConnectionsRepository {
         clientSecret: String
     ): FinancialConnectionsSession
 
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class
-    )
-    suspend fun postAuthorizationSession(
-        clientSecret: String,
-        institutionId: String
-    ): FinancialConnectionsSessionManifest.FinancialConnectionsAuthorizationSession
-
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class
-    )
-    suspend fun completeAuthorizationSession(
-        clientSecret: String,
-        sessionId: String,
-        publicToken: String? = null
-    ): FinancialConnectionsSessionManifest.FinancialConnectionsAuthorizationSession
-
     suspend fun postAuthorizationSessionAccounts(
         clientSecret: String,
         sessionId: String

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsRepository.kt
@@ -6,7 +6,6 @@ import com.stripe.android.core.exception.AuthenticationException
 import com.stripe.android.core.exception.InvalidRequestException
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccountList
 import com.stripe.android.financialconnections.model.FinancialConnectionsSession
-import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.model.GetFinancialConnectionsAcccountsParams
 import com.stripe.android.financialconnections.model.MixedOAuthParams
 import com.stripe.android.financialconnections.model.PartnerAccountsList

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsRepositoryImpl.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsRepositoryImpl.kt
@@ -5,7 +5,6 @@ import com.stripe.android.core.networking.ApiRequest.Companion.API_HOST
 import com.stripe.android.financialconnections.di.PUBLISHABLE_KEY
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccountList
 import com.stripe.android.financialconnections.model.FinancialConnectionsSession
-import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.FinancialConnectionsAuthorizationSession
 import com.stripe.android.financialconnections.model.GetFinancialConnectionsAcccountsParams
 import com.stripe.android.financialconnections.model.MixedOAuthParams
 import com.stripe.android.financialconnections.model.PartnerAccountsList

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsRepositoryImpl.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsRepositoryImpl.kt
@@ -55,25 +55,6 @@ internal class FinancialConnectionsRepositoryImpl @Inject constructor(
         )
     }
 
-    override suspend fun postAuthorizationSession(
-        clientSecret: String,
-        institutionId: String
-    ): FinancialConnectionsAuthorizationSession {
-        val request = apiRequestFactory.createPost(
-            url = authorizationSessionUrl,
-            options = options,
-            params = mapOf(
-                PARAMS_CLIENT_SECRET to clientSecret,
-                "use_mobile_handoff" to false,
-                "institution" to institutionId
-            )
-        )
-        return requestExecutor.execute(
-            request,
-            FinancialConnectionsAuthorizationSession.serializer()
-        )
-    }
-
     override suspend fun postAuthorizationSessionAccounts(
         clientSecret: String,
         sessionId: String,
@@ -107,26 +88,6 @@ internal class FinancialConnectionsRepositoryImpl @Inject constructor(
         return requestExecutor.execute(
             request,
             MixedOAuthParams.serializer()
-        )
-    }
-
-    override suspend fun completeAuthorizationSession(
-        clientSecret: String,
-        sessionId: String,
-        publicToken: String?
-    ): FinancialConnectionsAuthorizationSession {
-        val request = apiRequestFactory.createPost(
-            url = authorizeSessionUrl,
-            options = options,
-            params = mapOf(
-                PARAMS_ID to sessionId,
-                PARAMS_CLIENT_SECRET to clientSecret,
-                "public_token" to publicToken
-            ).filter { it.value != null }
-        )
-        return requestExecutor.execute(
-            request,
-            FinancialConnectionsAuthorizationSession.serializer()
         )
     }
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/GoNextTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/GoNextTest.kt
@@ -27,8 +27,10 @@ internal class GoNextTest {
         // When
         goNext(
             currentPane = NavigationDirections.consent,
-            manifest = sessionManifest().copy(nextPane = expectedNextStep),
-            authorizationSession = authorizationSession().copy(nextPane = NextPane.ACCOUNT_PICKER)
+            manifest = sessionManifest().copy(
+                nextPane = expectedNextStep,
+                activeAuthSession = authorizationSession().copy(nextPane = NextPane.ACCOUNT_PICKER)
+            ),
         )
 
         // Then
@@ -43,8 +45,10 @@ internal class GoNextTest {
         // When
         goNext(
             currentPane = NavigationDirections.institutionPicker,
-            manifest = sessionManifest().copy(nextPane = NextPane.CONSENT),
-            authorizationSession = authorizationSession().copy(nextPane = expectedNextStep)
+            manifest = sessionManifest().copy(
+                nextPane = NextPane.CONSENT,
+                activeAuthSession = authorizationSession().copy(nextPane = NextPane.PARTNER_AUTH)
+            ),
         )
 
         // Then
@@ -59,8 +63,10 @@ internal class GoNextTest {
         // When
         goNext(
             currentPane = NavigationDirections.partnerAuth,
-            manifest = sessionManifest().copy(nextPane = NextPane.CONSENT),
-            authorizationSession = authorizationSession().copy(nextPane = expectedNextStep)
+            manifest = sessionManifest().copy(
+                nextPane = NextPane.CONSENT,
+                activeAuthSession = authorizationSession().copy(nextPane = expectedNextStep)
+            ),
         )
 
         // Then

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/PostAuthorizationSessionTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/PostAuthorizationSessionTest.kt
@@ -8,14 +8,14 @@ import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.exception.InstitutionPlannedException
 import com.stripe.android.financialconnections.exception.InstitutionUnplannedException
 import com.stripe.android.financialconnections.model.Institution
-import com.stripe.android.financialconnections.networking.FakeFinancialConnectionsRepository
+import com.stripe.android.financialconnections.networking.FakeFinancialConnectionsManifestRepository
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import java.util.Date
 
 internal class PostAuthorizationSessionTest {
 
-    private val repository = FakeFinancialConnectionsRepository()
+    private val repository = FakeFinancialConnectionsManifestRepository()
     private val postAuthorizationSession = PostAuthorizationSession(
         repository = repository,
         configuration = FinancialConnectionsSheet.Configuration(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/FakeFinancialConnectionsManifestRepository.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/FakeFinancialConnectionsManifestRepository.kt
@@ -1,0 +1,43 @@
+package com.stripe.android.financialconnections.networking
+
+import com.stripe.android.financialconnections.ApiKeyFixtures
+import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
+import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.FinancialConnectionsAuthorizationSession
+import com.stripe.android.financialconnections.repository.FinancialConnectionsManifestRepository
+
+internal class FakeFinancialConnectionsManifestRepository : FinancialConnectionsManifestRepository {
+
+    var generateFinancialConnectionsSessionManifestProvider: () -> FinancialConnectionsSessionManifest =
+        { ApiKeyFixtures.sessionManifest() }
+    var getManifestProvider: () -> FinancialConnectionsSessionManifest =
+        { ApiKeyFixtures.sessionManifest() }
+    var markConsentAcquiredProvider: () -> FinancialConnectionsSessionManifest =
+        { ApiKeyFixtures.sessionManifest() }
+    var postAuthorizationSessionProvider: () -> FinancialConnectionsAuthorizationSession =
+        { ApiKeyFixtures.authorizationSession() }
+
+    override suspend fun generateFinancialConnectionsSessionManifest(
+        clientSecret: String,
+        applicationId: String
+    ): FinancialConnectionsSessionManifest {
+        return generateFinancialConnectionsSessionManifestProvider()
+    }
+
+    override suspend fun getOrFetchManifest(): FinancialConnectionsSessionManifest =
+        getManifestProvider()
+
+    override suspend fun markConsentAcquired(
+        clientSecret: String
+    ): FinancialConnectionsSessionManifest = markConsentAcquiredProvider()
+
+    override suspend fun postAuthorizationSession(
+        clientSecret: String,
+        institutionId: String
+    ): FinancialConnectionsAuthorizationSession = postAuthorizationSessionProvider()
+
+    override suspend fun completeAuthorizationSession(
+        clientSecret: String,
+        sessionId: String,
+        publicToken: String?
+    ): FinancialConnectionsAuthorizationSession = postAuthorizationSessionProvider()
+}

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/FakeFinancialConnectionsRepository.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/FakeFinancialConnectionsRepository.kt
@@ -1,10 +1,8 @@
 package com.stripe.android.financialconnections.networking
 
-import com.stripe.android.financialconnections.ApiKeyFixtures
 import com.stripe.android.financialconnections.financialConnectionsSessionWithNoMoreAccounts
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccountList
 import com.stripe.android.financialconnections.model.FinancialConnectionsSession
-import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.FinancialConnectionsAuthorizationSession
 import com.stripe.android.financialconnections.model.GetFinancialConnectionsAcccountsParams
 import com.stripe.android.financialconnections.model.MixedOAuthParams
 import com.stripe.android.financialconnections.model.PartnerAccountsList
@@ -17,8 +15,6 @@ internal class FakeFinancialConnectionsRepository : FinancialConnectionsReposito
         { financialConnectionsSessionWithNoMoreAccounts }
     var getAccountsResultProvider: () -> FinancialConnectionsAccountList =
         { moreFinancialConnectionsAccountList }
-    var postAuthorizationSessionProvider: () -> FinancialConnectionsAuthorizationSession =
-        { ApiKeyFixtures.authorizationSession() }
     var getAuthorizationSessionAccounts: () -> PartnerAccountsList =
         { TODO() }
     var postAuthorizationSessionOAuthResults: () -> MixedOAuthParams =
@@ -31,17 +27,6 @@ internal class FakeFinancialConnectionsRepository : FinancialConnectionsReposito
     override suspend fun getFinancialConnectionsSession(
         clientSecret: String
     ): FinancialConnectionsSession = getFinancialConnectionsSessionResultProvider()
-
-    override suspend fun postAuthorizationSession(
-        clientSecret: String,
-        institutionId: String
-    ): FinancialConnectionsAuthorizationSession = postAuthorizationSessionProvider()
-
-    override suspend fun completeAuthorizationSession(
-        clientSecret: String,
-        sessionId: String,
-        publicToken: String?
-    ): FinancialConnectionsAuthorizationSession = postAuthorizationSessionProvider()
 
     override suspend fun postAuthorizationSessionAccounts(
         clientSecret: String,


### PR DESCRIPTION
# Summary

Before:

- We were keeping the auth session object in the activity state and using it within the steps (composables) of the flow when needed. Reading this way is hard, as it requires composables to listen for activity state updates, pass it down to the corresponding viewmodel, etc. 
- We are already caching the session manifest in memory on a repository. This approach makes reads straightforward

Now:
- Since **Manifest contains an activeAuthSession field**, we'll be using that as the unique source of truth AuthSession.
- We weren't doing this before because some backend calls return an updated auth session. 
- This PR makes sure the cached session gets updated as well.
- On process kill, manifest + auth session are re-fetched from API.

# Motivation
- Easier auth session reads and avoid duplicating auth session instances on activity state and cached repo.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified

