### PR TITLE
Fix card metadata tests

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/cards/DefaultStaticCardAccountRanges.kt
+++ b/payments-core/src/main/java/com/stripe/android/cards/DefaultStaticCardAccountRanges.kt
@@ -102,21 +102,27 @@ class DefaultStaticCardAccountRanges : StaticCardAccountRanges {
             )
         }
 
+        // https://www.discoverglobalnetwork.com/content/dam/discover/en_us/dgn/docs/IPP-VAR-Enabler-Compliance.pdf
         @VisibleForTesting
         internal val UNIONPAY16_ACCOUNTS = setOf(
             BinRange(
-                low = "6200000000000000",
-                high = "6216828049999999"
+                low = "6221260000000000",
+                high = "6237969999999999"
             ),
 
             BinRange(
-                low = "6216828060000000",
-                high = "6299999999999999"
+                low = "6240000000000000",
+                high = "6269999999999999"
+            ),
+
+            BinRange(
+                low = "6282000000000000",
+                high = "6288999999999999"
             ),
 
             BinRange(
                 low = "8100000000000000",
-                high = "8199999999999999"
+                high = "8171999999999999"
             )
         ).map {
             AccountRange(
@@ -129,8 +135,23 @@ class DefaultStaticCardAccountRanges : StaticCardAccountRanges {
         @VisibleForTesting
         internal val UNIONPAY19_ACCOUNTS = setOf(
             BinRange(
-                low = "6216828050000000000",
-                high = "6216828059999999999"
+                low = "6221260000000000000",
+                high = "6237969999999999999"
+            ),
+
+            BinRange(
+                low = "6240000000000000000",
+                high = "6269999999999999999"
+            ),
+
+            BinRange(
+                low = "6282000000000000000",
+                high = "6288999999999999999"
+            ),
+
+            BinRange(
+                low = "8100000000000000000",
+                high = "8171999999999999999"
             )
         ).map {
             AccountRange(

--- a/payments-core/src/main/java/com/stripe/android/cards/DefaultStaticCardAccountRanges.kt
+++ b/payments-core/src/main/java/com/stripe/android/cards/DefaultStaticCardAccountRanges.kt
@@ -102,27 +102,21 @@ class DefaultStaticCardAccountRanges : StaticCardAccountRanges {
             )
         }
 
-        // https://www.discoverglobalnetwork.com/content/dam/discover/en_us/dgn/docs/IPP-VAR-Enabler-Compliance.pdf
         @VisibleForTesting
         internal val UNIONPAY16_ACCOUNTS = setOf(
             BinRange(
-                low = "6221260000000000",
-                high = "6237969999999999"
+                low = "6200000000000000",
+                high = "6216828049999999"
             ),
 
             BinRange(
-                low = "6240000000000000",
-                high = "6269999999999999"
-            ),
-
-            BinRange(
-                low = "6282000000000000",
-                high = "6288999999999999"
+                low = "6216828060000000",
+                high = "6299999999999999"
             ),
 
             BinRange(
                 low = "8100000000000000",
-                high = "8171999999999999"
+                high = "8199999999999999"
             )
         ).map {
             AccountRange(
@@ -135,23 +129,8 @@ class DefaultStaticCardAccountRanges : StaticCardAccountRanges {
         @VisibleForTesting
         internal val UNIONPAY19_ACCOUNTS = setOf(
             BinRange(
-                low = "6221260000000000000",
-                high = "6237969999999999999"
-            ),
-
-            BinRange(
-                low = "6240000000000000000",
-                high = "6269999999999999999"
-            ),
-
-            BinRange(
-                low = "6282000000000000000",
-                high = "6288999999999999999"
-            ),
-
-            BinRange(
-                low = "8100000000000000000",
-                high = "8171999999999999999"
+                low = "6216828050000000000",
+                high = "6216828059999999999"
             )
         ).map {
             AccountRange(

--- a/payments-core/src/test/java/com/stripe/android/CardNumberFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/CardNumberFixtures.kt
@@ -45,8 +45,13 @@ internal object CardNumberFixtures {
     val JCB_BIN = JCB_NO_SPACES.take(6)
     val JCB = CardNumber.Unvalidated(JCB_NO_SPACES)
 
-    const val UNIONPAY_16_NO_SPACES = "3568400000000000"
-    const val UNIONPAY_16_WITH_SPACES = "3568 4000 0000 0000"
+    const val UNIONPAY_16_NO_SPACES = "6200000000000005"
+    const val UNIONPAY_16_WITH_SPACES = "6200 0000 0000 0005"
     val UNIONPAY_16_BIN = UNIONPAY_16_NO_SPACES.take(6)
     val UNIONPAY_16 = CardNumber.Unvalidated(UNIONPAY_16_NO_SPACES)
+
+    const val UNIONPAY_19_NO_SPACES = "6200500000000000004"
+    const val UNIONPAY_19_WITH_SPACES = "6200 5000 0000 0000 004"
+    val UNIONPAY_19_BIN = UNIONPAY_19_NO_SPACES.take(6)
+    val UNIONPAY_19 = CardNumber.Unvalidated(UNIONPAY_19_NO_SPACES)
 }

--- a/payments-core/src/test/java/com/stripe/android/CardNumberFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/CardNumberFixtures.kt
@@ -45,13 +45,8 @@ internal object CardNumberFixtures {
     val JCB_BIN = JCB_NO_SPACES.take(6)
     val JCB = CardNumber.Unvalidated(JCB_NO_SPACES)
 
-    const val UNIONPAY_NO_SPACES = "6200000000000005"
-    const val UNIONPAY_WITH_SPACES = "6200 0000 0000 0005"
-    val UNIONPAY_BIN = UNIONPAY_NO_SPACES.take(6)
-    val UNIONPAY = CardNumber.Unvalidated(UNIONPAY_NO_SPACES)
-
-    const val UNIONPAY_19_NO_SPACES = "6200500000000000004"
-    const val UNIONPAY_19_WITH_SPACES = "6200 5000 0000 0000 004"
-    val UNIONPAY_19_BIN = UNIONPAY_19_NO_SPACES.take(6)
-    val UNIONPAY_19 = CardNumber.Unvalidated(UNIONPAY_19_NO_SPACES)
+    const val UNIONPAY_16_NO_SPACES = "3568400000000000"
+    const val UNIONPAY_16_WITH_SPACES = "3568 4000 0000 0000"
+    val UNIONPAY_16_BIN = UNIONPAY_16_NO_SPACES.take(6)
+    val UNIONPAY_16 = CardNumber.Unvalidated(UNIONPAY_16_NO_SPACES)
 }

--- a/payments-core/src/test/java/com/stripe/android/SourceEndToEndTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/SourceEndToEndTest.kt
@@ -110,7 +110,7 @@ internal class SourceEndToEndTest {
                 CardNumberFixtures.VISA_NO_SPACES to CardBrand.Visa,
                 CardNumberFixtures.MASTERCARD_NO_SPACES to CardBrand.MasterCard,
                 CardNumberFixtures.JCB_NO_SPACES to CardBrand.JCB,
-                CardNumberFixtures.UNIONPAY_NO_SPACES to CardBrand.UnionPay,
+                CardNumberFixtures.UNIONPAY_16_NO_SPACES to CardBrand.UnionPay,
                 CardNumberFixtures.DISCOVER_NO_SPACES to CardBrand.Discover,
                 CardNumberFixtures.DINERS_CLUB_14_NO_SPACES to CardBrand.DinersClub
             ).all { (cardNumber, cardBrand) ->

--- a/payments-core/src/test/java/com/stripe/android/StripeEndToEndTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripeEndToEndTest.kt
@@ -198,7 +198,7 @@ internal class StripeEndToEndTest {
                 CardNumberFixtures.VISA_NO_SPACES to CardBrand.Visa,
                 CardNumberFixtures.MASTERCARD_NO_SPACES to CardBrand.MasterCard,
                 CardNumberFixtures.JCB_NO_SPACES to CardBrand.JCB,
-                CardNumberFixtures.UNIONPAY_NO_SPACES to CardBrand.UnionPay,
+                CardNumberFixtures.UNIONPAY_16_NO_SPACES to CardBrand.UnionPay,
                 CardNumberFixtures.DISCOVER_NO_SPACES to CardBrand.Discover,
                 CardNumberFixtures.DINERS_CLUB_14_NO_SPACES to CardBrand.DinersClub
             ).all { (cardNumber, cardBrand) ->

--- a/payments-core/src/test/java/com/stripe/android/cards/AccountRangeFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/cards/AccountRangeFixtures.kt
@@ -60,12 +60,32 @@ internal object AccountRangeFixtures {
         brandInfo = AccountRange.BrandInfo.DinersClub
     )
 
+    val DISCOVER = AccountRange(
+        binRange = BinRange(
+            low = "6011000000000000",
+            high = "6011011999999999"
+        ),
+        panLength = 16,
+        brandInfo = AccountRange.BrandInfo.Discover,
+        country = "US"
+    )
+
     val UNIONPAY19 = AccountRange(
         binRange = BinRange(
             low = "6216828050000000000",
             high = "6216828059999999999"
         ),
         panLength = 19,
+        brandInfo = AccountRange.BrandInfo.UnionPay,
+        country = "CN"
+    )
+
+    val UNIONPAY16 = AccountRange(
+        binRange = BinRange(
+            low = "3568400000000000",
+            high = "3568409999999999"
+        ),
+        panLength = 16,
         brandInfo = AccountRange.BrandInfo.UnionPay,
         country = "CN"
     )

--- a/payments-core/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryTest.kt
@@ -21,7 +21,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
-import kotlin.test.Ignore
 import kotlin.test.Test
 
 @RunWith(RobolectricTestRunner::class)
@@ -33,10 +32,9 @@ internal class DefaultCardAccountRangeRepositoryTest {
     private val realStore = DefaultCardAccountRangeStore(application)
     private val realRepository = createRealRepository(realStore)
 
-    @Ignore("Failing due to remote change")
     @Suppress("LongMethod")
     @Test
-    fun `repository with real sources returns expected results`() = runBlocking {
+    fun `repository with real sources returns expected results`(): Unit = runBlocking {
         assertThat(
             realRepository.getAccountRange(
                 CardNumber.Unvalidated("42424")
@@ -83,7 +81,6 @@ internal class DefaultCardAccountRangeRepositoryTest {
         ).isEqualTo(
             AccountRangeFixtures.AMERICANEXPRESS
         )
-
         assertThat(
             realStore.get(BinFixtures.AMEX)
         ).hasSize(1)
@@ -105,27 +102,44 @@ internal class DefaultCardAccountRangeRepositoryTest {
         )
 
         assertThat(
-            realRepository.getAccountRange(
-                CardNumber.Unvalidated("356840")
-            )
-        ).isEqualTo(
-            AccountRangeFixtures.JCB
-        )
-        assertThat(
             realStore.get(BinFixtures.JCB)
         ).isEmpty()
 
         assertThat(
             realRepository.getAccountRange(
-                CardNumber.Unvalidated("621682")
+                CardNumber.Unvalidated("601100")
             )
         ).isEqualTo(
-            AccountRangeFixtures.UNIONPAY19
+            AccountRangeFixtures.DISCOVER
+        )
+        assertThat(
+            realStore.get(BinFixtures.DISCOVER)
+        ).containsExactly(
+            AccountRange(
+                binRange = BinRange(low = "6011000000000000", high = "6011011999999999"),
+                panLength = 16,
+                brandInfo = AccountRange.BrandInfo.Discover,
+                country = "US"
+            )
         )
 
         assertThat(
-            realStore.get(BinFixtures.UNIONPAY_CN)
-        ).hasSize(69)
+            realRepository.getAccountRange(
+                CardNumber.Unvalidated("356840")
+            )
+        ).isEqualTo(
+            AccountRangeFixtures.UNIONPAY16
+        )
+        assertThat(
+            realStore.get(BinFixtures.UNIONPAY16)
+        ).containsExactly(
+            AccountRange(
+                binRange = BinRange(low = "3568400000000000", high = "3568409999999999"),
+                panLength = 16,
+                brandInfo = AccountRange.BrandInfo.UnionPay,
+                country = "CN"
+            )
+        )
     }
 
     @Test

--- a/payments-core/src/test/java/com/stripe/android/model/BinFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/BinFixtures.kt
@@ -11,7 +11,7 @@ internal object BinFixtures {
     val DISCOVER = requireNotNull(Bin.create(CardNumberFixtures.DISCOVER_NO_SPACES))
     val DINERSCLUB14 = requireNotNull(Bin.create(CardNumberFixtures.DINERS_CLUB_14_NO_SPACES))
     val DINERSCLUB16 = requireNotNull(Bin.create(CardNumberFixtures.DINERS_CLUB_16_NO_SPACES))
-    val UNIONPAY16 = requireNotNull(Bin.create(CardNumberFixtures.UNIONPAY_16_NO_SPACES))
+    val UNIONPAY16 = requireNotNull(Bin.create("3568400000000000"))
 
     val FAKE = requireNotNull(Bin.create("999999"))
 }

--- a/payments-core/src/test/java/com/stripe/android/model/BinFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/BinFixtures.kt
@@ -11,8 +11,7 @@ internal object BinFixtures {
     val DISCOVER = requireNotNull(Bin.create(CardNumberFixtures.DISCOVER_NO_SPACES))
     val DINERSCLUB14 = requireNotNull(Bin.create(CardNumberFixtures.DINERS_CLUB_14_NO_SPACES))
     val DINERSCLUB16 = requireNotNull(Bin.create(CardNumberFixtures.DINERS_CLUB_16_NO_SPACES))
-    val UNIONPAY = requireNotNull(Bin.create(CardNumberFixtures.UNIONPAY_NO_SPACES))
-    val UNIONPAY_CN = requireNotNull(Bin.create("6216828050000000001"))
+    val UNIONPAY16 = requireNotNull(Bin.create(CardNumberFixtures.UNIONPAY_16_NO_SPACES))
 
     val FAKE = requireNotNull(Bin.create("999999"))
 }

--- a/payments-core/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
@@ -16,9 +16,9 @@ import com.stripe.android.CardNumberFixtures.DINERS_CLUB_16_NO_SPACES
 import com.stripe.android.CardNumberFixtures.DINERS_CLUB_16_WITH_SPACES
 import com.stripe.android.CardNumberFixtures.JCB_NO_SPACES
 import com.stripe.android.CardNumberFixtures.JCB_WITH_SPACES
-import com.stripe.android.CardNumberFixtures.UNIONPAY_BIN
-import com.stripe.android.CardNumberFixtures.UNIONPAY_NO_SPACES
-import com.stripe.android.CardNumberFixtures.UNIONPAY_WITH_SPACES
+import com.stripe.android.CardNumberFixtures.UNIONPAY_16_BIN
+import com.stripe.android.CardNumberFixtures.UNIONPAY_16_NO_SPACES
+import com.stripe.android.CardNumberFixtures.UNIONPAY_16_WITH_SPACES
 import com.stripe.android.CardNumberFixtures.VISA_BIN
 import com.stripe.android.CardNumberFixtures.VISA_NO_SPACES
 import com.stripe.android.CardNumberFixtures.VISA_WITH_SPACES
@@ -341,11 +341,11 @@ internal class CardNumberEditTextTest {
             paymentAnalyticsRequestFactory = analyticsRequestFactory
         )
 
-        cardNumberEditText.setText(UNIONPAY_NO_SPACES)
+        cardNumberEditText.setText(UNIONPAY_16_NO_SPACES)
         idleLooper()
 
         assertThat(cardNumberEditText.fieldText)
-            .isEqualTo(UNIONPAY_WITH_SPACES)
+            .isEqualTo(UNIONPAY_16_WITH_SPACES)
         assertThat(cardNumberEditText.cardBrand)
             .isEqualTo(CardBrand.Unknown)
     }
@@ -432,7 +432,7 @@ internal class CardNumberEditTextTest {
 
     @Test
     fun finishTypingCommonLengthCardNumber_whenInvalidCard_setsErrorValue() {
-        updateCardNumberAndIdle(withoutLastCharacter(UNIONPAY_NO_SPACES))
+        updateCardNumberAndIdle(withoutLastCharacter(UNIONPAY_16_NO_SPACES))
 
         // This makes the number officially invalid
         cardNumberEditText.append("3")
@@ -573,7 +573,7 @@ internal class CardNumberEditTextTest {
 
     @Test
     fun enterBrandBin_thenDelete_callsUpdateWithUnknown() {
-        updateCardNumberAndIdle(UNIONPAY_BIN)
+        updateCardNumberAndIdle(UNIONPAY_16_BIN)
         assertEquals(CardBrand.UnionPay, lastBrandChangeCallbackInvocation)
 
         ViewTestUtils.sendDeleteKeyEvent(cardNumberEditText)
@@ -704,7 +704,7 @@ internal class CardNumberEditTextTest {
                         it.addView(cardNumberEditText)
                     }
 
-                    cardNumberEditText.setText(UNIONPAY_NO_SPACES)
+                    cardNumberEditText.setText(UNIONPAY_16_NO_SPACES)
                     assertThat(cardNumberEditText.accountRangeService.accountRangeRepositoryJob)
                         .isNotNull()
 
@@ -833,7 +833,7 @@ internal class CardNumberEditTextTest {
         )
 
         // 620000 - valid BIN, call repo
-        cardNumberEditText.setText(UNIONPAY_BIN)
+        cardNumberEditText.setText(UNIONPAY_16_BIN)
         idleLooper()
         assertThat(repositoryCalls)
             .isEqualTo(1)
@@ -891,7 +891,7 @@ internal class CardNumberEditTextTest {
             },
             paymentAnalyticsRequestFactory = analyticsRequestFactory
         )
-        cardNumberEditText.setText(UNIONPAY_NO_SPACES)
+        cardNumberEditText.setText(UNIONPAY_16_NO_SPACES)
         idleLooper()
         assertThat(analyticsRequests)
             .hasSize(1)

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
@@ -134,6 +134,13 @@ internal class CardNumberControllerTest {
     }
 
     @Test
+    fun `Entering valid 16 digit UnionPay BIN returns accountRange of 16`() {
+        cardNumberController.onValueChange("6282000000000000")
+        idleLooper()
+        assertThat(cardNumberController.accountRangeService.accountRange!!.panLength).isEqualTo(16)
+    }
+
+    @Test
     fun `trailingIcon should have multi trailing icons when field is empty`() {
         val trailingIcons = mutableListOf<TextFieldIcon?>()
         cardNumberController.trailingIcon.asLiveData().observeForever {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Fix broken card metadata tests. UnionPay metadata was incorrect, this PR updates the fixtures to reflect `edge-internal` requests.

Can also test with:

```
curl https://api.stripe.com/edge-internal/card-metadata\?key=PUBLIC_KEY\&bin_prefix=PREFIX
```

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Enable card metadata tests: https://jira.corp.stripe.com/browse/RUN_MOBILESDK-1047

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

