### PR TITLE
Add Link status to analytics events

### DIFF
--- a/link/src/main/java/com/stripe/android/link/account/CookieStore.kt
+++ b/link/src/main/java/com/stripe/android/link/account/CookieStore.kt
@@ -15,7 +15,7 @@ class CookieStore @Inject internal constructor(
     private val store: EncryptedStore
 ) {
 
-    constructor(context: Context): this(EncryptedStore(context))
+    constructor(context: Context) : this(EncryptedStore(context))
 
     /**
      * Clear all local data.

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -878,11 +878,19 @@ public final class com/stripe/android/paymentsheet/addresselement/analytics/Defa
 }
 
 public final class com/stripe/android/paymentsheet/analytics/DefaultEventReporter_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/analytics/DefaultEventReporter_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/analytics/DefaultEventReporter_Factory;
 	public fun get ()Lcom/stripe/android/paymentsheet/analytics/DefaultEventReporter;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/paymentsheet/analytics/EventReporter$Mode;Lcom/stripe/android/core/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/PaymentAnalyticsRequestFactory;Lkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/paymentsheet/analytics/DefaultEventReporter;
+	public static fun newInstance (Lcom/stripe/android/paymentsheet/analytics/EventReporter$Mode;Lcom/stripe/android/core/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/PaymentAnalyticsRequestFactory;Lcom/stripe/android/paymentsheet/analytics/EventTimeProvider;Lkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/paymentsheet/analytics/DefaultEventReporter;
+}
+
+public final class com/stripe/android/paymentsheet/analytics/EventTimeProvider_Factory : dagger/internal/Factory {
+	public fun <init> ()V
+	public static fun create ()Lcom/stripe/android/paymentsheet/analytics/EventTimeProvider_Factory;
+	public fun get ()Lcom/stripe/android/paymentsheet/analytics/EventTimeProvider;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance ()Lcom/stripe/android/paymentsheet/analytics/EventTimeProvider;
 }
 
 public final class com/stripe/android/paymentsheet/databinding/ActivityPaymentOptionsBinding : androidx/viewbinding/ViewBinding {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
@@ -138,7 +138,10 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
             }
         }
 
-        sheetViewModel.eventReporter.onShowNewPaymentOptionForm()
+        sheetViewModel.eventReporter.onShowNewPaymentOptionForm(
+            linkEnabled = sheetViewModel.isLinkEnabled.value ?: false,
+            activeLinkSession = sheetViewModel.activeLinkSession.value ?: false
+        )
     }
 
     private fun setupRecyclerView(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
@@ -54,7 +54,10 @@ internal abstract class BasePaymentMethodsListFragment(
         this.config = nullableConfig
 
         setHasOptionsMenu(!sheetViewModel.paymentMethods.value.isNullOrEmpty())
-        sheetViewModel.eventReporter.onShowExistingPaymentOptions()
+        sheetViewModel.eventReporter.onShowExistingPaymentOptions(
+            linkEnabled = sheetViewModel.isLinkEnabled.value ?: false,
+            activeLinkSession = sheetViewModel.activeLinkSession.value ?: false
+        )
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -169,7 +169,8 @@ internal class PaymentOptionsViewModel @Inject constructor(
             stripeIntent.paymentMethodTypes.contains(PaymentMethod.Type.Link.code)
         ) {
             viewModelScope.launch {
-                when (linkLauncher.setup(stripeIntent, this)) {
+                val accountStatus = linkLauncher.setup(stripeIntent, this)
+                when (accountStatus) {
                     AccountStatus.Verified,
                     AccountStatus.VerificationStarted,
                     AccountStatus.NeedsVerification -> {
@@ -178,6 +179,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
                     }
                     AccountStatus.SignedOut -> {}
                 }
+                activeLinkSession.value = accountStatus == AccountStatus.Verified
                 _isLinkEnabled.value = true
             }
         } else {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -16,6 +16,7 @@ internal class DefaultEventReporter @Inject internal constructor(
     private val mode: EventReporter.Mode,
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,
     private val paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory,
+    private val eventTimeProvider: EventTimeProvider,
     @IOContext private val workContext: CoroutineContext
 ) : EventReporter {
     private var paymentSheetShownMillis: Long? = null
@@ -38,7 +39,7 @@ internal class DefaultEventReporter @Inject internal constructor(
     }
 
     override fun onShowExistingPaymentOptions(linkEnabled: Boolean, activeLinkSession: Boolean) {
-        paymentSheetShownMillis = System.currentTimeMillis()
+        paymentSheetShownMillis = eventTimeProvider.currentTimeMillis()
         fireEvent(
             PaymentSheetEvent.ShowExistingPaymentOptions(
                 mode = mode,
@@ -49,7 +50,7 @@ internal class DefaultEventReporter @Inject internal constructor(
     }
 
     override fun onShowNewPaymentOptionForm(linkEnabled: Boolean, activeLinkSession: Boolean) {
-        paymentSheetShownMillis = System.currentTimeMillis()
+        paymentSheetShownMillis = eventTimeProvider.currentTimeMillis()
         fireEvent(
             PaymentSheetEvent.ShowNewPaymentOptionForm(
                 mode = mode,
@@ -108,6 +109,6 @@ internal class DefaultEventReporter @Inject internal constructor(
     }
 
     private fun durationMillisFrom(start: Long?) = start?.let {
-        System.currentTimeMillis() - it
+        eventTimeProvider.currentTimeMillis() - it
     }?.takeIf { it > 0 }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -18,6 +18,7 @@ internal class DefaultEventReporter @Inject internal constructor(
     private val paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory,
     @IOContext private val workContext: CoroutineContext
 ) : EventReporter {
+    private var paymentSheetShownMillis: Long? = null
 
     override fun onInit(configuration: PaymentSheet.Configuration?) {
         fireEvent(
@@ -36,18 +37,24 @@ internal class DefaultEventReporter @Inject internal constructor(
         )
     }
 
-    override fun onShowExistingPaymentOptions() {
+    override fun onShowExistingPaymentOptions(linkEnabled: Boolean, activeLinkSession: Boolean) {
+        paymentSheetShownMillis = System.currentTimeMillis()
         fireEvent(
             PaymentSheetEvent.ShowExistingPaymentOptions(
-                mode = mode
+                mode = mode,
+                linkEnabled = linkEnabled,
+                activeLinkSession = activeLinkSession
             )
         )
     }
 
-    override fun onShowNewPaymentOptionForm() {
+    override fun onShowNewPaymentOptionForm(linkEnabled: Boolean, activeLinkSession: Boolean) {
+        paymentSheetShownMillis = System.currentTimeMillis()
         fireEvent(
             PaymentSheetEvent.ShowNewPaymentOptionForm(
-                mode = mode
+                mode = mode,
+                linkEnabled = linkEnabled,
+                activeLinkSession = activeLinkSession
             )
         )
     }
@@ -66,6 +73,7 @@ internal class DefaultEventReporter @Inject internal constructor(
             PaymentSheetEvent.Payment(
                 mode = mode,
                 paymentSelection = paymentSelection,
+                durationMillis = durationMillisFrom(paymentSheetShownMillis),
                 result = PaymentSheetEvent.Payment.Result.Success
             )
         )
@@ -76,6 +84,7 @@ internal class DefaultEventReporter @Inject internal constructor(
             PaymentSheetEvent.Payment(
                 mode = mode,
                 paymentSelection = paymentSelection,
+                durationMillis = durationMillisFrom(paymentSheetShownMillis),
                 result = PaymentSheetEvent.Payment.Result.Failure
             )
         )
@@ -97,4 +106,8 @@ internal class DefaultEventReporter @Inject internal constructor(
             )
         }
     }
+
+    private fun durationMillisFrom(start: Long?) = start?.let {
+        System.currentTimeMillis() - it
+    }?.takeIf { it > 0 }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -8,9 +8,9 @@ internal interface EventReporter {
 
     fun onDismiss()
 
-    fun onShowExistingPaymentOptions()
+    fun onShowExistingPaymentOptions(linkEnabled: Boolean, activeLinkSession: Boolean)
 
-    fun onShowNewPaymentOptionForm()
+    fun onShowNewPaymentOptionForm(linkEnabled: Boolean, activeLinkSession: Boolean)
 
     fun onSelectPaymentOption(paymentSelection: PaymentSelection)
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventTimeProvider.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventTimeProvider.kt
@@ -1,0 +1,7 @@
+package com.stripe.android.paymentsheet.analytics
+
+import javax.inject.Inject
+
+internal class EventTimeProvider @Inject constructor() {
+    fun currentTimeMillis() = System.currentTimeMillis()
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -88,17 +88,27 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     }
 
     class ShowNewPaymentOptionForm(
-        mode: EventReporter.Mode
+        mode: EventReporter.Mode,
+        linkEnabled: Boolean,
+        activeLinkSession: Boolean
     ) : PaymentSheetEvent() {
         override val eventName: String = formatEventName(mode, "sheet_newpm_show")
-        override val additionalParams: Map<String, Any> = mapOf()
+        override val additionalParams: Map<String, Any> = mapOf(
+            "link_enabled" to linkEnabled,
+            "active_link_session" to activeLinkSession
+        )
     }
 
     class ShowExistingPaymentOptions(
-        mode: EventReporter.Mode
+        mode: EventReporter.Mode,
+        linkEnabled: Boolean,
+        activeLinkSession: Boolean
     ) : PaymentSheetEvent() {
         override val eventName: String = formatEventName(mode, "sheet_savedpm_show")
-        override val additionalParams: Map<String, Any> = mapOf()
+        override val additionalParams: Map<String, Any> = mapOf(
+            "link_enabled" to linkEnabled,
+            "active_link_session" to activeLinkSession
+        )
     }
 
     class SelectPaymentOption(
@@ -113,11 +123,14 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
     class Payment(
         mode: EventReporter.Mode,
         result: Result,
+        durationMillis: Long?,
         paymentSelection: PaymentSelection?
     ) : PaymentSheetEvent() {
         override val eventName: String =
             formatEventName(mode, "payment_${analyticsValue(paymentSelection)}_$result")
-        override val additionalParams: Map<String, Any> = mapOf()
+        override val additionalParams: Map<String, Any> = durationMillis?.let {
+            mapOf("duration" to it / 1000f)
+        } ?: mapOf()
 
         enum class Result(private val code: String) {
             Success("success"),
@@ -139,6 +152,8 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         ) = when (paymentSelection) {
             PaymentSelection.GooglePay -> "googlepay"
             is PaymentSelection.Saved -> "savedpm"
+            PaymentSelection.Link,
+            is PaymentSelection.New.LinkInline -> "link"
             is PaymentSelection.New -> "newpm"
             else -> "unknown"
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -25,7 +25,8 @@ sealed class PaymentSelection : Parcelable {
     @Parcelize
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class Saved(
-        val paymentMethod: PaymentMethod
+        val paymentMethod: PaymentMethod,
+        internal val isGooglePay: Boolean = false
     ) : PaymentSelection()
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddPaymentMethodFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddPaymentMethodFragmentTest.kt
@@ -42,6 +42,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -213,7 +214,7 @@ internal class PaymentSheetAddPaymentMethodFragmentTest : PaymentSheetViewModelT
     fun `started fragment should report onShowNewPaymentOptionForm() event`() {
         createFragment { _, _, _ ->
             idleLooper()
-            verify(eventReporter).onShowNewPaymentOptionForm()
+            verify(eventReporter).onShowNewPaymentOptionForm(any(), any())
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
@@ -28,6 +28,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
@@ -192,7 +193,7 @@ internal class PaymentSheetListFragmentTest : PaymentSheetViewModelTestInjection
     @Test
     fun `started fragment should report onShowExistingPaymentOptions() event`() {
         createScenario().onFragment {
-            verify(eventReporter).onShowExistingPaymentOptions()
+            verify(eventReporter).onShowExistingPaymentOptions(any(), any())
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -10,6 +10,8 @@ import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
 import org.mockito.kotlin.argWhere
 import org.mockito.kotlin.mock
@@ -77,9 +79,10 @@ class DefaultEventReporterTest {
     }
 
     @Test
-    fun `onPaymentSuccess() should fire analytics request with expected event value`() {
+    fun `onPaymentSuccess() should fire analytics request with expected event value`() = runTest(UnconfinedTestDispatcher()) {
         // Log initial event so that duration is tracked
         completeEventReporter.onShowExistingPaymentOptions(false, false)
+        advanceTimeBy(1000L)
 
         completeEventReporter.onPaymentSuccess(
             PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
@@ -92,9 +95,10 @@ class DefaultEventReporterTest {
     }
 
     @Test
-    fun `onPaymentFailure() should fire analytics request with expected event value`() {
+    fun `onPaymentFailure() should fire analytics request with expected event value`() = runTest(UnconfinedTestDispatcher()) {
         // Log initial event so that duration is tracked
         completeEventReporter.onShowExistingPaymentOptions(false, false)
+        advanceTimeBy(1000L)
 
         completeEventReporter.onPaymentFailure(
             PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -93,7 +93,8 @@ class DefaultEventReporterTest {
         )
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
-                req.params["event"] == "mc_complete_payment_savedpm_success" && req.params.containsKey("duration")
+                req.params["event"] == "mc_complete_payment_savedpm_success" &&
+                    req.params["duration"] == 1f
             }
         )
     }
@@ -110,7 +111,8 @@ class DefaultEventReporterTest {
         )
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
-                req.params["event"] == "mc_complete_payment_savedpm_failure" && req.params.containsKey("duration")
+                req.params["event"] == "mc_complete_payment_savedpm_failure" &&
+                    req.params["duration"] == 1f
             }
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -51,13 +51,57 @@ class DefaultEventReporterTest {
     }
 
     @Test
+    fun `onShowExistingPaymentOptions() should fire analytics request with expected event value`() {
+        completeEventReporter.onShowExistingPaymentOptions(true, false)
+
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == "mc_complete_sheet_savedpm_show" &&
+                    req.params["link_enabled"] == true &&
+                    req.params["active_link_session"] == false
+            }
+        )
+    }
+
+    @Test
+    fun `onShowNewPaymentOptionForm() should fire analytics request with expected event value`() {
+        completeEventReporter.onShowNewPaymentOptionForm(false, true)
+
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == "mc_complete_sheet_newpm_show" &&
+                    req.params["link_enabled"] == false &&
+                    req.params["active_link_session"] == true
+            }
+        )
+    }
+
+    @Test
     fun `onPaymentSuccess() should fire analytics request with expected event value`() {
+        // Log initial event so that duration is tracked
+        completeEventReporter.onShowExistingPaymentOptions(false, false)
+
         completeEventReporter.onPaymentSuccess(
             PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
         )
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
-                req.params["event"] == "mc_complete_payment_savedpm_success"
+                req.params["event"] == "mc_complete_payment_savedpm_success" && req.params.containsKey("duration")
+            }
+        )
+    }
+
+    @Test
+    fun `onPaymentFailure() should fire analytics request with expected event value`() {
+        // Log initial event so that duration is tracked
+        completeEventReporter.onShowExistingPaymentOptions(false, false)
+
+        completeEventReporter.onPaymentFailure(
+            PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        )
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == "mc_complete_payment_savedpm_failure" && req.params.containsKey("duration")
             }
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -1,9 +1,13 @@
 package com.stripe.android.paymentsheet.analytics
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.link.LinkPaymentDetails
+import com.stripe.android.model.PaymentDetailsFixtures
+import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 
@@ -39,11 +43,126 @@ class PaymentSheetEventTest {
         assertThat(
             PaymentSheetEvent.Payment(
                 mode = EventReporter.Mode.Complete,
+                paymentSelection = PaymentSelection.New.Card(PaymentMethodCreateParamsFixtures.DEFAULT_CARD, mock(), mock()),
+                durationMillis = 1L,
+                result = PaymentSheetEvent.Payment.Result.Success
+            ).eventName
+        ).isEqualTo(
+            "mc_complete_payment_newpm_success"
+        )
+
+        assertThat(
+            PaymentSheetEvent.Payment(
+                mode = EventReporter.Mode.Complete,
+                paymentSelection = PaymentSelection.Saved(mock()),
+                durationMillis = 1L,
+                result = PaymentSheetEvent.Payment.Result.Success
+            ).eventName
+        ).isEqualTo(
+            "mc_complete_payment_savedpm_success"
+        )
+
+        assertThat(
+            PaymentSheetEvent.Payment(
+                mode = EventReporter.Mode.Complete,
                 paymentSelection = PaymentSelection.GooglePay,
+                durationMillis = 1L,
                 result = PaymentSheetEvent.Payment.Result.Success
             ).eventName
         ).isEqualTo(
             "mc_complete_payment_googlepay_success"
+        )
+
+        assertThat(
+            PaymentSheetEvent.Payment(
+                mode = EventReporter.Mode.Complete,
+                paymentSelection = PaymentSelection.Link,
+                durationMillis = 1L,
+                result = PaymentSheetEvent.Payment.Result.Success
+            ).eventName
+        ).isEqualTo(
+            "mc_complete_payment_link_success"
+        )
+
+        assertThat(
+            PaymentSheetEvent.Payment(
+                mode = EventReporter.Mode.Complete,
+                paymentSelection = PaymentSelection.New.LinkInline(
+                    LinkPaymentDetails.New(
+                        PaymentDetailsFixtures.CONSUMER_SINGLE_PAYMENT_DETAILS.paymentDetails.first(),
+                        mock(),
+                        mock()
+                    )
+                ),
+                durationMillis = 1L,
+                result = PaymentSheetEvent.Payment.Result.Success
+            ).eventName
+        ).isEqualTo(
+            "mc_complete_payment_link_success"
+        )
+    }
+
+    @Test
+    fun `Payment failure event should return expected toString()`() {
+        assertThat(
+            PaymentSheetEvent.Payment(
+                mode = EventReporter.Mode.Complete,
+                paymentSelection = PaymentSelection.New.Card(PaymentMethodCreateParamsFixtures.DEFAULT_CARD, mock(), mock()),
+                durationMillis = 1L,
+                result = PaymentSheetEvent.Payment.Result.Failure
+            ).eventName
+        ).isEqualTo(
+            "mc_complete_payment_newpm_failure"
+        )
+
+        assertThat(
+            PaymentSheetEvent.Payment(
+                mode = EventReporter.Mode.Complete,
+                paymentSelection = PaymentSelection.Saved(mock()),
+                durationMillis = 1L,
+                result = PaymentSheetEvent.Payment.Result.Failure
+            ).eventName
+        ).isEqualTo(
+            "mc_complete_payment_savedpm_failure"
+        )
+
+        assertThat(
+            PaymentSheetEvent.Payment(
+                mode = EventReporter.Mode.Complete,
+                paymentSelection = PaymentSelection.GooglePay,
+                durationMillis = 1L,
+                result = PaymentSheetEvent.Payment.Result.Failure
+            ).eventName
+        ).isEqualTo(
+            "mc_complete_payment_googlepay_failure"
+        )
+
+        assertThat(
+            PaymentSheetEvent.Payment(
+                mode = EventReporter.Mode.Complete,
+                paymentSelection = PaymentSelection.Link,
+                durationMillis = 1L,
+                result = PaymentSheetEvent.Payment.Result.Failure
+            ).eventName
+        ).isEqualTo(
+            "mc_complete_payment_link_failure"
+        )
+
+        assertThat(
+            PaymentSheetEvent.Payment(
+                mode = EventReporter.Mode.Complete,
+                paymentSelection = PaymentSelection.New.LinkInline(
+                    LinkPaymentDetails.New(
+                        PaymentDetailsFixtures.CONSUMER_SINGLE_PAYMENT_DETAILS.paymentDetails.first(),
+                        mock(),
+                        mock()
+                    )
+                ),
+                durationMillis = 1L,
+                result = PaymentSheetEvent.Payment.Result.Failure
+            ).eventName
+        ).isEqualTo(
+            "mc_complete_payment_link_failure"
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -70,6 +70,7 @@ import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argWhere
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isA
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -186,6 +187,30 @@ internal class DefaultFlowControllerTest {
         }
         verify(eventReporter)
             .onInit(PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY)
+    }
+
+    @Test
+    fun `successful payment should fire analytics event`() {
+        val viewModel = ViewModelProvider(activity)[FlowControllerViewModel::class.java]
+        val flowController = createFlowController(viewModel = viewModel)
+
+        viewModel.paymentSelection = PaymentSelection.New.Card(PaymentMethodCreateParamsFixtures.DEFAULT_CARD, mock(), mock())
+
+        flowController.onPaymentResult(PaymentResult.Completed)
+
+        verify(eventReporter).onPaymentSuccess(isA<PaymentSelection.New>())
+    }
+
+    @Test
+    fun `failed payment should fire analytics event`() {
+        val viewModel = ViewModelProvider(activity)[FlowControllerViewModel::class.java]
+        val flowController = createFlowController(viewModel = viewModel)
+
+        viewModel.paymentSelection = PaymentSelection.New.Card(PaymentMethodCreateParamsFixtures.DEFAULT_CARD, mock(), mock())
+
+        flowController.onPaymentResult(PaymentResult.Failed(RuntimeException()))
+
+        verify(eventReporter).onPaymentFailure(isA<PaymentSelection.New>())
     }
 
     @Test
@@ -857,19 +882,22 @@ internal class DefaultFlowControllerTest {
     private fun createFlowController(
         paymentMethods: List<PaymentMethod> = emptyList(),
         savedSelection: SavedSelection = SavedSelection.None,
-        stripeIntent: StripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
+        stripeIntent: StripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+        viewModel: FlowControllerViewModel = ViewModelProvider(activity)[FlowControllerViewModel::class.java]
     ): DefaultFlowController {
         return createFlowController(
             FakeFlowControllerInitializer(
                 paymentMethods,
                 savedSelection,
                 stripeIntent = stripeIntent
-            )
+            ),
+            viewModel
         )
     }
 
     private fun createFlowController(
-        flowControllerInitializer: FlowControllerInitializer
+        flowControllerInitializer: FlowControllerInitializer,
+        viewModel: FlowControllerViewModel = ViewModelProvider(activity)[FlowControllerViewModel::class.java]
     ) = DefaultFlowController(
         testScope,
         lifeCycleOwner,
@@ -881,7 +909,7 @@ internal class DefaultFlowControllerTest {
         INJECTOR_KEY,
         flowControllerInitializer,
         eventReporter,
-        ViewModelProvider(activity)[FlowControllerViewModel::class.java],
+        viewModel,
         paymentLauncherAssistedFactory,
         mock(),
         mock(),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add Link status to analytics events
- `link_enabled` indicates whether Link is available.
- `active_link_session` indicates whether the user is logged into a Link account.

Track how long it took from Payment Sheet shown until payment completed.

Also log payment succes/failure events for the custom flow.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Gather usage metrics.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
