### PR TITLE
BANKCON-4898 CollectBankAccountLauncher not using stripeAccountId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
   `PaymentSheet`, that clears any persisted authentication state.
 * [FIXED][5388](https://github.com/stripe/stripe-android/pull/5388) Fixed issue with Appearance API
   not working with `FlowController`
+* [FIXED][5399](https://github.com/stripe/stripe-android/pull/5399) Bank Account Payments that pass 
+  stripeAccountId for connected accounts will now succeed.
+
+### CollectBankAccountLauncher
+* [FIXED][5399](https://github.com/stripe/stripe-android/pull/5399) CollectBankAccountLauncher now 
+  accepts stripeAccountId for Connect merchants.
 
 ## 20.8.0 - 2022-08-01
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,9 +15,5 @@ org.gradle.jvmargs=-XX\:MaxHeapSize\=2048m -Xmx4608M -XX:+UseParallelGC
 android.useAndroidX=true
 android.enableJetifier=false
 
-# delete
-# PUBLISHABLE_KEY=pk_live_Uxk6GdfUJzeCePW1FdQmeOFM
-
-
 # Update StripeSdkVersion.VERSION_NAME when publishing a new release
 VERSION_NAME=20.8.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,5 +15,9 @@ org.gradle.jvmargs=-XX\:MaxHeapSize\=2048m -Xmx4608M -XX:+UseParallelGC
 android.useAndroidX=true
 android.enableJetifier=false
 
+# delete
+# PUBLISHABLE_KEY=pk_live_Uxk6GdfUJzeCePW1FdQmeOFM
+
+
 # Update StripeSdkVersion.VERSION_NAME when publishing a new release
 VERSION_NAME=20.8.0

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -6470,13 +6470,18 @@ public final class com/stripe/android/payments/bankaccount/CollectBankAccountCon
 
 public abstract interface class com/stripe/android/payments/bankaccount/CollectBankAccountLauncher {
 	public static final field Companion Lcom/stripe/android/payments/bankaccount/CollectBankAccountLauncher$Companion;
-	public abstract fun presentWithPaymentIntent (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/payments/bankaccount/CollectBankAccountConfiguration;)V
-	public abstract fun presentWithSetupIntent (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/payments/bankaccount/CollectBankAccountConfiguration;)V
+	public abstract fun presentWithPaymentIntent (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/payments/bankaccount/CollectBankAccountConfiguration;)V
+	public abstract fun presentWithSetupIntent (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/payments/bankaccount/CollectBankAccountConfiguration;)V
 }
 
 public final class com/stripe/android/payments/bankaccount/CollectBankAccountLauncher$Companion {
 	public final fun create (Landroidx/activity/ComponentActivity;Lkotlin/jvm/functions/Function1;)Lcom/stripe/android/payments/bankaccount/CollectBankAccountLauncher;
 	public final fun create (Landroidx/fragment/app/Fragment;Lkotlin/jvm/functions/Function1;)Lcom/stripe/android/payments/bankaccount/CollectBankAccountLauncher;
+}
+
+public final class com/stripe/android/payments/bankaccount/CollectBankAccountLauncher$DefaultImpls {
+	public static synthetic fun presentWithPaymentIntent$default (Lcom/stripe/android/payments/bankaccount/CollectBankAccountLauncher;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/payments/bankaccount/CollectBankAccountConfiguration;ILjava/lang/Object;)V
+	public static synthetic fun presentWithSetupIntent$default (Lcom/stripe/android/payments/bankaccount/CollectBankAccountLauncher;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/payments/bankaccount/CollectBankAccountConfiguration;ILjava/lang/Object;)V
 }
 
 public final class com/stripe/android/payments/bankaccount/di/CollectBankAccountModule_ProvidePublishableKeyFactory : dagger/internal/Factory {

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountLauncher.kt
@@ -87,7 +87,7 @@ internal class StripeCollectBankAccountLauncher constructor(
         )
     }
 
-    override fun  presentWithSetupIntent(
+    override fun presentWithSetupIntent(
         publishableKey: String,
         stripeAccountId: String?,
         clientSecret: String,

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountLauncher.kt
@@ -87,7 +87,7 @@ internal class StripeCollectBankAccountLauncher constructor(
         )
     }
 
-    override fun presentWithSetupIntent(
+    override fun  presentWithSetupIntent(
         publishableKey: String,
         stripeAccountId: String?,
         clientSecret: String,

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountLauncher.kt
@@ -17,12 +17,14 @@ interface CollectBankAccountLauncher {
 
     fun presentWithPaymentIntent(
         publishableKey: String,
+        stripeAccountId: String? = null,
         clientSecret: String,
         configuration: CollectBankAccountConfiguration
     )
 
     fun presentWithSetupIntent(
         publishableKey: String,
+        stripeAccountId: String? = null,
         clientSecret: String,
         configuration: CollectBankAccountConfiguration
     )
@@ -70,12 +72,14 @@ internal class StripeCollectBankAccountLauncher constructor(
 
     override fun presentWithPaymentIntent(
         publishableKey: String,
+        stripeAccountId: String?,
         clientSecret: String,
         configuration: CollectBankAccountConfiguration
     ) {
         hostActivityLauncher.launch(
             CollectBankAccountContract.Args.ForPaymentIntent(
                 publishableKey = publishableKey,
+                stripeAccountId = stripeAccountId,
                 clientSecret = clientSecret,
                 configuration = configuration,
                 attachToIntent = true
@@ -85,12 +89,14 @@ internal class StripeCollectBankAccountLauncher constructor(
 
     override fun presentWithSetupIntent(
         publishableKey: String,
+        stripeAccountId: String?,
         clientSecret: String,
         configuration: CollectBankAccountConfiguration
     ) {
         hostActivityLauncher.launch(
             CollectBankAccountContract.Args.ForSetupIntent(
                 publishableKey = publishableKey,
+                stripeAccountId = stripeAccountId,
                 clientSecret = clientSecret,
                 configuration = configuration,
                 attachToIntent = true

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/domain/AttachFinancialConnectionsSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/domain/AttachFinancialConnectionsSession.kt
@@ -19,13 +19,17 @@ internal class AttachFinancialConnectionsSession @Inject constructor(
     suspend fun forPaymentIntent(
         publishableKey: String,
         linkedAccountSessionId: String,
-        clientSecret: String
+        clientSecret: String,
+        stripeAccountId: String?
     ): Result<PaymentIntent> = kotlin.runCatching {
         stripeRepository.attachFinancialConnectionsSessionToPaymentIntent(
             financialConnectionsSessionId = linkedAccountSessionId,
             clientSecret = clientSecret,
             paymentIntentId = PaymentIntent.ClientSecret(clientSecret).paymentIntentId,
-            requestOptions = ApiRequest.Options(publishableKey)
+            requestOptions = ApiRequest.Options(
+                apiKey = publishableKey,
+                stripeAccount = stripeAccountId
+            )
         )
     }.mapCatching { it ?: throw InternalError("Error attaching session to PaymentIntent") }
 
@@ -38,13 +42,17 @@ internal class AttachFinancialConnectionsSession @Inject constructor(
     suspend fun forSetupIntent(
         publishableKey: String,
         linkedAccountSessionId: String,
-        clientSecret: String
+        clientSecret: String,
+        stripeAccountId: String?
     ): Result<SetupIntent> = kotlin.runCatching {
         stripeRepository.attachFinancialConnectionsSessionToSetupIntent(
             financialConnectionsSessionId = linkedAccountSessionId,
             clientSecret = clientSecret,
             setupIntentId = SetupIntent.ClientSecret(clientSecret).setupIntentId,
-            requestOptions = ApiRequest.Options(publishableKey)
+            requestOptions = ApiRequest.Options(
+                apiKey = publishableKey,
+                stripeAccount = stripeAccountId
+            )
         )
     }.mapCatching { it ?: throw InternalError("Error attaching session to SetupIntent") }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/domain/CreateFinancialConnectionsSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/domain/CreateFinancialConnectionsSession.kt
@@ -9,7 +9,7 @@ import com.stripe.android.networking.StripeRepository
 import javax.inject.Inject
 
 internal class CreateFinancialConnectionsSession @Inject constructor(
-    private val stripeRepository: StripeRepository
+    private val stripeRepository: StripeRepository,
 ) {
 
     /**
@@ -19,7 +19,8 @@ internal class CreateFinancialConnectionsSession @Inject constructor(
         publishableKey: String,
         clientSecret: String,
         customerName: String,
-        customerEmail: String?
+        customerEmail: String?,
+        stripeAccountId: String?
     ): Result<FinancialConnectionsSession> = kotlin.runCatching {
         stripeRepository.createPaymentIntentFinancialConnectionsSession(
             paymentIntentId = PaymentIntent.ClientSecret(clientSecret).paymentIntentId,
@@ -28,7 +29,10 @@ internal class CreateFinancialConnectionsSession @Inject constructor(
                 customerName = customerName,
                 customerEmailAddress = customerEmail
             ),
-            requestOptions = ApiRequest.Options(publishableKey)
+            requestOptions = ApiRequest.Options(
+                publishableKey,
+                stripeAccountId
+            )
         )
     }.mapCatching { it ?: throw InternalError("Error creating session for PaymentIntent") }
 
@@ -39,7 +43,8 @@ internal class CreateFinancialConnectionsSession @Inject constructor(
         publishableKey: String,
         clientSecret: String,
         customerName: String,
-        customerEmail: String?
+        customerEmail: String?,
+        stripeAccountId: String?
     ): Result<FinancialConnectionsSession> = kotlin.runCatching {
         stripeRepository.createSetupIntentFinancialConnectionsSession(
             setupIntentId = SetupIntent.ClientSecret(clientSecret).setupIntentId,
@@ -48,7 +53,10 @@ internal class CreateFinancialConnectionsSession @Inject constructor(
                 customerName = customerName,
                 customerEmailAddress = customerEmail
             ),
-            requestOptions = ApiRequest.Options(publishableKey)
+            requestOptions = ApiRequest.Options(
+                publishableKey,
+                stripeAccountId
+            )
         )
     }.mapCatching { it ?: throw InternalError("Error creating session for SetupIntent") }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/navigation/CollectBankAccountContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/navigation/CollectBankAccountContract.kt
@@ -40,6 +40,7 @@ class CollectBankAccountContract :
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     sealed class Args(
         open val publishableKey: String,
+        open val stripeAccountId: String?,
         open val clientSecret: String,
         open val configuration: CollectBankAccountConfiguration,
         open val attachToIntent: Boolean
@@ -48,21 +49,35 @@ class CollectBankAccountContract :
 
         @Parcelize
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        data class ForPaymentIntent constructor(
+        data class ForPaymentIntent(
             override val publishableKey: String,
+            override val stripeAccountId: String?,
             override val clientSecret: String,
             override val configuration: CollectBankAccountConfiguration,
             override val attachToIntent: Boolean
-        ) : Args(publishableKey, clientSecret, configuration, attachToIntent)
+        ) : Args(
+            publishableKey = publishableKey,
+            stripeAccountId = stripeAccountId,
+            clientSecret = clientSecret,
+            configuration = configuration,
+            attachToIntent = attachToIntent
+        )
 
         @Parcelize
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        data class ForSetupIntent constructor(
+        data class ForSetupIntent(
             override val publishableKey: String,
+            override val stripeAccountId: String?,
             override val clientSecret: String,
             override val configuration: CollectBankAccountConfiguration,
             override val attachToIntent: Boolean
-        ) : Args(publishableKey, clientSecret, configuration, attachToIntent)
+        ) : Args(
+            publishableKey = publishableKey,
+            stripeAccountId = stripeAccountId,
+            clientSecret = clientSecret,
+            configuration = configuration,
+            attachToIntent = attachToIntent
+        )
 
         companion object {
             fun fromIntent(intent: Intent): Args? {

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel.kt
@@ -135,11 +135,13 @@ internal class CollectBankAccountViewModel @Inject constructor(
             when (args) {
                 is ForPaymentIntent -> attachFinancialConnectionsSession.forPaymentIntent(
                     publishableKey = args.publishableKey,
+                    stripeAccountId = args.stripeAccountId,
                     clientSecret = args.clientSecret,
                     linkedAccountSessionId = financialConnectionsSession.id
                 )
                 is ForSetupIntent -> attachFinancialConnectionsSession.forSetupIntent(
                     publishableKey = args.publishableKey,
+                    stripeAccountId = args.stripeAccountId,
                     clientSecret = args.clientSecret,
                     linkedAccountSessionId = financialConnectionsSession.id
                 )

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel.kt
@@ -60,12 +60,14 @@ internal class CollectBankAccountViewModel @Inject constructor(
             is CollectBankAccountConfiguration.USBankAccount -> when (args) {
                 is ForPaymentIntent -> createFinancialConnectionsSession.forPaymentIntent(
                     publishableKey = args.publishableKey,
+                    stripeAccountId = args.stripeAccountId,
                     clientSecret = args.clientSecret,
                     customerName = configuration.name,
                     customerEmail = configuration.email
                 )
                 is ForSetupIntent -> createFinancialConnectionsSession.forSetupIntent(
                     publishableKey = args.publishableKey,
+                    stripeAccountId = args.stripeAccountId,
                     clientSecret = args.clientSecret,
                     customerName = configuration.name,
                     customerEmail = configuration.email

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/StripeCollectBankAccountLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/StripeCollectBankAccountLauncherTest.kt
@@ -27,6 +27,7 @@ class StripeCollectBankAccountLauncherTest {
         verify(mockHostActivityLauncher).launch(
             CollectBankAccountContract.Args.ForPaymentIntent(
                 publishableKey = PUBLISHABLE_KEY,
+                stripeAccountId = stripeAccountId,
                 clientSecret = CLIENT_SECRET,
                 configuration = CONFIGURATION,
                 attachToIntent = true
@@ -45,6 +46,7 @@ class StripeCollectBankAccountLauncherTest {
         verify(mockHostActivityLauncher).launch(
             CollectBankAccountContract.Args.ForSetupIntent(
                 publishableKey = PUBLISHABLE_KEY,
+                stripeAccountId = stripeAccountId,
                 clientSecret = CLIENT_SECRET,
                 configuration = CONFIGURATION,
                 attachToIntent = true

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/StripeCollectBankAccountLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/StripeCollectBankAccountLauncherTest.kt
@@ -19,15 +19,16 @@ class StripeCollectBankAccountLauncherTest {
     @Test
     fun `presentWithPaymentIntent - launches CollectBankAccountActivity with correct arguments`() {
         launcher.presentWithPaymentIntent(
-            PUBLISHABLE_KEY,
-            CLIENT_SECRET,
-            CONFIGURATION
+            publishableKey = PUBLISHABLE_KEY,
+            clientSecret = CLIENT_SECRET,
+            stripeAccountId = STRIPE_ACCOUNT_ID,
+            configuration = CONFIGURATION
         )
 
         verify(mockHostActivityLauncher).launch(
             CollectBankAccountContract.Args.ForPaymentIntent(
                 publishableKey = PUBLISHABLE_KEY,
-                stripeAccountId = stripeAccountId,
+                stripeAccountId = STRIPE_ACCOUNT_ID,
                 clientSecret = CLIENT_SECRET,
                 configuration = CONFIGURATION,
                 attachToIntent = true
@@ -38,15 +39,16 @@ class StripeCollectBankAccountLauncherTest {
     @Test
     fun `presentWithSetupIntent - launches CollectBankAccountActivity with correct arguments`() {
         launcher.presentWithSetupIntent(
-            PUBLISHABLE_KEY,
-            CLIENT_SECRET,
-            CONFIGURATION
+            publishableKey = PUBLISHABLE_KEY,
+            stripeAccountId = STRIPE_ACCOUNT_ID,
+            clientSecret = CLIENT_SECRET,
+            configuration = CONFIGURATION
         )
 
         verify(mockHostActivityLauncher).launch(
             CollectBankAccountContract.Args.ForSetupIntent(
                 publishableKey = PUBLISHABLE_KEY,
-                stripeAccountId = stripeAccountId,
+                stripeAccountId = STRIPE_ACCOUNT_ID,
                 clientSecret = CLIENT_SECRET,
                 configuration = CONFIGURATION,
                 attachToIntent = true
@@ -57,6 +59,7 @@ class StripeCollectBankAccountLauncherTest {
     companion object {
         private const val CLIENT_SECRET = "client_secret"
         private const val PUBLISHABLE_KEY = "publishableKey"
+        private const val STRIPE_ACCOUNT_ID = "stripe_account_id"
         private val CONFIGURATION = CollectBankAccountConfiguration.USBankAccount(
             name = "Carlos",
             email = null

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/domain/AttachFinancialConnectionsSessionTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/domain/AttachFinancialConnectionsSessionTest.kt
@@ -22,12 +22,14 @@ class AttachFinancialConnectionsSessionTest {
     private val stripeRepository = mock<StripeRepository>()
     private val attachFinancialConnectionsSession = AttachFinancialConnectionsSession(stripeRepository)
 
+    private val publishableKey = "publishable_key"
+    private val linkedAccountSessionId = "session_id"
+    private val stripeAccountId = "stripe_account_id"
+
     @Test
     fun `forPaymentIntent - given repository succeeds, linkedSession attached and paymentIntent returned`() {
         runTest {
             // Given
-            val publishableKey = "publishable_key"
-            val linkedAccountSessionId = "session_id"
             val clientSecret = "pi_1234_secret_5678"
             val paymentIntent = mock<PaymentIntent> {
                 on { this.clientSecret } doReturn clientSecret
@@ -36,9 +38,10 @@ class AttachFinancialConnectionsSessionTest {
 
             // When
             val result: Result<PaymentIntent> = attachFinancialConnectionsSession.forPaymentIntent(
-                publishableKey,
-                linkedAccountSessionId,
-                clientSecret
+                publishableKey = publishableKey,
+                linkedAccountSessionId = linkedAccountSessionId,
+                clientSecret = clientSecret,
+                stripeAccountId = stripeAccountId
             )
 
             // Then
@@ -56,8 +59,6 @@ class AttachFinancialConnectionsSessionTest {
     fun `forPaymentIntent - given repository returns null, results in internal error failure`() {
         runTest {
             // Given
-            val publishableKey = "publishable_key"
-            val linkedAccountSessionId = "session_id"
             val clientSecret = "pi_1234_secret_5678"
             givenAttachPaymentIntentReturns { null }
 
@@ -65,7 +66,8 @@ class AttachFinancialConnectionsSessionTest {
             val result: Result<PaymentIntent> = attachFinancialConnectionsSession.forPaymentIntent(
                 publishableKey,
                 linkedAccountSessionId,
-                clientSecret
+                clientSecret,
+                stripeAccountId
             )
 
             // Then
@@ -83,8 +85,6 @@ class AttachFinancialConnectionsSessionTest {
     fun `forPaymentIntent - given repository throws exception, results in internal error failure`() {
         runTest {
             // Given
-            val publishableKey = "publishable_key"
-            val linkedAccountSessionId = "session_id"
             val clientSecret = "pi_1234_secret_5678"
             val expectedException = APIException()
             givenAttachPaymentIntentReturns { throw expectedException }
@@ -93,7 +93,8 @@ class AttachFinancialConnectionsSessionTest {
             val result: Result<PaymentIntent> = attachFinancialConnectionsSession.forPaymentIntent(
                 publishableKey,
                 linkedAccountSessionId,
-                clientSecret
+                clientSecret,
+                stripeAccountId
             )
 
             // Then
@@ -111,8 +112,6 @@ class AttachFinancialConnectionsSessionTest {
     fun `forPaymentIntent - given wrong secret, results in internal error failure`() {
         runTest {
             // Given
-            val publishableKey = "publishable_key"
-            val linkedAccountSessionId = "session_id"
             val clientSecret = "wrong_secret"
             val paymentIntent = mock<PaymentIntent>()
             givenAttachPaymentIntentReturns { paymentIntent }
@@ -121,7 +120,8 @@ class AttachFinancialConnectionsSessionTest {
             val result: Result<PaymentIntent> = attachFinancialConnectionsSession.forPaymentIntent(
                 publishableKey,
                 linkedAccountSessionId,
-                clientSecret
+                clientSecret,
+                stripeAccountId
             )
 
             // Then
@@ -133,8 +133,6 @@ class AttachFinancialConnectionsSessionTest {
     fun `forSetupIntent - given repository succeeds, linkedSession attached and setupIntent returned`() {
         runTest {
             // Given
-            val publishableKey = "publishable_key"
-            val linkedAccountSessionId = "session_id"
             val clientSecret = "seti_1234_secret_5678"
             val setupIntent = mock<SetupIntent> {
                 on { this.clientSecret } doReturn clientSecret
@@ -145,7 +143,8 @@ class AttachFinancialConnectionsSessionTest {
             val result: Result<SetupIntent> = attachFinancialConnectionsSession.forSetupIntent(
                 publishableKey,
                 linkedAccountSessionId,
-                clientSecret
+                clientSecret,
+                stripeAccountId
             )
 
             // Then
@@ -153,7 +152,7 @@ class AttachFinancialConnectionsSessionTest {
                 clientSecret = clientSecret,
                 setupIntentId = "seti_1234",
                 financialConnectionsSessionId = linkedAccountSessionId,
-                requestOptions = ApiRequest.Options(publishableKey)
+                requestOptions = ApiRequest.Options(publishableKey, stripeAccountId)
             )
             assertThat((result)).isEqualTo(Result.success(setupIntent))
         }
@@ -163,8 +162,6 @@ class AttachFinancialConnectionsSessionTest {
     fun `forSetupIntent - given repository returns null, results in internal error failure`() {
         runTest {
             // Given
-            val publishableKey = "publishable_key"
-            val linkedAccountSessionId = "session_id"
             val clientSecret = "seti_1234_secret_5678"
             givenAttachSetupIntentReturns { null }
 
@@ -172,7 +169,8 @@ class AttachFinancialConnectionsSessionTest {
             val setupIntent: Result<SetupIntent> = attachFinancialConnectionsSession.forSetupIntent(
                 publishableKey,
                 linkedAccountSessionId,
-                clientSecret
+                clientSecret,
+                stripeAccountId
             )
 
             // Then
@@ -180,7 +178,7 @@ class AttachFinancialConnectionsSessionTest {
                 clientSecret = clientSecret,
                 setupIntentId = "seti_1234",
                 financialConnectionsSessionId = linkedAccountSessionId,
-                requestOptions = ApiRequest.Options(publishableKey)
+                requestOptions = ApiRequest.Options(publishableKey, stripeAccountId)
             )
             assertThat(setupIntent.exceptionOrNull()!!).isInstanceOf(InternalError::class.java)
         }
@@ -190,8 +188,6 @@ class AttachFinancialConnectionsSessionTest {
     fun `forSetupIntent - given repository throws exception, results in internal error failure`() {
         runTest {
             // Given
-            val publishableKey = "publishable_key"
-            val linkedAccountSessionId = "session_id"
             val clientSecret = "seti_1234_secret_5678"
             val expectedException = APIException()
             givenAttachSetupIntentReturns { throw expectedException }
@@ -200,7 +196,8 @@ class AttachFinancialConnectionsSessionTest {
             val setupIntent: Result<SetupIntent> = attachFinancialConnectionsSession.forSetupIntent(
                 publishableKey,
                 linkedAccountSessionId,
-                clientSecret
+                clientSecret,
+                stripeAccountId
             )
 
             // Then
@@ -208,7 +205,7 @@ class AttachFinancialConnectionsSessionTest {
                 clientSecret = clientSecret,
                 setupIntentId = "seti_1234",
                 financialConnectionsSessionId = linkedAccountSessionId,
-                requestOptions = ApiRequest.Options(publishableKey)
+                requestOptions = ApiRequest.Options(publishableKey, stripeAccountId)
             )
             assertThat(setupIntent.exceptionOrNull()!!).isEqualTo(expectedException)
         }
@@ -228,7 +225,8 @@ class AttachFinancialConnectionsSessionTest {
             val setupIntent: Result<SetupIntent> = attachFinancialConnectionsSession.forSetupIntent(
                 publishableKey,
                 linkedAccountSessionId,
-                clientSecret
+                clientSecret,
+                stripeAccountId
             )
 
             // Then

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/domain/AttachFinancialConnectionsSessionTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/domain/AttachFinancialConnectionsSessionTest.kt
@@ -49,7 +49,7 @@ class AttachFinancialConnectionsSessionTest {
                 clientSecret = clientSecret,
                 paymentIntentId = "pi_1234",
                 financialConnectionsSessionId = linkedAccountSessionId,
-                requestOptions = ApiRequest.Options(publishableKey)
+                requestOptions = ApiRequest.Options(publishableKey, stripeAccountId)
             )
             assertThat((result)).isEqualTo(Result.success(paymentIntent))
         }
@@ -64,10 +64,10 @@ class AttachFinancialConnectionsSessionTest {
 
             // When
             val result: Result<PaymentIntent> = attachFinancialConnectionsSession.forPaymentIntent(
-                publishableKey,
-                linkedAccountSessionId,
-                clientSecret,
-                stripeAccountId
+                publishableKey = publishableKey,
+                linkedAccountSessionId = linkedAccountSessionId,
+                clientSecret = clientSecret,
+                stripeAccountId = stripeAccountId
             )
 
             // Then
@@ -75,7 +75,7 @@ class AttachFinancialConnectionsSessionTest {
                 clientSecret = clientSecret,
                 paymentIntentId = "pi_1234",
                 financialConnectionsSessionId = linkedAccountSessionId,
-                requestOptions = ApiRequest.Options(publishableKey)
+                requestOptions = ApiRequest.Options(publishableKey, stripeAccountId)
             )
             assertThat(result.exceptionOrNull()!!).isInstanceOf(InternalError::class.java)
         }
@@ -91,10 +91,10 @@ class AttachFinancialConnectionsSessionTest {
 
             // When
             val result: Result<PaymentIntent> = attachFinancialConnectionsSession.forPaymentIntent(
-                publishableKey,
-                linkedAccountSessionId,
-                clientSecret,
-                stripeAccountId
+                publishableKey = publishableKey,
+                linkedAccountSessionId = linkedAccountSessionId,
+                clientSecret = clientSecret,
+                stripeAccountId = stripeAccountId
             )
 
             // Then
@@ -102,7 +102,7 @@ class AttachFinancialConnectionsSessionTest {
                 clientSecret = clientSecret,
                 paymentIntentId = "pi_1234",
                 financialConnectionsSessionId = linkedAccountSessionId,
-                requestOptions = ApiRequest.Options(publishableKey)
+                requestOptions = ApiRequest.Options(publishableKey, stripeAccountId)
             )
             assertThat(result.exceptionOrNull()!!).isEqualTo(expectedException)
         }

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/domain/CreateFinancialConnectionsSessionTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/domain/CreateFinancialConnectionsSessionTest.kt
@@ -41,7 +41,8 @@ class CreateFinancialConnectionsSessionTest {
                     publishableKey = publishableKey,
                     clientSecret = clientSecret,
                     customerName = customerName,
-                    customerEmail = null
+                    customerEmail = null,
+                    stripeAccountId = args.stripeAccountId
                 )
 
             // Then
@@ -72,7 +73,8 @@ class CreateFinancialConnectionsSessionTest {
                     publishableKey = publishableKey,
                     clientSecret = clientSecret,
                     customerName = customerName,
-                    customerEmail = null
+                    customerEmail = null,
+                    stripeAccountId = args.stripeAccountId
                 )
 
             // Then
@@ -106,7 +108,8 @@ class CreateFinancialConnectionsSessionTest {
                     publishableKey = publishableKey,
                     clientSecret = clientSecret,
                     customerName = customerName,
-                    customerEmail = null
+                    customerEmail = null,
+                    stripeAccountId = args.stripeAccountId
                 )
 
             // Then
@@ -137,7 +140,8 @@ class CreateFinancialConnectionsSessionTest {
                     publishableKey = publishableKey,
                     clientSecret = clientSecret,
                     customerName = customerName,
-                    customerEmail = null
+                    customerEmail = null,
+                    stripeAccountId = args.stripeAccountId
                 )
 
             // Then
@@ -159,7 +163,8 @@ class CreateFinancialConnectionsSessionTest {
                     publishableKey = publishableKey,
                     clientSecret = clientSecret,
                     customerName = customerName,
-                    customerEmail = null
+                    customerEmail = null,
+                    stripeAccountId = args.stripeAccountId
                 )
 
             // Then
@@ -190,7 +195,8 @@ class CreateFinancialConnectionsSessionTest {
                     publishableKey = publishableKey,
                     clientSecret = clientSecret,
                     customerName = customerName,
-                    customerEmail = null
+                    customerEmail = null,
+                    stripeAccountId = args.stripeAccountId
                 )
 
             // Then
@@ -223,7 +229,8 @@ class CreateFinancialConnectionsSessionTest {
                     publishableKey = publishableKey,
                     clientSecret = clientSecret,
                     customerName = customerName,
-                    customerEmail = null
+                    customerEmail = null,
+                    stripeAccountId = args.stripeAccountId
                 )
 
             // Then
@@ -254,7 +261,8 @@ class CreateFinancialConnectionsSessionTest {
                     publishableKey = publishableKey,
                     clientSecret = clientSecret,
                     customerName = customerName,
-                    customerEmail = null
+                    customerEmail = null,
+                    stripeAccountId = args.stripeAccountId
                 )
 
             // Then

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/domain/CreateFinancialConnectionsSessionTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/domain/CreateFinancialConnectionsSessionTest.kt
@@ -42,7 +42,7 @@ class CreateFinancialConnectionsSessionTest {
                     clientSecret = clientSecret,
                     customerName = customerName,
                     customerEmail = null,
-                    stripeAccountId = args.stripeAccountId
+                    stripeAccountId = null
                 )
 
             // Then
@@ -74,7 +74,7 @@ class CreateFinancialConnectionsSessionTest {
                     clientSecret = clientSecret,
                     customerName = customerName,
                     customerEmail = null,
-                    stripeAccountId = args.stripeAccountId
+                    stripeAccountId = null
                 )
 
             // Then
@@ -109,7 +109,7 @@ class CreateFinancialConnectionsSessionTest {
                     clientSecret = clientSecret,
                     customerName = customerName,
                     customerEmail = null,
-                    stripeAccountId = args.stripeAccountId
+                    stripeAccountId = null
                 )
 
             // Then
@@ -141,7 +141,7 @@ class CreateFinancialConnectionsSessionTest {
                     clientSecret = clientSecret,
                     customerName = customerName,
                     customerEmail = null,
-                    stripeAccountId = args.stripeAccountId
+                    stripeAccountId = null
                 )
 
             // Then
@@ -155,6 +155,7 @@ class CreateFinancialConnectionsSessionTest {
             // Given
             val publishableKey = "publishable_key"
             val clientSecret = "seti_1234_secret_5678"
+            val stripeAccountId = "accountId"
             givenCreateSessionWithSetupIntentReturns { linkedAccountSession }
 
             // When
@@ -164,7 +165,7 @@ class CreateFinancialConnectionsSessionTest {
                     clientSecret = clientSecret,
                     customerName = customerName,
                     customerEmail = null,
-                    stripeAccountId = args.stripeAccountId
+                    stripeAccountId = stripeAccountId
                 )
 
             // Then
@@ -175,7 +176,10 @@ class CreateFinancialConnectionsSessionTest {
                     customerName,
                     null
                 ),
-                requestOptions = ApiRequest.Options(publishableKey)
+                requestOptions = ApiRequest.Options(
+                    apiKey = publishableKey,
+                    stripeAccount = stripeAccountId
+                )
             )
             assertThat((paymentIntent)).isEqualTo(Result.success(linkedAccountSession))
         }
@@ -196,7 +200,7 @@ class CreateFinancialConnectionsSessionTest {
                     clientSecret = clientSecret,
                     customerName = customerName,
                     customerEmail = null,
-                    stripeAccountId = args.stripeAccountId
+                    stripeAccountId = null
                 )
 
             // Then
@@ -230,7 +234,7 @@ class CreateFinancialConnectionsSessionTest {
                     clientSecret = clientSecret,
                     customerName = customerName,
                     customerEmail = null,
-                    stripeAccountId = args.stripeAccountId
+                    stripeAccountId = null
                 )
 
             // Then
@@ -262,7 +266,7 @@ class CreateFinancialConnectionsSessionTest {
                     clientSecret = clientSecret,
                     customerName = customerName,
                     customerEmail = null,
-                    stripeAccountId = args.stripeAccountId
+                    stripeAccountId = null
                 )
 
             // Then

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
@@ -241,7 +241,8 @@ class CollectBankAccountViewModelTest {
                     publishableKey = publishableKey,
                     clientSecret = clientSecret,
                     customerName = name,
-                    customerEmail = email
+                    customerEmail = email,
+                    stripeAccountId = args.stripeAccountId
                 )
             }.doReturn(result)
         }
@@ -284,7 +285,8 @@ class CollectBankAccountViewModelTest {
                     publishableKey = publishableKey,
                     clientSecret = clientSecret,
                     customerName = name,
-                    customerEmail = email
+                    customerEmail = email,
+                    stripeAccountId = args.stripeAccountId
                 )
             }.doReturn(result)
         }
@@ -321,6 +323,7 @@ class CollectBankAccountViewModelTest {
     ): ForPaymentIntent {
         return ForPaymentIntent(
             publishableKey = publishableKey,
+            stripeAccountId = stripeAccountId,
             clientSecret = clientSecret,
             configuration = CollectBankAccountConfiguration.USBankAccount(
                 name,
@@ -335,6 +338,7 @@ class CollectBankAccountViewModelTest {
     ): ForSetupIntent {
         return ForSetupIntent(
             publishableKey = publishableKey,
+            stripeAccountId = stripeAccountId,
             clientSecret = clientSecret,
             configuration = CollectBankAccountConfiguration.USBankAccount(
                 name,

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
@@ -253,7 +253,7 @@ class CollectBankAccountViewModelTest {
                     clientSecret = clientSecret,
                     customerName = name,
                     customerEmail = email,
-                    stripeAccountId = null
+                    stripeAccountId = stripeAccountId
                 )
             }.doReturn(result)
         }
@@ -299,7 +299,7 @@ class CollectBankAccountViewModelTest {
                     clientSecret = clientSecret,
                     customerName = name,
                     customerEmail = email,
-                    stripeAccountId = null
+                    stripeAccountId = stripeAccountId
                 )
             }.doReturn(result)
         }

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
@@ -242,7 +242,7 @@ class CollectBankAccountViewModelTest {
                     clientSecret = clientSecret,
                     customerName = name,
                     customerEmail = email,
-                    stripeAccountId = args.stripeAccountId
+                    stripeAccountId = null
                 )
             }.doReturn(result)
         }
@@ -286,7 +286,7 @@ class CollectBankAccountViewModelTest {
                     clientSecret = clientSecret,
                     customerName = name,
                     customerEmail = email,
-                    stripeAccountId = args.stripeAccountId
+                    stripeAccountId = null
                 )
             }.doReturn(result)
         }
@@ -323,7 +323,7 @@ class CollectBankAccountViewModelTest {
     ): ForPaymentIntent {
         return ForPaymentIntent(
             publishableKey = publishableKey,
-            stripeAccountId = stripeAccountId,
+            stripeAccountId = null,
             clientSecret = clientSecret,
             configuration = CollectBankAccountConfiguration.USBankAccount(
                 name,
@@ -338,7 +338,7 @@ class CollectBankAccountViewModelTest {
     ): ForSetupIntent {
         return ForSetupIntent(
             publishableKey = publishableKey,
-            stripeAccountId = stripeAccountId,
+            stripeAccountId = null,
             clientSecret = clientSecret,
             configuration = CollectBankAccountConfiguration.USBankAccount(
                 name,

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
@@ -44,6 +44,7 @@ class CollectBankAccountViewModelTest {
     private val retrieveStripeIntent: RetrieveStripeIntent = mock()
 
     private val publishableKey = "publishable_key"
+    private val stripeAccountId = "stripe_account_id"
     private val clientSecret = "client_secret"
     private val name = "name"
     private val email = "email"
@@ -115,7 +116,12 @@ class CollectBankAccountViewModelTest {
 
             // Then
             cancelAndConsumeRemainingEvents()
-            verify(attachFinancialConnectionsSession, never()).forPaymentIntent(any(), any(), any())
+            verify(attachFinancialConnectionsSession, never()).forPaymentIntent(
+                any(),
+                any(),
+                any(),
+                any()
+            )
         }
     }
 
@@ -135,7 +141,12 @@ class CollectBankAccountViewModelTest {
 
             // Then
             cancelAndConsumeRemainingEvents()
-            verify(attachFinancialConnectionsSession, never()).forSetupIntent(any(), any(), any())
+            verify(attachFinancialConnectionsSession, never()).forSetupIntent(
+                any(),
+                any(),
+                any(),
+                any()
+            )
         }
     }
 
@@ -255,8 +266,9 @@ class CollectBankAccountViewModelTest {
             onBlocking {
                 forPaymentIntent(
                     publishableKey = publishableKey,
+                    linkedAccountSessionId = linkedAccountSessionId,
                     clientSecret = clientSecret,
-                    linkedAccountSessionId = linkedAccountSessionId
+                    stripeAccountId = stripeAccountId
                 )
             }.doReturn(result)
         }
@@ -269,8 +281,9 @@ class CollectBankAccountViewModelTest {
             onBlocking {
                 forSetupIntent(
                     publishableKey = publishableKey,
+                    linkedAccountSessionId = linkedAccountSessionId,
                     clientSecret = clientSecret,
-                    linkedAccountSessionId = linkedAccountSessionId
+                    stripeAccountId = stripeAccountId
                 )
             }.doReturn(result)
         }
@@ -323,7 +336,7 @@ class CollectBankAccountViewModelTest {
     ): ForPaymentIntent {
         return ForPaymentIntent(
             publishableKey = publishableKey,
-            stripeAccountId = null,
+            stripeAccountId = stripeAccountId,
             clientSecret = clientSecret,
             configuration = CollectBankAccountConfiguration.USBankAccount(
                 name,
@@ -338,7 +351,7 @@ class CollectBankAccountViewModelTest {
     ): ForSetupIntent {
         return ForSetupIntent(
             publishableKey = publishableKey,
-            stripeAccountId = null,
+            stripeAccountId = stripeAccountId,
             clientSecret = clientSecret,
             configuration = CollectBankAccountConfiguration.USBankAccount(
                 name,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/CollectBankAccountForPaymentSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/CollectBankAccountForPaymentSheetLauncher.kt
@@ -14,12 +14,14 @@ internal class CollectBankAccountForPaymentSheetLauncher(
 
     override fun presentWithPaymentIntent(
         publishableKey: String,
+        stripeAccountId: String?,
         clientSecret: String,
         configuration: CollectBankAccountConfiguration
     ) {
         hostActivityLauncher.launch(
             CollectBankAccountContract.Args.ForPaymentIntent(
                 publishableKey = publishableKey,
+                stripeAccountId = stripeAccountId,
                 clientSecret = clientSecret,
                 configuration = configuration,
                 attachToIntent = false
@@ -29,12 +31,14 @@ internal class CollectBankAccountForPaymentSheetLauncher(
 
     override fun presentWithSetupIntent(
         publishableKey: String,
+        stripeAccountId: String?,
         clientSecret: String,
         configuration: CollectBankAccountConfiguration
     ) {
         hostActivityLauncher.launch(
             CollectBankAccountContract.Args.ForSetupIntent(
                 publishableKey = publishableKey,
+                stripeAccountId = stripeAccountId,
                 clientSecret = clientSecret,
                 configuration = configuration,
                 attachToIntent = false

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -298,9 +298,10 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         when (clientSecret) {
             is PaymentIntentClientSecret -> {
                 collectBankAccountLauncher?.presentWithPaymentIntent(
-                    lazyPaymentConfig.get().publishableKey,
-                    clientSecret.value,
-                    CollectBankAccountConfiguration.USBankAccount(
+                    publishableKey = lazyPaymentConfig.get().publishableKey,
+                    stripeAccountId = lazyPaymentConfig.get().stripeAccountId,
+                    clientSecret = clientSecret.value,
+                    configuration = CollectBankAccountConfiguration.USBankAccount(
                         name.value,
                         email.value
                     )
@@ -308,9 +309,10 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
             }
             is SetupIntentClientSecret -> {
                 collectBankAccountLauncher?.presentWithSetupIntent(
-                    lazyPaymentConfig.get().publishableKey,
-                    clientSecret.value,
-                    CollectBankAccountConfiguration.USBankAccount(
+                    publishableKey = lazyPaymentConfig.get().publishableKey,
+                    stripeAccountId = lazyPaymentConfig.get().stripeAccountId,
+                    clientSecret = clientSecret.value,
+                    configuration = CollectBankAccountConfiguration.USBankAccount(
                         name.value,
                         email.value
                     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/CollectBankAccountForPaymentSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/CollectBankAccountForPaymentSheetLauncherTest.kt
@@ -20,15 +20,16 @@ class CollectBankAccountForPaymentSheetLauncherTest {
     @Test
     fun `presentWithPaymentIntent - launches CollectBankAccountActivity with correct arguments`() {
         launcher.presentWithPaymentIntent(
-            PUBLISHABLE_KEY,
-            CLIENT_SECRET,
-            CONFIGURATION
+            publishableKey = PUBLISHABLE_KEY,
+            stripeAccountId = STRIPE_ACCOUNT_ID,
+            clientSecret = CLIENT_SECRET,
+            configuration = CONFIGURATION
         )
 
         verify(mockHostActivityLauncher).launch(
             CollectBankAccountContract.Args.ForPaymentIntent(
                 publishableKey = PUBLISHABLE_KEY,
-                stripeAccountId = stripeAccountId,
+                stripeAccountId = STRIPE_ACCOUNT_ID,
                 clientSecret = CLIENT_SECRET,
                 configuration = CONFIGURATION,
                 attachToIntent = false
@@ -39,15 +40,16 @@ class CollectBankAccountForPaymentSheetLauncherTest {
     @Test
     fun `presentWithSetupIntent - launches CollectBankAccountActivity with correct arguments`() {
         launcher.presentWithSetupIntent(
-            PUBLISHABLE_KEY,
-            CLIENT_SECRET,
-            CONFIGURATION
+            publishableKey = PUBLISHABLE_KEY,
+            stripeAccountId = STRIPE_ACCOUNT_ID,
+            clientSecret = CLIENT_SECRET,
+            configuration = CONFIGURATION
         )
 
         verify(mockHostActivityLauncher).launch(
             CollectBankAccountContract.Args.ForSetupIntent(
                 publishableKey = PUBLISHABLE_KEY,
-                stripeAccountId = stripeAccountId,
+                stripeAccountId = STRIPE_ACCOUNT_ID,
                 clientSecret = CLIENT_SECRET,
                 configuration = CONFIGURATION,
                 attachToIntent = false
@@ -58,6 +60,7 @@ class CollectBankAccountForPaymentSheetLauncherTest {
     companion object {
         private const val CLIENT_SECRET = "client_secret"
         private const val PUBLISHABLE_KEY = "publishableKey"
+        private const val STRIPE_ACCOUNT_ID = "stripe_account_id"
         private val CONFIGURATION = CollectBankAccountConfiguration.USBankAccount(
             name = "Carlos",
             email = null

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/CollectBankAccountForPaymentSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/CollectBankAccountForPaymentSheetLauncherTest.kt
@@ -28,6 +28,7 @@ class CollectBankAccountForPaymentSheetLauncherTest {
         verify(mockHostActivityLauncher).launch(
             CollectBankAccountContract.Args.ForPaymentIntent(
                 publishableKey = PUBLISHABLE_KEY,
+                stripeAccountId = stripeAccountId,
                 clientSecret = CLIENT_SECRET,
                 configuration = CONFIGURATION,
                 attachToIntent = false
@@ -46,6 +47,7 @@ class CollectBankAccountForPaymentSheetLauncherTest {
         verify(mockHostActivityLauncher).launch(
             CollectBankAccountContract.Args.ForSetupIntent(
                 publishableKey = PUBLISHABLE_KEY,
+                stripeAccountId = stripeAccountId,
                 clientSecret = CLIENT_SECRET,
                 configuration = CONFIGURATION,
                 attachToIntent = false

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet.paymentdatacollection.ach
 
-import android.app.Application
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.test.core.app.ApplicationProvider
@@ -21,7 +20,6 @@ import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
 import com.stripe.android.ui.core.Amount
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.stateIn
@@ -42,11 +40,6 @@ import kotlin.test.Test
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 class USBankAccountFormViewModelTest {
-    private val lpmRepository =
-        LpmRepository(LpmRepository.LpmRepositoryArguments(ApplicationProvider.getApplicationContext<Application>().resources)).apply {
-            this.forceUpdate(listOf(PaymentMethod.Type.Card.code, PaymentMethod.Type.USBankAccount.code), null)
-        }
-    private val usBankAccount = lpmRepository.fromCode(PaymentMethod.Type.USBankAccount.code)!!
 
     private val defaultArgs = USBankAccountFormViewModel.Args(
         formArgs = FormFragmentArguments(
@@ -128,7 +121,7 @@ class USBankAccountFormViewModelTest {
 
             viewModel.handlePrimaryButtonClick(currentScreenState as USBankAccountFormScreenState.NameAndEmailCollection)
 
-            verify(collectBankAccountLauncher).presentWithPaymentIntent(any(), any(), any())
+            verify(collectBankAccountLauncher).presentWithPaymentIntent(any(), any(), any(), any())
         }
 
     @Test
@@ -222,7 +215,7 @@ class USBankAccountFormViewModelTest {
 
             viewModel.handlePrimaryButtonClick(currentScreenState as USBankAccountFormScreenState.NameAndEmailCollection)
 
-            verify(collectBankAccountLauncher).presentWithPaymentIntent(any(), any(), any())
+            verify(collectBankAccountLauncher).presentWithPaymentIntent(any(), any(), any(), any())
         }
 
     @Test
@@ -299,7 +292,10 @@ class USBankAccountFormViewModelTest {
     private fun createViewModel(
         args: USBankAccountFormViewModel.Args = defaultArgs
     ): USBankAccountFormViewModel {
-        val paymentConfiguration = PaymentConfiguration(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
+        val paymentConfiguration = PaymentConfiguration(
+            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+            STRIPE_ACCOUNT_ID
+        )
         return USBankAccountFormViewModel(
             args = args,
             application = ApplicationProvider.getApplicationContext(),
@@ -366,5 +362,6 @@ class USBankAccountFormViewModelTest {
         const val MERCHANT_NAME = "merchantName"
         const val CUSTOMER_NAME = "Jenny Rose"
         const val CUSTOMER_EMAIL = "email@email.com"
+        const val STRIPE_ACCOUNT_ID = "stripe_account_id"
     }
 }


### PR DESCRIPTION
# Summary

`CollectBankAccountLauncher` was not accepting `stripeAccountId`, required when making API calls on merchants using Connect.

This PR updates the method signature to accept an optional  `stripeAccountId` String.

# Motivation

https://jira.corp.stripe.com/browse/BANKCON-4898

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [X] Modified tests
- [ ] Manually verified

# Changelog
    - [Fixed] CollectBankAccountLauncher now accepts stripeAccountId for Connect merchants.
