### PR TITLE
BANKCON-4898 Adds stripeAccountId to FinancialConnectionsLauncher.Configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,16 @@
 * [FIXED][5399](https://github.com/stripe/stripe-android/pull/5399) Bank Account Payments that pass 
   stripeAccountId for connected accounts will now succeed.
 
-### CollectBankAccountLauncher
-* [FIXED][5399](https://github.com/stripe/stripe-android/pull/5399) CollectBankAccountLauncher now 
-  accepts stripeAccountId for Connect merchants.
+### Payments
 
+* [FIXED][5399](https://github.com/stripe/stripe-android/pull/5399) `CollectBankAccountLauncher` now 
+  accepts `stripeAccountId` for Connect merchants.
+
+### Financial Connections
+
+* [FIXED][5408](https://github.com/stripe/stripe-android/pull/5408) `FinancialConnectionsSheet#Configuration`
+  now accepts `stripeAccountId` for Connect merchants.
+* 
 ## 20.8.0 - 2022-08-01
 
 This release contains several bug fixes for Payments, PaymentSheet, deprecates `createForCompose`, 

--- a/example/src/main/java/com/stripe/example/activity/ConnectUSBankAccountActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/ConnectUSBankAccountActivity.kt
@@ -75,6 +75,7 @@ class ConnectUSBankAccountActivity : StripeIntentActivity() {
                         .postValue("Collecting bank account information for payment")
                     launcher.presentWithPaymentIntent(
                         publishableKey = settings.publishableKey,
+                        stripeAccountId = settings.stripeAccountId,
                         clientSecret = it.getString("secret"),
                         configuration = CollectBankAccountConfiguration.USBankAccount(
                             name = viewBinding.name.text?.toString() ?: "",

--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -21,15 +21,18 @@ public final class com/stripe/android/financialconnections/FinancialConnectionsS
 public final class com/stripe/android/financialconnections/FinancialConnectionsSheet$Configuration : android/os/Parcelable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$Configuration;
-	public static synthetic fun copy$default (Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$Configuration;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$Configuration;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$Configuration;
+	public static synthetic fun copy$default (Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$Configuration;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$Configuration;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFinancialConnectionsSessionClientSecret ()Ljava/lang/String;
 	public final fun getPublishableKey ()Ljava/lang/String;
+	public final fun getStripeAccountId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
@@ -245,6 +248,14 @@ public final class com/stripe/android/financialconnections/di/FinancialConnectio
 	public synthetic fun get ()Ljava/lang/Object;
 	public fun get ()Ljava/lang/String;
 	public static fun providesPublishableKey (Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$Configuration;)Ljava/lang/String;
+}
+
+public final class com/stripe/android/financialconnections/di/FinancialConnectionsSheetConfigurationModule_ProvidesStripeAccountIdFactory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/di/FinancialConnectionsSheetConfigurationModule_ProvidesStripeAccountIdFactory;
+	public synthetic fun get ()Ljava/lang/Object;
+	public fun get ()Ljava/lang/String;
+	public static fun providesStripeAccountId (Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$Configuration;)Ljava/lang/String;
 }
 
 public final class com/stripe/android/financialconnections/di/FinancialConnectionsSheetModule_ProvideAnalyticsRequestFactory$financial_connections_releaseFactory : dagger/internal/Factory {
@@ -1149,10 +1160,10 @@ public final class com/stripe/android/financialconnections/model/PaymentAccount$
 }
 
 public final class com/stripe/android/financialconnections/repository/FinancialConnectionsApiRepository_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/repository/FinancialConnectionsApiRepository_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/repository/FinancialConnectionsApiRepository_Factory;
 	public fun get ()Lcom/stripe/android/financialconnections/repository/FinancialConnectionsApiRepository;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Ljava/lang/String;Lcom/stripe/android/core/networking/StripeNetworkClient;Lcom/stripe/android/core/networking/ApiRequest$Factory;)Lcom/stripe/android/financialconnections/repository/FinancialConnectionsApiRepository;
+	public static fun newInstance (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/core/networking/StripeNetworkClient;Lcom/stripe/android/core/networking/ApiRequest$Factory;)Lcom/stripe/android/financialconnections/repository/FinancialConnectionsApiRepository;
 }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheet.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheet.kt
@@ -23,11 +23,13 @@ class FinancialConnectionsSheet internal constructor(
      *
      * @param financialConnectionsSessionClientSecret the session client secret
      * @param publishableKey the Stripe publishable key
+     * @param stripeAccountId (optional) connected account ID
      */
     @Parcelize
     data class Configuration(
         val financialConnectionsSessionClientSecret: String,
-        val publishableKey: String
+        val publishableKey: String,
+        val stripeAccountId: String? = null
     ) : Parcelable
 
     /**

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetConfigurationModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetConfigurationModule.kt
@@ -2,6 +2,7 @@ package com.stripe.android.financialconnections.di
 
 import android.app.Application
 import com.stripe.android.core.injection.ENABLE_LOGGING
+import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.financialconnections.BuildConfig
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityArgs
@@ -25,6 +26,13 @@ internal object FinancialConnectionsSheetConfigurationModule {
     fun providesPublishableKey(
         configuration: FinancialConnectionsSheet.Configuration
     ): String = configuration.publishableKey
+
+    @Provides
+    @Named(STRIPE_ACCOUNT_ID)
+    @Singleton
+    fun providesStripeAccountId(
+        configuration: FinancialConnectionsSheet.Configuration
+    ): String? = configuration.stripeAccountId
 
     @Provides
     @Named(ENABLE_LOGGING)

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsApiRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsApiRepository.kt
@@ -7,6 +7,7 @@ import com.stripe.android.core.exception.AuthenticationException
 import com.stripe.android.core.exception.InvalidRequestException
 import com.stripe.android.core.exception.PermissionException
 import com.stripe.android.core.exception.RateLimitException
+import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.model.parsers.StripeErrorJsonParser
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.HTTP_TOO_MANY_REQUESTS
@@ -27,6 +28,7 @@ import javax.inject.Named
 
 internal class FinancialConnectionsApiRepository @Inject constructor(
     @Named(PUBLISHABLE_KEY) publishableKey: String,
+    @Named(STRIPE_ACCOUNT_ID) stripeAccountId: String?,
     private val stripeNetworkClient: StripeNetworkClient,
     private val apiRequestFactory: ApiRequest.Factory
 ) : FinancialConnectionsRepository {
@@ -40,7 +42,8 @@ internal class FinancialConnectionsApiRepository @Inject constructor(
     }
 
     private val options = ApiRequest.Options(
-        apiKey = publishableKey
+        apiKey = publishableKey,
+        stripeAccount = stripeAccountId
     )
 
     override suspend fun getFinancialConnectionsAccounts(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsApiRepositoryTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsApiRepositoryTest.kt
@@ -25,7 +25,8 @@ class FinancialConnectionsApiRepositoryTest {
     private val financialConnectionsApiRepository = FinancialConnectionsApiRepository(
         publishableKey = ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
         stripeNetworkClient = mockStripeNetworkClient,
-        apiRequestFactory = apiRequestFactory
+        apiRequestFactory = apiRequestFactory,
+        stripeAccountId = null
     )
 
     @Test

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/domain/CreateFinancialConnectionsSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/domain/CreateFinancialConnectionsSession.kt
@@ -9,7 +9,7 @@ import com.stripe.android.networking.StripeRepository
 import javax.inject.Inject
 
 internal class CreateFinancialConnectionsSession @Inject constructor(
-    private val stripeRepository: StripeRepository,
+    private val stripeRepository: StripeRepository
 ) {
 
     /**

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountActivity.kt
@@ -55,8 +55,9 @@ internal class CollectBankAccountActivity : AppCompatActivity() {
 
     private fun OpenConnectionsFlow.launch() {
         financialConnectionsPaymentsProxy.present(
-            financialConnectionsSessionSecret,
-            publishableKey
+            financialConnectionsSessionClientSecret = financialConnectionsSessionSecret,
+            publishableKey = publishableKey,
+            stripeAccountId = stripeAccountId
         )
     }
 

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewEffect.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewEffect.kt
@@ -15,7 +15,8 @@ internal sealed class CollectBankAccountViewEffect {
      */
     data class OpenConnectionsFlow(
         val publishableKey: String,
-        val financialConnectionsSessionSecret: String
+        val financialConnectionsSessionSecret: String,
+        val stripeAccountId: String?
     ) : CollectBankAccountViewEffect()
 
     /**

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel.kt
@@ -80,7 +80,8 @@ internal class CollectBankAccountViewModel @Inject constructor(
                     _viewEffect.emit(
                         OpenConnectionsFlow(
                             financialConnectionsSessionSecret = financialConnectionsSessionSecret,
-                            publishableKey = args.publishableKey
+                            publishableKey = args.publishableKey,
+                            stripeAccountId = args.stripeAccountId
                         )
                     )
                 }

--- a/payments-core/src/main/java/com/stripe/android/payments/financialconnections/FinancialConnectionsPaymentsProxy.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/financialconnections/FinancialConnectionsPaymentsProxy.kt
@@ -13,7 +13,8 @@ import com.stripe.android.financialconnections.FinancialConnectionsSheetResult
 internal interface FinancialConnectionsPaymentsProxy {
     fun present(
         financialConnectionsSessionClientSecret: String,
-        publishableKey: String
+        publishableKey: String,
+        stripeAccountId: String?
     )
 
     companion object {
@@ -64,19 +65,25 @@ internal class DefaultFinancialConnectionsPaymentsProxy(
 ) : FinancialConnectionsPaymentsProxy {
     override fun present(
         financialConnectionsSessionClientSecret: String,
-        publishableKey: String
+        publishableKey: String,
+        stripeAccountId: String?
     ) {
         financialConnectionsSheet.present(
             FinancialConnectionsSheet.Configuration(
                 financialConnectionsSessionClientSecret,
-                publishableKey
+                publishableKey,
+                stripeAccountId
             )
         )
     }
 }
 
 internal class UnsupportedFinancialConnectionsPaymentsProxy : FinancialConnectionsPaymentsProxy {
-    override fun present(financialConnectionsSessionClientSecret: String, publishableKey: String) {
+    override fun present(
+        financialConnectionsSessionClientSecret: String,
+        publishableKey: String,
+        stripeAccountId: String?
+    ) {
         if (BuildConfig.DEBUG) {
             throw IllegalStateException(
                 "Missing financial-connections dependency, please add it to your apps build.gradle"

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
@@ -73,8 +73,9 @@ class CollectBankAccountViewModelTest {
             // Then
             assertThat(awaitItem()).isEqualTo(
                 OpenConnectionsFlow(
-                    publishableKey,
-                    financialConnectionsSession.clientSecret!!
+                    publishableKey = publishableKey,
+                    financialConnectionsSessionSecret = financialConnectionsSession.clientSecret!!,
+                    stripeAccountId = null
                 )
             )
         }
@@ -93,8 +94,9 @@ class CollectBankAccountViewModelTest {
             // Then
             assertThat(awaitItem()).isEqualTo(
                 OpenConnectionsFlow(
-                    publishableKey,
-                    financialConnectionsSession.clientSecret!!
+                    publishableKey = publishableKey,
+                    financialConnectionsSessionSecret = financialConnectionsSession.clientSecret!!,
+                    stripeAccountId = null
                 )
             )
         }

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModelTest.kt
@@ -75,7 +75,7 @@ class CollectBankAccountViewModelTest {
                 OpenConnectionsFlow(
                     publishableKey = publishableKey,
                     financialConnectionsSessionSecret = financialConnectionsSession.clientSecret!!,
-                    stripeAccountId = null
+                    stripeAccountId = stripeAccountId
                 )
             )
         }
@@ -96,7 +96,7 @@ class CollectBankAccountViewModelTest {
                 OpenConnectionsFlow(
                     publishableKey = publishableKey,
                     financialConnectionsSessionSecret = financialConnectionsSession.clientSecret!!,
-                    stripeAccountId = null
+                    stripeAccountId = stripeAccountId
                 )
             )
         }

--- a/payments-core/src/test/java/com/stripe/android/payments/financialconnections/FinancialConnectionsPaymentsProxyTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/financialconnections/FinancialConnectionsPaymentsProxyTest.kt
@@ -21,7 +21,11 @@ class FinancialConnectionsPaymentsProxyTest {
     private val mockActivity: AppCompatActivity = mock()
 
     private class FakeProxy : FinancialConnectionsPaymentsProxy {
-        override fun present(financialConnectionsSessionClientSecret: String, publishableKey: String) {
+        override fun present(
+            financialConnectionsSessionClientSecret: String,
+            publishableKey: String,
+            stripeAccountId: String?
+        ) {
             // noop
         }
     }
@@ -73,14 +77,22 @@ class FinancialConnectionsPaymentsProxyTest {
                 fragment = mockFragment,
                 onComplete = {},
                 isFinancialConnectionsAvailable = mockIsFinancialConnectionsAvailable
-            ).present("", "")
+            ).present(
+                financialConnectionsSessionClientSecret = "",
+                publishableKey = "",
+                stripeAccountId = null
+            )
         }
         assertFailsWith<IllegalStateException> {
             FinancialConnectionsPaymentsProxy.create(
                 activity = mockActivity,
                 onComplete = {},
                 isFinancialConnectionsAvailable = mockIsFinancialConnectionsAvailable
-            ).present("", "")
+            ).present(
+                financialConnectionsSessionClientSecret = "",
+                publishableKey = "",
+                stripeAccountId = null
+            )
         }
     }
 


### PR DESCRIPTION
# Summary
Same that happened with `CollectBankAccountLauncher`: Financial Connections was not accepting an optional `stripeAccountId` on its configuration object, required for Connected accounts. This PR adds it to the Configuration object and includes it as a header on internal API calls.

The best way to test this flow is to use a merchant with a connected account and pass the accountId as a header when creating the PI / SI on the backend. Ensure the client app also passes the `stripeAccountId` param matching the one used on the backend (you can define `STRIPE_ACCOUNT_ID=acct_...` in your `gradle.properties`).

Then, on the `example` app go to `Connect US bank account`, Before this PR, an ACHv2 payment would fail (Not a valid financialConnectionsSession). Now it should work.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [X] Manually verified: 

# Changelog

### Financial Connections

* [FIXED][5408](https://github.com/stripe/stripe-android/pull/5408) `FinancialConnectionsSheet#Configuration`
  now accepts `stripeAccountId` for Connect merchants.
