### PR TITLE
Add shipping details to payment sheet

### DIFF
--- a/link/api/link.api
+++ b/link/api/link.api
@@ -18,8 +18,8 @@ public final class com/stripe/android/link/LinkActivityContract$Args : com/strip
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/link/LinkActivityContract$Args$Companion;
-	public final fun copy (Lcom/stripe/android/model/StripeIntent;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethodCreateParams;Lcom/stripe/android/link/LinkActivityContract$Args$InjectionParams;)Lcom/stripe/android/link/LinkActivityContract$Args;
-	public static synthetic fun copy$default (Lcom/stripe/android/link/LinkActivityContract$Args;Lcom/stripe/android/model/StripeIntent;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/PaymentMethodCreateParams;Lcom/stripe/android/link/LinkActivityContract$Args$InjectionParams;ILjava/lang/Object;)Lcom/stripe/android/link/LinkActivityContract$Args;
+	public final fun copy (Lcom/stripe/android/model/StripeIntent;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethodCreateParams;Lcom/stripe/android/link/LinkActivityContract$Args$InjectionParams;)Lcom/stripe/android/link/LinkActivityContract$Args;
+	public static synthetic fun copy$default (Lcom/stripe/android/link/LinkActivityContract$Args;Lcom/stripe/android/model/StripeIntent;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethodCreateParams;Lcom/stripe/android/link/LinkActivityContract$Args$InjectionParams;ILjava/lang/Object;)Lcom/stripe/android/link/LinkActivityContract$Args;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -184,8 +184,8 @@ public final class com/stripe/android/link/LinkPaymentLauncher$Companion {
 public final class com/stripe/android/link/LinkPaymentLauncher_Factory {
 	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/link/LinkPaymentLauncher_Factory;
-	public fun get (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/link/LinkPaymentLauncher;
-	public static fun newInstance (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Landroid/content/Context;Ljava/util/Set;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ZLkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lcom/stripe/android/networking/PaymentAnalyticsRequestFactory;Lcom/stripe/android/core/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/StripeRepository;Lcom/stripe/android/ui/core/forms/resources/ResourceRepository;)Lcom/stripe/android/link/LinkPaymentLauncher;
+	public fun get (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lcom/stripe/android/link/LinkPaymentLauncher;
+	public static fun newInstance (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Landroid/content/Context;Ljava/util/Set;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ZLkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lcom/stripe/android/networking/PaymentAnalyticsRequestFactory;Lcom/stripe/android/core/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/StripeRepository;Lcom/stripe/android/ui/core/forms/resources/ResourceRepository;)Lcom/stripe/android/link/LinkPaymentLauncher;
 }
 
 public final class com/stripe/android/link/account/CookieStore_Factory : dagger/internal/Factory {
@@ -252,6 +252,14 @@ public final class com/stripe/android/link/injection/LinkActivityContractArgsMod
 	public static fun provideCustomerPhone (Lcom/stripe/android/link/LinkActivityContract$Args;)Ljava/lang/String;
 }
 
+public final class com/stripe/android/link/injection/LinkActivityContractArgsModule_Companion_ProvideInitialValuesMapFactory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/link/injection/LinkActivityContractArgsModule_Companion_ProvideInitialValuesMapFactory;
+	public synthetic fun get ()Ljava/lang/Object;
+	public fun get ()Ljava/util/Map;
+	public static fun provideInitialValuesMap (Lcom/stripe/android/link/LinkActivityContract$Args;)Ljava/util/Map;
+}
+
 public final class com/stripe/android/link/injection/LinkActivityContractArgsModule_Companion_ProvideMerchantNameFactory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;)V
 	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/link/injection/LinkActivityContractArgsModule_Companion_ProvideMerchantNameFactory;
@@ -270,7 +278,7 @@ public final class com/stripe/android/link/injection/LinkActivityContractArgsMod
 
 public final class com/stripe/android/link/injection/LinkPaymentLauncherFactory_Impl : com/stripe/android/link/injection/LinkPaymentLauncherFactory {
 	public static fun create (Lcom/stripe/android/link/LinkPaymentLauncher_Factory;)Ljavax/inject/Provider;
-	public fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/link/LinkPaymentLauncher;
+	public fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lcom/stripe/android/link/LinkPaymentLauncher;
 }
 
 public final class com/stripe/android/link/injection/NamedConstantsKt {

--- a/link/api/link.api
+++ b/link/api/link.api
@@ -252,12 +252,12 @@ public final class com/stripe/android/link/injection/LinkActivityContractArgsMod
 	public static fun provideCustomerPhone (Lcom/stripe/android/link/LinkActivityContract$Args;)Ljava/lang/String;
 }
 
-public final class com/stripe/android/link/injection/LinkActivityContractArgsModule_Companion_ProvideInitialValuesMapFactory : dagger/internal/Factory {
+public final class com/stripe/android/link/injection/LinkActivityContractArgsModule_Companion_ProvideInitialFormValuesMapFactory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/link/injection/LinkActivityContractArgsModule_Companion_ProvideInitialValuesMapFactory;
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/link/injection/LinkActivityContractArgsModule_Companion_ProvideInitialFormValuesMapFactory;
 	public synthetic fun get ()Ljava/lang/Object;
 	public fun get ()Ljava/util/Map;
-	public static fun provideInitialValuesMap (Lcom/stripe/android/link/LinkActivityContract$Args;)Ljava/util/Map;
+	public static fun provideInitialFormValuesMap (Lcom/stripe/android/link/LinkActivityContract$Args;)Ljava/util/Map;
 }
 
 public final class com/stripe/android/link/injection/LinkActivityContractArgsModule_Companion_ProvideMerchantNameFactory : dagger/internal/Factory {

--- a/link/src/main/java/com/stripe/android/link/LinkActivityContract.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivityContract.kt
@@ -31,6 +31,7 @@ class LinkActivityContract :
      * @param merchantName The customer-facing business name.
      * @param customerEmail Email of the customer, used to pre-fill the form.
      * @param customerPhone Phone number of the customer, used to pre-fill the form.
+     * @param initialFormValuesMap The initial form values for [FormController]
      * @param prefilledCardParams The payment method information prefilled by the user.
      * @param injectionParams Parameters needed to perform dependency injection.
      *                        If null, a new dependency graph will be created.
@@ -41,7 +42,7 @@ class LinkActivityContract :
         internal val merchantName: String,
         internal val customerEmail: String? = null,
         internal val customerPhone: String? = null,
-        internal val initialValueMap: Map<IdentifierSpec, String?>? = null,
+        internal val initialFormValuesMap: Map<IdentifierSpec, String?>? = null,
         internal val prefilledCardParams: PaymentMethodCreateParams? = null,
         internal val injectionParams: InjectionParams? = null
     ) : ActivityStarter.Args {

--- a/link/src/main/java/com/stripe/android/link/LinkActivityContract.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivityContract.kt
@@ -9,6 +9,7 @@ import androidx.core.os.bundleOf
 import com.stripe.android.core.injection.InjectorKey
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.view.ActivityStarter
 import kotlinx.parcelize.Parcelize
 
@@ -40,6 +41,7 @@ class LinkActivityContract :
         internal val merchantName: String,
         internal val customerEmail: String? = null,
         internal val customerPhone: String? = null,
+        internal val initialValueMap: Map<IdentifierSpec, String?>? = null,
         internal val prefilledCardParams: PaymentMethodCreateParams? = null,
         internal val injectionParams: InjectionParams? = null
     ) : ActivityStarter.Args {

--- a/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
@@ -20,7 +20,7 @@ import com.stripe.android.link.injection.DaggerLinkPaymentLauncherComponent
 import com.stripe.android.link.injection.LinkComponent
 import com.stripe.android.link.injection.LinkPaymentLauncherComponent
 import com.stripe.android.link.injection.MERCHANT_NAME
-import com.stripe.android.link.injection.INITIAL_VALUES_MAP
+import com.stripe.android.link.injection.INITIAL_FORM_VALUES_MAP
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.cardedit.CardEditViewModel
 import com.stripe.android.link.ui.inline.InlineSignupViewModel
@@ -56,7 +56,7 @@ class LinkPaymentLauncher @AssistedInject internal constructor(
     @Assisted(MERCHANT_NAME) private val merchantName: String,
     @Assisted(CUSTOMER_EMAIL) private val customerEmail: String?,
     @Assisted(CUSTOMER_PHONE) private val customerPhone: String?,
-    @Assisted(INITIAL_VALUES_MAP) private val initialValuesMap: Map<IdentifierSpec, String?>?,
+    @Assisted(INITIAL_FORM_VALUES_MAP) private val initialFormValuesMap: Map<IdentifierSpec, String?>?,
     context: Context,
     @Named(PRODUCT_USAGE) private val productUsage: Set<String>,
     @Named(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String,
@@ -74,7 +74,7 @@ class LinkPaymentLauncher @AssistedInject internal constructor(
         .merchantName(merchantName)
         .customerEmail(customerEmail)
         .customerPhone(customerPhone)
-        .initialValuesMap(initialValuesMap)
+        .initialFormValuesMap(initialFormValuesMap)
         .context(context)
         .ioContext(ioContext)
         .uiContext(uiContext)
@@ -153,7 +153,7 @@ class LinkPaymentLauncher @AssistedInject internal constructor(
             merchantName,
             customerEmail,
             customerPhone,
-            initialValuesMap,
+            initialFormValuesMap,
             prefilledNewCardParams,
             LinkActivityContract.Args.InjectionParams(
                 injectorKey,

--- a/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
@@ -20,6 +20,7 @@ import com.stripe.android.link.injection.DaggerLinkPaymentLauncherComponent
 import com.stripe.android.link.injection.LinkComponent
 import com.stripe.android.link.injection.LinkPaymentLauncherComponent
 import com.stripe.android.link.injection.MERCHANT_NAME
+import com.stripe.android.link.injection.INITIAL_VALUES_MAP
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.cardedit.CardEditViewModel
 import com.stripe.android.link.ui.inline.InlineSignupViewModel
@@ -35,6 +36,7 @@ import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.ui.core.address.AddressRepository
+import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.ui.core.forms.resources.ResourceRepository
 import com.stripe.android.ui.core.injection.NonFallbackInjectable
 import com.stripe.android.ui.core.injection.NonFallbackInjector
@@ -54,6 +56,7 @@ class LinkPaymentLauncher @AssistedInject internal constructor(
     @Assisted(MERCHANT_NAME) private val merchantName: String,
     @Assisted(CUSTOMER_EMAIL) private val customerEmail: String?,
     @Assisted(CUSTOMER_PHONE) private val customerPhone: String?,
+    @Assisted(INITIAL_VALUES_MAP) private val initialValuesMap: Map<IdentifierSpec, String?>?,
     context: Context,
     @Named(PRODUCT_USAGE) private val productUsage: Set<String>,
     @Named(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String,
@@ -71,6 +74,7 @@ class LinkPaymentLauncher @AssistedInject internal constructor(
         .merchantName(merchantName)
         .customerEmail(customerEmail)
         .customerPhone(customerPhone)
+        .initialValuesMap(initialValuesMap)
         .context(context)
         .ioContext(ioContext)
         .uiContext(uiContext)
@@ -149,6 +153,7 @@ class LinkPaymentLauncher @AssistedInject internal constructor(
             merchantName,
             customerEmail,
             customerPhone,
+            initialValuesMap,
             prefilledNewCardParams,
             LinkActivityContract.Args.InjectionParams(
                 injectorKey,

--- a/link/src/main/java/com/stripe/android/link/injection/LinkActivityContractArgsModule.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/LinkActivityContractArgsModule.kt
@@ -38,5 +38,10 @@ internal interface LinkActivityContractArgsModule {
         @Singleton
         @Named(CUSTOMER_PHONE)
         fun provideCustomerPhone(args: LinkActivityContract.Args) = args.customerPhone
+
+        @Provides
+        @Singleton
+        @Named(INITIAL_VALUES_MAP)
+        fun provideInitialValuesMap(args: LinkActivityContract.Args) = args.initialValueMap
     }
 }

--- a/link/src/main/java/com/stripe/android/link/injection/LinkActivityContractArgsModule.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/LinkActivityContractArgsModule.kt
@@ -41,7 +41,7 @@ internal interface LinkActivityContractArgsModule {
 
         @Provides
         @Singleton
-        @Named(INITIAL_VALUES_MAP)
-        fun provideInitialValuesMap(args: LinkActivityContract.Args) = args.initialValueMap
+        @Named(INITIAL_FORM_VALUES_MAP)
+        fun provideInitialFormValuesMap(args: LinkActivityContract.Args) = args.initialFormValuesMap
     }
 }

--- a/link/src/main/java/com/stripe/android/link/injection/LinkPaymentLauncherComponent.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/LinkPaymentLauncherComponent.kt
@@ -17,6 +17,7 @@ import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.ui.core.address.AddressRepository
+import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.ui.core.forms.resources.ResourceRepository
 import dagger.BindsInstance
 import dagger.Component
@@ -56,6 +57,9 @@ internal abstract class LinkPaymentLauncherComponent {
 
         @BindsInstance
         fun stripeIntent(@Named(LINK_INTENT) stripeIntent: StripeIntent): Builder
+
+        @BindsInstance
+        fun initialValuesMap(@Named(INITIAL_VALUES_MAP) initialValuesMap: Map<IdentifierSpec, String?>?): Builder
 
         @BindsInstance
         fun context(context: Context): Builder

--- a/link/src/main/java/com/stripe/android/link/injection/LinkPaymentLauncherComponent.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/LinkPaymentLauncherComponent.kt
@@ -59,7 +59,7 @@ internal abstract class LinkPaymentLauncherComponent {
         fun stripeIntent(@Named(LINK_INTENT) stripeIntent: StripeIntent): Builder
 
         @BindsInstance
-        fun initialValuesMap(@Named(INITIAL_VALUES_MAP) initialValuesMap: Map<IdentifierSpec, String?>?): Builder
+        fun initialFormValuesMap(@Named(INITIAL_FORM_VALUES_MAP) initialFormValuesMap: Map<IdentifierSpec, String?>?): Builder
 
         @BindsInstance
         fun context(context: Context): Builder

--- a/link/src/main/java/com/stripe/android/link/injection/LinkPaymentLauncherFactory.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/LinkPaymentLauncherFactory.kt
@@ -2,6 +2,7 @@ package com.stripe.android.link.injection
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.link.LinkPaymentLauncher
+import com.stripe.android.ui.core.elements.IdentifierSpec
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 
@@ -11,6 +12,7 @@ interface LinkPaymentLauncherFactory {
     fun create(
         @Assisted(MERCHANT_NAME) merchantName: String,
         @Assisted(CUSTOMER_EMAIL) customerEmail: String?,
-        @Assisted(CUSTOMER_PHONE) customerPhone: String?
+        @Assisted(CUSTOMER_PHONE) customerPhone: String?,
+        @Assisted(INITIAL_VALUES_MAP) initialValuesMap: Map<IdentifierSpec, String?>?
     ): LinkPaymentLauncher
 }

--- a/link/src/main/java/com/stripe/android/link/injection/LinkPaymentLauncherFactory.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/LinkPaymentLauncherFactory.kt
@@ -13,6 +13,6 @@ interface LinkPaymentLauncherFactory {
         @Assisted(MERCHANT_NAME) merchantName: String,
         @Assisted(CUSTOMER_EMAIL) customerEmail: String?,
         @Assisted(CUSTOMER_PHONE) customerPhone: String?,
-        @Assisted(INITIAL_VALUES_MAP) initialValuesMap: Map<IdentifierSpec, String?>?
+        @Assisted(INITIAL_FORM_VALUES_MAP) initialFormValuesMap: Map<IdentifierSpec, String?>?
     ): LinkPaymentLauncher
 }

--- a/link/src/main/java/com/stripe/android/link/injection/NamedConstants.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/NamedConstants.kt
@@ -24,7 +24,7 @@ const val CUSTOMER_PHONE = "customerPhone"
  * Identifies the shipping address passed in from the customer, used to pre-fill address forms.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-const val INITIAL_VALUES_MAP = "initialValuesMap"
+const val INITIAL_FORM_VALUES_MAP = "initialFormValuesMap"
 
 /**
  * Identifies the Stripe Intent being processed by Link.

--- a/link/src/main/java/com/stripe/android/link/injection/NamedConstants.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/NamedConstants.kt
@@ -21,6 +21,12 @@ const val CUSTOMER_EMAIL = "customerEmail"
 const val CUSTOMER_PHONE = "customerPhone"
 
 /**
+ * Identifies the shipping address passed in from the customer, used to pre-fill address forms.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+const val INITIAL_VALUES_MAP = "initialValuesMap"
+
+/**
  * Identifies the Stripe Intent being processed by Link.
  */
 internal const val LINK_INTENT = "linkIntent"

--- a/link/src/main/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModel.kt
@@ -72,16 +72,19 @@ internal class PaymentMethodViewModel @Inject constructor(
     val formController = MutableStateFlow<FormController?>(null)
 
     fun init(loadFromArgs: Boolean) {
+        val cardMap = args.prefilledCardParams?.toParamMap()
+            ?.takeIf { loadFromArgs }
+            ?.let { convertToFormValuesMap(it) }
+            ?: emptyMap()
+        val initialValuesMap = args.initialValueMap
+            ?: emptyMap()
+        val combinedMap = cardMap + initialValuesMap
         formController.value =
             formControllerProvider.get()
                 .formSpec(LayoutSpec(paymentMethod.formSpec))
                 .viewOnlyFields(emptySet())
                 .viewModelScope(viewModelScope)
-                .initialValues(
-                    args.prefilledCardParams?.toParamMap()?.takeIf { loadFromArgs }?.let {
-                        convertToFormValuesMap(it)
-                    } ?: emptyMap()
-                )
+                .initialValues(combinedMap)
                 .stripeIntent(args.stripeIntent)
                 .merchantName(args.merchantName)
                 .build().formController

--- a/link/src/main/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModel.kt
@@ -76,7 +76,7 @@ internal class PaymentMethodViewModel @Inject constructor(
             ?.takeIf { loadFromArgs }
             ?.let { convertToFormValuesMap(it) }
             ?: emptyMap()
-        val initialValuesMap = args.initialValueMap
+        val initialValuesMap = args.initialFormValuesMap
             ?: emptyMap()
         val combinedMap = cardMap + initialValuesMap
         formController.value =

--- a/link/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
@@ -27,6 +27,7 @@ class LinkActivityContractTest {
             "customer@email.com",
             "1234567890",
             null,
+            null,
             injectionParams
         )
 

--- a/link/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -38,6 +38,7 @@ class LinkActivityViewModelTest {
         CUSTOMER_EMAIL,
         CUSTOMER_PHONE,
         null,
+        null,
         LinkActivityContract.Args.InjectionParams(
             INJECTOR_KEY,
             setOf(PRODUCT_USAGE),

--- a/link/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
@@ -27,6 +27,7 @@ class LinkPaymentLauncherTest {
         MERCHANT_NAME,
         null,
         null,
+        null,
         context,
         setOf(PRODUCT_USAGE),
         { PUBLISHABLE_KEY },

--- a/link/src/test/java/com/stripe/android/link/ui/signup/SignUpViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/signup/SignUpViewModelTest.kt
@@ -52,6 +52,7 @@ class SignUpViewModelTest {
         CUSTOMER_EMAIL,
         CUSTOMER_PHONE,
         null,
+        null,
         LinkActivityContract.Args.InjectionParams(
             INJECTOR_KEY,
             setOf(PRODUCT_USAGE),

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -68,6 +68,35 @@ public final class com/stripe/android/ui/core/address/AddressRepository_Factory 
 	public static fun newInstance (Landroid/content/res/Resources;)Lcom/stripe/android/ui/core/address/AddressRepository;
 }
 
+public final class com/stripe/android/ui/core/address/ShippingAddress : android/os/Parcelable {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;Ljava/lang/Boolean;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lcom/stripe/android/model/Address;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;Ljava/lang/Boolean;)Lcom/stripe/android/ui/core/address/ShippingAddress;
+	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/address/ShippingAddress;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/Address;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/stripe/android/ui/core/address/ShippingAddress;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddress ()Lcom/stripe/android/model/Address;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPhone ()Ljava/lang/String;
+	public final fun getSameAsShippingEnabled ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/ui/core/address/ShippingAddress$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/address/ShippingAddress;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/address/ShippingAddress;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/ui/core/databinding/ActivityCardScanBinding : androidx/viewbinding/ViewBinding {
 	public final field fragmentContainer Landroidx/fragment/app/FragmentContainerView;
 	public static fun bind (Landroid/view/View;)Lcom/stripe/android/ui/core/databinding/ActivityCardScanBinding;
@@ -263,7 +292,7 @@ public abstract class com/stripe/android/ui/core/elements/CardNumberController :
 	public final fun onCardScanResult (Lcom/stripe/android/stripecardscan/cardscan/CardScanSheetResult;)V
 }
 
-public final class com/stripe/android/ui/core/elements/CheckboxElementUiKt {
+public final class com/stripe/android/ui/core/elements/CheckboxElementUIKt {
 }
 
 public final class com/stripe/android/ui/core/elements/ComposableSingletons$SectionUIKt {
@@ -441,10 +470,19 @@ public final class com/stripe/android/ui/core/elements/IdentifierSpec$Companion 
 	public final fun getOneLineAddress ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
 	public final fun getPhone ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
 	public final fun getPostalCode ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
+	public final fun getSameAsShipping ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
 	public final fun getSaveForFutureUse ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
 	public final fun getSortingCode ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
 	public final fun getState ()Lcom/stripe/android/ui/core/elements/IdentifierSpec;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/ui/core/elements/IdentifierSpec$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/elements/IdentifierSpec;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/elements/IdentifierSpec;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/ui/core/elements/KeyboardType : java/lang/Enum {
@@ -574,6 +612,25 @@ public final class com/stripe/android/ui/core/elements/PhoneNumberState$Companio
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/stripe/android/ui/core/elements/SameAsShippingController : com/stripe/android/ui/core/elements/InputController {
+	public static final field $stable I
+	public fun <init> (Z)V
+	public fun getError ()Lkotlinx/coroutines/flow/Flow;
+	public fun getFieldValue ()Lkotlinx/coroutines/flow/Flow;
+	public fun getFormFieldValue ()Lkotlinx/coroutines/flow/Flow;
+	public fun getLabel ()Lkotlinx/coroutines/flow/Flow;
+	public fun getRawFieldValue ()Lkotlinx/coroutines/flow/Flow;
+	public fun getShowOptionalLabel ()Z
+	public final fun getValue ()Lkotlinx/coroutines/flow/Flow;
+	public fun isComplete ()Lkotlinx/coroutines/flow/Flow;
+	public fun onRawValueChange (Ljava/lang/String;)V
+	public final fun onValueChange (Z)V
+}
+
+public final class com/stripe/android/ui/core/elements/SameAsShippingElementUIKt {
+	public static final field SAME_AS_SHIPPING_CHECKBOX_TEST_TAG Ljava/lang/String;
+}
+
 public final class com/stripe/android/ui/core/elements/SaveForFutureUseElementUIKt {
 	public static final field SAVE_FOR_FUTURE_CHECKBOX_TEST_TAG Ljava/lang/String;
 }
@@ -596,6 +653,10 @@ public final class com/stripe/android/ui/core/elements/SaveForFutureUseSpec$Comp
 }
 
 public final class com/stripe/android/ui/core/elements/SectionElementUIKt {
+}
+
+public final class com/stripe/android/ui/core/elements/SectionFieldElement$DefaultImpls {
+	public static fun getShouldRenderOutsideCard (Lcom/stripe/android/ui/core/elements/SectionFieldElement;)Z
 }
 
 public final class com/stripe/android/ui/core/elements/SectionUIKt {

--- a/payments-ui-core/res/values/totranslate.xml
+++ b/payments-ui-core/res/values/totranslate.xml
@@ -13,4 +13,5 @@
     <string name="stripe_paymentsheet_autocomplete_no_results_found">No results found</string>
     <string name="stripe_paymentsheet_address_element_shipping_address">Shipping Address</string>
     <string name="stripe_paymentsheet_address_element_primary_button">Save Address</string>
+    <string name="stripe_paymentsheet_address_element_same_as_shipping">Billing address is same as shipping</string>
 </resources>

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/address/ShippingAddress.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/address/ShippingAddress.kt
@@ -1,0 +1,13 @@
+package com.stripe.android.ui.core.address
+
+import android.os.Parcelable
+import com.stripe.android.model.Address
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class ShippingAddress(
+    val name: String?,
+    val phone: String?,
+    val address: Address?,
+    val sameAsShippingEnabled: Boolean?
+) : Parcelable

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingAddressElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingAddressElement.kt
@@ -20,16 +20,19 @@ class CardBillingAddressElement(
     countryDropdownFieldController: DropdownFieldController = DropdownFieldController(
         CountryConfig(countryCodes),
         rawValuesMap[IdentifierSpec.Country]
-    )
+    ),
+    sameAsShippingController: SameAsShippingController?
 ) : AddressElement(
     identifier,
     addressRepository,
     rawValuesMap,
     AddressType.Normal(),
     countryCodes,
-    countryDropdownFieldController
+    countryDropdownFieldController,
+    sameAsShippingController
 ) {
     // Save for future use puts this in the controller rather than element
+    // card and achv2 uses save for future use
     val hiddenIdentifiers: Flow<List<IdentifierSpec>> =
         countryDropdownFieldController.rawFieldValue.map { countryCode ->
             when (countryCode) {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingSpec.kt
@@ -15,15 +15,32 @@ data class CardBillingSpec(
     val allowedCountryCodes: Set<String> = supportedBillingCountries
 ) : FormItemSpec() {
     fun transform(
-        addressRepository: AddressRepository,
-        initialValues: Map<IdentifierSpec, String?>
-    ) = createSectionElement(
-        CardBillingAddressElement(
+        initialValues: Map<IdentifierSpec, String?>,
+        addressRepository: AddressRepository
+    ): SectionElement {
+        val sameAsShippingElement =
+            initialValues[IdentifierSpec.SameAsShipping]
+                ?.toBooleanStrictOrNull()
+                ?.let {
+                    SameAsShippingElement(
+                        identifier = IdentifierSpec.SameAsShipping,
+                        controller = SameAsShippingController(it)
+                    )
+                }
+        val addressElement = CardBillingAddressElement(
             IdentifierSpec.Generic("credit_billing"),
             addressRepository = addressRepository,
             countryCodes = allowedCountryCodes,
-            rawValuesMap = initialValues
-        ),
-        label = R.string.billing_details
-    )
+            rawValuesMap = initialValues,
+            sameAsShippingController = sameAsShippingElement?.controller
+        )
+
+        return createSectionElement(
+            listOfNotNull(
+                addressElement,
+                sameAsShippingElement
+            ),
+            R.string.billing_details
+        )
+    }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CheckboxElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CheckboxElementUI.kt
@@ -20,7 +20,7 @@ import com.stripe.android.ui.core.elements.menu.Checkbox
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-fun CheckboxElementUi(
+fun CheckboxElementUI(
     automationTestTag: String = "",
     isChecked: Boolean = false,
     label: String? = null,
@@ -37,7 +37,7 @@ fun CheckboxElementUi(
 
     Row(
         modifier = Modifier
-            .padding(vertical = 2.dp)
+            .requiredHeight(32.dp)
             .semantics {
                 testTag = automationTestTag
                 stateDescription = accessibilityDescription
@@ -48,8 +48,7 @@ fun CheckboxElementUi(
                 onValueChange = onValueChange,
                 enabled = isEnabled
             )
-            .fillMaxWidth()
-            .requiredHeight(48.dp),
+            .fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Checkbox(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/FormItemSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/FormItemSpec.kt
@@ -21,15 +21,27 @@ sealed class FormItemSpec {
     internal fun createSectionElement(
         sectionFieldElement: SectionFieldElement,
         label: Int? = null
-    ) =
-        SectionElement(
-            IdentifierSpec.Generic("${sectionFieldElement.identifier.v1}_section"),
-            sectionFieldElement,
+    ) = createSectionElement(
+        listOf(sectionFieldElement),
+        label
+    )
+
+    internal fun createSectionElement(
+        sectionFieldElements: List<SectionFieldElement>,
+        label: Int? = null
+    ): SectionElement {
+        val errorControllers = sectionFieldElements.map {
+            it.sectionFieldErrorController()
+        }
+        return SectionElement(
+            IdentifierSpec.Generic("${sectionFieldElements.first().identifier.v1}_section"),
+            sectionFieldElements,
             SectionController(
                 label,
-                listOf(sectionFieldElement.sectionFieldErrorController())
+                errorControllers
             )
         )
+    }
 }
 
 object FormItemSpecSerializer :

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IdentifierSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IdentifierSpec.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.ui.core.elements
 
+import android.os.Parcelable
 import androidx.annotation.RestrictTo
+import kotlinx.parcelize.Parcelize
 
 /**
  * This uniquely identifies a element in the form.  The vals here are for identifier
@@ -8,7 +10,8 @@ import androidx.annotation.RestrictTo
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @kotlinx.serialization.Serializable
-data class IdentifierSpec(val v1: String) {
+@Parcelize
+data class IdentifierSpec(val v1: String): Parcelable {
     constructor() : this("") {
     }
 
@@ -52,6 +55,7 @@ data class IdentifierSpec(val v1: String) {
         // Unique extracting functionality
         val SaveForFutureUse = IdentifierSpec("save_for_future_use")
         val OneLineAddress = IdentifierSpec("address")
+        val SameAsShipping = IdentifierSpec("same_as_shipping")
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
         fun get(value: String) = when (value) {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SameAsShippingController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SameAsShippingController.kt
@@ -1,0 +1,35 @@
+package com.stripe.android.ui.core.elements
+
+import com.stripe.android.ui.core.R
+import com.stripe.android.ui.core.forms.FormFieldEntry
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+
+class SameAsShippingController(
+    initialValue: Boolean
+) : InputController {
+    override val label: Flow<Int> =
+        MutableStateFlow(R.string.stripe_paymentsheet_address_element_same_as_shipping)
+    private val _value = MutableStateFlow(initialValue)
+    val value: Flow<Boolean> = _value
+    override val fieldValue: Flow<String> = value.map { it.toString() }
+    override val rawFieldValue: Flow<String?> = fieldValue
+
+    override val error: Flow<FieldError?> = flowOf(null)
+    override val showOptionalLabel: Boolean = false
+    override val isComplete: Flow<Boolean> = flowOf(true)
+    override val formFieldValue: Flow<FormFieldEntry> =
+        rawFieldValue.map { value ->
+            FormFieldEntry(value, true)
+        }
+
+    fun onValueChange(value: Boolean) {
+        _value.value = value
+    }
+
+    override fun onRawValueChange(rawValue: String) {
+        onValueChange(rawValue.toBooleanStrictOrNull() ?: true)
+    }
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SameAsShippingElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SameAsShippingElement.kt
@@ -1,0 +1,23 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.ui.core.forms.FormFieldEntry
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class SameAsShippingElement(
+    override val identifier: IdentifierSpec,
+    override val controller: SameAsShippingController,
+) : SectionSingleFieldElement(identifier) {
+    override val shouldRenderOutsideCard: Boolean
+        get() = true
+
+    override fun getFormFieldValueFlow(): Flow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
+        return controller.formFieldValue.map {
+            listOf(
+                identifier to it
+            )
+        }
+    }
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SameAsShippingElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SameAsShippingElementUI.kt
@@ -4,7 +4,7 @@ import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 
 const val SAME_AS_SHIPPING_CHECKBOX_TEST_TAG = "SAME_AS_SHIPPING_CHECKBOX_TEST_TAG"
 
@@ -15,12 +15,11 @@ fun SameAsShippingElementUI(
 ) {
     val checked by controller.value.collectAsState(false)
     val label by controller.label.collectAsState(null)
-    val resources = LocalContext.current.resources
 
     CheckboxElementUI(
         automationTestTag = SAME_AS_SHIPPING_CHECKBOX_TEST_TAG,
         isChecked = checked,
-        label = label?.let { resources.getString(it) },
+        label = label?.let { stringResource(it) },
         isEnabled = true,
         onValueChange = {
             controller.onValueChange(!checked)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SameAsShippingElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SameAsShippingElementUI.kt
@@ -6,24 +6,22 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
 
-const val SAVE_FOR_FUTURE_CHECKBOX_TEST_TAG = "SAVE_FOR_FUTURE_CHECKBOX_TEST_TAG"
+const val SAME_AS_SHIPPING_CHECKBOX_TEST_TAG = "SAME_AS_SHIPPING_CHECKBOX_TEST_TAG"
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-fun SaveForFutureUseElementUI(
-    enabled: Boolean,
-    element: SaveForFutureUseElement
+fun SameAsShippingElementUI(
+    controller: SameAsShippingController
 ) {
-    val controller = element.controller
-    val checked by controller.saveForFutureUse.collectAsState(true)
+    val checked by controller.value.collectAsState(false)
     val label by controller.label.collectAsState(null)
     val resources = LocalContext.current.resources
 
     CheckboxElementUI(
-        automationTestTag = SAVE_FOR_FUTURE_CHECKBOX_TEST_TAG,
+        automationTestTag = SAME_AS_SHIPPING_CHECKBOX_TEST_TAG,
         isChecked = checked,
-        label = label?.let { resources.getString(it, element.merchantName) },
-        isEnabled = enabled,
+        label = label?.let { resources.getString(it) },
+        isEnabled = true,
         onValueChange = {
             controller.onValueChange(!checked)
         }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionElementUI.kt
@@ -34,24 +34,45 @@ fun SectionElementUI(
             } ?: stringResource(it.errorMessage)
         }
 
-        Section(controller.label, sectionErrorString) {
-            element.fields.forEachIndexed { index, field ->
-                SectionFieldElementUI(
-                    enabled,
-                    field,
-                    hiddenIdentifiers = hiddenIdentifiers,
-                    lastTextFieldIdentifier = lastTextFieldIdentifier
-                )
-                if (index != element.fields.lastIndex) {
-                    Divider(
-                        color = MaterialTheme.paymentsColors.componentDivider,
-                        thickness = MaterialTheme.paymentsShapes.borderStrokeWidth.dp,
-                        modifier = Modifier.padding(
-                            horizontal = MaterialTheme.paymentsShapes.borderStrokeWidth.dp
-                        )
+        val elementsInsideCard = element.fields.filter {
+            !it.shouldRenderOutsideCard
+        }
+        val elementsOutsideCard = element.fields.filter {
+            it.shouldRenderOutsideCard
+        }
+
+        Section(
+            controller.label,
+            sectionErrorString,
+            contentOutsideCard = {
+                elementsOutsideCard.forEach { field ->
+                    SectionFieldElementUI(
+                        enabled,
+                        field,
+                        hiddenIdentifiers = hiddenIdentifiers,
+                        lastTextFieldIdentifier = lastTextFieldIdentifier
                     )
                 }
+            },
+            contentInCard = {
+                elementsInsideCard.forEachIndexed { index, field ->
+                    SectionFieldElementUI(
+                        enabled,
+                        field,
+                        hiddenIdentifiers = hiddenIdentifiers,
+                        lastTextFieldIdentifier = lastTextFieldIdentifier
+                    )
+                    if (index != element.fields.lastIndex) {
+                        Divider(
+                            color = MaterialTheme.paymentsColors.componentDivider,
+                            thickness = MaterialTheme.paymentsShapes.borderStrokeWidth.dp,
+                            modifier = Modifier.padding(
+                                horizontal = MaterialTheme.paymentsShapes.borderStrokeWidth.dp
+                            )
+                        )
+                    }
+                }
             }
-        }
+        )
     }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionFieldElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionFieldElement.kt
@@ -7,6 +7,8 @@ import kotlinx.coroutines.flow.Flow
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 sealed interface SectionFieldElement {
     val identifier: IdentifierSpec
+    val shouldRenderOutsideCard: Boolean
+        get() = false
 
     fun getFormFieldValueFlow(): Flow<List<Pair<IdentifierSpec, FormFieldEntry>>>
     fun sectionFieldErrorController(): SectionFieldErrorController

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionFieldElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionFieldElementUI.kt
@@ -1,8 +1,10 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.ImeAction
 
 @Composable
@@ -17,6 +19,11 @@ internal fun SectionFieldElementUI(
 ) {
     if (hiddenIdentifiers?.contains(field.identifier) == false) {
         when (val controller = field.sectionFieldErrorController()) {
+            is SameAsShippingController -> {
+                SameAsShippingElementUI(
+                    controller = controller
+                )
+            }
             is AddressTextFieldController -> {
                 AddressTextFieldUI(controller)
             }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionUI.kt
@@ -28,9 +28,12 @@ internal fun Section(
     contentOutsideCard: @Composable () -> Unit = {},
     contentInCard: @Composable () -> Unit
 ) {
-    Column(modifier = Modifier.padding(vertical = 8.dp)) {
+    Column(modifier = Modifier.padding(top = 8.dp)) {
         SectionTitle(title)
-        SectionCard(content = contentInCard)
+        SectionCard(
+            content = contentInCard,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
         if (error != null) {
             SectionError(error)
         }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/TransformSpecToElements.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/TransformSpecToElements.kt
@@ -3,6 +3,7 @@ package com.stripe.android.ui.core.forms
 import android.content.Context
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.address.AddressRepository
+import com.stripe.android.ui.core.address.ShippingAddress
 import com.stripe.android.ui.core.elements.AddressSpec
 import com.stripe.android.ui.core.elements.AffirmTextSpec
 import com.stripe.android.ui.core.elements.AfterpayClearpayTextSpec
@@ -79,8 +80,8 @@ class TransformSpecToElements(
                     addressResourceRepository.getRepository()
                 )
                 is CardBillingSpec -> it.transform(
-                    addressResourceRepository.getRepository(),
-                    initialValues
+                    initialValues,
+                    addressResourceRepository.getRepository()
                 )
                 is SepaMandateTextSpec -> it.transform(merchantName)
                 else -> EmptyFormElement()

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressElementTest.kt
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.shadows.ShadowLooper
 
+@ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 class AddressElementTest {
     private val addressRepository = AddressRepository(
@@ -46,7 +47,6 @@ class AddressElementTest {
         )
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `Verify controller error is updated as the fields change based on country`() {
         runBlocking {
@@ -54,7 +54,8 @@ class AddressElementTest {
             val addressElement = AddressElement(
                 IdentifierSpec.Generic("address"),
                 addressRepository,
-                countryDropdownFieldController = countryDropdownFieldController
+                countryDropdownFieldController = countryDropdownFieldController,
+                sameAsShippingController = null
             )
             var emailController =
                 (
@@ -89,13 +90,13 @@ class AddressElementTest {
         }
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `verify flow of form field values`() = runTest {
         val addressElement = AddressElement(
             IdentifierSpec.Generic("address"),
             addressRepository,
-            countryDropdownFieldController = countryDropdownFieldController
+            countryDropdownFieldController = countryDropdownFieldController,
+            sameAsShippingController = null
         )
         val formFieldValueFlow = addressElement.getFormFieldValueFlow()
         var emailController =
@@ -143,7 +144,8 @@ class AddressElementTest {
             IdentifierSpec.Generic("address"),
             addressRepository,
             countryDropdownFieldController = countryDropdownFieldController,
-            addressType = AddressType.ShippingCondensed(null, PhoneNumberState.REQUIRED) { }
+            addressType = AddressType.ShippingCondensed(null, PhoneNumberState.REQUIRED) { },
+            sameAsShippingController = null
         )
 
         val identifierSpecs = addressElement.fields.first().map {
@@ -159,7 +161,8 @@ class AddressElementTest {
             IdentifierSpec.Generic("address"),
             addressRepository,
             countryDropdownFieldController = countryDropdownFieldController,
-            addressType = AddressType.ShippingCondensed(null, PhoneNumberState.HIDDEN) { }
+            addressType = AddressType.ShippingCondensed(null, PhoneNumberState.HIDDEN) { },
+            sameAsShippingController = null
         )
 
         val identifierSpecs = addressElement.fields.first().map {
@@ -174,7 +177,8 @@ class AddressElementTest {
             IdentifierSpec.Generic("address"),
             addressRepository,
             countryDropdownFieldController = countryDropdownFieldController,
-            addressType = AddressType.ShippingCondensed(null, PhoneNumberState.OPTIONAL) { }
+            addressType = AddressType.ShippingCondensed(null, PhoneNumberState.OPTIONAL) { },
+            sameAsShippingController = null
         )
 
         val identifierSpecs = addressElement.fields.first().map {
@@ -191,7 +195,8 @@ class AddressElementTest {
             countryDropdownFieldController = countryDropdownFieldController,
             addressType = AddressType.ShippingExpanded(
                 PhoneNumberState.REQUIRED
-            )
+            ),
+            sameAsShippingController = null
         )
 
         val identifierSpecs = addressElement.fields.first().map {
@@ -209,7 +214,8 @@ class AddressElementTest {
             countryDropdownFieldController = countryDropdownFieldController,
             addressType = AddressType.ShippingExpanded(
                 PhoneNumberState.HIDDEN
-            )
+            ),
+            sameAsShippingController = null
         )
 
         val identifierSpecs = addressElement.fields.first().map {
@@ -226,7 +232,8 @@ class AddressElementTest {
             countryDropdownFieldController = countryDropdownFieldController,
             addressType = AddressType.ShippingExpanded(
                 PhoneNumberState.OPTIONAL
-            )
+            ),
+            sameAsShippingController = null
         )
 
         val identifierSpecs = addressElement.fields.first().map {
@@ -241,7 +248,8 @@ class AddressElementTest {
             IdentifierSpec.Generic("address"),
             addressRepository,
             countryDropdownFieldController = countryDropdownFieldController,
-            addressType = AddressType.Normal()
+            addressType = AddressType.Normal(),
+            sameAsShippingController = null
         )
 
         val identifierSpecs = addressElement.fields.first().map {
@@ -257,7 +265,8 @@ class AddressElementTest {
             IdentifierSpec.Generic("address"),
             addressRepository,
             countryDropdownFieldController = countryDropdownFieldController,
-            addressType = AddressType.Normal()
+            addressType = AddressType.Normal(),
+            sameAsShippingController = null
         )
 
         val identifierSpecs = addressElement.fields.first().map {
@@ -275,7 +284,8 @@ class AddressElementTest {
             addressType = AddressType.ShippingCondensed(
                 "some key",
                 PhoneNumberState.OPTIONAL
-            ) { }
+            ) { },
+            sameAsShippingController = null
         )
 
         val identifierSpecs = addressElement.fields.first().map {
@@ -293,7 +303,8 @@ class AddressElementTest {
             addressType = AddressType.ShippingCondensed(
                 null,
                 PhoneNumberState.OPTIONAL
-            ) { }
+            ) { },
+            sameAsShippingController = null
         )
 
         val identifierSpecs = addressElement.fields.first().map {
@@ -310,12 +321,41 @@ class AddressElementTest {
             countryDropdownFieldController = countryDropdownFieldController,
             addressType = AddressType.ShippingExpanded(
                 PhoneNumberState.OPTIONAL
-            )
+            ),
+            sameAsShippingController = null
         )
 
         val identifierSpecs = addressElement.fields.first().map {
             it.identifier
         }
         assertThat(identifierSpecs.contains(IdentifierSpec.OneLineAddress)).isFalse()
+    }
+
+    @Test
+    fun `when same as shipping is enabled billing address is the same as shipping`() = runTest {
+        val sameAsShippingController = SameAsShippingController(false)
+        val addressElement = AddressElement(
+            IdentifierSpec.Generic("address"),
+            addressRepository,
+            mapOf(
+                IdentifierSpec.SameAsShipping to "true",
+                IdentifierSpec.Country to "JP",
+            ),
+            countryDropdownFieldController = countryDropdownFieldController,
+            addressType = AddressType.Normal(),
+            sameAsShippingController = sameAsShippingController
+        )
+
+        val country = suspend {
+            addressElement.fields.first().map {
+                it.getFormFieldValueFlow().first()[0].second.value
+            }.first()
+        }
+
+        assertThat(country()).isEqualTo("US")
+
+        sameAsShippingController.onValueChange(true)
+
+        assertThat(country()).isEqualTo("JP")
     }
 }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardBillingAddressElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardBillingAddressElementTest.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.asLiveData
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth
 import com.stripe.android.ui.core.address.AddressRepository
+import kotlinx.coroutines.flow.flowOf
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -22,7 +23,8 @@ internal class CardBillingAddressElementTest {
         rawValuesMap = emptyMap(),
         addressRepository,
         emptySet(),
-        dropdownFieldController
+        dropdownFieldController,
+        null
     )
 
     init {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
@@ -18,6 +18,7 @@ import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.model.CountryUtils
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResult
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.example.R
 import com.stripe.android.paymentsheet.example.Settings
 import com.stripe.android.paymentsheet.example.databinding.ActivityPaymentSheetPlaygroundBinding
@@ -401,6 +402,21 @@ class PaymentSheetPlaygroundActivity : AppCompatActivity() {
             customer = viewModel.customerConfig.value,
             googlePay = googlePayConfig,
             defaultBillingDetails = defaultBilling,
+            shippingDetails = if (viewModel.getSavedToggleState().setShippingAddress) {
+                AddressDetails(
+                    address = PaymentSheet.Address(
+                        city = "San Francisco",
+                        country = "US",
+                        line1 = "510 Townsend St",
+                        postalCode = "94102",
+                        state = "California",
+                    ),
+                    name = "John Doe",
+                    isCheckboxSelected = true
+                )
+            } else {
+                 null
+            },
             allowsDelayedPaymentMethods = viewBinding.allowsDelayedPaymentMethodsOnButton.isChecked,
             appearance = appearance
         )

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
@@ -18,7 +18,6 @@ import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.model.CountryUtils
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResult
-import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.example.R
 import com.stripe.android.paymentsheet.example.Settings
 import com.stripe.android.paymentsheet.example.databinding.ActivityPaymentSheetPlaygroundBinding
@@ -402,21 +401,6 @@ class PaymentSheetPlaygroundActivity : AppCompatActivity() {
             customer = viewModel.customerConfig.value,
             googlePay = googlePayConfig,
             defaultBillingDetails = defaultBilling,
-            shippingDetails = if (viewModel.getSavedToggleState().setShippingAddress) {
-                AddressDetails(
-                    address = PaymentSheet.Address(
-                        city = "San Francisco",
-                        country = "US",
-                        line1 = "510 Townsend St",
-                        postalCode = "94102",
-                        state = "California",
-                    ),
-                    name = "John Doe",
-                    isCheckboxSelected = true
-                )
-            } else {
-                 null
-            },
             allowsDelayedPaymentMethods = viewBinding.allowsDelayedPaymentMethodsOnButton.isChecked,
             appearance = appearance
         )

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -269,20 +269,18 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration : 
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;)V
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;)V
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;)V
-	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;)V
-	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;Z)V
-	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;)V
-	public synthetic fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Z)V
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;ZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;ZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;
 	public final fun component3 ()Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
 	public final fun component4 ()Landroid/content/res/ColorStateList;
 	public final fun component5 ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;
-	public final fun component6 ()Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;
-	public final fun component7 ()Z
-	public final fun component8 ()Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;
-	public final fun copy (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
+	public final fun component6 ()Z
+	public final fun component7 ()Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;
+	public final fun copy (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;ZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;ZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAllowsDelayedPaymentMethods ()Z
@@ -292,7 +290,6 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration : 
 	public final fun getGooglePay ()Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
 	public final fun getMerchantDisplayName ()Ljava/lang/String;
 	public final fun getPrimaryButtonColor ()Landroid/content/res/ColorStateList;
-	public final fun getShippingDetails ()Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
@@ -309,7 +306,6 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration$Bu
 	public final fun googlePay (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun merchantDisplayName (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun primaryButtonColor (Landroid/content/res/ColorStateList;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
-	public final fun shippingDetails (Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration$Creator : android/os/Parcelable$Creator {

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -269,18 +269,20 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration : 
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;)V
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;)V
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;)V
-	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Z)V
-	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;ZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;)V
-	public synthetic fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;ZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;)V
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;Z)V
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;
 	public final fun component3 ()Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
 	public final fun component4 ()Landroid/content/res/ColorStateList;
 	public final fun component5 ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;
-	public final fun component6 ()Z
-	public final fun component7 ()Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;
-	public final fun copy (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;ZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;ZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
+	public final fun component6 ()Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;
+	public final fun component7 ()Z
+	public final fun component8 ()Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;
+	public final fun copy (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAllowsDelayedPaymentMethods ()Z
@@ -290,6 +292,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration : 
 	public final fun getGooglePay ()Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
 	public final fun getMerchantDisplayName ()Ljava/lang/String;
 	public final fun getPrimaryButtonColor ()Landroid/content/res/ColorStateList;
+	public final fun getShippingDetails ()Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
@@ -306,6 +309,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration$Bu
 	public final fun googlePay (Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun merchantDisplayName (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun primaryButtonColor (Landroid/content/res/ColorStateList;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
+	public final fun shippingDetails (Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration$Creator : android/os/Parcelable$Creator {
@@ -727,6 +731,34 @@ public final class com/stripe/android/paymentsheet/PaymentSheetViewModel_Factory
 	public static fun injectSubComponentBuilderProvider (Lcom/stripe/android/paymentsheet/PaymentSheetViewModel$Factory;Ljavax/inject/Provider;)V
 }
 
+public final class com/stripe/android/paymentsheet/addresselement/AddressDetails : android/os/Parcelable {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lcom/stripe/android/paymentsheet/addresselement/AddressDetails$Companion;
+	public static final field KEY Ljava/lang/String;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$Address;Ljava/lang/String;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$Address;Ljava/lang/String;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/stripe/android/paymentsheet/PaymentSheet$Address;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$Address;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$Address;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddress ()Lcom/stripe/android/paymentsheet/PaymentSheet$Address;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPhoneNumber ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isCheckboxSelected ()Ljava/lang/Boolean;
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/paymentsheet/addresselement/AddressDetails$Companion {
+}
+
 public final class com/stripe/android/paymentsheet/addresselement/AddressDetails$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;
@@ -780,6 +812,14 @@ public final class com/stripe/android/paymentsheet/addresselement/AddressLaunche
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/addresselement/AddressLauncher$AdditionalFieldsConfiguration;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/addresselement/AddressLauncher$AdditionalFieldsConfiguration;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/addresselement/AddressLauncher$AdditionalFieldsConfiguration$FieldConfiguration$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/addresselement/AddressLauncher$AdditionalFieldsConfiguration$FieldConfiguration;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/addresselement/AddressLauncher$AdditionalFieldsConfiguration$FieldConfiguration;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreenTest.kt
@@ -58,7 +58,8 @@ class InputAddressScreenTest {
                     title = "Address",
                     onPrimaryButtonClick = primaryButtonCallback,
                     onCloseClick = onCloseCallback,
-                    formContent = {}
+                    formContent = {},
+                    checkboxContent = {}
                 )
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
@@ -256,7 +256,7 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
                 merchantName = merchantName,
                 amount = amount,
                 billingDetails = config?.defaultBillingDetails,
-                shippingDetails = config?.shippingDetails,
+                shippingDetails = null, // TODO: config?.shippingDetails,
                 injectorKey = injectorKey,
                 initialPaymentMethodCreateParams =
                 newLpm?.paymentMethodCreateParams?.typeCode?.takeIf {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
@@ -256,6 +256,7 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
                 merchantName = merchantName,
                 amount = amount,
                 billingDetails = config?.defaultBillingDetails,
+                shippingDetails = config?.shippingDetails,
                 injectorKey = injectorKey,
                 initialPaymentMethodCreateParams =
                 newLpm?.paymentMethodCreateParams?.typeCode?.takeIf {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -12,6 +12,7 @@ import androidx.fragment.app.Fragment
 import com.stripe.android.link.account.CookieStore
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.flowcontroller.FlowControllerFactory
 import com.stripe.android.paymentsheet.model.PaymentOption
 import com.stripe.android.ui.core.PaymentsThemeDefaults
@@ -126,6 +127,13 @@ class PaymentSheet internal constructor(
         val defaultBillingDetails: BillingDetails? = null,
 
         /**
+         * The billing information for the customer.
+         *
+         * If set, PaymentSheet will pre-populate the form fields with the values provided.
+         */
+        val shippingDetails: AddressDetails? = null,
+
+        /**
          * If true, allows payment methods that do not move money at the end of the checkout.
          * Defaults to false.
          *
@@ -154,6 +162,7 @@ class PaymentSheet internal constructor(
             private var googlePay: GooglePayConfiguration? = null
             private var primaryButtonColor: ColorStateList? = null
             private var defaultBillingDetails: BillingDetails? = null
+            private var shippingDetails: AddressDetails? = null
             private var allowsDelayedPaymentMethods: Boolean = false
             private var appearance: Appearance = Appearance()
 
@@ -179,6 +188,9 @@ class PaymentSheet internal constructor(
             fun defaultBillingDetails(defaultBillingDetails: BillingDetails?) =
                 apply { this.defaultBillingDetails = defaultBillingDetails }
 
+            fun shippingDetails(shippingDetails: AddressDetails?) =
+                apply { this.shippingDetails = shippingDetails }
+
             fun allowsDelayedPaymentMethods(allowsDelayedPaymentMethods: Boolean) =
                 apply { this.allowsDelayedPaymentMethods = allowsDelayedPaymentMethods }
 
@@ -191,6 +203,7 @@ class PaymentSheet internal constructor(
                 googlePay,
                 primaryButtonColor,
                 defaultBillingDetails,
+                shippingDetails,
                 allowsDelayedPaymentMethods,
                 appearance
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -12,7 +12,6 @@ import androidx.fragment.app.Fragment
 import com.stripe.android.link.account.CookieStore
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
-import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.flowcontroller.FlowControllerFactory
 import com.stripe.android.paymentsheet.model.PaymentOption
 import com.stripe.android.ui.core.PaymentsThemeDefaults
@@ -127,13 +126,6 @@ class PaymentSheet internal constructor(
         val defaultBillingDetails: BillingDetails? = null,
 
         /**
-         * The billing information for the customer.
-         *
-         * If set, PaymentSheet will pre-populate the form fields with the values provided.
-         */
-        val shippingDetails: AddressDetails? = null,
-
-        /**
          * If true, allows payment methods that do not move money at the end of the checkout.
          * Defaults to false.
          *
@@ -162,7 +154,6 @@ class PaymentSheet internal constructor(
             private var googlePay: GooglePayConfiguration? = null
             private var primaryButtonColor: ColorStateList? = null
             private var defaultBillingDetails: BillingDetails? = null
-            private var shippingDetails: AddressDetails? = null
             private var allowsDelayedPaymentMethods: Boolean = false
             private var appearance: Appearance = Appearance()
 
@@ -188,9 +179,6 @@ class PaymentSheet internal constructor(
             fun defaultBillingDetails(defaultBillingDetails: BillingDetails?) =
                 apply { this.defaultBillingDetails = defaultBillingDetails }
 
-            fun shippingDetails(shippingDetails: AddressDetails?) =
-                apply { this.shippingDetails = shippingDetails }
-
             fun allowsDelayedPaymentMethods(allowsDelayedPaymentMethods: Boolean) =
                 apply { this.allowsDelayedPaymentMethods = allowsDelayedPaymentMethods }
 
@@ -203,7 +191,6 @@ class PaymentSheet internal constructor(
                 googlePay,
                 primaryButtonColor,
                 defaultBillingDetails,
-                shippingDetails,
                 allowsDelayedPaymentMethods,
                 appearance
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressDetails.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressDetails.kt
@@ -2,10 +2,11 @@ package com.stripe.android.paymentsheet.addresselement
 
 import android.os.Parcelable
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.ui.core.elements.IdentifierSpec
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-internal data class AddressDetails(
+data class AddressDetails(
     /**
      * The customer's full name
      */
@@ -39,3 +40,26 @@ internal fun AddressLauncher.DefaultAddressDetails.toAddressDetails(): AddressDe
         phoneNumber = this.phoneNumber,
         isCheckboxSelected = this.isCheckboxSelected
     )
+
+internal fun AddressDetails.toIdentifierMap(
+    billingDetails: PaymentSheet.BillingDetails? = null
+): Map<IdentifierSpec, String?> {
+    return if (billingDetails == null) {
+        mapOf(
+            IdentifierSpec.Name to name,
+            IdentifierSpec.Line1 to address?.line1,
+            IdentifierSpec.Line2 to address?.line2,
+            IdentifierSpec.City to address?.city,
+            IdentifierSpec.State to address?.state,
+            IdentifierSpec.PostalCode to address?.postalCode,
+            IdentifierSpec.Country to address?.country,
+            IdentifierSpec.Phone to phoneNumber
+        ).plus(
+            mapOf(
+                IdentifierSpec.SameAsShipping to isCheckboxSelected?.toString()
+            ).takeIf { isCheckboxSelected != null } ?: emptyMap()
+        )
+    } else {
+        emptyMap()
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
@@ -93,10 +93,9 @@ internal class AddressLauncher internal constructor(
         val buttonTitle: String? = null,
 
         /**
-         * Configuration for the field that collects a phone number.
-         * Defaults to HIDDEN
+         * Configuration for fields to collect in addition to the physical shipping address
          */
-        val phone: AdditionalFieldsConfiguration = AdditionalFieldsConfiguration.OPTIONAL,
+        val additionalFields: AdditionalFieldsConfiguration? = null,
 
         /**
          * Configuration for the title displayed at the top of the screen.
@@ -124,7 +123,7 @@ internal class AddressLauncher internal constructor(
             var defaultValues: DefaultAddressDetails? = null
             var allowedCountries: Set<String> = emptySet()
             var buttonTitle: String? = null
-            var phone: AdditionalFieldsConfiguration = AdditionalFieldsConfiguration.OPTIONAL
+            var additionalFields: AdditionalFieldsConfiguration? = null
             var title: String? = null
             var googlePlacesApiKey: String? = null
             var checkboxLabel: String? = null
@@ -141,8 +140,8 @@ internal class AddressLauncher internal constructor(
             fun buttonTitle(buttonTitle: String?) =
                 apply { this.buttonTitle = buttonTitle }
 
-            fun phone(phone: AdditionalFieldsConfiguration) =
-                apply { this.phone = phone }
+            fun additionalFields(additionalFields: AdditionalFieldsConfiguration) =
+                apply { this.additionalFields = additionalFields }
 
             fun title(title: String?) =
                 apply { this.title = title }
@@ -158,7 +157,7 @@ internal class AddressLauncher internal constructor(
                 defaultValues,
                 allowedCountries,
                 buttonTitle,
-                phone,
+                additionalFields,
                 title,
                 googlePlacesApiKey,
                 checkboxLabel
@@ -166,22 +165,34 @@ internal class AddressLauncher internal constructor(
         }
     }
 
+    /**
+     * @param phone Configuration for the field that collects a phone number. Defaults to
+     * [FieldConfiguration.OPTIONAL]
+     * @param checkboxLabel The label of a checkbox displayed below other fields. If nil, the
+     * checkbox is not displayed. Defaults to null
+     */
     @Parcelize
-    enum class AdditionalFieldsConfiguration : Parcelable {
-        /**
-         * The field is not displayed.
-         */
-        HIDDEN,
+    data class AdditionalFieldsConfiguration(
+        val phone: FieldConfiguration = FieldConfiguration.OPTIONAL,
+        val checkboxLabel: String? = null
+    ) : Parcelable {
+        @Parcelize
+        enum class FieldConfiguration : Parcelable {
+            /**
+             * The field is not displayed.
+             */
+            HIDDEN,
 
-        /**
-         * The field is displayed but the customer can leave it blank.
-         */
-        OPTIONAL,
+            /**
+             * The field is displayed but the customer can leave it blank.
+             */
+            OPTIONAL,
 
-        /**
-         * The field is displayed and the customer is required to fill it in.
-         */
-        REQUIRED
+            /**
+             * The field is displayed and the customer is required to fill it in.
+             */
+            REQUIRED
+        }
     }
 
     @Parcelize

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
@@ -168,11 +168,11 @@ internal class AddressLauncher internal constructor(
     /**
      * @param phone Configuration for the field that collects a phone number. Defaults to
      * [FieldConfiguration.OPTIONAL]
-     * @param checkboxLabel The label of a checkbox displayed below other fields. If nil, the
+     * @param checkboxLabel The label of a checkbox displayed below other fields. If null, the
      * checkbox is not displayed. Defaults to null
      */
     @Parcelize
-    data class AdditionalFieldsConfiguration(
+    data class AdditionalFieldsConfiguration @JvmOverloads constructor(
         val phone: FieldConfiguration = FieldConfiguration.OPTIONAL,
         val checkboxLabel: String? = null
     ) : Parcelable {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
@@ -21,7 +21,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.ui.AddressOptionsAppBar
 import com.stripe.android.ui.core.FormUI
-import com.stripe.android.ui.core.elements.CheckboxElementUi
+import com.stripe.android.ui.core.elements.CheckboxElementUI
 import com.stripe.android.ui.core.injection.NonFallbackInjector
 
 @Composable
@@ -121,7 +121,7 @@ internal fun InputAddressScreen(
                 },
                 checkboxContent = {
                     viewModel.args.config?.checkboxLabel?.let { label ->
-                        CheckboxElementUi(
+                        CheckboxElementUI(
                             isChecked = checkboxChecked,
                             label = label,
                             isEnabled = formEnabled,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -66,18 +66,8 @@ internal class InputAddressViewModel @Inject constructor(
 
         viewModelScope.launch {
             collectedAddress.collect { addressDetails ->
-                val initialValues: Map<IdentifierSpec, String?> = addressDetails?.let {
-                    mapOf(
-                        IdentifierSpec.Name to addressDetails.name,
-                        IdentifierSpec.Line1 to addressDetails.address?.line1,
-                        IdentifierSpec.Line2 to addressDetails.address?.line2,
-                        IdentifierSpec.City to addressDetails.address?.city,
-                        IdentifierSpec.State to addressDetails.address?.state,
-                        IdentifierSpec.PostalCode to addressDetails.address?.postalCode,
-                        IdentifierSpec.Country to addressDetails.address?.country,
-                        IdentifierSpec.Phone to addressDetails.phoneNumber
-                    )
-                } ?: emptyMap()
+                val initialValues: Map<IdentifierSpec, String?> = addressDetails?.toIdentifierMap()
+                    ?: emptyMap()
 
                 _formController.value = formControllerProvider.get()
                     .viewOnlyFields(emptySet())
@@ -118,7 +108,7 @@ internal class InputAddressViewModel @Inject constructor(
     }
 
     private fun buildFormSpec(condensedForm: Boolean): LayoutSpec {
-        val phoneNumberState = parsePhoneNumberConfig(args.config?.phone)
+        val phoneNumberState = parsePhoneNumberConfig(args.config?.additionalFields?.phone)
         val addressSpec = if (condensedForm) {
             AddressSpec(
                 showLabel = false,
@@ -220,12 +210,15 @@ internal class InputAddressViewModel @Inject constructor(
     internal companion object {
         // This mapping is required to prevent merchants from depending on ui-core
         fun parsePhoneNumberConfig(
-            configuration: AddressLauncher.AdditionalFieldsConfiguration?
+            configuration: AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration?
         ): PhoneNumberState {
             return when (configuration) {
-                AddressLauncher.AdditionalFieldsConfiguration.HIDDEN -> PhoneNumberState.HIDDEN
-                AddressLauncher.AdditionalFieldsConfiguration.OPTIONAL -> PhoneNumberState.OPTIONAL
-                AddressLauncher.AdditionalFieldsConfiguration.REQUIRED -> PhoneNumberState.REQUIRED
+                AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.HIDDEN ->
+                    PhoneNumberState.HIDDEN
+                AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.OPTIONAL ->
+                    PhoneNumberState.OPTIONAL
+                AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.REQUIRED ->
+                    PhoneNumberState.REQUIRED
                 null -> PhoneNumberState.OPTIONAL
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -39,6 +39,7 @@ import com.stripe.android.paymentsheet.PaymentOptionsViewModel
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResult
 import com.stripe.android.paymentsheet.PaymentSheetResultCallback
+import com.stripe.android.paymentsheet.addresselement.toIdentifierMap
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.injection.DaggerFlowControllerComponent
@@ -449,10 +450,21 @@ internal class DefaultFlowController @Inject internal constructor(
         val config = requireNotNull(initData.config)
 
         lifecycleScope.launch {
+            val customerPhone = if (config.shippingDetails?.isCheckboxSelected == true) {
+                config.shippingDetails.phoneNumber
+            } else {
+                config.defaultBillingDetails?.phone
+            }
+            val initialValuesMap = if (config.shippingDetails?.isCheckboxSelected == true) {
+                config.shippingDetails.toIdentifierMap(config.defaultBillingDetails)
+            } else {
+                emptyMap()
+            }
             val linkLauncher = linkPaymentLauncherFactory.create(
                 merchantName = config.merchantDisplayName,
                 customerEmail = config.defaultBillingDetails?.email,
-                customerPhone = config.defaultBillingDetails?.phone
+                customerPhone = customerPhone,
+                initialValuesMap = initialValuesMap
             )
             val accountStatus = linkLauncher.setup(
                 stripeIntent = initData.stripeIntent,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -39,6 +39,7 @@ import com.stripe.android.paymentsheet.PaymentOptionsViewModel
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResult
 import com.stripe.android.paymentsheet.PaymentSheetResultCallback
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.addresselement.toIdentifierMap
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.forms.FormViewModel
@@ -450,13 +451,14 @@ internal class DefaultFlowController @Inject internal constructor(
         val config = requireNotNull(initData.config)
 
         lifecycleScope.launch {
-            val customerPhone = if (config.shippingDetails?.isCheckboxSelected == true) {
-                config.shippingDetails.phoneNumber
+            val shippingDetails: AddressDetails? = null // TODO: config.shippingDetails
+            val customerPhone = if (shippingDetails?.isCheckboxSelected == true) {
+                shippingDetails.phoneNumber
             } else {
                 config.defaultBillingDetails?.phone
             }
-            val initialValuesMap = if (config.shippingDetails?.isCheckboxSelected == true) {
-                config.shippingDetails.toIdentifierMap(config.defaultBillingDetails)
+            val initialValuesMap = if (shippingDetails?.isCheckboxSelected == true) {
+                shippingDetails.toIdentifierMap(config.defaultBillingDetails)
             } else {
                 emptyMap()
             }
@@ -464,7 +466,7 @@ internal class DefaultFlowController @Inject internal constructor(
                 merchantName = config.merchantDisplayName,
                 customerEmail = config.defaultBillingDetails?.email,
                 customerPhone = customerPhone,
-                initialValuesMap = initialValuesMap
+                initialFormValuesMap = initialValuesMap
             )
             val accountStatus = linkLauncher.setup(
                 stripeIntent = initData.stripeIntent,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormFragmentArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormFragmentArguments.kt
@@ -5,6 +5,8 @@ import com.stripe.android.core.injection.InjectorKey
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.addresselement.toIdentifierMap
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.ui.core.forms.convertToFormValuesMap
@@ -18,6 +20,7 @@ internal data class FormFragmentArguments(
     val merchantName: String,
     val amount: Amount? = null,
     val billingDetails: PaymentSheet.BillingDetails? = null,
+    val shippingDetails: AddressDetails? = null,
     @InjectorKey val injectorKey: String,
     val initialPaymentMethodCreateParams: PaymentMethodCreateParams? = null
 ) : Parcelable
@@ -26,6 +29,11 @@ internal fun FormFragmentArguments.getInitialValuesMap(): Map<IdentifierSpec, St
     val initialValues = initialPaymentMethodCreateParams?.let {
         convertToFormValuesMap(it.toParamMap())
     } ?: emptyMap()
+
+    val shippingDetailsMap = shippingDetails
+        ?.toIdentifierMap()
+        ?.takeIf { billingDetails == null }
+        ?: emptyMap()
 
     return mapOf(
         IdentifierSpec.Name to this.billingDetails?.name,
@@ -37,5 +45,5 @@ internal fun FormFragmentArguments.getInitialValuesMap(): Map<IdentifierSpec, St
         IdentifierSpec.State to this.billingDetails?.address?.state,
         IdentifierSpec.Country to this.billingDetails?.address?.country,
         IdentifierSpec.PostalCode to this.billingDetails?.address?.postalCode
-    ).plus(initialValues)
+    ).plus(initialValues).plus(shippingDetailsMap)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -31,6 +31,7 @@ import com.stripe.android.paymentsheet.PaymentOptionsActivity
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetActivity
 import com.stripe.android.paymentsheet.PrefsRepository
+import com.stripe.android.paymentsheet.addresselement.toIdentifierMap
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -183,11 +184,24 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
 
     var usBankAccountSavedScreenState: USBankAccountFormScreenState? = null
 
-    val linkLauncher = linkPaymentLauncherFactory.create(
-        merchantName = merchantName,
-        customerEmail = config?.defaultBillingDetails?.email,
-        customerPhone = config?.defaultBillingDetails?.phone
-    )
+    val linkLauncher = linkPaymentLauncherFactory.let {
+        val customerPhone = if (config?.shippingDetails?.isCheckboxSelected == true) {
+            config.shippingDetails.phoneNumber
+        } else {
+            config?.defaultBillingDetails?.phone
+        }
+        val initialValuesMap = if (config?.shippingDetails?.isCheckboxSelected == true) {
+            config.shippingDetails.toIdentifierMap(config.defaultBillingDetails)
+        } else {
+            emptyMap()
+        }
+        return@let it.create(
+            merchantName = merchantName,
+            customerEmail = config?.defaultBillingDetails?.email,
+            customerPhone = customerPhone,
+            initialValuesMap = initialValuesMap
+        )
+    }
 
     protected val _showLinkVerificationDialog = MutableLiveData(false)
     val showLinkVerificationDialog: LiveData<Boolean> = _showLinkVerificationDialog

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -31,6 +31,7 @@ import com.stripe.android.paymentsheet.PaymentOptionsActivity
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetActivity
 import com.stripe.android.paymentsheet.PrefsRepository
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.addresselement.toIdentifierMap
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.FragmentConfig
@@ -185,21 +186,22 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
     var usBankAccountSavedScreenState: USBankAccountFormScreenState? = null
 
     val linkLauncher = linkPaymentLauncherFactory.let {
-        val customerPhone = if (config?.shippingDetails?.isCheckboxSelected == true) {
-            config.shippingDetails.phoneNumber
+        val shippingDetails: AddressDetails? = null // TODO: config.shippingDetails
+        val customerPhone = if (shippingDetails?.isCheckboxSelected == true) {
+            shippingDetails.phoneNumber
         } else {
             config?.defaultBillingDetails?.phone
         }
-        val initialValuesMap = if (config?.shippingDetails?.isCheckboxSelected == true) {
-            config.shippingDetails.toIdentifierMap(config.defaultBillingDetails)
+        val initialValuesMap = if (shippingDetails?.isCheckboxSelected == true) {
+            shippingDetails.toIdentifierMap(config?.defaultBillingDetails)
         } else {
             emptyMap()
         }
-        return@let it.create(
+        it.create(
             merchantName = merchantName,
             customerEmail = config?.defaultBillingDetails?.email,
             customerPhone = customerPhone,
-            initialValuesMap = initialValuesMap
+            initialFormValuesMap = initialValuesMap
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -23,7 +23,7 @@ import com.stripe.android.link.injection.CUSTOMER_EMAIL
 import com.stripe.android.link.injection.CUSTOMER_PHONE
 import com.stripe.android.link.injection.LinkPaymentLauncherFactory
 import com.stripe.android.link.injection.MERCHANT_NAME
-import com.stripe.android.link.injection.INITIAL_VALUES_MAP
+import com.stripe.android.link.injection.INITIAL_FORM_VALUES_MAP
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConfirmPaymentIntentParams
@@ -942,7 +942,7 @@ internal class DefaultFlowControllerTest {
                 @Assisted(MERCHANT_NAME) merchantName: String,
                 @Assisted(CUSTOMER_EMAIL) customerEmail: String?,
                 @Assisted(CUSTOMER_PHONE) customerPhone: String?,
-                @Assisted(INITIAL_VALUES_MAP) initialValuesMap: Map<IdentifierSpec, String?>?
+                @Assisted(INITIAL_FORM_VALUES_MAP) initialFormValuesMap: Map<IdentifierSpec, String?>?
             ): LinkPaymentLauncher {
                 return linkPaymentLauncher
             }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -23,6 +23,7 @@ import com.stripe.android.link.injection.CUSTOMER_EMAIL
 import com.stripe.android.link.injection.CUSTOMER_PHONE
 import com.stripe.android.link.injection.LinkPaymentLauncherFactory
 import com.stripe.android.link.injection.MERCHANT_NAME
+import com.stripe.android.link.injection.INITIAL_VALUES_MAP
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConfirmPaymentIntentParams
@@ -53,6 +54,7 @@ import com.stripe.android.paymentsheet.model.PaymentOption
 import com.stripe.android.paymentsheet.model.PaymentOptionFactory
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
+import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.view.ActivityScenarioFactory
 import dagger.assisted.Assisted
 import kotlinx.coroutines.CoroutineScope
@@ -939,7 +941,8 @@ internal class DefaultFlowControllerTest {
             override fun create(
                 @Assisted(MERCHANT_NAME) merchantName: String,
                 @Assisted(CUSTOMER_EMAIL) customerEmail: String?,
-                @Assisted(CUSTOMER_PHONE) customerPhone: String?
+                @Assisted(CUSTOMER_PHONE) customerPhone: String?,
+                @Assisted(INITIAL_VALUES_MAP) initialValuesMap: Map<IdentifierSpec, String?>?
             ): LinkPaymentLauncher {
                 return linkPaymentLauncher
             }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

- Add `shippingDetails` to `PaymentSheet.Configuration`
- Add `SameAsShippingElement`, a new checkbox element that will be shown below the `AddressElement` whenever the `shippingDetails` are supplied, default billing details is not enabled, and the merchant has configured for this checkbox

Shipping details is parsed into the initial values map to be used for the billing details. If customer requests same as shipping, then the billing details will be overwritten with the shipping information.

The checkbox is there if and only if the merchant has supplied the necessary configurations (shipping address config):
* shipping details included, unchecked: billing details is empty
* shipping details included, checked: billing details overwritten by shipping details
* shipping details included, default billing address included: no check box is shown
* shipping details not included: no checkbox is shown

This is enabled for Link add payment method screen and payment sheet, otherwise you should not see this new checkbox.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Address Element private beta

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots

https://user-images.githubusercontent.com/99316447/184999813-524e2bc8-19ba-46fb-9488-91d34ca83078.mov



