### PR TITLE
Fix issue with single-digit expiry month not being preserved in `PaymentSheet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### PaymentSheet
 
-* [ADDED][5422](https://github.com/stripe/stripe-android/pull/5422) Card expiration dates with a single-digit month are now preserved correctly when closing and re-opening the `PaymentSheet` via the `FlowController`.
+* [FIXED][5422](https://github.com/stripe/stripe-android/pull/5422) Card expiration dates with a single-digit month are now preserved correctly when closing and re-opening the `PaymentSheet` via the `FlowController`.
 
 ## 20.9.0 - 2022-08-16
 This release contains several bug fixes for Payments, PaymentSheet and Financial Connections. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## X.X.X - 2022-XX-XX
+
+### PaymentSheet
+
+* [ADDED][5422](https://github.com/stripe/stripe-android/pull/5422) Card expiration dates with a single-digit month are now preserved correctly when closing and re-opening the `PaymentSheet` via the `FlowController`.
+
 ## 20.9.0 - 2022-08-16
 This release contains several bug fixes for Payments, PaymentSheet and Financial Connections. 
 Adds `IdentityVerificationSheet#rememberIdentityVerificationSheet` for Identity. 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
@@ -60,7 +60,7 @@ internal class CardDetailsElement(
             controller.cvcElement.identifier to cvc,
             IdentifierSpec.CardBrand to FormFieldEntry(brand.code, true),
             IdentifierSpec.CardExpMonth to expirationDate.copy(
-                value = month.toString()
+                value = month.toString().padStart(length = 2, padChar = '0')
             ),
             IdentifierSpec.CardExpYear to expirationDate.copy(
                 value = year.toString()

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DateConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DateConfig.kt
@@ -33,7 +33,7 @@ internal class DateConfig : TextFieldConfig {
             Error.Blank
         } else {
             val newString = convertTo4DigitDate(input)
-            return when {
+            when {
                 newString.length < 4 -> {
                     Error.Incomplete(R.string.incomplete_expiry_date)
                 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DateConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DateConfig.kt
@@ -33,7 +33,7 @@ internal class DateConfig : TextFieldConfig {
             Error.Blank
         } else {
             val newString = convertTo4DigitDate(input)
-            when {
+            return when {
                 newString.length < 4 -> {
                     Error.Incomplete(R.string.incomplete_expiry_date)
                 }
@@ -41,7 +41,7 @@ internal class DateConfig : TextFieldConfig {
                     Error.Invalid(R.string.incomplete_expiry_date)
                 }
                 else -> {
-                    return determineTextFieldState(
+                    determineTextFieldState(
                         requireNotNull(newString.take(2).toIntOrNull()),
                         requireNotNull(newString.takeLast(2).toIntOrNull()),
                         // Calendar.getInstance().get(Calendar.MONTH) is 0-based, so add 1

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsElementTest.kt
@@ -46,7 +46,7 @@ class CardDetailsElementTest {
                 IdentifierSpec.CardNumber to FormFieldEntry("4242424242424242", true),
                 IdentifierSpec.CardCvc to FormFieldEntry("321", true),
                 IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
-                IdentifierSpec.CardExpMonth to FormFieldEntry("1", true),
+                IdentifierSpec.CardExpMonth to FormFieldEntry("01", true),
                 IdentifierSpec.CardExpYear to FormFieldEntry("2030", true)
             )
         )
@@ -71,7 +71,7 @@ class CardDetailsElementTest {
             }
 
         cardDetailsElement.controller.cvcElement.controller.onValueChange("321")
-        cardDetailsElement.controller.expirationDateElement.controller.onValueChange("130")
+        cardDetailsElement.controller.expirationDateElement.controller.onValueChange("1230")
 
         idleLooper()
 
@@ -80,7 +80,7 @@ class CardDetailsElementTest {
                 IdentifierSpec.CardNumber to FormFieldEntry("4242424242424242", true),
                 IdentifierSpec.CardCvc to FormFieldEntry("321", true),
                 IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
-                IdentifierSpec.CardExpMonth to FormFieldEntry("1", true),
+                IdentifierSpec.CardExpMonth to FormFieldEntry("12", true),
                 IdentifierSpec.CardExpYear to FormFieldEntry("2030", true)
             )
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where card expiration dates with a single-digit month weren’t preserved correctly when closing and re-opening a `PaymentSheet` via the `FlowController`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

The issue came from converting the month input to an integer and then back to a string without preserving any leading zeros. As a result, `01/23` would turn into `"123"` instead of `"0123"`, which was an invalid initial value for the expiration date element.

We’re doing this now with `month.toString().padStart(length = 2, padChar = '0')`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screen recordings

**Before**

https://user-images.githubusercontent.com/110940675/185220928-c6ad1716-8dfa-472c-a077-2dd86d7c0fb9.mp4

**After**

https://user-images.githubusercontent.com/110940675/185220984-a2789cef-2d70-4157-a9cb-d0d02eff875c.mp4

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

[Fixed] Card expiration dates with a single-digit month are now preserved correctly when closing and re-opening the `PaymentSheet` via the `FlowController`.
