### PR TITLE
Return EmptyFormElement when LPM spec is empty

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/TransformSpecToElements.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/TransformSpecToElements.kt
@@ -83,7 +83,6 @@ class TransformSpecToElements(
                     initialValues
                 )
                 is SepaMandateTextSpec -> it.transform(merchantName)
-                else -> EmptyFormElement()
             }
-        }
+        }.takeUnless { it.isEmpty() } ?: listOf(EmptyFormElement())
 }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/TransformSpecToElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/TransformSpecToElementTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.ui.core.elements.DropdownSpec
 import com.stripe.android.ui.core.elements.EmailConfig
 import com.stripe.android.ui.core.elements.EmailElement
 import com.stripe.android.ui.core.elements.EmailSpec
+import com.stripe.android.ui.core.elements.EmptyFormElement
 import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.ui.core.elements.KeyboardType
 import com.stripe.android.ui.core.elements.NameConfig
@@ -206,6 +207,15 @@ internal class TransformSpecToElementTest {
 
         assertThat(cardNumberElement.controller)
             .isInstanceOf(CardNumberViewOnlyController::class.java)
+    }
+
+    @Test
+    fun `Empty spec is transformed to single EmptyFormElement`() {
+        val formElement = transformSpecToElements.transform(
+            emptyList()
+        )
+
+        assertThat(formElement.first()).isEqualTo(EmptyFormElement())
     }
 
     companion object {

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/TransformSpecToElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/TransformSpecToElementTest.kt
@@ -215,7 +215,7 @@ internal class TransformSpecToElementTest {
             emptyList()
         )
 
-        assertThat(formElement.first()).isEqualTo(EmptyFormElement())
+        assertThat(formElement).containsExactly(EmptyFormElement())
     }
 
     companion object {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
When the payment method spec is empty, transform into an `EmptyFormElement`.
Before this change, the "Pay" button would stay disabled for a payment method that does not require any user input.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fixes bug and [failing test](https://app-automate.browserstack.com/dashboard/v2/builds/4209e73aebc5008ce2ebb2eb7595fdbbac28cf2b/sessions/tests/c288bd1c0c8d72759d511f33e04968964132787969b74a76).

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

