### PR TITLE
Fix ripple being rendered over payment method card

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentMethodsUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentMethodsUI.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -144,15 +145,18 @@ internal fun PaymentMethodUI(
                     )
                 )
                 .padding(horizontal = CARD_HORIZONTAL_PADDING.dp)
-                .selectable(
-                    selected = isSelected,
-                    enabled = isEnabled,
-                    onClick = {
-                        onItemSelectedListener(itemIndex)
-                    }
-                )
         ) {
-            Column {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .selectable(
+                        selected = isSelected,
+                        enabled = isEnabled,
+                        onClick = {
+                            onItemSelectedListener(itemIndex)
+                        }
+                    )
+            ) {
                 val colorFilter = if (tintOnSelected) ColorFilter.tint(color) else null
                 Image(
                     painter = painterResource(iconRes),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request makes sure that the ripple effect on the payment method cards is contained within the bounds of the card.

Previously, it drew over the bounds because the `selectable` modifier was set on the card itself. Now, the `selectable` modifier is set on the card’s child composable.

Another option would have been to clip the card, but that interfered with the card’s elevation shadow.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

UX polish.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![unclipped](https://user-images.githubusercontent.com/110940675/185428602-ed13782b-bcd8-4263-ba61-1b54b5b198c9.png) | ![clipped](https://user-images.githubusercontent.com/110940675/185428578-bb43e070-a5d7-4264-90d6-d9bba85b1a85.png) |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

_Nothing to add._
