### PR TITLE
Fix issue with country dropdown not updating country

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressElement.kt
@@ -68,6 +68,12 @@ open class AddressElement constructor(
             addressRepository.get(countryCode)
                 ?: emptyList()
         }
+        .map { fields ->
+            fields.forEach { field ->
+                field.setRawValue(rawValuesMap)
+            }
+            fields
+        }
 
     val fields = combine(
         countryElement.controller.rawFieldValue,
@@ -111,10 +117,9 @@ open class AddressElement constructor(
                     emptyValuesMap
                 }
             )
-        }
-
-        fields.forEach {
-            it.setRawValue(rawValuesMap)
+            fields.forEach {
+                it.setRawValue(rawValuesMap)
+            }
         }
 
         fields

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressElementTest.kt
@@ -8,6 +8,7 @@ import com.stripe.android.ui.core.address.AddressRepository
 import com.stripe.android.ui.core.forms.FormFieldEntry
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.last
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -136,6 +137,30 @@ class AddressElementTest {
             .isEqualTo(
                 FormFieldEntry("DE89370400440532013000", true)
             )
+    }
+
+    @Test
+    fun `changing country updates the fields`() = runTest {
+        val addressElement = AddressElement(
+            IdentifierSpec.Generic("address"),
+            addressRepository,
+            countryDropdownFieldController = countryDropdownFieldController,
+            sameAsShippingController = null
+        )
+
+        val country = suspend {
+            addressElement.fields.first().map {
+                it.getFormFieldValueFlow().first()[0].second.value
+            }.first()
+        }
+
+        countryDropdownFieldController.onValueChange(0)
+
+        assertThat(country()).isEqualTo("US")
+
+        countryDropdownFieldController.onValueChange(1)
+
+        assertThat(country()).isEqualTo("JP")
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Fix an issue where the country dropdown was not updating correctly. This was broken in this [previous PR](https://github.com/stripe/stripe-android/pull/5419)

To test the change, use the payment sheet playground and play around with different customer types, default billing address enabled/disabled, and update the country dropdown to different countries. Make sure that the fields get updated, for example, US should show zip code, Canada should show postal code, other countries may not have other fields for billing address.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

<img src="https://user-images.githubusercontent.com/99316447/185693768-99d3be5e-67cd-4569-ada0-a6de28b4604d.gif" height=400/>
