### PR TITLE
Revert "Bump ktlint from 0.46.1 to 0.47.0 (#5434)"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ ext {
     kotlinCoroutinesVersion = '1.6.4'
     kotlinSerializationVersion = '1.4.0'
     accompanistVersion = '0.25.1'
-    ktlintVersion = '0.47.0'
+    ktlintVersion = '0.46.1'
     // material 1.6 causes paymentsheet to not render correctly.
     // see here: https://github.com/material-components/material-components-android/issues/2702
     materialVersion = '1.5.0'


### PR DESCRIPTION
This reverts commit 2bb4c6961c15b8b6af3360cde775ad2729f77da0.

# Summary
<!-- Simple summary of what was changed. -->

Reverting this bump because we’re seeing issues with the new version (example [here](https://github.com/stripe/stripe-android/runs/7960933474?check_suite_focus=true)).

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Staying unblocked on main.
