### PR TITLE
Make Link SupportedPaymentMethod enum

### DIFF
--- a/link/api/link.api
+++ b/link/api/link.api
@@ -491,22 +491,6 @@ public final class com/stripe/android/link/ui/paymentmethod/PaymentMethodViewMod
 	public static fun injectSubComponentBuilderProvider (Lcom/stripe/android/link/ui/paymentmethod/PaymentMethodViewModel$Factory;Ljavax/inject/Provider;)V
 }
 
-public final class com/stripe/android/link/ui/paymentmethod/SupportedPaymentMethod$BankAccount$Creator : android/os/Parcelable$Creator {
-	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/ui/paymentmethod/SupportedPaymentMethod$BankAccount;
-	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/link/ui/paymentmethod/SupportedPaymentMethod$BankAccount;
-	public synthetic fun newArray (I)[Ljava/lang/Object;
-}
-
-public final class com/stripe/android/link/ui/paymentmethod/SupportedPaymentMethod$Card$Creator : android/os/Parcelable$Creator {
-	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/ui/paymentmethod/SupportedPaymentMethod$Card;
-	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/link/ui/paymentmethod/SupportedPaymentMethod$Card;
-	public synthetic fun newArray (I)[Ljava/lang/Object;
-}
-
 public final class com/stripe/android/link/ui/signup/ComposableSingletons$SignUpScreenKt {
 	public static final field INSTANCE Lcom/stripe/android/link/ui/signup/ComposableSingletons$SignUpScreenKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function2;

--- a/link/src/main/java/com/stripe/android/link/ui/paymentmethod/SupportedPaymentMethod.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/paymentmethod/SupportedPaymentMethod.kt
@@ -1,12 +1,10 @@
 package com.stripe.android.link.ui.paymentmethod
 
-import android.os.Parcelable
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerPaymentDetailsCreateParams
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.ui.core.elements.FormItemSpec
 import com.stripe.android.ui.core.forms.LinkCardForm
-import kotlinx.parcelize.Parcelize
 
 /**
  * Represents the Payment Methods that are supported by Link.
@@ -14,26 +12,11 @@ import kotlinx.parcelize.Parcelize
  * @param type The Payment Method type. Matches the [ConsumerPaymentDetails] types.
  * @param formSpec Specification of how the payment method data collection UI should look.
  */
-internal sealed class SupportedPaymentMethod(
+internal enum class SupportedPaymentMethod(
     val type: String,
     val formSpec: List<FormItemSpec>
-) : Parcelable {
-    /**
-     * Build the [ConsumerPaymentDetailsCreateParams] that will to create this payment method.
-     */
-    abstract fun createParams(
-        paymentMethodCreateParams: PaymentMethodCreateParams,
-        email: String
-    ): ConsumerPaymentDetailsCreateParams
-
-    /**
-     * A map containing additional parameters that must be sent during payment confirmation.
-     */
-    open fun extraConfirmationParams(paymentMethodCreateParams: PaymentMethodCreateParams):
-        Map<String, Any>? = null
-
-    @Parcelize
-    object Card : SupportedPaymentMethod(
+) {
+    Card(
         ConsumerPaymentDetails.Card.type,
         LinkCardForm.items
     ) {
@@ -52,10 +35,8 @@ internal sealed class SupportedPaymentMethod(
             (paymentMethodCreateParams.toParamMap()["card"] as? Map<*, *>)?.let { card ->
                 mapOf("card" to mapOf("cvc" to card["cvc"]))
             }
-    }
-
-    @Parcelize
-    object BankAccount : SupportedPaymentMethod(
+    },
+    BankAccount(
         ConsumerPaymentDetails.BankAccount.type,
         emptyList()
     ) {
@@ -65,7 +46,21 @@ internal sealed class SupportedPaymentMethod(
         ): ConsumerPaymentDetailsCreateParams {
             TODO("Not yet implemented")
         }
-    }
+    };
+
+    /**
+     * Build the [ConsumerPaymentDetailsCreateParams] that will to create this payment method.
+     */
+    abstract fun createParams(
+        paymentMethodCreateParams: PaymentMethodCreateParams,
+        email: String
+    ): ConsumerPaymentDetailsCreateParams
+
+    /**
+     * A map containing additional parameters that must be sent during payment confirmation.
+     */
+    open fun extraConfirmationParams(paymentMethodCreateParams: PaymentMethodCreateParams):
+        Map<String, Any>? = null
 
     internal companion object {
         val allTypes = setOf(Card.type, BankAccount.type)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
SupportedPaymentMethod was a sealed class, but it can be an enum.
This was causing some NoClassDefFoundError during inline signup. 

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix NoClassDefFoundError.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
