### PR TITLE
Add ability to ignore fields

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
@@ -49,6 +49,7 @@ class FieldValuesToParamsMapConverter {
             val destMap = mutableMapOf<String, Any?>()
 
             val formKeyValueMap = fieldValuePairs
+                .filterNot { it.key.ignoreField }
                 .mapValues { entry -> entry.value.value }
                 .mapKeys { it.key.v1 }
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IdentifierSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IdentifierSpec.kt
@@ -7,13 +7,17 @@ import kotlinx.parcelize.Parcelize
 /**
  * This uniquely identifies a element in the form.  The vals here are for identifier
  * specs that need to be found when pre-populating fields, or when extracting data.
+ * @param ignoreField set this to true to ensure that the field does not get put in the params list
+ * when making a Stripe request. Used in [FieldValuesToParamsMapConverter.kt]
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @kotlinx.serialization.Serializable
 @Parcelize
-data class IdentifierSpec(val v1: String) : Parcelable {
-    constructor() : this("") {
-    }
+data class IdentifierSpec(
+    val v1: String,
+    val ignoreField: Boolean = false
+) : Parcelable {
+    constructor() : this("")
 
     companion object {
         fun Generic(_value: String) = IdentifierSpec(_value)
@@ -55,7 +59,7 @@ data class IdentifierSpec(val v1: String) : Parcelable {
         // Unique extracting functionality
         val SaveForFutureUse = IdentifierSpec("save_for_future_use")
         val OneLineAddress = IdentifierSpec("address")
-        val SameAsShipping = IdentifierSpec("same_as_shipping")
+        val SameAsShipping = IdentifierSpec("same_as_shipping", ignoreField = true)
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
         fun get(value: String) = when (value) {

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
@@ -106,4 +106,29 @@ class FieldValuesToParamsMapConverterTest {
                 "}"
         )
     }
+
+    @Test
+    fun `test ignored fields`() {
+        val paymentMethodParams = FieldValuesToParamsMapConverter
+            .transformToPaymentMethodCreateParams(
+                mapOf(
+                    IdentifierSpec.Name to FormFieldEntry(
+                        "joe",
+                        true
+                    ),
+                    IdentifierSpec.SameAsShipping to FormFieldEntry(
+                        "true",
+                        true
+                    )
+                ),
+                "some code",
+                false
+            )
+
+        assertThat(
+            paymentMethodParams.toParamMap().toString()
+        ).isEqualTo(
+            "{type=some code, billing_details={name=joe}}"
+        )
+    }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Add ability to ignore certain fields from being converted to param map

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Address Element. `same_as_shipping` was being sent to param map and failing payment confirmations.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
