### PR TITLE
BANKCON-4416 Add manual account entry point to consent screen

### DIFF
--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -517,11 +517,11 @@ public final class com/stripe/android/financialconnections/features/consent/Comp
 }
 
 public final class com/stripe/android/financialconnections/features/consent/ConsentViewModel_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/features/consent/ConsentViewModel_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/features/consent/ConsentViewModel_Factory;
 	public fun get ()Lcom/stripe/android/financialconnections/features/consent/ConsentViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/financialconnections/features/consent/ConsentState;Lcom/stripe/android/financialconnections/domain/AcceptConsent;Lcom/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator;Lcom/stripe/android/financialconnections/repository/FinancialConnectionsManifestRepository;Lcom/stripe/android/core/Logger;)Lcom/stripe/android/financialconnections/features/consent/ConsentViewModel;
+	public static fun newInstance (Lcom/stripe/android/financialconnections/features/consent/ConsentState;Lcom/stripe/android/financialconnections/domain/AcceptConsent;Lcom/stripe/android/financialconnections/domain/GetManifest;Lcom/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator;Lcom/stripe/android/financialconnections/navigation/NavigationManager;Lcom/stripe/android/core/Logger;)Lcom/stripe/android/financialconnections/features/consent/ConsentViewModel;
 }
 
 public final class com/stripe/android/financialconnections/features/institutionpicker/ComposableSingletons$InstitutionPickerScreenKt {
@@ -539,6 +539,14 @@ public final class com/stripe/android/financialconnections/features/institutionp
 	public fun get ()Lcom/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
 	public static fun newInstance (Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$Configuration;Lcom/stripe/android/financialconnections/domain/SearchInstitutions;Lcom/stripe/android/financialconnections/domain/PostAuthorizationSession;Lcom/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator;Lcom/stripe/android/core/Logger;Lcom/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerState;)Lcom/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerViewModel;
+}
+
+public final class com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel_Factory;
+	public fun get ()Lcom/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Lcom/stripe/android/financialconnections/features/manualentry/ManualEntryState;)Lcom/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel;
 }
 
 public final class com/stripe/android/financialconnections/features/partnerauth/ComposableSingletons$PartnerAuthScreenKt {
@@ -1459,12 +1467,14 @@ public final class com/stripe/android/financialconnections/ui/ComposableSingleto
 	public static field lambda-3 Lkotlin/jvm/functions/Function3;
 	public static field lambda-4 Lkotlin/jvm/functions/Function3;
 	public static field lambda-5 Lkotlin/jvm/functions/Function3;
+	public static field lambda-6 Lkotlin/jvm/functions/Function3;
 	public fun <init> ()V
 	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-2$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-3$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-4$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-5$financial_connections_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-6$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity_MembersInjector : dagger/MembersInjector {

--- a/financial-connections/res/values/strings.xml
+++ b/financial-connections/res/values/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="consent_pane_tc">You agree to Stripe\'s <annotation clickable="terms">Terms</annotation> and <annotation clickable="privacy">Privacy Policy</annotation>. <annotation clickable="privacy_center">Learn more</annotation></string>
+    <string name="consent_pane_manual_entry"><annotation clickable="manual_entry">Enter account details manually instead</annotation></string>
     <string name="stripe_consent_pane_title">%1$s works with Stripe to link your accounts</string>
     <string name="stripe_consent_pane_title_no_businessname">This business works with Stripe to link your accounts</string>
     <string name="stripe_consent_pane_title_connected_account">%1$s and %2%s work with Stripe to link your accounts</string>

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeComponent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeComponent.kt
@@ -7,6 +7,7 @@ import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.features.accountpicker.AccountPickerSubcomponent
 import com.stripe.android.financialconnections.features.consent.ConsentSubcomponent
 import com.stripe.android.financialconnections.features.institutionpicker.InstitutionPickerSubcomponent
+import com.stripe.android.financialconnections.features.manualentry.ManualEntrySubcomponent
 import com.stripe.android.financialconnections.features.partnerauth.PartnerAuthSubcomponent
 import com.stripe.android.financialconnections.features.success.SuccessSubcomponent
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
@@ -36,6 +37,7 @@ internal interface FinancialConnectionsSheetNativeComponent {
     val consentBuilder: ConsentSubcomponent.Builder
     val institutionPickerBuilder: InstitutionPickerSubcomponent.Builder
     val accountPickerBuilder: AccountPickerSubcomponent.Builder
+    val manualEntryBuilder: ManualEntrySubcomponent.Builder
     val partnerAuthSubcomponent: PartnerAuthSubcomponent.Builder
     val successSubcomponent: SuccessSubcomponent.Builder
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
@@ -6,6 +6,7 @@ import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.features.accountpicker.AccountPickerSubcomponent
 import com.stripe.android.financialconnections.features.consent.ConsentSubcomponent
 import com.stripe.android.financialconnections.features.institutionpicker.InstitutionPickerSubcomponent
+import com.stripe.android.financialconnections.features.manualentry.ManualEntrySubcomponent
 import com.stripe.android.financialconnections.features.partnerauth.PartnerAuthSubcomponent
 import com.stripe.android.financialconnections.features.success.SuccessSubcomponent
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
@@ -25,6 +26,7 @@ import javax.inject.Singleton
 @Module(
     subcomponents = [
         ConsentSubcomponent::class,
+        ManualEntrySubcomponent::class,
         InstitutionPickerSubcomponent::class,
         PartnerAuthSubcomponent::class,
         SuccessSubcomponent::class,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentScreen.kt
@@ -170,6 +170,7 @@ private fun ConsentMainContent(
                 Spacer(modifier = Modifier.weight(1f))
             }
             ConsentFooter(
+                manualEntryEnabled = state.manualEntryEnabled,
                 acceptConsent = state.acceptConsent,
                 onClickableTextClick = onClickableTextClick,
                 onContinueClick = onContinueClick
@@ -181,6 +182,7 @@ private fun ConsentMainContent(
 @Composable
 private fun ConsentFooter(
     acceptConsent: Async<Unit>,
+    manualEntryEnabled: Boolean,
     onClickableTextClick: (String) -> Unit,
     onContinueClick: () -> Unit
 ) {
@@ -201,6 +203,19 @@ private fun ConsentFooter(
                 .fillMaxWidth()
         ) {
             Text(text = stringResource(R.string.stripe_consent_pane_agree))
+        }
+        if (manualEntryEnabled) {
+            Spacer(modifier = Modifier.size(24.dp))
+            AnnotatedText(
+                modifier = Modifier.fillMaxWidth(),
+                text = TextResource.StringId(R.string.consent_pane_manual_entry),
+                onClickableTextClick = { onClickableTextClick(it) },
+                defaultStyle = FinancialConnectionsTheme.typography.body.copy(
+                    textAlign = TextAlign.Center,
+                    color = FinancialConnectionsTheme.colors.textSecondary
+                )
+            )
+            Spacer(modifier = Modifier.size(16.dp))
         }
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentState.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentState.kt
@@ -7,6 +7,7 @@ import com.stripe.android.financialconnections.ui.TextResource
 
 internal data class ConsentState(
     val title: TextResource = TextResource.Text(""),
+    val manualEntryEnabled: Boolean = false,
     val disconnectUrl: String = "",
     val stripeToSUrl: String = "",
     val faqUrl: String = "",
@@ -31,5 +32,6 @@ internal enum class ConsentClickableText(val value: String) {
     DISCONNECT("disconnect"),
     DATA("data"),
     PRIVACY_CENTER("privacy_center"),
-    DATA_ACCESS("data_access")
+    DATA_ACCESS("data_access"),
+    MANUAL_ENTRY("manual_entry")
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentViewModel.kt
@@ -12,7 +12,6 @@ import com.stripe.android.financialconnections.features.consent.ConsentState.Vie
 import com.stripe.android.financialconnections.navigation.NavigationDirections
 import com.stripe.android.financialconnections.navigation.NavigationManager
 import com.stripe.android.financialconnections.presentation.FinancialConnectionsUrls
-import com.stripe.android.financialconnections.repository.FinancialConnectionsManifestRepository
 import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -70,17 +69,13 @@ internal class ConsentViewModel @Inject constructor(
             ConsentClickableText.DATA_ACCESS ->
                 setState { copy(viewEffect = OpenUrl(dataPolicyUrl)) }
             ConsentClickableText.MANUAL_ENTRY ->
-                navigationManager.navigate(NavigationDirections.institutionPicker)
+                navigationManager.navigate(NavigationDirections.manualEntry)
             null -> logger.error("Unrecognized clickable text: $tag")
         }
     }
 
     fun onViewEffectLaunched() {
-        setState {
-            copy(
-                viewEffect = null
-            )
-        }
+        setState { copy(viewEffect = null) }
     }
 
     companion object : MavericksViewModelFactory<ConsentViewModel, ConsentState> {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryScreen.kt
@@ -1,0 +1,12 @@
+@file:Suppress("TooManyFunctions")
+
+package com.stripe.android.financialconnections.features.manualentry
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+internal fun ManualEntryScreen() {
+    // val viewModel: ManualEntryViewModel = mavericksViewModel()
+    Text(text = "Manual entry!")
+}

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryStates.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryStates.kt
@@ -1,0 +1,17 @@
+package com.stripe.android.financialconnections.features.manualentry
+
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+
+internal class ManualEntryStates : PreviewParameterProvider<ManualEntryState> {
+    override val values = sequenceOf(
+        default()
+    )
+
+    override val count: Int
+        get() = super.count
+
+    // TODO@carlosmuvi migrate to PreviewParameterProvider when showkase adds support.
+    companion object {
+        fun default() = ManualEntryState()
+    }
+}

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntrySubcomponent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntrySubcomponent.kt
@@ -1,0 +1,19 @@
+package com.stripe.android.financialconnections.features.manualentry
+
+import dagger.BindsInstance
+import dagger.Subcomponent
+
+@Subcomponent
+internal interface ManualEntrySubcomponent {
+
+    val viewModel: ManualEntryViewModel
+
+    @Subcomponent.Builder
+    interface Builder {
+
+        @BindsInstance
+        fun initialState(initialState: ManualEntryState): Builder
+
+        fun build(): ManualEntrySubcomponent
+    }
+}

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel.kt
@@ -1,0 +1,35 @@
+package com.stripe.android.financialconnections.features.manualentry
+
+import com.airbnb.mvrx.MavericksState
+import com.airbnb.mvrx.MavericksViewModel
+import com.airbnb.mvrx.MavericksViewModelFactory
+import com.airbnb.mvrx.ViewModelContext
+import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
+import javax.inject.Inject
+
+@Suppress("LongParameterList")
+internal class ManualEntryViewModel @Inject constructor(
+    initialState: ManualEntryState,
+) : MavericksViewModel<ManualEntryState>(initialState) {
+
+    companion object :
+        MavericksViewModelFactory<ManualEntryViewModel, ManualEntryState> {
+
+        override fun create(
+            viewModelContext: ViewModelContext,
+            state: ManualEntryState
+        ): ManualEntryViewModel {
+            return viewModelContext.activity<FinancialConnectionsSheetNativeActivity>()
+                .viewModel
+                .activityRetainedComponent
+                .manualEntryBuilder
+                .initialState(state)
+                .build()
+                .viewModel
+        }
+    }
+}
+
+internal data class ManualEntryState(
+    val text: String = ""
+) : MavericksState

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/NavigationCommand.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/NavigationCommand.kt
@@ -38,6 +38,11 @@ internal object NavigationDirections {
         override val destination = "success"
     }
 
+    val manualEntry = object : NavigationCommand {
+        override val arguments = emptyList<NamedNavArgument>()
+        override val destination = "manual_entry"
+    }
+
     val Default = object : NavigationCommand {
         override val arguments = emptyList<NamedNavArgument>()
         override val destination = ""

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
@@ -22,6 +22,7 @@ import com.airbnb.mvrx.withState
 import com.stripe.android.financialconnections.features.accountpicker.AccountPickerScreen
 import com.stripe.android.financialconnections.features.consent.ConsentScreen
 import com.stripe.android.financialconnections.features.institutionpicker.InstitutionPickerScreen
+import com.stripe.android.financialconnections.features.manualentry.ManualEntryScreen
 import com.stripe.android.financialconnections.features.partnerauth.PartnerAuthScreen
 import com.stripe.android.financialconnections.features.success.SuccessScreen
 import com.stripe.android.financialconnections.navigation.NavigationDirections
@@ -79,6 +80,9 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), Ma
         NavHost(navController, startDestination = NavigationDirections.consent.destination) {
             composable(NavigationDirections.consent.destination) {
                 ConsentScreen()
+            }
+            composable(NavigationDirections.manualEntry.destination) {
+                ManualEntryScreen()
             }
             composable(NavigationDirections.institutionPicker.destination) {
                 InstitutionPickerScreen()

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/Text.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/Text.kt
@@ -6,6 +6,7 @@ import android.text.Annotation
 import android.text.SpannedString
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
@@ -18,6 +19,7 @@ internal fun AnnotatedText(
     text: TextResource,
     onClickableTextClick: (String) -> Unit,
     defaultStyle: TextStyle,
+    modifier: Modifier = Modifier,
     annotationStyles: Map<StringAnnotation, SpanStyle> = mapOf(
         StringAnnotation.CLICKABLE to FinancialConnectionsTheme.typography.bodyEmphasized
             .toSpanStyle()
@@ -34,6 +36,7 @@ internal fun AnnotatedText(
     ClickableText(
         text = resource,
         style = defaultStyle,
+        modifier = modifier,
         onClick = { offset ->
             resource.getStringAnnotations(
                 tag = StringAnnotation.CLICKABLE.value,


### PR DESCRIPTION
# Summary
- [Adds entry point on consent when allowManualEntry = true.](https://github.com/stripe/stripe-android/pull/5451/commits/cd2dc81049090e6b0a4384a06a7070c61342bc74)
- [Navigates to mock manual entry screen.](https://github.com/stripe/stripe-android/pull/5451/commits/aa0a4fbd8bbd5cdf997b68a1f31d89f715410030)
- [Regenerates API.](https://github.com/stripe/stripe-android/pull/5451/commits/ef73f88f31cfd8c5e3ff03746c77f82993f5c06c)

<img width="300" alt="image" src="https://user-images.githubusercontent.com/99293320/186261981-a887280f-e4d8-4cb5-921c-4a50833fe6b2.png">

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
