### PR TITLE
Pass shipping details to confirm

### DIFF
--- a/link/src/main/java/com/stripe/android/link/confirmation/ConfirmStripeIntentParamsFactory.kt
+++ b/link/src/main/java/com/stripe/android/link/confirmation/ConfirmStripeIntentParamsFactory.kt
@@ -27,22 +27,27 @@ internal sealed class ConfirmStripeIntentParamsFactory<out T : ConfirmStripeInte
     ): PaymentMethodCreateParams
 
     companion object {
-        fun createFactory(stripeIntent: StripeIntent) =
+        fun createFactory(
+            stripeIntent: StripeIntent,
+            shipping: ConfirmPaymentIntentParams.Shipping? = null
+        ) =
             when (stripeIntent) {
-                is PaymentIntent -> ConfirmPaymentIntentParamsFactory(stripeIntent)
+                is PaymentIntent -> ConfirmPaymentIntentParamsFactory(stripeIntent, shipping)
                 is SetupIntent -> ConfirmSetupIntentParamsFactory(stripeIntent)
             }
     }
 }
 
 internal class ConfirmPaymentIntentParamsFactory(
-    private val paymentIntent: PaymentIntent
+    private val paymentIntent: PaymentIntent,
+    private val shipping: ConfirmPaymentIntentParams.Shipping?
 ) : ConfirmStripeIntentParamsFactory<ConfirmPaymentIntentParams>() {
     override fun createConfirmStripeIntentParams(
         paymentMethodCreateParams: PaymentMethodCreateParams
     ) = ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
         paymentMethodCreateParams,
-        paymentIntent.clientSecret!!
+        paymentIntent.clientSecret!!,
+        shipping = shipping
     )
 
     override fun createPaymentMethodCreateParams(

--- a/link/src/main/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModel.kt
@@ -25,6 +25,7 @@ import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.ui.core.FieldValuesToParamsMapConverter
 import com.stripe.android.ui.core.FormController
+import com.stripe.android.ui.core.address.AddressUtil.toConfirmPaymentIntentShipping
 import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.ui.core.elements.LayoutSpec
 import com.stripe.android.ui.core.forms.FormFieldEntry
@@ -202,7 +203,10 @@ internal class PaymentMethodViewModel @Inject constructor(
     }
 
     private fun completePayment(linkPaymentDetails: LinkPaymentDetails) {
-        val params = ConfirmStripeIntentParamsFactory.createFactory(stripeIntent)
+        val params = ConfirmStripeIntentParamsFactory.createFactory(
+            stripeIntent,
+            args.shippingValues?.toConfirmPaymentIntentShipping()
+        )
             .createConfirmStripeIntentParams(linkPaymentDetails.paymentMethodCreateParams)
 
         confirmationManager.confirmStripeIntent(params) { result ->

--- a/link/src/main/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModel.kt
@@ -25,7 +25,7 @@ import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.ui.core.FieldValuesToParamsMapConverter
 import com.stripe.android.ui.core.FormController
-import com.stripe.android.ui.core.address.AddressUtil.toConfirmPaymentIntentShipping
+import com.stripe.android.ui.core.address.toConfirmPaymentIntentShipping
 import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.ui.core.elements.LayoutSpec
 import com.stripe.android.ui.core.forms.FormFieldEntry

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -19,7 +19,7 @@ import com.stripe.android.link.ui.PrimaryButtonState
 import com.stripe.android.link.ui.getErrorMessage
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.payments.paymentlauncher.PaymentResult
-import com.stripe.android.ui.core.address.AddressUtil.toConfirmPaymentIntentShipping
+import com.stripe.android.ui.core.address.toConfirmPaymentIntentShipping
 import com.stripe.android.ui.core.injection.NonFallbackInjectable
 import com.stripe.android.ui.core.injection.NonFallbackInjector
 import kotlinx.coroutines.delay

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -19,6 +19,7 @@ import com.stripe.android.link.ui.PrimaryButtonState
 import com.stripe.android.link.ui.getErrorMessage
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.payments.paymentlauncher.PaymentResult
+import com.stripe.android.ui.core.address.AddressUtil.toConfirmPaymentIntentShipping
 import com.stripe.android.ui.core.injection.NonFallbackInjectable
 import com.stripe.android.ui.core.injection.NonFallbackInjector
 import kotlinx.coroutines.delay
@@ -81,7 +82,10 @@ internal class WalletViewModel @Inject constructor(
 
         runCatching { requireNotNull(linkAccountManager.linkAccount.value) }.fold(
             onSuccess = { linkAccount ->
-                val paramsFactory = ConfirmStripeIntentParamsFactory.createFactory(stripeIntent)
+                val paramsFactory = ConfirmStripeIntentParamsFactory.createFactory(
+                    stripeIntent,
+                    args.shippingValues?.toConfirmPaymentIntentShipping()
+                )
                 val params = paramsFactory.createPaymentMethodCreateParams(
                     linkAccount.clientSecret,
                     selectedPaymentDetails

--- a/link/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModelTest.kt
@@ -207,7 +207,6 @@ class PaymentMethodViewModelTest {
         whenever(
             linkAccountManager.createCardPaymentDetails(anyOrNull(), anyOrNull(), anyOrNull())
         ).thenReturn(Result.success(value))
-        whenever(navigator.isOnRootScreen()).thenReturn(false)
         whenever(args.shippingValues).thenReturn(
             mapOf(
                 IdentifierSpec.Name to "Test Name",
@@ -215,41 +214,17 @@ class PaymentMethodViewModelTest {
             )
         )
 
-        createViewModel().startPayment(cardFormFieldValues)
+        createViewModel().startPayment(mapOf())
 
         val paramsCaptor = argumentCaptor<ConfirmStripeIntentParams>()
         verify(confirmationManager).confirmStripeIntent(paramsCaptor.capture(), any())
 
-        assertThat(paramsCaptor.firstValue.toParamMap()).isEqualTo(
+        assertThat(paramsCaptor.firstValue.toParamMap()["shipping"]).isEqualTo(
             mapOf(
-                "client_secret" to args.stripeIntent.clientSecret,
-                "use_stripe_sdk" to false,
-                "mandate_data" to mapOf(
-                    "customer_acceptance" to mapOf(
-                        "type" to "online",
-                        "online" to mapOf(
-                            "infer_from_client" to true
-                        )
-                    )
+                "address" to mapOf(
+                    "country" to "US"
                 ),
-                "shipping" to mapOf(
-                    "address" to mapOf(
-                        "country" to "US"
-                    ),
-                    "name" to "Test Name"
-                ),
-                "payment_method_data" to mapOf(
-                    "type" to "link",
-                    "link" to mapOf(
-                        "payment_details_id" to "QAAAKJ6",
-                        "credentials" to mapOf(
-                            "consumer_session_client_secret" to CLIENT_SECRET
-                        ),
-                        "card" to mapOf(
-                            "cvc" to "123"
-                        )
-                    )
-                )
+                "name" to "Test Name"
             )
         )
     }

--- a/link/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -19,7 +19,6 @@ import com.stripe.android.link.model.PaymentDetailsFixtures
 import com.stripe.android.link.model.StripeIntentFixtures
 import com.stripe.android.link.ui.ErrorMessage
 import com.stripe.android.link.ui.PrimaryButtonState
-import com.stripe.android.model.Address
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.ConsumerPaymentDetails
@@ -160,7 +159,6 @@ class WalletViewModelTest {
 
     @Test
     fun `when shippingValues are passed ConfirmPaymentIntentParams has shipping`() = runTest {
-        val paymentDetails = PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS.paymentDetails.first()
         whenever(linkAccountManager.listPaymentDetails())
             .thenReturn(Result.success(PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS))
         whenever(args.shippingValues).thenReturn(
@@ -172,25 +170,17 @@ class WalletViewModelTest {
 
         val viewModel = createViewModel()
 
-        viewModel.onItemSelected(paymentDetails)
         viewModel.onConfirmPayment()
 
         val paramsCaptor = argumentCaptor<ConfirmStripeIntentParams>()
         verify(confirmationManager).confirmStripeIntent(paramsCaptor.capture(), any())
 
-        assertThat(paramsCaptor.firstValue).isEqualTo(
-            ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
-                PaymentMethodCreateParams.createLink(
-                    paymentDetails.id,
-                    CLIENT_SECRET
+        assertThat(paramsCaptor.firstValue.toParamMap()["shipping"]).isEqualTo(
+            mapOf(
+                "address" to mapOf(
+                    "country" to "US"
                 ),
-                StripeIntentFixtures.PI_SUCCEEDED.clientSecret!!,
-                shipping = ConfirmPaymentIntentParams.Shipping(
-                    address = Address(
-                        country = "US"
-                    ),
-                    name = "Test Name"
-                )
+                "name" to "Test Name"
             )
         )
     }

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -68,9 +68,7 @@ public final class com/stripe/android/ui/core/address/AddressRepository_Factory 
 	public static fun newInstance (Landroid/content/res/Resources;)Lcom/stripe/android/ui/core/address/AddressRepository;
 }
 
-public final class com/stripe/android/ui/core/address/AddressUtil {
-	public static final field $stable I
-	public static final field INSTANCE Lcom/stripe/android/ui/core/address/AddressUtil;
+public final class com/stripe/android/ui/core/address/AddressUtilKt {
 }
 
 public final class com/stripe/android/ui/core/databinding/ActivityCardScanBinding : androidx/viewbinding/ViewBinding {

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -68,6 +68,9 @@ public final class com/stripe/android/ui/core/address/AddressRepository_Factory 
 	public static fun newInstance (Landroid/content/res/Resources;)Lcom/stripe/android/ui/core/address/AddressRepository;
 }
 
+public final class com/stripe/android/ui/core/address/AddressUtilKt {
+}
+
 public final class com/stripe/android/ui/core/databinding/ActivityCardScanBinding : androidx/viewbinding/ViewBinding {
 	public final field fragmentContainer Landroidx/fragment/app/FragmentContainerView;
 	public static fun bind (Landroid/view/View;)Lcom/stripe/android/ui/core/databinding/ActivityCardScanBinding;

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -68,7 +68,9 @@ public final class com/stripe/android/ui/core/address/AddressRepository_Factory 
 	public static fun newInstance (Landroid/content/res/Resources;)Lcom/stripe/android/ui/core/address/AddressRepository;
 }
 
-public final class com/stripe/android/ui/core/address/AddressUtilKt {
+public final class com/stripe/android/ui/core/address/AddressUtil {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/stripe/android/ui/core/address/AddressUtil;
 }
 
 public final class com/stripe/android/ui/core/databinding/ActivityCardScanBinding : androidx/viewbinding/ViewBinding {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/address/AddressUtil.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/address/AddressUtil.kt
@@ -7,21 +7,19 @@ import com.stripe.android.ui.core.elements.IdentifierSpec
 
 object AddressUtil {
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    fun Map<IdentifierSpec, String?>?.toConfirmPaymentIntentShipping():
-        ConfirmPaymentIntentParams.Shipping? {
-        return this?.let {
-            ConfirmPaymentIntentParams.Shipping(
-                name = this[IdentifierSpec.Name] ?: "",
-                address = Address.Builder()
-                    .setLine1(this[IdentifierSpec.Line1])
-                    .setLine2(this[IdentifierSpec.Line2])
-                    .setCity(this[IdentifierSpec.City])
-                    .setState(this[IdentifierSpec.State])
-                    .setCountry(this[IdentifierSpec.Country])
-                    .setPostalCode(this[IdentifierSpec.PostalCode])
-                    .build(),
-                phone = this[IdentifierSpec.Phone]
-            )
-        }
+    fun Map<IdentifierSpec, String?>.toConfirmPaymentIntentShipping():
+        ConfirmPaymentIntentParams.Shipping {
+        return ConfirmPaymentIntentParams.Shipping(
+            name = this[IdentifierSpec.Name] ?: "",
+            address = Address.Builder()
+                .setLine1(this[IdentifierSpec.Line1])
+                .setLine2(this[IdentifierSpec.Line2])
+                .setCity(this[IdentifierSpec.City])
+                .setState(this[IdentifierSpec.State])
+                .setCountry(this[IdentifierSpec.Country])
+                .setPostalCode(this[IdentifierSpec.PostalCode])
+                .build(),
+            phone = this[IdentifierSpec.Phone]
+        )
     }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/address/AddressUtil.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/address/AddressUtil.kt
@@ -1,3 +1,5 @@
+@file:Suppress("ktlint:filename")
+
 package com.stripe.android.ui.core.address
 
 import androidx.annotation.RestrictTo
@@ -5,21 +7,19 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.ui.core.elements.IdentifierSpec
 
-object AddressUtil {
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    fun Map<IdentifierSpec, String?>.toConfirmPaymentIntentShipping():
-        ConfirmPaymentIntentParams.Shipping {
-        return ConfirmPaymentIntentParams.Shipping(
-            name = this[IdentifierSpec.Name] ?: "",
-            address = Address.Builder()
-                .setLine1(this[IdentifierSpec.Line1])
-                .setLine2(this[IdentifierSpec.Line2])
-                .setCity(this[IdentifierSpec.City])
-                .setState(this[IdentifierSpec.State])
-                .setCountry(this[IdentifierSpec.Country])
-                .setPostalCode(this[IdentifierSpec.PostalCode])
-                .build(),
-            phone = this[IdentifierSpec.Phone]
-        )
-    }
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun Map<IdentifierSpec, String?>.toConfirmPaymentIntentShipping():
+    ConfirmPaymentIntentParams.Shipping {
+    return ConfirmPaymentIntentParams.Shipping(
+        name = this[IdentifierSpec.Name] ?: "",
+        address = Address.Builder()
+            .setLine1(this[IdentifierSpec.Line1])
+            .setLine2(this[IdentifierSpec.Line2])
+            .setCity(this[IdentifierSpec.City])
+            .setState(this[IdentifierSpec.State])
+            .setCountry(this[IdentifierSpec.Country])
+            .setPostalCode(this[IdentifierSpec.PostalCode])
+            .build(),
+        phone = this[IdentifierSpec.Phone]
+    )
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/address/AddressUtil.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/address/AddressUtil.kt
@@ -1,0 +1,27 @@
+package com.stripe.android.ui.core.address
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.model.Address
+import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.ui.core.elements.IdentifierSpec
+
+object AddressUtil {
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun Map<IdentifierSpec, String?>?.toConfirmPaymentIntentShipping():
+        ConfirmPaymentIntentParams.Shipping? {
+        return this?.let {
+            ConfirmPaymentIntentParams.Shipping(
+                name = this[IdentifierSpec.Name] ?: "",
+                address = Address.Builder()
+                    .setLine1(this[IdentifierSpec.Line1])
+                    .setLine2(this[IdentifierSpec.Line2])
+                    .setCity(this[IdentifierSpec.City])
+                    .setState(this[IdentifierSpec.State])
+                    .setCountry(this[IdentifierSpec.Country])
+                    .setPostalCode(this[IdentifierSpec.PostalCode])
+                    .build(),
+                phone = this[IdentifierSpec.Phone]
+            )
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -44,6 +44,7 @@ import com.stripe.android.payments.paymentlauncher.PaymentLauncher
 import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
+import com.stripe.android.paymentsheet.addresselement.toConfirmPaymentIntentShipping
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.injection.DaggerPaymentSheetLauncherComponent
 import com.stripe.android.paymentsheet.injection.PaymentSheetViewModelModule
@@ -107,7 +108,8 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     linkPaymentLauncherFactory = linkPaymentLauncherFactory
 ) {
     private val confirmParamsFactory = ConfirmStripeIntentParamsFactory.createFactory(
-        args.clientSecret
+        args.clientSecret,
+        args.config?.shippingDetails?.toConfirmPaymentIntentShipping()
     )
 
     @VisibleForTesting

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressDetails.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressDetails.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.paymentsheet.addresselement
 
 import android.os.Parcelable
+import com.stripe.android.model.Address
+import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.ui.core.elements.IdentifierSpec
 import kotlinx.parcelize.Parcelize
@@ -54,4 +56,19 @@ internal fun AddressDetails.toIdentifierMap(
     } else {
         emptyMap()
     }
+}
+
+internal fun AddressDetails.toConfirmPaymentIntentShipping(): ConfirmPaymentIntentParams.Shipping {
+    return ConfirmPaymentIntentParams.Shipping(
+        name = this.name ?: "",
+        address = Address.Builder()
+            .setLine1(this.address?.line1)
+            .setLine2(this.address?.line2)
+            .setCity(this.address?.city)
+            .setState(this.address?.state)
+            .setCountry(this.address?.country)
+            .setPostalCode(this.address?.postalCode)
+            .build(),
+        phone = this.phoneNumber
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -40,6 +40,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResult
 import com.stripe.android.paymentsheet.PaymentSheetResultCallback
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.addresselement.toConfirmPaymentIntentShipping
 import com.stripe.android.paymentsheet.addresselement.toIdentifierMap
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.forms.FormViewModel
@@ -280,7 +281,10 @@ internal class DefaultFlowController @Inject internal constructor(
         initData: InitData
     ) {
         val confirmParamsFactory =
-            ConfirmStripeIntentParamsFactory.createFactory(initData.clientSecret)
+            ConfirmStripeIntentParamsFactory.createFactory(
+                initData.clientSecret,
+                initData.config?.shippingDetails?.toConfirmPaymentIntentShipping()
+            )
 
         when (paymentSelection) {
             is PaymentSelection.Saved -> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/ConfirmStripeIntentParamsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/ConfirmStripeIntentParamsFactory.kt
@@ -17,16 +17,24 @@ internal sealed class ConfirmStripeIntentParamsFactory<out T : ConfirmStripeInte
     abstract fun create(paymentSelection: PaymentSelection.New): T
 
     companion object {
-        fun createFactory(clientSecret: ClientSecret) =
+        fun createFactory(
+            clientSecret: ClientSecret,
+            shipping: ConfirmPaymentIntentParams.Shipping?
+        ) =
             when (clientSecret) {
-                is PaymentIntentClientSecret -> ConfirmPaymentIntentParamsFactory(clientSecret)
-                is SetupIntentClientSecret -> ConfirmSetupIntentParamsFactory(clientSecret)
+                is PaymentIntentClientSecret -> {
+                    ConfirmPaymentIntentParamsFactory(clientSecret, shipping)
+                }
+                is SetupIntentClientSecret -> {
+                    ConfirmSetupIntentParamsFactory(clientSecret)
+                }
             }
     }
 }
 
 internal class ConfirmPaymentIntentParamsFactory(
-    private val clientSecret: ClientSecret
+    private val clientSecret: ClientSecret,
+    private val shipping: ConfirmPaymentIntentParams.Shipping?
 ) : ConfirmStripeIntentParamsFactory<ConfirmPaymentIntentParams>() {
     override fun create(paymentSelection: PaymentSelection.Saved) =
         ConfirmPaymentIntentParams.createWithPaymentMethodId(
@@ -48,7 +56,8 @@ internal class ConfirmPaymentIntentParamsFactory(
                 }
             },
             mandateData = MandateDataParams(MandateDataParams.Type.Online.DEFAULT)
-                .takeIf { paymentSelection.paymentMethod.type?.requiresMandate == true }
+                .takeIf { paymentSelection.paymentMethod.type?.requiresMandate == true },
+            shipping = shipping
         )
 
     override fun create(paymentSelection: PaymentSelection.New) =
@@ -95,7 +104,8 @@ internal class ConfirmPaymentIntentParamsFactory(
                         setupFutureUsage = null
                     )
                 }
-            }
+            },
+            shipping = shipping
         )
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormFragment.kt
@@ -135,6 +135,7 @@ internal class USBankAccountFormFragment : Fragment() {
             { requireActivity().application },
             {
                 USBankAccountFormViewModel.Args(
+                    sheetViewModel,
                     formArgs,
                     sheetViewModel is PaymentSheetViewModel,
                     clientSecret,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormFragment.kt
@@ -135,12 +135,12 @@ internal class USBankAccountFormFragment : Fragment() {
             { requireActivity().application },
             {
                 USBankAccountFormViewModel.Args(
-                    sheetViewModel,
                     formArgs,
                     sheetViewModel is PaymentSheetViewModel,
                     clientSecret,
                     sheetViewModel?.usBankAccountSavedScreenState,
-                    (sheetViewModel?.newPaymentSelection as? PaymentSelection.New.USBankAccount)
+                    (sheetViewModel?.newPaymentSelection as? PaymentSelection.New.USBankAccount),
+                    sheetViewModel?.config?.shippingDetails
                 )
             },
             this

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -25,6 +25,7 @@ import com.stripe.android.payments.bankaccount.CollectBankAccountConfiguration
 import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResult
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.addresselement.toConfirmPaymentIntentShipping
 import com.stripe.android.paymentsheet.model.ClientSecret
 import com.stripe.android.paymentsheet.model.ConfirmStripeIntentParamsFactory
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
@@ -33,6 +34,7 @@ import com.stripe.android.paymentsheet.model.SetupIntentClientSecret
 import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.di.DaggerUSBankAccountFormComponent
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.di.USBankAccountFormViewModelSubcomponent
+import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
 import com.stripe.android.ui.core.elements.SaveForFutureUseSpec
 import com.stripe.android.ui.core.elements.SimpleTextFieldController
@@ -410,7 +412,8 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
     private fun confirm(clientSecret: ClientSecret, paymentSelection: PaymentSelection.New) {
         viewModelScope.launch {
             val confirmParamsFactory = ConfirmStripeIntentParamsFactory.createFactory(
-                clientSecret
+                clientSecret,
+                args.sheetViewModel?.config?.shippingDetails?.toConfirmPaymentIntentShipping()
             )
             val confirmIntent = confirmParamsFactory.create(paymentSelection)
             _currentScreenState.update {
@@ -496,6 +499,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
      * @param clientSecret The client secret for the Stripe Intent being processed
      */
     data class Args(
+        val sheetViewModel: BaseSheetViewModel<*>?,
         val formArgs: FormFragmentArguments,
         val completePayment: Boolean,
         val clientSecret: ClientSecret?,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -25,6 +25,7 @@ import com.stripe.android.payments.bankaccount.CollectBankAccountConfiguration
 import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResult
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.addresselement.toConfirmPaymentIntentShipping
 import com.stripe.android.paymentsheet.model.ClientSecret
 import com.stripe.android.paymentsheet.model.ConfirmStripeIntentParamsFactory
@@ -34,7 +35,6 @@ import com.stripe.android.paymentsheet.model.SetupIntentClientSecret
 import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.di.DaggerUSBankAccountFormComponent
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.di.USBankAccountFormViewModelSubcomponent
-import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
 import com.stripe.android.ui.core.elements.SaveForFutureUseSpec
 import com.stripe.android.ui.core.elements.SimpleTextFieldController
@@ -413,7 +413,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         viewModelScope.launch {
             val confirmParamsFactory = ConfirmStripeIntentParamsFactory.createFactory(
                 clientSecret,
-                args.sheetViewModel?.config?.shippingDetails?.toConfirmPaymentIntentShipping()
+                args.shippingDetails?.toConfirmPaymentIntentShipping()
             )
             val confirmIntent = confirmParamsFactory.create(paymentSelection)
             _currentScreenState.update {
@@ -499,12 +499,12 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
      * @param clientSecret The client secret for the Stripe Intent being processed
      */
     data class Args(
-        val sheetViewModel: BaseSheetViewModel<*>?,
         val formArgs: FormFragmentArguments,
         val completePayment: Boolean,
         val clientSecret: ClientSecret?,
         val savedScreenState: USBankAccountFormScreenState?,
         val savedPaymentMethod: PaymentSelection.New.USBankAccount?,
+        val shippingDetails: AddressDetails?,
         @InjectorKey internal val injectorKey: String = DUMMY_INJECTOR_KEY
     )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.StripeIntentResult
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.DUMMY_INJECTOR_KEY
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
+import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
@@ -29,6 +30,7 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.PaymentSheetViewModel.CheckoutIdentifier
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -362,6 +364,54 @@ internal class PaymentSheetViewModelTest {
                     CLIENT_SECRET,
                     paymentMethodOptions = PaymentMethodOptionsParams.Card(
                         setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
+                    )
+                )
+            )
+    }
+
+    @Test
+    fun `checkout() with shipping should confirm new payment methods`() = runTest {
+        val confirmParams = mutableListOf<BaseSheetViewModel.Event<ConfirmStripeIntentParams>>()
+
+        val viewModel = createViewModel(
+            args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config?.copy(
+                    shippingDetails = AddressDetails(
+                        address = PaymentSheet.Address(
+                            country = "US"
+                        ),
+                        name = "Test Name"
+                    )
+                )
+            )
+        )
+
+        viewModel.startConfirm.observeForever {
+            confirmParams.add(it)
+        }
+
+        val paymentSelection = PaymentSelection.New.Card(
+            PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+            CardBrand.Visa,
+            customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse
+        )
+        viewModel.updateSelection(paymentSelection)
+        viewModel.checkout(CheckoutIdentifier.None)
+
+        assertThat(confirmParams).hasSize(1)
+        assertThat(confirmParams[0].peekContent())
+            .isEqualTo(
+                ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
+                    PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                    CLIENT_SECRET,
+                    paymentMethodOptions = PaymentMethodOptionsParams.Card(
+                        setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.OffSession
+                    ),
+                    shipping = ConfirmPaymentIntentParams.Shipping(
+                        address = Address(
+                            country = "US"
+                        ),
+                        name = "Test Name"
                     )
                 )
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/ConfirmPaymentIntentParamsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/ConfirmPaymentIntentParamsFactoryTest.kt
@@ -101,16 +101,9 @@ class ConfirmPaymentIntentParamsFactoryTest {
                 paymentSelection = PaymentSelection.Saved(
                     PaymentMethodFixtures.CARD_PAYMENT_METHOD
                 )
-            )
+            ).shipping
         ).isEqualTo(
-            ConfirmPaymentIntentParams.createWithPaymentMethodId(
-                paymentMethodId = "pm_123456789",
-                clientSecret = CLIENT_SECRET,
-                paymentMethodOptions = PaymentMethodOptionsParams.Card(
-                    setupFutureUsage = ConfirmPaymentIntentParams.SetupFutureUsage.Blank
-                ),
-                shipping = shippingDetails.toConfirmPaymentIntentShipping()
-            )
+            shippingDetails.toConfirmPaymentIntentShipping()
         )
     }
 
@@ -136,15 +129,9 @@ class ConfirmPaymentIntentParamsFactoryTest {
                     CardBrand.Visa,
                     customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest
                 )
-            )
+            ).shipping
         ).isEqualTo(
-            ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
-                paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
-                clientSecret = CLIENT_SECRET,
-                setupFutureUsage = null,
-                paymentMethodOptions = PaymentMethodOptionsParams.Card(),
-                shipping = shippingDetails.toConfirmPaymentIntentShipping()
-            )
+            shippingDetails.toConfirmPaymentIntentShipping()
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -42,7 +42,6 @@ import kotlin.test.Test
 class USBankAccountFormViewModelTest {
 
     private val defaultArgs = USBankAccountFormViewModel.Args(
-        sheetViewModel = null,
         formArgs = FormFragmentArguments(
             paymentMethodCode = PaymentMethod.Type.USBankAccount.code,
             showCheckbox = false,
@@ -58,7 +57,8 @@ class USBankAccountFormViewModelTest {
         completePayment = true,
         clientSecret = PaymentIntentClientSecret("pi_12345"),
         savedScreenState = null,
-        savedPaymentMethod = null
+        savedPaymentMethod = null,
+        shippingDetails = null
     )
 
     private val stripeRepository = mock<StripeRepository>()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -42,6 +42,7 @@ import kotlin.test.Test
 class USBankAccountFormViewModelTest {
 
     private val defaultArgs = USBankAccountFormViewModel.Args(
+        sheetViewModel = null,
         formArgs = FormFragmentArguments(
             paymentMethodCode = PaymentMethod.Type.USBankAccount.code,
             showCheckbox = false,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Pass shipping details to payment intent confirm

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Address Element private beta

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

Need to verify flows:
- Link
- Google Pay
- Payment sheet
- Payment options

Check Payment Intent in dashboard to make sure shipping details were attached

