### PR TITLE
Add postal validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## X.X.X - 2022-XX-XX
 
+### PaymentSheet
+
+* [ADDED][5456](https://github.com/stripe/stripe-android/pull/5456) Added postal code validation
+
 ## 20.10.0 - 2022-08-22
 This release contains several bug fixes for PaymentSheet and binary size optimization for Identity.
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/address/AddressRepository.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/address/AddressRepository.kt
@@ -45,7 +45,7 @@ class AddressRepository @Inject constructor(
         countryAddressSchemaPair.map { (countryCode, schemaList) ->
             countryCode to requireNotNull(
                 schemaList
-                    .transformToElementList()
+                    .transformToElementList(countryCode)
             )
         }.forEach { add(it.first, it.second) }
     }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PostalCodeConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PostalCodeConfig.kt
@@ -13,18 +13,27 @@ internal class PostalCodeConfig(
     override val trailingIcon: MutableStateFlow<TextFieldIcon?> = MutableStateFlow(null),
     country: String
 ) : TextFieldConfig {
-    override val debugLabel: String = "postal_code_text"
-    override val visualTransformation: VisualTransformation? = null
-    override val loading: MutableStateFlow<Boolean> = MutableStateFlow(false)
     private val format = CountryPostalFormat.forCountry(country)
+
+    override val debugLabel: String = "postal_code_text"
+    override val visualTransformation: VisualTransformation =
+        PostalCodeVisualTransformation(format)
+    override val loading: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
     override fun determineState(input: String): TextFieldState = object : TextFieldState {
         override fun shouldShowError(hasFocus: Boolean) = false
 
         override fun isValid(): Boolean {
             val formatted = input.replace(Regex("\\s+"), "")
-            return formatted.length in format.minimumLength..format.maximumLength &&
-                input.matches(format.regexPattern)
+            return when (format) {
+                is CountryPostalFormat.Other -> {
+                    true
+                }
+                else -> {
+                    formatted.length in format.minimumLength..format.maximumLength &&
+                        input.matches(format.regexPattern)
+                }
+            }
         }
 
         override fun getError(): FieldError? = null
@@ -54,7 +63,7 @@ internal class PostalCodeConfig(
     ) {
         object CA : CountryPostalFormat(
             minimumLength = 6,
-            maximumLength = 6,
+            maximumLength = 7,
             regexPattern = Regex("[a-zA-Z]\\d[a-zA-Z][\\s-]?\\d[a-zA-Z]\\d")
         )
         object US : CountryPostalFormat(
@@ -63,8 +72,8 @@ internal class PostalCodeConfig(
             regexPattern = Regex("\\d+")
         )
         object Other : CountryPostalFormat(
-            minimumLength = 4,
-            maximumLength = 12,
+            minimumLength = 0,
+            maximumLength = 0,
             regexPattern = Regex(".+")
         )
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PostalCodeConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PostalCodeConfig.kt
@@ -1,0 +1,81 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.annotation.StringRes
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.VisualTransformation
+import kotlinx.coroutines.flow.MutableStateFlow
+
+internal class PostalCodeConfig(
+    @StringRes override val label: Int,
+    override val capitalization: KeyboardCapitalization = KeyboardCapitalization.Words,
+    override val keyboard: KeyboardType = KeyboardType.Text,
+    override val trailingIcon: MutableStateFlow<TextFieldIcon?> = MutableStateFlow(null),
+    country: String
+) : TextFieldConfig {
+    override val debugLabel: String = "postal_code_text"
+    override val visualTransformation: VisualTransformation? = null
+    override val loading: MutableStateFlow<Boolean> = MutableStateFlow(false)
+    private val format = CountryPostalFormat.forCountry(country)
+
+    override fun determineState(input: String): TextFieldState = object : TextFieldState {
+        override fun shouldShowError(hasFocus: Boolean) = false
+
+        override fun isValid(): Boolean {
+            val formatted = input.replace(Regex("\\s+"), "")
+            return formatted.length in format.minimumLength..format.maximumLength &&
+                input.matches(format.regexPattern)
+        }
+
+        override fun getError(): FieldError? = null
+
+        override fun isFull(): Boolean = input.length >= format.minimumLength
+
+        override fun isBlank(): Boolean = input.isBlank()
+    }
+
+    override fun filter(userTyped: String): String =
+        if (
+            setOf(KeyboardType.Number, KeyboardType.NumberPassword).contains(keyboard)
+        ) {
+            userTyped.filter { it.isDigit() }
+        } else {
+            userTyped
+        }
+
+    override fun convertToRaw(displayName: String) = displayName
+
+    override fun convertFromRaw(rawValue: String) = rawValue
+
+    sealed class CountryPostalFormat(
+        val minimumLength: Int,
+        val maximumLength: Int,
+        val regexPattern: Regex
+    ) {
+        object CA : CountryPostalFormat(
+            minimumLength = 6,
+            maximumLength = 6,
+            regexPattern = Regex("[a-zA-Z]\\d[a-zA-Z][\\s-]?\\d[a-zA-Z]\\d")
+        )
+        object US : CountryPostalFormat(
+            minimumLength = 5,
+            maximumLength = 9,
+            regexPattern = Regex("\\d+")
+        )
+        object Other : CountryPostalFormat(
+            minimumLength = 4,
+            maximumLength = 12,
+            regexPattern = Regex(".+")
+        )
+
+        companion object {
+            fun forCountry(country: String): CountryPostalFormat {
+                return when (country) {
+                    "US" -> US
+                    "CA" -> CA
+                    else -> Other
+                }
+            }
+        }
+    }
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PostalCodeVisualTransformation.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PostalCodeVisualTransformation.kt
@@ -12,7 +12,6 @@ internal class PostalCodeVisualTransformation(
     override fun filter(text: AnnotatedString): TransformedText {
         return when (format) {
             is PostalCodeConfig.CountryPostalFormat.CA -> postalForCanada(text)
-            is PostalCodeConfig.CountryPostalFormat.US -> postalForUS(text)
             else -> TransformedText(text, OffsetMapping.Identity)
         }
     }
@@ -36,31 +35,6 @@ internal class PostalCodeVisualTransformation(
                 if (offset <= 3) return offset
                 if (offset <= 6) return offset - 1
                 return 6
-            }
-        }
-
-        return TransformedText(AnnotatedString(out), postalCodeOffsetTranslator)
-    }
-
-    private fun postalForUS(text: AnnotatedString): TransformedText {
-        var out = ""
-
-        for (i in text.text.indices) {
-            out += text.text[i]
-            if (i == 4 && i < text.text.length - 1) out += "-"
-        }
-
-        val postalCodeOffsetTranslator = object : OffsetMapping {
-            override fun originalToTransformed(offset: Int): Int {
-                if (offset <= 4) return offset
-                if (offset <= 8) return offset + 1
-                return 10
-            }
-
-            override fun transformedToOriginal(offset: Int): Int {
-                if (offset <= 5) return offset
-                if (offset <= 9) return offset - 1
-                return 9
             }
         }
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PostalCodeVisualTransformation.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PostalCodeVisualTransformation.kt
@@ -1,0 +1,69 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.input.VisualTransformation
+
+internal class PostalCodeVisualTransformation(
+    val format: PostalCodeConfig.CountryPostalFormat
+) : VisualTransformation {
+
+    override fun filter(text: AnnotatedString): TransformedText {
+        return when (format) {
+            is PostalCodeConfig.CountryPostalFormat.CA -> postalForCanada(text)
+            is PostalCodeConfig.CountryPostalFormat.US -> postalForUS(text)
+            else -> TransformedText(text, OffsetMapping.Identity)
+        }
+    }
+
+    private fun postalForCanada(text: AnnotatedString): TransformedText {
+        var out = ""
+
+        for (i in text.text.indices) {
+            out += text.text[i].uppercaseChar()
+            if (i == 2) out += " "
+        }
+
+        val postalCodeOffsetTranslator = object : OffsetMapping {
+            override fun originalToTransformed(offset: Int): Int {
+                if (offset <= 2) return offset
+                if (offset <= 5) return offset + 1
+                return 7
+            }
+
+            override fun transformedToOriginal(offset: Int): Int {
+                if (offset <= 3) return offset
+                if (offset <= 6) return offset - 1
+                return 6
+            }
+        }
+
+        return TransformedText(AnnotatedString(out), postalCodeOffsetTranslator)
+    }
+
+    private fun postalForUS(text: AnnotatedString): TransformedText {
+        var out = ""
+
+        for (i in text.text.indices) {
+            out += text.text[i]
+            if (i == 4 && i < text.text.length - 1) out += "-"
+        }
+
+        val postalCodeOffsetTranslator = object : OffsetMapping {
+            override fun originalToTransformed(offset: Int): Int {
+                if (offset <= 4) return offset
+                if (offset <= 8) return offset + 1
+                return 10
+            }
+
+            override fun transformedToOriginal(offset: Int): Int {
+                if (offset <= 5) return offset
+                if (offset <= 9) return offset - 1
+                return 9
+            }
+        }
+
+        return TransformedText(AnnotatedString(out), postalCodeOffsetTranslator)
+    }
+}

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/address/TransformAddressToElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/address/TransformAddressToElementTest.kt
@@ -22,7 +22,7 @@ class TransformAddressToElementTest {
     @Test
     fun `Read US Json`() = runBlocking {
         val addressSchema = readFile("src/main/assets/addressinfo/US.json")!!
-        val simpleTextList = addressSchema.transformToElementList()
+        val simpleTextList = addressSchema.transformToElementList("US")
 
         val addressLine1 = SimpleTextSpec(
             IdentifierSpec.Line1,

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PostalCodeConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PostalCodeConfigTest.kt
@@ -1,0 +1,49 @@
+package com.stripe.android.ui.core.elements
+
+import com.google.common.truth.Truth
+import com.stripe.android.core.R
+import org.junit.Test
+
+class PostalCodeConfigTest {
+
+    @Test
+    fun `verify US postal codes`() {
+        with(createConfigForCountry("US")) {
+            Truth.assertThat(determineStateForInput("").isValid()).isFalse()
+            Truth.assertThat(determineStateForInput("").isFull()).isFalse()
+            Truth.assertThat(determineStateForInput("12345").isValid()).isTrue()
+            Truth.assertThat(determineStateForInput("12345").isFull()).isTrue()
+            Truth.assertThat(determineStateForInput("1234567890").isValid()).isFalse()
+            Truth.assertThat(determineStateForInput("1234567890").isFull()).isTrue()
+            Truth.assertThat(determineStateForInput("abcde").isValid()).isFalse()
+            Truth.assertThat(determineStateForInput("abcde").isFull()).isTrue()
+        }
+    }
+
+    @Test
+    fun `verify CA postal codes`() {
+        with(createConfigForCountry("CA")) {
+            Truth.assertThat(determineStateForInput("").isValid()).isFalse()
+            Truth.assertThat(determineStateForInput("").isFull()).isFalse()
+            Truth.assertThat(determineStateForInput("AAA AAA").isValid()).isFalse()
+            Truth.assertThat(determineStateForInput("AAAAAA").isValid()).isFalse()
+            Truth.assertThat(determineStateForInput("A0A 0A0").isValid()).isTrue()
+            Truth.assertThat(determineStateForInput("A0A 0A0").isFull()).isTrue()
+            Truth.assertThat(determineStateForInput("A0A0A0").isValid()).isTrue()
+            Truth.assertThat(determineStateForInput("A0A0A0").isFull()).isTrue()
+            Truth.assertThat(determineStateForInput("A0A0A0A0").isValid()).isFalse()
+            Truth.assertThat(determineStateForInput("A0A0A0A0").isFull()).isTrue()
+        }
+    }
+
+    private fun createConfigForCountry(country: String): PostalCodeConfig {
+        return PostalCodeConfig(
+            label = R.string.address_label_postal_code,
+            country = country
+        )
+    }
+
+    private fun PostalCodeConfig.determineStateForInput(input: String): TextFieldState {
+        return determineState(filter(input))
+    }
+}

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PostalCodeConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PostalCodeConfigTest.kt
@@ -13,8 +13,6 @@ class PostalCodeConfigTest {
             Truth.assertThat(determineStateForInput("").isFull()).isFalse()
             Truth.assertThat(determineStateForInput("12345").isValid()).isTrue()
             Truth.assertThat(determineStateForInput("12345").isFull()).isTrue()
-            Truth.assertThat(determineStateForInput("1234567890").isValid()).isFalse()
-            Truth.assertThat(determineStateForInput("1234567890").isFull()).isTrue()
             Truth.assertThat(determineStateForInput("abcde").isValid()).isFalse()
             Truth.assertThat(determineStateForInput("abcde").isFull()).isTrue()
         }
@@ -31,8 +29,22 @@ class PostalCodeConfigTest {
             Truth.assertThat(determineStateForInput("A0A 0A0").isFull()).isTrue()
             Truth.assertThat(determineStateForInput("A0A0A0").isValid()).isTrue()
             Truth.assertThat(determineStateForInput("A0A0A0").isFull()).isTrue()
-            Truth.assertThat(determineStateForInput("A0A0A0A0").isValid()).isFalse()
-            Truth.assertThat(determineStateForInput("A0A0A0A0").isFull()).isTrue()
+        }
+    }
+
+    @Test
+    fun `verify other postal codes`() {
+        with(createConfigForCountry("UK")) {
+            Truth.assertThat(determineStateForInput("").isValid()).isFalse()
+            Truth.assertThat(determineStateForInput("").isFull()).isFalse()
+            Truth.assertThat(determineStateForInput(" ").isValid()).isFalse()
+            Truth.assertThat(determineStateForInput(" ").isFull()).isFalse()
+            Truth.assertThat(determineStateForInput("a").isValid()).isTrue()
+            Truth.assertThat(determineStateForInput("a").isFull()).isTrue()
+            Truth.assertThat(determineStateForInput("1").isValid()).isTrue()
+            Truth.assertThat(determineStateForInput("1").isFull()).isTrue()
+            Truth.assertThat(determineStateForInput("aaaaaa").isValid()).isTrue()
+            Truth.assertThat(determineStateForInput("111111").isValid()).isTrue()
         }
     }
 
@@ -44,6 +56,6 @@ class PostalCodeConfigTest {
     }
 
     private fun PostalCodeConfig.determineStateForInput(input: String): TextFieldState {
-        return determineState(filter(input))
+        return determineState(filter(convertFromRaw(input)))
     }
 }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PostalCodeVisualTransformationTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PostalCodeVisualTransformationTest.kt
@@ -7,25 +7,7 @@ import org.junit.Test
 internal class PostalCodeVisualTransformationTest {
 
     @Test
-    fun `verify US zip with zip+4`() {
-        val transform = PostalCodeVisualTransformation(
-            PostalCodeConfig.CountryPostalFormat.US
-        )
-        Truth.assertThat(transform.filter(AnnotatedString("902101234")).text.text)
-            .isEqualTo("90210-1234")
-    }
-
-    @Test
-    fun `verify US zip with zip+4 and less than 9`() {
-        val transform = PostalCodeVisualTransformation(
-            PostalCodeConfig.CountryPostalFormat.US
-        )
-        Truth.assertThat(transform.filter(AnnotatedString("90210123")).text.text)
-            .isEqualTo("90210-123")
-    }
-
-    @Test
-    fun `verify US zip without zip+4`() {
+    fun `verify US zip`() {
         val transform = PostalCodeVisualTransformation(
             PostalCodeConfig.CountryPostalFormat.US
         )

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PostalCodeVisualTransformationTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PostalCodeVisualTransformationTest.kt
@@ -1,0 +1,62 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.compose.ui.text.AnnotatedString
+import com.google.common.truth.Truth
+import org.junit.Test
+
+internal class PostalCodeVisualTransformationTest {
+
+    @Test
+    fun `verify US zip with zip+4`() {
+        val transform = PostalCodeVisualTransformation(
+            PostalCodeConfig.CountryPostalFormat.US
+        )
+        Truth.assertThat(transform.filter(AnnotatedString("902101234")).text.text)
+            .isEqualTo("90210-1234")
+    }
+
+    @Test
+    fun `verify US zip with zip+4 and less than 9`() {
+        val transform = PostalCodeVisualTransformation(
+            PostalCodeConfig.CountryPostalFormat.US
+        )
+        Truth.assertThat(transform.filter(AnnotatedString("90210123")).text.text)
+            .isEqualTo("90210-123")
+    }
+
+    @Test
+    fun `verify US zip without zip+4`() {
+        val transform = PostalCodeVisualTransformation(
+            PostalCodeConfig.CountryPostalFormat.US
+        )
+        Truth.assertThat(transform.filter(AnnotatedString("90210")).text.text)
+            .isEqualTo("90210")
+    }
+
+    @Test
+    fun `verify CA postal`() {
+        val transform = PostalCodeVisualTransformation(
+            PostalCodeConfig.CountryPostalFormat.CA
+        )
+        Truth.assertThat(transform.filter(AnnotatedString("A0A0A0")).text.text)
+            .isEqualTo("A0A 0A0")
+    }
+
+    @Test
+    fun `verify CA postal with less than 6`() {
+        val transform = PostalCodeVisualTransformation(
+            PostalCodeConfig.CountryPostalFormat.CA
+        )
+        Truth.assertThat(transform.filter(AnnotatedString("A0A0A")).text.text)
+            .isEqualTo("A0A 0A")
+    }
+
+    @Test
+    fun `verify CA postal with lower`() {
+        val transform = PostalCodeVisualTransformation(
+            PostalCodeConfig.CountryPostalFormat.CA
+        )
+        Truth.assertThat(transform.filter(AnnotatedString("a0a0a0")).text.text)
+            .isEqualTo("A0A 0A0")
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -470,7 +470,7 @@ internal class FormViewModelTest {
 
         val addressControllers = AddressControllers.create(formViewModel)
         addressControllers.controllers.forEachIndexed { index, textFieldController ->
-            textFieldController.onValueChange("1234")
+            textFieldController.onValueChange("12345")
             if (index == addressControllers.controllers.size - 1) {
                 assertThat(
                     formViewModel
@@ -561,7 +561,7 @@ internal class FormViewModelTest {
             .filter { it.label.first() != R.string.address_label_address_line2 }
         populateAddressControllers
             .forEachIndexed { index, textFieldController ->
-                textFieldController.onValueChange("1234")
+                textFieldController.onValueChange("12345")
 
                 if (index == populateAddressControllers.size - 1) {
                     assertThat(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Validate the postal code in payment sheet

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

- Address Element private beta
- https://jira.corp.stripe.com/browse/MOBILESDK-912

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

<img src="https://user-images.githubusercontent.com/99316447/186506340-d74c2763-fe11-4ffd-af5c-f4f3a97950b9.gif" height=400/>


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

- [Added] Postal code validation in PaymentSheet for CA, US zip codes
