### PR TITLE
Remove same as shipping checkbox from address element

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressDetails.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressDetails.kt
@@ -42,7 +42,8 @@ internal fun AddressLauncher.DefaultAddressDetails.toAddressDetails(): AddressDe
     )
 
 internal fun AddressDetails.toIdentifierMap(
-    billingDetails: PaymentSheet.BillingDetails? = null
+    billingDetails: PaymentSheet.BillingDetails? = null,
+    billingSameAsShipping: Boolean = true
 ): Map<IdentifierSpec, String?> {
     return if (billingDetails == null) {
         mapOf(
@@ -57,7 +58,7 @@ internal fun AddressDetails.toIdentifierMap(
         ).plus(
             mapOf(
                 IdentifierSpec.SameAsShipping to isCheckboxSelected?.toString()
-            ).takeIf { isCheckboxSelected != null } ?: emptyMap()
+            ).takeIf { isCheckboxSelected != null && billingSameAsShipping } ?: emptyMap()
         )
     } else {
         emptyMap()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -66,7 +66,8 @@ internal class InputAddressViewModel @Inject constructor(
 
         viewModelScope.launch {
             collectedAddress.collect { addressDetails ->
-                val initialValues: Map<IdentifierSpec, String?> = addressDetails?.toIdentifierMap()
+                val initialValues: Map<IdentifierSpec, String?> = addressDetails
+                    ?.toIdentifierMap(billingSameAsShipping = false)
                     ?: emptyMap()
 
                 _formController.value = formControllerProvider.get()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Remove same as shipping checkbox from address element. It should not appear on this screen.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Address element private beta

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

<img src ="https://user-images.githubusercontent.com/99316447/186508959-ca9ffa07-9a25-49a1-8420-b1467359eb05.png" height=400 />
