### PR TITLE
Fix checkbox label not showing provided text

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
@@ -107,26 +107,19 @@ internal class AddressLauncher internal constructor(
          * Google Places api key used to provide autocomplete suggestions
          * When null, autocomplete is disabled.
          */
-        val googlePlacesApiKey: String? = null,
-
-        /**
-         * The label of a checkbox displayed below other fields. If null, the checkbox is not displayed.
-         * Defaults to null
-         */
-        val checkboxLabel: String? = null
+        val googlePlacesApiKey: String? = null
     ) : Parcelable {
         /**
          * [Configuration] builder for cleaner object creation from Java.
          */
         class Builder {
-            var appearance: PaymentSheet.Appearance = PaymentSheet.Appearance()
-            var defaultValues: DefaultAddressDetails? = null
-            var allowedCountries: Set<String> = emptySet()
-            var buttonTitle: String? = null
-            var additionalFields: AdditionalFieldsConfiguration? = null
-            var title: String? = null
-            var googlePlacesApiKey: String? = null
-            var checkboxLabel: String? = null
+            private var appearance: PaymentSheet.Appearance = PaymentSheet.Appearance()
+            private var defaultValues: DefaultAddressDetails? = null
+            private var allowedCountries: Set<String> = emptySet()
+            private var buttonTitle: String? = null
+            private var additionalFields: AdditionalFieldsConfiguration? = null
+            private var title: String? = null
+            private var googlePlacesApiKey: String? = null
 
             fun appearance(appearance: PaymentSheet.Appearance) =
                 apply { this.appearance = appearance }
@@ -149,9 +142,6 @@ internal class AddressLauncher internal constructor(
             fun googlePlacesApiKey(googlePlacesApiKey: String?) =
                 apply { this.googlePlacesApiKey = googlePlacesApiKey }
 
-            fun checkBoxLabel(checkboxLabel: String?) =
-                apply { this.checkboxLabel = checkboxLabel }
-
             fun build() = Configuration(
                 appearance,
                 defaultValues,
@@ -159,8 +149,7 @@ internal class AddressLauncher internal constructor(
                 buttonTitle,
                 additionalFields,
                 title,
-                googlePlacesApiKey,
-                checkboxLabel
+                googlePlacesApiKey
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
@@ -120,7 +120,7 @@ internal fun InputAddressScreen(
                     }
                 },
                 checkboxContent = {
-                    viewModel.args.config?.checkboxLabel?.let { label ->
+                    viewModel.args.config?.additionalFields?.checkboxLabel?.let { label ->
                         CheckboxElementUI(
                             isChecked = checkboxChecked,
                             label = label,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where the checkbox label wasn’t set correctly even if the caller provided a custom label in the `additionalFields`. This happened because `InputAddressScreen` used `viewModel.args.config?.checkboxLabel` instead of `viewModel.args.config?.additionalFields?.checkboxLabel` to populate the checkbox. To fix this, we’re removing `config.checkboxLabel`.

As a small drive-by improvement, we’re making the properties of the builder private. Otherwise, it’d be confusing to have both properties and methods with the same name.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Bugfix.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screen recording

https://user-images.githubusercontent.com/110940675/186732278-c5f0ea02-da3e-4fb1-a5e3-449927c24b10.mp4

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

_Nothing to add._
