### PR TITLE
Rename defaultValues to address

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -831,14 +831,6 @@ public final class com/stripe/android/paymentsheet/addresselement/AddressLaunche
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/paymentsheet/addresselement/AddressLauncher$DefaultAddressDetails$Creator : android/os/Parcelable$Creator {
-	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/addresselement/AddressLauncher$DefaultAddressDetails;
-	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/addresselement/AddressLauncher$DefaultAddressDetails;
-	public synthetic fun newArray (I)[Ljava/lang/Object;
-}
-
 public final class com/stripe/android/paymentsheet/addresselement/AddressLauncherResult$Canceled$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/addresselement/AddressLauncherResult$Canceled;

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressDetails.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressDetails.kt
@@ -33,14 +33,6 @@ data class AddressDetails(
     }
 }
 
-internal fun AddressLauncher.DefaultAddressDetails.toAddressDetails(): AddressDetails =
-    AddressDetails(
-        name = this.name,
-        address = this.address,
-        phoneNumber = this.phoneNumber,
-        isCheckboxSelected = this.isCheckboxSelected
-    )
-
 internal fun AddressDetails.toIdentifierMap(
     billingDetails: PaymentSheet.BillingDetails? = null,
     billingSameAsShipping: Boolean = true

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
@@ -78,7 +78,7 @@ internal class AddressLauncher internal constructor(
         /**
          * The values to pre-populate shipping address fields with.
          */
-        val defaultValues: DefaultAddressDetails? = null,
+        val address: AddressDetails? = null,
 
         /**
          * A list of two-letter country codes representing countries the customers can select.
@@ -114,7 +114,7 @@ internal class AddressLauncher internal constructor(
          */
         class Builder {
             private var appearance: PaymentSheet.Appearance = PaymentSheet.Appearance()
-            private var defaultValues: DefaultAddressDetails? = null
+            private var address: AddressDetails? = null
             private var allowedCountries: Set<String> = emptySet()
             private var buttonTitle: String? = null
             private var additionalFields: AdditionalFieldsConfiguration? = null
@@ -124,8 +124,8 @@ internal class AddressLauncher internal constructor(
             fun appearance(appearance: PaymentSheet.Appearance) =
                 apply { this.appearance = appearance }
 
-            fun defaultValues(defaultValues: DefaultAddressDetails?) =
-                apply { this.defaultValues = defaultValues }
+            fun address(address: AddressDetails?) =
+                apply { this.address = address }
 
             fun allowedCountries(allowedCountries: Set<String>) =
                 apply { this.allowedCountries = allowedCountries }
@@ -144,7 +144,7 @@ internal class AddressLauncher internal constructor(
 
             fun build() = Configuration(
                 appearance,
-                defaultValues,
+                address,
                 allowedCountries,
                 buttonTitle,
                 additionalFields,
@@ -183,28 +183,4 @@ internal class AddressLauncher internal constructor(
             REQUIRED
         }
     }
-
-    @Parcelize
-    data class DefaultAddressDetails(
-        /**
-         * The customer's full name
-         */
-        val name: String? = null,
-
-        /**
-         * The customer's address
-         */
-        val address: PaymentSheet.Address? = null,
-
-        /**
-         * The customer's phone number, without formatting e.g. "5551234567"
-         */
-        val phoneNumber: String? = null,
-
-        /**
-         * Whether or not your custom checkbox is intially selected.
-         * Note: The checkbox is displayed below the other fields when AdditionalFieldsConfiguration.checkboxLabel is set.
-         */
-        val isCheckboxSelected: Boolean? = null
-    ) : Parcelable
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -30,7 +30,7 @@ internal class InputAddressViewModel @Inject constructor(
     private val eventReporter: AddressLauncherEventReporter,
     formControllerProvider: Provider<FormControllerSubcomponent.Builder>
 ) : ViewModel() {
-    private val _collectedAddress = MutableStateFlow(args.config?.defaultValues?.toAddressDetails())
+    private val _collectedAddress = MutableStateFlow(args.config?.address)
     val collectedAddress: StateFlow<AddressDetails?> = _collectedAddress
 
     private val _formController = MutableStateFlow<FormController?>(null)
@@ -82,7 +82,7 @@ internal class InputAddressViewModel @Inject constructor(
         }
 
         // allows merchants to check the box by default and to restore the value later.
-        args.config?.defaultValues?.isCheckboxSelected?.let {
+        args.config?.address?.isCheckboxSelected?.let {
             _checkboxChecked.value = it
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -46,9 +46,9 @@ class InputAddressViewModelTest {
     }
     private val eventReporter = mock<AddressLauncherEventReporter>()
 
-    private fun createViewModel(defaultAddress: AddressLauncher.DefaultAddressDetails? = null): InputAddressViewModel {
-        defaultAddress?.let {
-            whenever(config.defaultValues).thenReturn(defaultAddress)
+    private fun createViewModel(address: AddressDetails? = null): InputAddressViewModel {
+        address?.let {
+            whenever(config.address).thenReturn(address)
         }
         whenever(args.config).thenReturn(config)
         return InputAddressViewModel(
@@ -90,16 +90,16 @@ class InputAddressViewModelTest {
 
     @Test
     fun `default address from merchant is parsed`() = runTest(UnconfinedTestDispatcher()) {
-        val expectedAddress = AddressLauncher.DefaultAddressDetails(name = "skyler", address = PaymentSheet.Address(country = "US"))
+        val expectedAddress = AddressDetails(name = "skyler", address = PaymentSheet.Address(country = "US"))
 
         val viewModel = createViewModel(expectedAddress)
-        assertThat(viewModel.collectedAddress.value).isEqualTo(expectedAddress.toAddressDetails())
+        assertThat(viewModel.collectedAddress.value).isEqualTo(expectedAddress)
     }
 
     @Test
     fun `viewModel emits onComplete event`() = runTest(UnconfinedTestDispatcher()) {
         val viewModel = createViewModel(
-            AddressLauncher.DefaultAddressDetails(
+            AddressDetails(
                 address = PaymentSheet.Address(
                     line1 = "99 Broadway St",
                     city = "Seattle",
@@ -126,7 +126,7 @@ class InputAddressViewModelTest {
     @Test
     fun `default checkbox should emit true to start if passed by merchant`() = runTest(UnconfinedTestDispatcher()) {
         val viewModel = createViewModel(
-            AddressLauncher.DefaultAddressDetails(
+            AddressDetails(
                 isCheckboxSelected = true
             )
         )
@@ -136,7 +136,7 @@ class InputAddressViewModelTest {
     @Test
     fun `default checkbox should emit false to start if passed by merchant`() = runTest(UnconfinedTestDispatcher()) {
         val viewModel = createViewModel(
-            AddressLauncher.DefaultAddressDetails(
+            AddressDetails(
                 isCheckboxSelected = false
             )
         )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

* Rename `defaultValues` to `address`
* Remove `DefaultAddress` in favor of using the base `AddressDetails`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

To achieve a common android pattern where the screen is supplied the initial data. Developers can keep the state of the address element if they need to

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

