### PR TITLE
BANKCON-5020 Navigate to manual entry success pane after submitting account

### DIFF
--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -559,11 +559,26 @@ public final class com/stripe/android/financialconnections/features/manualentry/
 }
 
 public final class com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel_Factory;
 	public fun get ()Lcom/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/financialconnections/features/manualentry/ManualEntryState;Lcom/stripe/android/financialconnections/domain/AttachPaymentAccount;Lcom/stripe/android/financialconnections/domain/GetManifest;Lcom/stripe/android/core/Logger;)Lcom/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel;
+	public static fun newInstance (Lcom/stripe/android/financialconnections/features/manualentry/ManualEntryState;Lcom/stripe/android/financialconnections/domain/AttachPaymentAccount;Lcom/stripe/android/financialconnections/domain/GetManifest;Lcom/stripe/android/financialconnections/domain/GoNext;Lcom/stripe/android/core/Logger;)Lcom/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel;
+}
+
+public final class com/stripe/android/financialconnections/features/manualentrysuccess/ComposableSingletons$ManualEntrySuccessScreenKt {
+	public static final field INSTANCE Lcom/stripe/android/financialconnections/features/manualentrysuccess/ComposableSingletons$ManualEntrySuccessScreenKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-2 Lkotlin/jvm/functions/Function2;
+	public static field lambda-3 Lkotlin/jvm/functions/Function2;
+	public static field lambda-4 Lkotlin/jvm/functions/Function2;
+	public static field lambda-5 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-2$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-3$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-4$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-5$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class com/stripe/android/financialconnections/features/partnerauth/ComposableSingletons$PartnerAuthScreenKt {
@@ -1520,6 +1535,7 @@ public final class com/stripe/android/financialconnections/ui/ComposableSingleto
 	public static field lambda-4 Lkotlin/jvm/functions/Function3;
 	public static field lambda-5 Lkotlin/jvm/functions/Function3;
 	public static field lambda-6 Lkotlin/jvm/functions/Function3;
+	public static field lambda-7 Lkotlin/jvm/functions/Function3;
 	public fun <init> ()V
 	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-2$financial_connections_release ()Lkotlin/jvm/functions/Function3;
@@ -1527,6 +1543,7 @@ public final class com/stripe/android/financialconnections/ui/ComposableSingleto
 	public final fun getLambda-4$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-5$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-6$financial_connections_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-7$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity_MembersInjector : dagger/MembersInjector {

--- a/financial-connections/res/values/strings.xml
+++ b/financial-connections/res/values/strings.xml
@@ -82,5 +82,11 @@
     <string name="stripe_validation_account_confirm_mismatch">Your account numbers don\'t match.</string>
     <string name="stripe_manualentry_microdeposits_desc">Your bank information will be verified with micro-deposits to your account.</string>
     <string name="stripe_manualentry_account_type_disclaimer">Your account can be checking or savings.</string>
+    <string name="stripe_manualentrysuccess_title">Micro-deposits initiated</string>
+    <string name="stripe_manualentrysuccess_desc">Expect two small deposits to the account ending in ••••%1$s in 1–2 business days and an email with additional instructions to verify your bank account.</string>
+    <string name="stripe_manualentrysuccess_desc_noaccount">Expect two small deposits to your account in 1–2 business days and an email with additional instructions to verify your bank account.</string>
+    <string name="stripe_manualentrysuccess_desc_descriptorcode">Expect a $0.01 deposit to the account ending in ••••%1$s in 1–2 business days and an email with additional instructions to verify your bank account.</string>
+    <string name="stripe_manualentrysuccess_desc_noaccount_descriptorcode">Expect a $0.01 deposit to your account in 1–2 business days and an email with additional instructions to verify your bank account.</string>
+    <string name="stripe_manualentrysuccess_table_title">••••%1$s BANK STATEMENT</string>
 </resources>
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
@@ -74,7 +74,6 @@ internal class FinancialConnectionsSheetNativeModule {
     )
 
     @Singleton
-
     @Provides
     fun providesFinancialConnectionsInstitutionsRepository(
         requestExecutor: FinancialConnectionsRequestExecutor,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/GoNext.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/GoNext.kt
@@ -4,7 +4,6 @@ import com.stripe.android.core.Logger
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.NextPane
 import com.stripe.android.financialconnections.navigation.NavigationCommand
 import com.stripe.android.financialconnections.navigation.NavigationDirections
-import com.stripe.android.financialconnections.navigation.NavigationDirections.ManualEntrySuccessNavigation
 import com.stripe.android.financialconnections.navigation.NavigationManager
 import javax.inject.Inject
 
@@ -36,7 +35,7 @@ internal class GoNext @Inject constructor(
         NextPane.ACCOUNT_PICKER -> NavigationDirections.accountPicker
         NextPane.SUCCESS -> NavigationDirections.success
         NextPane.MANUAL_ENTRY -> NavigationDirections.manualEntry
-        NextPane.MANUAL_ENTRY_SUCCESS -> ManualEntrySuccessNavigation.navigationCommand(args)
+        NextPane.MANUAL_ENTRY_SUCCESS -> NavigationDirections.ManualEntrySuccess(args)
         NextPane.ATTACH_LINKED_PAYMENT_ACCOUNT,
         NextPane.AUTH_OPTIONS,
         NextPane.LINK_CONSENT,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/GoNext.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/GoNext.kt
@@ -4,6 +4,7 @@ import com.stripe.android.core.Logger
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.NextPane
 import com.stripe.android.financialconnections.navigation.NavigationCommand
 import com.stripe.android.financialconnections.navigation.NavigationDirections
+import com.stripe.android.financialconnections.navigation.NavigationDirections.ManualEntrySuccessNavigation
 import com.stripe.android.financialconnections.navigation.NavigationManager
 import javax.inject.Inject
 
@@ -15,26 +16,31 @@ internal class GoNext @Inject constructor(
     private val logger: Logger
 ) {
 
-    operator fun invoke(nextPane: NextPane): NavigationCommand {
-        val nextPaneDirection = nextPane.toNavigationCommand()
+    operator fun invoke(
+        nextPane: NextPane,
+        args: Map<String, Any?> = emptyMap()
+    ): NavigationCommand {
+        val nextPaneDirection = nextPane.toNavigationCommand(args)
         logger.debug("Navigating to next pane: ${nextPaneDirection.destination}")
         navigationManager.navigate(nextPaneDirection)
         return nextPaneDirection
     }
 
     @Suppress("ComplexMethod")
-    private fun NextPane.toNavigationCommand(): NavigationCommand = when (this) {
+    private fun NextPane.toNavigationCommand(
+        args: Map<String, Any?>
+    ): NavigationCommand = when (this) {
         NextPane.INSTITUTION_PICKER -> NavigationDirections.institutionPicker
         NextPane.PARTNER_AUTH -> NavigationDirections.partnerAuth
         NextPane.CONSENT -> NavigationDirections.consent
         NextPane.ACCOUNT_PICKER -> NavigationDirections.accountPicker
         NextPane.SUCCESS -> NavigationDirections.success
+        NextPane.MANUAL_ENTRY -> NavigationDirections.manualEntry
+        NextPane.MANUAL_ENTRY_SUCCESS -> ManualEntrySuccessNavigation.navigationCommand(args)
         NextPane.ATTACH_LINKED_PAYMENT_ACCOUNT,
         NextPane.AUTH_OPTIONS,
         NextPane.LINK_CONSENT,
         NextPane.LINK_LOGIN,
-        NextPane.MANUAL_ENTRY,
-        NextPane.MANUAL_ENTRY_SUCCESS,
         NextPane.NETWORKING_LINK_LOGIN_WARMUP,
         NextPane.NETWORKING_LINK_SIGNUP_PANE,
         NextPane.NETWORKING_LINK_VERIFICATION,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel.kt
@@ -10,7 +10,7 @@ import com.stripe.android.core.Logger
 import com.stripe.android.financialconnections.domain.AttachPaymentAccount
 import com.stripe.android.financialconnections.domain.GetManifest
 import com.stripe.android.financialconnections.domain.GoNext
-import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.*
+import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.NextPane
 import com.stripe.android.financialconnections.model.LinkAccountSessionPaymentAccount
 import com.stripe.android.financialconnections.model.PaymentAccountParams
 import com.stripe.android.financialconnections.navigation.NavigationDirections
@@ -74,6 +74,7 @@ internal class ManualEntryViewModel @Inject constructor(
         }
     }
 
+    @Suppress("MagicNumber")
     fun onSubmit() {
         suspend {
             val state = awaitState()

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel.kt
@@ -13,7 +13,7 @@ import com.stripe.android.financialconnections.domain.GoNext
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.*
 import com.stripe.android.financialconnections.model.LinkAccountSessionPaymentAccount
 import com.stripe.android.financialconnections.model.PaymentAccountParams
-import com.stripe.android.financialconnections.navigation.NavigationDirections.ManualEntrySuccessNavigation
+import com.stripe.android.financialconnections.navigation.NavigationDirections
 import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
 import javax.inject.Inject
 
@@ -85,7 +85,7 @@ internal class ManualEntryViewModel @Inject constructor(
             ).also {
                 goNext(
                     it.nextPane ?: NextPane.MANUAL_ENTRY_SUCCESS,
-                    args = ManualEntrySuccessNavigation.argMap(
+                    args = NavigationDirections.ManualEntrySuccess.argMap(
                         microdepositVerificationMethod = it.microdepositVerificationMethod,
                         last4 = state.account.first?.takeLast(4)
                     )
@@ -113,9 +113,9 @@ internal class ManualEntryViewModel @Inject constructor(
 }
 
 internal data class ManualEntryState(
-    val routing: Pair<String?, Int?> = "110000000" to null,
-    val account: Pair<String?, Int?> = "000123456789" to null,
-    val accountConfirm: Pair<String?, Int?> = "000123456789" to null,
+    val routing: Pair<String?, Int?> = null to null,
+    val account: Pair<String?, Int?> = null to null,
+    val accountConfirm: Pair<String?, Int?> = null to null,
     val linkPaymentAccount: Async<LinkAccountSessionPaymentAccount> = Uninitialized,
     val verifyWithMicrodeposits: Boolean = false
 ) : MavericksState {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessScreen.kt
@@ -82,7 +82,7 @@ internal fun ManualEntrySuccessContent(
                     color = FinancialConnectionsTheme.colors.textSecondary
                 )
             )
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(8.dp))
             TransactionHistoryTable(
                 microdepositVerificationMethod = microdepositVerificationMethod,
                 last4 = last4

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessScreen.kt
@@ -1,0 +1,39 @@
+@file:Suppress("TooManyFunctions")
+
+package com.stripe.android.financialconnections.features.manualentrysuccess
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.stripe.android.financialconnections.model.LinkAccountSessionPaymentAccount.MicrodepositVerificationMethod
+import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
+
+@Composable
+internal fun ManualEntrySuccessScreen(
+    microdepositVerificationMethod: MicrodepositVerificationMethod,
+    last4: String?
+) {
+    ManualEntrySuccessContent(
+        microdepositVerificationMethod,
+        last4
+    )
+}
+
+@Composable
+private fun ManualEntrySuccessContent(
+    microdepositVerificationMethod: MicrodepositVerificationMethod,
+    last4: String?
+) {
+    Column {
+        Text(microdepositVerificationMethod.value)
+        Text(last4 ?: "UNKNOWN")
+    }
+}
+
+@Preview
+@Composable
+internal fun ManualEntrySuccessScreenPreview() {
+    FinancialConnectionsTheme {
+    }
+}

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessScreen.kt
@@ -2,11 +2,40 @@
 
 package com.stripe.android.financialconnections.features.manualentrysuccess
 
+import android.app.Activity
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Divider
+import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.model.LinkAccountSessionPaymentAccount.MicrodepositVerificationMethod
+import com.stripe.android.financialconnections.ui.components.FinancialConnectionsButton
+import com.stripe.android.financialconnections.ui.components.FinancialConnectionsScaffold
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
 
 @Composable
@@ -15,25 +44,222 @@ internal fun ManualEntrySuccessScreen(
     last4: String?
 ) {
     ManualEntrySuccessContent(
-        microdepositVerificationMethod,
-        last4
+        microdepositVerificationMethod = microdepositVerificationMethod,
+        last4 = last4
     )
 }
 
 @Composable
-private fun ManualEntrySuccessContent(
+internal fun ManualEntrySuccessContent(
     microdepositVerificationMethod: MicrodepositVerificationMethod,
     last4: String?
 ) {
-    Column {
-        Text(microdepositVerificationMethod.value)
-        Text(last4 ?: "UNKNOWN")
+    val localContext = LocalContext.current
+    FinancialConnectionsScaffold {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+        ) {
+            Icon(
+                modifier = Modifier.size(40.dp),
+                painter = painterResource(R.drawable.stripe_ic_check),
+                contentDescription = null,
+                tint = FinancialConnectionsTheme.colors.textSuccess
+            )
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                text = stringResource(R.string.stripe_manualentrysuccess_title),
+                style = FinancialConnectionsTheme.typography.subtitle.copy(
+                    color = FinancialConnectionsTheme.colors.textPrimary
+                )
+            )
+            Text(
+                text = resolveText(microdepositVerificationMethod, last4),
+                style = FinancialConnectionsTheme.typography.body.copy(
+                    color = FinancialConnectionsTheme.colors.textSecondary
+                )
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            TransactionHistoryTable(
+                microdepositVerificationMethod = microdepositVerificationMethod,
+                last4 = last4
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            FinancialConnectionsButton(
+                loading = false,
+                onClick = {
+                    val activity = (localContext as? Activity)
+                    activity?.setResult(Activity.RESULT_OK)
+                    activity?.finish()
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+            ) {
+                Text(text = stringResource(R.string.success_pane_done))
+            }
+        }
+    }
+}
+@Composable
+internal fun resolveText(
+    microdepositVerificationMethod: MicrodepositVerificationMethod,
+    last4: String?
+) = when(microdepositVerificationMethod) {
+    MicrodepositVerificationMethod.AMOUNTS -> when {
+        last4 != null -> stringResource(R.string.stripe_manualentrysuccess_desc, last4)
+        else -> stringResource(R.string.stripe_manualentrysuccess_desc_noaccount)
+    }
+    MicrodepositVerificationMethod.DESCRIPTOR_CODE -> when {
+        last4 != null -> stringResource(R.string.stripe_manualentrysuccess_desc_descriptorcode, last4)
+        else -> stringResource(R.string.stripe_manualentrysuccess_desc_noaccount_descriptorcode)
+    }
+    MicrodepositVerificationMethod.UNKNOWN -> TODO()
+}
+
+@Composable
+internal fun TransactionHistoryTable(
+    last4: String?,
+    microdepositVerificationMethod: MicrodepositVerificationMethod
+) {
+    val shape = RoundedCornerShape(8.dp)
+    Box(
+        Modifier
+            .clip(shape)
+            .background(FinancialConnectionsTheme.colors.backgroundContainer)
+            .border(
+                border = BorderStroke(1.dp, FinancialConnectionsTheme.colors.borderDefault),
+                shape = shape
+            )
+    ) {
+        Column(
+            Modifier
+                .padding(start = 16.dp, end = 16.dp, top = 16.dp)
+        ) {
+            val titleColor = FinancialConnectionsTheme.colors.textSecondary
+            val tableData = buildTableRows(microdepositVerificationMethod)
+            val columnWeight = .33f
+            last4?.let {
+                Text(
+                    text = stringResource(R.string.stripe_manualentrysuccess_table_title, it),
+                    style = FinancialConnectionsTheme.typography.body.copy(color = titleColor)
+                )
+            }
+            Row {
+                TableCell(text = "Transaction", weight = columnWeight, titleColor)
+                TableCell(text = "Amount", weight = columnWeight, titleColor)
+                TableCell(text = "Type", weight = columnWeight, titleColor)
+            }
+            Divider(
+                modifier = Modifier.padding(top = 4.dp, bottom = 8.dp),
+                color = FinancialConnectionsTheme.colors.borderDefault
+            )
+            for (item in tableData) {
+                val (transaction, amount, type) = item
+                Row(Modifier.fillMaxWidth()) {
+                    TableCell(text = transaction.first, weight = columnWeight, transaction.second)
+                    TableCell(text = amount.first, weight = columnWeight, amount.second)
+                    TableCell(text = type.first, weight = columnWeight, type.second)
+                }
+            }
+        }
+        // Bottom fade.
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(36.dp)
+                .align(Alignment.BottomCenter)
+                .background(
+                    brush = Brush.verticalGradient(
+                        colors = listOf(
+                            FinancialConnectionsTheme.colors.textWhite.copy(alpha = 0f),
+                            FinancialConnectionsTheme.colors.textWhite.copy(alpha = 1f),
+                        )
+                    )
+                )
+        )
+    }
+}
+
+@Composable
+private fun buildTableRows(
+    microdepositVerificationMethod: MicrodepositVerificationMethod,
+): List<Triple<Pair<String, Color>, Pair<String, Color>, Pair<String, Color>>> {
+    val rowColor = FinancialConnectionsTheme.colors.textPrimary
+    val highlightColor = FinancialConnectionsTheme.colors.textBrand
+    return when (microdepositVerificationMethod) {
+        MicrodepositVerificationMethod.DESCRIPTOR_CODE -> listOf(
+            Triple("SMXXXX" to highlightColor, "$0.01" to rowColor, "ACH CREDIT" to rowColor),
+            Triple("GROCERIES" to rowColor, "$56.12" to rowColor, "VISA" to rowColor)
+        )
+        MicrodepositVerificationMethod.AMOUNTS -> listOf(
+            Triple("AMTS" to rowColor, "$0.XX" to highlightColor, "ACH CREDIT" to rowColor),
+            Triple("AMTS" to rowColor, "$0.XX" to highlightColor, "ACH CREDIT" to rowColor),
+            Triple("GROCERIES" to rowColor, "$56.12" to rowColor, "VISA" to rowColor)
+        )
+        MicrodepositVerificationMethod.UNKNOWN -> error("Unknown microdeposits type")
+    }
+}
+
+@Composable
+private fun RowScope.TableCell(
+    text: String,
+    weight: Float,
+    color: Color
+) {
+    Text(
+        text = text,
+        style = FinancialConnectionsTheme.typography.detailEmphasized.copy(
+            color = color
+        ),
+        modifier = Modifier
+            .padding(4.dp)
+            .weight(weight)
+    )
+}
+
+@Preview
+@Composable
+internal fun ManualEntrySuccessScreenPreviewAmount() {
+    FinancialConnectionsTheme {
+        ManualEntrySuccessContent(
+            MicrodepositVerificationMethod.AMOUNTS,
+            last4 = "1234"
+        )
     }
 }
 
 @Preview
 @Composable
-internal fun ManualEntrySuccessScreenPreview() {
+internal fun ManualEntrySuccessScreenPreviewDescriptor() {
     FinancialConnectionsTheme {
+        ManualEntrySuccessContent(
+            MicrodepositVerificationMethod.DESCRIPTOR_CODE,
+            last4 = "1234"
+        )
+    }
+}
+
+@Preview
+@Composable
+internal fun ManualEntrySuccessScreenPreviewAmountNoAccount() {
+    FinancialConnectionsTheme {
+        ManualEntrySuccessContent(
+            MicrodepositVerificationMethod.AMOUNTS,
+            last4 = null
+        )
+    }
+}
+
+@Preview
+@Composable
+internal fun ManualEntrySuccessScreenPreviewDescriptorNoAccount() {
+    FinancialConnectionsTheme {
+        ManualEntrySuccessContent(
+            MicrodepositVerificationMethod.DESCRIPTOR_CODE,
+            last4 = null
+        )
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessScreen.kt
@@ -107,7 +107,7 @@ internal fun ManualEntrySuccessContent(
 internal fun resolveText(
     microdepositVerificationMethod: MicrodepositVerificationMethod,
     last4: String?
-) = when(microdepositVerificationMethod) {
+) = when (microdepositVerificationMethod) {
     MicrodepositVerificationMethod.AMOUNTS -> when {
         last4 != null -> stringResource(R.string.stripe_manualentrysuccess_desc, last4)
         else -> stringResource(R.string.stripe_manualentrysuccess_desc_noaccount)
@@ -140,7 +140,6 @@ internal fun TransactionHistoryTable(
         ) {
             val titleColor = FinancialConnectionsTheme.colors.textSecondary
             val tableData = buildTableRows(microdepositVerificationMethod)
-            val columnWeight = .33f
             last4?.let {
                 Text(
                     text = stringResource(R.string.stripe_manualentrysuccess_table_title, it),
@@ -148,9 +147,9 @@ internal fun TransactionHistoryTable(
                 )
             }
             Row {
-                TableCell(text = "Transaction", weight = columnWeight, titleColor)
-                TableCell(text = "Amount", weight = columnWeight, titleColor)
-                TableCell(text = "Type", weight = columnWeight, titleColor)
+                TableCell(text = "Transaction", titleColor)
+                TableCell(text = "Amount", titleColor)
+                TableCell(text = "Type", titleColor)
             }
             Divider(
                 modifier = Modifier.padding(top = 4.dp, bottom = 8.dp),
@@ -159,9 +158,9 @@ internal fun TransactionHistoryTable(
             for (item in tableData) {
                 val (transaction, amount, type) = item
                 Row(Modifier.fillMaxWidth()) {
-                    TableCell(text = transaction.first, weight = columnWeight, transaction.second)
-                    TableCell(text = amount.first, weight = columnWeight, amount.second)
-                    TableCell(text = type.first, weight = columnWeight, type.second)
+                    TableCell(text = transaction.first, transaction.second)
+                    TableCell(text = amount.first, amount.second)
+                    TableCell(text = type.first, type.second)
                 }
             }
         }
@@ -206,7 +205,6 @@ private fun buildTableRows(
 @Composable
 private fun RowScope.TableCell(
     text: String,
-    weight: Float,
     color: Color
 ) {
     Text(
@@ -216,7 +214,7 @@ private fun RowScope.TableCell(
         ),
         modifier = Modifier
             .padding(4.dp)
-            .weight(weight)
+            .weight(1f)
     )
 }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/LinkAccountSessionPaymentAccount.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/LinkAccountSessionPaymentAccount.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.model
 
+import com.stripe.android.financialconnections.model.LinkAccountSessionPaymentAccount.MicrodepositVerificationMethod.UNKNOWN
 import kotlinx.serialization.Required
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -15,7 +16,7 @@ internal data class LinkAccountSessionPaymentAccount(
     val eligibleForNetworking: Boolean? = null,
 
     @SerialName(value = "microdeposit_verification_method")
-    val microdepositVerificationMethod: MicrodepositVerificationMethod? = null,
+    val microdepositVerificationMethod: MicrodepositVerificationMethod = UNKNOWN,
 
     @SerialName(value = "networking_successful")
     val networkingSuccessful: Boolean? = null,
@@ -27,7 +28,13 @@ internal data class LinkAccountSessionPaymentAccount(
 
     @Serializable
     enum class MicrodepositVerificationMethod(val value: String) {
-        @SerialName(value = "amounts") AMOUNTS("amounts"),
-        @SerialName(value = "descriptor_code") DESCRIPTOR_CODE("descriptor_code");
+        @SerialName(value = "amounts")
+        AMOUNTS("amounts"),
+
+        @SerialName(value = "descriptor_code")
+        DESCRIPTOR_CODE("descriptor_code"),
+
+        @SerialName(value = "unknown")
+        UNKNOWN("unknown");
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/NavigationCommand.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/NavigationCommand.kt
@@ -48,7 +48,7 @@ internal object NavigationDirections {
         override val destination = "manual_entry"
     }
 
-    object ManualEntrySuccessNavigation {
+    object ManualEntrySuccess {
 
         private const val KEY_MICRODEPOSITS = "microdeposits"
         private const val KEY_LAST4 = "last4"
@@ -75,8 +75,8 @@ internal object NavigationDirections {
 
         fun last4(backStackEntry: NavBackStackEntry): String? =
             backStackEntry.arguments?.getString(KEY_LAST4)
-        fun navigationCommand(args: Map<String, Any?>) = object : NavigationCommand {
-            override val arguments = ManualEntrySuccessNavigation.arguments
+        operator fun invoke(args: Map<String, Any?>) = object : NavigationCommand {
+            override val arguments = ManualEntrySuccess.arguments
             val last4 = args.getValue(KEY_LAST4) as? String
             val microdeposits = args.getValue(KEY_MICRODEPOSITS) as? MicrodepositVerificationMethod
             override val destination = "manual_entry_success?" +

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/NavigationCommand.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/navigation/NavigationCommand.kt
@@ -2,6 +2,11 @@ package com.stripe.android.financialconnections.navigation
 
 import android.util.Log
 import androidx.navigation.NamedNavArgument
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavType
+import androidx.navigation.NavType.EnumType
+import androidx.navigation.navArgument
+import com.stripe.android.financialconnections.model.LinkAccountSessionPaymentAccount.MicrodepositVerificationMethod
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
@@ -41,6 +46,43 @@ internal object NavigationDirections {
     val manualEntry = object : NavigationCommand {
         override val arguments = emptyList<NamedNavArgument>()
         override val destination = "manual_entry"
+    }
+
+    object ManualEntrySuccessNavigation {
+
+        private const val KEY_MICRODEPOSITS = "microdeposits"
+        private const val KEY_LAST4 = "last4"
+        const val route = "manual_entry_success?" +
+            "$KEY_MICRODEPOSITS={$KEY_MICRODEPOSITS}," +
+            "$KEY_LAST4={$KEY_LAST4}"
+
+        val arguments = listOf(
+            navArgument(KEY_LAST4) { type = NavType.StringType },
+            navArgument(KEY_MICRODEPOSITS) { type = EnumType(MicrodepositVerificationMethod::class.java) },
+        )
+
+        fun argMap(
+            microdepositVerificationMethod: MicrodepositVerificationMethod,
+            last4: String?
+        ): Map<String, Any?> = mapOf(
+            KEY_MICRODEPOSITS to microdepositVerificationMethod,
+            KEY_LAST4 to last4
+        )
+
+        fun microdeposits(backStackEntry: NavBackStackEntry): MicrodepositVerificationMethod =
+            backStackEntry.arguments?.getSerializable(KEY_MICRODEPOSITS)
+                as MicrodepositVerificationMethod
+
+        fun last4(backStackEntry: NavBackStackEntry): String? =
+            backStackEntry.arguments?.getString(KEY_LAST4)
+        fun navigationCommand(args: Map<String, Any?>) = object : NavigationCommand {
+            override val arguments = ManualEntrySuccessNavigation.arguments
+            val last4 = args.getValue(KEY_LAST4) as? String
+            val microdeposits = args.getValue(KEY_MICRODEPOSITS) as? MicrodepositVerificationMethod
+            override val destination = "manual_entry_success?" +
+                "$KEY_MICRODEPOSITS=$microdeposits," +
+                "$KEY_LAST4=$last4"
+        }
     }
 
     val Default = object : NavigationCommand {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
@@ -27,7 +27,6 @@ import com.stripe.android.financialconnections.features.manualentrysuccess.Manua
 import com.stripe.android.financialconnections.features.partnerauth.PartnerAuthScreen
 import com.stripe.android.financialconnections.features.success.SuccessScreen
 import com.stripe.android.financialconnections.navigation.NavigationDirections
-import com.stripe.android.financialconnections.navigation.NavigationDirections.ManualEntrySuccessNavigation
 import com.stripe.android.financialconnections.navigation.NavigationManager
 import com.stripe.android.financialconnections.presentation.CreateBrowserIntentForUrl
 import com.stripe.android.financialconnections.presentation.FinancialConnectionsSheetNativeViewEffect.OpenUrl
@@ -87,12 +86,14 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), Ma
                 ManualEntryScreen()
             }
             composable(
-                route = ManualEntrySuccessNavigation.route,
-                arguments = ManualEntrySuccessNavigation.arguments
+                route = NavigationDirections.ManualEntrySuccess.route,
+                arguments = NavigationDirections.ManualEntrySuccess.arguments
             ) {
                 ManualEntrySuccessScreen(
-                    microdepositVerificationMethod = ManualEntrySuccessNavigation.microdeposits(it),
-                    last4 = ManualEntrySuccessNavigation.last4(it)
+                    microdepositVerificationMethod = NavigationDirections
+                        .ManualEntrySuccess.microdeposits(it),
+                    last4 = NavigationDirections
+                        .ManualEntrySuccess.last4(it)
                 )
             }
             composable(NavigationDirections.institutionPicker.destination) {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
@@ -23,9 +23,11 @@ import com.stripe.android.financialconnections.features.accountpicker.AccountPic
 import com.stripe.android.financialconnections.features.consent.ConsentScreen
 import com.stripe.android.financialconnections.features.institutionpicker.InstitutionPickerScreen
 import com.stripe.android.financialconnections.features.manualentry.ManualEntryScreen
+import com.stripe.android.financialconnections.features.manualentrysuccess.ManualEntrySuccessScreen
 import com.stripe.android.financialconnections.features.partnerauth.PartnerAuthScreen
 import com.stripe.android.financialconnections.features.success.SuccessScreen
 import com.stripe.android.financialconnections.navigation.NavigationDirections
+import com.stripe.android.financialconnections.navigation.NavigationDirections.ManualEntrySuccessNavigation
 import com.stripe.android.financialconnections.navigation.NavigationManager
 import com.stripe.android.financialconnections.presentation.CreateBrowserIntentForUrl
 import com.stripe.android.financialconnections.presentation.FinancialConnectionsSheetNativeViewEffect.OpenUrl
@@ -83,6 +85,15 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), Ma
             }
             composable(NavigationDirections.manualEntry.destination) {
                 ManualEntryScreen()
+            }
+            composable(
+                route = ManualEntrySuccessNavigation.route,
+                arguments = ManualEntrySuccessNavigation.arguments
+            ) {
+                ManualEntrySuccessScreen(
+                    microdepositVerificationMethod = ManualEntrySuccessNavigation.microdeposits(it),
+                    last4 = ManualEntrySuccessNavigation.last4(it)
+                )
             }
             composable(NavigationDirections.institutionPicker.destination) {
                 InstitutionPickerScreen()


### PR DESCRIPTION
# Summary
- Navigates to success screen with two primitive arguments: last4 and microdeposit type.

This is the first case of navigating with arguments in the entire flow. Since next screen is dynamic, screens can include a generic map of arguments when triggering the next step. The destination screen will retrieve arguments from the `navBackStackEntry` when navigating.

We're not planning to use this pattern frequently, and rather we rely on the parent state shared across screens, but becomes handy for simple cases like this (we'll just be showing a success message that changes based on the received arguments)

# Screenshots

1. Amount verification
2. Descriptor verification
3. Amount verification without last4
4. Descriptor verification without last4
<img width="906" alt="image" src="https://user-images.githubusercontent.com/99293320/186998507-b5323214-7050-42d9-bc8e-63c6e90e5127.png">
