### PR TITLE
Clear keyboard when closing address element

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -34,6 +35,8 @@ internal fun InputAddressScreen(
     formContent: @Composable ColumnScope.() -> Unit,
     checkboxContent: @Composable ColumnScope.() -> Unit
 ) {
+    val focusManager = LocalFocusManager.current
+
     ScrollableColumn(
         modifier = Modifier
             .fillMaxHeight()
@@ -41,7 +44,10 @@ internal fun InputAddressScreen(
     ) {
         AddressOptionsAppBar(
             isRootScreen = true,
-            onButtonClick = { onCloseClick() }
+            onButtonClick = {
+                focusManager.clearFocus()
+                onCloseClick()
+            }
         )
         Column(
             Modifier
@@ -58,6 +64,7 @@ internal fun InputAddressScreen(
                 isEnabled = primaryButtonEnabled,
                 text = primaryButtonText
             ) {
+                focusManager.clearFocus()
                 onPrimaryButtonClick()
             }
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Close the keyboard when closing the address element sheet.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Polish for Address element

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

