### PR TITLE
Add logout menu in Link wallet

### DIFF
--- a/link/api/link.api
+++ b/link/api/link.api
@@ -320,6 +320,7 @@ public final class com/stripe/android/link/ui/ComposableSingletons$LinkAppBarKt 
 	public static field lambda-6 Lkotlin/jvm/functions/Function2;
 	public static field lambda-7 Lkotlin/jvm/functions/Function2;
 	public static field lambda-8 Lkotlin/jvm/functions/Function2;
+	public static field lambda-9 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
 	public final fun getLambda-1$link_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-2$link_release ()Lkotlin/jvm/functions/Function2;
@@ -329,6 +330,7 @@ public final class com/stripe/android/link/ui/ComposableSingletons$LinkAppBarKt 
 	public final fun getLambda-6$link_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-7$link_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-8$link_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-9$link_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class com/stripe/android/link/ui/ComposableSingletons$PrimaryButtonKt {

--- a/link/res/values/strings.xml
+++ b/link/res/values/strings.xml
@@ -2,6 +2,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="link">Link</string>
     <string name="back">Back</string>
+    <string name="menu">Menu</string>
 
     <string name="inline_sign_up_header">Save my info for secure 1-click checkout</string>
 
@@ -9,6 +10,7 @@
     <string name="sign_up_message">Pay faster at %1$s and thousands of merchants.</string>
     <string name="sign_up_terms">By joining Link, you agree to the &lt;a href=\"https://link.co/terms\"&gt;Terms&lt;/a&gt; and &lt;a href=\"https://link.co/privacy\"&gt;Privacy Policy&lt;/a&gt;.</string>
     <string name="sign_up">Join Link</string>
+    <string name="log_out">Log out of Link</string>
 
     <string name="verification_header">Enter your verification code</string>
     <string name="verification_message">Enter the code sent to %1$s to use Link to pay by default.</string>

--- a/link/src/androidTest/java/com/stripe/android/link/ui/LinkAppBarStateTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/LinkAppBarStateTest.kt
@@ -37,7 +37,8 @@ internal class LinkAppBarStateTest {
 
         val expected = LinkAppBarState(
             navigationIcon = R.drawable.ic_link_close,
-            hideHeader = false,
+            showHeader = true,
+            showOverflowMenu = false,
             email = null
         )
 
@@ -54,7 +55,8 @@ internal class LinkAppBarStateTest {
 
         val expected = LinkAppBarState(
             navigationIcon = R.drawable.ic_link_close,
-            hideHeader = false,
+            showHeader = true,
+            showOverflowMenu = false,
             email = null
         )
 
@@ -71,7 +73,8 @@ internal class LinkAppBarStateTest {
 
         val expected = LinkAppBarState(
             navigationIcon = R.drawable.ic_link_close,
-            hideHeader = false,
+            showHeader = true,
+            showOverflowMenu = false,
             email = "someone@stripe.com"
         )
 
@@ -88,7 +91,8 @@ internal class LinkAppBarStateTest {
 
         val expected = LinkAppBarState(
             navigationIcon = R.drawable.ic_link_close,
-            hideHeader = false,
+            showHeader = true,
+            showOverflowMenu = true,
             email = "someone@stripe.com"
         )
 
@@ -105,7 +109,8 @@ internal class LinkAppBarStateTest {
 
         val expected = LinkAppBarState(
             navigationIcon = R.drawable.ic_link_back,
-            hideHeader = true,
+            showHeader = false,
+            showOverflowMenu = false,
             email = null
         )
 
@@ -122,7 +127,8 @@ internal class LinkAppBarStateTest {
 
         val expected = LinkAppBarState(
             navigationIcon = R.drawable.ic_link_back,
-            hideHeader = true,
+            showHeader = false,
+            showOverflowMenu = false,
             email = null
         )
 
@@ -139,7 +145,8 @@ internal class LinkAppBarStateTest {
 
         val expected = LinkAppBarState(
             navigationIcon = R.drawable.ic_link_close,
-            hideHeader = false,
+            showHeader = true,
+            showOverflowMenu = false,
             email = null
         )
 

--- a/link/src/androidTest/java/com/stripe/android/link/ui/LinkAppBarTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/LinkAppBarTest.kt
@@ -27,26 +27,42 @@ internal class LinkAppBarTest {
     }
 
     @Test
-    fun on_button_click_button_callback_is_called() {
+    fun on_back_button_click_callback_is_called() {
         var count = 0
-        setContent(onButtonClick = { count++ })
+        setContent(onBackPress = { count++ })
 
         composeTestRule.onNodeWithContentDescription("Back").performClick()
+
+        assertThat(count).isEqualTo(1)
+    }
+
+    @Test
+    fun on_overflow_button_click_callback_is_called() {
+        var count = 0
+        setContent(showBottomSheetContent = { count++ })
+
+        composeTestRule.onNodeWithContentDescription("Menu").performClick()
+
         assertThat(count).isEqualTo(1)
     }
 
     private fun setContent(
         email: String? = null,
-        onButtonClick: () -> Unit = {}
+        onBackPress: () -> Unit = {},
+        onLogout: () -> Unit = {},
+        showBottomSheetContent: (BottomSheetContent?) -> Unit = {}
     ) = composeTestRule.setContent {
         DefaultLinkTheme {
             LinkAppBar(
                 state = LinkAppBarState(
                     navigationIcon = R.drawable.ic_link_close,
-                    hideHeader = false,
+                    showHeader = true,
+                    showOverflowMenu = true,
                     email = email
                 ),
-                onButtonClick = onButtonClick
+                onBackPress = onBackPress,
+                onLogout = onLogout,
+                showBottomSheetContent = showBottomSheetContent
             )
         }
     }

--- a/link/src/androidTest/java/com/stripe/android/link/ui/LinkLogoutSheetTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/LinkLogoutSheetTest.kt
@@ -1,0 +1,58 @@
+package com.stripe.android.link.ui
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.link.theme.DefaultLinkTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LinkLogoutSheetTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun on_logout_button_click_callback_is_called() {
+        val clickRecorder = MockClickRecorder()
+        setContent(clickRecorder)
+
+        composeTestRule.onNodeWithText("Log out of Link").performClick()
+
+        assertThat(clickRecorder).isEqualTo(MockClickRecorder(logoutClicked = true))
+    }
+
+    @Test
+    fun on_cancel_button_click_callback_is_called() {
+        val clickRecorder = MockClickRecorder()
+        setContent(clickRecorder)
+
+        composeTestRule.onNodeWithText("Cancel").performClick()
+
+        assertThat(clickRecorder).isEqualTo(MockClickRecorder(cancelClicked = true))
+    }
+
+    private fun setContent(
+        clickRecorder: MockClickRecorder
+    ) = composeTestRule.setContent {
+        DefaultLinkTheme {
+            LinkLogoutSheet(
+                onLogoutClick = clickRecorder::onLogoutClicked,
+                onCancelClick = clickRecorder::onCancelClick
+            )
+        }
+    }
+
+    private data class MockClickRecorder(
+        var logoutClicked: Boolean = false,
+        var cancelClicked: Boolean = false
+    ) {
+        fun onLogoutClicked() { logoutClicked = true }
+        fun onCancelClick() { cancelClicked = true }
+    }
+}

--- a/link/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -125,7 +125,18 @@ internal class LinkActivity : ComponentActivity() {
 
                         LinkAppBar(
                             state = appBarState,
-                            onButtonClick = { viewModel.navigator.onBack(userInitiated = true) }
+                            onBackPressed = viewModel::onBackPressed,
+                            onLogout = viewModel::logout,
+                            showBottomSheetContent = {
+                                if (it == null) {
+                                    coroutineScope.launch {
+                                        sheetState.hide()
+                                        bottomSheetContent = null
+                                    }
+                                } else {
+                                    bottomSheetContent = it
+                                }
+                            }
                         )
 
                         NavHost(navController, LinkScreen.Loading.route) {

--- a/link/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -49,6 +49,15 @@ internal class LinkActivityViewModel @Inject internal constructor(
         confirmationManager.setupPaymentLauncher(activityResultCaller)
     }
 
+    fun onBackPressed() {
+        navigator.onBack(userInitiated = true)
+    }
+
+    fun logout() {
+        navigator.dismiss()
+        linkAccountManager.logout()
+    }
+
     fun unregisterFromActivity() {
         confirmationManager.invalidatePaymentLauncher()
     }

--- a/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
@@ -26,6 +26,7 @@ import com.stripe.android.link.ui.cardedit.CardEditViewModel
 import com.stripe.android.link.ui.inline.InlineSignupViewModel
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.link.ui.paymentmethod.PaymentMethodViewModel
+import com.stripe.android.link.ui.paymentmethod.SupportedPaymentMethod
 import com.stripe.android.link.ui.signup.SignUpViewModel
 import com.stripe.android.link.ui.verification.VerificationViewModel
 import com.stripe.android.link.ui.wallet.WalletViewModel

--- a/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
@@ -26,7 +26,6 @@ import com.stripe.android.link.ui.cardedit.CardEditViewModel
 import com.stripe.android.link.ui.inline.InlineSignupViewModel
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.link.ui.paymentmethod.PaymentMethodViewModel
-import com.stripe.android.link.ui.paymentmethod.SupportedPaymentMethod
 import com.stripe.android.link.ui.signup.SignUpViewModel
 import com.stripe.android.link.ui.verification.VerificationViewModel
 import com.stripe.android.link.ui.wallet.WalletViewModel

--- a/link/src/main/java/com/stripe/android/link/ui/LinkAppBar.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/LinkAppBar.kt
@@ -5,17 +5,17 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -29,13 +29,14 @@ import androidx.compose.ui.unit.dp
 import com.stripe.android.link.R
 import com.stripe.android.link.theme.AppBarHeight
 import com.stripe.android.link.theme.DefaultLinkTheme
-import com.stripe.android.link.theme.MinimumTouchTargetSize
 import com.stripe.android.link.theme.linkColors
 
 @Composable
 internal fun LinkAppBar(
     state: LinkAppBarState,
-    onButtonClick: () -> Unit
+    onBackPressed: () -> Unit,
+    onLogout: () -> Unit,
+    showBottomSheetContent: (BottomSheetContent?) -> Unit
 ) {
     Row(
         modifier = Modifier
@@ -45,7 +46,7 @@ internal fun LinkAppBar(
         verticalAlignment = Alignment.Top
     ) {
         IconButton(
-            onClick = onButtonClick,
+            onClick = onBackPressed,
             modifier = Modifier.padding(4.dp)
         ) {
             Icon(
@@ -55,7 +56,7 @@ internal fun LinkAppBar(
             )
         }
 
-        val contentAlpha by animateFloatAsState(targetValue = if (state.hideHeader) 0f else 1f)
+        val contentAlpha by animateFloatAsState(targetValue = if (state.showHeader) 1f else 0f)
 
         Column(
             modifier = Modifier
@@ -88,7 +89,35 @@ internal fun LinkAppBar(
             }
         }
 
-        Spacer(modifier = Modifier.width(MinimumTouchTargetSize))
+        val overflowIconAlpha by animateFloatAsState(
+            targetValue = if (state.showOverflowMenu) 1f else 0f
+        )
+
+        IconButton(
+            onClick = {
+                showBottomSheetContent {
+                    LinkLogoutSheet(
+                        onLogoutClick = {
+                            showBottomSheetContent(null)
+                            onLogout()
+                        },
+                        onCancelClick = {
+                            showBottomSheetContent(null)
+                        }
+                    )
+                }
+            },
+            enabled = state.showOverflowMenu,
+            modifier = Modifier
+                .alpha(overflowIconAlpha)
+                .padding(4.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.MoreVert,
+                contentDescription = stringResource(R.string.menu),
+                tint = MaterialTheme.linkColors.closeButton
+            )
+        }
     }
 }
 
@@ -100,10 +129,13 @@ private fun LinkAppBar() {
             LinkAppBar(
                 state = LinkAppBarState(
                     navigationIcon = R.drawable.ic_link_close,
-                    hideHeader = false,
+                    showHeader = true,
+                    showOverflowMenu = true,
                     email = "email@example.com"
                 ),
-                onButtonClick = {}
+                onBackPressed = {},
+                onLogout = {},
+                showBottomSheetContent = {}
             )
         }
     }
@@ -117,10 +149,13 @@ private fun LinkAppBar_NoEmail() {
             LinkAppBar(
                 state = LinkAppBarState(
                     navigationIcon = R.drawable.ic_link_close,
-                    hideHeader = false,
+                    showHeader = true,
+                    showOverflowMenu = true,
                     email = null
                 ),
-                onButtonClick = {}
+                onBackPressed = {},
+                onLogout = {},
+                showBottomSheetContent = {}
             )
         }
     }
@@ -134,10 +169,13 @@ private fun LinkAppBar_ChildScreen() {
             LinkAppBar(
                 state = LinkAppBarState(
                     navigationIcon = R.drawable.ic_link_back,
-                    hideHeader = true,
+                    showHeader = false,
+                    showOverflowMenu = false,
                     email = "email@example.com"
                 ),
-                onButtonClick = {}
+                onBackPressed = {},
+                onLogout = {},
+                showBottomSheetContent = {}
             )
         }
     }
@@ -151,10 +189,13 @@ private fun LinkAppBar_ChildScreen_NoEmail() {
             LinkAppBar(
                 state = LinkAppBarState(
                     navigationIcon = R.drawable.ic_link_back,
-                    hideHeader = true,
+                    showHeader = false,
+                    showOverflowMenu = false,
                     email = null
                 ),
-                onButtonClick = {}
+                onBackPressed = {},
+                onLogout = {},
+                showBottomSheetContent = {}
             )
         }
     }

--- a/link/src/main/java/com/stripe/android/link/ui/LinkAppBarState.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/LinkAppBarState.kt
@@ -8,7 +8,8 @@ import com.stripe.android.link.R
 
 internal data class LinkAppBarState(
     @DrawableRes val navigationIcon: Int,
-    val hideHeader: Boolean,
+    val showHeader: Boolean,
+    val showOverflowMenu: Boolean,
     val email: String?
 )
 
@@ -32,13 +33,16 @@ internal fun rememberLinkAppBarState(
         val hideHeader = currentRoute in routesWithoutHeader
         val hideEmail = email.isNullOrBlank() || currentRoute in routesWithoutEmail
 
+        val showOverflowMenu = currentRoute == LinkScreen.Wallet.route
+
         LinkAppBarState(
             navigationIcon = if (isRootScreen) {
                 R.drawable.ic_link_close
             } else {
                 R.drawable.ic_link_back
             },
-            hideHeader = hideHeader,
+            showHeader = !hideHeader,
+            showOverflowMenu = showOverflowMenu,
             email = email?.takeIf { it.isNotBlank() && !hideEmail }
         )
     }

--- a/link/src/main/java/com/stripe/android/link/ui/LinkLogoutSheet.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/LinkLogoutSheet.kt
@@ -1,0 +1,35 @@
+package com.stripe.android.link.ui
+
+import androidx.compose.runtime.Composable
+import com.stripe.android.link.R
+import com.stripe.android.link.ui.menus.LinkMenu
+import com.stripe.android.link.ui.menus.LinkMenuItem
+
+internal sealed class LinkLogoutMenuItem(
+    override val textResId: Int,
+    override val isDestructive: Boolean = false
+) : LinkMenuItem {
+    object Logout : LinkLogoutMenuItem(textResId = R.string.log_out, isDestructive = true)
+    object Cancel : LinkLogoutMenuItem(textResId = R.string.cancel)
+}
+
+@Composable
+internal fun LinkLogoutSheet(
+    onLogoutClick: () -> Unit,
+    onCancelClick: () -> Unit
+) {
+    val items = listOf(
+        LinkLogoutMenuItem.Logout,
+        LinkLogoutMenuItem.Cancel
+    )
+
+    LinkMenu(
+        items = items,
+        onItemPress = { item ->
+            when (item) {
+                LinkLogoutMenuItem.Logout -> onLogoutClick()
+                LinkLogoutMenuItem.Cancel -> onCancelClick()
+            }
+        }
+    )
+}

--- a/link/src/main/java/com/stripe/android/link/ui/verification/VerificationDialog.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/verification/VerificationDialog.kt
@@ -86,7 +86,13 @@ fun LinkVerificationDialog(
 
                                     LinkAppBar(
                                         state = appBarState,
-                                        onButtonClick = onDismiss
+                                        onBackPressed = onDismiss,
+                                        onLogout = {
+                                            // This can't be invoked from the verification dialog
+                                        },
+                                        showBottomSheetContent = {
+                                            // This can't be invoked from the verification dialog
+                                        }
                                     )
 
                                     VerificationBody(

--- a/link/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.link
 
 import android.app.Application
 import androidx.lifecycle.Lifecycle
-import androidx.navigation.NavController
 import androidx.navigation.NavHostController
 import androidx.savedstate.SavedStateRegistry
 import androidx.savedstate.SavedStateRegistryOwner
@@ -54,7 +53,6 @@ class LinkActivityViewModelTest {
 
     private val linkAccountManager = mock<LinkAccountManager>()
     private val confirmationManager = mock<ConfirmationManager>()
-
     private val navigator = mock<Navigator>()
 
     init {

--- a/link/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -2,6 +2,8 @@ package com.stripe.android.link
 
 import android.app.Application
 import androidx.lifecycle.Lifecycle
+import androidx.navigation.NavController
+import androidx.navigation.NavHostController
 import androidx.savedstate.SavedStateRegistry
 import androidx.savedstate.SavedStateRegistryOwner
 import androidx.test.core.app.ApplicationProvider
@@ -20,7 +22,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argWhere
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.times
@@ -50,6 +54,7 @@ class LinkActivityViewModelTest {
 
     private val linkAccountManager = mock<LinkAccountManager>()
     private val confirmationManager = mock<ConfirmationManager>()
+
     private val navigator = mock<Navigator>()
 
     init {
@@ -132,6 +137,49 @@ class LinkActivityViewModelTest {
         )
     }
 
+    @Test
+    fun `Navigating back on root screen dismisses Link, but doesn't log out user`() {
+        val viewModel = createViewModel()
+        setupNavigation(hasBackStack = false)
+
+        viewModel.onBack()
+
+        spy(navigator).dismiss()
+        verify(linkAccountManager, never()).logout()
+    }
+
+    @Test
+    fun `Navigating back on child screen navigates back, but doesn't dismiss Link`() {
+        val viewModel = createViewModel()
+        setupNavigation(hasBackStack = true)
+
+        viewModel.onBack()
+
+        verify(navigator, never()).dismiss()
+        verify(linkAccountManager, never()).logout()
+    }
+
+    @Test
+    fun `Navigating back is prevented when back navigation is disabled`() {
+        val viewModel = createViewModel()
+        setupNavigation(backNavigationEnabled = false)
+
+        viewModel.onBack()
+
+        verify(navigator, never()).dismiss()
+        verify(linkAccountManager, never()).logout()
+    }
+
+    @Test
+    fun `Logging out logs out the user and dismisses Link`() {
+        val viewModel = createViewModel()
+
+        viewModel.logout()
+
+        verify(navigator).dismiss()
+        verify(linkAccountManager).logout()
+    }
+
     private fun createViewModel(args: LinkActivityContract.Args = defaultArgs) =
         LinkActivityViewModel(
             args,
@@ -139,6 +187,17 @@ class LinkActivityViewModelTest {
             navigator,
             confirmationManager
         )
+
+    private fun setupNavigation(
+        hasBackStack: Boolean = false,
+        backNavigationEnabled: Boolean = true
+    ) {
+        val mockNavController = mock<NavHostController> {
+            on { popBackStack() } doReturn hasBackStack
+        }
+        whenever(navigator.backNavigationEnabled).thenReturn(backNavigationEnabled)
+        whenever(navigator.navigationController).thenReturn(mockNavController)
+    }
 
     private companion object {
         const val INJECTOR_KEY = "injectorKey"

--- a/link/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -160,7 +160,7 @@ class LinkActivityViewModelTest {
     @Test
     fun `Navigating back is prevented when back navigation is disabled`() {
         val viewModel = createViewModel()
-        setupNavigation(backNavigationEnabled = false)
+        setupNavigation(userNavigationEnabled = false)
 
         viewModel.onBackPressed()
 
@@ -188,12 +188,12 @@ class LinkActivityViewModelTest {
 
     private fun setupNavigation(
         hasBackStack: Boolean = false,
-        backNavigationEnabled: Boolean = true
+        userNavigationEnabled: Boolean = true
     ) {
         val mockNavController = mock<NavHostController> {
             on { popBackStack() } doReturn hasBackStack
         }
-        whenever(navigator.backNavigationEnabled).thenReturn(backNavigationEnabled)
+        whenever(navigator.userNavigationEnabled).thenReturn(userNavigationEnabled)
         whenever(navigator.navigationController).thenReturn(mockNavController)
     }
 

--- a/link/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -140,7 +140,7 @@ class LinkActivityViewModelTest {
         val viewModel = createViewModel()
         setupNavigation(hasBackStack = false)
 
-        viewModel.onBack()
+        viewModel.onBackPressed()
 
         spy(navigator).dismiss()
         verify(linkAccountManager, never()).logout()
@@ -151,7 +151,7 @@ class LinkActivityViewModelTest {
         val viewModel = createViewModel()
         setupNavigation(hasBackStack = true)
 
-        viewModel.onBack()
+        viewModel.onBackPressed()
 
         verify(navigator, never()).dismiss()
         verify(linkAccountManager, never()).logout()
@@ -162,7 +162,7 @@ class LinkActivityViewModelTest {
         val viewModel = createViewModel()
         setupNavigation(backNavigationEnabled = false)
 
-        viewModel.onBack()
+        viewModel.onBackPressed()
 
         verify(navigator, never()).dismiss()
         verify(linkAccountManager, never()).logout()

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PostalCodeConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PostalCodeConfig.kt
@@ -27,9 +27,10 @@ internal class PostalCodeConfig(
         override fun isValid(): Boolean {
             return when (format) {
                 is CountryPostalFormat.Other -> input.isNotBlank()
-                else ->
+                else -> {
                     input.length in format.minimumLength..format.maximumLength &&
                         input.matches(format.regexPattern)
+                }
             }
         }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds a logout menu to the Link wallet’s navigation bar. When pressed, we close Link and log out the user.

The other change to Link’s behavior, namely that `Pay another way` no longer logs out the user, is coming in a separate pull request.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Offer users a way to log out.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screen recording

https://user-images.githubusercontent.com/110940675/186928849-c1d89ecf-139f-4fb0-a627-263ff9deaaf8.mp4

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

_Nothing to add._
