### PR TITLE
[Identity] update fileprovider name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * [ADDED][5456](https://github.com/stripe/stripe-android/pull/5456) Added postal code validation
 
+### Identity 
+
+* [FIXED][5474](https://github.com/stripe/stripe-android/pull/5474) Update fileprovider name.
+
 ## 20.10.0 - 2022-08-22
 This release contains several bug fixes for PaymentSheet and binary size optimization for Identity.
 

--- a/identity/src/main/AndroidManifest.xml
+++ b/identity/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
 
         <provider
             android:name="androidx.core.content.FileProvider"
-            android:authorities="${applicationId}.fileprovider"
+            android:authorities="${applicationId}.StripeIdentityFileprovider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data

--- a/identity/src/main/java/com/stripe/android/identity/utils/DefaultIdentityIO.kt
+++ b/identity/src/main/java/com/stripe/android/identity/utils/DefaultIdentityIO.kt
@@ -37,7 +37,7 @@ internal class DefaultIdentityIO @Inject constructor(private val context: Contex
 
     override fun createUriForFile(file: File): Uri = FileProvider.getUriForFile(
         context,
-        "${context.packageName}.fileprovider",
+        "${context.packageName}.StripeIdentityFileprovider",
         file
     )
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Change the file provider name to be Stipe Identity specific to avoid potential conflict with other libraries.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Other SDK might also use `${packagename}.fileprovider` as the fileprovider name, change the suffix would avoid the naming conflict.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
[Fixed] - Fixed a potential conflict when other libararies also define a file provider.