### PR TITLE
Set the shipping preference in instrumentation tests.

### DIFF
--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -255,6 +255,7 @@ class PlaygroundTestDriver(
 
         selectors.checkout.click()
         selectors.delayed.click()
+        selectors.shipping.click()
 
         // billing is not saved to preferences
         selectors.billing.click()


### PR DESCRIPTION
# Summary
Set the shipping preference in the playground in the instrumentation tests.
