### PR TITLE
Preserve payment selection for guests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@
 
 ### PaymentSheet
 
-* [CHANGED][5487](https://github.com/stripe/stripe-android/pull/5487) Updated Google Pay button to 
-  match new brand guidelines.
-* [ADDED][5502](https://github.com/stripe/stripe-android/pull/5502) Added phone number minimum 
+* [ADDED][5502](https://github.com/stripe/stripe-android/pull/5502) Added phone number minimum
   length validation
-* [ADDED][5518](https://github.com/stripe/stripe-android/pull/5518) Added state/province dropdown 
+* [ADDED][5518](https://github.com/stripe/stripe-android/pull/5518) Added state/province dropdown
   for US and Canada.
+* [CHANGED][5487](https://github.com/stripe/stripe-android/pull/5487) Updated Google Pay button to
+  match new brand guidelines.
+* [FIXED][5480](https://github.com/stripe/stripe-android/pull/5480) `FlowController` now correctly
+  preserves the previously selected payment method for guests.
 
 ## 20.11.0 - 2022-08-29
 This release adds postal code validation for PaymentSheet and fixed a fileprovider naming bug for Identity.

--- a/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
@@ -242,7 +242,7 @@ class LinkPaymentLauncher @AssistedInject internal constructor(
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
-        val LINK_ENABLED = BuildConfig.DEBUG
+        val LINK_ENABLED = false
         val supportedFundingSources = SupportedPaymentMethod.allTypes
     }
 }

--- a/link/src/main/java/com/stripe/android/link/injection/NamedConstants.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/NamedConstants.kt
@@ -33,6 +33,12 @@ const val CUSTOMER_NAME = "customerName"
 const val SHIPPING_VALUES = "shippingValues"
 
 /**
+ * Identifies whether Link is enabled.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+const val LINK_ENABLED = "linkEnabled"
+
+/**
  * Identifies the Stripe Intent being processed by Link.
  */
 internal const val LINK_INTENT = "linkIntent"

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -1068,11 +1068,11 @@ public final class com/stripe/android/paymentsheet/flowcontroller/DefaultFlowCon
 }
 
 public final class com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializer_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializer_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializer_Factory;
 	public fun get ()Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializer;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lcom/stripe/android/paymentsheet/repositories/StripeIntentRepository;Lcom/stripe/android/paymentsheet/model/StripeIntentValidator;Lcom/stripe/android/paymentsheet/repositories/CustomerRepository;Lcom/stripe/android/ui/core/forms/resources/ResourceRepository;Lcom/stripe/android/core/Logger;Lcom/stripe/android/paymentsheet/analytics/EventReporter;Lkotlin/coroutines/CoroutineContext;)Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializer;
+	public static fun newInstance (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lcom/stripe/android/paymentsheet/repositories/StripeIntentRepository;Lcom/stripe/android/paymentsheet/model/StripeIntentValidator;Lcom/stripe/android/paymentsheet/repositories/CustomerRepository;Lcom/stripe/android/ui/core/forms/resources/ResourceRepository;Lcom/stripe/android/core/Logger;Lcom/stripe/android/paymentsheet/analytics/EventReporter;Lkotlin/coroutines/CoroutineContext;Z)Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializer;
 }
 
 public final class com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController_Factory : dagger/internal/Factory {
@@ -1204,6 +1204,14 @@ public final class com/stripe/android/paymentsheet/injection/FlowControllerModul
 	public fun get ()Lcom/stripe/android/paymentsheet/analytics/EventReporter$Mode;
 	public synthetic fun get ()Ljava/lang/Object;
 	public static fun provideEventReporterMode ()Lcom/stripe/android/paymentsheet/analytics/EventReporter$Mode;
+}
+
+public final class com/stripe/android/paymentsheet/injection/FlowControllerModule_Companion_ProvideLinkEnabledFactory : dagger/internal/Factory {
+	public fun <init> ()V
+	public static fun create ()Lcom/stripe/android/paymentsheet/injection/FlowControllerModule_Companion_ProvideLinkEnabledFactory;
+	public fun get ()Ljava/lang/Boolean;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun provideLinkEnabled ()Z
 }
 
 public final class com/stripe/android/paymentsheet/injection/FlowControllerModule_Companion_ProvidePrefsRepositoryFactoryFactory : dagger/internal/Factory {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultPrefsRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultPrefsRepository.kt
@@ -9,7 +9,7 @@ import kotlin.coroutines.CoroutineContext
 
 internal class DefaultPrefsRepository(
     private val context: Context,
-    private val customerId: String,
+    private val customerId: String?,
     private val workContext: CoroutineContext
 ) : PrefsRepository {
     private val prefs: SharedPreferences by lazy {
@@ -51,7 +51,7 @@ internal class DefaultPrefsRepository(
     }
 
     private fun getKey(): String {
-        return "customer[$customerId]"
+        return customerId?.let { "customer[$it]" } ?: "guest"
     }
 
     private companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PrefsRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PrefsRepository.kt
@@ -10,13 +10,4 @@ internal interface PrefsRepository {
     ): SavedSelection
 
     fun savePaymentSelection(paymentSelection: PaymentSelection?)
-
-    class Noop : PrefsRepository {
-        override suspend fun getSavedSelection(
-            isGooglePayAvailable: Boolean,
-            isLinkAvailable: Boolean
-        ) = SavedSelection.None
-
-        override fun savePaymentSelection(paymentSelection: PaymentSelection?) {}
-    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializer.kt
@@ -4,7 +4,6 @@ import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayRepository
-import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.injection.LINK_ENABLED
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerInitializer.kt
@@ -5,6 +5,7 @@ import com.stripe.android.core.injection.IOContext
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.link.LinkPaymentLauncher
+import com.stripe.android.link.injection.LINK_ENABLED
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -23,6 +24,7 @@ import com.stripe.android.ui.core.forms.resources.ResourceRepository
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
+import javax.inject.Named
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
@@ -38,7 +40,8 @@ internal class DefaultFlowControllerInitializer @Inject constructor(
     private val lpmResourceRepository: ResourceRepository<LpmRepository>,
     private val logger: Logger,
     val eventReporter: EventReporter,
-    @IOContext private val workContext: CoroutineContext
+    @IOContext private val workContext: CoroutineContext,
+    @Named(LINK_ENABLED) private val isLinkEnabled: Boolean
 ) : FlowControllerInitializer {
 
     override suspend fun init(
@@ -50,7 +53,7 @@ internal class DefaultFlowControllerInitializer @Inject constructor(
             retrieveStripeIntent(clientSecret)
         }.fold(
             onSuccess = { stripeIntent ->
-                val isLinkReady = LinkPaymentLauncher.LINK_ENABLED &&
+                val isLinkReady = isLinkEnabled &&
                     stripeIntent.paymentMethodTypes.contains(PaymentMethod.Type.Link.code)
 
                 create(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/FlowControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/FlowControllerModule.kt
@@ -54,13 +54,11 @@ internal abstract class FlowControllerModule {
             appContext: Context,
             @IOContext workContext: CoroutineContext
         ): (PaymentSheet.CustomerConfiguration?) -> PrefsRepository = { customerConfig ->
-            customerConfig?.let {
-                DefaultPrefsRepository(
-                    appContext,
-                    it.id,
-                    workContext
-                )
-            } ?: PrefsRepository.Noop()
+            DefaultPrefsRepository(
+                appContext,
+                customerConfig?.id,
+                workContext
+            )
         }
 
         @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/FlowControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/FlowControllerModule.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import com.stripe.android.core.injection.IOContext
+import com.stripe.android.link.LinkPaymentLauncher
+import com.stripe.android.link.injection.LINK_ENABLED
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -69,6 +71,11 @@ internal abstract class FlowControllerModule {
         @Singleton
         @Named(PRODUCT_USAGE)
         fun provideProductUsageTokens() = setOf("PaymentSheet.FlowController")
+
+        @Provides
+        @Singleton
+        @Named(LINK_ENABLED)
+        fun provideLinkEnabled() = LinkPaymentLauncher.LINK_ENABLED
 
         @Provides
         @Singleton

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelModule.kt
@@ -29,13 +29,11 @@ internal class PaymentOptionsViewModelModule {
         appContext: Context,
         @IOContext workContext: CoroutineContext
     ): (PaymentSheet.CustomerConfiguration?) -> PrefsRepository = { customerConfig ->
-        customerConfig?.let {
-            DefaultPrefsRepository(
-                appContext,
-                it.id,
-                workContext
-            )
-        } ?: PrefsRepository.Noop()
+        DefaultPrefsRepository(
+            appContext,
+            customerConfig?.id,
+            workContext
+        )
     }
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
@@ -22,12 +22,10 @@ internal class PaymentSheetViewModelModule(private val starterArgs: PaymentSheet
         appContext: Context,
         @IOContext workContext: CoroutineContext
     ): PrefsRepository {
-        return starterArgs.config?.customer?.let { (id) ->
-            DefaultPrefsRepository(
-                appContext,
-                customerId = id,
-                workContext = workContext
-            )
-        } ?: PrefsRepository.Noop()
+        return DefaultPrefsRepository(
+            appContext,
+            customerId = starterArgs.config?.customer?.id,
+            workContext = workContext
+        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/model/PaymentIntentFixtures.kt
@@ -312,7 +312,8 @@ internal object PaymentIntentFixtures {
             "next_action": null,
             "payment_method": null,
             "payment_method_types": [
-                "card"
+                "card",
+                "link"
             ],
             "receipt_email": null,
             "setup_future_usage": null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FakePrefsRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FakePrefsRepository.kt
@@ -15,13 +15,20 @@ internal class FakePrefsRepository : PrefsRepository {
         paymentSelectionArgs.add(paymentSelection)
 
         when (paymentSelection) {
+            is PaymentSelection.Link -> {
+                SavedSelection.Link
+            }
             PaymentSelection.GooglePay -> {
                 SavedSelection.GooglePay
             }
             is PaymentSelection.Saved -> {
                 SavedSelection.PaymentMethod(paymentSelection.paymentMethod.id.orEmpty())
             }
-            else -> SavedSelection.None
+            is PaymentSelection.New.Card,
+            is PaymentSelection.New.GenericPaymentMethod,
+            is PaymentSelection.New.LinkInline,
+            is PaymentSelection.New.USBankAccount,
+            null -> SavedSelection.None
         }.let {
             savedSelection = it
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes a bug where the `FlowController` would show an incorrect payment method selection for guests that don’t have any saved payment methods.

Previously, we would use `PrefsRepository.NoOp` when no customer ID was provided to our SDK. Now, we use `DefaultPrefsRepository` and store a guest’s last saved payment method under a generic `"guest"` key. This is similar to iOS, which uses [an empty string](https://github.com/stripe/stripe-ios/blob/7e8bae121bc101d8b4738bd0899976d98c576fee/Stripe/DefaultPaymentMethodStore.swift#L56).

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Bugfix.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screen recordings

**Before**
The payment options sheet would default to Google Pay, even if Link was available and had been previously selected.

https://user-images.githubusercontent.com/110940675/187460230-c57ea366-1013-4124-bbd0-73d6a5c9d8c4.mp4

**After**
The payment options sheet now correctly shows link as the current payment selection when opening the sheet.

https://user-images.githubusercontent.com/110940675/187460505-7cbe71d6-c71e-4f0f-a3bd-90e692d0df0f.mp4

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

[Fixed] `FlowController` now correctly preserves the previously selected payment method for guests.
