### PR TITLE
[BANKCON-5050] Ignore query and fragment parameters when comparing return urls

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
@@ -78,9 +78,12 @@ internal class PartnerAuthViewModel @Inject constructor(
                 is Fail -> {
                     setState { copy(authenticationStatus = webStatus) }
                     when (val error = webStatus.error) {
-                        is WebAuthFlowCancelledException -> logger.debug("Web flow was cancelled")
-                        is WebAuthFlowFailedException -> logger.debug("Web flow failed! ${error.url}")
-                        else -> logger.error("error finishing web flow", error)
+                        is WebAuthFlowCancelledException ->
+                            logger.debug("Web flow was cancelled")
+                        is WebAuthFlowFailedException ->
+                            logger.debug("Web flow failed! received url: ${error.url}")
+                        else ->
+                            logger.error("error finishing web flow", error)
                     }
                 }
             }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/utils/UriComparator.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/utils/UriComparator.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.financialconnections.utils
+
+import android.net.Uri
+import com.stripe.android.core.Logger
+import javax.inject.Inject
+
+internal class UriComparator @Inject constructor(
+    private val logger: Logger
+) {
+    fun compareSchemeAuthorityAndPath(
+        uriString1: String,
+        uriString2: String
+    ): Boolean {
+        val uri1 = uriString1.toUriOrNull()
+        val uri2 = uriString2.toUriOrNull()
+        if (uri1 == null || uri2 == null) return false
+        return compareSchemeAuthorityAndPath(uri1, uri2)
+    }
+
+    private fun compareSchemeAuthorityAndPath(uri1: Uri, uri2: Uri): Boolean {
+        return uri1.authority.equals(uri2.authority) &&
+            uri1.scheme.equals(uri2.scheme) &&
+            uri1.path.equals(uri2.path)
+    }
+
+    private fun String.toUriOrNull(): Uri? {
+        Uri.parse(this).buildUpon().clearQuery()
+        return kotlin.runCatching {
+            return Uri.parse(this)
+        }.onFailure {
+            logger.error("Could not parse given URI $this", it)
+        }.getOrNull()
+    }
+}

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/utils/UriComparatorTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/utils/UriComparatorTest.kt
@@ -1,0 +1,75 @@
+package com.stripe.android.financialconnections.utils
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.Logger
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.ParameterizedRobolectricTestRunner
+
+@RunWith(ParameterizedRobolectricTestRunner::class)
+class UriComparatorTest(
+    private val uri1: String,
+    private val uri2: String,
+    private val result: Boolean
+) {
+    private val underTest = UriComparator(Logger.noop())
+
+    companion object {
+        @JvmStatic
+        @ParameterizedRobolectricTestRunner.Parameters
+        fun data() = listOf(
+            parameters(
+                uri1 = "stripe-auth://login",
+                uri2 = "stripe-auth://login",
+                equals = true
+            ),
+            parameters(
+                uri1 = "stripe-auth://login#",
+                uri2 = "stripe-auth://login",
+                equals = true
+            ),
+            parameters(
+                uri1 = "stripe-auth://login",
+                uri2 = "stripe-auth://otherlink",
+                equals = false
+            ),
+            parameters(
+                uri1 = "stripe-auth://link-accounts/login",
+                uri2 = "stripe-auth://link-accounts/login#authSessionId=1234",
+                equals = true
+            ),
+            parameters(
+                uri1 = "stripe-auth://link-accounts/com.stripe.android.paymentsheet.example/success?",
+                uri2 = "stripe-auth://link-accounts/com.stripe.android.paymentsheet.example/success?linked_account=fca_1LZmURHINT0kwo6s08HupcIf",
+                equals = true
+            ),
+            parameters(
+                uri1 = "stripe-auth://link-accounts/com.stripe.android.paymentsheet.example/success",
+                uri2 = "stripe-auth://link-accounts/com.stripe.android.otherapp/success",
+                equals = false
+            ),
+            parameters(
+                uri1 = "stripe-auth://link-accounts/com.stripe.android.paymentsheet.example/success",
+                uri2 = "stripe-auth://link-accounts/com.stripe.android.paymentsheet.example/error",
+                equals = false
+            ),
+        )
+
+        private fun parameters(
+            uri1: String,
+            uri2: String,
+            equals: Boolean
+        ): Array<Any> {
+            return arrayOf(
+                uri1,
+                uri2,
+                equals
+            )
+        }
+    }
+
+    @Test
+    fun compareUrlsReturn() {
+        assertThat(underTest.compareSchemeAuthorityAndPath(uri1, uri2)).isEqualTo(result)
+    }
+}


### PR DESCRIPTION
# Summary
- When receiving a deep link after partner authentication, we are using string.equals to compare urls.
- Now the partner authentication return url contains query and fragment params
- We need to compare urls ignoring params.

# Motivation

https://jira.corp.stripe.com/browse/BANKCON-5050

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified