### PR TITLE
Send collected name to backend in Link sign up

### DIFF
--- a/link/api/link.api
+++ b/link/api/link.api
@@ -438,7 +438,6 @@ public final class com/stripe/android/link/ui/inline/UserInput$SignIn : com/stri
 public final class com/stripe/android/link/ui/inline/UserInput$SignUp : com/stripe/android/link/ui/inline/UserInput {
 	public static final field $stable I
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;

--- a/link/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
+++ b/link/src/main/java/com/stripe/android/link/account/LinkAccountManager.kt
@@ -130,14 +130,18 @@ internal class LinkAccountManager @Inject constructor(
             is UserInput.SignIn -> lookupConsumer(userInput.email).mapCatching {
                 requireNotNull(it) { "Error fetching user account" }
             }
-            is UserInput.SignUp -> signUp(userInput.email, userInput.phone, userInput.country)
-                .also {
-                    if (it.isSuccess) {
-                        linkEventsReporter.onSignupCompleted(true)
-                    } else {
-                        linkEventsReporter.onSignupFailure(true)
-                    }
+            is UserInput.SignUp -> signUp(
+                email = userInput.email,
+                phone = userInput.phone,
+                country = userInput.country,
+                name = userInput.name
+            ).also {
+                if (it.isSuccess) {
+                    linkEventsReporter.onSignupCompleted(true)
+                } else {
+                    linkEventsReporter.onSignupFailure(true)
                 }
+            }
         }
 
     /**
@@ -146,9 +150,10 @@ internal class LinkAccountManager @Inject constructor(
     suspend fun signUp(
         email: String,
         phone: String,
-        country: String
+        country: String,
+        name: String?
     ): Result<LinkAccount> =
-        linkRepository.consumerSignUp(email, phone, country, cookie())
+        linkRepository.consumerSignUp(email, phone, country, name, cookie())
             .map { consumerSession ->
                 cookieStore.storeNewUserEmail(email)
                 setAccount(consumerSession)

--- a/link/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/link/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -57,6 +57,7 @@ internal class LinkApiRepository @Inject constructor(
         email: String,
         phone: String,
         country: String,
+        name: String?,
         authSessionCookie: String?
     ): Result<ConsumerSession> = withContext(workContext) {
         runCatching {
@@ -65,6 +66,7 @@ internal class LinkApiRepository @Inject constructor(
                     email,
                     phone,
                     country,
+                    name,
                     locale,
                     authSessionCookie,
                     ApiRequest.Options(

--- a/link/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
+++ b/link/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
@@ -29,6 +29,7 @@ internal interface LinkRepository {
         email: String,
         phone: String,
         country: String,
+        name: String?,
         authSessionCookie: String?
     ): Result<ConsumerSession>
 

--- a/link/src/main/java/com/stripe/android/link/ui/inline/UserInput.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/UserInput.kt
@@ -18,6 +18,6 @@ sealed class UserInput {
         val email: String,
         val phone: String,
         val country: String,
-        val name: String? = null
+        val name: String?
     ) : UserInput()
 }

--- a/link/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
@@ -141,8 +141,9 @@ internal class SignUpViewModel @Inject constructor(
         val email = requireNotNull(consumerEmail.value)
         val phone = phoneController.getE164PhoneNumber(requireNotNull(consumerPhoneNumber.value))
         val country = phoneController.getCountryCode()
+        val name = consumerName.value
         viewModelScope.launch {
-            linkAccountManager.signUp(email, phone, country).fold(
+            linkAccountManager.signUp(email, phone, country, name).fold(
                 onSuccess = {
                     onAccountFetched(it)
                     linkEventsReporter.onSignupCompleted()

--- a/link/src/test/java/com/stripe/android/link/account/LinkAccountManagerTest.kt
+++ b/link/src/test/java/com/stripe/android/link/account/LinkAccountManagerTest.kt
@@ -183,7 +183,7 @@ class LinkAccountManagerTest {
             val accountManager = accountManager()
             val phone = "phone"
             val country = "country"
-            val name = listOf("name", null).random()
+            val name = "name"
 
             accountManager.signInWithUserInput(UserInput.SignUp(EMAIL, phone, country, name))
 

--- a/link/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/link/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -88,7 +88,7 @@ class LinkApiRepositoryTest {
         val email = "email@example.com"
         val phone = "phone"
         val country = "US"
-        val name = listOf("name", null).random()
+        val name = "name"
         val cookie = "cookie2"
         linkRepository.consumerSignUp(email, phone, country, name, cookie)
 

--- a/link/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/link/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -88,13 +88,15 @@ class LinkApiRepositoryTest {
         val email = "email@example.com"
         val phone = "phone"
         val country = "US"
+        val name = listOf("name", null).random()
         val cookie = "cookie2"
-        linkRepository.consumerSignUp(email, phone, country, cookie)
+        linkRepository.consumerSignUp(email, phone, country, name, cookie)
 
         verify(stripeRepository).consumerSignUp(
             eq(email),
             eq(phone),
             eq(country),
+            eq(name),
             eq(Locale.US),
             eq(cookie),
             eq(ApiRequest.Options(PUBLISHABLE_KEY, STRIPE_ACCOUNT_ID))
@@ -104,10 +106,19 @@ class LinkApiRepositoryTest {
     @Test
     fun `consumerSignUp returns successful result`() = runTest {
         val consumerSession = mock<ConsumerSession>()
-        whenever(stripeRepository.consumerSignUp(any(), any(), any(), any(), anyOrNull(), any()))
-            .thenReturn(consumerSession)
+        whenever(
+            stripeRepository.consumerSignUp(
+                email = any(),
+                phoneNumber = any(),
+                country = any(),
+                name = anyOrNull(),
+                locale = anyOrNull(),
+                authSessionCookie = anyOrNull(),
+                requestOptions = any()
+            )
+        ).thenReturn(consumerSession)
 
-        val result = linkRepository.consumerSignUp("email", "phone", "country", "cookie")
+        val result = linkRepository.consumerSignUp("email", "phone", "name", "country", "cookie")
 
         assertThat(result.isSuccess).isTrue()
         assertThat(result.getOrNull()).isEqualTo(consumerSession)
@@ -115,10 +126,19 @@ class LinkApiRepositoryTest {
 
     @Test
     fun `consumerSignUp catches exception and returns failure`() = runTest {
-        whenever(stripeRepository.consumerSignUp(any(), any(), any(), any(), anyOrNull(), any()))
-            .thenThrow(RuntimeException("error"))
+        whenever(
+            stripeRepository.consumerSignUp(
+                email = any(),
+                phoneNumber = any(),
+                country = any(),
+                name = anyOrNull(),
+                locale = anyOrNull(),
+                authSessionCookie = anyOrNull(),
+                requestOptions = any()
+            )
+        ).thenThrow(RuntimeException("error"))
 
-        val result = linkRepository.consumerSignUp("email", "phone", "country", "cookie")
+        val result = linkRepository.consumerSignUp("email", "phone", "name", "country", "cookie")
 
         assertThat(result.isFailure).isTrue()
     }

--- a/link/src/test/java/com/stripe/android/link/ui/inline/InlineSignupViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/inline/InlineSignupViewModelTest.kt
@@ -116,31 +116,6 @@ class InlineSignupViewModelTest {
         }
 
     @Test
-    fun `When entered all fields for new account then it emits user input`() =
-        runTest(UnconfinedTestDispatcher()) {
-            val email = "valid@email.com"
-            val viewModel = createViewModel()
-            viewModel.toggleExpanded()
-            viewModel.emailController.onRawValueChange(email)
-
-            assertThat(viewModel.userInput.value).isNull()
-
-            whenever(linkAccountManager.lookupConsumer(any(), any()))
-                .thenReturn(Result.success(null))
-
-            // Advance past lookup debounce delay
-            advanceTimeBy(SignUpViewModel.LOOKUP_DEBOUNCE_MS + 100)
-
-            assertThat(viewModel.userInput.value).isNull()
-
-            val phone = "1234567890"
-            viewModel.phoneController.onRawValueChange(phone)
-
-            assertThat(viewModel.userInput.value)
-                .isEqualTo(UserInput.SignUp(email, "+1$phone", "US"))
-        }
-
-    @Test
     fun `When user input becomes invalid then it emits null user input`() =
         runTest(UnconfinedTestDispatcher()) {
             val email = "valid@email.com"
@@ -162,7 +137,7 @@ class InlineSignupViewModelTest {
             viewModel.phoneController.onRawValueChange(phone)
 
             assertThat(viewModel.userInput.value)
-                .isEqualTo(UserInput.SignUp(email, "+1$phone", "US"))
+                .isEqualTo(UserInput.SignUp(email, "+1$phone", "US", name = null))
 
             viewModel.phoneController.onRawValueChange("")
 
@@ -207,7 +182,8 @@ class InlineSignupViewModelTest {
             UserInput.SignUp(
                 email = "valid@email.com",
                 phone = "+11234567890",
-                country = CountryCode.US.value
+                country = CountryCode.US.value,
+                name = null
             )
         )
     }

--- a/link/src/test/java/com/stripe/android/link/ui/signup/SignUpViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/signup/SignUpViewModelTest.kt
@@ -182,7 +182,7 @@ class SignUpViewModelTest {
     fun `When signUp fails then an error message is shown`() =
         runTest(UnconfinedTestDispatcher()) {
             val errorMessage = "Error message"
-            whenever(linkAccountManager.signUp(any(), any(), any()))
+            whenever(linkAccountManager.signUp(any(), any(), any(), anyOrNull()))
                 .thenReturn(Result.failure(RuntimeException(errorMessage)))
 
             val viewModel = createViewModel()
@@ -203,7 +203,7 @@ class SignUpViewModelTest {
                 )
             )
 
-            whenever(linkAccountManager.signUp(any(), any(), any()))
+            whenever(linkAccountManager.signUp(any(), any(), any(), anyOrNull()))
                 .thenReturn(Result.success(linkAccount))
 
             viewModel.performValidSignup()
@@ -224,7 +224,7 @@ class SignUpViewModelTest {
                 )
             )
 
-            whenever(linkAccountManager.signUp(any(), any(), any()))
+            whenever(linkAccountManager.signUp(any(), any(), any(), anyOrNull()))
                 .thenReturn(Result.success(linkAccount))
 
             viewModel.performValidSignup()
@@ -244,7 +244,7 @@ class SignUpViewModelTest {
                 )
             )
 
-            whenever(linkAccountManager.signUp(any(), any(), any()))
+            whenever(linkAccountManager.signUp(any(), any(), any(), anyOrNull()))
                 .thenReturn(Result.success(linkAccount))
 
             viewModel.performValidSignup()
@@ -257,7 +257,7 @@ class SignUpViewModelTest {
         runTest(UnconfinedTestDispatcher()) {
             val viewModel = createViewModel()
 
-            whenever(linkAccountManager.signUp(any(), any(), any()))
+            whenever(linkAccountManager.signUp(any(), any(), any(), anyOrNull()))
                 .thenReturn(Result.failure(Exception()))
 
             viewModel.performValidSignup()

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1202,6 +1202,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
         email: String,
         phoneNumber: String,
         country: String,
+        name: String?,
         locale: Locale?,
         authSessionCookie: String?,
         requestOptions: ApiRequest.Options
@@ -1225,6 +1226,10 @@ class StripeApiRepository @JvmOverloads internal constructor(
                 ).plus(
                     locale?.let {
                         mapOf("locale" to it.toLanguageTag())
+                    } ?: emptyMap()
+                ).plus(
+                    name?.let {
+                        mapOf("legal_name" to it)
                     } ?: emptyMap()
                 )
             ),

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -411,6 +411,7 @@ abstract class StripeRepository {
         email: String,
         phoneNumber: String,
         country: String,
+        name: String?,
         locale: Locale?,
         authSessionCookie: String?,
         requestOptions: ApiRequest.Options

--- a/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
@@ -296,6 +296,7 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         email: String,
         phoneNumber: String,
         country: String,
+        name: String?,
         locale: Locale?,
         authSessionCookie: String?,
         requestOptions: ApiRequest.Options

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -1712,12 +1712,14 @@ internal class StripeApiRepositoryTest {
             val email = "email@example.com"
             val phoneNumber = "phone number"
             val country = "US"
+            val name = "name"
             val locale = Locale.US
             val cookie = "cookie1"
             create().consumerSignUp(
                 email,
                 phoneNumber,
                 country,
+                name,
                 locale,
                 cookie,
                 DEFAULT_OPTIONS
@@ -1730,6 +1732,7 @@ internal class StripeApiRepositoryTest {
                 assertEquals(this["email_address"], email)
                 assertEquals(this["phone_number"], phoneNumber)
                 assertEquals(this["country"], country)
+                assertEquals(this["legal_name"], name)
                 assertEquals(this["locale"], locale.toLanguageTag())
                 withNestedParams("cookies") {
                     assertEquals(this["verification_session_client_secrets"], listOf(cookie))


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

With this pull request, we’re now sending the collected name to the backend in the Link signup flows.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Name collection on Link signup.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots

🙅‍♂️

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

_Nothing to add._
