### PR TITLE
Tweak Link back navigation and logout logic

### DIFF
--- a/link/api/link.api
+++ b/link/api/link.api
@@ -82,8 +82,15 @@ public abstract class com/stripe/android/link/LinkActivityResult : android/os/Pa
 public final class com/stripe/android/link/LinkActivityResult$Canceled : com/stripe/android/link/LinkActivityResult {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public static final field INSTANCE Lcom/stripe/android/link/LinkActivityResult$Canceled;
+	public fun <init> (Lcom/stripe/android/link/LinkActivityResult$Canceled$Reason;)V
+	public final fun component1 ()Lcom/stripe/android/link/LinkActivityResult$Canceled$Reason;
+	public final fun copy (Lcom/stripe/android/link/LinkActivityResult$Canceled$Reason;)Lcom/stripe/android/link/LinkActivityResult$Canceled;
+	public static synthetic fun copy$default (Lcom/stripe/android/link/LinkActivityResult$Canceled;Lcom/stripe/android/link/LinkActivityResult$Canceled$Reason;ILjava/lang/Object;)Lcom/stripe/android/link/LinkActivityResult$Canceled;
 	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReason ()Lcom/stripe/android/link/LinkActivityResult$Canceled$Reason;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
@@ -93,6 +100,14 @@ public final class com/stripe/android/link/LinkActivityResult$Canceled$Creator :
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/link/LinkActivityResult$Canceled;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/link/LinkActivityResult$Canceled$Reason : java/lang/Enum {
+	public static final field BackPressed Lcom/stripe/android/link/LinkActivityResult$Canceled$Reason;
+	public static final field LoggedOut Lcom/stripe/android/link/LinkActivityResult$Canceled$Reason;
+	public static final field PayAnotherWay Lcom/stripe/android/link/LinkActivityResult$Canceled$Reason;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/link/LinkActivityResult$Canceled$Reason;
+	public static fun values ()[Lcom/stripe/android/link/LinkActivityResult$Canceled$Reason;
 }
 
 public final class com/stripe/android/link/LinkActivityResult$Completed : com/stripe/android/link/LinkActivityResult {

--- a/link/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -267,7 +267,7 @@ internal class LinkActivity : ComponentActivity() {
         viewModel.unregisterFromActivity()
     }
 
-    private fun dismiss(result: LinkActivityResult = LinkActivityResult.Canceled) {
+    private fun dismiss(result: LinkActivityResult) {
         setResult(
             result.resultCode,
             Intent().putExtras(LinkActivityContract.Result(result).toBundle())

--- a/link/src/main/java/com/stripe/android/link/LinkActivityContract.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivityContract.kt
@@ -7,6 +7,7 @@ import androidx.activity.result.contract.ActivityResultContract
 import androidx.annotation.RestrictTo
 import androidx.core.os.bundleOf
 import com.stripe.android.core.injection.InjectorKey
+import com.stripe.android.link.LinkActivityResult.Canceled.Reason.BackPressed
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.ui.core.elements.IdentifierSpec
@@ -21,8 +22,10 @@ class LinkActivityContract :
         Intent(context, LinkActivity::class.java)
             .putExtra(EXTRA_ARGS, input)
 
-    override fun parseResult(resultCode: Int, intent: Intent?) =
-        intent?.getParcelableExtra<Result>(EXTRA_RESULT)?.linkResult ?: LinkActivityResult.Canceled
+    override fun parseResult(resultCode: Int, intent: Intent?): LinkActivityResult {
+        val linkResult = intent?.getParcelableExtra<Result>(EXTRA_RESULT)?.linkResult
+        return linkResult ?: LinkActivityResult.Canceled(reason = BackPressed)
+    }
 
     /**
      * Arguments for launching [LinkActivity] to confirm a payment with Link.

--- a/link/src/main/java/com/stripe/android/link/LinkActivityResult.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivityResult.kt
@@ -17,7 +17,15 @@ sealed class LinkActivityResult(
      * The user cancelled the Link flow without completing it.
      */
     @Parcelize
-    object Canceled : LinkActivityResult(Activity.RESULT_CANCELED)
+    data class Canceled(
+        val reason: Reason
+    ) : LinkActivityResult(Activity.RESULT_CANCELED) {
+        enum class Reason {
+            BackPressed,
+            PayAnotherWay,
+            LoggedOut
+        }
+    }
 
     /**
      * Something went wrong. See [error] for more information.

--- a/link/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -9,6 +9,7 @@ import com.stripe.android.core.BuildConfig
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.Injectable
 import com.stripe.android.core.injection.WeakMapInjectorRegistry
+import com.stripe.android.link.LinkActivityResult.Canceled.Reason.LoggedOut
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.confirmation.ConfirmationManager
 import com.stripe.android.link.injection.DaggerLinkViewModelFactoryComponent
@@ -54,7 +55,7 @@ internal class LinkActivityViewModel @Inject internal constructor(
     }
 
     fun logout() {
-        navigator.dismiss()
+        navigator.cancel(reason = LoggedOut)
         linkAccountManager.logout()
     }
 

--- a/link/src/main/java/com/stripe/android/link/model/Navigator.kt
+++ b/link/src/main/java/com/stripe/android/link/model/Navigator.kt
@@ -3,6 +3,7 @@ package com.stripe.android.link.model
 import androidx.lifecycle.asFlow
 import androidx.navigation.NavHostController
 import com.stripe.android.link.LinkActivityResult
+import com.stripe.android.link.LinkActivityResult.Canceled.Reason.BackPressed
 import com.stripe.android.link.LinkScreen
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -49,7 +50,7 @@ internal class Navigator @Inject constructor() {
         if (!userInitiated || userNavigationEnabled) {
             navigationController?.let { navController ->
                 if (!navController.popBackStack()) {
-                    dismiss()
+                    cancel(reason = BackPressed)
                 }
             }
         }
@@ -58,10 +59,14 @@ internal class Navigator @Inject constructor() {
     /**
      * Dismisses the Link Activity with the given [result].
      */
-    fun dismiss(result: LinkActivityResult = LinkActivityResult.Canceled) =
-        onDismiss?.let {
-            it(result)
-        }
+    fun dismiss(result: LinkActivityResult) = onDismiss?.invoke(result)
+
+    /**
+     * Dismisses the Link Activity with the given [result].
+     */
+    fun cancel(reason: LinkActivityResult.Canceled.Reason) {
+        dismiss(LinkActivityResult.Canceled(reason))
+    }
 
     fun isOnRootScreen() = navigationController?.isOnRootScreen()
 }

--- a/link/src/main/java/com/stripe/android/link/model/Navigator.kt
+++ b/link/src/main/java/com/stripe/android/link/model/Navigator.kt
@@ -62,7 +62,7 @@ internal class Navigator @Inject constructor() {
     fun dismiss(result: LinkActivityResult) = onDismiss?.invoke(result)
 
     /**
-     * Dismisses the Link Activity with the given [result].
+     * Cancels the Link Activity with the given [reason].
      */
     fun cancel(reason: LinkActivityResult.Canceled.Reason) {
         dismiss(LinkActivityResult.Canceled(reason))

--- a/link/src/main/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModel.kt
@@ -7,6 +7,7 @@ import com.stripe.android.core.Logger
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetLinkResult
 import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.LinkActivityResult
+import com.stripe.android.link.LinkActivityResult.Canceled.Reason.PayAnotherWay
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.LinkScreen
 import com.stripe.android.link.R
@@ -197,8 +198,7 @@ internal class PaymentMethodViewModel @Inject constructor(
 
     private fun payAnotherWay() {
         clearError()
-        navigator.dismiss()
-        linkAccountManager.logout()
+        navigator.cancel(reason = PayAnotherWay)
     }
 
     private fun completePayment(linkPaymentDetails: LinkPaymentDetails) {

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.stripe.android.core.Logger
 import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.LinkActivityResult
+import com.stripe.android.link.LinkActivityResult.Canceled.Reason.PayAnotherWay
 import com.stripe.android.link.LinkScreen
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.confirmation.ConfirmStripeIntentParamsFactory
@@ -121,8 +122,7 @@ internal class WalletViewModel @Inject constructor(
     }
 
     fun payAnotherWay() {
-        navigator.dismiss()
-        linkAccountManager.logout()
+        navigator.cancel(reason = PayAnotherWay)
     }
 
     fun addNewPaymentMethod(clearBackStack: Boolean = false) {

--- a/link/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -9,6 +9,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.injection.Injectable
 import com.stripe.android.core.injection.WeakMapInjectorRegistry
+import com.stripe.android.link.LinkActivityResult.Canceled.Reason
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.confirmation.ConfirmationManager
 import com.stripe.android.link.model.Navigator
@@ -22,6 +23,7 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argWhere
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.reset
@@ -142,7 +144,7 @@ class LinkActivityViewModelTest {
 
         viewModel.onBackPressed()
 
-        spy(navigator).dismiss()
+        verify(navigator).onBack(userInitiated = eq(true))
         verify(linkAccountManager, never()).logout()
     }
 
@@ -153,7 +155,7 @@ class LinkActivityViewModelTest {
 
         viewModel.onBackPressed()
 
-        verify(navigator, never()).dismiss()
+        verify(navigator, never()).dismiss(any())
         verify(linkAccountManager, never()).logout()
     }
 
@@ -164,7 +166,7 @@ class LinkActivityViewModelTest {
 
         viewModel.onBackPressed()
 
-        verify(navigator, never()).dismiss()
+        verify(navigator, never()).dismiss(any())
         verify(linkAccountManager, never()).logout()
     }
 
@@ -174,7 +176,7 @@ class LinkActivityViewModelTest {
 
         viewModel.logout()
 
-        verify(navigator).dismiss()
+        verify(navigator).cancel(eq(Reason.LoggedOut))
         verify(linkAccountManager).logout()
     }
 

--- a/link/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModelTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.financialconnections.launcher.FinancialConnectionsShee
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
 import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.LinkActivityResult
+import com.stripe.android.link.LinkActivityResult.Canceled.Reason
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.LinkScreen
 import com.stripe.android.link.R
@@ -54,6 +55,7 @@ import org.mockito.kotlin.argWhere
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -409,13 +411,13 @@ class PaymentMethodViewModelTest {
     }
 
     @Test
-    fun `payAnotherWay dismisses and logs out`() = runTest {
+    fun `payAnotherWay dismisses, but doesn't log out`() = runTest {
         whenever(navigator.isOnRootScreen()).thenReturn(true)
 
         createViewModel().onSecondaryButtonClick()
 
-        verify(navigator).dismiss()
-        verify(linkAccountManager).logout()
+        verify(navigator).cancel(reason = eq(Reason.PayAnotherWay))
+        verify(linkAccountManager, never()).logout()
     }
 
     @Test

--- a/link/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -8,6 +8,7 @@ import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.Injectable
 import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.LinkActivityResult
+import com.stripe.android.link.LinkActivityResult.Canceled.Reason
 import com.stripe.android.link.LinkScreen
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.confirmation.ConfirmationManager
@@ -44,6 +45,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.clearInvocations
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -287,7 +289,8 @@ class WalletViewModelTest {
 
         viewModel.payAnotherWay()
 
-        verify(navigator).dismiss()
+        verify(navigator).cancel(reason = eq(Reason.PayAnotherWay))
+        verify(linkAccountManager, never()).logout()
     }
 
     @Test

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -140,7 +140,7 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
         setupTopContainer()
 
         linkButton.apply {
-            onClick = { viewModel.launchLink() }
+            onClick = { viewModel.launchLink(launchedDirectly = false) }
             linkPaymentLauncher = viewModel.linkLauncher
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -512,7 +512,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             prefsRepository.savePaymentSelection(PaymentSelection.Link)
             _paymentSheetResult.value = PaymentSheetResult.Completed
         } else if (cancelPaymentFlow) {
-            // We launched the user straight into link, but they decided to exit out of it.
+            // We launched the user straight into Link, but they decided to exit out of it.
             _paymentSheetResult.value = PaymentSheetResult.Canceled
         } else {
             setContentVisible(true)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -28,6 +28,7 @@ import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContra
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.LinkActivityResult
+import com.stripe.android.link.LinkActivityResult.Canceled.Reason
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.LinkPaymentLauncher.Companion.LINK_ENABLED
@@ -148,6 +149,8 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
     private var linkActivityResultLauncher:
         ActivityResultLauncher<LinkActivityContract.Args>? = null
+
+    private var launchedLinkDirectly: Boolean = false
 
     @VisibleForTesting
     internal val googlePayLauncherConfig: GooglePayPaymentMethodLauncher.Config? =
@@ -438,7 +441,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             viewModelScope.launch {
                 val accountStatus = linkLauncher.setup(stripeIntent, this)
                 when (accountStatus) {
-                    AccountStatus.Verified -> launchLink()
+                    AccountStatus.Verified -> launchLink(launchedDirectly = true)
                     AccountStatus.VerificationStarted,
                     AccountStatus.NeedsVerification -> {
                         linkVerificationCallback = { success ->
@@ -446,7 +449,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                             _showLinkVerificationDialog.value = false
 
                             if (success) {
-                                launchLink()
+                                launchLink(launchedDirectly = true)
                             }
                         }
                         _showLinkVerificationDialog.value = true
@@ -466,13 +469,17 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         isReturningUser: Boolean
     ) {
         if (isReturningUser) {
-            launchLink(paymentMethodCreateParams)
+            launchLink(launchedDirectly = false, paymentMethodCreateParams)
         } else {
             super.completeLinkInlinePayment(paymentMethodCreateParams, isReturningUser)
         }
     }
 
-    fun launchLink(paymentMethodCreateParams: PaymentMethodCreateParams? = null) {
+    fun launchLink(
+        launchedDirectly: Boolean,
+        paymentMethodCreateParams: PaymentMethodCreateParams? = null
+    ) {
+        launchedLinkDirectly = launchedDirectly
         linkActivityResultLauncher?.let { activityResultLauncher ->
             linkLauncher.present(
                 activityResultLauncher,
@@ -495,15 +502,21 @@ internal class PaymentSheetViewModel @Inject internal constructor(
      * Method called with the result of launching the Link UI to collect a payment.
      */
     private fun onLinkActivityResult(result: LinkActivityResult) {
-        val paymentResult = result.convertToPaymentResult()
-        if (paymentResult is PaymentResult.Completed) {
+        val completePaymentFlow = result is LinkActivityResult.Completed
+        val cancelPaymentFlow = launchedLinkDirectly &&
+            result is LinkActivityResult.Canceled && result.reason == Reason.BackPressed
+
+        if (completePaymentFlow) {
             // If payment was completed inside the Link UI, dismiss immediately.
             eventReporter.onPaymentSuccess(PaymentSelection.Link)
             prefsRepository.savePaymentSelection(PaymentSelection.Link)
             _paymentSheetResult.value = PaymentSheetResult.Completed
+        } else if (cancelPaymentFlow) {
+            // We launched the user straight into link, but they decided to exit out of it.
+            _paymentSheetResult.value = PaymentSheetResult.Canceled
         } else {
             setContentVisible(true)
-            onPaymentResult(paymentResult)
+            onPaymentResult(result.convertToPaymentResult())
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates the back navigation and logout logic in Link. Here’s what changed:
1. Instead of logging the user out when they select `Pay another way`, we simply close Link and return to the payment sheet.
2. If we have launched Link directly, closing Link (by pressing the back button or the `X`), we completely close the payment flow.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Update to new intended behavior.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

_Nothing to add._
