### PR TITLE
[Identity] provide default values for nullable error fields

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/navigation/ErrorFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ErrorFragment.kt
@@ -103,15 +103,22 @@ internal class ErrorFragment(
             navigate(
                 R.id.action_global_errorFragment,
                 bundleOf(
-                    ARG_ERROR_TITLE to requirementError.title,
-                    ARG_ERROR_CONTENT to requirementError.body,
+                    ARG_ERROR_TITLE to (
+                        requirementError.title ?: context.getString(R.string.error)
+                        ),
+                    ARG_ERROR_CONTENT to (
+                        requirementError.body
+                            ?: context.getString(R.string.unexpected_error_try_again)
+                        ),
                     ARG_GO_BACK_BUTTON_DESTINATION to
                         if (requirementError.requirement.matchesFromFragment(fromFragment)) {
                             fromFragment
                         } else {
                             UNEXPECTED_DESTINATION
                         },
-                    ARG_GO_BACK_BUTTON_TEXT to requirementError.backButtonText,
+                    ARG_GO_BACK_BUTTON_TEXT to (
+                        requirementError.backButtonText ?: context.getString(R.string.go_back)
+                        ),
                     ARG_SHOULD_FAIL to false,
                     ARG_CAUSE to IllegalStateException("VerificationPageDataRequirementError: $requirementError")
                 )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Provide default values for nullable fields from the error response.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
`ErrorFragment` would expect the values to be non null.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
