### PR TITLE
Fix issue with injected shipping values

### DIFF
--- a/link/api/link.api
+++ b/link/api/link.api
@@ -272,14 +272,6 @@ public final class com/stripe/android/link/injection/LinkActivityContractArgsMod
 	public static fun provideMerchantName (Lcom/stripe/android/link/LinkActivityContract$Args;)Ljava/lang/String;
 }
 
-public final class com/stripe/android/link/injection/LinkActivityContractArgsModule_Companion_ProvideShippingValuesFactory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/link/injection/LinkActivityContractArgsModule_Companion_ProvideShippingValuesFactory;
-	public synthetic fun get ()Ljava/lang/Object;
-	public fun get ()Ljava/util/Map;
-	public static fun provideShippingValues (Lcom/stripe/android/link/LinkActivityContract$Args;)Ljava/util/Map;
-}
-
 public final class com/stripe/android/link/injection/LinkActivityContractArgsModule_Companion_ProvideStripeIntentFactory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;)V
 	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/link/injection/LinkActivityContractArgsModule_Companion_ProvideStripeIntentFactory;

--- a/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
@@ -74,7 +74,6 @@ class LinkPaymentLauncher @AssistedInject internal constructor(
         .merchantName(merchantName)
         .customerEmail(customerEmail)
         .customerPhone(customerPhone)
-        .shippingValues(shippingValues)
         .context(context)
         .ioContext(ioContext)
         .uiContext(uiContext)

--- a/link/src/main/java/com/stripe/android/link/injection/LinkActivityContractArgsModule.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/LinkActivityContractArgsModule.kt
@@ -38,10 +38,5 @@ internal interface LinkActivityContractArgsModule {
         @Singleton
         @Named(CUSTOMER_PHONE)
         fun provideCustomerPhone(args: LinkActivityContract.Args) = args.customerPhone
-
-        @Provides
-        @Singleton
-        @Named(SHIPPING_VALUES)
-        fun provideShippingValues(args: LinkActivityContract.Args) = args.shippingValues
     }
 }

--- a/link/src/main/java/com/stripe/android/link/injection/LinkPaymentLauncherComponent.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/LinkPaymentLauncherComponent.kt
@@ -17,7 +17,6 @@ import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.ui.core.address.AddressRepository
-import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.ui.core.forms.resources.ResourceRepository
 import dagger.BindsInstance
 import dagger.Component
@@ -57,9 +56,6 @@ internal abstract class LinkPaymentLauncherComponent {
 
         @BindsInstance
         fun stripeIntent(@Named(LINK_INTENT) stripeIntent: StripeIntent): Builder
-
-        @BindsInstance
-        fun shippingValues(@Named(SHIPPING_VALUES) shippingValues: Map<IdentifierSpec, String?>?): Builder
 
         @BindsInstance
         fun context(context: Context): Builder

--- a/link/src/main/java/com/stripe/android/link/injection/NamedConstants.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/NamedConstants.kt
@@ -24,7 +24,7 @@ const val CUSTOMER_PHONE = "customerPhone"
  * Identifies the shipping address passed in from the customer, used to pre-fill address forms.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-const val SHIPPING_VALUES = "linkShippingValues"
+const val SHIPPING_VALUES = "shippingValues"
 
 /**
  * Identifies the Stripe Intent being processed by Link.

--- a/link/src/main/java/com/stripe/android/link/injection/NamedConstants.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/NamedConstants.kt
@@ -24,7 +24,7 @@ const val CUSTOMER_PHONE = "customerPhone"
  * Identifies the shipping address passed in from the customer, used to pre-fill address forms.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-const val SHIPPING_VALUES = "shippingValues"
+const val SHIPPING_VALUES = "linkShippingValues"
 
 /**
  * Identifies the Stripe Intent being processed by Link.

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/injection/FormControllerModule.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/injection/FormControllerModule.kt
@@ -2,6 +2,7 @@ package com.stripe.android.ui.core.injection
 
 import android.content.Context
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.injection.SHIPPING_VALUES
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.ui.core.Amount
@@ -11,6 +12,7 @@ import com.stripe.android.ui.core.forms.TransformSpecToElements
 import com.stripe.android.ui.core.forms.resources.ResourceRepository
 import dagger.Module
 import dagger.Provides
+import javax.inject.Named
 
 @Module
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -25,7 +27,7 @@ abstract class FormControllerModule {
             merchantName: String,
             stripeIntent: StripeIntent?,
             initialValues: Map<IdentifierSpec, String?>,
-            shippingValues: Map<IdentifierSpec, String?>?,
+            @Named(SHIPPING_VALUES) shippingValues: Map<IdentifierSpec, String?>?,
             viewOnlyFields: Set<IdentifierSpec>
         ) = TransformSpecToElements(
             addressResourceRepository = addressResourceRepository,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/injection/FormControllerModule.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/injection/FormControllerModule.kt
@@ -2,6 +2,7 @@ package com.stripe.android.ui.core.injection
 
 import android.content.Context
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.injection.INITIAL_VALUES
 import com.stripe.android.core.injection.SHIPPING_VALUES
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.StripeIntent
@@ -26,7 +27,7 @@ abstract class FormControllerModule {
             context: Context,
             merchantName: String,
             stripeIntent: StripeIntent?,
-            initialValues: Map<IdentifierSpec, String?>,
+            @Named(INITIAL_VALUES) initialValues: Map<IdentifierSpec, String?>,
             @Named(SHIPPING_VALUES) shippingValues: Map<IdentifierSpec, String?>?,
             viewOnlyFields: Set<IdentifierSpec>
         ) = TransformSpecToElements(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/injection/FormControllerSubcomponent.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/injection/FormControllerSubcomponent.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.ui.core.injection
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.injection.INITIAL_VALUES
 import com.stripe.android.core.injection.SHIPPING_VALUES
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.ui.core.FormController
@@ -28,7 +29,9 @@ interface FormControllerSubcomponent {
         fun formSpec(formSpec: LayoutSpec): Builder
 
         @BindsInstance
-        fun initialValues(initialValues: Map<IdentifierSpec, String?>): Builder
+        fun initialValues(
+            @Named(INITIAL_VALUES) initialValues: Map<IdentifierSpec, String?>
+        ): Builder
 
         @BindsInstance
         fun shippingValues(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -464,7 +464,7 @@ internal class DefaultFlowController @Inject internal constructor(
             val shippingAddress = if (shippingDetails?.isCheckboxSelected == true) {
                 shippingDetails.toIdentifierMap(config.defaultBillingDetails)
             } else {
-                emptyMap()
+                null
             }
             val linkLauncher = linkPaymentLauncherFactory.create(
                 merchantName = config.merchantDisplayName,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -195,7 +195,7 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
         val shippingAddress = if (shippingDetails?.isCheckboxSelected == true) {
             shippingDetails.toIdentifierMap(config?.defaultBillingDetails)
         } else {
-            emptyMap()
+            null
         }
         it.create(
             merchantName = merchantName,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -1027,7 +1027,7 @@ internal class DefaultFlowControllerTest {
                 @Assisted(MERCHANT_NAME) merchantName: String,
                 @Assisted(CUSTOMER_EMAIL) customerEmail: String?,
                 @Assisted(CUSTOMER_PHONE) customerPhone: String?,
-                @Assisted(SHIPPING_VALUES) initialFormValuesMap: Map<IdentifierSpec, String?>?
+                @Assisted(SHIPPING_VALUES) shippingValues: Map<IdentifierSpec, String?>?
             ): LinkPaymentLauncher {
                 return linkPaymentLauncher
             }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -47,6 +47,7 @@ import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.PaymentSheetResult
 import com.stripe.android.paymentsheet.PaymentSheetResultCallback
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.addresselement.AddressElementActivityContract
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.ClientSecret
@@ -71,6 +72,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argWhere
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isA
 import org.mockito.kotlin.isNull
@@ -724,6 +726,89 @@ internal class DefaultFlowControllerTest {
         flowController.confirm()
 
         verify(paymentLauncher).confirm(any<ConfirmPaymentIntentParams>())
+    }
+
+    @Test
+    fun `confirmPaymentSelection() with Link and shipping should have shipping details in confirm params`() = runTest {
+        whenever(linkPaymentLauncher.setup(any(), any())).thenReturn(AccountStatus.SignedOut)
+
+        val flowController = createFlowController(
+            savedSelection = SavedSelection.Link,
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.paymentMethodTypes.plus("link")
+            )
+        )
+
+        flowController.configureWithPaymentIntent(
+            PaymentSheetFixtures.CLIENT_SECRET,
+            PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY.copy(
+                shippingDetails = AddressDetails(
+                    name = "Test"
+                )
+            )
+        ) { _, _ -> }
+
+        flowController.onPaymentOptionResult(
+            PaymentOptionResult.Succeeded(
+                PaymentSelection.New.LinkInline(
+                    LinkPaymentDetails.New(
+                        PaymentDetailsFixtures.CONSUMER_SINGLE_PAYMENT_DETAILS.paymentDetails.first(),
+                        mock(),
+                        PaymentMethodCreateParamsFixtures.DEFAULT_CARD
+                    )
+                )
+            )
+        )
+
+        flowController.confirm()
+
+        val paramsCaptor = argumentCaptor<ConfirmPaymentIntentParams>()
+
+        verify(paymentLauncher).confirm(paramsCaptor.capture())
+
+        assertThat(paramsCaptor.firstValue.toParamMap()["shipping"]).isEqualTo(
+            mapOf(
+                "address" to emptyMap<String, String>(),
+                "name" to "Test"
+            )
+        )
+    }
+
+    @Test
+    fun `confirmPaymentSelection() with Link and no shipping should not have shipping details in confirm params`() = runTest {
+        whenever(linkPaymentLauncher.setup(any(), any())).thenReturn(AccountStatus.SignedOut)
+
+        val flowController = createFlowController(
+            savedSelection = SavedSelection.Link,
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.paymentMethodTypes.plus("link")
+            )
+        )
+
+        flowController.configureWithPaymentIntent(
+            PaymentSheetFixtures.CLIENT_SECRET,
+            PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
+        ) { _, _ -> }
+
+        flowController.onPaymentOptionResult(
+            PaymentOptionResult.Succeeded(
+                PaymentSelection.New.LinkInline(
+                    LinkPaymentDetails.New(
+                        PaymentDetailsFixtures.CONSUMER_SINGLE_PAYMENT_DETAILS.paymentDetails.first(),
+                        mock(),
+                        PaymentMethodCreateParamsFixtures.DEFAULT_CARD
+                    )
+                )
+            )
+        )
+
+        flowController.confirm()
+
+        val paramsCaptor = argumentCaptor<ConfirmPaymentIntentParams>()
+
+        verify(paymentLauncher).confirm(paramsCaptor.capture())
+
+        assertThat(paramsCaptor.firstValue.toParamMap()["shipping"]).isNull()
     }
 
     private fun verifyPaymentSelection(

--- a/stripe-core/src/main/java/com/stripe/android/core/injection/NamedConstants.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/injection/NamedConstants.kt
@@ -21,6 +21,12 @@ const val PUBLISHABLE_KEY = "publishableKey"
 const val STRIPE_ACCOUNT_ID = "stripeAccountId"
 
 /**
+ * Name for form initial values
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+const val INITIAL_VALUES = "initialValues"
+
+/**
  * Name for user's shipping address
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

The shipping values were injected with initial values, this PR adds the named parameter so that injection works correctly.

Fix an issue with Link payments sending empty shipping map when it should be null.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Address element private beta

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
