### PR TITLE
Add prefilled name in Link signup

### DIFF
--- a/link/api/link.api
+++ b/link/api/link.api
@@ -18,8 +18,8 @@ public final class com/stripe/android/link/LinkActivityContract$Args : com/strip
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/link/LinkActivityContract$Args$Companion;
-	public final fun copy (Lcom/stripe/android/model/StripeIntent;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethodCreateParams;Lcom/stripe/android/link/LinkActivityContract$Args$InjectionParams;)Lcom/stripe/android/link/LinkActivityContract$Args;
-	public static synthetic fun copy$default (Lcom/stripe/android/link/LinkActivityContract$Args;Lcom/stripe/android/model/StripeIntent;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethodCreateParams;Lcom/stripe/android/link/LinkActivityContract$Args$InjectionParams;ILjava/lang/Object;)Lcom/stripe/android/link/LinkActivityContract$Args;
+	public final fun copy (Lcom/stripe/android/model/StripeIntent;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethodCreateParams;Lcom/stripe/android/link/LinkActivityContract$Args$InjectionParams;)Lcom/stripe/android/link/LinkActivityContract$Args;
+	public static synthetic fun copy$default (Lcom/stripe/android/link/LinkActivityContract$Args;Lcom/stripe/android/model/StripeIntent;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethodCreateParams;Lcom/stripe/android/link/LinkActivityContract$Args$InjectionParams;ILjava/lang/Object;)Lcom/stripe/android/link/LinkActivityContract$Args;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -196,8 +196,8 @@ public final class com/stripe/android/link/LinkPaymentDetails$Saved$Creator : an
 public final class com/stripe/android/link/LinkPaymentLauncher_Factory {
 	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/link/LinkPaymentLauncher_Factory;
-	public fun get (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lcom/stripe/android/link/LinkPaymentLauncher;
-	public static fun newInstance (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Landroid/content/Context;Ljava/util/Set;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ZLkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lcom/stripe/android/networking/PaymentAnalyticsRequestFactory;Lcom/stripe/android/core/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/StripeRepository;Lcom/stripe/android/ui/core/forms/resources/ResourceRepository;)Lcom/stripe/android/link/LinkPaymentLauncher;
+	public fun get (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lcom/stripe/android/link/LinkPaymentLauncher;
+	public static fun newInstance (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Landroid/content/Context;Ljava/util/Set;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ZLkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lcom/stripe/android/networking/PaymentAnalyticsRequestFactory;Lcom/stripe/android/core/networking/AnalyticsRequestExecutor;Lcom/stripe/android/networking/StripeRepository;Lcom/stripe/android/ui/core/forms/resources/ResourceRepository;)Lcom/stripe/android/link/LinkPaymentLauncher;
 }
 
 public final class com/stripe/android/link/account/CookieStore_Factory : dagger/internal/Factory {
@@ -282,7 +282,7 @@ public final class com/stripe/android/link/injection/LinkActivityContractArgsMod
 
 public final class com/stripe/android/link/injection/LinkPaymentLauncherFactory_Impl : com/stripe/android/link/injection/LinkPaymentLauncherFactory {
 	public static fun create (Lcom/stripe/android/link/LinkPaymentLauncher_Factory;)Ljavax/inject/Provider;
-	public fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lcom/stripe/android/link/LinkPaymentLauncher;
+	public fun create (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lcom/stripe/android/link/LinkPaymentLauncher;
 }
 
 public final class com/stripe/android/link/injection/NamedConstantsKt {
@@ -411,11 +411,11 @@ public final class com/stripe/android/link/ui/inline/ComposableSingletons$LinkIn
 }
 
 public final class com/stripe/android/link/ui/inline/InlineSignupViewModel_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/link/ui/inline/InlineSignupViewModel_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/link/ui/inline/InlineSignupViewModel_Factory;
 	public fun get ()Lcom/stripe/android/link/ui/inline/InlineSignupViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/model/StripeIntent;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/link/account/LinkAccountManager;Lcom/stripe/android/link/analytics/LinkEventsReporter;Lcom/stripe/android/core/Logger;)Lcom/stripe/android/link/ui/inline/InlineSignupViewModel;
+	public static fun newInstance (Lcom/stripe/android/model/StripeIntent;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/link/account/LinkAccountManager;Lcom/stripe/android/link/analytics/LinkEventsReporter;Lcom/stripe/android/core/Logger;)Lcom/stripe/android/link/ui/inline/InlineSignupViewModel;
 }
 
 public final class com/stripe/android/link/ui/inline/InlineSignupViewModel_Factory_MembersInjector : dagger/MembersInjector {

--- a/link/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -251,7 +251,7 @@ internal class LinkActivity : ComponentActivity() {
                                 AccountStatus.VerificationStarted ->
                                     LinkScreen.Verification
                                 AccountStatus.SignedOut ->
-                                    LinkScreen.SignUp(starterArgs.customerEmail)
+                                    LinkScreen.SignUp(starterArgs.customerEmail, starterArgs.customerName)
                             },
                             clearBackStack = true
                         )

--- a/link/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -251,7 +251,7 @@ internal class LinkActivity : ComponentActivity() {
                                 AccountStatus.VerificationStarted ->
                                     LinkScreen.Verification
                                 AccountStatus.SignedOut ->
-                                    LinkScreen.SignUp(starterArgs.customerEmail, starterArgs.customerName)
+                                    LinkScreen.SignUp(starterArgs.customerEmail)
                             },
                             clearBackStack = true
                         )

--- a/link/src/main/java/com/stripe/android/link/LinkActivityContract.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivityContract.kt
@@ -45,6 +45,7 @@ class LinkActivityContract :
         internal val merchantName: String,
         internal val customerEmail: String? = null,
         internal val customerPhone: String? = null,
+        internal val customerName: String? = null,
         internal val shippingValues: Map<IdentifierSpec, String?>? = null,
         internal val prefilledCardParams: PaymentMethodCreateParams? = null,
         internal val injectionParams: InjectionParams? = null

--- a/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
@@ -15,6 +15,7 @@ import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.analytics.LinkEventsReporter
 import com.stripe.android.link.injection.CUSTOMER_EMAIL
+import com.stripe.android.link.injection.CUSTOMER_NAME
 import com.stripe.android.link.injection.CUSTOMER_PHONE
 import com.stripe.android.link.injection.DaggerLinkPaymentLauncherComponent
 import com.stripe.android.link.injection.LinkComponent
@@ -56,6 +57,7 @@ class LinkPaymentLauncher @AssistedInject internal constructor(
     @Assisted(MERCHANT_NAME) private val merchantName: String,
     @Assisted(CUSTOMER_EMAIL) private val customerEmail: String?,
     @Assisted(CUSTOMER_PHONE) private val customerPhone: String?,
+    @Assisted(CUSTOMER_NAME) private val customerName: String?,
     @Assisted(SHIPPING_VALUES) private val shippingValues: Map<IdentifierSpec, String?>?,
     context: Context,
     @Named(PRODUCT_USAGE) private val productUsage: Set<String>,
@@ -74,6 +76,7 @@ class LinkPaymentLauncher @AssistedInject internal constructor(
         .merchantName(merchantName)
         .customerEmail(customerEmail)
         .customerPhone(customerPhone)
+        .customerName(customerName)
         .context(context)
         .ioContext(ioContext)
         .uiContext(uiContext)
@@ -152,6 +155,7 @@ class LinkPaymentLauncher @AssistedInject internal constructor(
             merchantName,
             customerEmail,
             customerPhone,
+            customerName,
             shippingValues,
             prefilledNewCardParams,
             LinkActivityContract.Args.InjectionParams(

--- a/link/src/main/java/com/stripe/android/link/injection/LinkPaymentLauncherComponent.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/LinkPaymentLauncherComponent.kt
@@ -55,6 +55,9 @@ internal abstract class LinkPaymentLauncherComponent {
         fun customerPhone(@Named(CUSTOMER_PHONE) customerPhone: String?): Builder
 
         @BindsInstance
+        fun customerName(@Named(CUSTOMER_NAME) customerName: String?): Builder
+
+        @BindsInstance
         fun stripeIntent(@Named(LINK_INTENT) stripeIntent: StripeIntent): Builder
 
         @BindsInstance

--- a/link/src/main/java/com/stripe/android/link/injection/LinkPaymentLauncherFactory.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/LinkPaymentLauncherFactory.kt
@@ -13,6 +13,7 @@ interface LinkPaymentLauncherFactory {
         @Assisted(MERCHANT_NAME) merchantName: String,
         @Assisted(CUSTOMER_EMAIL) customerEmail: String?,
         @Assisted(CUSTOMER_PHONE) customerPhone: String?,
+        @Assisted(CUSTOMER_NAME) customerName: String?,
         @Assisted(SHIPPING_VALUES) shippingValues: Map<IdentifierSpec, String?>?
     ): LinkPaymentLauncher
 }

--- a/link/src/main/java/com/stripe/android/link/injection/NamedConstants.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/NamedConstants.kt
@@ -21,6 +21,12 @@ const val CUSTOMER_EMAIL = "customerEmail"
 const val CUSTOMER_PHONE = "customerPhone"
 
 /**
+ * Identifies the name of the customer using the app, used to pre-fill the form.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+const val CUSTOMER_NAME = "customerName"
+
+/**
  * Identifies the shipping address passed in from the customer, used to pre-fill address forms.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/link/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewModel.kt
@@ -8,6 +8,7 @@ import com.stripe.android.core.model.CountryCode
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.analytics.LinkEventsReporter
 import com.stripe.android.link.injection.CUSTOMER_EMAIL
+import com.stripe.android.link.injection.CUSTOMER_NAME
 import com.stripe.android.link.injection.CUSTOMER_PHONE
 import com.stripe.android.link.injection.LINK_INTENT
 import com.stripe.android.link.injection.MERCHANT_NAME
@@ -35,6 +36,7 @@ internal class InlineSignupViewModel @Inject constructor(
     @Named(MERCHANT_NAME) val merchantName: String,
     @Named(CUSTOMER_EMAIL) customerEmail: String?,
     @Named(CUSTOMER_PHONE) customerPhone: String?,
+    @Named(CUSTOMER_NAME) customerName: String?,
     private val linkAccountManager: LinkAccountManager,
     private val linkEventsReporter: LinkEventsReporter,
     private val logger: Logger
@@ -43,10 +45,12 @@ internal class InlineSignupViewModel @Inject constructor(
         if (linkAccountManager.hasUserLoggedOut(customerEmail)) null else customerEmail
     private val prefilledPhone =
         customerPhone?.takeUnless { linkAccountManager.hasUserLoggedOut(customerEmail) } ?: ""
+    private val prefilledName =
+        customerName?.takeUnless { linkAccountManager.hasUserLoggedOut(customerEmail) }
 
     val emailController = SimpleTextFieldController.createEmailSectionController(prefilledEmail)
     val phoneController = PhoneNumberController.createPhoneNumberController(prefilledPhone)
-    val nameController = SimpleTextFieldController.createNameSectionController(null) // TODO
+    val nameController = SimpleTextFieldController.createNameSectionController(prefilledName)
 
     /**
      * Emits the email entered in the form if valid, null otherwise.

--- a/link/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -51,12 +50,14 @@ internal class SignUpViewModel @Inject constructor(
         if (linkAccountManager.hasUserLoggedOut(customerEmail)) null else customerEmail
     private val prefilledPhone =
         args.customerPhone?.takeUnless { linkAccountManager.hasUserLoggedOut(customerEmail) } ?: ""
+    private val prefilledName =
+        args.customerName?.takeUnless { linkAccountManager.hasUserLoggedOut(customerEmail) } ?: ""
 
     val merchantName: String = args.merchantName
 
     val emailController = SimpleTextFieldController.createEmailSectionController(prefilledEmail)
     val phoneController = PhoneNumberController.createPhoneNumberController(prefilledPhone)
-    val nameController = SimpleTextFieldController.createNameSectionController(null) // TODO
+    val nameController = SimpleTextFieldController.createNameSectionController(prefilledName)
 
     /**
      * Emits the email entered in the form if valid, null otherwise.

--- a/link/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
@@ -26,6 +26,7 @@ class LinkActivityContractTest {
             "Merchant, Inc",
             "customer@email.com",
             "1234567890",
+            "Name",
             null,
             null,
             injectionParams

--- a/link/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -42,6 +42,7 @@ class LinkActivityViewModelTest {
         MERCHANT_NAME,
         CUSTOMER_EMAIL,
         CUSTOMER_PHONE,
+        CUSTOMER_NAME,
         null,
         null,
         LinkActivityContract.Args.InjectionParams(
@@ -207,6 +208,7 @@ class LinkActivityViewModelTest {
 
         const val MERCHANT_NAME = "merchantName"
         const val CUSTOMER_EMAIL = "customer@email.com"
+        const val CUSTOMER_NAME = "Customer"
         const val CUSTOMER_PHONE = "1234567890"
     }
 }

--- a/link/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
@@ -28,6 +28,7 @@ class LinkPaymentLauncherTest {
         null,
         null,
         null,
+        null,
         context,
         setOf(PRODUCT_USAGE),
         { PUBLISHABLE_KEY },

--- a/link/src/test/java/com/stripe/android/link/ui/inline/InlineSignupViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/inline/InlineSignupViewModelTest.kt
@@ -49,7 +49,7 @@ class InlineSignupViewModelTest {
     @Test
     fun `When email is provided it should not trigger lookup and should collect phone number`() =
         runTest(UnconfinedTestDispatcher()) {
-            val viewModel = createViewModel()
+            val viewModel = createViewModel(prefilledEmail = CUSTOMER_EMAIL)
             viewModel.toggleExpanded()
             assertThat(viewModel.signUpState.value).isEqualTo(SignUpState.InputtingPhoneOrName)
 
@@ -64,6 +64,7 @@ class InlineSignupViewModelTest {
                 merchantName = MERCHANT_NAME,
                 customerEmail = CUSTOMER_EMAIL,
                 customerPhone = CUSTOMER_PHONE,
+                customerName = CUSTOMER_NAME,
                 linkAccountManager = linkAccountManager,
                 linkEventsReporter = linkEventsReporter,
                 logger = Logger.noop()
@@ -212,13 +213,38 @@ class InlineSignupViewModelTest {
             )
         }
 
+    @Test
+    fun `Prefilled values are handled correctly`() = runTest(UnconfinedTestDispatcher()) {
+        val viewModel = createViewModel(
+            countryCode = CountryCode.GB,
+            prefilledEmail = CUSTOMER_EMAIL,
+            prefilledName = CUSTOMER_NAME,
+            prefilledPhone = "+44$CUSTOMER_PHONE"
+        )
+
+        viewModel.toggleExpanded()
+
+        val expectedInput = UserInput.SignUp(
+            email = CUSTOMER_EMAIL,
+            phone = "+44$CUSTOMER_PHONE",
+            country = CountryCode.GB.value,
+            name = CUSTOMER_NAME
+        )
+
+        assertThat(viewModel.userInput.value).isEqualTo(expectedInput)
+    }
+
     private fun createViewModel(
-        countryCode: CountryCode = CountryCode.US
+        countryCode: CountryCode = CountryCode.US,
+        prefilledEmail: String? = null,
+        prefilledName: String? = null,
+        prefilledPhone: String? = null
     ) = InlineSignupViewModel(
         stripeIntent = mockStripeIntent(countryCode),
         merchantName = MERCHANT_NAME,
-        customerEmail = CUSTOMER_EMAIL,
-        customerPhone = null,
+        customerEmail = prefilledEmail,
+        customerName = prefilledName,
+        customerPhone = prefilledPhone,
         linkAccountManager = linkAccountManager,
         linkEventsReporter = linkEventsReporter,
         logger = Logger.noop()
@@ -257,5 +283,6 @@ class InlineSignupViewModelTest {
         const val MERCHANT_NAME = "merchantName"
         const val CUSTOMER_EMAIL = "customer@email.com"
         const val CUSTOMER_PHONE = "1234567890"
+        const val CUSTOMER_NAME = "Customer"
     }
 }

--- a/link/src/test/java/com/stripe/android/link/ui/signup/SignUpViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/signup/SignUpViewModelTest.kt
@@ -54,6 +54,7 @@ class SignUpViewModelTest {
         MERCHANT_NAME,
         CUSTOMER_EMAIL,
         CUSTOMER_PHONE,
+        CUSTOMER_NAME,
         null,
         null,
         LinkActivityContract.Args.InjectionParams(
@@ -143,7 +144,7 @@ class SignUpViewModelTest {
     @Test
     fun `When email is provided it should not trigger lookup and should collect phone number`() =
         runTest(UnconfinedTestDispatcher()) {
-            val viewModel = createViewModel()
+            val viewModel = createViewModel(prefilledEmail = CUSTOMER_EMAIL)
             assertThat(viewModel.signUpState.value).isEqualTo(SignUpState.InputtingPhoneOrName)
 
             verify(linkAccountManager, times(0)).lookupConsumer(any(), any())
@@ -288,9 +289,19 @@ class SignUpViewModelTest {
 
         viewModel.emailController.onRawValueChange("me@myself.com")
         viewModel.phoneController.onRawValueChange("1234567890")
+        viewModel.nameController.onRawValueChange("")
         assertThat(viewModel.isReadyToSignUp.value).isFalse()
 
         viewModel.nameController.onRawValueChange("Someone from Canada")
+        assertThat(viewModel.isReadyToSignUp.value).isTrue()
+    }
+
+    @Test
+    fun `Prefilled values are handled correctly`() = runTest(UnconfinedTestDispatcher()) {
+        val viewModel = createViewModel(
+            prefilledEmail = CUSTOMER_EMAIL,
+            countryCode = CountryCode.US
+        )
         assertThat(viewModel.isReadyToSignUp.value).isTrue()
     }
 
@@ -321,7 +332,7 @@ class SignUpViewModelTest {
 
         val factory = SignUpViewModel.Factory(
             injector,
-            null
+            email = null
         )
         val factorySpy = spy(factory)
         val createdViewModel = factorySpy.create(SignUpViewModel::class.java)
@@ -329,7 +340,7 @@ class SignUpViewModelTest {
     }
 
     private fun createViewModel(
-        prefilledEmail: String? = CUSTOMER_EMAIL,
+        prefilledEmail: String? = null,
         args: LinkActivityContract.Args = defaultArgs,
         countryCode: CountryCode = CountryCode.US
     ): SignUpViewModel {
@@ -380,5 +391,6 @@ class SignUpViewModelTest {
         const val MERCHANT_NAME = "merchantName"
         const val CUSTOMER_EMAIL = "customer@email.com"
         const val CUSTOMER_PHONE = "1234567890"
+        const val CUSTOMER_NAME = "Customer"
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -470,6 +470,7 @@ internal class DefaultFlowController @Inject internal constructor(
                 merchantName = config.merchantDisplayName,
                 customerEmail = config.defaultBillingDetails?.email,
                 customerPhone = customerPhone,
+                customerName = config.defaultBillingDetails?.name,
                 shippingValues = shippingAddress
             )
             val accountStatus = linkLauncher.setup(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -201,6 +201,7 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
             merchantName = merchantName,
             customerEmail = config?.defaultBillingDetails?.email,
             customerPhone = customerPhone,
+            customerName = config?.defaultBillingDetails?.name,
             shippingValues = shippingAddress
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.injection.CUSTOMER_EMAIL
+import com.stripe.android.link.injection.CUSTOMER_NAME
 import com.stripe.android.link.injection.CUSTOMER_PHONE
 import com.stripe.android.link.injection.LinkPaymentLauncherFactory
 import com.stripe.android.link.injection.MERCHANT_NAME
@@ -1027,6 +1028,7 @@ internal class DefaultFlowControllerTest {
                 @Assisted(MERCHANT_NAME) merchantName: String,
                 @Assisted(CUSTOMER_EMAIL) customerEmail: String?,
                 @Assisted(CUSTOMER_PHONE) customerPhone: String?,
+                @Assisted(CUSTOMER_NAME) customerName: String?,
                 @Assisted(SHIPPING_VALUES) shippingValues: Map<IdentifierSpec, String?>?
             ): LinkPaymentLauncher {
                 return linkPaymentLauncher


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request makes sure we pre-fill the name field in Link signup if a name is available.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Make signup as easy as possible.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screen recording

https://user-images.githubusercontent.com/110940675/188200664-9185664f-ba49-4a09-8b42-66cdf7b13fb8.mp4

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
