### PR TITLE
Add CVC check in payment details

### DIFF
--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -53,6 +53,7 @@ import com.stripe.android.link.ui.completePaymentButtonLabel
 import com.stripe.android.link.ui.paymentmethod.SupportedPaymentMethod
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.model.CvcCheck
 import com.stripe.android.ui.core.elements.Html
 import com.stripe.android.ui.core.injection.NonFallbackInjector
 
@@ -69,7 +70,8 @@ private fun WalletBodyPreview() {
                         2022,
                         12,
                         CardBrand.Visa,
-                        "4242"
+                        "4242",
+                        CvcCheck.Pass
                     ),
                     ConsumerPaymentDetails.Card(
                         "id2",
@@ -77,7 +79,8 @@ private fun WalletBodyPreview() {
                         2023,
                         11,
                         CardBrand.MasterCard,
-                        "4444"
+                        "4444",
+                        CvcCheck.Fail
                     )
                 ),
                 supportedTypes = SupportedPaymentMethod.allTypes,

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -2486,18 +2486,20 @@ public final class com/stripe/android/model/ConsumerPaymentDetails$Card : com/st
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/ConsumerPaymentDetails$Card$Companion;
 	public static final field type Ljava/lang/String;
-	public fun <init> (Ljava/lang/String;ZIILcom/stripe/android/model/CardBrand;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;ZIILcom/stripe/android/model/CardBrand;Ljava/lang/String;Lcom/stripe/android/model/CvcCheck;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Z
 	public final fun component3 ()I
 	public final fun component4 ()I
 	public final fun component5 ()Lcom/stripe/android/model/CardBrand;
 	public final fun component6 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;ZIILcom/stripe/android/model/CardBrand;Ljava/lang/String;)Lcom/stripe/android/model/ConsumerPaymentDetails$Card;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/ConsumerPaymentDetails$Card;Ljava/lang/String;ZIILcom/stripe/android/model/CardBrand;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/ConsumerPaymentDetails$Card;
+	public final fun component7 ()Lcom/stripe/android/model/CvcCheck;
+	public final fun copy (Ljava/lang/String;ZIILcom/stripe/android/model/CardBrand;Ljava/lang/String;Lcom/stripe/android/model/CvcCheck;)Lcom/stripe/android/model/ConsumerPaymentDetails$Card;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/ConsumerPaymentDetails$Card;Ljava/lang/String;ZIILcom/stripe/android/model/CardBrand;Ljava/lang/String;Lcom/stripe/android/model/CvcCheck;ILjava/lang/Object;)Lcom/stripe/android/model/ConsumerPaymentDetails$Card;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBrand ()Lcom/stripe/android/model/CardBrand;
+	public final fun getCvcCheck ()Lcom/stripe/android/model/CvcCheck;
 	public final fun getExpiryMonth ()I
 	public final fun getExpiryYear ()I
 	public fun getId ()Ljava/lang/String;

--- a/payments-core/src/main/java/com/stripe/android/model/ConsumerPaymentDetails.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConsumerPaymentDetails.kt
@@ -24,7 +24,8 @@ data class ConsumerPaymentDetails internal constructor(
         val expiryYear: Int,
         val expiryMonth: Int,
         val brand: CardBrand,
-        val last4: String
+        val last4: String,
+        val cvcCheck: CvcCheck
     ) : PaymentDetails(id, isDefault, Companion.type) {
         companion object {
             const val type = "card"

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParser.kt
@@ -5,6 +5,7 @@ import com.stripe.android.core.model.StripeJsonUtils.optString
 import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.model.CvcCheck
 import org.json.JSONObject
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -26,13 +27,15 @@ class ConsumerPaymentDetailsJsonParser : ModelJsonParser<ConsumerPaymentDetails>
             when (it.lowercase()) {
                 ConsumerPaymentDetails.Card.type -> {
                     val cardDetails = json.getJSONObject(FIELD_CARD_DETAILS)
+                    val checks = cardDetails.getJSONObject(FIELD_CARD_CHECKS)
                     ConsumerPaymentDetails.Card(
                         json.getString(FIELD_ID),
                         json.getBoolean(FIELD_IS_DEFAULT),
                         cardDetails.getInt(FIELD_CARD_EXPIRY_YEAR),
                         cardDetails.getInt(FIELD_CARD_EXPIRY_MONTH),
                         CardBrand.fromCode(cardBrandFix(cardDetails.getString(FIELD_CARD_BRAND))),
-                        cardDetails.getString(FIELD_CARD_LAST_4)
+                        cardDetails.getString(FIELD_CARD_LAST_4),
+                        CvcCheck.fromCode(checks.getString(FIELD_CARD_CVC_CHECK))
                     )
                 }
                 ConsumerPaymentDetails.BankAccount.type -> {
@@ -72,6 +75,8 @@ class ConsumerPaymentDetailsJsonParser : ModelJsonParser<ConsumerPaymentDetails>
         private const val FIELD_CARD_EXPIRY_MONTH = "exp_month"
         private const val FIELD_CARD_BRAND = "brand"
         private const val FIELD_CARD_LAST_4 = "last4"
+        private const val FIELD_CARD_CHECKS = "checks"
+        private const val FIELD_CARD_CVC_CHECK = "cvc_check"
 
         private const val FIELD_BANK_ACCOUNT_DETAILS = "bank_account_details"
         private const val FIELD_BANK_ACCOUNT_BANK_ICON_CODE = "bank_icon_code"

--- a/payments-core/src/test/java/com/stripe/android/model/ConsumerFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ConsumerFixtures.kt
@@ -257,7 +257,7 @@ object ConsumerFixtures {
                     "checks": {
                       "address_line1_check": "STATE_INVALID",
                       "address_postal_code_check": "PASS",
-                      "cvc_check": "PASS"
+                      "cvc_check": "FAIL"
                     },
                     "exp_month": 4,
                     "exp_year": 2024,

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParserTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.model.parsers
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerFixtures
 import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.model.CvcCheck
 import org.json.JSONObject
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -22,7 +23,8 @@ class ConsumerPaymentDetailsJsonParserTest {
                         expiryYear = 2023,
                         expiryMonth = 12,
                         brand = CardBrand.MasterCard,
-                        last4 = "4444"
+                        last4 = "4444",
+                        cvcCheck = CvcCheck.Pass
                     )
                 )
             )
@@ -60,7 +62,8 @@ class ConsumerPaymentDetailsJsonParserTest {
                         expiryYear = 2023,
                         expiryMonth = 12,
                         brand = CardBrand.MasterCard,
-                        last4 = "4444"
+                        last4 = "4444",
+                        cvcCheck = CvcCheck.Pass
                     ),
                     ConsumerPaymentDetails.Card(
                         id = "QAAAKIL",
@@ -68,7 +71,8 @@ class ConsumerPaymentDetailsJsonParserTest {
                         expiryYear = 2024,
                         expiryMonth = 4,
                         brand = CardBrand.Visa,
-                        last4 = "4242"
+                        last4 = "4242",
+                        cvcCheck = CvcCheck.Fail
                     ),
                     ConsumerPaymentDetails.BankAccount(
                         id = "wAAACGA",
@@ -138,7 +142,7 @@ class ConsumerPaymentDetailsJsonParserTest {
                     "checks": {
                       "address_line1_check": "STATE_INVALID",
                       "address_postal_code_check": "PASS",
-                      "cvc_check": "PASS"
+                      "cvc_check": "FAIL"
                     },
                     "exp_month": 4,
                     "exp_year": 2024,
@@ -163,7 +167,8 @@ class ConsumerPaymentDetailsJsonParserTest {
                         expiryYear = 2023,
                         expiryMonth = 12,
                         brand = CardBrand.AmericanExpress,
-                        last4 = "4444"
+                        last4 = "4444",
+                        cvcCheck = CvcCheck.Pass
                     ),
                     ConsumerPaymentDetails.Card(
                         id = "QAAAKIL",
@@ -171,7 +176,8 @@ class ConsumerPaymentDetailsJsonParserTest {
                         expiryYear = 2024,
                         expiryMonth = 4,
                         brand = CardBrand.DinersClub,
-                        last4 = "4242"
+                        last4 = "4242",
+                        cvcCheck = CvcCheck.Fail
                     )
                 )
             )

--- a/payments-model/src/main/java/com/stripe/android/model/CvcCheck.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/CvcCheck.kt
@@ -1,0 +1,20 @@
+package com.stripe.android.model
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+enum class CvcCheck(
+    val code: String
+) {
+    Pass("PASS"),
+    Fail("FAIL"),
+    Unavailable("UNAVAILABLE"),
+    Unchecked("UNCHECKED");
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    companion object {
+        fun fromCode(code: String?): CvcCheck {
+            return values().firstOrNull { it.code.equals(code, ignoreCase = true) } ?: Unavailable
+        }
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds the CVC check information to `ConsumerPaymentDetails.Card`. This will be used when we want to recollect CVCs in Link.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

CVC recollection in Link.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots

🙅‍♂️ 

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

_Nothing to add._
