### PR TITLE
Add UI for updating expired card in Link

### DIFF
--- a/link/api/link.api
+++ b/link/api/link.api
@@ -583,10 +583,6 @@ public final class com/stripe/android/link/ui/wallet/PaymentDetailsResult$Succes
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/link/ui/wallet/WalletScreenKt {
-	public static final fun ExpiryDateAndCvcForm (Lcom/stripe/android/ui/core/elements/TextFieldController;Lcom/stripe/android/ui/core/elements/CvcController;Landroidx/compose/runtime/Composer;I)V
-}
-
 public final class com/stripe/android/link/ui/wallet/WalletViewModel_Factory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/link/ui/wallet/WalletViewModel_Factory;

--- a/link/api/link.api
+++ b/link/api/link.api
@@ -559,15 +559,6 @@ public final class com/stripe/android/link/ui/wallet/ComposableSingletons$Paymen
 	public final fun getLambda-1$link_release ()Lkotlin/jvm/functions/Function2;
 }
 
-public final class com/stripe/android/link/ui/wallet/ComposableSingletons$WalletScreenKt {
-	public static final field INSTANCE Lcom/stripe/android/link/ui/wallet/ComposableSingletons$WalletScreenKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function2;
-	public static field lambda-2 Lkotlin/jvm/functions/Function2;
-	public fun <init> ()V
-	public final fun getLambda-1$link_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-2$link_release ()Lkotlin/jvm/functions/Function2;
-}
-
 public final class com/stripe/android/link/ui/wallet/PaymentDetailsResult$Cancelled$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/ui/wallet/PaymentDetailsResult$Cancelled;
@@ -590,6 +581,10 @@ public final class com/stripe/android/link/ui/wallet/PaymentDetailsResult$Succes
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/link/ui/wallet/PaymentDetailsResult$Success;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/link/ui/wallet/WalletScreenKt {
+	public static final fun ExpiryDateAndCvcForm (Lcom/stripe/android/ui/core/elements/TextFieldController;Lcom/stripe/android/ui/core/elements/CvcController;Landroidx/compose/runtime/Composer;I)V
 }
 
 public final class com/stripe/android/link/ui/wallet/WalletViewModel_Factory : dagger/internal/Factory {

--- a/link/src/androidTest/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.filter
 import androidx.compose.ui.test.filterToOne
@@ -40,7 +41,12 @@ import com.stripe.android.link.ui.paymentmethod.SupportedPaymentMethod
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.CvcCheck
+import com.stripe.android.ui.core.elements.CvcController
+import com.stripe.android.ui.core.elements.DateConfig
+import com.stripe.android.ui.core.elements.SimpleTextFieldController
+import com.stripe.android.ui.core.elements.TextFieldController
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import org.junit.Rule
 import org.junit.Test
@@ -57,7 +63,7 @@ internal class WalletScreenTest {
         ConsumerPaymentDetails.Card(
             id = "id1",
             isDefault = true,
-            expiryYear = 2022,
+            expiryYear = 2026,
             expiryMonth = 12,
             brand = CardBrand.Visa,
             last4 = "4242",
@@ -66,7 +72,7 @@ internal class WalletScreenTest {
         ConsumerPaymentDetails.Card(
             id = "id2",
             isDefault = false,
-            expiryYear = 2023,
+            expiryYear = 2020,
             expiryMonth = 11,
             brand = CardBrand.MasterCard,
             last4 = "4444",
@@ -75,7 +81,7 @@ internal class WalletScreenTest {
         ConsumerPaymentDetails.Card(
             id = "id3",
             isDefault = false,
-            expiryYear = 2023,
+            expiryYear = 2026,
             expiryMonth = 11,
             brand = CardBrand.AmericanExpress,
             last4 = "0005",
@@ -383,12 +389,65 @@ internal class WalletScreenTest {
         composeTestRule.onNodeWithText(errorMessage).assertExists()
     }
 
+    @Test
+    fun when_no_payment_method_is_selected_doesnt_show_expiry_date_form() {
+        setContent(
+            isExpanded = false,
+            selectedItem = null
+        )
+
+        composeTestRule.onNodeWithText("MM / YY").assertDoesNotExist()
+        composeTestRule.onNodeWithText("CVC").assertDoesNotExist()
+    }
+
+    @Test
+    fun when_bank_account_is_selected_doesnt_show_expiry_date_form() {
+        setContent(
+            isExpanded = false,
+            selectedItem = paymentDetails[4]
+        )
+
+        composeTestRule.onNodeWithText("MM / YY").assertDoesNotExist()
+        composeTestRule.onNodeWithText("CVC").assertDoesNotExist()
+    }
+
+    @Test
+    fun when_selected_card_is_not_expired_doesnt_show_expiry_date_form() {
+        val initiallySelectedItem = paymentDetails[0]
+        setContent(
+            isExpanded = false,
+            selectedItem = initiallySelectedItem
+        )
+
+        composeTestRule.onNodeWithText("MM / YY").assertDoesNotExist()
+        composeTestRule.onNodeWithText("CVC").assertDoesNotExist()
+    }
+
+    @Test
+    fun when_selected_card_is_expired_shows_expiry_date_form() {
+        val initiallySelectedItem = paymentDetails[1]
+        setContent(
+            isExpanded = false,
+            selectedItem = initiallySelectedItem
+        )
+
+        composeTestRule.onNodeWithText("MM / YY")
+            .assertExists()
+            .assertIsEnabled()
+
+        composeTestRule.onNodeWithText("CVC")
+            .assertExists()
+            .assertIsEnabled()
+    }
+
     private fun setContent(
         supportedTypes: Set<String> = SupportedPaymentMethod.allTypes,
         selectedItem: ConsumerPaymentDetails.PaymentDetails? = paymentDetails.first(),
         isExpanded: Boolean = true,
         primaryButtonState: PrimaryButtonState = PrimaryButtonState.Enabled,
         errorMessage: ErrorMessage? = null,
+        expiryDateController: TextFieldController = SimpleTextFieldController(DateConfig()),
+        cvcController: CvcController = CvcController(cardBrandFlow = flowOf(CardBrand.Visa)),
         setExpanded: (Boolean) -> Unit = {},
         onItemSelected: (ConsumerPaymentDetails.PaymentDetails) -> Unit = {},
         onAddNewPaymentMethodClick: () -> Unit = {},
@@ -430,6 +489,8 @@ internal class WalletScreenTest {
                     primaryButtonLabel = primaryButtonLabel,
                     primaryButtonState = primaryButtonState,
                     errorMessage = errorMessage,
+                    expiryDateController = expiryDateController,
+                    cvcController = cvcController,
                     setExpanded = setExpanded,
                     onItemSelected = onItemSelected,
                     onAddNewPaymentMethodClick = onAddNewPaymentMethodClick,

--- a/link/src/main/java/com/stripe/android/link/theme/Color.kt
+++ b/link/src/main/java/com/stripe/android/link/theme/Color.kt
@@ -78,7 +78,9 @@ internal fun PaymentsThemeForLink(
                 primary = ActionGreen
             )
         ),
-        shapes = PaymentsThemeDefaults.shapes,
+        shapes = PaymentsThemeDefaults.shapes.copy(
+            cornerRadius = 9f
+        ),
         typography = PaymentsThemeDefaults.typography
     ) {
         content()

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -316,7 +316,7 @@ internal fun WalletBody(
 }
 
 @Composable
-fun ExpiryDateAndCvcForm(
+internal fun ExpiryDateAndCvcForm(
     expiryDateController: TextFieldController,
     cvcController: CvcController
 ) {

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -18,14 +18,20 @@ import com.stripe.android.link.model.supportedPaymentMethodTypes
 import com.stripe.android.link.ui.ErrorMessage
 import com.stripe.android.link.ui.PrimaryButtonState
 import com.stripe.android.link.ui.getErrorMessage
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.ui.core.address.toConfirmPaymentIntentShipping
+import com.stripe.android.ui.core.elements.CvcConfig
+import com.stripe.android.ui.core.elements.CvcController
+import com.stripe.android.ui.core.elements.DateConfig
+import com.stripe.android.ui.core.elements.SimpleTextFieldController
 import com.stripe.android.ui.core.injection.NonFallbackInjectable
 import com.stripe.android.ui.core.injection.NonFallbackInjector
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Provider
@@ -53,6 +59,19 @@ internal class WalletViewModel @Inject constructor(
 
     private val _selectedItem = MutableStateFlow<ConsumerPaymentDetails.PaymentDetails?>(null)
     val selectedItem: StateFlow<ConsumerPaymentDetails.PaymentDetails?> = _selectedItem
+
+    val expiryDateController = SimpleTextFieldController(
+        textFieldConfig = DateConfig(),
+        initialValue = null
+    )
+
+    val cvcController = CvcController(
+        cvcTextFieldConfig = CvcConfig(),
+        cardBrandFlow = selectedItem.map {
+            (it as? ConsumerPaymentDetails.Card)?.brand ?: CardBrand.Unknown
+        },
+        initialValue = null
+    )
 
     private val _primaryButtonState = MutableStateFlow(PrimaryButtonState.Disabled)
     val primaryButtonState: StateFlow<PrimaryButtonState> = _primaryButtonState

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -66,11 +66,9 @@ internal class WalletViewModel @Inject constructor(
     )
 
     val cvcController = CvcController(
-        cvcTextFieldConfig = CvcConfig(),
         cardBrandFlow = selectedItem.map {
             (it as? ConsumerPaymentDetails.Card)?.brand ?: CardBrand.Unknown
-        },
-        initialValue = null
+        }
     )
 
     private val _primaryButtonState = MutableStateFlow(PrimaryButtonState.Disabled)

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -2506,6 +2506,7 @@ public final class com/stripe/android/model/ConsumerPaymentDetails$Card : com/st
 	public final fun getLast4 ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun isDefault ()Z
+	public final fun isExpired ()Z
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
 }

--- a/payments-core/src/main/java/com/stripe/android/model/ConsumerPaymentDetails.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConsumerPaymentDetails.kt
@@ -3,6 +3,7 @@ package com.stripe.android.model
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeModel
+import com.stripe.android.view.DateUtils
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -27,6 +28,13 @@ data class ConsumerPaymentDetails internal constructor(
         val last4: String,
         val cvcCheck: CvcCheck
     ) : PaymentDetails(id, isDefault, Companion.type) {
+
+        val isExpired: Boolean
+            get() = !DateUtils.isExpiryDataValid(
+                expiryMonth = expiryMonth,
+                expiryYear = expiryYear
+            )
+
         companion object {
             const val type = "card"
 

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -296,6 +296,10 @@ public final class com/stripe/android/ui/core/elements/CountrySpec$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/stripe/android/ui/core/elements/DateConfig$Companion {
+	public final fun determineTextFieldState (IIII)Lcom/stripe/android/ui/core/elements/TextFieldState;
+}
+
 public final class com/stripe/android/ui/core/elements/DisplayField : java/lang/Enum {
 	public static final field Companion Lcom/stripe/android/ui/core/elements/DisplayField$Companion;
 	public static final field Country Lcom/stripe/android/ui/core/elements/DisplayField;

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcConfig.kt
@@ -1,12 +1,14 @@
 package com.stripe.android.ui.core.elements
 
+import androidx.annotation.RestrictTo
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
 import com.stripe.android.model.CardBrand
 import com.stripe.android.ui.core.R
 
-internal class CvcConfig : CardDetailsTextFieldConfig {
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class CvcConfig : CardDetailsTextFieldConfig {
     override val capitalization: KeyboardCapitalization = KeyboardCapitalization.None
     override val debugLabel: String = "cvc"
     override val label: Int = R.string.cvc_number_hint

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcController.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.ui.core.elements
 
+import androidx.annotation.RestrictTo
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import com.stripe.android.model.CardBrand
@@ -10,10 +11,11 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 
-internal class CvcController constructor(
-    private val cvcTextFieldConfig: CvcConfig,
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class CvcController constructor(
+    private val cvcTextFieldConfig: CvcConfig = CvcConfig(),
     cardBrandFlow: Flow<CardBrand>,
-    initialValue: String?,
+    initialValue: String? = null,
     override val showOptionalLabel: Boolean = false
 ) : TextFieldController, SectionFieldErrorController {
     override val capitalization: KeyboardCapitalization = cvcTextFieldConfig.capitalization

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcElement.kt
@@ -1,6 +1,9 @@
 package com.stripe.android.ui.core.elements
 
-internal data class CvcElement(
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class CvcElement(
     val _identifier: IdentifierSpec,
     override val controller: CvcController
 ) : SectionSingleFieldElement(_identifier) {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DateConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/DateConfig.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.ui.core.elements
 
+import androidx.annotation.RestrictTo
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -11,7 +12,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import java.util.Calendar
 
-internal class DateConfig : TextFieldConfig {
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class DateConfig : TextFieldConfig {
     override val capitalization: KeyboardCapitalization = KeyboardCapitalization.None
     override val debugLabel = "date"
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/ExpiryDateVisualTransformation.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/ExpiryDateVisualTransformation.kt
@@ -1,11 +1,13 @@
 package com.stripe.android.ui.core.elements
 
+import androidx.annotation.RestrictTo
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
 
-internal class ExpiryDateVisualTransformation : VisualTransformation {
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class ExpiryDateVisualTransformation : VisualTransformation {
     private val separator = " / "
 
     override fun filter(text: AnnotatedString): TransformedText {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/FormItemSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/FormItemSpec.kt
@@ -21,27 +21,12 @@ sealed class FormItemSpec {
     internal fun createSectionElement(
         sectionFieldElement: SectionFieldElement,
         label: Int? = null
-    ) = createSectionElement(
-        listOf(sectionFieldElement),
-        label
-    )
+    ): SectionElement = SectionElement.wrap(sectionFieldElement, label)
 
     internal fun createSectionElement(
         sectionFieldElements: List<SectionFieldElement>,
         label: Int? = null
-    ): SectionElement {
-        val errorControllers = sectionFieldElements.map {
-            it.sectionFieldErrorController()
-        }
-        return SectionElement(
-            IdentifierSpec.Generic("${sectionFieldElements.first().identifier.v1}_section"),
-            sectionFieldElements,
-            SectionController(
-                label,
-                errorControllers
-            )
-        )
-    }
+    ): SectionElement = SectionElement.wrap(sectionFieldElements, label)
 }
 
 object FormItemSpecSerializer :

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionElement.kt
@@ -31,4 +31,35 @@ data class SectionElement(
         ) {
             it.toList().flatten()
         }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    companion object {
+
+        fun wrap(
+            sectionFieldElement: SectionFieldElement,
+            label: Int? = null
+        ): SectionElement {
+            return wrap(
+                sectionFieldElements = listOf(sectionFieldElement),
+                label = label
+            )
+        }
+
+        fun wrap(
+            sectionFieldElements: List<SectionFieldElement>,
+            label: Int? = null
+        ): SectionElement {
+            val errorControllers = sectionFieldElements.map {
+                it.sectionFieldErrorController()
+            }
+            return SectionElement(
+                IdentifierSpec.Generic("${sectionFieldElements.first().identifier.v1}_section"),
+                sectionFieldElements,
+                SectionController(
+                    label,
+                    errorControllers
+                )
+            )
+        }
+    }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds the UI for updating expired credit cards inline in Link.

It does not yet include any logic. That’s coming in a follow-up pull request, because we want to refactor the state management in `WalletViewModel` first.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

![Screenshot_20220902_141813](https://user-images.githubusercontent.com/110940675/188214450-cbcf871f-905f-4e5a-bfa1-d69f76c95934.png)

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

_Nothing to add._
