### PR TITLE
Bug fixes for address element private beta

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PostalCodeConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PostalCodeConfig.kt
@@ -4,6 +4,7 @@ import androidx.annotation.StringRes
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
+import com.stripe.android.ui.core.R
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlin.math.max
 
@@ -12,7 +13,7 @@ internal class PostalCodeConfig(
     override val capitalization: KeyboardCapitalization = KeyboardCapitalization.Words,
     override val keyboard: KeyboardType = KeyboardType.Text,
     override val trailingIcon: MutableStateFlow<TextFieldIcon?> = MutableStateFlow(null),
-    country: String
+    private val country: String
 ) : TextFieldConfig {
     private val format = CountryPostalFormat.forCountry(country)
 
@@ -22,7 +23,7 @@ internal class PostalCodeConfig(
     override val loading: MutableStateFlow<Boolean> = MutableStateFlow(false)
 
     override fun determineState(input: String): TextFieldState = object : TextFieldState {
-        override fun shouldShowError(hasFocus: Boolean) = false
+        override fun shouldShowError(hasFocus: Boolean) = getError() != null && !hasFocus
 
         override fun isValid(): Boolean {
             return when (format) {
@@ -34,7 +35,17 @@ internal class PostalCodeConfig(
             }
         }
 
-        override fun getError(): FieldError? = null
+        override fun getError(): FieldError? {
+            return when {
+                input.isNotBlank() && !isFull() && country == "US" -> {
+                    FieldError(R.string.address_zip_invalid)
+                }
+                input.isNotBlank() && !isFull() -> {
+                    FieldError(R.string.address_zip_postal_invalid)
+                }
+                else -> null
+            }
+        }
 
         override fun isFull(): Boolean = input.length >= format.minimumLength
 

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PostalCodeConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PostalCodeConfigTest.kt
@@ -48,6 +48,15 @@ class PostalCodeConfigTest {
         }
     }
 
+    @Test
+    fun `invalid postal codes emit error`() {
+        with(createConfigForCountry("US")) {
+            Truth.assertThat(determineStateForInput("").getError()).isNull()
+            Truth.assertThat(determineStateForInput("1234").getError()).isNotNull()
+            Truth.assertThat(determineStateForInput("12345").getError()).isNull()
+        }
+    }
+
     private fun createConfigForCountry(country: String): PostalCodeConfig {
         return PostalCodeConfig(
             label = R.string.address_label_postal_code,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModel.kt
@@ -183,8 +183,9 @@ internal class AutocompleteViewModel @Inject constructor(
         navigator.onBack()
     }
 
-    private fun clearQuery() {
+    fun clearQuery() {
         textFieldController.onRawValueChange("")
+        _predictions.value = null
     }
 
     internal class Debouncer {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.MaterialTheme
@@ -40,6 +41,7 @@ internal fun InputAddressScreen(
     ScrollableColumn(
         modifier = Modifier
             .fillMaxHeight()
+            .imePadding()
             .background(MaterialTheme.colors.surface)
     ) {
         AddressOptionsAppBar(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

- Fix issue with scrolling in the input address screen for the address element when keyboard appears (fixed with `imePadding`)
- Add error state for postal codes when they are incomplete and only show them when not focused
- Fix issue with clearing autocomplete results

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Address element private beta

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots

Scrolling issue fix:

<img src="https://user-images.githubusercontent.com/99316447/188222333-1bddf2b5-b0be-45bc-aec3-5b9e08433342.gif" height=400/>

Postal code error fix: 

<img src="https://user-images.githubusercontent.com/99316447/188222358-f1234482-071e-451b-95fb-3184f801ec9c.gif" height=400/>

Autocomplete clear results fix: 

<img src="https://user-images.githubusercontent.com/99316447/188222375-df431a71-f4c3-4174-bc5f-ccb7d50e38ea.gif" height=400/>

