### PR TITLE
Refactor UI state in wallet screen

### DIFF
--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -101,7 +101,7 @@ private fun WalletBodyPreview() {
                     supportedTypes = SupportedPaymentMethod.allTypes,
                     selectedItem = paymentDetailsList.first(),
                     isExpanded = true,
-                    errorMessage = ErrorMessage.Raw("Something went wrong"),
+                    errorMessage = ErrorMessage.Raw("Something went wrong")
                 ),
                 primaryButtonLabel = "Pay $10.99",
                 expiryDateController = SimpleTextFieldController(textFieldConfig = DateConfig()),

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
@@ -2,6 +2,7 @@ package com.stripe.android.link.ui.wallet
 
 import com.stripe.android.link.ui.ErrorMessage
 import com.stripe.android.link.ui.PrimaryButtonState
+import com.stripe.android.link.ui.getErrorMessage
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.ui.core.forms.FormFieldEntry
@@ -64,6 +65,7 @@ internal data class WalletUiState(
     fun updateWithPaymentResult(paymentResult: PaymentResult): WalletUiState {
         return copy(
             hasCompleted = paymentResult is PaymentResult.Completed,
+            errorMessage = (paymentResult as? PaymentResult.Failed)?.throwable?.getErrorMessage(),
             isProcessing = false
         )
     }

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
@@ -1,0 +1,88 @@
+package com.stripe.android.link.ui.wallet
+
+import com.stripe.android.link.ui.ErrorMessage
+import com.stripe.android.link.ui.PrimaryButtonState
+import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.payments.paymentlauncher.PaymentResult
+import com.stripe.android.ui.core.forms.FormFieldEntry
+
+internal data class WalletUiState(
+    val supportedTypes: Set<String>,
+    val paymentDetailsList: List<ConsumerPaymentDetails.PaymentDetails> = emptyList(),
+    val selectedItem: ConsumerPaymentDetails.PaymentDetails? = null,
+    val isExpanded: Boolean = false,
+    val isProcessing: Boolean = false,
+    val hasCompleted: Boolean = false,
+    val errorMessage: ErrorMessage? = null,
+    val expiryDateInput: FormFieldEntry = FormFieldEntry(value = null),
+    val cvcInput: FormFieldEntry = FormFieldEntry(value = null)
+) {
+
+    val primaryButtonState: PrimaryButtonState
+        get() {
+            val hasPaymentDetails = paymentDetailsList.isNotEmpty()
+            val isExpired = (selectedItem as? ConsumerPaymentDetails.Card)?.isExpired ?: false
+            val hasRequiredExpiryInput = expiryDateInput.isComplete && cvcInput.isComplete
+
+            val disableButton = !hasPaymentDetails || (isExpired && !hasRequiredExpiryInput)
+
+            return if (hasCompleted) {
+                PrimaryButtonState.Completed
+            } else if (isProcessing) {
+                PrimaryButtonState.Processing
+            } else if (disableButton) {
+                PrimaryButtonState.Disabled
+            } else {
+                PrimaryButtonState.Enabled
+            }
+        }
+
+    val isSelectedItemValid: Boolean
+        get() = selectedItem?.let { supportedTypes.contains(it.type) } ?: false
+
+    fun updateWithResponse(
+        response: ConsumerPaymentDetails,
+        initialSelectedItemId: String?
+    ): WalletUiState {
+        // Select selectedItem if provided, otherwise the previously selected item
+        val selectedItem = (initialSelectedItemId ?: selectedItem?.id)?.let { itemId ->
+            response.paymentDetails.firstOrNull { it.id == itemId }
+        } ?: getDefaultItemSelection(response.paymentDetails)
+
+        return copy(
+            paymentDetailsList = response.paymentDetails,
+            selectedItem = selectedItem,
+            isExpanded = false,
+            isProcessing = false
+        )
+    }
+
+    fun updateWithError(errorMessage: ErrorMessage): WalletUiState {
+        return copy(errorMessage = errorMessage)
+    }
+
+    fun updateWithPaymentResult(paymentResult: PaymentResult): WalletUiState {
+        return copy(
+            hasCompleted = paymentResult is PaymentResult.Completed,
+            isProcessing = false
+        )
+    }
+
+    fun setProcessing(): WalletUiState {
+        return copy(
+            isProcessing = true,
+            errorMessage = null
+        )
+    }
+
+    /**
+     * The item that should be selected by default from the [paymentDetailsList].
+     *
+     * @return the default item, if supported. Otherwise the first supported item on the list.
+     */
+    private fun getDefaultItemSelection(
+        paymentDetailsList: List<ConsumerPaymentDetails.PaymentDetails>
+    ) = paymentDetailsList.filter { supportedTypes.contains(it.type) }.let { filteredItems ->
+        filteredItems.firstOrNull { it.isDefault } ?: filteredItems.firstOrNull()
+    }
+}

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -22,7 +22,6 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.ui.core.address.toConfirmPaymentIntentShipping
-import com.stripe.android.ui.core.elements.CvcConfig
 import com.stripe.android.ui.core.elements.CvcController
 import com.stripe.android.ui.core.elements.DateConfig
 import com.stripe.android.ui.core.elements.SimpleTextFieldController
@@ -32,6 +31,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Provider
@@ -43,22 +43,18 @@ internal class WalletViewModel @Inject constructor(
     private val confirmationManager: ConfirmationManager,
     private val logger: Logger
 ) : ViewModel() {
+
     private val stripeIntent = args.stripeIntent
 
-    private val _paymentDetailsList =
-        MutableStateFlow<List<ConsumerPaymentDetails.PaymentDetails>>(emptyList())
-    val paymentDetailsList: StateFlow<List<ConsumerPaymentDetails.PaymentDetails>> =
-        _paymentDetailsList
-
-    val supportedTypes = args.stripeIntent.supportedPaymentMethodTypes(
-        requireNotNull(linkAccountManager.linkAccount.value)
+    private val _uiState = MutableStateFlow(
+        value = WalletUiState(
+            supportedTypes = args.stripeIntent.supportedPaymentMethodTypes(
+                requireNotNull(linkAccountManager.linkAccount.value)
+            )
+        )
     )
 
-    private val _isExpanded = MutableStateFlow(false)
-    val isExpanded: StateFlow<Boolean> = _isExpanded
-
-    private val _selectedItem = MutableStateFlow<ConsumerPaymentDetails.PaymentDetails?>(null)
-    val selectedItem: StateFlow<ConsumerPaymentDetails.PaymentDetails?> = _selectedItem
+    val uiState: StateFlow<WalletUiState> = _uiState
 
     val expiryDateController = SimpleTextFieldController(
         textFieldConfig = DateConfig(),
@@ -66,19 +62,35 @@ internal class WalletViewModel @Inject constructor(
     )
 
     val cvcController = CvcController(
-        cardBrandFlow = selectedItem.map {
-            (it as? ConsumerPaymentDetails.Card)?.brand ?: CardBrand.Unknown
+        cardBrandFlow = uiState.map {
+            (it.selectedItem as? ConsumerPaymentDetails.Card)?.brand ?: CardBrand.Unknown
         }
     )
 
-    private val _primaryButtonState = MutableStateFlow(PrimaryButtonState.Disabled)
-    val primaryButtonState: StateFlow<PrimaryButtonState> = _primaryButtonState
-
-    private val _errorMessage = MutableStateFlow<ErrorMessage?>(null)
-    val errorMessage: StateFlow<ErrorMessage?> = _errorMessage
-
     init {
         loadPaymentDetails(true)
+
+        viewModelScope.launch {
+            _uiState.collect {
+                navigator.userNavigationEnabled = !it.primaryButtonState.isBlocking
+            }
+        }
+
+        viewModelScope.launch {
+            expiryDateController.formFieldValue.collect { input ->
+                _uiState.update {
+                    it.copy(expiryDateInput = input)
+                }
+            }
+        }
+
+        viewModelScope.launch {
+            cvcController.formFieldValue.collect { input ->
+                _uiState.update {
+                    it.copy(cvcInput = input)
+                }
+            }
+        }
 
         viewModelScope.launch {
             navigator.getResultFlow<PaymentDetailsResult>(PaymentDetailsResult.KEY)?.collect {
@@ -93,10 +105,11 @@ internal class WalletViewModel @Inject constructor(
     }
 
     fun onConfirmPayment() {
-        val selectedPaymentDetails = selectedItem.value ?: return
+        val selectedPaymentDetails = uiState.value.selectedItem ?: return
 
-        clearError()
-        setState(PrimaryButtonState.Processing)
+        _uiState.update {
+            it.setProcessing()
+        }
 
         runCatching { requireNotNull(linkAccountManager.linkAccount.value) }.fold(
             onSuccess = { linkAccount ->
@@ -113,20 +126,14 @@ internal class WalletViewModel @Inject constructor(
                 ) { result ->
                     result.fold(
                         onSuccess = { paymentResult ->
-                            when (paymentResult) {
-                                is PaymentResult.Canceled -> {
-                                    // no-op, let the user continue their flow
-                                    setState(PrimaryButtonState.Enabled)
-                                }
-                                is PaymentResult.Failed -> {
-                                    onError(paymentResult.throwable)
-                                }
-                                is PaymentResult.Completed -> {
-                                    setState(PrimaryButtonState.Completed)
-                                    viewModelScope.launch {
-                                        delay(PrimaryButtonState.COMPLETED_DELAY_MS)
-                                        navigator.dismiss(LinkActivityResult.Completed)
-                                    }
+                            _uiState.update {
+                                it.updateWithPaymentResult(paymentResult)
+                            }
+
+                            if (paymentResult is PaymentResult.Completed) {
+                                viewModelScope.launch {
+                                    delay(PrimaryButtonState.COMPLETED_DELAY_MS)
+                                    navigator.dismiss(LinkActivityResult.Completed)
                                 }
                             }
                         },
@@ -139,7 +146,9 @@ internal class WalletViewModel @Inject constructor(
     }
 
     fun setExpanded(expanded: Boolean) {
-        _isExpanded.value = expanded
+        _uiState.update {
+            it.copy(isExpanded = expanded)
+        }
     }
 
     fun payAnotherWay() {
@@ -156,8 +165,9 @@ internal class WalletViewModel @Inject constructor(
     }
 
     fun deletePaymentMethod(paymentDetails: ConsumerPaymentDetails.PaymentDetails) {
-        setState(PrimaryButtonState.Processing)
-        clearError()
+        _uiState.update {
+            it.setProcessing()
+        }
 
         viewModelScope.launch {
             linkAccountManager.deletePaymentDetails(
@@ -172,27 +182,27 @@ internal class WalletViewModel @Inject constructor(
     }
 
     fun onItemSelected(item: ConsumerPaymentDetails.PaymentDetails) {
-        _selectedItem.value = item
+        _uiState.update {
+            it.copy(selectedItem = item)
+        }
     }
 
     private fun loadPaymentDetails(
         initialSetup: Boolean = false,
         selectedItem: String? = null
     ) {
-        setState(PrimaryButtonState.Processing)
+        _uiState.update {
+            it.setProcessing()
+        }
+
         viewModelScope.launch {
             linkAccountManager.listPaymentDetails().fold(
                 onSuccess = { response ->
-                    setState(PrimaryButtonState.Enabled)
-                    _paymentDetailsList.value = response.paymentDetails
-
-                    // Select selectedItem if provided, otherwise the previously selected item
-                    _selectedItem.value = (selectedItem ?: _selectedItem.value?.id)?.let { itemId ->
-                        response.paymentDetails.firstOrNull { it.id == itemId }
-                    } ?: getDefaultItemSelection(response.paymentDetails)
-
-                    if (_selectedItem.value?.id == selectedItem) {
-                        _isExpanded.value = false
+                    _uiState.update {
+                        it.updateWithResponse(
+                            response = response,
+                            initialSelectedItemId = selectedItem
+                        )
                     }
 
                     if (initialSetup && args.prefilledCardParams != null) {
@@ -212,7 +222,9 @@ internal class WalletViewModel @Inject constructor(
     }
 
     private fun clearError() {
-        _errorMessage.value = null
+        _uiState.update {
+            it.copy(errorMessage = null)
+        }
     }
 
     private fun onError(error: Throwable) = error.getErrorMessage().let {
@@ -221,29 +233,14 @@ internal class WalletViewModel @Inject constructor(
     }
 
     private fun onError(error: ErrorMessage) {
-        setState(PrimaryButtonState.Enabled)
-        _errorMessage.value = error
+        _uiState.update {
+            it.updateWithError(error)
+        }
     }
 
     private fun onFatal(fatalError: Throwable) {
         logger.error("Fatal error: ", fatalError)
         navigator.dismiss(LinkActivityResult.Failed(fatalError))
-    }
-
-    private fun setState(state: PrimaryButtonState) {
-        _primaryButtonState.value = state
-        navigator.userNavigationEnabled = !state.isBlocking
-    }
-
-    /**
-     * The item that should be selected by default from the [paymentDetailsList].
-     *
-     * @return the default item, if supported. Otherwise the first supported item on the list.
-     */
-    private fun getDefaultItemSelection(
-        paymentDetailsList: List<ConsumerPaymentDetails.PaymentDetails>
-    ) = paymentDetailsList.filter { supportedTypes.contains(it.type) }.let { filteredItems ->
-        filteredItems.firstOrNull { it.isDefault } ?: filteredItems.firstOrNull()
     }
 
     internal class Factory(

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -233,9 +233,9 @@ internal class WalletViewModel @Inject constructor(
         }
     }
 
-    private fun onError(error: Throwable) = error.getErrorMessage().let {
+    private fun onError(error: Throwable) {
         logger.error("Error: ", error)
-        onError(it)
+        onError(error.getErrorMessage())
     }
 
     private fun onError(error: ErrorMessage) {

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -130,10 +130,16 @@ internal class WalletViewModel @Inject constructor(
                                 it.updateWithPaymentResult(paymentResult)
                             }
 
-                            if (paymentResult is PaymentResult.Completed) {
-                                viewModelScope.launch {
-                                    delay(PrimaryButtonState.COMPLETED_DELAY_MS)
-                                    navigator.dismiss(LinkActivityResult.Completed)
+                            when (paymentResult) {
+                                is PaymentResult.Canceled -> Unit
+                                is PaymentResult.Failed -> {
+                                    logger.error("Error: ", paymentResult.throwable)
+                                }
+                                is PaymentResult.Completed -> {
+                                    viewModelScope.launch {
+                                        delay(PrimaryButtonState.COMPLETED_DELAY_MS)
+                                        navigator.dismiss(LinkActivityResult.Completed)
+                                    }
                                 }
                             }
                         },

--- a/link/src/test/java/com/stripe/android/link/ui/wallet/WalletUiStateTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/wallet/WalletUiStateTest.kt
@@ -8,15 +8,19 @@ import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.CvcCheck
 import com.stripe.android.ui.core.forms.FormFieldEntry
 import org.junit.Test
+import java.util.Calendar
+import kotlin.random.Random
 
 class WalletUiStateTest {
 
     @Test
     fun `Primary button is enabled correctly`() {
+        val validCard = mockCard()
+
         val uiState = WalletUiState(
             supportedTypes = SupportedPaymentMethod.allTypes,
-            paymentDetailsList = mockPaymentDetailsList(),
-            selectedItem = mockPaymentDetailsList().last(),
+            paymentDetailsList = listOf(validCard),
+            selectedItem = validCard,
             isProcessing = false,
             hasCompleted = false
         )
@@ -26,10 +30,12 @@ class WalletUiStateTest {
 
     @Test
     fun `Primary button state is correct when the payment has completed`() {
+        val validCard = mockCard()
+
         val uiState = WalletUiState(
             supportedTypes = SupportedPaymentMethod.allTypes,
-            paymentDetailsList = mockPaymentDetailsList(),
-            selectedItem = mockPaymentDetailsList().last(),
+            paymentDetailsList = listOf(validCard),
+            selectedItem = validCard,
             isProcessing = false,
             hasCompleted = true
         )
@@ -39,10 +45,12 @@ class WalletUiStateTest {
 
     @Test
     fun `Primary button state is correct when the payment is processing`() {
+        val validCard = mockCard()
+
         val uiState = WalletUiState(
             supportedTypes = SupportedPaymentMethod.allTypes,
-            paymentDetailsList = mockPaymentDetailsList(),
-            selectedItem = mockPaymentDetailsList().last(),
+            paymentDetailsList = listOf(validCard),
+            selectedItem = validCard,
             isProcessing = true,
             hasCompleted = false
         )
@@ -52,10 +60,12 @@ class WalletUiStateTest {
 
     @Test
     fun `Primary button is disabled if selected card is expired and form hasn't been filled out`() {
+        val validCard = mockCard(isExpired = true)
+
         val uiState = WalletUiState(
             supportedTypes = SupportedPaymentMethod.allTypes,
-            paymentDetailsList = mockPaymentDetailsList(),
-            selectedItem = mockPaymentDetailsList().first(),
+            paymentDetailsList = listOf(validCard),
+            selectedItem = validCard,
             isProcessing = false,
             hasCompleted = false
         )
@@ -65,10 +75,12 @@ class WalletUiStateTest {
 
     @Test
     fun `Primary button is enabled if selected card is expired, but the form has been filled out`() {
+        val validCard = mockCard(isExpired = true)
+
         val uiState = WalletUiState(
             supportedTypes = SupportedPaymentMethod.allTypes,
-            paymentDetailsList = mockPaymentDetailsList(),
-            selectedItem = mockPaymentDetailsList().first(),
+            paymentDetailsList = listOf(validCard),
+            selectedItem = validCard,
             isProcessing = false,
             hasCompleted = false,
             expiryDateInput = FormFieldEntry("1226", isComplete = true),
@@ -78,24 +90,22 @@ class WalletUiStateTest {
         assertThat(uiState.primaryButtonState).isEqualTo(PrimaryButtonState.Enabled)
     }
 
-    private fun mockPaymentDetailsList() = listOf(
-        ConsumerPaymentDetails.Card(
-            "id1",
-            true,
-            2022,
-            1,
-            CardBrand.Visa,
-            "4242",
-            CvcCheck.Pass
-        ),
-        ConsumerPaymentDetails.Card(
-            "id2",
-            false,
-            2026,
-            12,
-            CardBrand.MasterCard,
-            "4444",
-            CvcCheck.Fail
+    private fun mockCard(
+        isExpired: Boolean = false,
+        cvcCheck: CvcCheck = CvcCheck.Pass
+    ): ConsumerPaymentDetails.Card {
+        val id = Random.nextInt()
+        val year = Calendar.getInstance().get(Calendar.YEAR)
+        val expiryYear = if (isExpired) year - 1 else year + 1
+
+        return ConsumerPaymentDetails.Card(
+            id = "id$id",
+            isDefault = true,
+            expiryYear = expiryYear,
+            expiryMonth = 1,
+            brand = CardBrand.Visa,
+            last4 = "4242",
+            cvcCheck = cvcCheck
         )
-    )
+    }
 }

--- a/link/src/test/java/com/stripe/android/link/ui/wallet/WalletUiStateTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/wallet/WalletUiStateTest.kt
@@ -1,0 +1,101 @@
+package com.stripe.android.link.ui.wallet
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.link.ui.PrimaryButtonState
+import com.stripe.android.link.ui.paymentmethod.SupportedPaymentMethod
+import com.stripe.android.model.CardBrand
+import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.model.CvcCheck
+import com.stripe.android.ui.core.forms.FormFieldEntry
+import org.junit.Test
+
+class WalletUiStateTest {
+
+    @Test
+    fun `Primary button is enabled correctly`() {
+        val uiState = WalletUiState(
+            supportedTypes = SupportedPaymentMethod.allTypes,
+            paymentDetailsList = mockPaymentDetailsList(),
+            selectedItem = mockPaymentDetailsList().last(),
+            isProcessing = false,
+            hasCompleted = false
+        )
+
+        assertThat(uiState.primaryButtonState).isEqualTo(PrimaryButtonState.Enabled)
+    }
+
+    @Test
+    fun `Primary button state is correct when the payment has completed`() {
+        val uiState = WalletUiState(
+            supportedTypes = SupportedPaymentMethod.allTypes,
+            paymentDetailsList = mockPaymentDetailsList(),
+            selectedItem = mockPaymentDetailsList().last(),
+            isProcessing = false,
+            hasCompleted = true
+        )
+
+        assertThat(uiState.primaryButtonState).isEqualTo(PrimaryButtonState.Completed)
+    }
+
+    @Test
+    fun `Primary button state is correct when the payment is processing`() {
+        val uiState = WalletUiState(
+            supportedTypes = SupportedPaymentMethod.allTypes,
+            paymentDetailsList = mockPaymentDetailsList(),
+            selectedItem = mockPaymentDetailsList().last(),
+            isProcessing = true,
+            hasCompleted = false
+        )
+
+        assertThat(uiState.primaryButtonState).isEqualTo(PrimaryButtonState.Processing)
+    }
+
+    @Test
+    fun `Primary button is disabled if selected card is expired and form hasn't been filled out`() {
+        val uiState = WalletUiState(
+            supportedTypes = SupportedPaymentMethod.allTypes,
+            paymentDetailsList = mockPaymentDetailsList(),
+            selectedItem = mockPaymentDetailsList().first(),
+            isProcessing = false,
+            hasCompleted = false
+        )
+
+        assertThat(uiState.primaryButtonState).isEqualTo(PrimaryButtonState.Disabled)
+    }
+
+    @Test
+    fun `Primary button is enabled if selected card is expired, but the form has been filled out`() {
+        val uiState = WalletUiState(
+            supportedTypes = SupportedPaymentMethod.allTypes,
+            paymentDetailsList = mockPaymentDetailsList(),
+            selectedItem = mockPaymentDetailsList().first(),
+            isProcessing = false,
+            hasCompleted = false,
+            expiryDateInput = FormFieldEntry("1226", isComplete = true),
+            cvcInput = FormFieldEntry("123", isComplete = true)
+        )
+
+        assertThat(uiState.primaryButtonState).isEqualTo(PrimaryButtonState.Enabled)
+    }
+
+    private fun mockPaymentDetailsList() = listOf(
+        ConsumerPaymentDetails.Card(
+            "id1",
+            true,
+            2022,
+            1,
+            CardBrand.Visa,
+            "4242",
+            CvcCheck.Pass
+        ),
+        ConsumerPaymentDetails.Card(
+            "id2",
+            false,
+            2026,
+            12,
+            CardBrand.MasterCard,
+            "4444",
+            CvcCheck.Fail
+        )
+    )
+}

--- a/link/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -99,7 +99,7 @@ class WalletViewModelTest {
 
         val viewModel = createViewModel()
 
-        assertThat(viewModel.paymentDetailsList.value).containsExactly(card1, card2)
+        assertThat(viewModel.uiState.value.paymentDetailsList).containsExactly(card1, card2)
     }
 
     @Test
@@ -194,7 +194,7 @@ class WalletViewModelTest {
 
         viewModel.onItemSelected(paymentDetails)
 
-        assertThat(viewModel.selectedItem.value).isEqualTo(paymentDetails)
+        assertThat(viewModel.uiState.value.selectedItem).isEqualTo(paymentDetails)
     }
 
     @Test
@@ -204,7 +204,7 @@ class WalletViewModelTest {
         val viewModel = createViewModel()
         viewModel.onItemSelected(deletedPaymentDetails)
 
-        assertThat(viewModel.selectedItem.value).isEqualTo(deletedPaymentDetails)
+        assertThat(viewModel.uiState.value.selectedItem).isEqualTo(deletedPaymentDetails)
 
         whenever(linkAccountManager.deletePaymentDetails(anyOrNull()))
             .thenReturn(Result.success(Unit))
@@ -220,7 +220,7 @@ class WalletViewModelTest {
 
         viewModel.deletePaymentMethod(deletedPaymentDetails)
 
-        assertThat(viewModel.selectedItem.value)
+        assertThat(viewModel.uiState.value.selectedItem)
             .isEqualTo(PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS.paymentDetails.first())
     }
 
@@ -237,7 +237,7 @@ class WalletViewModelTest {
         val viewModel = createViewModel()
 
         val bankAccount = PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS.paymentDetails[2]
-        assertThat(viewModel.selectedItem.value).isEqualTo(bankAccount)
+        assertThat(viewModel.uiState.value.selectedItem).isEqualTo(bankAccount)
     }
 
     @Test
@@ -253,7 +253,7 @@ class WalletViewModelTest {
 
         callbackCaptor.firstValue(Result.success(PaymentResult.Failed(RuntimeException(errorThrown))))
 
-        assertThat(viewModel.errorMessage.value).isEqualTo(ErrorMessage.Raw(errorThrown))
+        assertThat(viewModel.uiState.value.errorMessage).isEqualTo(ErrorMessage.Raw(errorThrown))
     }
 
     @Test
@@ -267,7 +267,7 @@ class WalletViewModelTest {
         clearInvocations(linkAccountManager)
 
         // Initially has two elements
-        assertThat(viewModel.paymentDetailsList.value)
+        assertThat(viewModel.uiState.value.paymentDetailsList)
             .containsExactlyElementsIn(paymentDetails.paymentDetails)
 
         whenever(linkAccountManager.deletePaymentDetails(anyOrNull()))
@@ -293,7 +293,7 @@ class WalletViewModelTest {
 
         viewModel.deletePaymentMethod(PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS.paymentDetails.first())
 
-        assertThat(viewModel.errorMessage.value).isEqualTo(ErrorMessage.Raw(errorThrown))
+        assertThat(viewModel.uiState.value.errorMessage).isEqualTo(ErrorMessage.Raw(errorThrown))
     }
 
     @Test
@@ -306,11 +306,10 @@ class WalletViewModelTest {
         whenever(linkAccountManager.listPaymentDetails())
             .thenReturn(Result.success(PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS))
 
-        val paymentDetails = PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS.paymentDetails.first()
         val viewModel = createViewModel()
         viewModel.onConfirmPayment()
 
-        assertThat(viewModel.primaryButtonState.value).isEqualTo(PrimaryButtonState.Completed)
+        assertThat(viewModel.uiState.value.primaryButtonState).isEqualTo(PrimaryButtonState.Completed)
 
         advanceTimeBy(PrimaryButtonState.COMPLETED_DELAY_MS + 1)
 
@@ -377,7 +376,7 @@ class WalletViewModelTest {
         val error = ErrorMessage.Raw("Error message")
         flow.emit(PaymentDetailsResult.Failure(error))
 
-        assertThat(viewModel.errorMessage.value).isEqualTo(error)
+        assertThat(viewModel.uiState.value.errorMessage).isEqualTo(error)
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request refactors the UI state in the wallet screen. Instead of exposing multiple observable values, we now expose a single `WalletUiState`.

This makes state management easier, as we’re adding the logic for updating the card expiry date and the card CVC.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Simpler state management.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

_Nothing to add._
