### PR TITLE
Add CVC recollection in Link wallet

### DIFF
--- a/link/res/values/strings.xml
+++ b/link/res/values/strings.xml
@@ -32,6 +32,8 @@
     <string name="wallet_remove_card_confirmation">Are you sure you want to remove this card?</string>
     <string name="wallet_remove_account_confirmation">Are you sure you want to remove this account?</string>
     <string name="wallet_bank_account_terms">By continuing, you agree to authorize payments pursuant to &lt;a href=\"https://stripe.com/legal/ach-payments/authorization\"&gt;these terms&lt;/a&gt;.</string>
+    <string name="wallet_update_expired_card_error">This card has expired. Update your card info or choose a different payment method.</string>
+    <string name="wallet_recollect_cvc_error">For security, please re-enter your card’s security code.</string>
 
     <string name="add_payment_method">Add a payment method</string>
     <string name="add_bank_account">Add bank account</string>

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/PaymentDetails.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/PaymentDetails.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -39,6 +40,7 @@ import com.stripe.android.link.theme.linkShapes
 import com.stripe.android.link.ui.ErrorText
 import com.stripe.android.link.ui.ErrorTextStyle
 import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.model.ConsumerPaymentDetails.Card
 
 @Composable
 internal fun PaymentDetailsListItem(
@@ -75,7 +77,19 @@ internal fun PaymentDetailsListItem(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 PaymentDetails(paymentDetails = paymentDetails, enabled = isSupported)
+
                 Spacer(modifier = Modifier.weight(1f))
+
+                val showWarning = (paymentDetails as? Card)?.isExpired ?: false
+                if (showWarning && !isSelected) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_link_error),
+                        contentDescription = null,
+                        modifier = Modifier.size(20.dp),
+                        tint = MaterialTheme.linkColors.errorText
+                    )
+                }
+
                 if (paymentDetails.isDefault) {
                     Box(
                         modifier = Modifier
@@ -129,7 +143,7 @@ internal fun PaymentDetails(
     enabled: Boolean
 ) {
     when (paymentDetails) {
-        is ConsumerPaymentDetails.Card -> {
+        is Card -> {
             CardInfo(card = paymentDetails, enabled = enabled)
         }
         is ConsumerPaymentDetails.BankAccount -> {
@@ -140,7 +154,7 @@ internal fun PaymentDetails(
 
 @Composable
 internal fun CardInfo(
-    card: ConsumerPaymentDetails.Card,
+    card: Card,
     enabled: Boolean
 ) {
     CompositionLocalProvider(LocalContentAlpha provides if (enabled) 1f else 0.6f) {

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -75,20 +75,20 @@ private fun WalletBodyPreview() {
         ConsumerPaymentDetails.Card(
             "id1",
             true,
-            2022,
-            1,
+            2030,
+            12,
             CardBrand.Visa,
             "4242",
-            CvcCheck.Pass
+            CvcCheck.Fail
         ),
         ConsumerPaymentDetails.Card(
             "id2",
             false,
-            2023,
-            11,
+            2022,
+            1,
             CardBrand.MasterCard,
             "4444",
-            CvcCheck.Fail
+            CvcCheck.Pass
         )
     )
 
@@ -260,12 +260,12 @@ internal fun WalletBody(
             )
         }
 
-        Spacer(modifier = Modifier.height(20.dp))
-
         uiState.errorMessage?.let {
             ErrorText(
                 text = it.getMessage(LocalContext.current.resources),
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 16.dp)
             )
         }
 
@@ -274,10 +274,13 @@ internal fun WalletBody(
                 CardDetailsRecollectionForm(
                     expiryDateController = expiryDateController,
                     cvcController = cvcController,
-                    isCardExpired = selectedCard.isExpired
+                    isCardExpired = selectedCard.isExpired,
+                    modifier = Modifier.padding(top = 16.dp)
                 )
             }
         }
+
+        Spacer(modifier = Modifier.height(16.dp))
 
         PrimaryButton(
             label = primaryButtonLabel,
@@ -298,7 +301,8 @@ internal fun WalletBody(
 internal fun CardDetailsRecollectionForm(
     expiryDateController: TextFieldController,
     cvcController: CvcController,
-    isCardExpired: Boolean
+    isCardExpired: Boolean,
+    modifier: Modifier = Modifier
 ) {
     val cvcElement = remember(cvcController) {
         CvcElement(
@@ -314,37 +318,41 @@ internal fun CardDetailsRecollectionForm(
     }
 
     PaymentsThemeForLink {
-        ErrorText(
-            text = stringResource(errorTextResId),
-            modifier = Modifier.fillMaxWidth()
-        )
+        Column(modifier) {
+            ErrorText(
+                text = stringResource(errorTextResId),
+                modifier = Modifier.fillMaxWidth()
+            )
 
-        Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-            if (isCardExpired) {
-                val expiryDateElement = remember(expiryDateController) {
-                    SimpleTextElement(
-                        identifier = IdentifierSpec.Generic("date"),
-                        controller = expiryDateController
-                    )
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                if (isCardExpired) {
+                    val expiryDateElement = remember(expiryDateController) {
+                        SimpleTextElement(
+                            identifier = IdentifierSpec.Generic("date"),
+                            controller = expiryDateController
+                        )
+                    }
+
+                    Box(modifier = Modifier.weight(0.5f)) {
+                        SectionElementUI(
+                            enabled = true,
+                            element = SectionElement.wrap(expiryDateElement),
+                            hiddenIdentifiers = emptyList(),
+                            lastTextFieldIdentifier = cvcElement.identifier
+                        )
+                    }
                 }
 
                 Box(modifier = Modifier.weight(0.5f)) {
                     SectionElementUI(
                         enabled = true,
-                        element = SectionElement.wrap(expiryDateElement),
+                        element = SectionElement.wrap(cvcElement),
                         hiddenIdentifiers = emptyList(),
                         lastTextFieldIdentifier = cvcElement.identifier
                     )
                 }
-            }
-
-            Box(modifier = Modifier.weight(0.5f)) {
-                SectionElementUI(
-                    enabled = true,
-                    element = SectionElement.wrap(cvcElement),
-                    hiddenIdentifiers = emptyList(),
-                    lastTextFieldIdentifier = cvcElement.identifier
-                )
             }
         }
     }

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -277,6 +277,10 @@ internal fun WalletBody(
             )
         }
 
+        if (card != null && card.cvcCheck.requiresRecollection) {
+            CvcForm(cvcController = cvcController)
+        }
+
         PrimaryButton(
             label = primaryButtonLabel,
             state = uiState.primaryButtonState,
@@ -330,6 +334,27 @@ internal fun ExpiryDateAndCvcForm(
                     lastTextFieldIdentifier = cvcElement.identifier
                 )
             }
+        }
+    }
+}
+
+@Composable
+internal fun CvcForm(cvcController: CvcController) {
+    val cvcElement = remember(cvcController) {
+        CvcElement(
+            _identifier = IdentifierSpec.CardCvc,
+            controller = cvcController
+        )
+    }
+
+    PaymentsThemeForLink {
+        Box {
+            SectionElementUI(
+                enabled = true,
+                element = SectionElement.wrap(cvcElement),
+                hiddenIdentifiers = emptyList(),
+                lastTextFieldIdentifier = cvcElement.identifier
+            )
         }
     }
 }

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
@@ -4,6 +4,7 @@ import com.stripe.android.link.ui.ErrorMessage
 import com.stripe.android.link.ui.PrimaryButtonState
 import com.stripe.android.link.ui.getErrorMessage
 import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.model.ConsumerPaymentDetails.Card
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.ui.core.forms.FormFieldEntry
 
@@ -21,11 +22,17 @@ internal data class WalletUiState(
 
     val primaryButtonState: PrimaryButtonState
         get() {
-            val isExpired = (selectedItem as? ConsumerPaymentDetails.Card)?.isExpired ?: false
+            val card = selectedItem as? Card
+            val isExpired = card?.isExpired ?: false
             val hasRequiredExpiryInput = expiryDateInput.isComplete && cvcInput.isComplete
 
+            val requiresCvcRecollection = card?.cvcCheck?.requiresRecollection ?: false
+            val hasRequiredCvcInput = cvcInput.isComplete
+
             val isSelectedItemValid = selectedItem?.isValid ?: false
-            val disableButton = !isSelectedItemValid || (isExpired && !hasRequiredExpiryInput)
+            val disableButton = !isSelectedItemValid ||
+                (isExpired && !hasRequiredExpiryInput) ||
+                (requiresCvcRecollection && !hasRequiredCvcInput)
 
             return if (hasCompleted) {
                 PrimaryButtonState.Completed

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
@@ -20,19 +20,22 @@ internal data class WalletUiState(
     val cvcInput: FormFieldEntry = FormFieldEntry(value = null)
 ) {
 
+    val selectedCard: Card?
+        get() = selectedItem as? Card
+
     val primaryButtonState: PrimaryButtonState
         get() {
             val card = selectedItem as? Card
             val isExpired = card?.isExpired ?: false
-            val hasRequiredExpiryInput = expiryDateInput.isComplete && cvcInput.isComplete
-
             val requiresCvcRecollection = card?.cvcCheck?.requiresRecollection ?: false
-            val hasRequiredCvcInput = cvcInput.isComplete
+
+            val isMissingExpiryDateInput = !(expiryDateInput.isComplete && cvcInput.isComplete)
+            val isMissingCvcInput = !cvcInput.isComplete
 
             val isSelectedItemValid = selectedItem?.isValid ?: false
             val disableButton = !isSelectedItemValid ||
-                (isExpired && !hasRequiredExpiryInput) ||
-                (requiresCvcRecollection && !hasRequiredCvcInput)
+                (isExpired && isMissingExpiryDateInput) ||
+                (requiresCvcRecollection && isMissingCvcInput)
 
             return if (hasCompleted) {
                 PrimaryButtonState.Completed
@@ -49,7 +52,6 @@ internal data class WalletUiState(
         response: ConsumerPaymentDetails,
         initialSelectedItemId: String?
     ): WalletUiState {
-        // Select initialSelectedItemId if provided, otherwise the previously selected item
         val selectedItem = (initialSelectedItemId ?: selectedItem?.id)?.let { itemId ->
             response.paymentDetails.firstOrNull { it.id == itemId }
         } ?: getDefaultItemSelection(response.paymentDetails)

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -139,7 +139,7 @@ internal class WalletViewModel @Inject constructor(
             shipping = args.shippingValues?.toConfirmPaymentIntentShipping()
         )
 
-        val cvc = uiState.value.cvcInput.value
+        val cvc = uiState.value.cvcInput.takeIf { it.isComplete }?.value
         val extraParams = if (cvc != null) {
             mapOf("card" to mapOf("cvc" to cvc))
         } else {

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -211,6 +211,13 @@ internal class WalletViewModel @Inject constructor(
     }
 
     fun onItemSelected(item: ConsumerPaymentDetails.PaymentDetails) {
+        if (item == uiState.value.selectedItem) {
+            return
+        }
+
+        expiryDateController.onRawValueChange("")
+        cvcController.onRawValueChange("")
+
         _uiState.update {
             it.copy(selectedItem = item)
         }

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -19,6 +19,7 @@ import com.stripe.android.link.ui.ErrorMessage
 import com.stripe.android.link.ui.PrimaryButtonState
 import com.stripe.android.link.ui.getErrorMessage
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.ui.core.address.toConfirmPaymentIntentShipping
@@ -113,42 +114,64 @@ internal class WalletViewModel @Inject constructor(
 
         runCatching { requireNotNull(linkAccountManager.linkAccount.value) }.fold(
             onSuccess = { linkAccount ->
-                val paramsFactory = ConfirmStripeIntentParamsFactory.createFactory(
-                    stripeIntent,
-                    args.shippingValues?.toConfirmPaymentIntentShipping()
+                val params = createConfirmStripeIntentParams(
+                    selectedPaymentDetails = selectedPaymentDetails,
+                    linkAccount = linkAccount
                 )
-                val params = paramsFactory.createPaymentMethodCreateParams(
-                    linkAccount.clientSecret,
-                    selectedPaymentDetails
-                )
-                confirmationManager.confirmStripeIntent(
-                    paramsFactory.createConfirmStripeIntentParams(params)
-                ) { result ->
-                    result.fold(
-                        onSuccess = { paymentResult ->
-                            _uiState.update {
-                                it.updateWithPaymentResult(paymentResult)
-                            }
 
-                            when (paymentResult) {
-                                is PaymentResult.Canceled -> Unit
-                                is PaymentResult.Failed -> {
-                                    logger.error("Error: ", paymentResult.throwable)
-                                }
-                                is PaymentResult.Completed -> {
-                                    viewModelScope.launch {
-                                        delay(PrimaryButtonState.COMPLETED_DELAY_MS)
-                                        navigator.dismiss(LinkActivityResult.Completed)
-                                    }
-                                }
-                            }
-                        },
+                confirmationManager.confirmStripeIntent(params) { result ->
+                    result.fold(
+                        onSuccess = ::handleConfirmPaymentSuccess,
                         onFailure = ::onError
                     )
                 }
             },
             onFailure = ::onError
         )
+    }
+
+    private fun createConfirmStripeIntentParams(
+        selectedPaymentDetails: ConsumerPaymentDetails.PaymentDetails,
+        linkAccount: LinkAccount
+    ): ConfirmStripeIntentParams {
+        val paramsFactory = ConfirmStripeIntentParamsFactory.createFactory(
+            stripeIntent = stripeIntent,
+            shipping = args.shippingValues?.toConfirmPaymentIntentShipping()
+        )
+
+        val cvc = uiState.value.cvcInput.value
+        val extraParams = if (cvc != null) {
+            mapOf("card" to mapOf("cvc" to cvc))
+        } else {
+            null
+        }
+
+        val params = paramsFactory.createPaymentMethodCreateParams(
+            consumerSessionClientSecret = linkAccount.clientSecret,
+            selectedPaymentDetails = selectedPaymentDetails,
+            extraParams = extraParams
+        )
+
+        return paramsFactory.createConfirmStripeIntentParams(params)
+    }
+
+    private fun handleConfirmPaymentSuccess(paymentResult: PaymentResult) {
+        _uiState.update {
+            it.updateWithPaymentResult(paymentResult)
+        }
+
+        when (paymentResult) {
+            is PaymentResult.Canceled -> Unit
+            is PaymentResult.Failed -> {
+                logger.error("Error: ", paymentResult.throwable)
+            }
+            is PaymentResult.Completed -> {
+                viewModelScope.launch {
+                    delay(PrimaryButtonState.COMPLETED_DELAY_MS)
+                    navigator.dismiss(LinkActivityResult.Completed)
+                }
+            }
+        }
     }
 
     fun setExpanded(expanded: Boolean) {

--- a/link/src/test/java/com/stripe/android/link/ui/wallet/WalletUiStateTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/wallet/WalletUiStateTest.kt
@@ -99,12 +99,12 @@ class WalletUiStateTest {
 
     @Test
     fun `Primary button is disabled if selected card is expired and form hasn't been filled out`() {
-        val validCard = mockCard(isExpired = true)
+        val expiredCard = mockCard(isExpired = true)
 
         val uiState = WalletUiState(
             supportedTypes = SupportedPaymentMethod.allTypes,
-            paymentDetailsList = listOf(validCard),
-            selectedItem = validCard,
+            paymentDetailsList = listOf(expiredCard),
+            selectedItem = expiredCard,
             isProcessing = false,
             hasCompleted = false
         )
@@ -114,16 +114,48 @@ class WalletUiStateTest {
 
     @Test
     fun `Primary button is enabled if selected card is expired, but the form has been filled out`() {
-        val validCard = mockCard(isExpired = true)
+        val expiredCard = mockCard(isExpired = true)
 
         val uiState = WalletUiState(
             supportedTypes = SupportedPaymentMethod.allTypes,
-            paymentDetailsList = listOf(validCard),
-            selectedItem = validCard,
+            paymentDetailsList = listOf(expiredCard),
+            selectedItem = expiredCard,
             isProcessing = false,
             hasCompleted = false,
             expiryDateInput = FormFieldEntry("1226", isComplete = true),
             cvcInput = FormFieldEntry("123", isComplete = true)
+        )
+
+        assertThat(uiState.primaryButtonState).isEqualTo(PrimaryButtonState.Enabled)
+    }
+
+    @Test
+    fun `Primary button is disabled if required CVC check hasn't been filled out`() {
+        val uncheckedCard = mockCard(cvcCheck = CvcCheck.Fail)
+
+        val uiState = WalletUiState(
+            supportedTypes = SupportedPaymentMethod.allTypes,
+            paymentDetailsList = listOf(uncheckedCard),
+            selectedItem = uncheckedCard,
+            isProcessing = false,
+            hasCompleted = false,
+            cvcInput = FormFieldEntry(value = null)
+        )
+
+        assertThat(uiState.primaryButtonState).isEqualTo(PrimaryButtonState.Disabled)
+    }
+
+    @Test
+    fun `Primary button is enabled if required CVC check has been filled out`() {
+        val uncheckedCard = mockCard(cvcCheck = CvcCheck.Fail)
+
+        val uiState = WalletUiState(
+            supportedTypes = SupportedPaymentMethod.allTypes,
+            paymentDetailsList = listOf(uncheckedCard),
+            selectedItem = uncheckedCard,
+            isProcessing = false,
+            hasCompleted = false,
+            cvcInput = FormFieldEntry(value = "123", isComplete = true)
         )
 
         assertThat(uiState.primaryButtonState).isEqualTo(PrimaryButtonState.Enabled)

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -2504,6 +2504,7 @@ public final class com/stripe/android/model/ConsumerPaymentDetails$Card : com/st
 	public final fun getExpiryYear ()I
 	public fun getId ()Ljava/lang/String;
 	public final fun getLast4 ()Ljava/lang/String;
+	public final fun getRequiresCardDetailsRecollection ()Z
 	public fun hashCode ()I
 	public fun isDefault ()Z
 	public final fun isExpired ()Z

--- a/payments-core/src/main/java/com/stripe/android/model/ConsumerPaymentDetails.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConsumerPaymentDetails.kt
@@ -29,6 +29,9 @@ data class ConsumerPaymentDetails internal constructor(
         val cvcCheck: CvcCheck
     ) : PaymentDetails(id, isDefault, Companion.type) {
 
+        val requiresCardDetailsRecollection: Boolean
+            get() = isExpired || cvcCheck.requiresRecollection
+
         val isExpired: Boolean
             get() = !DateUtils.isExpiryDataValid(
                 expiryMonth = expiryMonth,

--- a/payments-model/src/main/java/com/stripe/android/model/CvcCheck.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/CvcCheck.kt
@@ -10,10 +10,10 @@ enum class CvcCheck(
     Fail("FAIL"),
     Unavailable("UNAVAILABLE"),
     Unchecked("UNCHECKED"),
-    Unknown("UNKNOWN"),;
+    Unknown("UNKNOWN");
 
     val requiresRecollection: Boolean
-        get() = true // this in setOf(Fail, Unavailable, Unchecked)
+        get() = this in setOf(Fail, Unavailable, Unchecked)
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {

--- a/payments-model/src/main/java/com/stripe/android/model/CvcCheck.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/CvcCheck.kt
@@ -9,12 +9,16 @@ enum class CvcCheck(
     Pass("PASS"),
     Fail("FAIL"),
     Unavailable("UNAVAILABLE"),
-    Unchecked("UNCHECKED");
+    Unchecked("UNCHECKED"),
+    Unknown("UNKNOWN"),;
+
+    val requiresRecollection: Boolean
+        get() = true // this in setOf(Fail, Unavailable, Unchecked)
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
         fun fromCode(code: String?): CvcCheck {
-            return values().firstOrNull { it.code.equals(code, ignoreCase = true) } ?: Unavailable
+            return values().firstOrNull { it.code.equals(code, ignoreCase = true) } ?: Unknown
         }
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds CVC recollection to the Link wallet.

If the backend indicates that a CVC check is necessary, we display the CVC input field. The pay button is only enabled once a valid input has been entered. Then, we add the CVC to the `PaymentMethodCreateParams` as extra parameters.

The UX isn’t fully polished yet. For instance, the CVC input field currently allows input longer than 3 digits. I will fix this in a follow-up pull request.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

CVC recollection for Link payments.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screen recording

https://user-images.githubusercontent.com/110940675/188912649-323a1621-c883-4cda-9706-6e8e93d80ff0.mp4

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

_Nothing to add._
