### PR TITLE
Animate card expansion and collapse in Link wallet

### DIFF
--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.link.ui.wallet
 
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -205,44 +206,46 @@ internal fun WalletBody(
     ScrollableTopLevelColumn {
         Spacer(modifier = Modifier.height(12.dp))
 
-        if (uiState.isExpanded) {
-            ExpandedPaymentDetails(
-                uiState = uiState,
-                onItemSelected = {
-                    onItemSelected(it)
-                    setExpanded(false)
-                },
-                onMenuButtonClick = {
-                    showBottomSheetContent {
-                        WalletPaymentMethodMenu(
-                            paymentDetails = it,
-                            onEditClick = {
-                                showBottomSheetContent(null)
-                                onEditPaymentMethod(it)
-                            },
-                            onRemoveClick = {
-                                showBottomSheetContent(null)
-                                itemBeingRemoved = it
-                            },
-                            onCancelClick = {
-                                showBottomSheetContent(null)
-                            }
-                        )
+        Box(modifier = Modifier.animateContentSize()) {
+            if (uiState.isExpanded) {
+                ExpandedPaymentDetails(
+                    uiState = uiState,
+                    onItemSelected = {
+                        onItemSelected(it)
+                        setExpanded(false)
+                    },
+                    onMenuButtonClick = {
+                        showBottomSheetContent {
+                            WalletPaymentMethodMenu(
+                                paymentDetails = it,
+                                onEditClick = {
+                                    showBottomSheetContent(null)
+                                    onEditPaymentMethod(it)
+                                },
+                                onRemoveClick = {
+                                    showBottomSheetContent(null)
+                                    itemBeingRemoved = it
+                                },
+                                onCancelClick = {
+                                    showBottomSheetContent(null)
+                                }
+                            )
+                        }
+                    },
+                    onAddNewPaymentMethodClick = onAddNewPaymentMethodClick,
+                    onCollapse = {
+                        setExpanded(false)
                     }
-                },
-                onAddNewPaymentMethodClick = onAddNewPaymentMethodClick,
-                onCollapse = {
-                    setExpanded(false)
-                }
-            )
-        } else {
-            CollapsedPaymentDetails(
-                selectedPaymentMethod = uiState.selectedItem!!,
-                enabled = !uiState.primaryButtonState.isBlocking,
-                onClick = {
-                    setExpanded(true)
-                }
-            )
+                )
+            } else {
+                CollapsedPaymentDetails(
+                    selectedPaymentMethod = uiState.selectedItem!!,
+                    enabled = !uiState.primaryButtonState.isBlocking,
+                    onClick = {
+                        setExpanded(true)
+                    }
+                )
+            }
         }
 
         if (uiState.selectedItem is ConsumerPaymentDetails.BankAccount) {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds animation for expanding and collapsing the payment methods card in the Link wallet.

_Note_: The animation isn’t perfect when looking at it in slow motion. However, I do think it’s an improvement over the existing behavior.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

UX polish.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screen recordings

| Before | After |
| ------------- | ------------- |
| <video src="https://user-images.githubusercontent.com/110940675/188906722-cbe11cfb-ee61-42c2-8019-4cfc6ec7573f.mp4">  | <video src="https://user-images.githubusercontent.com/110940675/188906741-04bff429-1ef6-4aa3-a80a-2aea28e99e02.mp4"> |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

_Nothing to add._
