### PR TITLE
Clip card in Link wallet to fix ripple drawing

### DIFF
--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -349,6 +350,7 @@ internal fun CollapsedPaymentDetails(
                 color = MaterialTheme.linkColors.componentBorder,
                 shape = MaterialTheme.linkShapes.large
             )
+            .clip(MaterialTheme.linkShapes.large)
             .background(
                 color = MaterialTheme.linkColors.componentBackground,
                 shape = MaterialTheme.linkShapes.large
@@ -400,6 +402,7 @@ private fun ExpandedPaymentDetails(
                 color = MaterialTheme.linkColors.componentBorder,
                 shape = MaterialTheme.linkShapes.large
             )
+            .clip(MaterialTheme.linkShapes.large)
             .background(
                 color = MaterialTheme.linkColors.componentBackground,
                 shape = MaterialTheme.linkShapes.large


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request clips the collapsed and expanded card in the Link wallet, making sure that the ripple effect is not drawn outside of it.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

UX polish.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before | After |
| ------------- | ------------- |
| ![Screenshot_20220907_104952](https://user-images.githubusercontent.com/110940675/188909011-22dcc010-a6c0-495d-9e19-6bd335af649a.png) | ![Screenshot_20220907_105044](https://user-images.githubusercontent.com/110940675/188909166-bf6b3bd0-5e95-49d8-99d7-d2474a6254fb.png) |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

_Nothing to add._
