### PR TITLE
Handle errors during email lookup

### DIFF
--- a/link/src/androidTest/java/com/stripe/android/link/ui/inline/LinkInlineSignupViewTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/inline/LinkInlineSignupViewTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.link.theme.DefaultLinkTheme
+import com.stripe.android.link.ui.ErrorMessage
 import com.stripe.android.link.ui.progressIndicatorTestTag
 import com.stripe.android.link.ui.signup.SignUpState
 import com.stripe.android.ui.core.elements.PhoneNumberController
@@ -79,6 +80,26 @@ internal class LinkInlineSignupViewTest {
         onNameField().assertDoesNotExist()
     }
 
+    @Test
+    fun when_error_message_not_null_in_state_InputtingPhoneOrName_then_it_is_visible() {
+        val errorMessage = "Error message"
+        setContent(
+            signUpState = SignUpState.InputtingPhoneOrName,
+            errorMessage = ErrorMessage.Raw(errorMessage)
+        )
+        composeTestRule.onNodeWithText(errorMessage).assertExists()
+    }
+
+    @Test
+    fun when_error_message_not_null_in_state_InputtingEmail_then_it_is_visible() {
+        val errorMessage = "Error message"
+        setContent(
+            signUpState = SignUpState.InputtingEmail,
+            errorMessage = ErrorMessage.Raw(errorMessage)
+        )
+        composeTestRule.onNodeWithText(errorMessage).assertExists()
+    }
+
     private fun setContent(
         merchantName: String = "Example, Inc.",
         emailElement: SimpleTextFieldController =
@@ -90,6 +111,7 @@ internal class LinkInlineSignupViewTest {
         enabled: Boolean = true,
         expanded: Boolean = true,
         requiresNameCollection: Boolean = false,
+        errorMessage: ErrorMessage? = null,
         toggleExpanded: () -> Unit = {},
         onUserInteracted: () -> Unit = {}
     ) = composeTestRule.setContent {
@@ -103,6 +125,7 @@ internal class LinkInlineSignupViewTest {
                 enabled,
                 expanded,
                 requiresNameCollection,
+                errorMessage,
                 toggleExpanded,
                 onUserInteracted
             )

--- a/link/src/androidTest/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
@@ -101,9 +101,16 @@ internal class SignUpScreenTest {
     }
 
     @Test
-    fun when_error_message_is_not_null_then_it_is_visible() {
+    fun when_error_message_not_null_in_state_InputtingPhoneOrName_then_it_is_visible() {
         val errorMessage = "Error message"
         setContent(SignUpState.InputtingPhoneOrName, errorMessage = ErrorMessage.Raw(errorMessage))
+        composeTestRule.onNodeWithText(errorMessage).assertExists()
+    }
+
+    @Test
+    fun when_error_message_not_null_in_state_InputtingEmail_then_it_is_visible() {
+        val errorMessage = "Error message"
+        setContent(SignUpState.InputtingEmail, errorMessage = ErrorMessage.Raw(errorMessage))
         composeTestRule.onNodeWithText(errorMessage).assertExists()
     }
 
@@ -112,24 +119,23 @@ internal class SignUpScreenTest {
         isReadyToSignUp: Boolean = true,
         requiresNameCollection: Boolean = false,
         errorMessage: ErrorMessage? = null
-    ) =
-        composeTestRule.setContent {
-            DefaultLinkTheme {
-                SignUpBody(
-                    merchantName = "Example, Inc.",
-                    emailController = SimpleTextFieldController
-                        .createEmailSectionController(""),
-                    phoneNumberController = PhoneNumberController.createPhoneNumberController(),
-                    nameController = SimpleTextFieldController
-                        .createNameSectionController(null),
-                    signUpState = signUpState,
-                    isReadyToSignUp = isReadyToSignUp,
-                    requiresNameCollection = requiresNameCollection,
-                    errorMessage = errorMessage,
-                    onSignUpClick = {}
-                )
-            }
+    ) = composeTestRule.setContent {
+        DefaultLinkTheme {
+            SignUpBody(
+                merchantName = "Example, Inc.",
+                emailController = SimpleTextFieldController
+                    .createEmailSectionController(""),
+                phoneNumberController = PhoneNumberController.createPhoneNumberController(),
+                nameController = SimpleTextFieldController
+                    .createNameSectionController(null),
+                signUpState = signUpState,
+                isReadyToSignUp = isReadyToSignUp,
+                requiresNameCollection = requiresNameCollection,
+                errorMessage = errorMessage,
+                onSignUpClick = {}
+            )
         }
+    }
 
     private fun onEmailField() = composeTestRule.onNodeWithText("Email")
     private fun onProgressIndicator() = composeTestRule.onNodeWithTag(progressIndicatorTestTag)

--- a/link/src/androidTest/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
@@ -36,7 +36,6 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.link.ui.BottomSheetContent
 import com.stripe.android.link.ui.ErrorMessage
-import com.stripe.android.link.ui.PrimaryButtonState
 import com.stripe.android.link.ui.paymentmethod.SupportedPaymentMethod
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
@@ -444,7 +443,6 @@ internal class WalletScreenTest {
         supportedTypes: Set<String> = SupportedPaymentMethod.allTypes,
         selectedItem: ConsumerPaymentDetails.PaymentDetails? = paymentDetails.first(),
         isExpanded: Boolean = true,
-        primaryButtonState: PrimaryButtonState = PrimaryButtonState.Enabled,
         errorMessage: ErrorMessage? = null,
         expiryDateController: TextFieldController = SimpleTextFieldController(DateConfig()),
         cvcController: CvcController = CvcController(cardBrandFlow = flowOf(CardBrand.Visa)),
@@ -482,13 +480,14 @@ internal class WalletScreenTest {
         ) {
             DefaultLinkTheme {
                 WalletBody(
-                    paymentDetailsList = paymentDetailsList,
-                    supportedTypes = supportedTypes,
-                    selectedItem = selectedItem,
-                    isExpanded = isExpanded,
+                    uiState = WalletUiState(
+                        paymentDetailsList = paymentDetailsList,
+                        supportedTypes = supportedTypes,
+                        selectedItem = selectedItem,
+                        isExpanded = isExpanded,
+                        errorMessage = errorMessage
+                    ),
                     primaryButtonLabel = primaryButtonLabel,
-                    primaryButtonState = primaryButtonState,
-                    errorMessage = errorMessage,
                     expiryDateController = expiryDateController,
                     cvcController = cvcController,
                     setExpanded = setExpanded,

--- a/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignupView.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignupView.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.AbstractComposeView
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
@@ -39,6 +40,8 @@ import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.R
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.link.theme.linkShapes
+import com.stripe.android.link.ui.ErrorMessage
+import com.stripe.android.link.ui.ErrorText
 import com.stripe.android.link.ui.LinkTerms
 import com.stripe.android.link.ui.signup.EmailCollectionSection
 import com.stripe.android.link.ui.signup.SignUpState
@@ -68,6 +71,7 @@ private fun Preview() {
                 enabled = true,
                 expanded = true,
                 requiresNameCollection = true,
+                errorMessage = null,
                 toggleExpanded = {},
                 onUserInteracted = {}
             )
@@ -91,6 +95,7 @@ private fun LinkInlineSignup(
     val signUpState by viewModel.signUpState.collectAsState(SignUpState.InputtingEmail)
     val isExpanded by viewModel.isExpanded.collectAsState(false)
     val userInput by viewModel.userInput.collectAsState()
+    val errorMessage by viewModel.errorMessage.collectAsState()
 
     onSelected(isExpanded)
     onUserInput(userInput)
@@ -113,6 +118,7 @@ private fun LinkInlineSignup(
         enabled = enabled,
         expanded = isExpanded,
         requiresNameCollection = viewModel.requiresNameCollection,
+        errorMessage = errorMessage,
         toggleExpanded = viewModel::toggleExpanded,
         onUserInteracted = onUserInteracted
     )
@@ -128,6 +134,7 @@ internal fun LinkInlineSignup(
     enabled: Boolean,
     expanded: Boolean,
     requiresNameCollection: Boolean,
+    errorMessage: ErrorMessage?,
     toggleExpanded: () -> Unit,
     onUserInteracted: () -> Unit
 ) {
@@ -196,6 +203,16 @@ internal fun LinkInlineSignup(
                         )
 
                         AnimatedVisibility(
+                            visible = signUpState != SignUpState.InputtingPhoneOrName &&
+                                errorMessage != null
+                        ) {
+                            ErrorText(
+                                text = errorMessage!!.getMessage(LocalContext.current.resources),
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                        }
+
+                        AnimatedVisibility(
                             visible = signUpState == SignUpState.InputtingPhoneOrName
                         ) {
                             Column(modifier = Modifier.fillMaxWidth()) {
@@ -216,6 +233,13 @@ internal fun LinkInlineSignup(
                                         textFieldController = nameController,
                                         imeAction = ImeAction.Done,
                                         enabled = enabled
+                                    )
+                                }
+
+                                AnimatedVisibility(visible = errorMessage != null) {
+                                    ErrorText(
+                                        text = errorMessage!!.getMessage(LocalContext.current.resources),
+                                        modifier = Modifier.fillMaxWidth()
                                     )
                                 }
 

--- a/link/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
@@ -134,8 +134,15 @@ internal fun SignUpBody(
             )
         }
         AnimatedVisibility(
-            visible = signUpState == SignUpState.InputtingPhoneOrName
+            visible = signUpState != SignUpState.InputtingPhoneOrName &&
+                errorMessage != null
         ) {
+            ErrorText(
+                text = errorMessage!!.getMessage(LocalContext.current.resources),
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+        AnimatedVisibility(visible = signUpState == SignUpState.InputtingPhoneOrName) {
             Column(modifier = Modifier.fillMaxWidth()) {
                 PaymentsThemeForLink {
                     PhoneNumberCollectionSection(
@@ -164,9 +171,9 @@ internal fun SignUpBody(
                         textAlign = TextAlign.Center
                     )
                 }
-                errorMessage?.let {
+                AnimatedVisibility(visible = errorMessage != null) {
                     ErrorText(
-                        text = it.getMessage(LocalContext.current.resources),
+                        text = errorMessage!!.getMessage(LocalContext.current.resources),
                         modifier = Modifier.fillMaxWidth()
                     )
                 }

--- a/link/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
@@ -106,6 +106,7 @@ internal class SignUpViewModel @Inject constructor(
             coroutineScope = viewModelScope,
             emailFlow = consumerEmail,
             onStateChanged = {
+                clearError()
                 _signUpStatus.value = it
             },
             onValidEmailEntered = {
@@ -175,7 +176,10 @@ internal class SignUpViewModel @Inject constructor(
                     linkEventsReporter.onSignupStarted()
                 }
             },
-            onFailure = ::onError
+            onFailure = {
+                _signUpStatus.value = SignUpState.InputtingEmail
+                onError(it)
+            }
         )
     }
 

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -208,7 +208,7 @@ internal fun WalletBody(
         Spacer(modifier = Modifier.height(12.dp))
 
         Box(modifier = Modifier.animateContentSize()) {
-            if (uiState.isExpanded) {
+            if (uiState.isExpanded || uiState.selectedItem == null) {
                 ExpandedPaymentDetails(
                     uiState = uiState,
                     onItemSelected = {
@@ -240,7 +240,7 @@ internal fun WalletBody(
                 )
             } else {
                 CollapsedPaymentDetails(
-                    selectedPaymentMethod = uiState.selectedItem!!,
+                    selectedPaymentMethod = uiState.selectedItem,
                     enabled = !uiState.primaryButtonState.isBlocking,
                     onClick = {
                         setExpanded(true)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
- Show error message when `consumer/lookup` fails.
- Fix `WalletScreenTest`, show `WalletScreen` collapsed when no item is selected.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Error handling.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

