### PR TITLE
Add inline expiry date updating to Link wallet

### DIFF
--- a/link/api/link.api
+++ b/link/api/link.api
@@ -559,6 +559,13 @@ public final class com/stripe/android/link/ui/wallet/ComposableSingletons$Paymen
 	public final fun getLambda-1$link_release ()Lkotlin/jvm/functions/Function2;
 }
 
+public final class com/stripe/android/link/ui/wallet/ComposableSingletons$WalletScreenKt {
+	public static final field INSTANCE Lcom/stripe/android/link/ui/wallet/ComposableSingletons$WalletScreenKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public fun <init> ()V
+	public final fun getLambda-1$link_release ()Lkotlin/jvm/functions/Function3;
+}
+
 public final class com/stripe/android/link/ui/wallet/PaymentDetailsResult$Cancelled$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/ui/wallet/PaymentDetailsResult$Cancelled;

--- a/link/res/values/strings.xml
+++ b/link/res/values/strings.xml
@@ -34,7 +34,6 @@
     <string name="wallet_bank_account_terms">By continuing, you agree to authorize payments pursuant to &lt;a href=\"https://stripe.com/legal/ach-payments/authorization\"&gt;these terms&lt;/a&gt;.</string>
     <string name="wallet_update_expired_card_error">This card has expired. Update your card info or choose a different payment method.</string>
     <string name="wallet_recollect_cvc_error">For security, please re-enter your card’s security code.</string>
-    <string name="wallet_something_went_wrong_error">Something went wrong. Please try again in a few seconds.</string>
 
     <string name="add_payment_method">Add a payment method</string>
     <string name="add_bank_account">Add bank account</string>

--- a/link/res/values/strings.xml
+++ b/link/res/values/strings.xml
@@ -34,6 +34,7 @@
     <string name="wallet_bank_account_terms">By continuing, you agree to authorize payments pursuant to &lt;a href=\"https://stripe.com/legal/ach-payments/authorization\"&gt;these terms&lt;/a&gt;.</string>
     <string name="wallet_update_expired_card_error">This card has expired. Update your card info or choose a different payment method.</string>
     <string name="wallet_recollect_cvc_error">For security, please re-enter your card’s security code.</string>
+    <string name="wallet_something_went_wrong_error">Something went wrong. Please try again in a few seconds.</string>
 
     <string name="add_payment_method">Add a payment method</string>
     <string name="add_bank_account">Add bank account</string>

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/PaymentDetails.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/PaymentDetails.kt
@@ -80,16 +80,6 @@ internal fun PaymentDetailsListItem(
 
                 Spacer(modifier = Modifier.weight(1f))
 
-                val showWarning = (paymentDetails as? Card)?.isExpired ?: false
-                if (showWarning && !isSelected) {
-                    Icon(
-                        painter = painterResource(R.drawable.ic_link_error),
-                        contentDescription = null,
-                        modifier = Modifier.size(20.dp),
-                        tint = MaterialTheme.linkColors.errorText
-                    )
-                }
-
                 if (paymentDetails.isDefault) {
                     Box(
                         modifier = Modifier
@@ -108,6 +98,16 @@ internal fun PaymentDetailsListItem(
                             fontWeight = FontWeight.Medium
                         )
                     }
+                }
+
+                val showWarning = (paymentDetails as? Card)?.isExpired ?: false
+                if (showWarning && !isSelected) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_link_error),
+                        contentDescription = null,
+                        modifier = Modifier.size(20.dp),
+                        tint = MaterialTheme.linkColors.errorText
+                    )
                 }
             }
             if (!isSupported) {

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.link.ui.wallet
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -291,7 +292,7 @@ internal fun WalletBody(
         }
 
         uiState.selectedCard?.let { selectedCard ->
-            if (selectedCard.requiresCardDetailsRecollection) {
+            AnimatedVisibility(visible = selectedCard.requiresCardDetailsRecollection) {
                 CardDetailsRecollectionForm(
                     expiryDateController = expiryDateController,
                     cvcController = cvcController,

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -13,11 +13,13 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.AlertDialog
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
+import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -134,6 +136,21 @@ internal fun WalletBody(
     )
 
     val uiState by viewModel.uiState.collectAsState()
+
+    uiState.alertMessage?.let { alertMessage ->
+        AlertDialog(
+            text = { Text(alertMessage.getMessage(LocalContext.current.resources)) },
+            onDismissRequest = viewModel::onAlertDismissed,
+            confirmButton = {
+                TextButton(onClick = viewModel::onAlertDismissed) {
+                    Text(
+                        text = stringResource(android.R.string.ok),
+                        color = MaterialTheme.linkColors.actionLabel
+                    )
+                }
+            }
+        )
+    }
 
     if (uiState.paymentDetailsList.isEmpty()) {
         Box(

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.link.ui.wallet
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -292,7 +291,7 @@ internal fun WalletBody(
         }
 
         uiState.selectedCard?.let { selectedCard ->
-            AnimatedVisibility(visible = selectedCard.requiresCardDetailsRecollection) {
+            if (selectedCard.requiresCardDetailsRecollection) {
                 CardDetailsRecollectionForm(
                     expiryDateController = expiryDateController,
                     cvcController = cvcController,

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
@@ -59,18 +59,6 @@ internal data class WalletUiState(
 
         val isSelectedItemValid = selectedItem?.isValid ?: false
 
-//        // TODO: For testing only!
-//        val details = response.paymentDetails.map { pd ->
-//            if (pd is Card && pd.last4 == "4242") {
-//                pd.copy(
-//                    expiryMonth = 1,
-//                    expiryYear = 2022
-//                )
-//            } else {
-//                pd
-//            }
-//        }
-
         return copy(
             paymentDetailsList = response.paymentDetails,
             selectedItem = selectedItem,

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
@@ -67,25 +67,6 @@ internal data class WalletUiState(
         )
     }
 
-    fun updatePaymentDetails(
-        updatedPaymentDetails: ConsumerPaymentDetails.PaymentDetails
-    ): WalletUiState {
-        return copy(
-            paymentDetailsList = paymentDetailsList.map { paymentDetails ->
-                if (paymentDetails.id == updatedPaymentDetails.id) {
-                    updatedPaymentDetails
-                } else {
-                    paymentDetails
-                }
-            },
-            selectedItem = if (selectedItem?.id == updatedPaymentDetails.id) {
-                updatedPaymentDetails
-            } else {
-                selectedItem
-            }
-        )
-    }
-
     fun updateWithError(errorMessage: ErrorMessage): WalletUiState {
         return copy(
             errorMessage = errorMessage,

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
@@ -59,20 +59,20 @@ internal data class WalletUiState(
 
         val isSelectedItemValid = selectedItem?.isValid ?: false
 
-        // TODO: For testing only!
-        val details = response.paymentDetails.map { pd ->
-            if (pd is Card && pd.last4 == "4242") {
-                pd.copy(
-                    expiryMonth = 1,
-                    expiryYear = 2022
-                )
-            } else {
-                pd
-            }
-        }
+//        // TODO: For testing only!
+//        val details = response.paymentDetails.map { pd ->
+//            if (pd is Card && pd.last4 == "4242") {
+//                pd.copy(
+//                    expiryMonth = 1,
+//                    expiryYear = 2022
+//                )
+//            } else {
+//                pd
+//            }
+//        }
 
         return copy(
-            paymentDetailsList = details,
+            paymentDetailsList = response.paymentDetails,
             selectedItem = selectedItem,
             isExpanded = !isSelectedItemValid,
             isProcessing = false

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
@@ -17,7 +17,8 @@ internal data class WalletUiState(
     val hasCompleted: Boolean = false,
     val errorMessage: ErrorMessage? = null,
     val expiryDateInput: FormFieldEntry = FormFieldEntry(value = null),
-    val cvcInput: FormFieldEntry = FormFieldEntry(value = null)
+    val cvcInput: FormFieldEntry = FormFieldEntry(value = null),
+    val alertMessage: ErrorMessage? = null
 ) {
 
     val selectedCard: Card?
@@ -58,11 +59,42 @@ internal data class WalletUiState(
 
         val isSelectedItemValid = selectedItem?.isValid ?: false
 
+        // TODO: For testing only!
+        val details = response.paymentDetails.map { pd ->
+            if (pd is Card && pd.last4 == "4242") {
+                pd.copy(
+                    expiryMonth = 1,
+                    expiryYear = 2022
+                )
+            } else {
+                pd
+            }
+        }
+
         return copy(
-            paymentDetailsList = response.paymentDetails,
+            paymentDetailsList = details,
             selectedItem = selectedItem,
             isExpanded = !isSelectedItemValid,
             isProcessing = false
+        )
+    }
+
+    fun updatePaymentDetails(
+        updatedPaymentDetails: ConsumerPaymentDetails.PaymentDetails
+    ): WalletUiState {
+        return copy(
+            paymentDetailsList = paymentDetailsList.map { paymentDetails ->
+                if (paymentDetails.id == updatedPaymentDetails.id) {
+                    updatedPaymentDetails
+                } else {
+                    paymentDetails
+                }
+            },
+            selectedItem = if (selectedItem?.id == updatedPaymentDetails.id) {
+                updatedPaymentDetails
+            } else {
+                selectedItem
+            }
         )
     }
 

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -29,7 +29,6 @@ import com.stripe.android.ui.core.FieldValuesToParamsMapConverter
 import com.stripe.android.ui.core.address.toConfirmPaymentIntentShipping
 import com.stripe.android.ui.core.elements.CvcController
 import com.stripe.android.ui.core.elements.DateConfig
-import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.ui.core.elements.SimpleTextFieldController
 import com.stripe.android.ui.core.elements.createExpiryDateFormFieldValues
 import com.stripe.android.ui.core.injection.NonFallbackInjectable
@@ -39,7 +38,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Provider
@@ -139,15 +137,7 @@ internal class WalletViewModel @Inject constructor(
                         it.id == selectedPaymentDetails.id
                     }
 
-                    val state = _uiState.updateAndGet {
-                        it.updatePaymentDetails(updatedPaymentDetails)
-                    }
-
-                    if (state.primaryButtonState == PrimaryButtonState.Enabled) {
-                        // Retry with the updated payment details, but only if there's no issue
-                        // with the newly entered information
-                        performPaymentConfirmation(updatedPaymentDetails, linkAccount)
-                    }
+                    performPaymentConfirmation(updatedPaymentDetails, linkAccount)
                 },
                 onFailure = { error ->
                     _uiState.update {
@@ -363,10 +353,8 @@ internal class WalletViewModel @Inject constructor(
 
 private fun WalletUiState.toPaymentMethodCreateParams(): PaymentMethodCreateParams {
     val expiryDateValues = createExpiryDateFormFieldValues(expiryDateInput)
-    val fieldValuePairs = mapOf(IdentifierSpec.CardCvc to cvcInput) + expiryDateValues
-
     return FieldValuesToParamsMapConverter.transformToPaymentMethodCreateParams(
-        fieldValuePairs = fieldValuePairs,
+        fieldValuePairs = expiryDateValues,
         code = PaymentMethod.Type.Card.code,
         requiresMandate = false
     )

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -8,7 +8,6 @@ import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkActivityResult.Canceled.Reason.PayAnotherWay
 import com.stripe.android.link.LinkScreen
-import com.stripe.android.link.R
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.confirmation.ConfirmStripeIntentParamsFactory
 import com.stripe.android.link.confirmation.ConfirmationManager
@@ -173,12 +172,10 @@ internal class WalletViewModel @Inject constructor(
 
                 performPaymentConfirmation(updatedPaymentDetails, linkAccount)
             },
-            onFailure = {
+            onFailure = { error ->
                 _uiState.update {
                     it.copy(
-                        alertMessage = ErrorMessage.FromResources(
-                            stringResId = R.string.wallet_something_went_wrong_error
-                        ),
+                        alertMessage = error.getErrorMessage(),
                         isProcessing = false
                     )
                 }

--- a/link/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -470,41 +470,6 @@ class WalletViewModelTest {
     }
 
     @Test
-    fun `Updates UI state if updating expired card info succeeds`() = runTest {
-        val expiredCard = mockCard(isExpired = true)
-        val updatedCard = expiredCard.copy(
-            expiryMonth = 12,
-            expiryYear = 2030
-        )
-
-        val originalResponse = CONSUMER_PAYMENT_DETAILS.copy(
-            paymentDetails = listOf(expiredCard) + CONSUMER_PAYMENT_DETAILS.paymentDetails
-        )
-
-        val mockUpdateResponse = CONSUMER_PAYMENT_DETAILS.copy(
-            paymentDetails = listOf(updatedCard) + CONSUMER_PAYMENT_DETAILS.paymentDetails
-        )
-
-        whenever(linkAccountManager.listPaymentDetails())
-            .thenReturn(Result.success(originalResponse))
-
-        whenever(linkAccountManager.updatePaymentDetails(any()))
-            .thenReturn(Result.success(mockUpdateResponse))
-
-        val viewModel = createViewModel()
-
-        viewModel.onItemSelected(expiredCard)
-        viewModel.expiryDateController.onRawValueChange("1230")
-        viewModel.cvcController.onRawValueChange("123")
-
-        viewModel.onConfirmPayment()
-
-        assertThat(viewModel.uiState.value.alertMessage).isNull()
-        assertThat(viewModel.uiState.value.paymentDetailsList).isEqualTo(mockUpdateResponse.paymentDetails)
-        assertThat(viewModel.uiState.value.selectedItem).isEqualTo(updatedCard)
-    }
-
-    @Test
     fun `Resets expiry date and CVC controllers when new payment method is selected`() = runTest {
         val paymentDetails = CONSUMER_PAYMENT_DETAILS.paymentDetails[1]
         whenever(linkAccountManager.listPaymentDetails())

--- a/link/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.savedstate.SavedStateRegistry
 import androidx.savedstate.SavedStateRegistryOwner
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.R
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.injection.Injectable
@@ -11,7 +12,6 @@ import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkActivityResult.Canceled.Reason
 import com.stripe.android.link.LinkScreen
-import com.stripe.android.link.R
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.confirmation.ConfirmationManager
 import com.stripe.android.link.confirmation.PaymentConfirmationCallback
@@ -465,7 +465,7 @@ class WalletViewModelTest {
         viewModel.onConfirmPayment()
 
         assertThat(viewModel.uiState.value.alertMessage).isEqualTo(
-            ErrorMessage.FromResources(R.string.wallet_something_went_wrong_error)
+            ErrorMessage.FromResources(R.string.stripe_failure_connection_error)
         )
     }
 

--- a/link/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -5,18 +5,20 @@ import androidx.savedstate.SavedStateRegistry
 import androidx.savedstate.SavedStateRegistryOwner
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.Logger
+import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.injection.Injectable
 import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkActivityResult.Canceled.Reason
 import com.stripe.android.link.LinkScreen
+import com.stripe.android.link.R
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.confirmation.ConfirmationManager
 import com.stripe.android.link.confirmation.PaymentConfirmationCallback
 import com.stripe.android.link.injection.SignedInViewModelSubcomponent
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.model.Navigator
-import com.stripe.android.link.model.PaymentDetailsFixtures
+import com.stripe.android.link.model.PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS
 import com.stripe.android.link.model.StripeIntentFixtures
 import com.stripe.android.link.ui.ErrorMessage
 import com.stripe.android.link.ui.PrimaryButtonState
@@ -24,6 +26,7 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.model.ConsumerPaymentDetailsUpdateParams
 import com.stripe.android.model.CvcCheck
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.payments.paymentlauncher.PaymentResult
@@ -54,6 +57,7 @@ import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
+import java.util.Calendar
 import javax.inject.Provider
 
 @ExperimentalCoroutinesApi
@@ -123,7 +127,7 @@ class WalletViewModelTest {
         runTest {
             whenever(args.prefilledCardParams).thenReturn(mock())
             whenever(linkAccountManager.listPaymentDetails())
-                .thenReturn(Result.success(PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS))
+                .thenReturn(Result.success(CONSUMER_PAYMENT_DETAILS))
 
             createViewModel()
 
@@ -137,9 +141,9 @@ class WalletViewModelTest {
 
     @Test
     fun `onSelectedPaymentDetails starts payment confirmation`() = runTest {
-        val paymentDetails = PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS.paymentDetails.first()
+        val paymentDetails = CONSUMER_PAYMENT_DETAILS.paymentDetails.first()
         whenever(linkAccountManager.listPaymentDetails())
-            .thenReturn(Result.success(PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS))
+            .thenReturn(Result.success(CONSUMER_PAYMENT_DETAILS))
         whenever(args.shippingValues)
             .thenReturn(null)
 
@@ -165,7 +169,7 @@ class WalletViewModelTest {
     @Test
     fun `when shippingValues are passed ConfirmPaymentIntentParams has shipping`() = runTest {
         whenever(linkAccountManager.listPaymentDetails())
-            .thenReturn(Result.success(PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS))
+            .thenReturn(Result.success(CONSUMER_PAYMENT_DETAILS))
         whenever(args.shippingValues).thenReturn(
             mapOf(
                 IdentifierSpec.Name to "Test Name",
@@ -192,7 +196,7 @@ class WalletViewModelTest {
 
     @Test
     fun `onItemSelected updates selected item`() {
-        val paymentDetails = PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS.paymentDetails.first()
+        val paymentDetails = CONSUMER_PAYMENT_DETAILS.paymentDetails.first()
         val viewModel = createViewModel()
 
         viewModel.onItemSelected(paymentDetails)
@@ -203,7 +207,7 @@ class WalletViewModelTest {
     @Test
     fun `when selected item is removed then default item is selected`() = runTest {
         val deletedPaymentDetails =
-            PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS.paymentDetails[1]
+            CONSUMER_PAYMENT_DETAILS.paymentDetails[1]
         val viewModel = createViewModel()
         viewModel.onItemSelected(deletedPaymentDetails)
 
@@ -214,8 +218,8 @@ class WalletViewModelTest {
         whenever(linkAccountManager.listPaymentDetails())
             .thenReturn(
                 Result.success(
-                    PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS.copy(
-                        paymentDetails = PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS.paymentDetails
+                    CONSUMER_PAYMENT_DETAILS.copy(
+                        paymentDetails = CONSUMER_PAYMENT_DETAILS.paymentDetails
                             .filter { it != deletedPaymentDetails }
                     )
                 )
@@ -224,7 +228,7 @@ class WalletViewModelTest {
         viewModel.deletePaymentMethod(deletedPaymentDetails)
 
         assertThat(viewModel.uiState.value.selectedItem)
-            .isEqualTo(PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS.paymentDetails.first())
+            .isEqualTo(CONSUMER_PAYMENT_DETAILS.paymentDetails.first())
     }
 
     @Test
@@ -235,11 +239,11 @@ class WalletViewModelTest {
             )
         )
         whenever(linkAccountManager.listPaymentDetails())
-            .thenReturn(Result.success(PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS))
+            .thenReturn(Result.success(CONSUMER_PAYMENT_DETAILS))
 
         val viewModel = createViewModel()
 
-        val bankAccount = PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS.paymentDetails[2]
+        val bankAccount = CONSUMER_PAYMENT_DETAILS.paymentDetails[2]
         assertThat(viewModel.uiState.value.selectedItem).isEqualTo(bankAccount)
     }
 
@@ -248,7 +252,7 @@ class WalletViewModelTest {
         val errorThrown = "Error message"
         val viewModel = createViewModel()
 
-        viewModel.onItemSelected(PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS.paymentDetails.first())
+        viewModel.onItemSelected(CONSUMER_PAYMENT_DETAILS.paymentDetails.first())
         viewModel.onConfirmPayment()
 
         val callbackCaptor = argumentCaptor<PaymentConfirmationCallback>()
@@ -261,7 +265,7 @@ class WalletViewModelTest {
 
     @Test
     fun `deletePaymentMethod fetches payment details when successful`() = runTest {
-        val paymentDetails = PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS
+        val paymentDetails = CONSUMER_PAYMENT_DETAILS
         whenever(linkAccountManager.listPaymentDetails())
             .thenReturn(Result.success(paymentDetails))
 
@@ -286,7 +290,7 @@ class WalletViewModelTest {
     @Test
     fun `when payment method deletion fails then an error message is shown`() = runTest {
         whenever(linkAccountManager.listPaymentDetails())
-            .thenReturn(Result.success(PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS))
+            .thenReturn(Result.success(CONSUMER_PAYMENT_DETAILS))
 
         val errorThrown = "Error message"
         val viewModel = createViewModel()
@@ -294,7 +298,7 @@ class WalletViewModelTest {
         whenever(linkAccountManager.deletePaymentDetails(anyOrNull()))
             .thenReturn(Result.failure(RuntimeException(errorThrown)))
 
-        viewModel.deletePaymentMethod(PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS.paymentDetails.first())
+        viewModel.deletePaymentMethod(CONSUMER_PAYMENT_DETAILS.paymentDetails.first())
 
         assertThat(viewModel.uiState.value.errorMessage).isEqualTo(ErrorMessage.Raw(errorThrown))
     }
@@ -307,7 +311,7 @@ class WalletViewModelTest {
             }
         }
         whenever(linkAccountManager.listPaymentDetails())
-            .thenReturn(Result.success(PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS))
+            .thenReturn(Result.success(CONSUMER_PAYMENT_DETAILS))
 
         val viewModel = createViewModel()
         viewModel.onConfirmPayment()
@@ -340,7 +344,7 @@ class WalletViewModelTest {
 
     @Test
     fun `Update payment method navigates to CardEdit screen`() = runTest {
-        val paymentDetails = PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS
+        val paymentDetails = CONSUMER_PAYMENT_DETAILS
         whenever(linkAccountManager.listPaymentDetails())
             .thenReturn(Result.success(paymentDetails))
 
@@ -409,7 +413,7 @@ class WalletViewModelTest {
     @Test
     fun `Does not send CVC if paying with card that does not require CVC recollection`() = runTest {
         whenever(linkAccountManager.listPaymentDetails())
-            .thenReturn(Result.success(PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS))
+            .thenReturn(Result.success(CONSUMER_PAYMENT_DETAILS))
 
         val paymentDetails = mockCard(cvcCheck = CvcCheck.Pass)
         val viewModel = createViewModel()
@@ -428,10 +432,83 @@ class WalletViewModelTest {
     }
 
     @Test
-    fun `Resets expiry date and CVC controllers when new payment method is selected`() = runTest {
-        val paymentDetails = PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS.paymentDetails[1]
+    fun `Updates payment details when paying with expired card`() = runTest {
+        val expiredCard = mockCard(isExpired = true)
+        val viewModel = createViewModel()
+
+        viewModel.onItemSelected(expiredCard)
+        viewModel.expiryDateController.onRawValueChange("1230")
+        viewModel.cvcController.onRawValueChange("123")
+
+        viewModel.onConfirmPayment()
+
+        val paramsCaptor = argumentCaptor<ConsumerPaymentDetailsUpdateParams>()
+        verify(linkAccountManager).updatePaymentDetails(paramsCaptor.capture())
+
+        val paramsMap = paramsCaptor.firstValue.toParamMap()
+        assertThat(paramsMap["exp_month"]).isEqualTo("12")
+        assertThat(paramsMap["exp_year"]).isEqualTo("2030")
+    }
+
+    @Test
+    fun `Shows alert dialog if updating expired card info fails`() = runTest {
+        whenever(linkAccountManager.updatePaymentDetails(any()))
+            .thenReturn(Result.failure(APIConnectionException()))
+
+        val expiredCard = mockCard(isExpired = true)
+        val viewModel = createViewModel()
+
+        viewModel.onItemSelected(expiredCard)
+        viewModel.expiryDateController.onRawValueChange("1230")
+        viewModel.cvcController.onRawValueChange("123")
+
+        viewModel.onConfirmPayment()
+
+        assertThat(viewModel.uiState.value.alertMessage).isEqualTo(
+            ErrorMessage.FromResources(R.string.wallet_something_went_wrong_error)
+        )
+    }
+
+    @Test
+    fun `Updates UI state if updating expired card info succeeds`() = runTest {
+        val expiredCard = mockCard(isExpired = true)
+        val updatedCard = expiredCard.copy(
+            expiryMonth = 12,
+            expiryYear = 2030
+        )
+
+        val originalResponse = CONSUMER_PAYMENT_DETAILS.copy(
+            paymentDetails = listOf(expiredCard) + CONSUMER_PAYMENT_DETAILS.paymentDetails
+        )
+
+        val mockUpdateResponse = CONSUMER_PAYMENT_DETAILS.copy(
+            paymentDetails = listOf(updatedCard) + CONSUMER_PAYMENT_DETAILS.paymentDetails
+        )
+
         whenever(linkAccountManager.listPaymentDetails())
-            .thenReturn(Result.success(PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS))
+            .thenReturn(Result.success(originalResponse))
+
+        whenever(linkAccountManager.updatePaymentDetails(any()))
+            .thenReturn(Result.success(mockUpdateResponse))
+
+        val viewModel = createViewModel()
+
+        viewModel.onItemSelected(expiredCard)
+        viewModel.expiryDateController.onRawValueChange("1230")
+        viewModel.cvcController.onRawValueChange("123")
+
+        viewModel.onConfirmPayment()
+
+        assertThat(viewModel.uiState.value.alertMessage).isNull()
+        assertThat(viewModel.uiState.value.paymentDetailsList).isEqualTo(mockUpdateResponse.paymentDetails)
+        assertThat(viewModel.uiState.value.selectedItem).isEqualTo(updatedCard)
+    }
+
+    @Test
+    fun `Resets expiry date and CVC controllers when new payment method is selected`() = runTest {
+        val paymentDetails = CONSUMER_PAYMENT_DETAILS.paymentDetails[1]
+        whenever(linkAccountManager.listPaymentDetails())
+            .thenReturn(Result.success(CONSUMER_PAYMENT_DETAILS))
 
         val viewModel = createViewModel().apply {
             expiryDateController.onRawValueChange("1230")
@@ -447,9 +524,9 @@ class WalletViewModelTest {
 
     @Test
     fun `Expiry date and CVC values are kept when existing payment method is selected`() = runTest {
-        val paymentDetails = PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS.paymentDetails.first()
+        val paymentDetails = CONSUMER_PAYMENT_DETAILS.paymentDetails.first()
         whenever(linkAccountManager.listPaymentDetails())
-            .thenReturn(Result.success(PaymentDetailsFixtures.CONSUMER_PAYMENT_DETAILS))
+            .thenReturn(Result.success(CONSUMER_PAYMENT_DETAILS))
 
         val viewModel = createViewModel().apply {
             expiryDateController.onRawValueChange("1230")
@@ -506,11 +583,17 @@ class WalletViewModelTest {
             logger
         )
 
-    private fun mockCard(cvcCheck: CvcCheck): ConsumerPaymentDetails.Card {
+    private fun mockCard(
+        cvcCheck: CvcCheck = CvcCheck.Pass,
+        isExpired: Boolean = false
+    ): ConsumerPaymentDetails.Card {
+        val currentYear = Calendar.getInstance().get(Calendar.YEAR)
+        val expiryYear = if (isExpired) currentYear - 1 else currentYear + 1
+
         return ConsumerPaymentDetails.Card(
             id = "id_123",
             isDefault = true,
-            expiryYear = 2022,
+            expiryYear = expiryYear,
             expiryMonth = 12,
             brand = CardBrand.Visa,
             last4 = "4242",

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -277,6 +277,9 @@ public final class com/stripe/android/ui/core/elements/CardBillingSpec$Companion
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/stripe/android/ui/core/elements/CardDetailsElementKt {
+}
+
 public final class com/stripe/android/ui/core/elements/CardDetailsSectionElementUIKt {
 }
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.ui.core.elements
 
 import android.content.Context
+import androidx.annotation.RestrictTo
 import com.stripe.android.ui.core.forms.FormFieldEntry
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -45,26 +46,38 @@ internal class CardDetailsElement(
         controller.expirationDateElement.controller.formFieldValue,
         controller.numberElement.controller.cardBrandFlow
     ) { number, cvc, expirationDate, brand ->
-        var month = -1
-        var year = -1
-        expirationDate.value?.let { date ->
-            val newString = convertTo4DigitDate(date)
-            if (newString.length == 4) {
-                month = requireNotNull(newString.take(2).toIntOrNull())
-                year = requireNotNull(newString.takeLast(2).toIntOrNull()) + 2000
-            }
-        }
-
         listOf(
             controller.numberElement.identifier to number,
             controller.cvcElement.identifier to cvc,
-            IdentifierSpec.CardBrand to FormFieldEntry(brand.code, true),
-            IdentifierSpec.CardExpMonth to expirationDate.copy(
-                value = month.toString().padStart(length = 2, padChar = '0')
-            ),
-            IdentifierSpec.CardExpYear to expirationDate.copy(
-                value = year.toString()
-            )
-        )
+            IdentifierSpec.CardBrand to FormFieldEntry(brand.code, true)
+        ) + createExpiryDateFormFieldValues(expirationDate).toList()
     }
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun createExpiryDateFormFieldValues(
+    entry: FormFieldEntry
+): Map<IdentifierSpec, FormFieldEntry> {
+    var month = -1
+    var year = -1
+    entry.value?.let { date ->
+        val newString = convertTo4DigitDate(date)
+        if (newString.length == 4) {
+            month = requireNotNull(newString.take(2).toIntOrNull())
+            year = requireNotNull(newString.takeLast(2).toIntOrNull()) + 2000
+        }
+    }
+
+    val monthEntry = entry.copy(
+        value = month.toString().padStart(length = 2, padChar = '0')
+    )
+
+    val yearEntry = entry.copy(
+        value = year.toString()
+    )
+
+    return mapOf(
+        IdentifierSpec.CardExpMonth to monthEntry,
+        IdentifierSpec.CardExpYear to yearEntry
+    )
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds the ability to update the card expiry date (and CVC) in the Link wallet.

_Note_: Right now, we can end up with two error banners on this screen (see third screen recording). We’ll tweak this behavior in a follow-up pull request.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screen recordings

<details>
  <summary>A successful card info update and payment</summary>
  
  We keep the form on screen until the payment is done.

  <video src="https://user-images.githubusercontent.com/110940675/189212701-a5323379-9d7a-46c4-bf02-d06cd0996458.mp4" />
  ```
</details>

<details>
  <summary>A failed card info update</summary>

  We show an alert, just like we do on iOS.

  <video src="https://user-images.githubusercontent.com/110940675/189212737-208f851a-0530-4612-b47f-d10c9bcae7cd.mp4" />
  ```
</details>

<details>
  <summary>A successful card info update, but failed payment</summary>

  We keep the form on screen, so that the user can update their CVC if necessary. Right now, this means showing two errors banners. I’ll be working with design to see how we can improve this.

  <video src="https://user-images.githubusercontent.com/110940675/189212773-4051200e-5e25-49e2-b0ae-320535db384c.mp4" />
  ```
</details>

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

_Nothing to add._
