### PR TITLE
Use RowElement for Link card details recollection form

### DIFF
--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -64,13 +63,17 @@ import com.stripe.android.ui.core.elements.CvcElement
 import com.stripe.android.ui.core.elements.DateConfig
 import com.stripe.android.ui.core.elements.Html
 import com.stripe.android.ui.core.elements.IdentifierSpec
+import com.stripe.android.ui.core.elements.RowController
+import com.stripe.android.ui.core.elements.RowElement
 import com.stripe.android.ui.core.elements.SectionElement
 import com.stripe.android.ui.core.elements.SectionElementUI
+import com.stripe.android.ui.core.elements.SectionSingleFieldElement
 import com.stripe.android.ui.core.elements.SimpleTextElement
 import com.stripe.android.ui.core.elements.SimpleTextFieldController
 import com.stripe.android.ui.core.elements.TextFieldController
 import com.stripe.android.ui.core.injection.NonFallbackInjector
 import kotlinx.coroutines.flow.flowOf
+import java.util.UUID
 
 @Preview
 @Composable
@@ -325,10 +328,25 @@ internal fun CardDetailsRecollectionForm(
     isCardExpired: Boolean,
     modifier: Modifier = Modifier
 ) {
-    val cvcElement = remember(cvcController) {
-        CvcElement(
-            _identifier = IdentifierSpec.CardCvc,
-            controller = cvcController
+    val rowElement = remember(expiryDateController, cvcController) {
+        val rowFields: List<SectionSingleFieldElement> = buildList {
+            if (isCardExpired) {
+                this += SimpleTextElement(
+                    identifier = IdentifierSpec.Generic("date"),
+                    controller = expiryDateController
+                )
+            }
+
+            this += CvcElement(
+                _identifier = IdentifierSpec.CardCvc,
+                controller = cvcController
+            )
+        }
+
+        RowElement(
+            _identifier = IdentifierSpec.Generic("row_" + UUID.randomUUID().leastSignificantBits),
+            fields = rowFields,
+            controller = RowController(rowFields)
         )
     }
 
@@ -347,34 +365,12 @@ internal fun CardDetailsRecollectionForm(
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-                if (isCardExpired) {
-                    val expiryDateElement = remember(expiryDateController) {
-                        SimpleTextElement(
-                            identifier = IdentifierSpec.Generic("date"),
-                            controller = expiryDateController
-                        )
-                    }
-
-                    Box(modifier = Modifier.weight(0.5f)) {
-                        SectionElementUI(
-                            enabled = true,
-                            element = SectionElement.wrap(expiryDateElement),
-                            hiddenIdentifiers = emptyList(),
-                            lastTextFieldIdentifier = cvcElement.identifier
-                        )
-                    }
-                }
-
-                Box(modifier = Modifier.weight(0.5f)) {
-                    SectionElementUI(
-                        enabled = true,
-                        element = SectionElement.wrap(cvcElement),
-                        hiddenIdentifiers = emptyList(),
-                        lastTextFieldIdentifier = cvcElement.identifier
-                    )
-                }
-            }
+            SectionElementUI(
+                enabled = true,
+                element = SectionElement.wrap(rowElement),
+                hiddenIdentifiers = emptyList(),
+                lastTextFieldIdentifier = rowElement.fields.last().identifier
+            )
         }
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request polishes the UX for the Link card details recollection form. Instead of using a `Row` with two individual `SectionElement`s, we now use a container `RowElement`. This is required for the `FocusRequester` to move the focus correctly between the expiry date and CVC fields.

It does result in a small UI change (we now have to use a divider between the fields instead of just plain spacing), but it brings the behavior more in line with the forms in the payment method screen and in the payment sheet.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before | After |
| ------------- | ------------- |
| ![Screenshot_20220908_162607](https://user-images.githubusercontent.com/110940675/189219118-3e78fa24-a4a3-4f3f-af69-843c0166d0a3.png) | ![Screenshot_20220908_162358](https://user-images.githubusercontent.com/110940675/189218766-79cc7acf-1efd-4e8f-a40e-abbbfe1e5115.png) |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

_Nothing to add._
