### PR TITLE
[BANKCON-5123] Cancel AuthSession when Partner Auth closes without finishing

### DIFF
--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -366,12 +366,20 @@ public final class com/stripe/android/financialconnections/domain/AcceptConsent_
 	public static fun newInstance (Lcom/stripe/android/financialconnections/repository/FinancialConnectionsManifestRepository;Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$Configuration;)Lcom/stripe/android/financialconnections/domain/AcceptConsent;
 }
 
+public final class com/stripe/android/financialconnections/domain/CancelAuthorizationSession_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/domain/CancelAuthorizationSession_Factory;
+	public fun get ()Lcom/stripe/android/financialconnections/domain/CancelAuthorizationSession;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Lcom/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator;Lcom/stripe/android/financialconnections/repository/FinancialConnectionsManifestRepository;Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$Configuration;)Lcom/stripe/android/financialconnections/domain/CancelAuthorizationSession;
+}
+
 public final class com/stripe/android/financialconnections/domain/CompleteAuthorizationSession_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/domain/CompleteAuthorizationSession_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/domain/CompleteAuthorizationSession_Factory;
 	public fun get ()Lcom/stripe/android/financialconnections/domain/CompleteAuthorizationSession;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/financialconnections/repository/FinancialConnectionsManifestRepository;Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$Configuration;)Lcom/stripe/android/financialconnections/domain/CompleteAuthorizationSession;
+	public static fun newInstance (Lcom/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator;Lcom/stripe/android/financialconnections/repository/FinancialConnectionsManifestRepository;Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$Configuration;)Lcom/stripe/android/financialconnections/domain/CompleteAuthorizationSession;
 }
 
 public final class com/stripe/android/financialconnections/domain/CompleteFinancialConnectionsSession_Factory : dagger/internal/Factory {
@@ -622,11 +630,11 @@ public final class com/stripe/android/financialconnections/features/partnerauth/
 }
 
 public final class com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel_Factory;
 	public fun get ()Lcom/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/financialconnections/domain/CompleteAuthorizationSession;Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$Configuration;Lcom/stripe/android/financialconnections/domain/GetManifest;Lcom/stripe/android/financialconnections/domain/GoNext;Lcom/stripe/android/financialconnections/repository/FinancialConnectionsRepository;Lcom/stripe/android/financialconnections/domain/PollAuthorizationSessionOAuthResults;Lcom/stripe/android/core/Logger;Lcom/stripe/android/financialconnections/features/partnerauth/PartnerAuthState;)Lcom/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel;
+	public static fun newInstance (Lcom/stripe/android/financialconnections/domain/CompleteAuthorizationSession;Lcom/stripe/android/financialconnections/domain/PostAuthorizationSession;Lcom/stripe/android/financialconnections/domain/CancelAuthorizationSession;Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$Configuration;Lcom/stripe/android/financialconnections/domain/GetManifest;Lcom/stripe/android/financialconnections/domain/GoNext;Lcom/stripe/android/financialconnections/domain/PollAuthorizationSessionOAuthResults;Lcom/stripe/android/core/Logger;Lcom/stripe/android/financialconnections/features/partnerauth/PartnerAuthState;)Lcom/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel;
 }
 
 public final class com/stripe/android/financialconnections/features/reset/ComposableSingletons$ResetScreenKt {
@@ -1560,11 +1568,11 @@ public final class com/stripe/android/financialconnections/network/FinancialConn
 }
 
 public final class com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel_Factory;
 	public fun get ()Lcom/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeComponent;Lcom/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator;Lcom/stripe/android/financialconnections/domain/GetManifest;Lcom/stripe/android/financialconnections/utils/UriComparator;Lcom/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeState;)Lcom/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel;
+	public static fun newInstance (Lcom/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeComponent;Lcom/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator;Lcom/stripe/android/financialconnections/domain/GetManifest;Lcom/stripe/android/financialconnections/utils/UriComparator;Lcom/stripe/android/core/Logger;Lcom/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeState;)Lcom/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel;
 }
 
 public final class com/stripe/android/financialconnections/repository/FinancialConnectionsRepositoryImpl_Factory : dagger/internal/Factory {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/CancelAuthorizationSession.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/CancelAuthorizationSession.kt
@@ -6,7 +6,7 @@ import com.stripe.android.financialconnections.model.FinancialConnectionsSession
 import com.stripe.android.financialconnections.repository.FinancialConnectionsManifestRepository
 import javax.inject.Inject
 
-internal class CompleteAuthorizationSession @Inject constructor(
+internal class CancelAuthorizationSession @Inject constructor(
     private val coordinator: NativeAuthFlowCoordinator,
     private val repository: FinancialConnectionsManifestRepository,
     private val configuration: FinancialConnectionsSheet.Configuration
@@ -14,12 +14,10 @@ internal class CompleteAuthorizationSession @Inject constructor(
 
     suspend operator fun invoke(
         authorizationSessionId: String,
-        publicToken: String?
     ): FinancialConnectionsSessionManifest.FinancialConnectionsAuthorizationSession {
-        return repository.completeAuthorizationSession(
+        return repository.cancelAuthorizationSession(
             clientSecret = configuration.financialConnectionsSessionClientSecret,
             sessionId = authorizationSessionId,
-            publicToken = publicToken
         ).also { coordinator().emit(Message.ClearPartnerWebAuth) }
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator.kt
@@ -20,7 +20,14 @@ internal class NativeAuthFlowCoordinator @Inject constructor() {
     }
 
     internal sealed interface Message {
-        object OpenWebAuthFlow : Message
+        /**
+         * Opens partner auth in a web browser instance.
+         */
+        object OpenPartnerWebAuth : Message
+        /**
+         * Ensures partner web auth status gets cleared after the current session is finished.
+         */
+        object ClearPartnerWebAuth : Message
         object Finish : Message
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ErrorContent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ErrorContent.kt
@@ -38,6 +38,19 @@ internal fun UnclassifiedErrorContent() {
 }
 
 @Composable
+internal fun InstitutionUnknownErrorContent(
+    onSelectAnotherBank: () -> Unit
+) {
+    ErrorContent(
+        iconPainter = painterResource(id = R.drawable.stripe_ic_brandicon_institution),
+        title = stringResource(R.string.stripe_error_generic_title),
+        content = stringResource(R.string.stripe_error_unplanned_downtime_desc),
+        ctaText = stringResource(R.string.stripe_error_cta_select_another_bank),
+        onCtaClick = onSelectAnotherBank
+    )
+}
+
+@Composable
 internal fun InstitutionUnplannedDowntimeErrorContent(
     exception: InstitutionUnplannedException,
     onSelectAnotherBank: () -> Unit

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthScreen.kt
@@ -29,9 +29,9 @@ import com.airbnb.mvrx.compose.collectAsState
 import com.airbnb.mvrx.compose.mavericksActivityViewModel
 import com.airbnb.mvrx.compose.mavericksViewModel
 import com.stripe.android.financialconnections.R
+import com.stripe.android.financialconnections.features.common.InstitutionUnknownErrorContent
 import com.stripe.android.financialconnections.features.common.LoadingContent
 import com.stripe.android.financialconnections.features.common.PartnerCallout
-import com.stripe.android.financialconnections.features.common.UnclassifiedErrorContent
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.FinancialConnectionsAuthorizationSession.Flow
 import com.stripe.android.financialconnections.presentation.FinancialConnectionsSheetNativeViewModel
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsButton
@@ -55,13 +55,18 @@ internal fun PartnerAuthScreen() {
     LaunchedEffect(webAuthFlow.value) {
         viewModel.onWebAuthFlowFinished(webAuthFlow.value)
     }
-    PartnerAuthScreenContent(state.value, viewModel::onLaunchAuthClick)
+    PartnerAuthScreenContent(
+        state.value,
+        viewModel::onLaunchAuthClick,
+        viewModel::onSelectAnotherBank
+    )
 }
 
 @Composable
 private fun PartnerAuthScreenContent(
     state: PartnerAuthState,
-    onContinueClick: () -> Unit
+    onContinueClick: () -> Unit,
+    onSelectAnotherBank: () -> Unit,
 ) {
     FinancialConnectionsScaffold {
         when (state.authenticationStatus) {
@@ -77,7 +82,7 @@ private fun PartnerAuthScreenContent(
             )
             is Fail -> {
                 // TODO@carlosmuvi translate error type to specific error screen.
-                UnclassifiedErrorContent()
+                InstitutionUnknownErrorContent(onSelectAnotherBank)
             }
         }
     }
@@ -147,7 +152,8 @@ internal fun PrepaneContentPreview() {
                 authenticationStatus = Uninitialized,
                 flow = Flow.FINICITY_CONNECT_V2_OAUTH
             ),
-            onContinueClick = {}
+            onContinueClick = {},
+            onSelectAnotherBank = {}
         )
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
@@ -11,16 +11,15 @@ import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.ViewModelContext
 import com.stripe.android.core.Logger
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
+import com.stripe.android.financialconnections.domain.CancelAuthorizationSession
 import com.stripe.android.financialconnections.domain.CompleteAuthorizationSession
 import com.stripe.android.financialconnections.domain.GetManifest
 import com.stripe.android.financialconnections.domain.GoNext
 import com.stripe.android.financialconnections.domain.PollAuthorizationSessionOAuthResults
 import com.stripe.android.financialconnections.exception.WebAuthFlowCancelledException
-import com.stripe.android.financialconnections.exception.WebAuthFlowFailedException
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.FinancialConnectionsAuthorizationSession
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.FinancialConnectionsAuthorizationSession.Flow
 import com.stripe.android.financialconnections.model.MixedOAuthParams
-import com.stripe.android.financialconnections.repository.FinancialConnectionsRepository
 import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -28,10 +27,10 @@ import javax.inject.Inject
 @Suppress("LongParameterList")
 internal class PartnerAuthViewModel @Inject constructor(
     val completeAuthorizationSession: CompleteAuthorizationSession,
+    val cancelAuthorizationSession: CancelAuthorizationSession,
     val configuration: FinancialConnectionsSheet.Configuration,
     val getManifest: GetManifest,
     val goNext: GoNext,
-    val repository: FinancialConnectionsRepository,
     val pollAuthorizationSessionOAuthResults: PollAuthorizationSessionOAuthResults,
     val logger: Logger,
     initialState: PartnerAuthState
@@ -58,9 +57,17 @@ internal class PartnerAuthViewModel @Inject constructor(
         }
     }
 
+    fun onSelectAnotherBank() {
+        viewModelScope.launch {
+            val authSession = getManifest().activeAuthSession!!
+            goNext(authSession.nextPane)
+        }
+    }
+
     fun onWebAuthFlowFinished(
         webStatus: Async<String>
     ) {
+        logger.debug("Web AuthFlow status received $webStatus")
         viewModelScope.launch {
             val authSession = getManifest().activeAuthSession!!
             when (webStatus) {
@@ -76,17 +83,41 @@ internal class PartnerAuthViewModel @Inject constructor(
                     )
                 }
                 is Fail -> {
-                    setState { copy(authenticationStatus = webStatus) }
                     when (val error = webStatus.error) {
-                        is WebAuthFlowCancelledException ->
-                            logger.debug("Web flow was cancelled")
-                        is WebAuthFlowFailedException ->
-                            logger.debug("Web flow failed! received url: ${error.url}")
-                        else ->
-                            logger.error("error finishing web flow", error)
+                        is WebAuthFlowCancelledException -> onAuthCancelled(authSession)
+                        else -> onAuthFailed(error, authSession)
                     }
                 }
             }
+        }
+    }
+
+    private suspend fun onAuthFailed(
+        error: Throwable,
+        authSession: FinancialConnectionsAuthorizationSession
+    ) {
+        kotlin.runCatching {
+            logger.error("Auth failed, cancelling AuthSession", error)
+            cancelAuthorizationSession(authSession.id)
+            setState { copy(authenticationStatus = Fail(error)) }
+        }.onFailure {
+            logger.error("failed cancelling session after failed web flow", it)
+        }
+    }
+
+    private suspend fun onAuthCancelled(
+        authSession: FinancialConnectionsAuthorizationSession
+    ) {
+        setState { copy(authenticationStatus = Loading()) }
+        kotlin.runCatching {
+            logger.debug("Auth cancelled, cancelling AuthSession")
+            val updatedSession = cancelAuthorizationSession(
+                authorizationSessionId = authSession.id,
+            )
+            goNext(updatedSession.nextPane)
+        }.onFailure {
+            logger.error("failed cancelling session after cancelled web flow", it)
+            setState { copy(authenticationStatus = Fail(it)) }
         }
     }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
@@ -17,6 +17,7 @@ import com.stripe.android.financialconnections.di.FinancialConnectionsSheetNativ
 import com.stripe.android.financialconnections.domain.GetManifest
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message
+import com.stripe.android.financialconnections.exception.WebAuthFlowCancelledException
 import com.stripe.android.financialconnections.exception.WebAuthFlowFailedException
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetNativeActivityArgs
 import com.stripe.android.financialconnections.presentation.FinancialConnectionsSheetNativeViewEffect.Finish
@@ -95,8 +96,7 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
     fun onResume() {
         setState {
             if (webAuthFlow is Loading) {
-                // copy(webAuthFlow = Fail(WebAuthFlowCancelledException()))
-                copy(webAuthFlow = Fail(WebAuthFlowFailedException(null)))
+                copy(webAuthFlow = Fail(WebAuthFlowCancelledException()))
             } else this
         }
     }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/FakeFinancialConnectionsManifestRepository.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/networking/FakeFinancialConnectionsManifestRepository.kt
@@ -16,6 +16,8 @@ internal class FakeFinancialConnectionsManifestRepository : FinancialConnections
         { ApiKeyFixtures.sessionManifest() }
     var postAuthorizationSessionProvider: () -> FinancialConnectionsAuthorizationSession =
         { ApiKeyFixtures.authorizationSession() }
+    var cancelAuthorizationSessionProvider: () -> FinancialConnectionsAuthorizationSession =
+        { ApiKeyFixtures.authorizationSession() }
     var postMarkLinkingMoreAccountsProvider: () -> FinancialConnectionsSessionManifest =
         { ApiKeyFixtures.sessionManifest() }
 
@@ -47,4 +49,9 @@ internal class FakeFinancialConnectionsManifestRepository : FinancialConnections
     override suspend fun postMarkLinkingMoreAccounts(
         clientSecret: String
     ): FinancialConnectionsSessionManifest = postMarkLinkingMoreAccountsProvider()
+
+    override suspend fun cancelAuthorizationSession(
+        clientSecret: String,
+        sessionId: String
+    ): FinancialConnectionsAuthorizationSession = cancelAuthorizationSessionProvider()
 }


### PR DESCRIPTION
# Summary
- call `auth_sessions/cancel` on the PartnerAuthPane:
  - when user closes the Partner AuthFlow web browser instance (and allows to select another bank)
  - when any error happens while in the Partner AuthFlow returning from the web browser instance (and redirects to resulting `AuthSession#NextPane`)