### PR TITLE
Clear OTP when verification failed

### DIFF
--- a/link/src/androidTest/java/com/stripe/android/link/ui/verification/VerificationScreenTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/verification/VerificationScreenTest.kt
@@ -5,6 +5,8 @@ import android.view.KeyEvent.KEYCODE_DEL
 import androidx.activity.ComponentActivity
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.runtime.remember
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.input.key.KeyEvent
 import androidx.compose.ui.input.key.NativeKeyEvent
 import androidx.compose.ui.test.assertIsFocused
@@ -197,6 +199,7 @@ internal class VerificationScreenTest {
                 otpElement = otpElement,
                 isProcessing = isProcessing,
                 errorMessage = errorMessage,
+                focusRequester = remember { FocusRequester() },
                 onBack = onBack,
                 onChangeEmailClick = onChangeEmailClick,
                 onResendCodeClick = onResendCodeClick

--- a/link/src/main/java/com/stripe/android/link/ui/cardedit/CardEditScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/cardedit/CardEditScreen.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.link.ui.cardedit
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ColumnScope
@@ -172,9 +173,9 @@ internal fun CardEditBody(
                 )
             }
         }
-        errorMessage?.let {
+        AnimatedVisibility(visible = errorMessage != null) {
             ErrorText(
-                text = it.getMessage(LocalContext.current.resources),
+                text = errorMessage?.getMessage(LocalContext.current.resources).orEmpty(),
                 modifier = Modifier.fillMaxWidth()
             )
         }

--- a/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignupView.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignupView.kt
@@ -207,7 +207,8 @@ internal fun LinkInlineSignup(
                                 errorMessage != null
                         ) {
                             ErrorText(
-                                text = errorMessage!!.getMessage(LocalContext.current.resources),
+                                text = errorMessage?.getMessage(LocalContext.current.resources)
+                                    .orEmpty(),
                                 modifier = Modifier.fillMaxWidth()
                             )
                         }
@@ -238,7 +239,8 @@ internal fun LinkInlineSignup(
 
                                 AnimatedVisibility(visible = errorMessage != null) {
                                     ErrorText(
-                                        text = errorMessage!!.getMessage(LocalContext.current.resources),
+                                        text = errorMessage?.getMessage(LocalContext.current.resources)
+                                            .orEmpty(),
                                         modifier = Modifier.fillMaxWidth()
                                     )
                                 }

--- a/link/src/main/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodBody.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodBody.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.link.ui.paymentmethod
 
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -197,9 +198,9 @@ internal fun PaymentMethodBody(
             }
             Spacer(modifier = Modifier.height(8.dp))
         }
-        errorMessage?.let {
+        AnimatedVisibility(visible = errorMessage != null) {
             ErrorText(
-                text = it.getMessage(LocalContext.current.resources),
+                text = errorMessage?.getMessage(LocalContext.current.resources).orEmpty(),
                 modifier = Modifier.fillMaxWidth()
             )
         }

--- a/link/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
@@ -138,7 +138,7 @@ internal fun SignUpBody(
                 errorMessage != null
         ) {
             ErrorText(
-                text = errorMessage!!.getMessage(LocalContext.current.resources),
+                text = errorMessage?.getMessage(LocalContext.current.resources).orEmpty(),
                 modifier = Modifier.fillMaxWidth()
             )
         }
@@ -173,7 +173,7 @@ internal fun SignUpBody(
                 }
                 AnimatedVisibility(visible = errorMessage != null) {
                     ErrorText(
-                        text = errorMessage!!.getMessage(LocalContext.current.resources),
+                        text = errorMessage?.getMessage(LocalContext.current.resources).orEmpty(),
                         modifier = Modifier.fillMaxWidth()
                     )
                 }

--- a/link/src/main/java/com/stripe/android/link/ui/verification/VerificationScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/verification/VerificationScreen.kt
@@ -125,6 +125,7 @@ internal fun VerificationBody(
         if (requestFocus) {
             focusRequester.requestFocus()
             keyboardController?.show()
+            viewModel.onFocusRequested()
         }
     }
 

--- a/link/src/main/java/com/stripe/android/link/ui/verification/VerificationViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/verification/VerificationViewModel.kt
@@ -16,6 +16,7 @@ import com.stripe.android.link.ui.getErrorMessage
 import com.stripe.android.ui.core.elements.OTPSpec
 import com.stripe.android.ui.core.injection.NonFallbackInjectable
 import com.stripe.android.ui.core.injection.NonFallbackInjector
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -40,6 +41,9 @@ internal class VerificationViewModel @Inject constructor(
 
     private val _errorMessage = MutableStateFlow<ErrorMessage?>(null)
     val errorMessage: StateFlow<ErrorMessage?> = _errorMessage
+
+    private val _requestFocus = MutableStateFlow(true)
+    val requestFocus: StateFlow<Boolean> = _requestFocus
 
     /**
      * Callback when user has successfully verified their account. If not overridden, defaults to
@@ -86,8 +90,17 @@ internal class VerificationViewModel @Inject constructor(
                     onVerificationCompleted()
                 },
                 onFailure = {
+                    _requestFocus.value = false
                     onError(it)
                     linkEventsReporter.on2FAFailure()
+                    viewModelScope.launch {
+                        delay(50)
+                        for (i in 0 until otpElement.controller.otpLength) {
+                            delay(10)
+                            otpElement.controller.onValueChanged(i, "")
+                        }
+                        _requestFocus.value = true
+                    }
                 }
             )
         }

--- a/link/src/main/java/com/stripe/android/link/ui/verification/VerificationViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/verification/VerificationViewModel.kt
@@ -90,7 +90,6 @@ internal class VerificationViewModel @Inject constructor(
                     onVerificationCompleted()
                 },
                 onFailure = {
-                    _requestFocus.value = false
                     onError(it)
                     linkEventsReporter.on2FAFailure()
                     viewModelScope.launch {
@@ -130,6 +129,10 @@ internal class VerificationViewModel @Inject constructor(
         clearError()
         navigator.navigateTo(LinkScreen.SignUp(), clearBackStack = true)
         linkAccountManager.logout()
+    }
+
+    fun onFocusRequested() {
+        _requestFocus.value = false
     }
 
     private fun clearError() {

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.link.ui.wallet
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -284,9 +285,9 @@ internal fun WalletBody(
             )
         }
 
-        uiState.errorMessage?.let {
+        AnimatedVisibility(visible = uiState.errorMessage != null) {
             ErrorText(
-                text = it.getMessage(LocalContext.current.resources),
+                text = uiState.errorMessage?.getMessage(LocalContext.current.resources).orEmpty(),
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(top = 16.dp)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPElementUI.kt
@@ -20,7 +20,6 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -38,7 +37,6 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.TextRange

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPElementUI.kt
@@ -59,11 +59,10 @@ fun OTPElementUI(
     colors: OTPElementColors = OTPElementColors(
         selectedBorder = MaterialTheme.colors.primary,
         placeholder = MaterialTheme.paymentsColors.placeholderText
-    )
+    ),
+    focusRequester: FocusRequester = remember { FocusRequester() }
 ) {
     val focusManager = LocalFocusManager.current
-    val focusRequester = remember { FocusRequester() }
-    val keyboardController = LocalSoftwareKeyboardController.current
 
     Row(
         modifier = modifier.fillMaxWidth(),
@@ -195,11 +194,6 @@ fun OTPElementUI(
                     }
                 )
             }
-        }
-
-        LaunchedEffect(Unit) {
-            focusRequester.requestFocus()
-            keyboardController?.show()
         }
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
- Clear OTP fields when verification failed.
- Animate showing/hiding error message. Still can't unwrap it inside the animation block because it's called after `errorMessage` turns null.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
UI Fixes.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

https://user-images.githubusercontent.com/77990083/189454141-7240b10e-446c-4063-9cb7-038faafec66e.mp4


