### PR TITLE
Fix issue with custom flow PaymentSheet getting clipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   match new brand guidelines.
 * [FIXED][5480](https://github.com/stripe/stripe-android/pull/5480) `FlowController` now correctly
   preserves the previously selected payment method for guests.
+* [FIXED][5545](https://github.com/stripe/stripe-android/pull/5545) Fix an issue where custom flow 
+  PaymentSheet UI would have the bottom of the form cut off
 
 ## 20.11.0 - 2022-08-29
 This release adds postal code validation for PaymentSheet and fixed a fileprovider naming bug for Identity.

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestFieldPopulation.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestFieldPopulation.kt
@@ -6,8 +6,11 @@ import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.Automatic
 import com.stripe.android.test.core.Billing
+import com.stripe.android.test.core.Browser
 import com.stripe.android.test.core.Currency
 import com.stripe.android.test.core.Customer
 import com.stripe.android.test.core.DelayedPMs
@@ -90,6 +93,24 @@ class TestFieldPopulation {
         authorizationAction = null
     )
 
+    private val bancontact = TestParameters(
+        lpmRepository.fromCode("bancontact")!!,
+        Customer.New,
+        LinkState.Off,
+        GooglePayState.Off,
+        Currency.EUR,
+        IntentType.Pay,
+        Billing.Off,
+        shipping = Shipping.Off,
+        delayed = DelayedPMs.Off,
+        automatic = Automatic.Off,
+        saveCheckboxValue = false,
+        saveForFutureUseCheckboxVisible = false,
+        useBrowser = Browser.Chrome,
+        authorizationAction = AuthorizeAction.Authorize,
+        merchantCountryCode = "GB"
+    )
+
     @Ignore("Testing of dropdowns is not yet supported")
     fun testDropdowns() {
 
@@ -137,6 +158,18 @@ class TestFieldPopulation {
         ) {
             composeTestRule.onNodeWithText("IBAN")
                 .performTextInput("DE89370400440532013000")
+        }
+    }
+
+    @Test
+    fun testSinglePaymentMethodWithoutGooglePayAndKeyboardInput() {
+        testDriver.confirmNewOrGuestComplete(
+            bancontact.copy(
+                supportedPaymentMethods = listOf(PaymentMethod.Type.Bancontact.code)
+            )
+        ) {
+            composeTestRule.onNodeWithText("Full name")
+                .performTextInput("Jenny Rosen")
         }
     }
 

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -120,7 +120,9 @@ class PlaygroundTestDriver(
         setup(testParameters)
         launchComplete()
 
-        selectors.paymentSelection.click()
+        if (testParameters.supportedPaymentMethods.size > 1) {
+            selectors.paymentSelection.click()
+        }
 
         // This takes a screenshot so that translation strings of placeholders
         // and labels and design can all be verified
@@ -404,6 +406,10 @@ class PlaygroundTestDriver(
         intent.putExtra(
             PaymentSheetPlaygroundActivity.USE_SNAPSHOT_RETURNING_CUSTOMER_EXTRA,
             testParameters.snapshotReturningCustomer
+        )
+        intent.putExtra(
+            PaymentSheetPlaygroundActivity.SUPPORTED_PAYMENT_METHODS_EXTRA,
+            testParameters.supportedPaymentMethods.toTypedArray()
         )
         val scenario = ActivityScenario.launch<PaymentSheetPlaygroundActivity>(intent)
         scenario.onActivity { activity ->

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/TestParameters.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/TestParameters.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.test.core
 
+import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.ui.core.forms.resources.LpmRepository.SupportedPaymentMethod
 
@@ -25,7 +26,8 @@ data class TestParameters(
     val forceDarkMode: Boolean? = null,
     val appearance: PaymentSheet.Appearance = PaymentSheet.Appearance(),
     val snapshotReturningCustomer: Boolean = false,
-    val merchantCountryCode: String
+    val merchantCountryCode: String,
+    val supportedPaymentMethods: List<PaymentMethodCode> = listOf()
 )
 
 /**

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
@@ -186,7 +186,8 @@ class PaymentSheetPlaygroundActivity : AppCompatActivity() {
                     linkEnabled,
                     setShippingAddress,
                     setAutomaticPaymentMethods,
-                    backendUrl
+                    backendUrl,
+                    intent.extras?.getStringArray(SUPPORTED_PAYMENT_METHODS_EXTRA)?.toList()
                 )
             }
         }
@@ -470,6 +471,7 @@ class PaymentSheetPlaygroundActivity : AppCompatActivity() {
         const val FORCE_DARK_MODE_EXTRA = "ForceDark"
         const val APPEARANCE_EXTRA = "Appearance"
         const val USE_SNAPSHOT_RETURNING_CUSTOMER_EXTRA = "UseSnapshotReturningCustomer"
+        const val SUPPORTED_PAYMENT_METHODS_EXTRA = "SupportedPaymentMethods"
         private const val merchantName = "Example, Inc."
         private const val sharedPreferencesName = "playgroundToggles"
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
@@ -60,7 +60,8 @@ data class CheckoutRequest(
     val set_shipping_address: Boolean,
     val automatic_payment_methods: Boolean,
     val use_link: Boolean,
-    val merchant_country_code: String
+    val merchant_country_code: String,
+    val supported_payment_methods: List<String>?
 )
 
 @Serializable

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/viewmodel/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/viewmodel/PaymentSheetPlaygroundViewModel.kt
@@ -144,7 +144,8 @@ class PaymentSheetPlaygroundViewModel(
         linkEnabled: Boolean,
         setShippingAddress: Boolean,
         setAutomaticPaymentMethod: Boolean,
-        backendUrl: String
+        backendUrl: String,
+        supportedPaymentMethods: List<String>?
     ) {
         customerConfig.value = null
         clientSecret.value = null
@@ -158,7 +159,8 @@ class PaymentSheetPlaygroundViewModel(
             set_shipping_address = setShippingAddress,
             automatic_payment_methods = setAutomaticPaymentMethod,
             use_link = linkEnabled,
-            merchant_country_code = merchantCountry.value
+            merchant_country_code = merchantCountry.value,
+            supported_payment_methods = supportedPaymentMethods
         )
 
         Fuel.post(backendUrl + "checkout")

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.ui
 
+import android.animation.LayoutTransition
 import android.content.pm.ActivityInfo
 import android.content.res.ColorStateList
 import android.graphics.Insets
@@ -97,6 +98,9 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
                 0f
             }
         }
+
+        bottomSheet.layoutTransition.enableTransitionType(LayoutTransition.CHANGING)
+        fragmentContainerParent.layoutTransition.enableTransitionType(LayoutTransition.CHANGING)
 
         bottomSheetController.setup()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet
 
+import android.animation.LayoutTransition
 import android.content.Context
 import androidx.activity.result.ActivityResultLauncher
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
@@ -960,6 +961,28 @@ internal class PaymentSheetActivityTest {
 
             viewModel.updateBelowButtonText(null)
             assertThat(activity.viewBinding.notes.isVisible).isFalse()
+        }
+    }
+
+    @Test
+    fun `verify animation is enabled for layout transition changes`() {
+        val scenario = activityScenario()
+        scenario.launch(intent).onActivity { activity ->
+            // wait for bottom sheet to animate in
+            idleLooper()
+
+            assertThat(
+                activity.viewBinding.bottomSheet.layoutTransition.isTransitionTypeEnabled(
+                    LayoutTransition.CHANGING
+                )
+            ).isTrue()
+
+            assertThat(
+                activity.viewBinding.fragmentContainerParent.layoutTransition
+                    .isTransitionTypeEnabled(
+                        LayoutTransition.CHANGING
+                    )
+            ).isTrue()
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Fix an issue where the custom flow PaymentSheet is getting clipped when save for future use and zip code are present in the billing address form.

The clipping issue was introduced in https://github.com/stripe/stripe-android/pull/4961. Added the animations back in and verified that the keyboard issue is not present when there is only 1 payment method and google pay is disabled. Also added a browserstack test just to make sure it is not reintroduced.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

https://jira.corp.stripe.com/browse/RUN_MOBILESDK-1470

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots

<img src="https://user-images.githubusercontent.com/99316447/189761211-f92e1eeb-faa6-48da-8a6e-d3000628bb76.png" height=400 />

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

- [Fixed] Fix an issue where custom flow PaymentSheet UI would have the bottom of the form cut off
