### PR TITLE
Fix expiry date field issue in `CardInputWidget`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## X.X.X - 2022-XX-XX
 
+### Payments
+
+* [FIXED][5547](https://github.com/stripe/stripe-android/pull/5547) Expiry dates in `CardInputWidget`, `CardMultilineWidget`, and `CardFormView` are no longer formatted incorrectly on certain devices.
+
 ### PaymentSheet
 
 * [FIXED][5624](https://github.com/stripe/stripe-android/pull/5624) `CollectBankAccountResult` included intents will now contain the expanded `payment_method` field.
@@ -9,10 +13,6 @@
 ## 20.14.0 - 2022-09-26
 This release fixes a payment-method related error in `PaymentSheet` and manages missing permissions
 on Financial Connections.
-
-### Payments
-
-* [FIXED][5547](https://github.com/stripe/stripe-android/pull/5547) Expiry dates in `CardInputWidget`, `CardMultilineWidget`, and `CardFormView` are no longer formatted incorrectly on certain devices.
 
 ### PaymentSheet
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 This release fixes a payment-method related error in `PaymentSheet` and manages missing permissions
 on Financial Connections.
 
+### Payments
+
+* [FIXED][5547](https://github.com/stripe/stripe-android/pull/5547) Expiry dates in `CardInputWidget`, `CardMultilineWidget`, and `CardFormView` are no longer formatted incorrectly on certain devices.
+
 ### PaymentSheet
 
 * [FIXED][5592](https://github.com/stripe/stripe-android/pull/5592)[5613](https://github.com/stripe/stripe-android/pull/5613) Fix deletion of the last used payment method.

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -7812,7 +7812,6 @@ public class com/stripe/android/view/StripeEditText : com/google/android/materia
 	public final fun getDefaultErrorColorInt ()I
 	public fun getOnFocusChangeListener ()Landroid/view/View$OnFocusChangeListener;
 	public final fun getShouldShowError ()Z
-	protected final fun isLastKeyDelete ()Z
 	public fun onCreateInputConnection (Landroid/view/inputmethod/EditorInfo;)Landroid/view/inputmethod/InputConnection;
 	public fun onInitializeAccessibilityNodeInfo (Landroid/view/accessibility/AccessibilityNodeInfo;)V
 	public fun onRestoreInstanceState (Landroid/os/Parcelable;)V
@@ -7823,7 +7822,6 @@ public class com/stripe/android/view/StripeEditText : com/google/android/materia
 	public final fun setErrorColor (I)V
 	public final fun setErrorMessage (Ljava/lang/String;)V
 	public final fun setErrorMessageListener (Lcom/stripe/android/view/StripeEditText$ErrorMessageListener;)V
-	protected final fun setLastKeyDelete (Z)V
 	public final fun setOnFocusChangeListener (Landroid/view/View$OnFocusChangeListener;)V
 	public final fun setShouldShowError (Z)V
 	public fun setTextColor (I)V

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/domain/AttachFinancialConnectionsSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/domain/AttachFinancialConnectionsSession.kt
@@ -28,7 +28,7 @@ internal class AttachFinancialConnectionsSession @Inject constructor(
             paymentIntentId = PaymentIntent.ClientSecret(clientSecret).paymentIntentId,
             requestOptions = ApiRequest.Options(
                 apiKey = publishableKey,
-                stripeAccount = stripeAccountId,
+                stripeAccount = stripeAccountId
             ),
             expandFields = EXPAND_PAYMENT_METHOD
         )

--- a/payments-core/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt
@@ -177,7 +177,7 @@ class ExpiryDateEditText @JvmOverloads constructor(
                 }
 
                 override fun afterTextChanged(s: Editable?) {
-                    if (!isLastKeyDelete && formattedDate != null) {
+                    if (formattedDate != null) {
                         setTextSilent(formattedDate)
                         newCursorPosition?.let {
                             setSelection(it.coerceIn(0, fieldText.length))

--- a/payments-core/src/main/java/com/stripe/android/view/StripeEditText.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/StripeEditText.kt
@@ -86,6 +86,12 @@ open class StripeEditText @JvmOverloads constructor(
 
     private var errorMessageListener: ErrorMessageListener? = null
 
+    private val isLastKeyDeleteTextWatcher = object : StripeTextWatcher() {
+        override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+            isLastKeyDelete = count == 0
+        }
+    }
+
     /**
      * The color used for error text.
      */
@@ -199,13 +205,9 @@ open class StripeEditText @JvmOverloads constructor(
         // On some devices, the OnKeyListener isn't invoked for software keyboards. It is invoked on
         // other devices such as my Pixel. To fix the issue for all devices, we're adding an
         // additional text watcher to keep isLastKeyDelete in the correct state.
-        val textWatcher = object : StripeTextWatcher() {
-            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-                isLastKeyDelete = count == 0
-            }
+        if (isLastKeyDeleteTextWatcher !in textWatchers.orEmpty()) {
+            addTextChangedListener(isLastKeyDeleteTextWatcher)
         }
-
-        addTextChangedListener(textWatcher)
 
         // This method works for hard keyboards and older phones.
         setOnKeyListener { _, keyCode, event ->

--- a/payments-core/src/main/java/com/stripe/android/view/StripeEditText.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/StripeEditText.kt
@@ -212,16 +212,22 @@ open class StripeEditText @JvmOverloads constructor(
 
         // This method works for hard keyboards and older phones.
         setOnKeyListener { _, keyCode, event ->
-            isLastKeyDelete = isDeleteKey(keyCode, event)
-            if (isLastKeyDelete && length() == 0) {
-                deleteEmptyListener?.onDeleteEmpty()
+            if (event.action == KeyEvent.ACTION_DOWN) {
+                // We only care about ACTION_DOWN and will ignore ACTION_UP
+                val isDelete = isDeleteKey(keyCode)
+                isLastKeyDelete = isDelete
+
+                if (isLastKeyDelete && length() == 0) {
+                    deleteEmptyListener?.onDeleteEmpty()
+                }
             }
+
             false
         }
     }
 
-    private fun isDeleteKey(keyCode: Int, event: KeyEvent): Boolean {
-        return keyCode == KeyEvent.KEYCODE_DEL && event.action == KeyEvent.ACTION_DOWN
+    private fun isDeleteKey(keyCode: Int): Boolean {
+        return keyCode == KeyEvent.KEYCODE_DEL
     }
 
     fun interface DeleteEmptyListener {

--- a/payments-core/src/main/java/com/stripe/android/view/StripeEditText.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/StripeEditText.kt
@@ -33,7 +33,8 @@ open class StripeEditText @JvmOverloads constructor(
     attrs: AttributeSet? = null,
     defStyleAttr: Int = androidx.appcompat.R.attr.editTextStyle
 ) : TextInputEditText(context, attrs, defStyleAttr) {
-    protected var isLastKeyDelete: Boolean = false
+    @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
+    internal var isLastKeyDelete: Boolean = false
 
     private var afterTextChangedListener: AfterTextChangedListener? = null
     private var deleteEmptyListener: DeleteEmptyListener? = null

--- a/payments-core/src/main/java/com/stripe/android/view/StripeEditText.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/StripeEditText.kt
@@ -196,6 +196,17 @@ open class StripeEditText @JvmOverloads constructor(
     }
 
     private fun listenForDeleteEmpty() {
+        // On some devices, the OnKeyListener isn't invoked for software keyboards. It is invoked on
+        // other devices such as my Pixel. To fix the issue for all devices, we're adding an
+        // additional text watcher to keep isLastKeyDelete in the correct state.
+        val textWatcher = object : StripeTextWatcher() {
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                isLastKeyDelete = count == 0
+            }
+        }
+
+        addTextChangedListener(textWatcher)
+
         // This method works for hard keyboards and older phones.
         setOnKeyListener { _, keyCode, event ->
             isLastKeyDelete = isDeleteKey(keyCode, event)

--- a/payments-core/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/ExpiryDateEditTextTest.kt
@@ -85,14 +85,14 @@ class ExpiryDateEditTextTest {
     }
 
     @Test
-    fun afterInputThreeDigits_whenDeletingOne_textDoesContainSlash() {
+    fun afterInputThreeDigits_whenDeletingOne_textDoesNotContainSlash() {
         expiryDateEditText.append("1")
         expiryDateEditText.append("2")
         expiryDateEditText.append("3")
 
         ViewTestUtils.sendDeleteKeyEvent(expiryDateEditText)
         assertThat(expiryDateEditText.text.toString())
-            .isEqualTo("12/")
+            .isEqualTo("12")
     }
 
     @Test
@@ -213,14 +213,14 @@ class ExpiryDateEditTextTest {
     }
 
     @Test
-    fun delete_whenAcrossSeparator_deletesSeparator() {
+    fun delete_whenAcrossSeparator_deletesSeparatorAndLastCharacterBeforeSeparator() {
         expiryDateEditText.append("12")
         assertThat(expiryDateEditText.text.toString())
             .isEqualTo("12/")
 
         ViewTestUtils.sendDeleteKeyEvent(expiryDateEditText)
         assertThat(expiryDateEditText.text.toString())
-            .isEqualTo("12")
+            .isEqualTo("1")
     }
 
     @Test
@@ -376,15 +376,7 @@ class ExpiryDateEditTextTest {
 
         ViewTestUtils.sendDeleteKeyEvent(expiryDateEditText)
         assertThat(expiryDateEditText.fieldText)
-            .isEqualTo("12 / ")
-
-        ViewTestUtils.sendDeleteKeyEvent(expiryDateEditText)
-        assertThat(expiryDateEditText.fieldText)
-            .isEqualTo("12 /")
-
-        ViewTestUtils.sendDeleteKeyEvent(expiryDateEditText)
-        assertThat(expiryDateEditText.fieldText)
-            .isEqualTo("12 ")
+            .isEqualTo("12")
     }
 
     @Test

--- a/payments-core/src/test/java/com/stripe/android/view/StripeEditTextTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/StripeEditTextTest.kt
@@ -252,4 +252,6 @@ internal class StripeEditTextTest {
 
 private fun EditText.enterBackspace() {
     dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DEL))
+    setText(text.toString().dropLast(1))
+    dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_DEL))
 }

--- a/payments-core/src/test/java/com/stripe/android/view/StripeEditTextTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/StripeEditTextTest.kt
@@ -3,7 +3,9 @@ package com.stripe.android.view
 import android.content.Context
 import android.content.res.ColorStateList
 import android.text.TextWatcher
+import android.view.KeyEvent
 import android.view.View
+import android.widget.EditText
 import androidx.annotation.ColorInt
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.core.content.ContextCompat
@@ -18,6 +20,7 @@ import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
@@ -213,9 +216,40 @@ internal class StripeEditTextTest {
         verifyNoMoreInteractions(textWatcher2)
     }
 
+    @Test
+    fun invokesDeleteListenerIfFieldIsEmpty() {
+        val deleteListener = mock<StripeEditText.DeleteEmptyListener>()
+        editText.setDeleteEmptyListener(deleteListener)
+
+        editText.setText("1")
+        editText.enterBackspace()
+        verify(deleteListener, never()).onDeleteEmpty()
+
+        editText.enterBackspace()
+        verify(deleteListener).onDeleteEmpty()
+    }
+
+    @Test
+    fun setsIsLastKeyDeleteCorrectlyOnSoftKeyboardInput() {
+        // We use `setText()` to simulate the behavior on software keyboards, which result in
+        // OnKeyListener being called on some devices, but not others.
+        editText.setText("1")
+        assertThat(editText.isLastKeyDelete).isFalse()
+
+        editText.enterBackspace()
+        assertThat(editText.isLastKeyDelete).isTrue()
+
+        editText.setText("2")
+        assertThat(editText.isLastKeyDelete).isFalse()
+    }
+
     private fun verifyTextWatcherIsTriggered(watcher: TextWatcher, count: Int) {
         verify(watcher, times(count)).beforeTextChanged(any(), any(), any(), any())
         verify(watcher, times(count)).onTextChanged(any(), any(), any(), any())
         verify(watcher, times(count)).afterTextChanged(any())
     }
+}
+
+private fun EditText.enterBackspace() {
+    dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DEL))
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue in `CardInputWidget` that occurred on some devices, such as those from Samsung.

A quick explanation: On the affected devices, the `StripeEditText`’s `OnKeyListener` wasn’t called for all key presses, but only for presses of the backspace. With that, the class’s `isLastKeyDelete` was always `true` after a backspace press, resulting in the `ExpiryDateEditText`’s text not being updated.

We’re adding a `TextWatcher` in addition to the `OnKeyListener` to make sure that the `isLastKeyDelete` property is always in the correct state.

Also, we’re removing the `!isLastKeyDelete` condition in `ExpiryDateEditText`’s `afterTextChanged`. This condition prevented a behavior we actually want: If the current text is `12 / 2` and the user presses backspace, we want to end up with `12` instead of `12 /`. This behavior was explicitly called out in [a comment](https://github.com/stripe/stripe-android/blob/5b6dc50686b3162830431a4e948bda84481e656a/payments-core/src/main/java/com/stripe/android/view/ExpiryDateEditText.kt#L144), but must have been broken some time ago.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Resolves: https://github.com/stripe/stripe-android/issues/5539

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

[Fixed] Expiry dates in `CardInputWidget`, `CardMultilineWidget`, and `CardFormView` are no longer formatted incorrectly on certain devices.
