### PR TITLE
Make `PaymentMethod.Card.networks` field public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## X.X.X - 2022-XX-XX
 
+### Payments
+
+* [CHANGED] [5552](https://github.com/stripe/stripe-android/pull/5552) Make `PaymentMethod.Card.networks` field public.
+
 ## 20.12.0 - 2022-09-13
 This release upgrades `compileSdkVersion` to 33, updates Google Pay button to match the new brand 
 guidelines and fixes some bugs in `FlowController`.

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -3567,10 +3567,12 @@ public final class com/stripe/android/model/PaymentMethod$Card : com/stripe/andr
 	public final field fingerprint Ljava/lang/String;
 	public final field funding Ljava/lang/String;
 	public final field last4 Ljava/lang/String;
+	public final field networks Lcom/stripe/android/model/PaymentMethod$Card$Networks;
 	public final field threeDSecureUsage Lcom/stripe/android/model/PaymentMethod$Card$ThreeDSecureUsage;
 	public final field wallet Lcom/stripe/android/model/wallets/Wallet;
 	public final fun component1 ()Lcom/stripe/android/model/CardBrand;
 	public final fun component10 ()Lcom/stripe/android/model/wallets/Wallet;
+	public final fun component11 ()Lcom/stripe/android/model/PaymentMethod$Card$Networks;
 	public final fun component2 ()Lcom/stripe/android/model/PaymentMethod$Card$Checks;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/Integer;

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -677,7 +677,7 @@ constructor(
         @JvmField val wallet: Wallet? = null,
 
         @JvmField
-        internal val networks: Networks? = null
+        val networks: Networks? = null
     ) : TypeData() {
         override val type: Type get() = Type.Card
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request exposes `PaymentMethod.networks`, which is also a part of [Stripe’s public API](https://stripe.com/docs/api/payment_methods/object#payment_method_object-card-networks).

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Request from EMEA Cards team.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

_tbd_
