### PR TITLE
[link] Do not show log out overflow menu unless Link account is fully logged in

### DIFF
--- a/link/src/androidTest/java/com/stripe/android/link/ui/LinkAppBarStateTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/LinkAppBarStateTest.kt
@@ -6,6 +6,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.link.LinkScreen
 import com.stripe.android.link.R
+import com.stripe.android.link.model.AccountStatus
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -21,7 +22,8 @@ internal class LinkAppBarStateTest {
         val state = buildLinkAppBarState(
             isRootScreen = true,
             currentRoute = LinkScreen.Wallet.route,
-            email = " "
+            email = " ",
+            accountStatus = AccountStatus.SignedOut
         )
 
         assertThat(state.email).isNull()
@@ -32,14 +34,16 @@ internal class LinkAppBarStateTest {
         val state = buildLinkAppBarState(
             isRootScreen = true,
             currentRoute = LinkScreen.Loading.route,
-            email = null
+            email = null,
+            accountStatus = AccountStatus.SignedOut
         )
 
         val expected = LinkAppBarState(
             navigationIcon = R.drawable.ic_link_close,
             showHeader = true,
             showOverflowMenu = false,
-            email = null
+            email = null,
+            accountStatus = AccountStatus.SignedOut
         )
 
         assertThat(state).isEqualTo(expected)
@@ -50,14 +54,16 @@ internal class LinkAppBarStateTest {
         val state = buildLinkAppBarState(
             isRootScreen = true,
             currentRoute = LinkScreen.Verification.route,
-            email = "someone@stripe.com"
+            email = "someone@stripe.com",
+            accountStatus = AccountStatus.VerificationStarted
         )
 
         val expected = LinkAppBarState(
             navigationIcon = R.drawable.ic_link_close,
             showHeader = true,
             showOverflowMenu = false,
-            email = null
+            email = null,
+            accountStatus = AccountStatus.VerificationStarted
         )
 
         assertThat(state).isEqualTo(expected)
@@ -68,14 +74,16 @@ internal class LinkAppBarStateTest {
         val state = buildLinkAppBarState(
             isRootScreen = true,
             currentRoute = LinkScreen.VerificationDialog.route,
-            email = "someone@stripe.com"
+            email = "someone@stripe.com",
+            accountStatus = AccountStatus.VerificationStarted
         )
 
         val expected = LinkAppBarState(
             navigationIcon = R.drawable.ic_link_close,
             showHeader = true,
             showOverflowMenu = false,
-            email = "someone@stripe.com"
+            email = "someone@stripe.com",
+            accountStatus = AccountStatus.VerificationStarted
         )
 
         assertThat(state).isEqualTo(expected)
@@ -86,14 +94,16 @@ internal class LinkAppBarStateTest {
         val state = buildLinkAppBarState(
             isRootScreen = true,
             currentRoute = LinkScreen.Wallet.route,
-            email = "someone@stripe.com"
+            email = "someone@stripe.com",
+            accountStatus = AccountStatus.Verified
         )
 
         val expected = LinkAppBarState(
             navigationIcon = R.drawable.ic_link_close,
             showHeader = true,
             showOverflowMenu = true,
-            email = "someone@stripe.com"
+            email = "someone@stripe.com",
+            accountStatus = AccountStatus.Verified
         )
 
         assertThat(state).isEqualTo(expected)
@@ -104,14 +114,16 @@ internal class LinkAppBarStateTest {
         val state = buildLinkAppBarState(
             isRootScreen = true,
             currentRoute = LinkScreen.PaymentMethod.route,
-            email = "someone@stripe.com"
+            email = "someone@stripe.com",
+            accountStatus = AccountStatus.Verified
         )
 
         val expected = LinkAppBarState(
             navigationIcon = R.drawable.ic_link_close,
             showHeader = true,
             showOverflowMenu = true,
-            email = "someone@stripe.com"
+            email = "someone@stripe.com",
+            accountStatus = AccountStatus.Verified
         )
 
         assertThat(state).isEqualTo(expected)
@@ -122,14 +134,16 @@ internal class LinkAppBarStateTest {
         val state = buildLinkAppBarState(
             isRootScreen = false,
             currentRoute = LinkScreen.PaymentMethod.route,
-            email = "someone@stripe.com"
+            email = "someone@stripe.com",
+            accountStatus = AccountStatus.Verified
         )
 
         val expected = LinkAppBarState(
             navigationIcon = R.drawable.ic_link_back,
             showHeader = false,
             showOverflowMenu = false,
-            email = null
+            email = null,
+            accountStatus = AccountStatus.Verified
         )
 
         assertThat(state).isEqualTo(expected)
@@ -140,14 +154,16 @@ internal class LinkAppBarStateTest {
         val state = buildLinkAppBarState(
             isRootScreen = false,
             currentRoute = LinkScreen.CardEdit.route,
-            email = "someone@stripe.com"
+            email = "someone@stripe.com",
+            accountStatus = AccountStatus.Verified
         )
 
         val expected = LinkAppBarState(
             navigationIcon = R.drawable.ic_link_back,
             showHeader = false,
             showOverflowMenu = false,
-            email = null
+            email = null,
+            accountStatus = AccountStatus.Verified
         )
 
         assertThat(state).isEqualTo(expected)
@@ -158,14 +174,36 @@ internal class LinkAppBarStateTest {
         val state = buildLinkAppBarState(
             isRootScreen = true,
             currentRoute = LinkScreen.SignUp.route,
-            email = null
+            email = null,
+            accountStatus = AccountStatus.SignedOut
         )
 
         val expected = LinkAppBarState(
             navigationIcon = R.drawable.ic_link_close,
             showHeader = true,
             showOverflowMenu = false,
-            email = null
+            email = null,
+            accountStatus = AccountStatus.SignedOut
+        )
+
+        assertThat(state).isEqualTo(expected)
+    }
+
+    @Test
+    fun signupScreenShowsCorrectAppBarStateWithEmail() {
+        val state = buildLinkAppBarState(
+            isRootScreen = true,
+            currentRoute = LinkScreen.SignUp.route,
+            email = "someone@stripe.com",
+            accountStatus = AccountStatus.NeedsVerification
+        )
+
+        val expected = LinkAppBarState(
+            navigationIcon = R.drawable.ic_link_close,
+            showHeader = true,
+            showOverflowMenu = false,
+            email = null,
+            accountStatus = AccountStatus.NeedsVerification
         )
 
         assertThat(state).isEqualTo(expected)
@@ -174,12 +212,13 @@ internal class LinkAppBarStateTest {
     private fun buildLinkAppBarState(
         isRootScreen: Boolean,
         currentRoute: String?,
-        email: String?
+        email: String?,
+        accountStatus: AccountStatus?
     ): LinkAppBarState {
         var state: LinkAppBarState? = null
 
         composeTestRule.setContent {
-            state = rememberLinkAppBarState(isRootScreen, currentRoute, email)
+            state = rememberLinkAppBarState(isRootScreen, currentRoute, email, accountStatus)
         }
 
         return state ?: throw AssertionError(

--- a/link/src/androidTest/java/com/stripe/android/link/ui/LinkAppBarTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/LinkAppBarTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.link.R
+import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.theme.DefaultLinkTheme
 import org.junit.Rule
 import org.junit.Test
@@ -19,7 +20,7 @@ internal class LinkAppBarTest {
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
-    fun email_is_shown_when_provided() {
+    fun verified_email_is_shown_when_provided() {
         val email = "test@stripe.com"
         setContent(email)
 
@@ -48,6 +49,7 @@ internal class LinkAppBarTest {
 
     private fun setContent(
         email: String? = null,
+        accountStatus: AccountStatus? = null,
         onBackPress: () -> Unit = {},
         onLogout: () -> Unit = {},
         showBottomSheetContent: (BottomSheetContent?) -> Unit = {}
@@ -58,7 +60,8 @@ internal class LinkAppBarTest {
                     navigationIcon = R.drawable.ic_link_close,
                     showHeader = true,
                     showOverflowMenu = true,
-                    email = email
+                    email = email,
+                    accountStatus = accountStatus
                 ),
                 onBackPressed = onBackPress,
                 onLogout = onLogout,

--- a/link/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -115,12 +115,12 @@ internal class LinkActivity : ComponentActivity() {
                     Column(Modifier.fillMaxWidth()) {
                         val linkAccount by viewModel.linkAccount.collectAsState(null)
                         val isOnRootScreen by isRootScreenFlow().collectAsState(true)
-
                         val backStackEntry by navController.currentBackStackEntryAsState()
                         val appBarState = rememberLinkAppBarState(
                             isRootScreen = isOnRootScreen,
                             currentRoute = backStackEntry?.destination?.route,
-                            email = linkAccount?.email
+                            email = linkAccount?.email,
+                            accountStatus = linkAccount?.accountStatus
                         )
 
                         LinkAppBar(

--- a/link/src/main/java/com/stripe/android/link/ui/LinkAppBar.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/LinkAppBar.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.stripe.android.link.R
+import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.theme.AppBarHeight
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.link.theme.linkColors
@@ -131,7 +132,8 @@ private fun LinkAppBarPreview() {
                     navigationIcon = R.drawable.ic_link_close,
                     showHeader = true,
                     showOverflowMenu = true,
-                    email = "email@example.com"
+                    email = "email@example.com",
+                    accountStatus = AccountStatus.Verified
                 ),
                 onBackPressed = {},
                 onLogout = {},
@@ -151,7 +153,8 @@ private fun LinkAppBar_NoEmail() {
                     navigationIcon = R.drawable.ic_link_close,
                     showHeader = true,
                     showOverflowMenu = true,
-                    email = null
+                    email = null,
+                    accountStatus = AccountStatus.SignedOut
                 ),
                 onBackPressed = {},
                 onLogout = {},
@@ -171,7 +174,8 @@ private fun LinkAppBar_ChildScreen() {
                     navigationIcon = R.drawable.ic_link_back,
                     showHeader = false,
                     showOverflowMenu = false,
-                    email = "email@example.com"
+                    email = "email@example.com",
+                    accountStatus = AccountStatus.Verified
                 ),
                 onBackPressed = {},
                 onLogout = {},
@@ -191,7 +195,8 @@ private fun LinkAppBar_ChildScreen_NoEmail() {
                     navigationIcon = R.drawable.ic_link_back,
                     showHeader = false,
                     showOverflowMenu = false,
-                    email = null
+                    email = null,
+                    accountStatus = AccountStatus.SignedOut
                 ),
                 onBackPressed = {},
                 onLogout = {},

--- a/link/src/main/java/com/stripe/android/link/ui/LinkAppBarState.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/LinkAppBarState.kt
@@ -5,19 +5,22 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import com.stripe.android.link.LinkScreen
 import com.stripe.android.link.R
+import com.stripe.android.link.model.AccountStatus
 
 internal data class LinkAppBarState(
     @DrawableRes val navigationIcon: Int,
     val showHeader: Boolean,
     val showOverflowMenu: Boolean,
-    val email: String?
+    val email: String?,
+    val accountStatus: AccountStatus?
 )
 
 @Composable
 internal fun rememberLinkAppBarState(
     isRootScreen: Boolean,
     currentRoute: String?,
-    email: String?
+    email: String?,
+    accountStatus: AccountStatus?
 ): LinkAppBarState {
     return remember(currentRoute, email) {
         val showHeader = when (currentRoute) {
@@ -36,7 +39,7 @@ internal fun rememberLinkAppBarState(
 
         // If there's an email address, we want to allow the user to log
         // out of the existing account.
-        val showOverflowMenu = isRootScreen && email != null
+        val showOverflowMenu = isRootScreen && email != null && accountStatus == AccountStatus.Verified
 
         LinkAppBarState(
             navigationIcon = if (isRootScreen) {
@@ -46,7 +49,8 @@ internal fun rememberLinkAppBarState(
             },
             showHeader = showHeader,
             showOverflowMenu = showOverflowMenu,
-            email = email?.takeUnless { it.isBlank() || hideEmail }
+            email = email?.takeUnless { it.isBlank() || hideEmail },
+            accountStatus = accountStatus
         )
     }
 }

--- a/link/src/main/java/com/stripe/android/link/ui/verification/VerificationDialog.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/verification/VerificationDialog.kt
@@ -81,7 +81,8 @@ fun LinkVerificationDialog(
                                     val appBarState = rememberLinkAppBarState(
                                         isRootScreen = true,
                                         currentRoute = backStackEntry?.destination?.route,
-                                        email = account.email
+                                        email = account.email,
+                                        accountStatus = account.accountStatus
                                     )
 
                                     LinkAppBar(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
The three dots overflow icon was showing a log out of link option even when the log in process was not fully completed yet (e.g. OTP verification incomplete). This change makes the logic for showing the overflow menu aware of the account status and only shows it if the account status is fully verified.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Item 12 from Link in Android dogfooding (https://paper.dropbox.com/doc/Link-Android-GA-Dogfooding-912--BpJ5pPAPD7SonTpoMcWANbgpAg-u4ksiof3jZUG9wY9klDBg) 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
|  ![2022-09-15 10 10 19](https://user-images.githubusercontent.com/107639562/190467863-6aa80a11-dc9f-457a-8c61-ac10e65929ac.gif) | ![2022-09-15 10 10 22](https://user-images.githubusercontent.com/107639562/190467872-3d2ed880-392e-42a1-891e-c057227421dd.gif) |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
