### PR TITLE
Use OnBackPressedDispatcher to handle back

### DIFF
--- a/link/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.ViewTreeObserver
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
@@ -123,9 +124,11 @@ internal class LinkActivity : ComponentActivity() {
                             email = linkAccount?.email
                         )
 
+                        BackHandler(onBack = viewModel::onBackPressed)
+
                         LinkAppBar(
                             state = appBarState,
-                            onBackPressed = viewModel::onBackPressed,
+                            onBackPressed = onBackPressedDispatcher::onBackPressed,
                             onLogout = viewModel::logout,
                             showBottomSheetContent = {
                                 if (it == null) {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Link app bar back button was directly calling `Navigator.onBack`.
Verification screen needs to clean up the account state when the user navigates back without completing the verification. That is done by adding a `BackHandler` that calls [`VerificationViewModel.onBack`](https://github.com/stripe/stripe-android/blob/6445a07a653736b6d90bc82ee53333e556c90720/link/src/main/java/com/stripe/android/link/ui/verification/VerificationViewModel.kt#L121).
Make the app bar back action be handled by the `onBackPressedDispatcher`, which will call the VerificationScreen `BackHandler` first.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix account state when user doesn't complete verification.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
https://user-images.githubusercontent.com/77990083/190291822-f714eaea-2459-4477-bc36-40e762b5e1d4.mp4

https://user-images.githubusercontent.com/77990083/190291853-001f6a39-5175-437f-beec-6b8a3ad398d9.mp4



