### PR TITLE
Fix issue with `FocusDirection` in card details form

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElementUI.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.unit.dp
 import com.stripe.android.ui.core.paymentsColors
 import com.stripe.android.ui.core.paymentsShapes
@@ -17,11 +18,22 @@ internal fun CardDetailsElementUI(
     lastTextFieldIdentifier: IdentifierSpec?
 ) {
     controller.fields.forEachIndexed { index, field ->
+        // We need to adjust the focus direction, because some devices (Samsung, OnePlus) will
+        // navigate to the CVC field if we use `FocusDirection.Down`. We only adjust this for the
+        // card number field, because changing this for all fields will allow loops where pressing
+        // the backspace in the first field will circle back to the last field.
+        val nextFocusDirection = if (field.identifier == IdentifierSpec.CardNumber) {
+            FocusDirection.Next
+        } else {
+            FocusDirection.Down
+        }
+
         SectionFieldElementUI(
             enabled,
             field,
             hiddenIdentifiers = hiddenIdentifiers,
-            lastTextFieldIdentifier = lastTextFieldIdentifier
+            lastTextFieldIdentifier = lastTextFieldIdentifier,
+            nextFocusDirection = nextFocusDirection
         )
         if (index != controller.fields.lastIndex) {
             Divider(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionFieldElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionFieldElementUI.kt
@@ -12,8 +12,8 @@ internal fun SectionFieldElementUI(
     modifier: Modifier = Modifier,
     hiddenIdentifiers: List<IdentifierSpec>? = null,
     lastTextFieldIdentifier: IdentifierSpec?,
-    nextFocusDirection: FocusDirection = FocusDirection.Down,
-    previousFocusDirection: FocusDirection = FocusDirection.Up
+    nextFocusDirection: FocusDirection = FocusDirection.Next,
+    previousFocusDirection: FocusDirection = FocusDirection.Previous
 ) {
     if (hiddenIdentifiers?.contains(field.identifier) == false) {
         when (val controller = field.sectionFieldErrorController()) {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionFieldElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionFieldElementUI.kt
@@ -12,8 +12,8 @@ internal fun SectionFieldElementUI(
     modifier: Modifier = Modifier,
     hiddenIdentifiers: List<IdentifierSpec>? = null,
     lastTextFieldIdentifier: IdentifierSpec?,
-    nextFocusDirection: FocusDirection = FocusDirection.Next,
-    previousFocusDirection: FocusDirection = FocusDirection.Previous
+    nextFocusDirection: FocusDirection = FocusDirection.Down,
+    previousFocusDirection: FocusDirection = FocusDirection.Up
 ) {
     if (hiddenIdentifiers?.contains(field.identifier) == false) {
         when (val controller = field.sectionFieldErrorController()) {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request switches to using `FocusDirection.Next` instead of `FocusDirection.Up` in the card number field of `CardDetailsElementUI`, because the latter didn’t work correctly on some devices (OnePlus, Samsung).

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

UX polish.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screen recordings

## On a Samsung device

Now working correctly 🥳

| Before  | After |
| ------------- | ------------- |
| <video src="https://user-images.githubusercontent.com/110940675/190438262-2b9a76b2-c4c7-438a-b8bb-a0321b7a1899.mp4" /> | <video src="https://user-images.githubusercontent.com/110940675/190438364-f06b8357-9b72-4b53-ad1c-efd7f8bf9ff4.mp4" /> |

## On a Pixel emulator

Still working as expected 💪

| Before  | After |
| ------------- | ------------- |
| <video src="https://user-images.githubusercontent.com/110940675/190444560-9dafd35e-adaa-4d14-85e8-d130d29f88ff.mp4" /> | <video src="https://user-images.githubusercontent.com/110940675/190444640-50e86354-e124-45c1-9f8c-33ed603f7121.mp4" /> |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

_Nothing to add._