### PR TITLE
Fix keyboard action type in card details form

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormUI.kt
@@ -72,7 +72,8 @@ fun FormUI(
                         is CardDetailsSectionElement -> CardDetailsSectionElementUI(
                             enabled,
                             element.controller,
-                            hiddenIdentifiers
+                            hiddenIdentifiers,
+                            lastTextFieldIdentifier
                         )
                         is BsbElement -> BsbElementUI(enabled, element, lastTextFieldIdentifier)
                         is OTPElement -> OTPElementUI(enabled, element)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUI.kt
@@ -20,7 +20,8 @@ import com.stripe.android.ui.core.cardscan.CardScanActivity
 fun CardDetailsSectionElementUI(
     enabled: Boolean,
     controller: CardDetailsSectionController,
-    hiddenIdentifiers: List<IdentifierSpec>?
+    hiddenIdentifiers: List<IdentifierSpec>?,
+    lastTextFieldIdentifier: IdentifierSpec?
 ) {
     Row(
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -47,8 +48,8 @@ fun CardDetailsSectionElementUI(
         }
     }
     SectionElementUI(
-        enabled,
-        SectionElement(
+        enabled = enabled,
+        element = SectionElement(
             IdentifierSpec.Generic("credit_details"),
             listOf(controller.cardDetailsElement),
             SectionController(
@@ -56,7 +57,7 @@ fun CardDetailsSectionElementUI(
                 listOf(controller.cardDetailsElement.sectionFieldErrorController())
             )
         ),
-        hiddenIdentifiers ?: emptyList(),
-        IdentifierSpec.Generic("card_details")
+        hiddenIdentifiers = hiddenIdentifiers ?: emptyList(),
+        lastTextFieldIdentifier = lastTextFieldIdentifier
     )
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes the keyboard action type in the card details form if we don’t show the postal code text field.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

UX polish.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

_Nothing to add._
