### PR TITLE
Close keyboard when attempting Link payment

### DIFF
--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
@@ -222,6 +223,14 @@ internal fun WalletBody(
 
             openDialog = false
             itemBeingRemoved = null
+        }
+    }
+
+    val focusManager = LocalFocusManager.current
+
+    LaunchedEffect(uiState.isProcessing) {
+        if (uiState.isProcessing) {
+            focusManager.clearFocus()
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request makes sure that we clear the focus when attempting a payment in Link. This closes the software keyboard and removes the potential focus from the expiry date or CVC field.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

UX polish.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screen recording

https://user-images.githubusercontent.com/110940675/190512927-662b57ce-5df6-4521-bc95-64e17d95486d.mp4

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

_Nothing to add._
