### PR TITLE
Fix wallet expanded logic

### DIFF
--- a/link/src/androidTest/java/com/stripe/android/link/ui/verification/VerificationScreenTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/verification/VerificationScreenTest.kt
@@ -167,12 +167,6 @@ internal class VerificationScreenTest {
     }
 
     @Test
-    fun focus_on_first_otp_field_at_start() {
-        setContent()
-        onOtpField(0).assertIsFocused()
-    }
-
-    @Test
     fun when_error_message_is_not_null_then_it_is_visible() {
         val errorMessage = "Error message"
         setContent(errorMessage = ErrorMessage.Raw(errorMessage))

--- a/link/src/androidTest/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
@@ -227,6 +227,22 @@ internal class WalletScreenTest {
     }
 
     @Test
+    fun when_no_selected_payment_method_then_wallet_is_expanded() {
+        var selectedItem: ConsumerPaymentDetails.PaymentDetails? = null
+        setContent(
+            selectedItem = null,
+            isExpanded = false,
+            onItemSelected = {
+                selectedItem = it
+            }
+        )
+
+        assertExpanded()
+        assertThat(selectedItem).isNull()
+        onPrimaryButton().assertIsNotEnabled()
+    }
+
+    @Test
     fun add_new_payment_method_click_triggers_action() {
         var count = 0
         setContent(

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
@@ -62,7 +62,7 @@ internal data class WalletUiState(
         return copy(
             paymentDetailsList = response.paymentDetails,
             selectedItem = selectedItem,
-            isExpanded = if (isSelectedItemValid) isExpanded else false,
+            isExpanded = if (isSelectedItemValid) isExpanded else true,
             isProcessing = false
         )
     }

--- a/link/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -317,10 +317,11 @@ class WalletViewModelTest {
                 .thenReturn(Result.success(Unit))
 
             // Only the bank account is returned, which is not supported
-            whenever(linkAccountManager.listPaymentDetails())
-                .thenReturn(Result.success(paymentDetails.copy(
-                    paymentDetails = listOf(paymentDetails.paymentDetails[1])
-                )))
+            whenever(linkAccountManager.listPaymentDetails()).thenReturn(
+                Result.success(
+                    paymentDetails.copy(paymentDetails = listOf(paymentDetails.paymentDetails[1]))
+                )
+            )
 
             // Delete the selected item
             viewModel.deletePaymentMethod(defaultItem)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
#5557 set the wallet to collapsed when the selected item is invalid. Fix that and add a test.
Remove failing `VerificationScreenTest` now that focus is not requested automatically. Calling `requestFocus` from tests causes a crash: `java.lang.IllegalStateException: LayoutCoordinate operations are only valid when isAttached is true`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fixes for Link GA.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
