### PR TITLE
Fix Link keyboard visibility issues

### DIFF
--- a/link/src/main/java/com/stripe/android/link/ui/verification/VerificationScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/verification/VerificationScreen.kt
@@ -47,6 +47,7 @@ import com.stripe.android.ui.core.elements.OTPElement
 import com.stripe.android.ui.core.elements.OTPElementUI
 import com.stripe.android.ui.core.elements.OTPSpec
 import com.stripe.android.ui.core.injection.NonFallbackInjector
+import kotlinx.coroutines.delay
 
 @Preview
 @Composable
@@ -123,6 +124,9 @@ internal fun VerificationBody(
 
     LaunchedEffect(requestFocus) {
         if (requestFocus) {
+            // Workaround for https://issuetracker.google.com/issues/204502668
+            // Keyboard is not shown when requesting focus in a Dialog
+            delay(200)
             focusRequester.requestFocus()
             keyboardController?.show()
             viewModel.onFocusRequested()

--- a/link/src/main/java/com/stripe/android/link/ui/verification/VerificationScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/verification/VerificationScreen.kt
@@ -124,8 +124,8 @@ internal fun VerificationBody(
 
     LaunchedEffect(requestFocus) {
         if (requestFocus) {
-            // Workaround for https://issuetracker.google.com/issues/204502668
-            // Keyboard is not shown when requesting focus in a Dialog
+            // Workaround for keyboard not being shown when focus is requested in a Dialog
+            // https://issuetracker.google.com/issues/204502668
             delay(200)
             focusRequester.requestFocus()
             keyboardController?.show()

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPElementUI.kt
@@ -25,7 +25,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
@@ -47,7 +46,7 @@ import androidx.compose.ui.unit.dp
 import com.stripe.android.ui.core.getBorderStrokeWidth
 import com.stripe.android.ui.core.paymentsColors
 
-@OptIn(ExperimentalComposeUiApi::class, ExperimentalMaterialApi::class)
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun OTPElementUI(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
@@ -117,7 +117,7 @@ fun TextField(
     val label by textFieldController.label.collectAsState(null)
 
     LaunchedEffect(fieldState) {
-        // When field is in focus and just became full, move to next field
+        // When field is in focus and full, move to next field so the user can keep typing
         if (fieldState == TextFieldStateConstants.Valid.Full && hasFocus) {
             focusManager.moveFocus(nextFocusDirection)
         }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldUI.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.TextField
 import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -114,20 +115,12 @@ fun TextField(
         TextFieldStateConstants.Error.Blank
     )
     val label by textFieldController.label.collectAsState(null)
-    var processedIsFull by rememberSaveable { mutableStateOf(false) }
 
-    /**
-     * This is setup so that when a field is full it still allows more characters
-     * to be entered, it just triggers next focus when the event happens.
-     */
-    @Suppress("UNUSED_VALUE")
-    processedIsFull = if (fieldState == TextFieldStateConstants.Valid.Full) {
-        if (!processedIsFull) {
+    LaunchedEffect(fieldState) {
+        // When field is in focus and just became full, move to next field
+        if (fieldState == TextFieldStateConstants.Valid.Full && hasFocus) {
             focusManager.moveFocus(nextFocusDirection)
         }
-        true
-    } else {
-        false
     }
 
     TextField(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
- On Verification Dialog, keyboard is not showing when the OTP field gets focus. This is a known [Compose issue](https://issuetracker.google.com/issues/204502668). Couldn't find a better solution than the workaround of delaying the focus request.
- When showing the card form with populated fields, the second field was requesting focus. That was because we tell FocusManager to move focus to the next element when one is full, so the user can keep typing. Limited that to only when the TextField has focus.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fixes for Link GA.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
