### PR TITLE
[BANKCON-5133] Complete financial connections session on all required scenarios.

### DIFF
--- a/financial-connections-example/build.gradle
+++ b/financial-connections-example/build.gradle
@@ -74,4 +74,5 @@ dependencies {
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$androidxComposeVersion"
     debugImplementation "androidx.compose.ui:ui-tooling:$androidxComposeVersion"
     debugImplementation "androidx.compose.ui:ui-test-manifest:$androidxComposeVersion"
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.9.1'
 }

--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -547,6 +547,21 @@ public final class com/stripe/android/financialconnections/features/common/Compo
 	public final fun getLambda-3$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 }
 
+public final class com/stripe/android/financialconnections/features/common/ComposableSingletons$CloseDialogKt {
+	public static final field INSTANCE Lcom/stripe/android/financialconnections/features/common/ComposableSingletons$CloseDialogKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-2 Lkotlin/jvm/functions/Function3;
+	public static field lambda-3 Lkotlin/jvm/functions/Function2;
+	public static field lambda-4 Lkotlin/jvm/functions/Function2;
+	public static field lambda-5 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-2$financial_connections_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-3$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-4$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-5$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+}
+
 public final class com/stripe/android/financialconnections/features/common/ComposableSingletons$ErrorContentKt {
 	public static final field INSTANCE Lcom/stripe/android/financialconnections/features/common/ComposableSingletons$ErrorContentKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function2;
@@ -1617,6 +1632,7 @@ public final class com/stripe/android/financialconnections/ui/FinancialConnectio
 public final class com/stripe/android/financialconnections/ui/components/ComposableSingletons$ButtonKt {
 	public static final field INSTANCE Lcom/stripe/android/financialconnections/ui/components/ComposableSingletons$ButtonKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-10 Lkotlin/jvm/functions/Function2;
 	public static field lambda-2 Lkotlin/jvm/functions/Function2;
 	public static field lambda-3 Lkotlin/jvm/functions/Function3;
 	public static field lambda-4 Lkotlin/jvm/functions/Function2;
@@ -1624,8 +1640,10 @@ public final class com/stripe/android/financialconnections/ui/components/Composa
 	public static field lambda-6 Lkotlin/jvm/functions/Function2;
 	public static field lambda-7 Lkotlin/jvm/functions/Function3;
 	public static field lambda-8 Lkotlin/jvm/functions/Function2;
+	public static field lambda-9 Lkotlin/jvm/functions/Function3;
 	public fun <init> ()V
 	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-10$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-2$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-3$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-4$financial_connections_release ()Lkotlin/jvm/functions/Function2;
@@ -1633,6 +1651,7 @@ public final class com/stripe/android/financialconnections/ui/components/Composa
 	public final fun getLambda-6$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-7$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-8$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-9$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/stripe/android/financialconnections/ui/components/ComposableSingletons$ScaffoldKt {

--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -635,6 +635,14 @@ public final class com/stripe/android/financialconnections/features/manualentrys
 	public final fun getLambda-5$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 }
 
+public final class com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessViewModel_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessViewModel_Factory;
+	public fun get ()Lcom/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessViewModel;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Lcom/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessState;Lcom/stripe/android/financialconnections/domain/CompleteFinancialConnectionsSession;Lcom/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator;Lcom/stripe/android/core/Logger;)Lcom/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessViewModel;
+}
+
 public final class com/stripe/android/financialconnections/features/partnerauth/ComposableSingletons$PartnerAuthScreenKt {
 	public static final field INSTANCE Lcom/stripe/android/financialconnections/features/partnerauth/ComposableSingletons$PartnerAuthScreenKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function3;
@@ -1583,11 +1591,11 @@ public final class com/stripe/android/financialconnections/network/FinancialConn
 }
 
 public final class com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel_Factory : dagger/internal/Factory {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel_Factory;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel_Factory;
 	public fun get ()Lcom/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun newInstance (Lcom/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeComponent;Lcom/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator;Lcom/stripe/android/financialconnections/domain/GetManifest;Lcom/stripe/android/financialconnections/utils/UriComparator;Lcom/stripe/android/core/Logger;Lcom/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeState;)Lcom/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel;
+	public static fun newInstance (Lcom/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeComponent;Lcom/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator;Lcom/stripe/android/financialconnections/domain/GetManifest;Lcom/stripe/android/financialconnections/utils/UriComparator;Lcom/stripe/android/financialconnections/domain/CompleteFinancialConnectionsSession;Lcom/stripe/android/core/Logger;Lcom/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeState;)Lcom/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel;
 }
 
 public final class com/stripe/android/financialconnections/repository/FinancialConnectionsRepositoryImpl_Factory : dagger/internal/Factory {
@@ -1654,13 +1662,6 @@ public final class com/stripe/android/financialconnections/ui/components/Composa
 	public final fun getLambda-9$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 }
 
-public final class com/stripe/android/financialconnections/ui/components/ComposableSingletons$ScaffoldKt {
-	public static final field INSTANCE Lcom/stripe/android/financialconnections/ui/components/ComposableSingletons$ScaffoldKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function2;
-	public fun <init> ()V
-	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function2;
-}
-
 public final class com/stripe/android/financialconnections/ui/components/ComposableSingletons$TextFieldKt {
 	public static final field INSTANCE Lcom/stripe/android/financialconnections/ui/components/ComposableSingletons$TextFieldKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function2;
@@ -1672,9 +1673,11 @@ public final class com/stripe/android/financialconnections/ui/components/Composa
 	public static final field INSTANCE Lcom/stripe/android/financialconnections/ui/components/ComposableSingletons$TopAppBarKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function2;
 	public static field lambda-2 Lkotlin/jvm/functions/Function2;
+	public static field lambda-3 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
 	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-2$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-3$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class com/stripe/android/financialconnections/ui/theme/ComposableSingletons$TypeKt {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeComponent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeComponent.kt
@@ -9,6 +9,7 @@ import com.stripe.android.financialconnections.features.attachpayment.AttachPaym
 import com.stripe.android.financialconnections.features.consent.ConsentSubcomponent
 import com.stripe.android.financialconnections.features.institutionpicker.InstitutionPickerSubcomponent
 import com.stripe.android.financialconnections.features.manualentry.ManualEntrySubcomponent
+import com.stripe.android.financialconnections.features.manualentrysuccess.ManualEntrySuccessSubcomponent
 import com.stripe.android.financialconnections.features.partnerauth.PartnerAuthSubcomponent
 import com.stripe.android.financialconnections.features.reset.ResetSubcomponent
 import com.stripe.android.financialconnections.features.success.SuccessSubcomponent
@@ -40,6 +41,7 @@ internal interface FinancialConnectionsSheetNativeComponent {
     val institutionPickerBuilder: InstitutionPickerSubcomponent.Builder
     val accountPickerBuilder: AccountPickerSubcomponent.Builder
     val manualEntryBuilder: ManualEntrySubcomponent.Builder
+    val manualEntrySuccessBuilder: ManualEntrySuccessSubcomponent.Builder
     val partnerAuthSubcomponent: PartnerAuthSubcomponent.Builder
     val successSubcomponent: SuccessSubcomponent.Builder
     val attachPaymentSubcomponent: AttachPaymentSubcomponent.Builder

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
@@ -59,20 +59,24 @@ import com.stripe.android.financialconnections.features.common.LoadingContent
 import com.stripe.android.financialconnections.features.common.NoSupportedPaymentMethodTypeAccountsErrorContent
 import com.stripe.android.financialconnections.features.common.UnclassifiedErrorContent
 import com.stripe.android.financialconnections.model.PartnerAccount
+import com.stripe.android.financialconnections.presentation.parentViewModel
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsButton
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsOutlinedTextField
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsScaffold
+import com.stripe.android.financialconnections.ui.components.FinancialConnectionsTopAppBar
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
 
 @Composable
 internal fun AccountPickerScreen() {
     val viewModel: AccountPickerViewModel = mavericksViewModel()
+    val parentViewModel = parentViewModel()
     val state: State<AccountPickerState> = viewModel.collectAsState()
     AccountPickerContent(
         state = state.value,
         onAccountClicked = viewModel::onAccountClicked,
         onSelectAccounts = viewModel::selectAccounts,
         onSelectAnotherBank = viewModel::selectAnotherBank,
+        onCloseClick = parentViewModel::onCloseClick,
     )
 }
 
@@ -81,9 +85,12 @@ private fun AccountPickerContent(
     state: AccountPickerState,
     onAccountClicked: (PartnerAccount) -> Unit,
     onSelectAccounts: () -> Unit,
-    onSelectAnotherBank: () -> Unit
+    onSelectAnotherBank: () -> Unit,
+    onCloseClick: () -> Unit
 ) {
-    FinancialConnectionsScaffold {
+    FinancialConnectionsScaffold(
+        topBar = { FinancialConnectionsTopAppBar(onCloseClick = onCloseClick) }
+    ) {
         when (val payload = state.payload) {
             Uninitialized, is Loading -> AccountPickerLoading()
             is Success -> when (payload().skipAccountSelection) {
@@ -385,7 +392,8 @@ internal fun AccountPickerPreviewMultiSelect() {
             AccountPickerStates.multiSelect(),
             onAccountClicked = {},
             onSelectAccounts = {},
-            onSelectAnotherBank = {}
+            onSelectAnotherBank = {},
+            onCloseClick = {}
         )
     }
 }
@@ -402,7 +410,8 @@ internal fun AccountPickerPreviewSingleSelect() {
             AccountPickerStates.singleSelect(),
             onAccountClicked = {},
             onSelectAccounts = {},
-            onSelectAnotherBank = {}
+            onSelectAnotherBank = {},
+            onCloseClick = {}
         )
     }
 }
@@ -419,7 +428,8 @@ internal fun AccountPickerPreviewDropdown() {
             AccountPickerStates.dropdown(),
             onAccountClicked = {},
             onSelectAccounts = {},
-            onSelectAnotherBank = {}
+            onSelectAnotherBank = {},
+            onCloseClick = {}
         )
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentScreen.kt
@@ -15,21 +15,32 @@ import com.airbnb.mvrx.compose.mavericksViewModel
 import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.features.common.LoadingContent
 import com.stripe.android.financialconnections.features.common.UnclassifiedErrorContent
+import com.stripe.android.financialconnections.presentation.parentViewModel
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsScaffold
+import com.stripe.android.financialconnections.ui.components.FinancialConnectionsTopAppBar
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
 
 @Composable
 internal fun AttachPaymentScreen() {
     val viewModel: AttachPaymentViewModel = mavericksViewModel()
+    val parentViewModel = parentViewModel()
     val state = viewModel.collectAsState()
     BackHandler(enabled = true) {}
-    AttachPaymentContent(state.value.payload)
+    AttachPaymentContent(
+        payload = state.value.payload,
+        onCloseClick = parentViewModel::onCloseClick
+    )
 }
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
-private fun AttachPaymentContent(payload: Async<AttachPaymentState.Payload>) {
-    FinancialConnectionsScaffold {
+private fun AttachPaymentContent(
+    payload: Async<AttachPaymentState.Payload>,
+    onCloseClick: () -> Unit
+) {
+    FinancialConnectionsScaffold(
+        topBar = { FinancialConnectionsTopAppBar(onCloseClick = onCloseClick) }
+    ) {
         when (payload) {
             Uninitialized, is Loading -> TODO()
             is Success -> LoadingContent(
@@ -58,6 +69,9 @@ private fun AttachPaymentContent(payload: Async<AttachPaymentState.Payload>) {
 @Preview
 internal fun AttachPaymentScreenPreview() {
     FinancialConnectionsTheme {
-        AttachPaymentContent(Uninitialized)
+        AttachPaymentContent(
+            payload = Uninitialized,
+            onCloseClick = {}
+        )
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/CloseDialog.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/CloseDialog.kt
@@ -1,0 +1,47 @@
+package com.stripe.android.financialconnections.features.common
+
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import com.stripe.android.financialconnections.ui.components.FinancialConnectionsButton
+import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
+
+@Composable
+internal fun CloseDialog(
+    onConfirmClick: () -> Unit
+) {
+    AlertDialog(
+        backgroundColor = FinancialConnectionsTheme.colors.backgroundContainer,
+        onDismissRequest = {},
+        title = {
+            Text(
+                text = "Are you sure you want to cancel?",
+                style = FinancialConnectionsTheme.typography.body
+            )
+        },
+        text = {
+            Text(
+                text = "TBD",
+                style = FinancialConnectionsTheme.typography.body
+            )
+        },
+        confirmButton = {
+            FinancialConnectionsButton(
+                size = FinancialConnectionsButton.Size.Pill,
+                type = FinancialConnectionsButton.Type.Critical,
+                onClick = onConfirmClick
+            ) {
+                Text("This is the Confirm Button")
+            }
+        },
+        dismissButton = {
+            FinancialConnectionsButton(
+                size = FinancialConnectionsButton.Size.Pill,
+                type = FinancialConnectionsButton.Type.Secondary,
+                onClick = {}
+            ) {
+                Text("This is the dismiss Button")
+            }
+        }
+    )
+}

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentScreen.kt
@@ -40,10 +40,12 @@ import com.airbnb.mvrx.compose.mavericksViewModel
 import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.features.consent.ConsentState.ViewEffect
 import com.stripe.android.financialconnections.presentation.CreateBrowserIntentForUrl
+import com.stripe.android.financialconnections.presentation.parentViewModel
 import com.stripe.android.financialconnections.ui.TextResource
 import com.stripe.android.financialconnections.ui.components.AnnotatedText
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsButton
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsScaffold
+import com.stripe.android.financialconnections.ui.components.FinancialConnectionsTopAppBar
 import com.stripe.android.financialconnections.ui.components.StringAnnotation
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
 import kotlinx.coroutines.launch
@@ -53,6 +55,7 @@ import kotlinx.coroutines.launch
 internal fun ConsentScreen() {
     // update step state when manifest changes
     val viewModel: ConsentViewModel = mavericksViewModel()
+    val parentViewModel = parentViewModel()
     val state = viewModel.collectAsState()
 
     // create bottom sheet state.
@@ -77,7 +80,8 @@ internal fun ConsentScreen() {
         bottomSheetState = bottomSheetState,
         onContinueClick = viewModel::onContinueClick,
         onClickableTextClick = viewModel::onClickableTextClick,
-        onConfirmModalClick = { scope.launch { bottomSheetState.hide() } }
+        onConfirmModalClick = { scope.launch { bottomSheetState.hide() } },
+        onCloseClick = parentViewModel::onCloseClick
     )
 }
 
@@ -104,13 +108,15 @@ private fun ViewEffect(
     }
 }
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 private fun ConsentContent(
     state: ConsentState,
     bottomSheetState: ModalBottomSheetState,
     onContinueClick: () -> Unit,
     onClickableTextClick: (String) -> Unit,
-    onConfirmModalClick: () -> Unit
+    onConfirmModalClick: () -> Unit,
+    onCloseClick: () -> Unit
 ) {
     val scrollState = rememberScrollState()
     ModalBottomSheetLayout(
@@ -131,7 +137,8 @@ private fun ConsentContent(
                 scrollState = scrollState,
                 state = state,
                 onClickableTextClick = onClickableTextClick,
-                onContinueClick = onContinueClick
+                onContinueClick = onContinueClick,
+                onCloseClick = onCloseClick
             )
         }
     )
@@ -142,9 +149,12 @@ private fun ConsentMainContent(
     scrollState: ScrollState,
     state: ConsentState,
     onClickableTextClick: (String) -> Unit,
-    onContinueClick: () -> Unit
+    onContinueClick: () -> Unit,
+    onCloseClick: () -> Unit
 ) {
-    FinancialConnectionsScaffold {
+    FinancialConnectionsScaffold(
+        topBar = { FinancialConnectionsTopAppBar(onCloseClick = onCloseClick) }
+    ) {
         Column(
             Modifier.fillMaxSize()
         ) {
@@ -341,14 +351,15 @@ internal fun ContentPreview(
 ) {
     FinancialConnectionsTheme {
         ConsentContent(
+            state = state,
             bottomSheetState = rememberModalBottomSheetState(
                 ModalBottomSheetValue.Hidden,
                 skipHalfExpanded = true
             ),
-            state = state,
             onContinueClick = {},
+            onClickableTextClick = {},
             onConfirmModalClick = {},
-            onClickableTextClick = {}
+            onCloseClick = {}
         )
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
@@ -57,6 +57,7 @@ import com.stripe.android.financialconnections.features.common.LoadingContent
 import com.stripe.android.financialconnections.features.common.UnclassifiedErrorContent
 import com.stripe.android.financialconnections.model.FinancialConnectionsInstitution
 import com.stripe.android.financialconnections.model.InstitutionResponse
+import com.stripe.android.financialconnections.presentation.parentViewModel
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsOutlinedTextField
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsScaffold
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsTopAppBar
@@ -65,6 +66,7 @@ import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsThem
 @Composable
 internal fun InstitutionPickerScreen() {
     val viewModel: InstitutionPickerViewModel = mavericksViewModel()
+    val parentViewModel = parentViewModel()
     val state by viewModel.collectAsState()
 
     // when in select institution error, back goes back to bank selection.
@@ -78,11 +80,12 @@ internal fun InstitutionPickerScreen() {
         selectInstitution = state.selectInstitution,
         searchMode = state.searchMode,
         query = state.query,
-        onQueryChanged = { viewModel.onQueryChanged(it) },
-        onInstitutionSelected = { viewModel.onInstitutionSelected(it) },
-        onCancelSearchClick = { viewModel.onCancelSearchClick() },
-        onSearchFocused = { viewModel.onSearchFocused() },
-        onSelectAnotherBank = { viewModel.onSelectAnotherBank() },
+        onQueryChanged = viewModel::onQueryChanged,
+        onInstitutionSelected = viewModel::onInstitutionSelected,
+        onCancelSearchClick = viewModel::onCancelSearchClick,
+        onSearchFocused = viewModel::onSearchFocused,
+        onSelectAnotherBank = viewModel::onSelectAnotherBank,
+        onCloseClick = parentViewModel::onCloseClick
     )
 }
 
@@ -97,12 +100,15 @@ private fun InstitutionPickerContent(
     onInstitutionSelected: (FinancialConnectionsInstitution) -> Unit,
     onSelectAnotherBank: () -> Unit,
     onCancelSearchClick: () -> Unit,
+    onCloseClick: () -> Unit,
     onSearchFocused: () -> Unit
 ) {
     FinancialConnectionsScaffold(
         topBar = {
             if (!searchMode) {
-                FinancialConnectionsTopAppBar()
+                FinancialConnectionsTopAppBar(
+                    onCloseClick = onCloseClick
+                )
             }
         }
     ) {
@@ -373,7 +379,8 @@ internal fun SearchModeSearchingInstitutions(
             onInstitutionSelected = {},
             onCancelSearchClick = {},
             onSearchFocused = {},
-            onSelectAnotherBank = {}
+            onSelectAnotherBank = {},
+            onCloseClick = {}
         )
     }
 }
@@ -394,7 +401,8 @@ internal fun SearchModeWithResults(
             onInstitutionSelected = {},
             onCancelSearchClick = {},
             onSearchFocused = {},
-            onSelectAnotherBank = {}
+            onSelectAnotherBank = {},
+            onCloseClick = {}
         )
     }
 }
@@ -415,7 +423,8 @@ internal fun SearchModeSelectingInstitutions(
             onInstitutionSelected = {},
             onCancelSearchClick = {},
             onSearchFocused = {},
-            onSelectAnotherBank = {}
+            onSelectAnotherBank = {},
+            onCloseClick = {}
         )
     }
 }
@@ -436,7 +445,8 @@ internal fun SearchModeNoResults(
             onInstitutionSelected = {},
             onCancelSearchClick = {},
             onSearchFocused = {},
-            onSelectAnotherBank = {}
+            onSelectAnotherBank = {},
+            onCloseClick = {}
         )
     }
 }
@@ -457,7 +467,8 @@ internal fun SearchModeNoQuery(
             onInstitutionSelected = {},
             onCancelSearchClick = {},
             onSearchFocused = {},
-            onSelectAnotherBank = {}
+            onSelectAnotherBank = {},
+            onCloseClick = {}
         )
     }
 }
@@ -478,7 +489,8 @@ internal fun NoSearchMode(
             onInstitutionSelected = {},
             onCancelSearchClick = {},
             onSearchFocused = {},
-            onSelectAnotherBank = {}
+            onSelectAnotherBank = {},
+            onCloseClick = {}
         )
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryScreen.kt
@@ -25,14 +25,17 @@ import com.airbnb.mvrx.compose.mavericksViewModel
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.model.LinkAccountSessionPaymentAccount
+import com.stripe.android.financialconnections.presentation.parentViewModel
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsButton
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsOutlinedTextField
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsScaffold
+import com.stripe.android.financialconnections.ui.components.FinancialConnectionsTopAppBar
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
 
 @Composable
 internal fun ManualEntryScreen() {
     val viewModel: ManualEntryViewModel = mavericksViewModel()
+    val parentViewModel = parentViewModel()
     val state: State<ManualEntryState> = viewModel.collectAsState()
 
     ManualEntryContent(
@@ -40,12 +43,13 @@ internal fun ManualEntryScreen() {
         account = state.value.account,
         accountConfirm = state.value.accountConfirm,
         isValidForm = state.value.isValidForm,
-        linkPaymentAccountStatus = state.value.linkPaymentAccount,
         verifyWithMicrodeposits = state.value.verifyWithMicrodeposits,
+        linkPaymentAccountStatus = state.value.linkPaymentAccount,
         onRoutingEntered = viewModel::onRoutingEntered,
         onAccountEntered = viewModel::onAccountEntered,
         onAccountConfirmEntered = viewModel::onAccountConfirmEntered,
-        onSubmit = viewModel::onSubmit
+        onSubmit = viewModel::onSubmit,
+        onCloseClick = parentViewModel::onCloseClick,
     )
 }
 
@@ -62,9 +66,12 @@ private fun ManualEntryContent(
     onAccountEntered: (String) -> Unit,
     onAccountConfirmEntered: (String) -> Unit,
     onSubmit: () -> Unit,
+    onCloseClick: () -> Unit,
 ) {
     val scrollState = rememberScrollState()
-    FinancialConnectionsScaffold {
+    FinancialConnectionsScaffold(
+        topBar = { FinancialConnectionsTopAppBar(onCloseClick = onCloseClick) }
+    ) {
         Column(
             Modifier.fillMaxSize()
         ) {
@@ -183,12 +190,13 @@ internal fun ManualEntryScreenPreview() {
             account = "" to null,
             accountConfirm = "" to null,
             isValidForm = true,
-            linkPaymentAccountStatus = Uninitialized,
             verifyWithMicrodeposits = true,
+            linkPaymentAccountStatus = Uninitialized,
             onRoutingEntered = {},
             onAccountEntered = {},
             onAccountConfirmEntered = {},
             onSubmit = {},
+            onCloseClick = {},
         )
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessScreen.kt
@@ -34,8 +34,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.model.LinkAccountSessionPaymentAccount.MicrodepositVerificationMethod
+import com.stripe.android.financialconnections.presentation.parentViewModel
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsButton
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsScaffold
+import com.stripe.android.financialconnections.ui.components.FinancialConnectionsTopAppBar
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
 
 @Composable
@@ -43,19 +45,24 @@ internal fun ManualEntrySuccessScreen(
     microdepositVerificationMethod: MicrodepositVerificationMethod,
     last4: String?
 ) {
+    val parentViewModel = parentViewModel()
     ManualEntrySuccessContent(
         microdepositVerificationMethod = microdepositVerificationMethod,
-        last4 = last4
+        last4 = last4,
+        onCloseClick = parentViewModel::onCloseClick
     )
 }
 
 @Composable
 internal fun ManualEntrySuccessContent(
     microdepositVerificationMethod: MicrodepositVerificationMethod,
-    last4: String?
+    last4: String?,
+    onCloseClick: () -> Unit
 ) {
     val localContext = LocalContext.current
-    FinancialConnectionsScaffold {
+    FinancialConnectionsScaffold(
+        topBar = { FinancialConnectionsTopAppBar(onCloseClick = onCloseClick) }
+    ) {
         Column(
             verticalArrangement = Arrangement.spacedBy(16.dp),
             modifier = Modifier
@@ -224,7 +231,8 @@ internal fun ManualEntrySuccessScreenPreviewAmount() {
     FinancialConnectionsTheme {
         ManualEntrySuccessContent(
             MicrodepositVerificationMethod.AMOUNTS,
-            last4 = "1234"
+            last4 = "1234",
+            onCloseClick = {}
         )
     }
 }
@@ -235,7 +243,8 @@ internal fun ManualEntrySuccessScreenPreviewDescriptor() {
     FinancialConnectionsTheme {
         ManualEntrySuccessContent(
             MicrodepositVerificationMethod.DESCRIPTOR_CODE,
-            last4 = "1234"
+            last4 = "1234",
+            onCloseClick = {}
         )
     }
 }
@@ -246,7 +255,8 @@ internal fun ManualEntrySuccessScreenPreviewAmountNoAccount() {
     FinancialConnectionsTheme {
         ManualEntrySuccessContent(
             MicrodepositVerificationMethod.AMOUNTS,
-            last4 = null
+            last4 = null,
+            onCloseClick = {}
         )
     }
 }
@@ -257,7 +267,8 @@ internal fun ManualEntrySuccessScreenPreviewDescriptorNoAccount() {
     FinancialConnectionsTheme {
         ManualEntrySuccessContent(
             MicrodepositVerificationMethod.DESCRIPTOR_CODE,
-            last4 = null
+            last4 = null,
+            onCloseClick = {}
         )
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessSubcomponent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessSubcomponent.kt
@@ -1,0 +1,19 @@
+package com.stripe.android.financialconnections.features.manualentrysuccess
+
+import dagger.BindsInstance
+import dagger.Subcomponent
+
+@Subcomponent
+internal interface ManualEntrySuccessSubcomponent {
+
+    val viewModel: ManualEntrySuccessViewModel
+
+    @Subcomponent.Builder
+    interface Builder {
+
+        @BindsInstance
+        fun initialState(initialState: ManualEntrySuccessState): Builder
+
+        fun build(): ManualEntrySuccessSubcomponent
+    }
+}

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntryViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntryViewModel.kt
@@ -1,0 +1,63 @@
+package com.stripe.android.financialconnections.features.manualentrysuccess
+
+import com.airbnb.mvrx.Async
+import com.airbnb.mvrx.MavericksState
+import com.airbnb.mvrx.MavericksViewModel
+import com.airbnb.mvrx.MavericksViewModelFactory
+import com.airbnb.mvrx.Uninitialized
+import com.airbnb.mvrx.ViewModelContext
+import com.stripe.android.core.Logger
+import com.stripe.android.financialconnections.domain.CompleteFinancialConnectionsSession
+import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
+import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.Finish
+import com.stripe.android.financialconnections.model.FinancialConnectionsSession
+import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
+import javax.inject.Inject
+
+@Suppress("LongParameterList")
+internal class ManualEntrySuccessViewModel @Inject constructor(
+    initialState: ManualEntrySuccessState,
+    private val completeFinancialConnectionsSession: CompleteFinancialConnectionsSession,
+    private val nativeAuthFlowCoordinator: NativeAuthFlowCoordinator,
+    private val logger: Logger
+) : MavericksViewModel<ManualEntrySuccessState>(initialState) {
+
+    init {
+        logErrors()
+    }
+
+    private fun logErrors() {
+        onAsync(ManualEntrySuccessState::completeAuthSession, onFail = {
+            logger.error("Error completing session", it)
+        })
+    }
+
+    fun onSubmit() {
+        suspend {
+            completeFinancialConnectionsSession().also {
+                nativeAuthFlowCoordinator().emit(Finish)
+            }
+        }.execute { copy(completeAuthSession = it) }
+    }
+
+    companion object :
+        MavericksViewModelFactory<ManualEntrySuccessViewModel, ManualEntrySuccessState> {
+
+        override fun create(
+            viewModelContext: ViewModelContext,
+            state: ManualEntrySuccessState
+        ): ManualEntrySuccessViewModel {
+            return viewModelContext.activity<FinancialConnectionsSheetNativeActivity>()
+                .viewModel
+                .activityRetainedComponent
+                .manualEntrySuccessBuilder
+                .initialState(state)
+                .build()
+                .viewModel
+        }
+    }
+}
+
+internal data class ManualEntrySuccessState(
+    val completeAuthSession: Async<FinancialConnectionsSession> = Uninitialized
+) : MavericksState

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthScreen.kt
@@ -34,14 +34,17 @@ import com.stripe.android.financialconnections.features.common.LoadingContent
 import com.stripe.android.financialconnections.features.common.PartnerCallout
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.FinancialConnectionsAuthorizationSession.Flow
 import com.stripe.android.financialconnections.presentation.FinancialConnectionsSheetNativeViewModel
+import com.stripe.android.financialconnections.presentation.parentViewModel
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsButton
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsScaffold
+import com.stripe.android.financialconnections.ui.components.FinancialConnectionsTopAppBar
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
 
 @Composable
 internal fun PartnerAuthScreen() {
     // activity view model
     val activityViewModel: FinancialConnectionsSheetNativeViewModel = mavericksActivityViewModel()
+    val parentViewModel = parentViewModel()
     val webAuthFlow = activityViewModel.collectAsState { it.webAuthFlow }
 
     // step view model
@@ -56,9 +59,10 @@ internal fun PartnerAuthScreen() {
         viewModel.onWebAuthFlowFinished(webAuthFlow.value)
     }
     PartnerAuthScreenContent(
-        state.value,
-        viewModel::onLaunchAuthClick,
-        viewModel::onSelectAnotherBank
+        state = state.value,
+        onContinueClick = viewModel::onLaunchAuthClick,
+        onSelectAnotherBank = viewModel::onSelectAnotherBank,
+        onCloseClick = parentViewModel::onCloseClick
     )
 }
 
@@ -67,8 +71,11 @@ private fun PartnerAuthScreenContent(
     state: PartnerAuthState,
     onContinueClick: () -> Unit,
     onSelectAnotherBank: () -> Unit,
+    onCloseClick: () -> Unit
 ) {
-    FinancialConnectionsScaffold {
+    FinancialConnectionsScaffold(
+        topBar = { FinancialConnectionsTopAppBar(onCloseClick = onCloseClick) }
+    ) {
         when (state.authenticationStatus) {
             is Uninitialized -> PrePaneContent(
                 institutionName = state.institutionName,
@@ -153,7 +160,8 @@ internal fun PrepaneContentPreview() {
                 flow = Flow.FINICITY_CONNECT_V2_OAUTH
             ),
             onContinueClick = {},
-            onSelectAnotherBank = {}
+            onSelectAnotherBank = {},
+            onCloseClick = {}
         )
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/reset/ResetScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/reset/ResetScreen.kt
@@ -12,20 +12,31 @@ import com.airbnb.mvrx.compose.collectAsState
 import com.airbnb.mvrx.compose.mavericksViewModel
 import com.stripe.android.financialconnections.features.common.LoadingContent
 import com.stripe.android.financialconnections.features.common.UnclassifiedErrorContent
+import com.stripe.android.financialconnections.presentation.parentViewModel
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsScaffold
+import com.stripe.android.financialconnections.ui.components.FinancialConnectionsTopAppBar
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
 
 @Composable
 internal fun ResetScreen() {
     val viewModel: ResetViewModel = mavericksViewModel()
+    val parentViewModel = parentViewModel()
     val state = viewModel.collectAsState()
     BackHandler(enabled = true) {}
-    ResetContent(state.value.payload)
+    ResetContent(
+        payload = state.value.payload,
+        onCloseClick = parentViewModel::onCloseClick
+    )
 }
 
 @Composable
-private fun ResetContent(payload: Async<Unit>) {
-    FinancialConnectionsScaffold {
+private fun ResetContent(
+    payload: Async<Unit>,
+    onCloseClick: () -> Unit
+) {
+    FinancialConnectionsScaffold(
+        topBar = { FinancialConnectionsTopAppBar(onCloseClick = onCloseClick) }
+    ) {
         when (payload) {
             Uninitialized, is Loading -> LoadingContent()
             is Success -> LoadingContent()
@@ -38,6 +49,9 @@ private fun ResetContent(payload: Async<Unit>) {
 @Preview
 internal fun ResetScreenPreview() {
     FinancialConnectionsTheme {
-        ResetContent(Uninitialized)
+        ResetContent(
+            payload = Uninitialized,
+            onCloseClick = {}
+        )
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessScreen.kt
@@ -25,17 +25,20 @@ import com.stripe.android.financialconnections.features.common.AccessibleDataCal
 import com.stripe.android.financialconnections.features.common.AccessibleDataCalloutWithAccounts
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
 import com.stripe.android.financialconnections.model.PartnerAccount
+import com.stripe.android.financialconnections.presentation.parentViewModel
 import com.stripe.android.financialconnections.ui.TextResource
 import com.stripe.android.financialconnections.ui.components.AnnotatedText
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsButton
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsButtonType
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsScaffold
+import com.stripe.android.financialconnections.ui.components.FinancialConnectionsTopAppBar
 import com.stripe.android.financialconnections.ui.components.StringAnnotation
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
 
 @Composable
-internal fun SuccessScreen() {
+internal fun SuccessScreen(onCloseClick: () -> Unit) {
     val viewModel: SuccessViewModel = mavericksViewModel()
+    val parentViewModel = parentViewModel()
     val state = viewModel.collectAsState()
     BackHandler(enabled = true) {}
     state.value.payload()?.let { payload ->
@@ -43,10 +46,11 @@ internal fun SuccessScreen() {
             accessibleDataModel = payload.accessibleData,
             disconnectUrl = payload.disconnectUrl,
             accounts = payload.accounts.data,
-            showLinkAnotherAccount = payload.showLinkAnotherAccount,
             loading = state.value.completeSession is Loading,
             onDoneClick = viewModel::onDoneClick,
             onLinkAnotherAccountClick = viewModel::onLinkAnotherAccountClick,
+            onCloseClick = parentViewModel::onCloseClick,
+            showLinkAnotherAccount = payload.showLinkAnotherAccount,
         )
     }
 }
@@ -61,9 +65,12 @@ private fun SuccessContent(
     onDoneClick: () -> Unit,
     onLinkAnotherAccountClick: () -> Unit,
     showLinkAnotherAccount: Boolean,
+    onCloseClick: () -> Unit,
 ) {
     val uriHandler = LocalUriHandler.current
-    FinancialConnectionsScaffold {
+    FinancialConnectionsScaffold(
+        topBar = { FinancialConnectionsTopAppBar(onCloseClick = onCloseClick) }
+    ) {
         Column(
             verticalArrangement = Arrangement.spacedBy(16.dp),
             modifier = Modifier
@@ -172,7 +179,8 @@ internal fun SuccessScreenPreview() {
             loading = false,
             onDoneClick = {},
             onLinkAnotherAccountClick = {},
-            showLinkAnotherAccount = true
+            showLinkAnotherAccount = true,
+            onCloseClick = {}
         )
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessScreen.kt
@@ -29,14 +29,13 @@ import com.stripe.android.financialconnections.presentation.parentViewModel
 import com.stripe.android.financialconnections.ui.TextResource
 import com.stripe.android.financialconnections.ui.components.AnnotatedText
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsButton
-import com.stripe.android.financialconnections.ui.components.FinancialConnectionsButtonType
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsScaffold
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsTopAppBar
 import com.stripe.android.financialconnections.ui.components.StringAnnotation
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
 
 @Composable
-internal fun SuccessScreen(onCloseClick: () -> Unit) {
+internal fun SuccessScreen() {
     val viewModel: SuccessViewModel = mavericksViewModel()
     val parentViewModel = parentViewModel()
     val state = viewModel.collectAsState()
@@ -109,7 +108,7 @@ private fun SuccessContent(
             if (showLinkAnotherAccount) {
                 FinancialConnectionsButton(
                     loading = loading,
-                    type = FinancialConnectionsButtonType.Secondary,
+                    type = FinancialConnectionsButton.Type.Secondary,
                     enabled = loading.not(),
                     onClick = onLinkAnotherAccountClick,
                     modifier = Modifier

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
@@ -13,6 +13,7 @@ import com.airbnb.mvrx.Success
 import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.ViewModelContext
 import com.airbnb.mvrx.compose.mavericksActivityViewModel
+import com.stripe.android.core.Logger
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.di.DaggerFinancialConnectionsSheetNativeComponent
 import com.stripe.android.financialconnections.di.FinancialConnectionsSheetNativeComponent

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
@@ -2,6 +2,7 @@ package com.stripe.android.financialconnections.presentation
 
 import android.content.Intent
 import androidx.compose.runtime.Composable
+import androidx.navigation.compose.NavHost
 import com.airbnb.mvrx.Async
 import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Loading
@@ -114,10 +115,19 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
         setState { copy(viewEffect = null) }
     }
 
+    fun onCloseClick() = close()
+
+    /**
+     * [NavHost] handles back presses except for when backstack is empty, where it delegates
+     * to the container activity. [onBackPressed] will be triggered on these empty backstack cases.
+     */
+    fun onBackPressed() = close()
+
     @OptIn(DelicateCoroutinesApi::class)
-    fun onCloseClick() {
+    private fun close() {
         // Asynchronously complete the session while activity is closing.
-        // Using [GlobalScope]
+        // Using [GlobalScope] to prevent the call from cancel while activity finishes.
+        logger.debug("User intentionally closed the AuthFlow.")
         GlobalScope.launch {
             kotlin
                 .runCatching { completeFinancialConnectionsSession() }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.financialconnections.presentation
 
 import android.content.Intent
+import androidx.compose.runtime.Composable
 import com.airbnb.mvrx.Async
 import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Loading
@@ -10,15 +11,17 @@ import com.airbnb.mvrx.MavericksViewModelFactory
 import com.airbnb.mvrx.Success
 import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.ViewModelContext
-import com.stripe.android.core.Logger
+import com.airbnb.mvrx.compose.mavericksActivityViewModel
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.di.DaggerFinancialConnectionsSheetNativeComponent
 import com.stripe.android.financialconnections.di.FinancialConnectionsSheetNativeComponent
+import com.stripe.android.financialconnections.domain.CompleteFinancialConnectionsSession
 import com.stripe.android.financialconnections.domain.GetManifest
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message
 import com.stripe.android.financialconnections.exception.WebAuthFlowCancelledException
 import com.stripe.android.financialconnections.exception.WebAuthFlowFailedException
+import com.stripe.android.financialconnections.features.accountpicker.AccountPickerState
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetNativeActivityArgs
 import com.stripe.android.financialconnections.presentation.FinancialConnectionsSheetNativeViewEffect.Finish
 import com.stripe.android.financialconnections.presentation.FinancialConnectionsSheetNativeViewEffect.OpenUrl
@@ -36,16 +39,13 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
     private val nativeAuthFlowCoordinator: NativeAuthFlowCoordinator,
     private val getManifest: GetManifest,
     private val uriComparator: UriComparator,
+    private val completeFinancialConnectionsSession: CompleteFinancialConnectionsSession,
     private val logger: Logger,
     initialState: FinancialConnectionsSheetNativeState
 ) : MavericksViewModel<FinancialConnectionsSheetNativeState>(initialState) {
 
     init {
-        viewModelScope.launch {
-            stateFlow.collect {
-                logger.debug("Native state: $it")
-            }
-        }
+        logErrors()
         viewModelScope.launch {
             nativeAuthFlowCoordinator().collect { message ->
                 when (message) {
@@ -62,6 +62,12 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    private fun logErrors() {
+        onAsync(FinancialConnectionsSheetNativeState::completeFinancialConnectionsSession, onFail = {
+            logger.error("Error completing session before closing", it)
+        })
     }
 
     /**
@@ -114,6 +120,13 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
         setState { copy(viewEffect = null) }
     }
 
+    fun onCloseClick() {
+        suspend {
+            completeFinancialConnectionsSession()
+            setState { copy(viewEffect = Finish) }
+        }.execute { copy(completeFinancialConnectionsSession = it) }
+    }
+
     companion object :
         MavericksViewModelFactory<FinancialConnectionsSheetNativeViewModel, FinancialConnectionsSheetNativeState> {
 
@@ -140,6 +153,7 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
 internal data class FinancialConnectionsSheetNativeState(
     val webAuthFlow: Async<String>,
     val configuration: FinancialConnectionsSheet.Configuration,
+    val completeFinancialConnectionsSession: Async<Unit>,
     val viewEffect: FinancialConnectionsSheetNativeViewEffect?
 ) : MavericksState {
 
@@ -150,10 +164,13 @@ internal data class FinancialConnectionsSheetNativeState(
     constructor(args: FinancialConnectionsSheetNativeActivityArgs) : this(
         webAuthFlow = Uninitialized,
         configuration = args.configuration,
+        completeFinancialConnectionsSession = Uninitialized,
         viewEffect = null
     )
 }
 
+@Composable
+internal fun parentViewModel(): FinancialConnectionsSheetNativeViewModel = mavericksActivityViewModel()
 internal sealed interface FinancialConnectionsSheetNativeViewEffect {
     /**
      * Open the Web AuthFlow.

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
@@ -115,7 +115,16 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
         setState { copy(viewEffect = null) }
     }
 
-    fun onCloseClick() = close()
+    fun onCloseClick() {
+        // TODO@carlosmuvi: show close dialog instead of directly closing depending on pane.
+        if (false) {
+            setState { copy(showCloseDialog = true) }
+        } else {
+            close()
+        }
+    }
+
+    fun onCloseConfirm() = close()
 
     /**
      * [NavHost] handles back presses except for when backstack is empty, where it delegates
@@ -162,6 +171,7 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
 internal data class FinancialConnectionsSheetNativeState(
     val webAuthFlow: Async<String>,
     val configuration: FinancialConnectionsSheet.Configuration,
+    val showCloseDialog: Boolean,
     val viewEffect: FinancialConnectionsSheetNativeViewEffect?
 ) : MavericksState {
 
@@ -172,6 +182,7 @@ internal data class FinancialConnectionsSheetNativeState(
     constructor(args: FinancialConnectionsSheetNativeActivityArgs) : this(
         webAuthFlow = Uninitialized,
         configuration = args.configuration,
+        showCloseDialog = false,
         viewEffect = null
     )
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import androidx.activity.addCallback
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.Box
@@ -49,6 +50,7 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), Ma
         super.onCreate(savedInstanceState)
         viewModel.activityRetainedComponent.inject(this)
         viewModel.onEach { postInvalidate() }
+        onBackPressedDispatcher.addCallback { viewModel.onBackPressed() }
         setContent {
             FinancialConnectionsTheme {
                 Column {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
@@ -85,6 +85,7 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), Ma
     @Composable
     fun NavHost() {
         val navController = rememberNavController()
+        val onCloseClick = { viewModel.onCloseClick() }
         NavigationEffect(navController)
         NavHost(navController, startDestination = NavigationDirections.consent.destination) {
             composable(NavigationDirections.consent.destination) {
@@ -114,7 +115,7 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), Ma
                 AccountPickerScreen()
             }
             composable(NavigationDirections.success.destination) {
-                SuccessScreen()
+                SuccessScreen(onCloseClick)
             }
             composable(NavigationDirections.reset.destination) {
                 ResetScreen()

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
@@ -157,7 +157,12 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), Ma
      */
     private fun NavOptionsBuilder.popUpAfterAuth(navController: NavHostController) {
         val destination: String = navController.currentBackStackEntry?.destination?.route ?: return
-        if (navController.currentDestination?.route == NavigationDirections.partnerAuth.destination) {
+        val destinationsToSkipOnBack = listOf(
+            NavigationDirections.partnerAuth.destination,
+            NavigationDirections.reset.destination
+        )
+        if (destinationsToSkipOnBack.contains(navController.currentDestination?.route)
+        ) {
             popUpTo(destination) {
                 inclusive = true
             }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
@@ -147,7 +147,7 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), Ma
             navigationManager.commands.collect { command ->
                 if (command.destination.isNotEmpty()) {
                     navController.navigate(command.destination) {
-                        popUpAfterAuth(navController)
+                        popUpIfNotBackwardsNavigable(navController)
                     }
                 }
             }
@@ -155,9 +155,9 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), Ma
     }
 
     /**
-     * Skips auth screens from back navigation.
+     * Removes screens that are not backwards-navigable from the backstack.
      */
-    private fun NavOptionsBuilder.popUpAfterAuth(navController: NavHostController) {
+    private fun NavOptionsBuilder.popUpIfNotBackwardsNavigable(navController: NavHostController) {
         val destination: String = navController.currentBackStackEntry?.destination?.route ?: return
         val destinationsToSkipOnBack = listOf(
             NavigationDirections.partnerAuth.destination,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
@@ -19,10 +19,12 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.airbnb.mvrx.MavericksView
+import com.airbnb.mvrx.compose.collectAsState
 import com.airbnb.mvrx.viewModel
 import com.airbnb.mvrx.withState
 import com.stripe.android.financialconnections.features.accountpicker.AccountPickerScreen
 import com.stripe.android.financialconnections.features.attachpayment.AttachPaymentScreen
+import com.stripe.android.financialconnections.features.common.CloseDialog
 import com.stripe.android.financialconnections.features.consent.ConsentScreen
 import com.stripe.android.financialconnections.features.institutionpicker.InstitutionPickerScreen
 import com.stripe.android.financialconnections.features.manualentry.ManualEntryScreen
@@ -54,7 +56,11 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), Ma
         setContent {
             FinancialConnectionsTheme {
                 Column {
-                    Box(modifier = Modifier.weight(1f)) { NavHost() }
+                    Box(modifier = Modifier.weight(1f)) {
+                        val showCloseDialog = viewModel.collectAsState { it.showCloseDialog }
+                        if (showCloseDialog.value) CloseDialog(viewModel::onCloseConfirm)
+                        NavHost()
+                    }
                 }
             }
         }
@@ -87,7 +93,6 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), Ma
     @Composable
     fun NavHost() {
         val navController = rememberNavController()
-        val onCloseClick = { viewModel.onCloseClick() }
         NavigationEffect(navController)
         NavHost(navController, startDestination = NavigationDirections.consent.destination) {
             composable(NavigationDirections.consent.destination) {
@@ -117,7 +122,7 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), Ma
                 AccountPickerScreen()
             }
             composable(NavigationDirections.success.destination) {
-                SuccessScreen(onCloseClick)
+                SuccessScreen()
             }
             composable(NavigationDirections.reset.destination) {
                 ResetScreen()

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/Button.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/Button.kt
@@ -25,7 +25,8 @@ import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsThem
 internal fun FinancialConnectionsButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    type: FinancialConnectionsButtonType = FinancialConnectionsButtonType.Primary,
+    type: FinancialConnectionsButton.Type = FinancialConnectionsButton.Type.Primary,
+    size: FinancialConnectionsButton.Size = FinancialConnectionsButton.Size.Regular,
     enabled: Boolean = true,
     loading: Boolean = false,
     content: @Composable (RowScope.() -> Unit)
@@ -35,12 +36,7 @@ internal fun FinancialConnectionsButton(
         modifier = modifier,
         enabled = enabled,
         shape = RoundedCornerShape(12.dp),
-        contentPadding = PaddingValues(
-            start = 16.dp,
-            top = 16.dp,
-            end = 16.dp,
-            bottom = 16.dp
-        ),
+        contentPadding = size.paddingValues(),
         colors = type.buttonColors(),
         content = {
             ProvideTextStyle(
@@ -62,31 +58,71 @@ internal fun FinancialConnectionsButton(
     )
 }
 
-internal sealed class FinancialConnectionsButtonType {
+internal object FinancialConnectionsButton {
 
-    @Composable
-    abstract fun buttonColors(): ButtonColors
+    internal sealed class Type {
 
-    object Primary : FinancialConnectionsButtonType() {
         @Composable
-        override fun buttonColors(): ButtonColors {
-            return buttonColors(
-                backgroundColor = colors.textBrand,
-                contentColor = colors.textWhite,
-                disabledBackgroundColor = colors.textBrand.copy(alpha = 0.12f),
-                disabledContentColor = colors.textWhite,
-            )
+        abstract fun buttonColors(): ButtonColors
+
+        object Primary : Type() {
+            @Composable
+            override fun buttonColors(): ButtonColors {
+                return buttonColors(
+                    backgroundColor = colors.textBrand,
+                    contentColor = colors.textWhite,
+                    disabledBackgroundColor = colors.textBrand.copy(alpha = 0.12f),
+                    disabledContentColor = colors.textWhite,
+                )
+            }
+        }
+
+        object Secondary : Type() {
+            @Composable
+            override fun buttonColors(): ButtonColors {
+                return buttonColors(
+                    backgroundColor = colors.textWhite,
+                    contentColor = colors.textPrimary,
+                    disabledBackgroundColor = colors.textWhite,
+                    disabledContentColor = colors.textPrimary.copy(alpha = 0.12f),
+                )
+            }
+        }
+
+        object Critical : Type() {
+            @Composable
+            override fun buttonColors(): ButtonColors {
+                return buttonColors(
+                    backgroundColor = colors.textCritical,
+                    contentColor = colors.textWhite,
+                    disabledBackgroundColor = colors.textCritical.copy(alpha = 0.12f),
+                    disabledContentColor = colors.textPrimary.copy(alpha = 0.12f),
+                )
+            }
         }
     }
 
-    object Secondary : FinancialConnectionsButtonType() {
+    sealed class Size {
         @Composable
-        override fun buttonColors(): ButtonColors {
-            return buttonColors(
-                backgroundColor = colors.textWhite,
-                contentColor = colors.textPrimary,
-                disabledBackgroundColor = colors.textWhite,
-                disabledContentColor = colors.textPrimary.copy(alpha = 0.12f),
+        abstract fun paddingValues(): PaddingValues
+
+        object Pill : Size() {
+            @Composable
+            override fun paddingValues(): PaddingValues = PaddingValues(
+                start = 8.dp,
+                top = 4.dp,
+                end = 8.dp,
+                bottom = 4.dp
+            )
+        }
+
+        object Regular : Size() {
+            @Composable
+            override fun paddingValues(): PaddingValues = PaddingValues(
+                start = 16.dp,
+                top = 16.dp,
+                end = 16.dp,
+                bottom = 16.dp
             )
         }
     }
@@ -123,7 +159,7 @@ internal fun FinancialConnectionsButtonLoadingPreview() {
 internal fun FinancialConnectionsButtonSecondaryPreview() {
     FinancialConnectionsTheme {
         FinancialConnectionsButton(
-            type = FinancialConnectionsButtonType.Secondary,
+            type = FinancialConnectionsButton.Type.Secondary,
             loading = false,
             onClick = { }
         ) {
@@ -137,9 +173,25 @@ internal fun FinancialConnectionsButtonSecondaryPreview() {
 internal fun FinancialConnectionsButtonSecondaryDisabledPreview() {
     FinancialConnectionsTheme {
         FinancialConnectionsButton(
-            type = FinancialConnectionsButtonType.Secondary,
+            type = FinancialConnectionsButton.Type.Secondary,
             loading = false,
             enabled = false,
+            onClick = { }
+        ) {
+            Text(text = "Sample text")
+        }
+    }
+}
+
+@Composable
+@Preview(group = "Components", name = "Pill button - critical - disabled")
+internal fun FinancialConnectionsButtonCriticalPreview() {
+    FinancialConnectionsTheme {
+        FinancialConnectionsButton(
+            type = FinancialConnectionsButton.Type.Critical,
+            size = FinancialConnectionsButton.Size.Pill,
+            loading = false,
+            enabled = true,
             onClick = { }
         ) {
             Text(text = "Sample text")

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/Scaffold.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/Scaffold.kt
@@ -9,7 +9,7 @@ import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsThem
 
 @Composable
 internal fun FinancialConnectionsScaffold(
-    topBar: @Composable () -> Unit = { FinancialConnectionsTopAppBar() },
+    topBar: @Composable () -> Unit,
     content: @Composable (PaddingValues) -> Unit
 ) {
     Scaffold(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/TopAppBar.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/TopAppBar.kt
@@ -3,7 +3,10 @@
 package com.stripe.android.financialconnections.ui.components
 
 import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -19,11 +22,19 @@ internal fun FinancialConnectionsTopAppBar(
             contentDescription = null // decorative element
         )
     },
-    navigationIcon: @Composable (() -> Unit)? = null
+    onCloseClick: () -> Unit,
 ) {
     TopAppBar(
         title = title,
-        navigationIcon = navigationIcon,
+        navigationIcon = {
+            IconButton(onClick = onCloseClick) {
+                Icon(
+                    imageVector = Icons.Filled.Close,
+                    contentDescription = "Close icon",
+                    tint = FinancialConnectionsTheme.colors.textSecondary
+                )
+            }
+        },
         backgroundColor = FinancialConnectionsTheme.colors.textWhite,
         contentColor = FinancialConnectionsTheme.colors.textBrand,
         elevation = 0.dp
@@ -34,6 +45,6 @@ internal fun FinancialConnectionsTopAppBar(
 @Preview(group = "Components", name = "TopAppBar - idle")
 internal fun FinancialConnectionsTopAppBarPreview() {
     FinancialConnectionsTheme {
-        FinancialConnectionsTopAppBar()
+        FinancialConnectionsTopAppBar {}
     }
 }


### PR DESCRIPTION
# Summary
- Adds close button to `FinancialConnectionsTopAppbar`.
- Calls `sessions/complete` and closes session when user clicks close.
- Calls `sessions/complete` and closes when user clicks back and backstack empty.
- Calls `sessions/complete` after success / manual entry success.

# Test
Run financial connections and click the close button on the toolbar.

https://user-images.githubusercontent.com/99293320/190543173-33f4e3df-a863-4f8a-b9da-f836be46dde1.mp4

# Motivation
https://jira.corp.stripe.com/browse/BANKCON-5133