### PR TITLE
Fix issue with text not showing in OTP

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPElementUI.kt
@@ -89,7 +89,6 @@ fun OTPElementUI(
                 )
             ) {
                 val value by element.controller.fieldValues[index].collectAsState("")
-
                 var textFieldModifier = Modifier
                     .height(56.dp)
                     .onFocusChanged { focusState ->
@@ -181,12 +180,8 @@ fun OTPElementUI(
                                 placeholderColor = colors.placeholder,
                                 disabledPlaceholderColor = colors.placeholder
                             ),
-                            contentPadding = PaddingValues(
-                                TextFieldPadding,
-                                TextFieldPadding,
-                                TextFieldPadding,
-                                TextFieldPadding
-                            )
+                            // TextField has a default padding, here we are specifying 0.dp padding
+                            contentPadding = PaddingValues()
                         )
                     }
                 )
@@ -200,5 +195,3 @@ data class OTPElementColors(
     val selectedBorder: Color,
     val placeholder: Color
 )
-
-private val TextFieldPadding = 12.dp


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Fix an issue where text is not appearing in OTP cell when the font size is too big. It looks like the text is not appearing because of the textfield padding default is 16, was set to 12. This PR sets the padding to 0, and when tested with different font sizes, seems to work.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Link GA

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/99316447/190708399-d6bd36f7-0a68-4cc2-9d49-c6488f46c6dc.png" height=400/>  | <img src="https://user-images.githubusercontent.com/99316447/190708419-7b76cdaf-f4bf-43ac-a1b9-3fc0f696d02c.png" height=400/>  |

