### PR TITLE
Add `Set as default` functionality in Link wallet

### DIFF
--- a/link/build.gradle
+++ b/link/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     testImplementation "org.robolectric:robolectric:$robolectricVersion"
     testImplementation "androidx.test:core:$androidTestVersion"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinCoroutinesVersion"
+    testImplementation testLibs.turbine
 
     androidTestImplementation "com.google.truth:truth:$truthVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidTestJunitVersion"

--- a/link/res/values/strings.xml
+++ b/link/res/values/strings.xml
@@ -26,6 +26,7 @@
     <string name="wallet_expand_accessibility">Change selection</string>
     <string name="wallet_default">Default</string>
     <string name="wallet_update_card">Update card</string>
+    <string name="wallet_set_as_default">Set as default</string>
     <string name="wallet_remove_card">Remove card</string>
     <string name="wallet_remove_linked_account">Remove linked account</string>
     <string name="wallet_unavailable">Unavailable for this purchase</string>

--- a/link/src/main/java/com/stripe/android/link/ui/cardedit/CardEditViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/cardedit/CardEditViewModel.kt
@@ -107,10 +107,10 @@ internal class CardEditViewModel @Inject constructor(
             )
 
         viewModelScope.launch {
-            val updateParams = ConsumerPaymentDetailsUpdateParams.Card(
-                paymentDetails.id,
-                setAsDefault.value.takeUnless { isDefault || it == isDefault },
-                paymentMethodCreateParams
+            val updateParams = ConsumerPaymentDetailsUpdateParams(
+                id = paymentDetails.id,
+                isDefault = setAsDefault.value.takeUnless { isDefault || it == isDefault },
+                cardPaymentMethodCreateParams = paymentMethodCreateParams
             )
 
             linkAccountManager.updatePaymentDetails(updateParams).fold(

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/PaymentDetails.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/PaymentDetails.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.LocalContentAlpha
@@ -35,6 +36,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.stripe.android.link.R
 import com.stripe.android.link.model.icon
+import com.stripe.android.link.theme.MinimumTouchTargetSize
 import com.stripe.android.link.theme.linkColors
 import com.stripe.android.link.theme.linkShapes
 import com.stripe.android.link.ui.ErrorText
@@ -48,6 +50,7 @@ internal fun PaymentDetailsListItem(
     enabled: Boolean,
     isSupported: Boolean,
     isSelected: Boolean,
+    isUpdating: Boolean,
     onClick: () -> Unit,
     onMenuButtonClick: () -> Unit
 ) {
@@ -118,16 +121,31 @@ internal fun PaymentDetailsListItem(
                 )
             }
         }
-        IconButton(
-            onClick = onMenuButtonClick,
-            modifier = Modifier.padding(end = 6.dp),
-            enabled = enabled
+
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .size(MinimumTouchTargetSize)
+                .padding(end = 12.dp)
         ) {
-            Icon(
-                imageVector = Icons.Filled.MoreVert,
-                contentDescription = stringResource(R.string.edit),
-                tint = MaterialTheme.linkColors.actionLabelLight
-            )
+            if (isUpdating) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(24.dp),
+                    strokeWidth = 2.dp
+                )
+            } else {
+                IconButton(
+                    onClick = onMenuButtonClick,
+                    enabled = enabled
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.MoreVert,
+                        contentDescription = stringResource(R.string.edit),
+                        tint = MaterialTheme.linkColors.actionLabelLight,
+                        modifier = Modifier.size(24.dp)
+                    )
+                }
+            }
         }
     }
     TabRowDefaults.Divider(

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletPaymentMethodMenu.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletPaymentMethodMenu.kt
@@ -21,6 +21,10 @@ internal sealed class WalletPaymentMethodMenuItem(
         textResId = R.string.wallet_update_card
     )
 
+    object SetAsDefault : WalletPaymentMethodMenuItem(
+        textResId = R.string.wallet_set_as_default
+    )
+
     object Cancel : WalletPaymentMethodMenuItem(
         textResId = R.string.cancel
     )
@@ -30,12 +34,17 @@ internal sealed class WalletPaymentMethodMenuItem(
 internal fun WalletPaymentMethodMenu(
     paymentDetails: ConsumerPaymentDetails.PaymentDetails,
     onEditClick: () -> Unit,
+    onSetDefaultClick: () -> Unit,
     onRemoveClick: () -> Unit,
     onCancelClick: () -> Unit
 ) {
     val items = buildList {
         if (paymentDetails is ConsumerPaymentDetails.Card) {
             add(WalletPaymentMethodMenuItem.EditCard)
+        }
+
+        if (!paymentDetails.isDefault) {
+            add(WalletPaymentMethodMenuItem.SetAsDefault)
         }
 
         add(WalletPaymentMethodMenuItem.RemoveItem(textResId = paymentDetails.removeLabel))
@@ -47,6 +56,7 @@ internal fun WalletPaymentMethodMenu(
         onItemPress = { item ->
             when (item) {
                 is WalletPaymentMethodMenuItem.EditCard -> onEditClick()
+                is WalletPaymentMethodMenuItem.SetAsDefault -> onSetDefaultClick()
                 is WalletPaymentMethodMenuItem.RemoveItem -> onRemoveClick()
                 is WalletPaymentMethodMenuItem.Cancel -> onCancelClick()
             }

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -118,6 +118,7 @@ private fun WalletBodyPreview() {
                 onItemSelected = {},
                 onAddNewPaymentMethodClick = {},
                 onEditPaymentMethod = {},
+                onSetDefault = {},
                 onDeletePaymentMethod = {},
                 onPrimaryButtonClick = {},
                 onPayAnotherWayClick = {},
@@ -179,6 +180,7 @@ internal fun WalletBody(
             onItemSelected = viewModel::onItemSelected,
             onAddNewPaymentMethodClick = viewModel::addNewPaymentMethod,
             onEditPaymentMethod = viewModel::editPaymentMethod,
+            onSetDefault = viewModel::setDefault,
             onDeletePaymentMethod = viewModel::deletePaymentMethod,
             onPrimaryButtonClick = viewModel::onConfirmPayment,
             onPayAnotherWayClick = viewModel::payAnotherWay,
@@ -197,6 +199,7 @@ internal fun WalletBody(
     onItemSelected: (ConsumerPaymentDetails.PaymentDetails) -> Unit,
     onAddNewPaymentMethodClick: () -> Unit,
     onEditPaymentMethod: (ConsumerPaymentDetails.PaymentDetails) -> Unit,
+    onSetDefault: (ConsumerPaymentDetails.PaymentDetails) -> Unit,
     onDeletePaymentMethod: (ConsumerPaymentDetails.PaymentDetails) -> Unit,
     onPrimaryButtonClick: () -> Unit,
     onPayAnotherWayClick: () -> Unit,
@@ -252,6 +255,10 @@ internal fun WalletBody(
                                 onEditClick = {
                                     showBottomSheetContent(null)
                                     onEditPaymentMethod(it)
+                                },
+                                onSetDefaultClick = {
+                                    showBottomSheetContent(null)
+                                    onSetDefault(it)
                                 },
                                 onRemoveClick = {
                                     showBottomSheetContent(null)
@@ -493,6 +500,7 @@ private fun ExpandedPaymentDetails(
                 enabled = isEnabled,
                 isSupported = uiState.supportedTypes.contains(item.type),
                 isSelected = uiState.selectedItem?.id == item.id,
+                isUpdating = uiState.paymentMethodIdBeingUpdated == item.id,
                 onClick = {
                     onItemSelected(item)
                 },

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
@@ -69,9 +69,9 @@ internal data class WalletUiState(
         )
     }
 
-    fun updateWithSetDefaultResult(response: ConsumerPaymentDetails): WalletUiState {
-        val updatedPaymentMethod = response.paymentDetails.single()
-
+    fun updateWithSetDefaultResult(
+        updatedPaymentMethod: ConsumerPaymentDetails.PaymentDetails
+    ): WalletUiState {
         val paymentMethods = paymentDetailsList.map { paymentMethod ->
             if (paymentMethod.id == updatedPaymentMethod.id) {
                 updatedPaymentMethod

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletUiState.kt
@@ -4,6 +4,7 @@ import com.stripe.android.link.ui.ErrorMessage
 import com.stripe.android.link.ui.PrimaryButtonState
 import com.stripe.android.link.ui.getErrorMessage
 import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.model.ConsumerPaymentDetails.BankAccount
 import com.stripe.android.model.ConsumerPaymentDetails.Card
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.ui.core.forms.FormFieldEntry
@@ -18,7 +19,8 @@ internal data class WalletUiState(
     val errorMessage: ErrorMessage? = null,
     val expiryDateInput: FormFieldEntry = FormFieldEntry(value = null),
     val cvcInput: FormFieldEntry = FormFieldEntry(value = null),
-    val alertMessage: ErrorMessage? = null
+    val alertMessage: ErrorMessage? = null,
+    val paymentMethodIdBeingUpdated: String? = null
 ) {
 
     val selectedCard: Card?
@@ -64,6 +66,29 @@ internal data class WalletUiState(
             selectedItem = selectedItem,
             isExpanded = if (isSelectedItemValid) isExpanded else true,
             isProcessing = false
+        )
+    }
+
+    fun updateWithSetDefaultResult(response: ConsumerPaymentDetails): WalletUiState {
+        val updatedPaymentMethod = response.paymentDetails.single()
+
+        val paymentMethods = paymentDetailsList.map { paymentMethod ->
+            if (paymentMethod.id == updatedPaymentMethod.id) {
+                updatedPaymentMethod
+            } else {
+                when (paymentMethod) {
+                    is BankAccount -> paymentMethod.copy(isDefault = false)
+                    is Card -> paymentMethod.copy(isDefault = false)
+                }
+            }
+        }
+
+        val selectedItem = paymentMethods.firstOrNull { it.id == selectedItem?.id }
+
+        return copy(
+            paymentDetailsList = paymentMethods,
+            selectedItem = selectedItem,
+            paymentMethodIdBeingUpdated = null
         )
     }
 

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -240,6 +240,35 @@ internal class WalletViewModel @Inject constructor(
         navigator.navigateTo(LinkScreen.CardEdit(paymentDetails.id))
     }
 
+    fun setDefault(paymentDetails: ConsumerPaymentDetails.PaymentDetails) {
+        _uiState.update {
+            it.copy(paymentMethodIdBeingUpdated = paymentDetails.id)
+        }
+
+        viewModelScope.launch {
+            val updateParams = ConsumerPaymentDetailsUpdateParams.Card(
+                id = paymentDetails.id,
+                isDefault = true,
+                cardPaymentMethodCreateParams = null
+            )
+
+            delay(2_000L)
+
+            linkAccountManager.updatePaymentDetails(updateParams).fold(
+                onSuccess = { response ->
+                    _uiState.update {
+                        it.updateWithSetDefaultResult(response)
+                    }
+                },
+                onFailure = {
+                    _uiState.update {
+                        it.copy(paymentMethodIdBeingUpdated = null)
+                    }
+                }
+            )
+        }
+    }
+
     fun deletePaymentMethod(paymentDetails: ConsumerPaymentDetails.PaymentDetails) {
         _uiState.update {
             it.setProcessing()

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -252,8 +252,6 @@ internal class WalletViewModel @Inject constructor(
                 cardPaymentMethodCreateParams = null
             )
 
-            delay(2_000L)
-
             linkAccountManager.updatePaymentDetails(updateParams).fold(
                 onSuccess = { response ->
                     _uiState.update {

--- a/link/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/link/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -650,7 +650,7 @@ class LinkApiRepositoryTest {
     @Test
     fun `updatePaymentDetails sends correct parameters`() = runTest {
         val secret = "secret"
-        val params = ConsumerPaymentDetailsUpdateParams.Card("id")
+        val params = ConsumerPaymentDetailsUpdateParams("id")
         val consumerKey = "key"
 
         linkRepository.updatePaymentDetails(
@@ -669,7 +669,7 @@ class LinkApiRepositoryTest {
     @Test
     fun `updatePaymentDetails without consumerPublishableKey sends correct parameters`() = runTest {
         val secret = "secret"
-        val params = ConsumerPaymentDetailsUpdateParams.Card("id")
+        val params = ConsumerPaymentDetailsUpdateParams("id")
 
         linkRepository.updatePaymentDetails(
             params,
@@ -692,7 +692,7 @@ class LinkApiRepositoryTest {
             .thenReturn(consumerPaymentDetails)
 
         val result = linkRepository.updatePaymentDetails(
-            ConsumerPaymentDetailsUpdateParams.Card("id"),
+            ConsumerPaymentDetailsUpdateParams("id"),
             "secret",
             "key"
         )
@@ -707,7 +707,7 @@ class LinkApiRepositoryTest {
             .thenThrow(RuntimeException("error"))
 
         val result = linkRepository.updatePaymentDetails(
-            ConsumerPaymentDetailsUpdateParams.Card("id"),
+            ConsumerPaymentDetailsUpdateParams("id"),
             "secret",
             "key"
         )

--- a/link/src/test/java/com/stripe/android/link/ui/cardedit/CardEditViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/cardedit/CardEditViewModelTest.kt
@@ -8,7 +8,6 @@ import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.model.Navigator
 import com.stripe.android.link.model.PaymentDetailsFixtures
 import com.stripe.android.link.ui.wallet.PaymentDetailsResult
-import com.stripe.android.model.ConsumerPaymentDetailsUpdateParams
 import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.ui.core.forms.FormFieldEntry
 import com.stripe.android.ui.core.injection.FormControllerSubcomponent
@@ -111,16 +110,15 @@ class CardEditViewModelTest {
 
         verify(linkAccountManager).updatePaymentDetails(
             argWhere {
-                it is ConsumerPaymentDetailsUpdateParams.Card &&
-                    it.toParamMap() == mapOf(
-                    "is_default" to true,
-                    "exp_month" to "12",
-                    "exp_year" to "2040",
-                    "billing_address" to mapOf(
-                        "country_code" to "US",
-                        "postal_code" to "12345"
-                    )
+                it.toParamMap() == mapOf(
+                "is_default" to true,
+                "exp_month" to "12",
+                "exp_year" to "2040",
+                "billing_address" to mapOf(
+                    "country_code" to "US",
+                    "postal_code" to "12345"
                 )
+            )
             }
         )
     }
@@ -135,8 +133,7 @@ class CardEditViewModelTest {
 
             verify(linkAccountManager).updatePaymentDetails(
                 argWhere {
-                    it is ConsumerPaymentDetailsUpdateParams.Card &&
-                        it.toParamMap() == mapOf(
+                    it.toParamMap() == mapOf(
                         "exp_month" to "12",
                         "exp_year" to "2040",
                         "billing_address" to mapOf(
@@ -157,8 +154,7 @@ class CardEditViewModelTest {
 
         verify(linkAccountManager).updatePaymentDetails(
             argWhere {
-                it is ConsumerPaymentDetailsUpdateParams.Card &&
-                    it.toParamMap() == mapOf(
+                it.toParamMap() == mapOf(
                     "exp_month" to "12",
                     "exp_year" to "2040",
                     "billing_address" to mapOf(

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -2568,32 +2568,11 @@ public final class com/stripe/android/model/ConsumerPaymentDetailsCreateParams$C
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/model/ConsumerPaymentDetailsUpdateParams$Card : com/stripe/android/model/ConsumerPaymentDetailsUpdateParams {
-	public static final field $stable I
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Lcom/stripe/android/model/PaymentMethodCreateParams;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Lcom/stripe/android/model/PaymentMethodCreateParams;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/Boolean;
-	public final fun component3 ()Lcom/stripe/android/model/PaymentMethodCreateParams;
-	public final fun copy (Ljava/lang/String;Ljava/lang/Boolean;Lcom/stripe/android/model/PaymentMethodCreateParams;)Lcom/stripe/android/model/ConsumerPaymentDetailsUpdateParams$Card;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/ConsumerPaymentDetailsUpdateParams$Card;Ljava/lang/String;Ljava/lang/Boolean;Lcom/stripe/android/model/PaymentMethodCreateParams;ILjava/lang/Object;)Lcom/stripe/android/model/ConsumerPaymentDetailsUpdateParams$Card;
-	public fun describeContents ()I
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getCardPaymentMethodCreateParams ()Lcom/stripe/android/model/PaymentMethodCreateParams;
-	public fun getId ()Ljava/lang/String;
-	public fun hashCode ()I
-	public final fun isDefault ()Ljava/lang/Boolean;
-	public fun toParamMap ()Ljava/util/Map;
-	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
-public final class com/stripe/android/model/ConsumerPaymentDetailsUpdateParams$Card$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/model/ConsumerPaymentDetailsUpdateParams$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ConsumerPaymentDetailsUpdateParams$Card;
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ConsumerPaymentDetailsUpdateParams;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/model/ConsumerPaymentDetailsUpdateParams$Card;
+	public final fun newArray (I)[Lcom/stripe/android/model/ConsumerPaymentDetailsUpdateParams;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 

--- a/payments-core/src/main/java/com/stripe/android/model/ConsumerPaymentDetailsUpdateParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConsumerPaymentDetailsUpdateParams.kt
@@ -5,31 +5,28 @@ import androidx.annotation.RestrictTo
 import kotlinx.parcelize.Parcelize
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-sealed class ConsumerPaymentDetailsUpdateParams : StripeParamsModel, Parcelable {
-    abstract val id: String
+@Parcelize
+class ConsumerPaymentDetailsUpdateParams(
+    val id: String,
+    val isDefault: Boolean? = null,
+    val cardPaymentMethodCreateParams: PaymentMethodCreateParams? = null
+) : StripeParamsModel, Parcelable {
 
-    @Parcelize
-    data class Card(
-        override val id: String,
-        val isDefault: Boolean? = null,
-        val cardPaymentMethodCreateParams: PaymentMethodCreateParams? = null
-    ) : ConsumerPaymentDetailsUpdateParams() {
-        override fun toParamMap(): Map<String, Any> {
-            val params: MutableMap<String, Any> = mutableMapOf()
+    override fun toParamMap(): Map<String, Any> {
+        val params: MutableMap<String, Any> = mutableMapOf()
 
-            isDefault?.let { params["is_default"] = it }
+        isDefault?.let { params["is_default"] = it }
 
-            cardPaymentMethodCreateParams?.toParamMap()?.let { map ->
-                (map["card"] as? Map<*, *>)?.let { card ->
-                    card["exp_month"]?.let { params["exp_month"] = it }
-                    card["exp_year"]?.let { params["exp_year"] = it }
-                }
-                ConsumerPaymentDetails.Card.getAddressFromMap(map)?.let {
-                    params[it.first] = it.second
-                }
+        cardPaymentMethodCreateParams?.toParamMap()?.let { map ->
+            (map["card"] as? Map<*, *>)?.let { card ->
+                card["exp_month"]?.let { params["exp_month"] = it }
+                card["exp_year"]?.let { params["exp_year"] = it }
             }
-
-            return params
+            ConsumerPaymentDetails.Card.getAddressFromMap(map)?.let {
+                params[it.first] = it.second
+            }
         }
+
+        return params
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/model/ConsumerPaymentDetailsUpdateParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ConsumerPaymentDetailsUpdateParamsTest.kt
@@ -32,7 +32,7 @@ class ConsumerPaymentDetailsUpdateParamsTest {
         )
 
         Truth.assertThat(
-            ConsumerPaymentDetailsUpdateParams.Card(
+            ConsumerPaymentDetailsUpdateParams(
                 id = id,
                 cardPaymentMethodCreateParams = paymentMethodCreateParams
             ).toParamMap()
@@ -53,7 +53,7 @@ class ConsumerPaymentDetailsUpdateParamsTest {
         val id = "payment_details_id"
 
         Truth.assertThat(
-            ConsumerPaymentDetailsUpdateParams.Card(
+            ConsumerPaymentDetailsUpdateParams(
                 id = id,
                 isDefault = true
             ).toParamMap()
@@ -91,7 +91,7 @@ class ConsumerPaymentDetailsUpdateParamsTest {
         )
 
         Truth.assertThat(
-            ConsumerPaymentDetailsUpdateParams.Card(
+            ConsumerPaymentDetailsUpdateParams(
                 id = id,
                 cardPaymentMethodCreateParams = paymentMethodCreateParams,
                 isDefault = false

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -1996,7 +1996,7 @@ internal class StripeApiRepositoryTest {
             val id = "id"
             val clientSecret = "secret"
             val isDefault = true
-            val paymentDetailsUpdateParams = ConsumerPaymentDetailsUpdateParams.Card(
+            val paymentDetailsUpdateParams = ConsumerPaymentDetailsUpdateParams(
                 id,
                 isDefault,
                 PaymentMethodCreateParamsFixtures.DEFAULT_CARD


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds the missing `Set as default` functionality to the Link wallet.

Like iOS, we show a progress indicator while the network request is happening. In case of an error, we don’t show any error message (again, like iOS), but we hide the progress indicator.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Link launch.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screen recording

https://user-images.githubusercontent.com/110940675/190711730-b1437a0b-3663-4d63-aa6c-302f24816314.mp4

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

_Nothing to add._
