### PR TITLE
Fix complex list item encoding

### DIFF
--- a/camera-core/src/main/java/com/stripe/android/camera/framework/Stat.kt
+++ b/camera-core/src/main/java/com/stripe/android/camera/framework/Stat.kt
@@ -53,7 +53,7 @@ object Stats {
         StatTrackerImpl { startedAt, result ->
             taskMutex.withLock {
                 val list = tasks[name]
-                if (list == null) {
+                if (list.isNullOrEmpty()) {
                     tasks[name] = listOf(TaskStats(startedAt, startedAt.elapsedSince(), result))
                 } else {
                     tasks[name] = list + TaskStats(startedAt, startedAt.elapsedSince(), result)
@@ -204,8 +204,7 @@ class StatTrackerImpl(
     private val onComplete: suspend (ClockMark, String?) -> Unit
 ) : StatTracker {
     override val startedAt = Clock.markNow()
-    override suspend fun trackResult(result: String?) =
-        coroutineScope { launch { onComplete(startedAt, result) } }.let { }
+    override suspend fun trackResult(result: String?) = onComplete(startedAt, result)
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/camera-core/src/main/java/com/stripe/android/camera/framework/Stat.kt
+++ b/camera-core/src/main/java/com/stripe/android/camera/framework/Stat.kt
@@ -8,8 +8,6 @@ import com.stripe.android.camera.framework.time.Clock
 import com.stripe.android.camera.framework.time.ClockMark
 import com.stripe.android.camera.framework.time.Duration
 import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.sync.Mutex

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityDocumentScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityDocumentScanFragment.kt
@@ -251,7 +251,9 @@ internal abstract class IdentityDocumentScanFragment(
                                         notSubmitBlock =
                                         if (verificationPage.requireSelfie()) {
                                             ({ findNavController().navigate(R.id.action_global_selfieFragment) })
-                                        } else null
+                                        } else {
+                                            null
+                                        }
                                     )
                                 }.onFailure { throwable ->
                                     Log.e(

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanActivity.kt
@@ -108,7 +108,6 @@ internal class CardScanActivity : ScanActivity(), SimpleScanStateful<CardScanSta
                         )
                     )
                 setResult(RESULT_OK, intent)
-                closeScanner()
             }
 
             override fun userCanceled(reason: CancellationReason) {
@@ -145,6 +144,8 @@ internal class CardScanActivity : ScanActivity(), SimpleScanStateful<CardScanSta
                     changeScanState(CardScanState.Correct)
                     cameraAdapter.unbindFromLifecycle(this@CardScanActivity)
                     resultListener.cardScanComplete(ScannedCard(result.pan))
+                    scanStat.trackResult("card_scanned")
+                    closeScanner()
                 }.let { }
             }
 

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanFragment.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanFragment.kt
@@ -38,7 +38,6 @@ import com.stripe.android.stripecardscan.scanui.util.getFloatResource
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.math.min
 import kotlin.math.roundToInt

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanFragment.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanFragment.kt
@@ -38,6 +38,7 @@ import com.stripe.android.stripecardscan.scanui.util.getFloatResource
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.math.min
 import kotlin.math.roundToInt
@@ -126,6 +127,8 @@ class CardScanFragment : ScanFragment(), SimpleScanStateful<CardScanState> {
                     changeScanState(CardScanState.Correct)
                     activity?.let { cameraAdapter.unbindFromLifecycle(it) }
                     resultListener.cardScanComplete(ScannedCard(result.pan))
+                    scanStat.trackResult("scan_complete")
+                    closeScanner()
                 }.let { }
             }
 

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/util/Encode.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/util/Encode.kt
@@ -25,7 +25,7 @@ internal fun b64Encode(b: ByteArray): String =
  * [Map] so that the parameters can be named.
  */
 internal fun <T> encodeToXWWWFormUrl(serializer: SerializationStrategy<T>, value: T): String =
-    QueryStringFactory.create(json.encodeToJsonElement(serializer, value).toMap())
+    QueryStringFactory.createFromParamsWithEmptyValues(json.encodeToJsonElement(serializer, value).toMap())
 
 /**
  * Encode a serializable object to a JSON string

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/util/Encode.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/util/Encode.kt
@@ -25,7 +25,9 @@ internal fun b64Encode(b: ByteArray): String =
  * [Map] so that the parameters can be named.
  */
 internal fun <T> encodeToXWWWFormUrl(serializer: SerializationStrategy<T>, value: T): String =
-    QueryStringFactory.createFromParamsWithEmptyValues(json.encodeToJsonElement(serializer, value).toMap())
+    QueryStringFactory.createFromParamsWithEmptyValues(
+        json.encodeToJsonElement(serializer, value).toMap()
+    )
 
 /**
  * Encode a serializable object to a JSON string

--- a/stripecardscan/src/test/java/com/stripe/android/stripecardscan/framework/util/EncodeTest.kt
+++ b/stripecardscan/src/test/java/com/stripe/android/stripecardscan/framework/util/EncodeTest.kt
@@ -207,10 +207,10 @@ class EncodeTest {
         assertEquals(
             expected = "field_3=true" +
                 "&field_1=aa" +
-                "&field_2%5B%5D%5Bsub_field_1%5D=bb" +
-                "&field_2%5B%5D%5Bsub_field_2%5D=22" +
-                "&field_2%5B%5D%5Bsub_field_1%5D=cc" +
-                "&field_2%5B%5D%5Bsub_field_2%5D=33",
+                "&field_2%5B0%5D%5Bsub_field_1%5D=bb" +
+                "&field_2%5B0%5D%5Bsub_field_2%5D=22" +
+                "&field_2%5B1%5D%5Bsub_field_1%5D=cc" +
+                "&field_2%5B1%5D%5Bsub_field_2%5D=33",
             actual = encodeToXWWWFormUrl(
                 serializer = TestClassArray.serializer(),
                 value = TestClassArray(

--- a/stripecardscan/src/test/java/com/stripe/android/stripecardscan/framework/util/EncodeTest.kt
+++ b/stripecardscan/src/test/java/com/stripe/android/stripecardscan/framework/util/EncodeTest.kt
@@ -19,7 +19,7 @@ class EncodeTest {
         )
 
         assertEquals(
-            expected = "field_1=aa&field_2=1&field_3=true",
+            expected = "field_3=true&field_1=aa&field_2=1",
             actual = encodeToXWWWFormUrl(
                 serializer = TestClassFlat.serializer(),
                 value = TestClassFlat("aa", 1, true)
@@ -39,7 +39,7 @@ class EncodeTest {
         )
 
         assertEquals(
-            expected = "field_1=aa&field_2=1&field_3=&field_4=true",
+            expected = "field_4=true&field_1=aa&field_2=1",
             actual = encodeToXWWWFormUrl(
                 serializer = TestClassFlat.serializer(),
                 value = TestClassFlat("aa", 1, null, true)
@@ -65,8 +65,11 @@ class EncodeTest {
         )
 
         assertEquals(
-            expected = "field_1=aa&field_2=1&field_3=true" +
-                "&field_4%5Bsub_field_1%5D=bb&field_4%5Bsub_field_2%5D=2",
+            expected = "field_3=true" +
+                "&field_4%5Bsub_field_1%5D=bb" +
+                "&field_4%5Bsub_field_2%5D=2" +
+                "&field_1=aa" +
+                "&field_2=1",
             actual = encodeToXWWWFormUrl(
                 serializer = TestClassBase.serializer(),
                 value = TestClassBase(
@@ -107,10 +110,12 @@ class EncodeTest {
         )
 
         assertEquals(
-            expected = "field_1=aa&field_2=1&field_3=true" +
-                "&field_4%5Bsub_field_1%5D=bb&field_4%5Bsub_field_2%5D=2" +
+            expected = "field_3=true" +
+                "&field_4%5Bsub_field_1%5D=bb" +
                 "&field_4%5Bsub_field_3%5D%5Bsub_sub_field_1%5D=3" +
-                "&field_4%5Bsub_field_3%5D%5Bsub_sub_field_2%5D=false",
+                "&field_4%5Bsub_field_3%5D%5Bsub_sub_field_2%5D=false" +
+                "&field_4%5Bsub_field_2%5D=2" +
+                "&field_1=aa&field_2=1",
             actual = encodeToXWWWFormUrl(
                 serializer = TestClassBase.serializer(),
                 value = TestClassBase(
@@ -155,12 +160,15 @@ class EncodeTest {
         )
 
         assertEquals(
-            expected = "field_1=aa&field_2=1&field_3=true&field_4%5Bsub_field_1%5D=bb" +
+            expected = "field_3=true" +
+                "&field_4%5Bsub_field_1%5D=bb" +
+                "&field_4%5Bsub_field_3%5D%5Bsub_sub_field_1%5D=3" +
+                "&field_4%5Bsub_field_3%5D%5Bsub_sub_field_2%5D=false" +
                 "&field_4%5Bsub_field_2%5D%5B%5D=2" +
                 "&field_4%5Bsub_field_2%5D%5B%5D=4" +
                 "&field_4%5Bsub_field_2%5D%5B%5D=6" +
-                "&field_4%5Bsub_field_3%5D%5Bsub_sub_field_1%5D=3" +
-                "&field_4%5Bsub_field_3%5D%5Bsub_sub_field_2%5D=false",
+                "&field_1=aa" +
+                "&field_2=1",
             actual = encodeToXWWWFormUrl(
                 serializer = TestClassBase.serializer(),
                 value = TestClassBase(
@@ -197,12 +205,12 @@ class EncodeTest {
         )
 
         assertEquals(
-            expected = "field_1=aa" +
+            expected = "field_3=true" +
+                "&field_1=aa" +
                 "&field_2%5B%5D%5Bsub_field_1%5D=bb" +
                 "&field_2%5B%5D%5Bsub_field_2%5D=22" +
                 "&field_2%5B%5D%5Bsub_field_1%5D=cc" +
-                "&field_2%5B%5D%5Bsub_field_2%5D=33" +
-                "&field_3=true",
+                "&field_2%5B%5D%5Bsub_field_2%5D=33",
             actual = encodeToXWWWFormUrl(
                 serializer = TestClassArray.serializer(),
                 value = TestClassArray(


### PR DESCRIPTION
# Summary
When encoding a list of object in form-url-encoding, we must include the index when the list contains non-primitives.

# Motivation
https://jira.corp.stripe.com/browse/BOUNCER-1305

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [X] Manually verified
