### PR TITLE
Refactor Compose usage in USBankAccountFragment

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormFragment.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -48,6 +47,7 @@ import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SetupIntentClientSecret
+import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormScreenState.NameAndEmailCollection
 import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
@@ -215,8 +215,8 @@ internal class USBankAccountFormFragment : Fragment() {
                 LaunchedEffect(currentScreenState) {
                     sheetViewModel?.onError(currentScreenState.error)
 
-                    val shouldProcess = currentScreenState is USBankAccountFormScreenState.NameAndEmailCollection || completePayment
-                    val enabled = if (currentScreenState is USBankAccountFormScreenState.NameAndEmailCollection) {
+                    val shouldProcess = currentScreenState is NameAndEmailCollection || completePayment
+                    val enabled = if (currentScreenState is NameAndEmailCollection) {
                         viewModel.requiredFields.value
                     } else {
                         true
@@ -235,7 +235,7 @@ internal class USBankAccountFormFragment : Fragment() {
                 }
 
                 when (val screenState = currentScreenState) {
-                    is USBankAccountFormScreenState.NameAndEmailCollection -> {
+                    is NameAndEmailCollection -> {
                         NameAndEmailCollectionScreen(screenState)
                     }
                     is USBankAccountFormScreenState.MandateCollection -> {
@@ -261,7 +261,7 @@ internal class USBankAccountFormFragment : Fragment() {
 
     @Composable
     private fun NameAndEmailCollectionScreen(
-        screenState: USBankAccountFormScreenState.NameAndEmailCollection
+        screenState: NameAndEmailCollection
     ) {
         Column(Modifier.fillMaxWidth()) {
             NameAndEmailForm(screenState.name, screenState.email)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormFragment.kt
@@ -127,7 +127,7 @@ internal class USBankAccountFormFragment : Fragment() {
         }
     }
 
-    private val viewModel by viewModels<USBankAccountFormViewModel> {
+    private val viewModel by activityViewModels<USBankAccountFormViewModel> {
         USBankAccountFormViewModel.Factory(
             applicationSupplier = { requireActivity().application },
             argsSupplier = {
@@ -138,15 +138,13 @@ internal class USBankAccountFormFragment : Fragment() {
                     formArgs = formArgs,
                     isCompleteFlow = sheetViewModel is PaymentSheetViewModel,
                     clientSecret = clientSecret,
-                    savedScreenState = sheetViewModel?.usBankAccountSavedScreenState,
                     savedPaymentMethod = savedPaymentMethod,
                     shippingDetails = sheetViewModel?.config?.shippingDetails,
                     onConfirmStripeIntent = { params ->
                         (sheetViewModel as? PaymentSheetViewModel)?.confirmStripeIntent(params)
                     },
-                    onUpdateSelectionAndFinish = { paymentSelection, savedAccount ->
+                    onUpdateSelectionAndFinish = { paymentSelection ->
                         sheetViewModel?.updateSelection(paymentSelection)
-                        sheetViewModel?.usBankAccountSavedScreenState = savedAccount
                         sheetViewModel?.onFinish()
                     }
                 )
@@ -255,12 +253,6 @@ internal class USBankAccountFormFragment : Fragment() {
     }
 
     override fun onDetach() {
-        sheetViewModel?.usBankAccountSavedScreenState =
-            viewModel.currentScreenState.value.updateInputs(
-                viewModel.name.value,
-                viewModel.email.value,
-                viewModel.saveForFutureUse.value
-            )
         sheetViewModel?.updateBelowButtonText(null)
         sheetViewModel?.updatePrimaryButtonUIState(null)
         viewModel.onDestroy()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormFragment.kt
@@ -213,25 +213,7 @@ internal class USBankAccountFormFragment : Fragment() {
                 val currentScreenState by viewModel.currentScreenState.collectAsState()
 
                 LaunchedEffect(currentScreenState) {
-                    sheetViewModel?.onError(currentScreenState.error)
-
-                    val shouldProcess = currentScreenState is NameAndEmailCollection || completePayment
-                    val enabled = if (currentScreenState is NameAndEmailCollection) {
-                        viewModel.requiredFields.value
-                    } else {
-                        true
-                    }
-
-                    updatePrimaryButton(
-                        text = currentScreenState.primaryButtonText,
-                        onClick = {
-                            viewModel.handlePrimaryButtonClick(currentScreenState)
-                        },
-                        enabled = enabled,
-                        shouldProcess = shouldProcess
-                    )
-
-                    updateMandateText(currentScreenState.mandateText)
+                    handleScreenStateChanged(currentScreenState)
                 }
 
                 when (val screenState = currentScreenState) {
@@ -250,6 +232,26 @@ internal class USBankAccountFormFragment : Fragment() {
                 }
             }
         }
+    }
+
+    private fun handleScreenStateChanged(screenState: USBankAccountFormScreenState) {
+        sheetViewModel?.onError(screenState.error)
+
+        val showProcessingWhenClicked = screenState is NameAndEmailCollection || completePayment
+        val enabled = if (screenState is NameAndEmailCollection) {
+            viewModel.requiredFields.value
+        } else {
+            true
+        }
+
+        updatePrimaryButton(
+            text = screenState.primaryButtonText,
+            onClick = { viewModel.handlePrimaryButtonClick(screenState) },
+            enabled = enabled,
+            shouldShowProcessingWhenClicked = showProcessingWhenClicked
+        )
+
+        updateMandateText(screenState.mandateText)
     }
 
     override fun onDetach() {
@@ -447,7 +449,7 @@ internal class USBankAccountFormFragment : Fragment() {
     private fun updatePrimaryButton(
         text: String?,
         onClick: () -> Unit,
-        shouldProcess: Boolean = true,
+        shouldShowProcessingWhenClicked: Boolean = true,
         enabled: Boolean = true,
         visible: Boolean = true
     ) {
@@ -456,7 +458,7 @@ internal class USBankAccountFormFragment : Fragment() {
             PrimaryButton.UIState(
                 label = text,
                 onClick = {
-                    if (shouldProcess) {
+                    if (shouldShowProcessingWhenClicked) {
                         sheetViewModel?.updatePrimaryButtonState(
                             PrimaryButton.State.StartProcessing
                         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormScreenState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormScreenState.kt
@@ -73,22 +73,6 @@ internal sealed class USBankAccountFormScreenState(
             this.copy(name = name, email = email, saveForFutureUsage = saveForFutureUsage)
     }
 
-//    data class ConfirmIntent(
-//        val confirmIntentParams: ConfirmStripeIntentParams
-//    ) : USBankAccountFormScreenState() {
-//        override fun updateInputs(name: String, email: String?, saveForFutureUsage: Boolean) = this
-//    }
-
-//    data class Finished(
-//        val paymentSelection: PaymentSelection,
-//        val financialConnectionsSessionId: String,
-//        val intentId: String,
-//        val last4: String,
-//        val bankName: String
-//    ) : USBankAccountFormScreenState() {
-//        override fun updateInputs(name: String, email: String?, saveForFutureUsage: Boolean) = this
-//    }
-
     abstract fun updateInputs(
         name: String,
         email: String?,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormScreenState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormScreenState.kt
@@ -9,12 +9,18 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 internal sealed class USBankAccountFormScreenState(
     @StringRes open val error: Int? = null
 ) {
+    abstract val primaryButtonText: String?
+    abstract val mandateText: String?
+
     class NameAndEmailCollection(
         @StringRes override val error: Int? = null,
         val name: String,
         val email: String?,
-        val primaryButtonText: String?
+        override val primaryButtonText: String?
     ) : USBankAccountFormScreenState() {
+
+        override val mandateText: String? = null
+
         override fun updateInputs(name: String, email: String?, saveForFutureUsage: Boolean) =
             NameAndEmailCollection(
                 error = error,
@@ -30,8 +36,8 @@ internal sealed class USBankAccountFormScreenState(
         val paymentAccount: FinancialConnectionsAccount,
         val financialConnectionsSessionId: String,
         val intentId: String,
-        val primaryButtonText: String?,
-        val mandateText: String,
+        override val primaryButtonText: String?,
+        override val mandateText: String?,
         val saveForFutureUsage: Boolean
     ) : USBankAccountFormScreenState() {
         override fun updateInputs(name: String, email: String?, saveForFutureUsage: Boolean) =
@@ -44,8 +50,8 @@ internal sealed class USBankAccountFormScreenState(
         val paymentAccount: BankAccount,
         val financialConnectionsSessionId: String,
         val intentId: String,
-        val primaryButtonText: String?,
-        val mandateText: String,
+        override val primaryButtonText: String?,
+        override val mandateText: String?,
         val saveForFutureUsage: Boolean
     ) : USBankAccountFormScreenState() {
         override fun updateInputs(name: String, email: String?, saveForFutureUsage: Boolean) =
@@ -59,29 +65,29 @@ internal sealed class USBankAccountFormScreenState(
         val intentId: String,
         val bankName: String,
         val last4: String?,
-        val primaryButtonText: String?,
-        val mandateText: String,
+        override val primaryButtonText: String?,
+        override val mandateText: String?,
         val saveForFutureUsage: Boolean
     ) : USBankAccountFormScreenState() {
         override fun updateInputs(name: String, email: String?, saveForFutureUsage: Boolean) =
             this.copy(name = name, email = email, saveForFutureUsage = saveForFutureUsage)
     }
 
-    data class ConfirmIntent(
-        val confirmIntentParams: ConfirmStripeIntentParams
-    ) : USBankAccountFormScreenState() {
-        override fun updateInputs(name: String, email: String?, saveForFutureUsage: Boolean) = this
-    }
+//    data class ConfirmIntent(
+//        val confirmIntentParams: ConfirmStripeIntentParams
+//    ) : USBankAccountFormScreenState() {
+//        override fun updateInputs(name: String, email: String?, saveForFutureUsage: Boolean) = this
+//    }
 
-    data class Finished(
-        val paymentSelection: PaymentSelection,
-        val financialConnectionsSessionId: String,
-        val intentId: String,
-        val last4: String,
-        val bankName: String
-    ) : USBankAccountFormScreenState() {
-        override fun updateInputs(name: String, email: String?, saveForFutureUsage: Boolean) = this
-    }
+//    data class Finished(
+//        val paymentSelection: PaymentSelection,
+//        val financialConnectionsSessionId: String,
+//        val intentId: String,
+//        val last4: String,
+//        val bankName: String
+//    ) : USBankAccountFormScreenState() {
+//        override fun updateInputs(name: String, email: String?, saveForFutureUsage: Boolean) = this
+//    }
 
     abstract fun updateInputs(
         name: String,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormScreenState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormScreenState.kt
@@ -3,8 +3,6 @@ package com.stripe.android.paymentsheet.paymentdatacollection.ach
 import androidx.annotation.StringRes
 import com.stripe.android.financialconnections.model.BankAccount
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
-import com.stripe.android.model.ConfirmStripeIntentParams
-import com.stripe.android.paymentsheet.model.PaymentSelection
 
 internal sealed class USBankAccountFormScreenState(
     @StringRes open val error: Int? = null

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -38,7 +38,6 @@ import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.getPMsToAdd
-import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormScreenState
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.ui.core.Amount
@@ -176,8 +175,6 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
 
     private val _notesText = MutableLiveData<String?>()
     internal val notesText: LiveData<String?> = _notesText
-
-    var usBankAccountSavedScreenState: USBankAccountFormScreenState? = null
 
     protected val _showLinkVerificationDialog = MutableLiveData(false)
     val showLinkVerificationDialog: LiveData<Boolean> = _showLinkVerificationDialog

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -31,7 +31,6 @@ import kotlinx.coroutines.test.setMain
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -45,7 +44,7 @@ import kotlin.test.Test
 class USBankAccountFormViewModelTest {
 
     private val onConfirmStripeIntent: (ConfirmStripeIntentParams) -> Unit = mock()
-    private val onUpdateSelectionAndFinish: (PaymentSelection, USBankAccountFormScreenState?) -> Unit = mock()
+    private val onUpdateSelectionAndFinish: (PaymentSelection) -> Unit = mock()
 
     private val defaultArgs = USBankAccountFormViewModel.Args(
         formArgs = FormFragmentArguments(
@@ -62,7 +61,6 @@ class USBankAccountFormViewModelTest {
         ),
         isCompleteFlow = true,
         clientSecret = PaymentIntentClientSecret("pi_12345"),
-        savedScreenState = null,
         savedPaymentMethod = null,
         shippingDetails = null,
         onConfirmStripeIntent = onConfirmStripeIntent,
@@ -199,7 +197,7 @@ class USBankAccountFormViewModelTest {
             val expectedBankAccount = session.paymentAccount as BankAccount
 
             val argumentCaptor = argumentCaptor<PaymentSelection>()
-            verify(onUpdateSelectionAndFinish).invoke(argumentCaptor.capture(), isNull())
+            verify(onUpdateSelectionAndFinish).invoke(argumentCaptor.capture())
 
             val actualBankAccount = argumentCaptor.firstValue as PaymentSelection.New.USBankAccount
             assertThat(expectedBankAccount.last4).isEqualTo(actualBankAccount.last4)
@@ -227,7 +225,7 @@ class USBankAccountFormViewModelTest {
             val expectedBankAccount = session.paymentAccount as FinancialConnectionsAccount
 
             val argumentCaptor = argumentCaptor<PaymentSelection>()
-            verify(onUpdateSelectionAndFinish).invoke(argumentCaptor.capture(), isNull())
+            verify(onUpdateSelectionAndFinish).invoke(argumentCaptor.capture())
 
             val actualBankAccount = argumentCaptor.firstValue as PaymentSelection.New.USBankAccount
             assertThat(expectedBankAccount.last4).isEqualTo(actualBankAccount.last4)
@@ -277,34 +275,6 @@ class USBankAccountFormViewModelTest {
                         intentId = "1234",
                         paymentMethodCreateParams = mock(),
                         customerRequestedSave = mock()
-                    )
-                )
-            )
-
-            val currentScreenState = viewModel.currentScreenState.stateIn(viewModel.viewModelScope).value
-
-            assertThat(
-                currentScreenState
-            ).isInstanceOf(
-                USBankAccountFormScreenState.SavedAccount::class.java
-            )
-        }
-
-    @Test
-    fun `when saved screen state, saved screen state is emitted`() =
-        runTest(UnconfinedTestDispatcher()) {
-            val viewModel = createViewModel(
-                defaultArgs.copy(
-                    savedScreenState = USBankAccountFormScreenState.SavedAccount(
-                        name = "Test",
-                        email = "test@email.com",
-                        bankName = "Test",
-                        last4 = "Test",
-                        financialConnectionsSessionId = "1234",
-                        intentId = "1234",
-                        primaryButtonText = "Test",
-                        mandateText = "Test",
-                        saveForFutureUsage = true
                     )
                 )
             )


### PR DESCRIPTION
Co-authored-by: James Woo <jameswoo@stripe.com>

# Summary
<!-- Simple summary of what was changed. -->

This pull request refactors our Compose usage in `USBankAccountFragment`. Instead of calling `setContent` for each screen state, we now observe the screen state within `setContent`. This will make it easier to eventually drop the fragment and move this to a pure-Compose payment sheet.

To achieve that, we remove two screen states (`ConfirmIntent` and `Finished`), as they weren’t really screen states to begin with. The side effects of each screen state are handled in a `LaunchedEffect(currentScreenState)`.

We were also able to remove `BaseSheetViewModel.usBankAccountSavedScreenState`, as we’re now scoping the `USBankAccountFormViewModel` to the activity instead of the fragment.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

A pure-Compose payment sheet.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

_Nothing to add._
