### PR TITLE
Fix deletion of saved PM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## X.X.X - 2022-XX-XX
 
+### PaymentSheet
+
+* [FIXED][5592](https://github.com/stripe/stripe-android/pull/5592) Fix deletion of the last used payment method.
+
 ## 20.13.0 - 2022-09-19
 This release makes the `PaymentMethod.Card.networks` field public, fixes the Alipay integration and the card scan form encoding.
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
@@ -164,7 +164,6 @@ internal abstract class BasePaymentMethodsListFragment(
     }
 
     private fun deletePaymentMethod(item: PaymentOptionsAdapter.Item.SavedPaymentMethod) {
-        adapter.removeItem(item)
         sheetViewModel.removePaymentMethod(item.paymentMethod)
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
@@ -267,16 +267,18 @@ internal class PaymentOptionsAdapter(
                     parent,
                     width,
                     lpmRepository,
-                    ::onItemSelected
-                ) { position ->
-                    onItemSelected(
-                        position = findInitialSelectedPosition(savedSelection),
-                        isClick = false,
-                        force = true
-                    )
-                    paymentMethodDeleteListener(items[position] as Item.SavedPaymentMethod)
-                    notifyItemRemoved(position)
-                }
+                    onItemSelectedListener = ::onItemSelected,
+                    onRemoveListener = { position ->
+                        paymentMethodDeleteListener(items[position] as Item.SavedPaymentMethod)
+                        removeItem(items[position])
+                        notifyItemRemoved(position)
+                        onItemSelected(
+                            position = findInitialSelectedPosition(savedSelection),
+                            isClick = false,
+                            force = true
+                        )
+                    }
+                )
         }
     }
 
@@ -310,7 +312,7 @@ internal class PaymentOptionsAdapter(
         private val composeView: ComposeView,
         private val width: Dp,
         private val lpmRepository: LpmRepository,
-        private val onRemoveListener: (Int) -> Unit,
+        @get:VisibleForTesting internal val onRemoveListener: (Int) -> Unit,
         private val onItemSelectedListener: ((Int, Boolean) -> Unit)
     ) : PaymentOptionViewHolder(
         composeView

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAdapterTest.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.paymentsheet
 
+import android.widget.LinearLayout
+import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
@@ -372,6 +374,33 @@ class PaymentOptionsAdapterTest {
             .isEqualTo(1)
         assertThat(adapter.selectedItem)
             .isNull()
+    }
+
+    @Test
+    fun `Selected item should be updated when deleted`() {
+        val savedPaymentMethod = paymentMethods[2]
+        val adapter = createConfiguredAdapter(
+            fragmentConfig = CONFIG.copy(
+                isGooglePayReady = true,
+                savedSelection = SavedSelection.PaymentMethod(savedPaymentMethod.id!!)
+            ),
+            showGooglePay = false
+        )
+
+        assertThat((adapter.selectedItem as PaymentOptionsAdapter.Item.SavedPaymentMethod).paymentMethod)
+            .isEqualTo(savedPaymentMethod)
+
+        val position = adapter.items.indexOf(adapter.selectedItem)
+        val viewHolder = adapter.onCreateViewHolder(
+            LinearLayout(ApplicationProvider.getApplicationContext()),
+            adapter.getItemViewType(position)
+        ) as PaymentOptionsAdapter.SavedPaymentMethodViewHolder
+        adapter.bindViewHolder(viewHolder, position)
+        viewHolder.onRemoveListener(position)
+
+        assertThat(paymentMethodsDeleted.map { it.paymentMethod }).containsExactly(savedPaymentMethod)
+        assertThat((adapter.selectedItem as PaymentOptionsAdapter.Item.SavedPaymentMethod).paymentMethod)
+            .isEqualTo(paymentMethods[0])
     }
 
     private fun createConfiguredAdapter(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
@@ -257,26 +257,6 @@ internal class PaymentSheetListFragmentTest : PaymentSheetViewModelTestInjection
         }
     }
 
-    @Test
-    fun `deletePaymentMethod() removes item from adapter`() {
-        createScenario(
-            initialState = Lifecycle.State.INITIALIZED,
-            paymentMethods = PAYMENT_METHODS
-        ).moveToState(Lifecycle.State.STARTED).onFragment { fragment ->
-            idleLooper()
-
-            val adapter = recyclerView(fragment).adapter as PaymentOptionsAdapter
-            assertThat(adapter.itemCount).isEqualTo(3)
-
-            fragment.isEditing = true
-            adapter.paymentMethodDeleteListener(
-                adapter.items[2] as PaymentOptionsAdapter.Item.SavedPaymentMethod
-            )
-
-            assertThat(adapter.itemCount).isEqualTo(2)
-        }
-    }
-
     private fun recyclerView(it: PaymentSheetListFragment) =
         it.requireView().findViewById<RecyclerView>(R.id.recycler)
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
When the user deletes a saved PM that was last used, we were keeping it as the selected item. If the user then confirms the payment without changing the selection, the payment would fail because we'd try to use the deleted PM.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[Fix bug](https://github.com/stripe/stripe-android/issues/5372#issuecomment-1253499836) when deleting the payment method that was last used.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

https://user-images.githubusercontent.com/77990083/191637074-4ca941fe-6e0a-48d4-a67d-08bbbf961626.mp4


