### PR TITLE
Clear signed up email on logout

### DIFF
--- a/link/src/main/java/com/stripe/android/link/account/CookieStore.kt
+++ b/link/src/main/java/com/stripe/android/link/account/CookieStore.kt
@@ -57,6 +57,7 @@ class CookieStore @Inject internal constructor(
     internal fun logout(email: String) {
         storeLoggedOutEmail(email)
         store.delete(AUTH_SESSION_COOKIE)
+        store.delete(SIGNED_UP_EMAIL)
     }
 
     /**

--- a/link/src/test/java/com/stripe/android/link/account/CookieStoreTest.kt
+++ b/link/src/test/java/com/stripe/android/link/account/CookieStoreTest.kt
@@ -52,7 +52,7 @@ class CookieStoreTest {
     }
 
     @Test
-    fun `logout stores hashed email and clears cookie`() {
+    fun `logout stores hashed email and clears cookie and signed up email`() {
         val cookieStore = createCookieStore()
         val email = "test@stripe.com"
         cookieStore.logout(email)
@@ -62,6 +62,7 @@ class CookieStoreTest {
             eq("49644df5404ea8ee8f0ec46cdb1dd7756c5661d6387fd1705a072f2fbf020f48")
         )
         verify(store).delete(eq(AUTH_SESSION_COOKIE))
+        verify(store).delete(eq(SIGNED_UP_EMAIL))
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
When a customer signs up, the email is stored temporarily so they're remembered and asked to authenticate when they return.
If they log out, clear that email so that they are not remembered.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
User was being remembered after logging out.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified
