### PR TITLE
[BANKCON] Remove duplicated permission disclaimers on callouts.

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/AccessibleDataCallout.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/AccessibleDataCallout.kt
@@ -152,11 +152,12 @@ private fun List<Permissions>.toStringRes(): List<Int> = mapNotNull {
     when (it) {
         Permissions.BALANCES -> R.string.data_accessible_type_balances
         Permissions.OWNERSHIP -> R.string.data_accessible_type_ownership
-        Permissions.PAYMENT_METHOD -> R.string.data_accessible_type_accountdetails
+        Permissions.PAYMENT_METHOD,
+        Permissions.ACCOUNT_NUMBERS -> R.string.data_accessible_type_accountdetails
         Permissions.TRANSACTIONS -> R.string.data_accessible_type_transactions
         Permissions.UNKNOWN -> null
     }
-}
+}.distinct()
 
 internal data class AccessibleDataCalloutModel(
     val businessName: String?,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/AccessibleDataCallout.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/AccessibleDataCallout.kt
@@ -187,7 +187,8 @@ internal fun AccessibleDataCalloutPreview() {
                     Permissions.PAYMENT_METHOD,
                     Permissions.BALANCES,
                     Permissions.OWNERSHIP,
-                    Permissions.TRANSACTIONS
+                    Permissions.TRANSACTIONS,
+                    Permissions.ACCOUNT_NUMBERS
                 ),
                 isStripeDirect = true,
                 dataPolicyUrl = ""

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentTextBuilder.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentTextBuilder.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.financialconnections.features.consent
 
 import com.stripe.android.financialconnections.R
-import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
+import com.stripe.android.financialconnections.model.FinancialConnectionsAccount.Permissions
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.ui.TextResource
 
@@ -69,29 +69,26 @@ internal object ConsentTextBuilder {
     fun getRequestedDataBullets(manifest: FinancialConnectionsSessionManifest): List<Pair<TextResource, TextResource>> {
         return manifest.permissions.mapNotNull { permission ->
             when (permission) {
-                FinancialConnectionsAccount.Permissions.BALANCES ->
-                    Pair(
-                        TextResource.StringId(R.string.stripe_consent_requested_data_balances_title),
-                        TextResource.StringId(R.string.stripe_consent_requested_data_balances_desc)
-                    )
-                FinancialConnectionsAccount.Permissions.OWNERSHIP ->
-                    Pair(
-                        TextResource.StringId(R.string.stripe_consent_requested_data_ownership_title),
-                        TextResource.StringId(R.string.stripe_consent_requested_data_ownership_desc)
-                    )
-                FinancialConnectionsAccount.Permissions.PAYMENT_METHOD ->
-                    Pair(
-                        TextResource.StringId(R.string.stripe_consent_requested_data_accountdetails_title),
-                        TextResource.StringId(R.string.stripe_consent_requested_data_accountdetails_desc)
-                    )
-                FinancialConnectionsAccount.Permissions.TRANSACTIONS ->
-                    Pair(
-                        TextResource.StringId(R.string.stripe_consent_requested_data_transactions_title),
-                        TextResource.StringId(R.string.stripe_consent_requested_data_transactions_desc)
-                    )
-                FinancialConnectionsAccount.Permissions.UNKNOWN -> null
+                Permissions.BALANCES -> Pair(
+                    TextResource.StringId(R.string.stripe_consent_requested_data_balances_title),
+                    TextResource.StringId(R.string.stripe_consent_requested_data_balances_desc)
+                )
+                Permissions.OWNERSHIP -> Pair(
+                    TextResource.StringId(R.string.stripe_consent_requested_data_ownership_title),
+                    TextResource.StringId(R.string.stripe_consent_requested_data_ownership_desc)
+                )
+                Permissions.PAYMENT_METHOD,
+                Permissions.ACCOUNT_NUMBERS -> Pair(
+                    TextResource.StringId(R.string.stripe_consent_requested_data_accountdetails_title),
+                    TextResource.StringId(R.string.stripe_consent_requested_data_accountdetails_desc)
+                )
+                Permissions.TRANSACTIONS -> Pair(
+                    TextResource.StringId(R.string.stripe_consent_requested_data_transactions_title),
+                    TextResource.StringId(R.string.stripe_consent_requested_data_transactions_desc)
+                )
+                Permissions.UNKNOWN -> null
             }
-        }
+        }.distinct()
     }
 
     fun getBusinessName(manifest: FinancialConnectionsSessionManifest): String? {

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/consent/ConsentTextBuilderTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/consent/ConsentTextBuilderTest.kt
@@ -1,0 +1,32 @@
+package com.stripe.android.financialconnections.features.consent
+
+import com.stripe.android.financialconnections.ApiKeyFixtures
+import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.financialconnections.R
+import com.stripe.android.financialconnections.ui.TextResource
+import org.junit.Test
+
+class ConsentTextBuilderTest {
+
+    @Test
+    fun `getDataBullets - When account numbers and payment method are present, no duplicated texts are shown`() {
+        val manifestWithDuplicatedPermissions = ApiKeyFixtures.sessionManifest().copy(
+            permissions = listOf(
+                FinancialConnectionsAccount.Permissions.ACCOUNT_NUMBERS,
+                FinancialConnectionsAccount.Permissions.PAYMENT_METHOD
+            )
+        )
+        val result: List<Pair<TextResource, TextResource>> =
+            ConsentTextBuilder.getRequestedDataBullets(
+                manifestWithDuplicatedPermissions
+            )
+
+        assertThat(result).containsExactly(
+            Pair(
+                TextResource.StringId(R.string.stripe_consent_requested_data_accountdetails_title),
+                TextResource.StringId(R.string.stripe_consent_requested_data_accountdetails_desc)
+            )
+        )
+    }
+}


### PR DESCRIPTION
# Summary

**PAYMENT_METHODS** and **ACCOUNT_NUMBERS** map to identical disclaimer texts on callouts. This PR ensures no duplicates are shown if both permissions are present.

Context: https://stripe.slack.com/archives/C01DNBVURH9/p1663788621058329

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
