### PR TITLE
Parse billing address for ConsumerPaymentDetails.Card

### DIFF
--- a/link/src/main/java/com/stripe/android/link/ui/cardedit/CardEditViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/cardedit/CardEditViewModel.kt
@@ -143,6 +143,12 @@ internal class CardEditViewModel @Inject constructor(
         IdentifierSpec.CardBrand to brand.code,
         IdentifierSpec.CardExpMonth to expiryMonth.toString().padStart(length = 2, padChar = '0'),
         IdentifierSpec.CardExpYear to expiryYear.toString()
+    ).plus(
+        billingAddress?.countryCode?.value?.let {
+            mapOf(IdentifierSpec.Country to it)
+        } ?: emptyMap()
+    ).plus(
+        billingAddress?.postalCode?.let { mapOf(IdentifierSpec.PostalCode to it) } ?: emptyMap()
     )
 
     internal class Factory(

--- a/link/src/test/java/com/stripe/android/link/ui/cardedit/CardEditViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/cardedit/CardEditViewModelTest.kt
@@ -111,14 +111,14 @@ class CardEditViewModelTest {
         verify(linkAccountManager).updatePaymentDetails(
             argWhere {
                 it.toParamMap() == mapOf(
-                "is_default" to true,
-                "exp_month" to "12",
-                "exp_year" to "2040",
-                "billing_address" to mapOf(
-                    "country_code" to "US",
-                    "postal_code" to "12345"
+                    "is_default" to true,
+                    "exp_month" to "12",
+                    "exp_year" to "2040",
+                    "billing_address" to mapOf(
+                        "country_code" to "US",
+                        "postal_code" to "12345"
+                    )
                 )
-            )
             }
         )
     }

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -2481,12 +2481,38 @@ public final class com/stripe/android/model/ConsumerPaymentDetails$BankAccount$C
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/model/ConsumerPaymentDetails$BillingAddress : android/os/Parcelable {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Lcom/stripe/android/core/model/CountryCode;Ljava/lang/String;)V
+	public final fun component1 ()Lcom/stripe/android/core/model/CountryCode;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Lcom/stripe/android/core/model/CountryCode;Ljava/lang/String;)Lcom/stripe/android/model/ConsumerPaymentDetails$BillingAddress;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/ConsumerPaymentDetails$BillingAddress;Lcom/stripe/android/core/model/CountryCode;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/ConsumerPaymentDetails$BillingAddress;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCountryCode ()Lcom/stripe/android/core/model/CountryCode;
+	public final fun getPostalCode ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/model/ConsumerPaymentDetails$BillingAddress$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ConsumerPaymentDetails$BillingAddress;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/model/ConsumerPaymentDetails$BillingAddress;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/model/ConsumerPaymentDetails$Card : com/stripe/android/model/ConsumerPaymentDetails$PaymentDetails {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/model/ConsumerPaymentDetails$Card$Companion;
 	public static final field type Ljava/lang/String;
-	public fun <init> (Ljava/lang/String;ZIILcom/stripe/android/model/CardBrand;Ljava/lang/String;Lcom/stripe/android/model/CvcCheck;)V
+	public fun <init> (Ljava/lang/String;ZIILcom/stripe/android/model/CardBrand;Ljava/lang/String;Lcom/stripe/android/model/CvcCheck;Lcom/stripe/android/model/ConsumerPaymentDetails$BillingAddress;)V
+	public synthetic fun <init> (Ljava/lang/String;ZIILcom/stripe/android/model/CardBrand;Ljava/lang/String;Lcom/stripe/android/model/CvcCheck;Lcom/stripe/android/model/ConsumerPaymentDetails$BillingAddress;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Z
 	public final fun component3 ()I
@@ -2494,10 +2520,12 @@ public final class com/stripe/android/model/ConsumerPaymentDetails$Card : com/st
 	public final fun component5 ()Lcom/stripe/android/model/CardBrand;
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Lcom/stripe/android/model/CvcCheck;
-	public final fun copy (Ljava/lang/String;ZIILcom/stripe/android/model/CardBrand;Ljava/lang/String;Lcom/stripe/android/model/CvcCheck;)Lcom/stripe/android/model/ConsumerPaymentDetails$Card;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/ConsumerPaymentDetails$Card;Ljava/lang/String;ZIILcom/stripe/android/model/CardBrand;Ljava/lang/String;Lcom/stripe/android/model/CvcCheck;ILjava/lang/Object;)Lcom/stripe/android/model/ConsumerPaymentDetails$Card;
+	public final fun component8 ()Lcom/stripe/android/model/ConsumerPaymentDetails$BillingAddress;
+	public final fun copy (Ljava/lang/String;ZIILcom/stripe/android/model/CardBrand;Ljava/lang/String;Lcom/stripe/android/model/CvcCheck;Lcom/stripe/android/model/ConsumerPaymentDetails$BillingAddress;)Lcom/stripe/android/model/ConsumerPaymentDetails$Card;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/ConsumerPaymentDetails$Card;Ljava/lang/String;ZIILcom/stripe/android/model/CardBrand;Ljava/lang/String;Lcom/stripe/android/model/CvcCheck;Lcom/stripe/android/model/ConsumerPaymentDetails$BillingAddress;ILjava/lang/Object;)Lcom/stripe/android/model/ConsumerPaymentDetails$Card;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBillingAddress ()Lcom/stripe/android/model/ConsumerPaymentDetails$BillingAddress;
 	public final fun getBrand ()Lcom/stripe/android/model/CardBrand;
 	public final fun getCvcCheck ()Lcom/stripe/android/model/CvcCheck;
 	public final fun getExpiryMonth ()I

--- a/payments-core/src/main/java/com/stripe/android/model/ConsumerPaymentDetails.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConsumerPaymentDetails.kt
@@ -2,6 +2,7 @@ package com.stripe.android.model
 
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.model.StripeModel
 import com.stripe.android.view.DateUtils
 import kotlinx.parcelize.Parcelize
@@ -26,7 +27,8 @@ data class ConsumerPaymentDetails internal constructor(
         val expiryMonth: Int,
         val brand: CardBrand,
         val last4: String,
-        val cvcCheck: CvcCheck
+        val cvcCheck: CvcCheck,
+        val billingAddress: BillingAddress? = null
     ) : PaymentDetails(id, isDefault, Companion.type) {
 
         val requiresCardDetailsRecollection: Boolean
@@ -76,4 +78,10 @@ data class ConsumerPaymentDetails internal constructor(
             const val type = "bank_account"
         }
     }
+
+    @Parcelize
+    data class BillingAddress(
+        val countryCode: CountryCode?,
+        val postalCode: String?
+    ) : Parcelable
 }

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParser.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model.parsers
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.model.StripeJsonUtils.optString
 import com.stripe.android.core.model.parsers.ModelJsonParser
 import com.stripe.android.model.CardBrand
@@ -28,6 +29,7 @@ class ConsumerPaymentDetailsJsonParser : ModelJsonParser<ConsumerPaymentDetails>
                 ConsumerPaymentDetails.Card.type -> {
                     val cardDetails = json.getJSONObject(FIELD_CARD_DETAILS)
                     val checks = cardDetails.getJSONObject(FIELD_CARD_CHECKS)
+
                     ConsumerPaymentDetails.Card(
                         json.getString(FIELD_ID),
                         json.getBoolean(FIELD_IS_DEFAULT),
@@ -35,7 +37,8 @@ class ConsumerPaymentDetailsJsonParser : ModelJsonParser<ConsumerPaymentDetails>
                         cardDetails.getInt(FIELD_CARD_EXPIRY_MONTH),
                         CardBrand.fromCode(cardBrandFix(cardDetails.getString(FIELD_CARD_BRAND))),
                         cardDetails.getString(FIELD_CARD_LAST_4),
-                        CvcCheck.fromCode(checks.getString(FIELD_CARD_CVC_CHECK))
+                        CvcCheck.fromCode(checks.getString(FIELD_CARD_CVC_CHECK)),
+                        parseBillingAddress(json)
                     )
                 }
                 ConsumerPaymentDetails.BankAccount.type -> {
@@ -50,6 +53,14 @@ class ConsumerPaymentDetailsJsonParser : ModelJsonParser<ConsumerPaymentDetails>
                 }
                 else -> null
             }
+        }
+
+    private fun parseBillingAddress(json: JSONObject) =
+        json.getJSONObject(FIELD_BILLING_ADDRESS).let { address ->
+            ConsumerPaymentDetails.BillingAddress(
+                optString(address, FIELD_ADDRESS_COUNTRY_CODE)?.let { CountryCode(it) },
+                optString(address, FIELD_ADDRESS_POSTAL_CODE)
+            )
         }
 
     /**
@@ -69,6 +80,10 @@ class ConsumerPaymentDetailsJsonParser : ModelJsonParser<ConsumerPaymentDetails>
         private const val FIELD_TYPE = "type"
         private const val FIELD_ID = "id"
         private const val FIELD_IS_DEFAULT = "is_default"
+
+        private const val FIELD_BILLING_ADDRESS = "billing_address"
+        private const val FIELD_ADDRESS_COUNTRY_CODE = "country_code"
+        private const val FIELD_ADDRESS_POSTAL_CODE = "postal_code"
 
         private const val FIELD_CARD_DETAILS = "card_details"
         private const val FIELD_CARD_EXPIRY_YEAR = "exp_year"

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParserTest.kt
@@ -181,7 +181,11 @@ class ConsumerPaymentDetailsJsonParserTest {
                         expiryMonth = 12,
                         brand = CardBrand.AmericanExpress,
                         last4 = "4444",
-                        cvcCheck = CvcCheck.Pass
+                        cvcCheck = CvcCheck.Pass,
+                        billingAddress = ConsumerPaymentDetails.BillingAddress(
+                            CountryCode.US,
+                            "12312"
+                        )
                     ),
                     ConsumerPaymentDetails.Card(
                         id = "QAAAKIL",
@@ -190,7 +194,11 @@ class ConsumerPaymentDetailsJsonParserTest {
                         expiryMonth = 4,
                         brand = CardBrand.DinersClub,
                         last4 = "4242",
-                        cvcCheck = CvcCheck.Fail
+                        cvcCheck = CvcCheck.Fail,
+                        billingAddress = ConsumerPaymentDetails.BillingAddress(
+                            CountryCode.US,
+                            "42424"
+                        )
                     )
                 )
             )

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ConsumerPaymentDetailsJsonParserTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.model.parsers
 
+import com.stripe.android.core.model.CountryCode
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerFixtures
 import com.stripe.android.model.ConsumerPaymentDetails
@@ -24,7 +25,11 @@ class ConsumerPaymentDetailsJsonParserTest {
                         expiryMonth = 12,
                         brand = CardBrand.MasterCard,
                         last4 = "4444",
-                        cvcCheck = CvcCheck.Pass
+                        cvcCheck = CvcCheck.Pass,
+                        billingAddress = ConsumerPaymentDetails.BillingAddress(
+                            CountryCode.US,
+                            "12312"
+                        )
                     )
                 )
             )
@@ -63,7 +68,11 @@ class ConsumerPaymentDetailsJsonParserTest {
                         expiryMonth = 12,
                         brand = CardBrand.MasterCard,
                         last4 = "4444",
-                        cvcCheck = CvcCheck.Pass
+                        cvcCheck = CvcCheck.Pass,
+                        billingAddress = ConsumerPaymentDetails.BillingAddress(
+                            CountryCode.US,
+                            "12312"
+                        )
                     ),
                     ConsumerPaymentDetails.Card(
                         id = "QAAAKIL",
@@ -72,7 +81,11 @@ class ConsumerPaymentDetailsJsonParserTest {
                         expiryMonth = 4,
                         brand = CardBrand.Visa,
                         last4 = "4242",
-                        cvcCheck = CvcCheck.Fail
+                        cvcCheck = CvcCheck.Fail,
+                        billingAddress = ConsumerPaymentDetails.BillingAddress(
+                            CountryCode.US,
+                            "42424"
+                        )
                     ),
                     ConsumerPaymentDetails.BankAccount(
                         id = "wAAACGA",


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Parse country and postal code from billing address for ConsumerPaymentDetails.Card.
Use them to populate the form when updating a card.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Populate country and postal code when editing a card.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
