### PR TITLE
Disable default checkbox in card edit screen if card is already default

### DIFF
--- a/link/res/values-b+es+419/strings.xml
+++ b/link/res/values-b+es+419/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Cerrar sesión de Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Establecer como método de pago predeterminado</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Tu método predeterminado</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Mostrar menú</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-ca-rES/strings.xml
+++ b/link/res/values-ca-rES/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Tanca la sessió a Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Configura com a mètode de pagament per defecte</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Aquesta és l\'opció per defecte</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Mostra el menú</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-cs-rCZ/strings.xml
+++ b/link/res/values-cs-rCZ/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Odhlásit ze služby Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Nastavit jako výchozí způsob platby</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Toto je výchozí nastavení</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Zobrazit nabídku</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-da/strings.xml
+++ b/link/res/values-da/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Log ud af Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Angiv som standardbetalingsmetode</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Dette er din standard</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Vis menu</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-de/strings.xml
+++ b/link/res/values-de/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Von Link abmelden</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Als Standard-Zahlungsmethode festlegen</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Dies ist Ihre Standard-Methode</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Menü anzeigen</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-el-rGR/strings.xml
+++ b/link/res/values-el-rGR/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Αποσύνδεση από το Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Ορισμός ως προεπιλεγμένη μέθοδος πληρωμής</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Αυτή είναι η προεπιλογή σας</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Εμφάνιση μενού</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-en-rGB/strings.xml
+++ b/link/res/values-en-rGB/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Log out of Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Set as default payment method</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">This is your default</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Show menu</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-es/strings.xml
+++ b/link/res/values-es/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Cerrar la sesión de Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Establecer como método de pago predeterminado</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Este es tu valor predeterminado</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Mostrar menú</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-et-rEE/strings.xml
+++ b/link/res/values-et-rEE/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Logi Link välja</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Määra vaikimisi makseviisiks</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">See on teie vaikimisi makseviis</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Kuva menüü</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-fi/strings.xml
+++ b/link/res/values-fi/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Kirjaudu ulos Link-palvelusta</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Aseta oletusarvoiseksi maksutavaksi</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Tämä on oletusarvoinen</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Näytä valikko</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-fil/strings.xml
+++ b/link/res/values-fil/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Mag-log out sa Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">I-set bilang default na paraan ng pagbabayad</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Ito ang iyong default</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Ipakita ang menu</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-fr-rCA/strings.xml
+++ b/link/res/values-fr-rCA/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Déconnexion de Link with Stripe</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Définir comme moyen de paiement par défaut</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Votre moyen de paiement par défaut</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Afficher le menu</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-fr/strings.xml
+++ b/link/res/values-fr/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Se déconnecter de Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Définir comme moyen de paiement par défaut</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Votre moyen de paiement par défaut</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Afficher le menu</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-hr/strings.xml
+++ b/link/res/values-hr/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Odjavite se s Linka</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Postavi kao zadani način plaćanja</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Ovo je vaša zadana vrijednost</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Prikaži izbornik</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-hu/strings.xml
+++ b/link/res/values-hu/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Kijelentkezés a Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Legyen ez az alapértelmezett fizetési mód</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Ez az alapértelmezett</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Menü megjelenítése</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-in/strings.xml
+++ b/link/res/values-in/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Keluar dari Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Atur sebagai metode pembayaran default</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Ini default Anda</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Tampilkan menu</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-it/strings.xml
+++ b/link/res/values-it/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Esci da Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Imposta come modalità di pagamento predefinita</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">È la tua impostazione predefinita</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Mostra menu</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-ja/strings.xml
+++ b/link/res/values-ja/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Link からログアウト</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">デフォルトの決済手段として設定する</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">これはデフォルトです</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">メニューを表示</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-ko/strings.xml
+++ b/link/res/values-ko/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Link 로그아웃</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">결제 방식 기본값으로 설정</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">기본값입니다</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">메뉴 표시</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-lt-rLT/strings.xml
+++ b/link/res/values-lt-rLT/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Atsijungti nuo „Link“</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Nustatyti kaip numatytąjį mokėjimo būdą</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Tai jūsų numatytasis mokėjimo būdas</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Rodyti meniu</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-lv-rLV/strings.xml
+++ b/link/res/values-lv-rLV/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Izrakstīties no Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Iestatīt kā noklusējuma maksājuma veidu</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Tas ir jūsu noklusējums</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Rādīt izvēlni</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-ms-rMY/strings.xml
+++ b/link/res/values-ms-rMY/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Log keluar dari Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Tetapkan sebagai kaedah pembayaran tetapan asal</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Ini tetapan asal anda</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Paparkan menu</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-mt/strings.xml
+++ b/link/res/values-mt/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Oħroġ minn Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Qiegħed bħala l-metodu tal-pagament standard</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Dan il-metodu tal-pagament standard tiegħek</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Uri l-menù</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-nb/strings.xml
+++ b/link/res/values-nb/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Logg ut av Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Angi som standard betalingsmetode</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Dette er standarden din</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Vis meny</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-nl/strings.xml
+++ b/link/res/values-nl/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Afmelden bij Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Instellen als standaardbetaalmethode</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Dit is je standaard</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Menu weergeven</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-nn-rNO/strings.xml
+++ b/link/res/values-nn-rNO/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Logg ut av Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Angi som standard betalingsmåte</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Dette er di standardinnstilling</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Vis meny</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-pl-rPL/strings.xml
+++ b/link/res/values-pl-rPL/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Wyloguj się z Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Użyj jako domyślnej metody płatności</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">To Twoje ustawienie domyślne</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Pokaż menu</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-pt-rBR/strings.xml
+++ b/link/res/values-pt-rBR/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Sair do Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Definir como forma de pagamento padrão</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Este é o seu padrão</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Mostrar o menu</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-pt-rPT/strings.xml
+++ b/link/res/values-pt-rPT/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Terminar sessão no Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Definir como método de pagamento predefinido</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Este é o seu método predefinido</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Mostrar menu</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-ro-rRO/strings.xml
+++ b/link/res/values-ro-rRO/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Deconectare de la Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Setați ca metodă de plată implicită</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Aceasta este setarea dvs. implicită</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Afișare meniu</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-ru/strings.xml
+++ b/link/res/values-ru/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Выйти из Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Назначить способом оплаты по умолчанию</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Это ваше значение по умолчанию</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Показать меню</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-sk-rSK/strings.xml
+++ b/link/res/values-sk-rSK/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Odhlásiť sa zo služby Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Nastaviť ako predvolený spôsob platby</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Toto je váš predvolený spôsob platby</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Zobraziť ponuku</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-sl-rSI/strings.xml
+++ b/link/res/values-sl-rSI/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Odjava iz storitve Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Nastavi kot privzeti način plačila</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">To je vaš privzeti način plačila</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Pokaži meni</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-sv/strings.xml
+++ b/link/res/values-sv/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Logga ut från Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Ställ in som standardbetalningsmetod</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Detta är din standardbetalningsmetod</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Visa meny</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-th/strings.xml
+++ b/link/res/values-th/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">ออกจากระบบ Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">ตั้งเป็นวิธีการชำระเงินเริ่มต้น</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">นี่คือค่าเริ่มต้นของคุณ</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">แสดงเมนู</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-tr/strings.xml
+++ b/link/res/values-tr/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Link\'ten çıkış yap</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Varsayılan ödeme yöntemi olarak ayarla</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Bu varsayılan ödeme yönteminizdir</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Menüyü göster</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-vi/strings.xml
+++ b/link/res/values-vi/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Đăng xuất khỏi Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Đặt làm phương thức thanh toán mặc định</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">Đây là thông tin mặc định của bạn</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Hiển thị trình đơn</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-zh-rHK/strings.xml
+++ b/link/res/values-zh-rHK/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">退出 Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">設置為預設支付方式</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">這是您的預設支付方式</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">顯示選單</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-zh-rTW/strings.xml
+++ b/link/res/values-zh-rTW/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">退出 Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">設定為預設支付方式</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">這是您的預設支付方式</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">顯示選單</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values-zh/strings.xml
+++ b/link/res/values-zh/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">退出 Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">设置为默认支付方式</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">这是您的默认地址</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">显示菜单</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/res/values/strings.xml
+++ b/link/res/values/strings.xml
@@ -10,8 +10,6 @@
   <string name="log_out">Log out of Link</string>
   <!-- Label of a checkbox that when checked makes a payment method as the default one. -->
   <string name="pm_set_as_default">Set as default payment method</string>
-  <!-- Text of a label indicating that a payment method is the default. -->
-  <string name="pm_your_default">This is your default</string>
   <!-- Accessibility label for an action or a button that shows a menu. -->
   <string name="show_menu">Show menu</string>
   <!-- Title for a button that when tapped creates a Link account for the user. -->

--- a/link/src/androidTest/java/com/stripe/android/link/ui/cardedit/CardEditScreenTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/cardedit/CardEditScreenTest.kt
@@ -106,7 +106,7 @@ internal class CardEditScreenTest {
         testTag = DEFAULT_PAYMENT_METHOD_CHECKBOX_TAG
     )
 
-    private fun onSetAsDefaultLabel() = composeTestRule.onNodeWithText("Set as default payment")
+    private fun onSetAsDefaultLabel() = composeTestRule.onNodeWithText("Set as default payment method")
 
     private fun onUpdateCardButton() = composeTestRule.onNode(
         matcher = hasText("Update card").and(hasParent(hasClickAction())),

--- a/link/src/androidTest/java/com/stripe/android/link/ui/cardedit/CardEditScreenTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/cardedit/CardEditScreenTest.kt
@@ -1,10 +1,13 @@
 package com.stripe.android.link.ui.cardedit
 
 import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasParent
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -21,17 +24,15 @@ internal class CardEditScreenTest {
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
-    fun when_default_show_default_label() {
+    fun when_default_show_show_disabled_checkbox() {
         setContent(isDefault = true)
-        onDefaultLabel().assertExists()
-        onSetAsDefaultLabel().assertDoesNotExist()
+        onDefaultCheckboxRow().assertIsNotEnabled()
     }
 
     @Test
-    fun when_not_default_show_checkbox() {
+    fun when_not_default_show_enabled_checkbox() {
         setContent(isDefault = false)
-        onDefaultLabel().assertDoesNotExist()
-        onSetAsDefaultLabel().assertExists()
+        onDefaultCheckboxRow().assertIsEnabled()
     }
 
     @Test
@@ -101,13 +102,16 @@ internal class CardEditScreenTest {
         }
     }
 
-    private fun onDefaultLabel() = composeTestRule.onNodeWithText("This is your default")
+    private fun onDefaultCheckboxRow() = composeTestRule.onNodeWithTag(
+        testTag = DEFAULT_PAYMENT_METHOD_CHECKBOX_TAG
+    )
+
     private fun onSetAsDefaultLabel() = composeTestRule.onNodeWithText("Set as default payment")
-    private fun onUpdateCardButton() =
-        composeTestRule.onNode(
-            hasText("Update card").and(hasParent(hasClickAction())),
-            useUnmergedTree = true
-        )
+
+    private fun onUpdateCardButton() = composeTestRule.onNode(
+        matcher = hasText("Update card").and(hasParent(hasClickAction())),
+        useUnmergedTree = true
+    )
 
     private fun onCancelButton() = composeTestRule.onNodeWithText("Cancel")
 }

--- a/link/src/main/java/com/stripe/android/link/ui/cardedit/CardEditScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/cardedit/CardEditScreen.kt
@@ -3,15 +3,11 @@ package com.stripe.android.link.ui.cardedit
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.selection.selectable
-import androidx.compose.material.Checkbox
-import androidx.compose.material.CheckboxDefaults
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
@@ -21,9 +17,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -33,7 +27,6 @@ import com.stripe.android.link.R
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.link.theme.PaymentsThemeForLink
-import com.stripe.android.link.theme.linkColors
 import com.stripe.android.link.ui.ErrorMessage
 import com.stripe.android.link.ui.ErrorText
 import com.stripe.android.link.ui.PrimaryButton
@@ -42,6 +35,7 @@ import com.stripe.android.link.ui.ScrollableTopLevelColumn
 import com.stripe.android.link.ui.SecondaryButton
 import com.stripe.android.link.ui.forms.Form
 import com.stripe.android.link.ui.wallet.PaymentDetailsResult
+import com.stripe.android.ui.core.elements.CheckboxElementUI
 import com.stripe.android.ui.core.injection.NonFallbackInjector
 
 internal const val DEFAULT_PAYMENT_METHOD_CHECKBOX_TAG = "DEFAULT_PAYMENT_METHOD_CHECKBOX"
@@ -142,18 +136,16 @@ internal fun CardEditBody(
         )
         PaymentsThemeForLink {
             formContent()
-        }
-        Spacer(modifier = Modifier.height(8.dp))
 
-        DefaultPaymentMethodCheckbox(
-            setAsDefaultChecked = setAsDefaultChecked,
-            isDefault = isDefault,
-            isProcessing = isProcessing,
-            onSetAsDefaultClick = onSetAsDefaultClick,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 16.dp)
-        )
+            Spacer(modifier = Modifier.height(8.dp))
+
+            DefaultPaymentMethodCheckbox(
+                setAsDefaultChecked = setAsDefaultChecked,
+                isDefault = isDefault,
+                isProcessing = isProcessing,
+                onSetAsDefaultClick = onSetAsDefaultClick,
+            )
+        }
 
         AnimatedVisibility(visible = errorMessage != null) {
             ErrorText(
@@ -184,37 +176,17 @@ private fun DefaultPaymentMethodCheckbox(
     isDefault: Boolean,
     isProcessing: Boolean,
     onSetAsDefaultClick: (Boolean) -> Unit,
-    modifier: Modifier = Modifier
 ) {
     val isChecked = isDefault || setAsDefaultChecked
     val canCheck = !isDefault && !isProcessing
 
-    Row(
-        modifier = modifier
-            .testTag(DEFAULT_PAYMENT_METHOD_CHECKBOX_TAG)
-            .selectable(
-                selected = false,
-                enabled = canCheck,
-                onClick = {
-                    onSetAsDefaultClick(!setAsDefaultChecked)
-                }
-            )
-    ) {
-        Checkbox(
-            checked = isChecked,
-            onCheckedChange = null, // needs to be null for accessibility on row click to work
-            modifier = Modifier.padding(end = 8.dp),
-            enabled = canCheck,
-            colors = CheckboxDefaults.colors(
-                checkedColor = MaterialTheme.colors.primary,
-                uncheckedColor = MaterialTheme.linkColors.disabledText
-            )
-        )
-        Text(
-            text = stringResource(R.string.pm_set_as_default),
-            style = MaterialTheme.typography.h6,
-            color = MaterialTheme.colors.onPrimary,
-            modifier = Modifier.alpha(if (canCheck) 1f else 0.6f)
-        )
-    }
+    CheckboxElementUI(
+        automationTestTag = DEFAULT_PAYMENT_METHOD_CHECKBOX_TAG,
+        isChecked = isChecked,
+        label = stringResource(R.string.pm_set_as_default),
+        isEnabled = canCheck,
+        onValueChange = {
+            onSetAsDefaultClick(!setAsDefaultChecked)
+        }
+    )
 }

--- a/link/src/main/java/com/stripe/android/link/ui/cardedit/CardEditScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/cardedit/CardEditScreen.kt
@@ -176,7 +176,7 @@ internal fun CardEditBody(
 }
 
 @Composable
-fun DefaultPaymentMethodCheckbox(
+private fun DefaultPaymentMethodCheckbox(
     setAsDefaultChecked: Boolean,
     isDefault: Boolean,
     isProcessing: Boolean,

--- a/link/src/main/java/com/stripe/android/link/ui/cardedit/CardEditScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/cardedit/CardEditScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -42,6 +43,8 @@ import com.stripe.android.link.ui.SecondaryButton
 import com.stripe.android.link.ui.forms.Form
 import com.stripe.android.link.ui.wallet.PaymentDetailsResult
 import com.stripe.android.ui.core.injection.NonFallbackInjector
+
+internal const val DEFAULT_PAYMENT_METHOD_CHECKBOX_TAG = "DEFAULT_PAYMENT_METHOD_CHECKBOX"
 
 @Preview
 @Composable
@@ -188,6 +191,7 @@ private fun DefaultPaymentMethodCheckbox(
 
     Row(
         modifier = modifier
+            .testTag(DEFAULT_PAYMENT_METHOD_CHECKBOX_TAG)
             .selectable(
                 selected = false,
                 enabled = canCheck,

--- a/link/src/main/java/com/stripe/android/link/ui/cardedit/CardEditScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/cardedit/CardEditScreen.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.link.ui.cardedit
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
@@ -10,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.material.Checkbox
 import androidx.compose.material.CheckboxDefaults
 import androidx.compose.material.CircularProgressIndicator
@@ -21,6 +21,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -140,39 +141,17 @@ internal fun CardEditBody(
             formContent()
         }
         Spacer(modifier = Modifier.height(8.dp))
-        if (isDefault) {
-            Text(
-                text = stringResource(R.string.pm_your_default),
-                modifier = Modifier.padding(vertical = 16.dp),
-                style = MaterialTheme.typography.h6,
-                color = MaterialTheme.linkColors.disabledText
-            )
-        } else {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 16.dp)
-                    .clickable {
-                        onSetAsDefaultClick(!setAsDefaultChecked)
-                    }
-            ) {
-                Checkbox(
-                    checked = setAsDefaultChecked,
-                    onCheckedChange = null, // needs to be null for accessibility on row click to work
-                    modifier = Modifier.padding(end = 8.dp),
-                    enabled = !isProcessing,
-                    colors = CheckboxDefaults.colors(
-                        checkedColor = MaterialTheme.colors.primary,
-                        uncheckedColor = MaterialTheme.linkColors.disabledText
-                    )
-                )
-                Text(
-                    text = stringResource(R.string.pm_set_as_default),
-                    style = MaterialTheme.typography.h6,
-                    color = MaterialTheme.colors.onPrimary
-                )
-            }
-        }
+
+        DefaultPaymentMethodCheckbox(
+            setAsDefaultChecked = setAsDefaultChecked,
+            isDefault = isDefault,
+            isProcessing = isProcessing,
+            onSetAsDefaultClick = onSetAsDefaultClick,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 16.dp)
+        )
+
         AnimatedVisibility(visible = errorMessage != null) {
             ErrorText(
                 text = errorMessage?.getMessage(LocalContext.current.resources).orEmpty(),
@@ -192,6 +171,46 @@ internal fun CardEditBody(
             enabled = !isProcessing,
             label = stringResource(id = R.string.cancel),
             onClick = onCancelClick
+        )
+    }
+}
+
+@Composable
+fun DefaultPaymentMethodCheckbox(
+    setAsDefaultChecked: Boolean,
+    isDefault: Boolean,
+    isProcessing: Boolean,
+    onSetAsDefaultClick: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val isChecked = isDefault || setAsDefaultChecked
+    val canCheck = !isDefault && !isProcessing
+
+    Row(
+        modifier = modifier
+            .selectable(
+                selected = false,
+                enabled = canCheck,
+                onClick = {
+                    onSetAsDefaultClick(!setAsDefaultChecked)
+                }
+            )
+    ) {
+        Checkbox(
+            checked = isChecked,
+            onCheckedChange = null, // needs to be null for accessibility on row click to work
+            modifier = Modifier.padding(end = 8.dp),
+            enabled = canCheck,
+            colors = CheckboxDefaults.colors(
+                checkedColor = MaterialTheme.colors.primary,
+                uncheckedColor = MaterialTheme.linkColors.disabledText
+            )
+        )
+        Text(
+            text = stringResource(R.string.pm_set_as_default),
+            style = MaterialTheme.typography.h6,
+            color = MaterialTheme.colors.onPrimary,
+            modifier = Modifier.alpha(if (canCheck) 1f else 0.6f)
         )
     }
 }

--- a/scripts/localize.sh
+++ b/scripts/localize.sh
@@ -95,3 +95,4 @@ do
     ls -1 android/$MODULE/ | paste -sd "," - | sed 's/[,]*values[-]*//g'
 done
 
+rm -rf android/*


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request makes a change to the Link card edit screen. Previously, we showed a label `This is your default` if the card was the current default. Now, we show the same checkbox and label `Set as default payment` as for non-default cards, but we disable any interaction.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Link polish.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before | After |
| ------------- | ------------- |
| <img width="673" alt="Screen Shot 2022-09-29 at 2 38 51 PM" src="https://user-images.githubusercontent.com/110940675/193115532-39ac5e90-f45e-4e94-9ccb-8efb6394d422.png"> | <img width="673" alt="Screen Shot 2022-09-29 at 3 34 41 PM" src="https://user-images.githubusercontent.com/110940675/193125731-6525e4dd-315d-423d-bf45-0e4fd8ffba52.png"> |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

_Nothing to add._
