### PR TITLE
[BANKCON-5390] Adds back navigation on toolbar

### DIFF
--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -1633,10 +1633,14 @@ public final class com/stripe/android/financialconnections/ui/components/Composa
 	public static field lambda-1 Lkotlin/jvm/functions/Function2;
 	public static field lambda-2 Lkotlin/jvm/functions/Function2;
 	public static field lambda-3 Lkotlin/jvm/functions/Function2;
+	public static field lambda-4 Lkotlin/jvm/functions/Function2;
+	public static field lambda-5 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
 	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-2$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-3$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-4$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-5$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class com/stripe/android/financialconnections/ui/theme/ComposableSingletons$TypeKt {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
@@ -2,6 +2,7 @@
 
 package com.stripe.android.financialconnections.features.accountpicker
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -70,6 +71,7 @@ import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsThem
 internal fun AccountPickerScreen() {
     val viewModel: AccountPickerViewModel = mavericksViewModel()
     val parentViewModel = parentViewModel()
+    BackHandler(true) {}
     val state: State<AccountPickerState> = viewModel.collectAsState()
     AccountPickerContent(
         state = state.value,
@@ -89,7 +91,12 @@ private fun AccountPickerContent(
     onCloseClick: () -> Unit
 ) {
     FinancialConnectionsScaffold(
-        topBar = { FinancialConnectionsTopAppBar(onCloseClick = onCloseClick) }
+        topBar = {
+            FinancialConnectionsTopAppBar(
+                onCloseClick = onCloseClick,
+                showBack = false
+            )
+        }
     ) {
         when (val payload = state.payload) {
             Uninitialized, is Loading -> AccountPickerLoading()

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentScreen.kt
@@ -39,7 +39,12 @@ private fun AttachPaymentContent(
     onCloseClick: () -> Unit
 ) {
     FinancialConnectionsScaffold(
-        topBar = { FinancialConnectionsTopAppBar(onCloseClick = onCloseClick) }
+        topBar = {
+            FinancialConnectionsTopAppBar(
+                onCloseClick = onCloseClick,
+                showBack = false
+            )
+        }
     ) {
         when (payload) {
             Uninitialized, is Loading -> LoadingContent()

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessScreen.kt
@@ -2,6 +2,7 @@
 
 package com.stripe.android.financialconnections.features.manualentrysuccess
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -48,6 +49,7 @@ internal fun ManualEntrySuccessScreen(
 ) {
     val parentViewModel = parentViewModel()
     val viewModel: ManualEntrySuccessViewModel = mavericksViewModel()
+    BackHandler(true) {}
     val completeAuthSessionAsync = viewModel
         .collectAsState(ManualEntrySuccessState::completeAuthSession)
     ManualEntrySuccessContent(
@@ -68,7 +70,12 @@ internal fun ManualEntrySuccessContent(
     onDoneClick: () -> Unit
 ) {
     FinancialConnectionsScaffold(
-        topBar = { FinancialConnectionsTopAppBar(onCloseClick = onCloseClick) }
+        topBar = {
+            FinancialConnectionsTopAppBar(
+                onCloseClick = onCloseClick,
+                showBack = false
+            )
+        }
     ) {
         Column(
             verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthScreen.kt
@@ -80,7 +80,12 @@ private fun PartnerAuthScreenContent(
     onCloseClick: () -> Unit
 ) {
     FinancialConnectionsScaffold(
-        topBar = { FinancialConnectionsTopAppBar(onCloseClick = onCloseClick) }
+        topBar = {
+            FinancialConnectionsTopAppBar(
+                onCloseClick = onCloseClick,
+                showBack = state.canNavigateBack
+            )
+        }
     ) {
         when (val payload = state.payload) {
             Uninitialized, is Loading -> LoadingContent(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
@@ -178,5 +178,11 @@ internal data class PartnerAuthState(
     )
 
     val canNavigateBack: Boolean
-        get() = authenticationStatus !is Loading && authenticationStatus !is Success
+        get() =
+            // Authentication running -> don't allow back navigation
+            authenticationStatus !is Loading
+                && authenticationStatus !is Success
+                // Failures posting institution -> don't allow back navigation
+                && payload !is Fail
+
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
@@ -176,4 +176,7 @@ internal data class PartnerAuthState(
         val flow: Flow?,
         val showPartnerDisclosure: Boolean
     )
+
+    val canNavigateBack: Boolean
+        get() = authenticationStatus is Loading || authenticationStatus is Success
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
@@ -178,5 +178,5 @@ internal data class PartnerAuthState(
     )
 
     val canNavigateBack: Boolean
-        get() = authenticationStatus is Loading || authenticationStatus is Success
+        get() = authenticationStatus !is Loading && authenticationStatus !is Success
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
@@ -180,9 +180,8 @@ internal data class PartnerAuthState(
     val canNavigateBack: Boolean
         get() =
             // Authentication running -> don't allow back navigation
-            authenticationStatus !is Loading
-                && authenticationStatus !is Success
+            authenticationStatus !is Loading &&
+                authenticationStatus !is Success &&
                 // Failures posting institution -> don't allow back navigation
-                && payload !is Fail
-
+                payload !is Fail
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessScreen.kt
@@ -68,7 +68,12 @@ private fun SuccessContent(
 ) {
     val uriHandler = LocalUriHandler.current
     FinancialConnectionsScaffold(
-        topBar = { FinancialConnectionsTopAppBar(onCloseClick = onCloseClick) }
+        topBar = {
+            FinancialConnectionsTopAppBar(
+                onCloseClick = onCloseClick,
+                showBack = false
+            )
+        }
     ) {
         Column(
             verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
@@ -11,7 +11,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptionsBuilder
@@ -94,41 +96,45 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), Ma
     fun NavHost() {
         val navController = rememberNavController()
         NavigationEffect(navController)
-        NavHost(navController, startDestination = NavigationDirections.consent.destination) {
-            composable(NavigationDirections.consent.destination) {
-                ConsentScreen()
-            }
-            composable(NavigationDirections.manualEntry.destination) {
-                ManualEntryScreen()
-            }
-            composable(
-                route = NavigationDirections.ManualEntrySuccess.route,
-                arguments = NavigationDirections.ManualEntrySuccess.arguments
-            ) {
-                ManualEntrySuccessScreen(
-                    microdepositVerificationMethod = NavigationDirections
-                        .ManualEntrySuccess.microdeposits(it),
-                    last4 = NavigationDirections
-                        .ManualEntrySuccess.last4(it)
-                )
-            }
-            composable(NavigationDirections.institutionPicker.destination) {
-                InstitutionPickerScreen()
-            }
-            composable(NavigationDirections.partnerAuth.destination) {
-                PartnerAuthScreen()
-            }
-            composable(NavigationDirections.accountPicker.destination) {
-                AccountPickerScreen()
-            }
-            composable(NavigationDirections.success.destination) {
-                SuccessScreen()
-            }
-            composable(NavigationDirections.reset.destination) {
-                ResetScreen()
-            }
-            composable(NavigationDirections.attachLinkedPaymentAccount.destination) {
-                AttachPaymentScreen()
+        CompositionLocalProvider(
+            LocalNavHostController provides navController,
+        ) {
+            NavHost(navController, startDestination = NavigationDirections.consent.destination) {
+                composable(NavigationDirections.consent.destination) {
+                    ConsentScreen()
+                }
+                composable(NavigationDirections.manualEntry.destination) {
+                    ManualEntryScreen()
+                }
+                composable(
+                    route = NavigationDirections.ManualEntrySuccess.route,
+                    arguments = NavigationDirections.ManualEntrySuccess.arguments
+                ) {
+                    ManualEntrySuccessScreen(
+                        microdepositVerificationMethod = NavigationDirections
+                            .ManualEntrySuccess.microdeposits(it),
+                        last4 = NavigationDirections
+                            .ManualEntrySuccess.last4(it)
+                    )
+                }
+                composable(NavigationDirections.institutionPicker.destination) {
+                    InstitutionPickerScreen()
+                }
+                composable(NavigationDirections.partnerAuth.destination) {
+                    PartnerAuthScreen()
+                }
+                composable(NavigationDirections.accountPicker.destination) {
+                    AccountPickerScreen()
+                }
+                composable(NavigationDirections.success.destination) {
+                    SuccessScreen()
+                }
+                composable(NavigationDirections.reset.destination) {
+                    ResetScreen()
+                }
+                composable(NavigationDirections.attachLinkedPaymentAccount.destination) {
+                    AttachPaymentScreen()
+                }
             }
         }
     }
@@ -175,4 +181,8 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), Ma
             }
         }
     }
+}
+
+internal val LocalNavHostController = staticCompositionLocalOf<NavHostController> {
+    error("No NavHostController provided")
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/TopAppBar.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/TopAppBar.kt
@@ -6,13 +6,18 @@ import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.stripe.android.financialconnections.R
+import com.stripe.android.financialconnections.ui.LocalNavHostController
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
 
+/**
+ *
+ */
 @Composable
 internal fun FinancialConnectionsTopAppBar(
     title: @Composable () -> Unit = {
@@ -21,11 +26,24 @@ internal fun FinancialConnectionsTopAppBar(
             contentDescription = null // decorative element
         )
     },
+    showBack: Boolean = true,
     onCloseClick: () -> Unit
 ) {
+    val navigation = LocalNavHostController.current
     TopAppBar(
         title = title,
-        navigationIcon = {
+        navigationIcon = if (navigation.previousBackStackEntry != null && showBack) {
+            {
+                IconButton(onClick = { navigation.popBackStack() }) {
+                    Icon(
+                        imageVector = Icons.Filled.ArrowBack,
+                        contentDescription = "Back icon",
+                        tint = FinancialConnectionsTheme.colors.textSecondary
+                    )
+                }
+            }
+        } else null,
+        actions = {
             IconButton(onClick = onCloseClick) {
                 Icon(
                     imageVector = Icons.Filled.Close,
@@ -43,6 +61,9 @@ internal fun FinancialConnectionsTopAppBar(
 @Preview(group = "Components", name = "TopAppBar - idle")
 internal fun FinancialConnectionsTopAppBarPreview() {
     FinancialConnectionsTheme {
-        FinancialConnectionsTopAppBar {}
+        FinancialConnectionsTopAppBar(
+            title = {},
+            onCloseClick = {}
+        )
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/TopAppBar.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/TopAppBar.kt
@@ -15,9 +15,6 @@ import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.ui.LocalNavHostController
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
 
-/**
- *
- */
 @Composable
 internal fun FinancialConnectionsTopAppBar(
     title: @Composable () -> Unit = {


### PR DESCRIPTION
# Summary
- Shows back navigation on toolbar if a) backstack is not empty and b) screen does not block back navigation (via `showBack` flag).

https://user-images.githubusercontent.com/99293320/192070588-e5b1bca1-3ec1-4487-9d98-2befbfa938df.mp4


