### PR TITLE
Fix deletion of last saved payment method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### PaymentSheet
 
-* [FIXED][5592](https://github.com/stripe/stripe-android/pull/5592) Fix deletion of the last used payment method.
+* [FIXED][5592](https://github.com/stripe/stripe-android/pull/5592)[5613](https://github.com/stripe/stripe-android/pull/5613) Fix deletion of the last used payment method.
 
 ## 20.13.0 - 2022-09-19
 This release makes the `PaymentMethod.Card.networks` field public, fixes the Alipay integration and the card scan form encoding.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
@@ -27,8 +27,10 @@ internal abstract class BasePaymentMethodsListFragment(
     abstract val sheetViewModel: BaseSheetViewModel<*>
 
     protected lateinit var config: FragmentConfig
-    private lateinit var adapter: PaymentOptionsAdapter
-    private var editMenuItem: MenuItem? = null
+    @VisibleForTesting
+    lateinit var adapter: PaymentOptionsAdapter
+    @VisibleForTesting
+    var editMenuItem: MenuItem? = null
 
     @VisibleForTesting
     internal var isEditing = false
@@ -96,6 +98,7 @@ internal abstract class BasePaymentMethodsListFragment(
                 color = Color(appearance.getColors(context.isSystemDarkTheme()).appBarIcon),
                 fontFamily = appearance.typography.fontResId
             )
+            isVisible = adapter.hasSavedItems()
         }
     }
 
@@ -163,8 +166,12 @@ internal abstract class BasePaymentMethodsListFragment(
         sheetViewModel.updateSelection(paymentSelection)
     }
 
-    private fun deletePaymentMethod(item: PaymentOptionsAdapter.Item.SavedPaymentMethod) {
+    @VisibleForTesting
+    fun deletePaymentMethod(item: PaymentOptionsAdapter.Item.SavedPaymentMethod) {
         sheetViewModel.removePaymentMethod(item.paymentMethod)
+        if (!adapter.hasSavedItems()) {
+            isEditing = false
+        }
     }
 
     private companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
@@ -29,8 +29,7 @@ internal abstract class BasePaymentMethodsListFragment(
     protected lateinit var config: FragmentConfig
     @VisibleForTesting
     lateinit var adapter: PaymentOptionsAdapter
-    @VisibleForTesting
-    var editMenuItem: MenuItem? = null
+    private var editMenuItem: MenuItem? = null
 
     @VisibleForTesting
     internal var isEditing = false

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
@@ -26,9 +26,9 @@ internal abstract class BasePaymentMethodsListFragment(
 ) {
     abstract val sheetViewModel: BaseSheetViewModel<*>
 
-    protected lateinit var config: FragmentConfig
     @VisibleForTesting
     lateinit var adapter: PaymentOptionsAdapter
+    protected lateinit var config: FragmentConfig
     private var editMenuItem: MenuItem? = null
 
     @VisibleForTesting

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
@@ -123,7 +123,9 @@ internal class PaymentOptionsAdapter(
         notifyDataSetChanged()
     }
 
-    fun removeItem(item: Item) {
+    fun hasSavedItems() = items.filterIsInstance<Item.SavedPaymentMethod>().isNotEmpty()
+
+    private fun removeItem(item: Item) {
         val itemIndex = items.indexOf(item)
         items = items.toMutableList().apply { removeAt(itemIndex) }
         notifyItemRemoved(itemIndex)
@@ -269,14 +271,17 @@ internal class PaymentOptionsAdapter(
                     lpmRepository,
                     onItemSelectedListener = ::onItemSelected,
                     onRemoveListener = { position ->
-                        paymentMethodDeleteListener(items[position] as Item.SavedPaymentMethod)
-                        removeItem(items[position])
-                        notifyItemRemoved(position)
-                        onItemSelected(
-                            position = findInitialSelectedPosition(savedSelection),
-                            isClick = false,
-                            force = true
-                        )
+                        val removedItem = items[position] as Item.SavedPaymentMethod
+                        removeItem(removedItem)
+                        paymentMethodDeleteListener(removedItem)
+                        selectedItemPosition = findInitialSelectedPosition(savedSelection)
+                        if (selectedItemPosition != NO_POSITION) {
+                            onItemSelected(
+                                position = selectedItemPosition,
+                                isClick = false,
+                                force = true
+                            )
+                        }
                     }
                 )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -424,7 +424,10 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
     fun removePaymentMethod(paymentMethod: PaymentMethod) = runBlocking {
         launch {
             paymentMethod.id?.let { paymentMethodId ->
-                if ((selection.value as? PaymentSelection.Saved)?.paymentMethod?.id == paymentMethodId) {
+                if (
+                    (selection.value as? PaymentSelection.Saved)
+                        ?.paymentMethod?.id == paymentMethodId
+                ) {
                     _selection.value = null
                 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -424,6 +424,10 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
     fun removePaymentMethod(paymentMethod: PaymentMethod) = runBlocking {
         launch {
             paymentMethod.id?.let { paymentMethodId ->
+                if ((selection.value as? PaymentSelection.Saved)?.paymentMethod?.id == paymentMethodId) {
+                    _selection.value = null
+                }
+
                 savedStateHandle[SAVE_PAYMENT_METHODS] = _paymentMethods.value?.filter {
                     it.id != paymentMethodId
                 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -190,6 +190,23 @@ internal class PaymentOptionsViewModelTest {
     }
 
     @Test
+    fun `Removing selected payment method clears selection`() = runTest {
+        val cards = PaymentMethodFixtures.createCards(3)
+        val viewModel = createViewModel(
+            args = PAYMENT_OPTION_CONTRACT_ARGS.copy(paymentMethods = cards)
+        )
+
+        val selection = PaymentSelection.Saved(cards[1])
+        viewModel.updateSelection(selection)
+        assertThat(viewModel.selection.value).isEqualTo(selection)
+
+        viewModel.removePaymentMethod(selection.paymentMethod)
+        idleLooper()
+
+        assertThat(viewModel.selection.value).isNull()
+    }
+
+    @Test
     fun `when paymentMethods is empty, primary button and text below button are gone`() = runTest {
         val paymentMethod = PaymentMethodFixtures.US_BANK_ACCOUNT
         val viewModel = createViewModel(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
@@ -101,6 +101,22 @@ internal class PaymentSheetListFragmentTest : PaymentSheetViewModelTestInjection
     }
 
     @Test
+    fun `When last item is deleted then edit menu item is hidden`() {
+        val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+
+        createScenario(
+            fragmentConfig = FRAGMENT_CONFIG.copy(
+                savedSelection = SavedSelection.PaymentMethod(paymentMethod.id.orEmpty())
+            ),
+        ).onFragment { fragment ->
+            fragment.isEditing = true
+            fragment.adapter.items = fragment.adapter.items.dropLast(1)
+            fragment.deletePaymentMethod(PaymentOptionsAdapter.Item.SavedPaymentMethod(paymentMethod))
+            assertThat(fragment.isEditing).isFalse()
+        }
+    }
+
+    @Test
     fun `sets up adapter`() {
         createScenario(
             initialState = Lifecycle.State.INITIALIZED

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
@@ -107,7 +107,7 @@ internal class PaymentSheetListFragmentTest : PaymentSheetViewModelTestInjection
         createScenario(
             fragmentConfig = FRAGMENT_CONFIG.copy(
                 savedSelection = SavedSelection.PaymentMethod(paymentMethod.id.orEmpty())
-            ),
+            )
         ).onFragment { fragment ->
             fragment.isEditing = true
             fragment.adapter.items = fragment.adapter.items.dropLast(1)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
When the last saved payment method was deleted on Payment Sheet, the selection wasn't cleared on the ViewModel.
Now the selection is cleared, we exit edit mode and hide the edit button since there are no items left to delete.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Follow up to #5592.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

https://user-images.githubusercontent.com/77990083/192072959-6980aa9e-8f49-498c-aaba-e6ae369fe3e8.mp4

