### PR TITLE
Render UPI form in payment sheet

### DIFF
--- a/payments-core/res/values/totranslate.xml
+++ b/payments-core/res/values/totranslate.xml
@@ -7,5 +7,5 @@
     <string name="becs_widget_account_number_invalid">The account number you entered is invalid.</string>
 
     <!-- UPI -->
-    <string name="invalid_upi_id">This code is invalid.</string>
+    <string name="invalid_upi_id">Invalid UPI ID.</string>
 </resources>

--- a/payments-core/res/values/totranslate.xml
+++ b/payments-core/res/values/totranslate.xml
@@ -5,4 +5,7 @@
     -->
     <!-- Error string displayed to user when they enter in an invalid account number. Account number refers to a US bank account number -->
     <string name="becs_widget_account_number_invalid">The account number you entered is invalid.</string>
+
+    <!-- UPI -->
+    <string name="invalid_upi_id">This code is invalid.</string>
 </resources>

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -966,6 +966,23 @@ public final class com/stripe/android/ui/core/elements/TranslationId$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/stripe/android/ui/core/elements/UpiSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/UpiSpec$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/ui/core/elements/UpiSpec;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/ui/core/elements/UpiSpec;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/ui/core/elements/UpiSpec$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy$Companion {
 	public final fun create (Landroid/content/Context;Ljava/lang/String;Lcom/stripe/android/ui/core/elements/autocomplete/IsPlacesAvailable;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;)Lcom/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy;
 	public static synthetic fun create$default (Lcom/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy$Companion;Landroid/content/Context;Ljava/lang/String;Lcom/stripe/android/ui/core/elements/autocomplete/IsPlacesAvailable;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy;

--- a/payments-ui-core/res/values/totranslate.xml
+++ b/payments-ui-core/res/values/totranslate.xml
@@ -8,6 +8,10 @@
     <string name="stripe_paymentsheet_pay_with_bank_title">Pay with your bank account in just a few steps.</string>
     <string name="stripe_paymentsheet_remove_bank_account_title">Remove bank account</string>
 
+    <!-- UPI -->
+    <string name="stripe_paymentsheet_buy_using_upi_id">Buy using a UPI ID</string>
+    <string name="upi_id_label">UPI ID</string>
+
     <!-- Shipping Address Element -->
     <string name="stripe_paymentsheet_enter_address_manually">Enter address manually</string>
     <string name="stripe_paymentsheet_autocomplete_no_results_found">No results found</string>

--- a/payments-ui-core/src/main/assets/lpms.json
+++ b/payments-ui-core/src/main/assets/lpms.json
@@ -447,6 +447,10 @@
   {
     "type": "upi",
     "async": false,
-    "fields": []
+    "fields": [
+      {
+        "type": "upi"
+      }
+    ]
   }
 ]

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/FormItemSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/FormItemSpec.kt
@@ -52,6 +52,7 @@ object FormItemSpecSerializer :
             "text" -> SimpleTextSpec.serializer()
             "card_details" -> CardDetailsSectionSpec.serializer()
             "card_billing" -> CardBillingSpec.serializer()
+            "upi" -> UpiSpec.serializer()
             else -> EmptyFormSpec.serializer()
         }
     }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/UpiConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/UpiConfig.kt
@@ -1,0 +1,47 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.annotation.RestrictTo
+import androidx.annotation.StringRes
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.VisualTransformation
+import com.stripe.android.ui.core.R
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class UpiConfig : TextFieldConfig {
+
+    private val upiPattern: Regex by lazy {
+        // From: https://stackoverflow.com/questions/55143204/how-to-validate-a-upi-id-using-regex
+        "[a-zA-Z0-9.\\-_]{2,256}@[a-zA-Z]{2,64}".toRegex()
+    }
+
+    @StringRes
+    override val label: Int = R.string.upi_id_label
+
+    override val capitalization: KeyboardCapitalization = KeyboardCapitalization.None
+    override val debugLabel: String = "upi_id"
+    override val keyboard: KeyboardType = KeyboardType.Email
+    override val visualTransformation: VisualTransformation? = null
+    override val trailingIcon: StateFlow<TextFieldIcon?> = MutableStateFlow(value = null)
+    override val loading: StateFlow<Boolean> = MutableStateFlow(value = false)
+
+    override fun determineState(input: String): TextFieldState {
+        val isValid = upiPattern.matches(input)
+
+        return if (input.isEmpty()) {
+            TextFieldStateConstants.Error.Blank
+        } else if (isValid) {
+            TextFieldStateConstants.Valid.Limitless
+        } else {
+            TextFieldStateConstants.Error.Incomplete(errorMessageResId = R.string.invalid_upi_id)
+        }
+    }
+
+    override fun filter(userTyped: String): String = userTyped.trim()
+
+    override fun convertToRaw(displayName: String): String = displayName
+
+    override fun convertFromRaw(rawValue: String): String = rawValue
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/UpiElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/UpiElement.kt
@@ -1,0 +1,21 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.ui.core.forms.FormFieldEntry
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
+class UpiElement(
+    override val identifier: IdentifierSpec,
+    override val controller: InputController = SimpleTextFieldController(
+        textFieldConfig = UpiConfig()
+    )
+) : SectionSingleFieldElement(identifier = identifier) {
+
+    override fun getFormFieldValueFlow(): Flow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
+        return controller.formFieldValue.map { entry ->
+            listOf(identifier to entry)
+        }
+    }
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/UpiSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/UpiSpec.kt
@@ -1,0 +1,20 @@
+package com.stripe.android.ui.core.elements
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.ui.core.R
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
+@Serializable
+data class UpiSpec(
+    @SerialName("api_path")
+    override val apiPath: IdentifierSpec = IdentifierSpec.Generic("upi")
+) : FormItemSpec() {
+    fun transform(): SectionElement {
+        return createSectionElement(
+            sectionFieldElement = UpiElement(identifier = apiPath),
+            label = R.string.stripe_paymentsheet_buy_using_upi_id
+        )
+    }
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/TransformSpecToElements.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/TransformSpecToElements.kt
@@ -30,6 +30,7 @@ import com.stripe.android.ui.core.elements.SaveForFutureUseSpec
 import com.stripe.android.ui.core.elements.SepaMandateTextSpec
 import com.stripe.android.ui.core.elements.SimpleTextSpec
 import com.stripe.android.ui.core.elements.StaticTextSpec
+import com.stripe.android.ui.core.elements.UpiSpec
 import com.stripe.android.ui.core.forms.resources.ResourceRepository
 
 /**
@@ -86,6 +87,7 @@ class TransformSpecToElements(
                     shippingValues
                 )
                 is SepaMandateTextSpec -> it.transform(merchantName)
+                is UpiSpec -> it.transform()
             }
         }.takeUnless { it.isEmpty() } ?: listOf(EmptyFormElement())
 }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/UpiConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/UpiConfigTest.kt
@@ -1,4 +1,41 @@
 package com.stripe.android.ui.core.elements
 
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ui.core.elements.TextFieldStateConstants.Error.Blank
+import com.stripe.android.ui.core.elements.TextFieldStateConstants.Error.Incomplete
+import com.stripe.android.ui.core.elements.TextFieldStateConstants.Valid.Limitless
+import org.junit.Test
+
 class UpiConfigTest {
+
+    private val config = UpiConfig()
+
+    @Test
+    fun `Treats empty input as blank`() {
+        val state = config.determineState("")
+        assertThat(state).isEqualTo(Blank)
+    }
+
+    @Test
+    fun `Rejects blank input`() {
+        assertThat(config.filter(" ")).isEqualTo("")
+    }
+
+    @Test
+    fun `Treats input without @ sign as incomplete`() {
+        val state = config.determineState("a")
+        assertThat(state).isInstanceOf(Incomplete::class.java)
+    }
+
+    @Test
+    fun `Treats input not matching VPA format as incomplete`() {
+        val state = config.determineState("abc@abc.de")
+        assertThat(state).isInstanceOf(Incomplete::class.java)
+    }
+
+    @Test
+    fun `Treats valid input as valid and limitless`() {
+        val state = config.determineState("payment.success@stripeupi")
+        assertThat(state).isInstanceOf(Limitless::class.java)
+    }
 }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/UpiConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/UpiConfigTest.kt
@@ -1,0 +1,4 @@
+package com.stripe.android.ui.core.elements
+
+class UpiConfigTest {
+}

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/TransformSpecToElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/TransformSpecToElementTest.kt
@@ -28,6 +28,8 @@ import com.stripe.android.ui.core.elements.SimpleTextSpec
 import com.stripe.android.ui.core.elements.StaticTextElement
 import com.stripe.android.ui.core.elements.StaticTextSpec
 import com.stripe.android.ui.core.elements.TranslationId
+import com.stripe.android.ui.core.elements.UpiElement
+import com.stripe.android.ui.core.elements.UpiSpec
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.ui.core.forms.resources.StaticAddressResourceRepository
 import kotlinx.coroutines.flow.first
@@ -218,6 +220,17 @@ internal class TransformSpecToElementTest {
         )
 
         assertThat(formElement).containsExactly(EmptyFormElement())
+    }
+
+    @Test
+    fun `UPI spec is transformed into UPI element wrapped in section`() {
+        val upiSpec = UpiSpec()
+        val formElement = transformSpecToElements.transform(listOf(upiSpec))
+
+        val sectionElement = formElement.first() as SectionElement
+        val upiElement = sectionElement.fields.first() as UpiElement
+
+        assertThat(sectionElement.fields).containsExactly(upiElement)
     }
 
     companion object {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds UPI rendering in the payment sheet.

We accomplish that by adding a new `UpiSpec` that transform to a `UpiElement` wrapped in a `SectionElement`. We use a standard `SimpleTextFieldController`, but provide it with a custom `UpiTextConfig` for input validation.

### Note on the input validation

Input that doesn’t match the UPI ID regex is matched to `Error.Incomplete`, not `Error.Invalid`. That’s because we don’t want the text field error to show up mid-typing.

We _could_ add an invalid state for input that can never be valid if the user continues typing, such as `payments@stripe.` (notice the dot at the end). The user would have to remove the suffix `.com` before it can become valid.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

UPI launch.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screen recording

https://user-images.githubusercontent.com/110940675/192296585-4442b251-30cf-47dd-943c-9fcc76500529.mp4

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

_Nothing to add._
