### PR TITLE
fix: make card brand view center vertically inside CardInputWidget

### DIFF
--- a/payments-core/res/layout/card_input_widget.xml
+++ b/payments-core/res/layout/card_input_widget.xml
@@ -9,7 +9,8 @@
         android:layout_height="@dimen/card_brand_view_height"
         android:layout_marginTop="@dimen/stripe_card_icon_padding"
         android:layout_marginBottom="@dimen/stripe_card_icon_padding"
-        android:layout_marginEnd="@dimen/stripe_card_icon_padding" />
+        android:layout_marginEnd="@dimen/stripe_card_icon_padding"
+        android:layout_gravity="center_vertical" />
 
     <FrameLayout
         android:id="@+id/container"


### PR DESCRIPTION
# Summary
Make the CardBrandView positioned center vertically inside CardInputWidget, to align the same behavior on iOS.

# Motivation
https://github.com/stripe/stripe-react-native/issues/847

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/7088631/192471472-c3f9c9c1-b213-4a8f-9c39-67e76bb06706.png) | ![image](https://user-images.githubusercontent.com/7088631/192471551-e287d06f-00d8-4456-ac43-fc616967f445.png) |

Note that in the screenshots above, I change the CardInputWidget's height to fixed `65dp` instead of `wrap_content` to reproduce the issue.

# Changelog
[Fixed] Fix card brand view not positioned center vertically inside CardInputWidget