### PR TITLE
[BANKCON-5411] Expands payment_method when attaching FCSessions to PI / SI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## X.X.X - 2022-XX-XX
+
+### PaymentSheet
+
+* [FIXED][5624](https://github.com/stripe/stripe-android/pull/5624) `CollectBankAccountResult` included intents will now contain the expanded `payment_method` field.
+
 ## 20.14.0 - 2022-09-26
 This release fixes a payment-method related error in `PaymentSheet` and manages missing permissions
 on Financial Connections.

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1550,7 +1550,8 @@ class StripeApiRepository @JvmOverloads internal constructor(
         clientSecret: String,
         paymentIntentId: String,
         financialConnectionsSessionId: String,
-        requestOptions: ApiRequest.Options
+        requestOptions: ApiRequest.Options,
+        expandFields: List<String>
     ): PaymentIntent? {
         return fetchStripeModel(
             apiRequestFactory.createPost(
@@ -1559,9 +1560,8 @@ class StripeApiRepository @JvmOverloads internal constructor(
                     financialConnectionsSessionId
                 ),
                 requestOptions,
-                mapOf(
-                    "client_secret" to clientSecret
-                )
+                mapOf("client_secret" to clientSecret)
+                    .plus(createExpandParam(expandFields))
             ),
             PaymentIntentJsonParser()
         ) {
@@ -1576,7 +1576,8 @@ class StripeApiRepository @JvmOverloads internal constructor(
         clientSecret: String,
         setupIntentId: String,
         financialConnectionsSessionId: String,
-        requestOptions: ApiRequest.Options
+        requestOptions: ApiRequest.Options,
+        expandFields: List<String>
     ): SetupIntent? {
         return fetchStripeModel(
             apiRequestFactory.createPost(
@@ -1585,9 +1586,8 @@ class StripeApiRepository @JvmOverloads internal constructor(
                     financialConnectionsSessionId
                 ),
                 requestOptions,
-                mapOf(
-                    "client_secret" to clientSecret
-                )
+                mapOf("client_secret" to clientSecret)
+                    .plus(createExpandParam(expandFields))
             ),
             SetupIntentJsonParser()
         ) {

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -502,7 +502,8 @@ abstract class StripeRepository {
         clientSecret: String,
         paymentIntentId: String,
         financialConnectionsSessionId: String,
-        requestOptions: ApiRequest.Options
+        requestOptions: ApiRequest.Options,
+        expandFields: List<String>
     ): PaymentIntent?
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -510,7 +511,8 @@ abstract class StripeRepository {
         clientSecret: String,
         setupIntentId: String,
         financialConnectionsSessionId: String,
-        requestOptions: ApiRequest.Options
+        requestOptions: ApiRequest.Options,
+        expandFields: List<String>
     ): SetupIntent?
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/domain/AttachFinancialConnectionsSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/domain/AttachFinancialConnectionsSession.kt
@@ -28,8 +28,9 @@ internal class AttachFinancialConnectionsSession @Inject constructor(
             paymentIntentId = PaymentIntent.ClientSecret(clientSecret).paymentIntentId,
             requestOptions = ApiRequest.Options(
                 apiKey = publishableKey,
-                stripeAccount = stripeAccountId
-            )
+                stripeAccount = stripeAccountId,
+            ),
+            expandFields = EXPAND_PAYMENT_METHOD
         )
     }.mapCatching { it ?: throw InternalError("Error attaching session to PaymentIntent") }
 
@@ -52,7 +53,12 @@ internal class AttachFinancialConnectionsSession @Inject constructor(
             requestOptions = ApiRequest.Options(
                 apiKey = publishableKey,
                 stripeAccount = stripeAccountId
-            )
+            ),
+            expandFields = EXPAND_PAYMENT_METHOD
         )
     }.mapCatching { it ?: throw InternalError("Error attaching session to SetupIntent") }
+
+    private companion object {
+        private val EXPAND_PAYMENT_METHOD = listOf("payment_method")
+    }
 }

--- a/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
@@ -382,7 +382,8 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         clientSecret: String,
         paymentIntentId: String,
         financialConnectionsSessionId: String,
-        requestOptions: ApiRequest.Options
+        requestOptions: ApiRequest.Options,
+        expandFields: List<String>
     ): PaymentIntent? {
         return null
     }
@@ -391,7 +392,8 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         clientSecret: String,
         setupIntentId: String,
         financialConnectionsSessionId: String,
-        requestOptions: ApiRequest.Options
+        requestOptions: ApiRequest.Options,
+        expandFields: List<String>
     ): SetupIntent? {
         return null
     }

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -2130,10 +2130,11 @@ internal class StripeApiRepositoryTest {
 
             val clientSecret = "pi_client_secret_123"
             val response = create().attachFinancialConnectionsSessionToPaymentIntent(
-                clientSecret,
-                "pi_12345",
-                "las_123456",
-                DEFAULT_OPTIONS
+                clientSecret = clientSecret,
+                paymentIntentId = "pi_12345",
+                financialConnectionsSessionId = "las_123456",
+                requestOptions = DEFAULT_OPTIONS,
+                expandFields = listOf("payment_method")
             )
 
             verify(stripeNetworkClient).executeRequest(
@@ -2181,10 +2182,11 @@ internal class StripeApiRepositoryTest {
 
             val clientSecret = "si_client_secret_123"
             val response = create().attachFinancialConnectionsSessionToSetupIntent(
-                clientSecret,
-                "si_12345",
-                "las_123456",
-                DEFAULT_OPTIONS
+                clientSecret = clientSecret,
+                setupIntentId = "si_12345",
+                financialConnectionsSessionId = "las_123456",
+                requestOptions = DEFAULT_OPTIONS,
+                expandFields = listOf("payment_method")
             )
 
             verify(stripeNetworkClient).executeRequest(

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/domain/AttachFinancialConnectionsSessionTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/domain/AttachFinancialConnectionsSessionTest.kt
@@ -49,7 +49,8 @@ class AttachFinancialConnectionsSessionTest {
                 clientSecret = clientSecret,
                 paymentIntentId = "pi_1234",
                 financialConnectionsSessionId = linkedAccountSessionId,
-                requestOptions = ApiRequest.Options(publishableKey, stripeAccountId)
+                requestOptions = ApiRequest.Options(publishableKey, stripeAccountId),
+                expandFields = listOf("payment_method")
             )
             assertThat((result)).isEqualTo(Result.success(paymentIntent))
         }
@@ -75,7 +76,8 @@ class AttachFinancialConnectionsSessionTest {
                 clientSecret = clientSecret,
                 paymentIntentId = "pi_1234",
                 financialConnectionsSessionId = linkedAccountSessionId,
-                requestOptions = ApiRequest.Options(publishableKey, stripeAccountId)
+                requestOptions = ApiRequest.Options(publishableKey, stripeAccountId),
+                expandFields = listOf("payment_method")
             )
             assertThat(result.exceptionOrNull()!!).isInstanceOf(InternalError::class.java)
         }
@@ -102,7 +104,8 @@ class AttachFinancialConnectionsSessionTest {
                 clientSecret = clientSecret,
                 paymentIntentId = "pi_1234",
                 financialConnectionsSessionId = linkedAccountSessionId,
-                requestOptions = ApiRequest.Options(publishableKey, stripeAccountId)
+                requestOptions = ApiRequest.Options(publishableKey, stripeAccountId),
+                expandFields = listOf("payment_method")
             )
             assertThat(result.exceptionOrNull()!!).isEqualTo(expectedException)
         }
@@ -152,7 +155,8 @@ class AttachFinancialConnectionsSessionTest {
                 clientSecret = clientSecret,
                 setupIntentId = "seti_1234",
                 financialConnectionsSessionId = linkedAccountSessionId,
-                requestOptions = ApiRequest.Options(publishableKey, stripeAccountId)
+                requestOptions = ApiRequest.Options(publishableKey, stripeAccountId),
+                expandFields = listOf("payment_method")
             )
             assertThat((result)).isEqualTo(Result.success(setupIntent))
         }
@@ -178,7 +182,8 @@ class AttachFinancialConnectionsSessionTest {
                 clientSecret = clientSecret,
                 setupIntentId = "seti_1234",
                 financialConnectionsSessionId = linkedAccountSessionId,
-                requestOptions = ApiRequest.Options(publishableKey, stripeAccountId)
+                requestOptions = ApiRequest.Options(publishableKey, stripeAccountId),
+                expandFields = listOf("payment_method")
             )
             assertThat(setupIntent.exceptionOrNull()!!).isInstanceOf(InternalError::class.java)
         }
@@ -205,7 +210,8 @@ class AttachFinancialConnectionsSessionTest {
                 clientSecret = clientSecret,
                 setupIntentId = "seti_1234",
                 financialConnectionsSessionId = linkedAccountSessionId,
-                requestOptions = ApiRequest.Options(publishableKey, stripeAccountId)
+                requestOptions = ApiRequest.Options(publishableKey, stripeAccountId),
+                expandFields = listOf("payment_method")
             )
             assertThat(setupIntent.exceptionOrNull()!!).isEqualTo(expectedException)
         }
@@ -240,6 +246,7 @@ class AttachFinancialConnectionsSessionTest {
                 any(),
                 any(),
                 any(),
+                any(),
                 any()
             )
         ).thenAnswer { paymentIntent() }
@@ -248,6 +255,7 @@ class AttachFinancialConnectionsSessionTest {
     private suspend fun givenAttachSetupIntentReturns(setupIntent: () -> SetupIntent?) {
         whenever(
             stripeRepository.attachFinancialConnectionsSessionToSetupIntent(
+                any(),
                 any(),
                 any(),
                 any(),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -342,7 +342,8 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
                                 ApiRequest.Options(
                                     apiKey = lazyPaymentConfig.get().publishableKey,
                                     stripeAccount = lazyPaymentConfig.get().stripeAccountId
-                                )
+                                ),
+                                expandFields = emptyList()
                             )
                         }
                         is SetupIntentClientSecret -> {
@@ -353,7 +354,8 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
                                 ApiRequest.Options(
                                     apiKey = lazyPaymentConfig.get().publishableKey,
                                     stripeAccount = lazyPaymentConfig.get().stripeAccountId
-                                )
+                                ),
+                                expandFields = emptyList()
                             )
                         }
                     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -320,7 +320,7 @@ class USBankAccountFormViewModelTest {
             )
         )
         whenever(
-            stripeRepository.attachFinancialConnectionsSessionToPaymentIntent(any(), any(), any(), any())
+            stripeRepository.attachFinancialConnectionsSessionToPaymentIntent(any(), any(), any(), any(), any())
         ).thenReturn(paymentIntent)
 
         return CollectBankAccountResult.Completed(
@@ -347,7 +347,7 @@ class USBankAccountFormViewModelTest {
             )
         )
         whenever(
-            stripeRepository.attachFinancialConnectionsSessionToPaymentIntent(any(), any(), any(), any())
+            stripeRepository.attachFinancialConnectionsSessionToPaymentIntent(any(), any(), any(), any(), any())
         ).thenReturn(paymentIntent)
 
         return CollectBankAccountResult.Completed(


### PR DESCRIPTION
# Summary
Integrators don't currently have a way to retrieve the financial connections account id from the output of `CollectBankAccount` flow.

# Motivation
Feature parity with [iOS](https://github.com/stripe/stripe-ios/blob/3fdd5cb4ac44f651d7cc8ee31e4406806f37effa/Stripe/STPAPIClient%2BLinkAccountSession.swift#L83) and StripeJS

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified

# Changelog
    - [Changed] `CollectBankAccountResult` included intents will now contain the expanded `payment_method` field. 