### PR TITLE
Make `hiddenIdentifiers` a set, make FormUI stateless

### DIFF
--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -392,7 +392,7 @@ internal fun CardDetailsRecollectionForm(
             SectionElementUI(
                 enabled = true,
                 element = SectionElement.wrap(rowElement),
-                hiddenIdentifiers = emptyList(),
+                hiddenIdentifiers = emptySet(),
                 lastTextFieldIdentifier = rowElement.fields.last().identifier
             )
         }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormController.kt
@@ -64,7 +64,7 @@ class FormController @Inject constructor(
      */
     val hiddenIdentifiers =
         cardBillingElement.map {
-            it?.hiddenIdentifiers ?: flowOf(emptyList())
+            it?.hiddenIdentifiers ?: flowOf(emptySet())
         }.flattenConcat()
 
     /**

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormUI.kt
@@ -36,18 +36,38 @@ import kotlinx.coroutines.flow.Flow
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun FormUI(
-    hiddenIdentifiersFlow: Flow<List<IdentifierSpec>>,
+    hiddenIdentifiersFlow: Flow<Set<IdentifierSpec>>,
     enabledFlow: Flow<Boolean>,
     elementsFlow: Flow<List<FormElement>?>,
     lastTextFieldIdentifierFlow: Flow<IdentifierSpec?>,
     loadingComposable: @Composable ColumnScope.() -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val hiddenIdentifiers by hiddenIdentifiersFlow.collectAsState(emptyList())
+    val hiddenIdentifiers by hiddenIdentifiersFlow.collectAsState(emptySet())
     val enabled by enabledFlow.collectAsState(true)
     val elements by elementsFlow.collectAsState(null)
     val lastTextFieldIdentifier by lastTextFieldIdentifierFlow.collectAsState(null)
 
+    FormUI(
+        hiddenIdentifiers = hiddenIdentifiers,
+        enabled = enabled,
+        elements = elements,
+        lastTextFieldIdentifier = lastTextFieldIdentifier,
+        loadingComposable = loadingComposable,
+        modifier = modifier
+    )
+}
+
+@Composable
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun FormUI(
+    hiddenIdentifiers: Set<IdentifierSpec>,
+    enabled: Boolean,
+    elements: List<FormElement>?,
+    lastTextFieldIdentifier: IdentifierSpec?,
+    loadingComposable: @Composable ColumnScope.() -> Unit,
+    modifier: Modifier = Modifier
+) {
     Column(
         modifier = modifier.fillMaxWidth(1f)
     ) {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressElementUI.kt
@@ -16,16 +16,14 @@ import com.stripe.android.ui.core.paymentsShapes
 internal fun AddressElementUI(
     enabled: Boolean,
     controller: AddressController,
-    hiddenIdentifiers: List<IdentifierSpec>?,
+    hiddenIdentifiers: Set<IdentifierSpec>,
     lastTextFieldIdentifier: IdentifierSpec?
 ) {
     val fields by controller.fieldsFlowable.collectAsState(null)
 
     // The last rendered field is not always the last field in the list.
     // So we need to pre filter so we know when to stop drawing dividers.
-    fields?.filter {
-        (hiddenIdentifiers?.contains(it.identifier) == false)
-    }?.let { fieldList ->
+    fields?.filterNot { hiddenIdentifiers.contains(it.identifier) }?.let { fieldList ->
         Column {
             fieldList.forEachIndexed { index, field ->
                 SectionFieldElementUI(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingAddressElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingAddressElement.kt
@@ -35,17 +35,19 @@ class CardBillingAddressElement(
 ) {
     // Save for future use puts this in the controller rather than element
     // card and achv2 uses save for future use
-    val hiddenIdentifiers: Flow<List<IdentifierSpec>> =
+    val hiddenIdentifiers: Flow<Set<IdentifierSpec>> =
         countryDropdownFieldController.rawFieldValue.map { countryCode ->
             when (countryCode) {
                 "US", "GB", "CA" -> {
                     FieldType.values()
                         .filterNot { it == FieldType.PostalCode }
                         .map { it.identifierSpec }
+                        .toSet()
                 }
                 else -> {
                     FieldType.values()
                         .map { it.identifierSpec }
+                        .toSet()
                 }
             }
         }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElementUI.kt
@@ -14,7 +14,7 @@ import com.stripe.android.ui.core.paymentsShapes
 internal fun CardDetailsElementUI(
     enabled: Boolean,
     controller: CardDetailsController,
-    hiddenIdentifiers: List<IdentifierSpec>?,
+    hiddenIdentifiers: Set<IdentifierSpec>,
     lastTextFieldIdentifier: IdentifierSpec?
 ) {
     controller.fields.forEachIndexed { index, field ->

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUI.kt
@@ -20,7 +20,7 @@ import com.stripe.android.ui.core.cardscan.CardScanActivity
 fun CardDetailsSectionElementUI(
     enabled: Boolean,
     controller: CardDetailsSectionController,
-    hiddenIdentifiers: List<IdentifierSpec>?,
+    hiddenIdentifiers: Set<IdentifierSpec>,
     lastTextFieldIdentifier: IdentifierSpec?
 ) {
     Row(
@@ -57,7 +57,7 @@ fun CardDetailsSectionElementUI(
                 listOf(controller.cardDetailsElement.sectionFieldErrorController())
             )
         ),
-        hiddenIdentifiers = hiddenIdentifiers ?: emptyList(),
+        hiddenIdentifiers = hiddenIdentifiers,
         lastTextFieldIdentifier = lastTextFieldIdentifier
     )
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/RowElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/RowElementUI.kt
@@ -21,7 +21,7 @@ import com.stripe.android.ui.core.paymentsShapes
 internal fun RowElementUI(
     enabled: Boolean,
     controller: RowController,
-    hiddenIdentifiers: List<IdentifierSpec>,
+    hiddenIdentifiers: Set<IdentifierSpec>,
     lastTextFieldIdentifier: IdentifierSpec?
 ) {
     val visibleFields = controller.fields.filter { !hiddenIdentifiers.contains(it.identifier) }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionElementUI.kt
@@ -18,7 +18,7 @@ import com.stripe.android.ui.core.paymentsShapes
 fun SectionElementUI(
     enabled: Boolean,
     element: SectionElement,
-    hiddenIdentifiers: List<IdentifierSpec>,
+    hiddenIdentifiers: Set<IdentifierSpec>,
     lastTextFieldIdentifier: IdentifierSpec?
 ) {
     if (!hiddenIdentifiers.contains(element.identifier)) {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionFieldElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SectionFieldElementUI.kt
@@ -10,12 +10,12 @@ internal fun SectionFieldElementUI(
     enabled: Boolean,
     field: SectionFieldElement,
     modifier: Modifier = Modifier,
-    hiddenIdentifiers: List<IdentifierSpec>? = null,
+    hiddenIdentifiers: Set<IdentifierSpec> = emptySet(),
     lastTextFieldIdentifier: IdentifierSpec?,
     nextFocusDirection: FocusDirection = FocusDirection.Down,
     previousFocusDirection: FocusDirection = FocusDirection.Up
 ) {
-    if (hiddenIdentifiers?.contains(field.identifier) == false) {
+    if (!hiddenIdentifiers.contains(field.identifier)) {
         when (val controller = field.sectionFieldErrorController()) {
             is SameAsShippingController -> {
                 SameAsShippingElementUI(

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardBillingAddressElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardBillingAddressElementTest.kt
@@ -51,7 +51,7 @@ internal class CardBillingAddressElementTest {
 
     @Test
     fun `Verify that when US is selected postal is not hidden`() {
-        val hiddenIdFlowValues = mutableListOf<List<IdentifierSpec>>()
+        val hiddenIdFlowValues = mutableListOf<Set<IdentifierSpec>>()
         cardBillingElement.hiddenIdentifiers.asLiveData()
             .observeForever {
                 hiddenIdFlowValues.add(it)
@@ -63,7 +63,7 @@ internal class CardBillingAddressElementTest {
 
     @Test
     fun `Verify that when GB is selected postal is not hidden`() {
-        val hiddenIdFlowValues = mutableListOf<List<IdentifierSpec>>()
+        val hiddenIdFlowValues = mutableListOf<Set<IdentifierSpec>>()
         cardBillingElement.hiddenIdentifiers.asLiveData()
             .observeForever {
                 hiddenIdFlowValues.add(it)
@@ -75,7 +75,7 @@ internal class CardBillingAddressElementTest {
 
     @Test
     fun `Verify that when CA is selected postal is not hidden`() {
-        val hiddenIdFlowValues = mutableListOf<List<IdentifierSpec>>()
+        val hiddenIdFlowValues = mutableListOf<Set<IdentifierSpec>>()
         cardBillingElement.hiddenIdentifiers.asLiveData()
             .observeForever {
                 hiddenIdFlowValues.add(it)
@@ -87,7 +87,7 @@ internal class CardBillingAddressElementTest {
 
     @Test
     fun `Verify that when DE is selected postal IS hidden`() {
-        val hiddenIdFlowValues = mutableListOf<List<IdentifierSpec>>()
+        val hiddenIdFlowValues = mutableListOf<Set<IdentifierSpec>>()
         cardBillingElement.hiddenIdentifiers.asLiveData()
             .observeForever {
                 hiddenIdFlowValues.add(it)
@@ -97,7 +97,7 @@ internal class CardBillingAddressElementTest {
         verifyPostalHidden(hiddenIdFlowValues[1])
     }
 
-    fun verifyPostalShown(hiddenIdentifiers: List<IdentifierSpec>) {
+    fun verifyPostalShown(hiddenIdentifiers: Set<IdentifierSpec>) {
         Truth.assertThat(hiddenIdentifiers).doesNotContain(IdentifierSpec.PostalCode)
         Truth.assertThat(hiddenIdentifiers).doesNotContain(IdentifierSpec.Country)
         Truth.assertThat(hiddenIdentifiers).contains(IdentifierSpec.Line1)
@@ -106,7 +106,7 @@ internal class CardBillingAddressElementTest {
         Truth.assertThat(hiddenIdentifiers).contains(IdentifierSpec.City)
     }
 
-    fun verifyPostalHidden(hiddenIdentifiers: List<IdentifierSpec>) {
+    fun verifyPostalHidden(hiddenIdentifiers: Set<IdentifierSpec>) {
         Truth.assertThat(hiddenIdentifiers).doesNotContain(IdentifierSpec.Country)
         Truth.assertThat(hiddenIdentifiers).contains(IdentifierSpec.PostalCode)
         Truth.assertThat(hiddenIdentifiers).contains(IdentifierSpec.Line1)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/CompleteFormFieldValueFilter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/CompleteFormFieldValueFilter.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.combine
  */
 internal class CompleteFormFieldValueFilter(
     private val currentFieldValueMap: Flow<Map<IdentifierSpec, FormFieldEntry>>,
-    private val hiddenIdentifiers: Flow<List<IdentifierSpec>>,
+    private val hiddenIdentifiers: Flow<Set<IdentifierSpec>>,
     val showingMandate: Flow<Boolean>,
     private val userRequestedReuse: Flow<PaymentSelection.CustomerRequestedSave>
 ) {
@@ -32,7 +32,7 @@ internal class CompleteFormFieldValueFilter(
 
     private fun filterFlow(
         idFieldSnapshotMap: Map<IdentifierSpec, FormFieldEntry>,
-        hiddenIdentifiers: List<IdentifierSpec>,
+        hiddenIdentifiers: Set<IdentifierSpec>,
         showingMandate: Boolean,
         userRequestedReuse: PaymentSelection.CustomerRequestedSave
     ): FormFieldValues? {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormUI.kt
@@ -37,7 +37,7 @@ internal fun Form(
 
 @Composable
 internal fun FormInternal(
-    hiddenIdentifiersFlow: Flow<List<IdentifierSpec>>,
+    hiddenIdentifiersFlow: Flow<Set<IdentifierSpec>>,
     enabledFlow: Flow<Boolean>,
     elementsFlow: Flow<List<FormElement>?>,
     lastTextFieldIdentifierFlow: Flow<IdentifierSpec?>,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
@@ -162,17 +162,17 @@ internal class FormViewModel @Inject internal constructor(
                 ?.filterIsInstance<CardBillingAddressElement>()
                 ?.firstOrNull()
         }
-    private var externalHiddenIdentifiers = MutableStateFlow(emptyList<IdentifierSpec>())
+    private var externalHiddenIdentifiers = MutableStateFlow(emptySet<IdentifierSpec>())
 
     @VisibleForTesting
-    internal fun addHiddenIdentifiers(identifierSpecs: List<IdentifierSpec>) {
+    internal fun addHiddenIdentifiers(identifierSpecs: Set<IdentifierSpec>) {
         externalHiddenIdentifiers.value = identifierSpecs
     }
 
     internal val hiddenIdentifiers = combine(
         saveForFutureUseVisible,
         cardBillingElement.map {
-            it?.hiddenIdentifiers ?: flowOf(emptyList())
+            it?.hiddenIdentifiers ?: flowOf(emptySet())
         }.flattenConcat(),
         externalHiddenIdentifiers
     ) { showFutureUse, cardBillingIdentifiers, saveFutureUseIdentifiers ->

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/CompleteFormFieldValueFilterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/CompleteFormFieldValueFilterTest.kt
@@ -1,19 +1,19 @@
 package com.stripe.android.paymentsheet.forms
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.ui.core.elements.SimpleTextFieldController
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.ui.core.elements.EmailConfig
 import com.stripe.android.ui.core.elements.EmailElement
 import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.ui.core.elements.SectionController
 import com.stripe.android.ui.core.elements.SectionElement
+import com.stripe.android.ui.core.elements.SimpleTextFieldController
 import com.stripe.android.ui.core.forms.FormFieldEntry
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
 @ExperimentalCoroutinesApi
@@ -22,7 +22,7 @@ class CompleteFormFieldValueFilterTest {
     private val emailController = SimpleTextFieldController(EmailConfig())
     private var emailSection: SectionElement
 
-    private val hiddenIdentifersFlow = MutableStateFlow<List<IdentifierSpec>>(emptyList())
+    private val hiddenIdentifersFlow = MutableStateFlow<Set<IdentifierSpec>>(emptySet())
 
     private val fieldFlow = MutableStateFlow(
         mapOf(
@@ -80,7 +80,7 @@ class CompleteFormFieldValueFilterTest {
     @Test
     fun `If an hidden field is incomplete field pairs have the non-hidden values`() {
         runTest {
-            hiddenIdentifersFlow.value = listOf(IdentifierSpec.Email)
+            hiddenIdentifersFlow.value = setOf(IdentifierSpec.Email)
 
             val formFieldValues = transformElementToFormFieldValueFlow.filterFlow()
 
@@ -102,7 +102,7 @@ class CompleteFormFieldValueFilterTest {
                     IdentifierSpec.Email to FormFieldEntry("email@email.com", true)
                 )
 
-            hiddenIdentifersFlow.value = listOf(emailSection.fields[0].identifier)
+            hiddenIdentifersFlow.value = setOf(emailSection.fields[0].identifier)
 
             val formFieldValue = transformElementToFormFieldValueFlow.filterFlow().first()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -205,7 +205,7 @@ internal class FormViewModelTest {
             transformSpecToElement = TransformSpecToElement(addressResourceRepository, args, context)
         )
 
-        val values = mutableListOf<List<IdentifierSpec>>()
+        val values = mutableListOf<Set<IdentifierSpec>>()
         formViewModel.hiddenIdentifiers.asLiveData()
             .observeForever {
                 values.add(it)
@@ -216,7 +216,7 @@ internal class FormViewModelTest {
 
         ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
-        assertThat(values[1][0]).isEqualTo(
+        assertThat(values[1]).containsExactly(
             IdentifierSpec.SaveForFutureUse
         )
     }
@@ -266,7 +266,7 @@ internal class FormViewModelTest {
             transformSpecToElement = TransformSpecToElement(addressResourceRepository, args, context)
         )
 
-        formViewModel.addHiddenIdentifiers(listOf(IdentifierSpec.Email))
+        formViewModel.addHiddenIdentifiers(setOf(IdentifierSpec.Email))
 
         // Verify formFieldValues does not contain email
         assertThat(formViewModel.lastTextFieldIdentifier.first()?.v1).isEqualTo(
@@ -305,7 +305,7 @@ internal class FormViewModelTest {
             formViewModel.completeFormValues.first()?.fieldValuePairs
         ).containsKey(IdentifierSpec.Email)
 
-        formViewModel.addHiddenIdentifiers(listOf(IdentifierSpec.Email))
+        formViewModel.addHiddenIdentifiers(setOf(IdentifierSpec.Email))
 
         // Verify formFieldValues does not contain email
         assertThat(formViewModel.completeFormValues.first()?.fieldValuePairs)
@@ -342,7 +342,7 @@ internal class FormViewModelTest {
         // Verify formFieldValues is null because the email is required and invalid
         assertThat(formViewModel.completeFormValues.first()).isNull()
 
-        formViewModel.addHiddenIdentifiers(listOf(IdentifierSpec.Email))
+        formViewModel.addHiddenIdentifiers(setOf(IdentifierSpec.Email))
 
         // Verify formFieldValues is not null even though the card number is invalid
         // (because it is not required)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Make `hiddenIdentifiers` a set, make FormUI stateless.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Payment Sheet in Compose

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
