### PR TITLE
Add Data Theorem workflow

### DIFF
--- a/.github/workflows/datatheorem_sast.yaml
+++ b/.github/workflows/datatheorem_sast.yaml
@@ -1,0 +1,32 @@
+name: Data Theorem Build 
+on:
+  schedule:
+    # every day at 8am
+    - cron: '0 8 * * *'
+jobs:
+  apk:
+    name: Generate and upload APK
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Build debug APK
+        run: ./gradlew :paymentsheet-example:assembleDebug
+      - name: Upload to Data Theorem
+        uses: datatheorem/datatheorem-mobile-secure-action@v2.0.1
+        with:
+          UPLOAD_BINARY_PATH: "./paymentsheet-example/build/outputs/apk/debug/paymentsheet-example-debug.apk"
+          DT_UPLOAD_API_KEY: ${{ secrets.DT_UPLOAD_API_KEY }}


### PR DESCRIPTION
# Summary
Add Data Theorem workflow for paymentsheet-example, which is used to exercise the Stripe SDK.

# Motivation
APPSEC-4978

# Testing
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

There are a few environmental problems testing things locally with act, so we'll need to evaluate here as well.

# Screenshots
N/A

# Changelog
N/A
