### PR TITLE
Make `LinkPaymentLauncher` stateless

### DIFF
--- a/link/api/link.api
+++ b/link/api/link.api
@@ -18,8 +18,8 @@ public final class com/stripe/android/link/LinkActivityContract$Args : com/strip
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/link/LinkActivityContract$Args$Companion;
-	public final fun copy (Lcom/stripe/android/model/StripeIntent;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethodCreateParams;Lcom/stripe/android/link/LinkActivityContract$Args$InjectionParams;)Lcom/stripe/android/link/LinkActivityContract$Args;
-	public static synthetic fun copy$default (Lcom/stripe/android/link/LinkActivityContract$Args;Lcom/stripe/android/model/StripeIntent;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethodCreateParams;Lcom/stripe/android/link/LinkActivityContract$Args$InjectionParams;ILjava/lang/Object;)Lcom/stripe/android/link/LinkActivityContract$Args;
+	public final fun copy (Lcom/stripe/android/link/LinkPaymentLauncher$Configuration;Lcom/stripe/android/model/PaymentMethodCreateParams;Lcom/stripe/android/link/LinkActivityContract$Args$InjectionParams;)Lcom/stripe/android/link/LinkActivityContract$Args;
+	public static synthetic fun copy$default (Lcom/stripe/android/link/LinkActivityContract$Args;Lcom/stripe/android/link/LinkPaymentLauncher$Configuration;Lcom/stripe/android/model/PaymentMethodCreateParams;Lcom/stripe/android/link/LinkActivityContract$Args$InjectionParams;ILjava/lang/Object;)Lcom/stripe/android/link/LinkActivityContract$Args;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -257,36 +257,52 @@ public final class com/stripe/android/link/injection/DaggerLinkViewModelFactoryC
 	public static fun builder ()Lcom/stripe/android/link/injection/LinkViewModelFactoryComponent$Builder;
 }
 
-public final class com/stripe/android/link/injection/LinkActivityContractArgsModule_Companion_ProvideCustomerEmailFactory : dagger/internal/Factory {
+public final class com/stripe/android/link/injection/LinkActivityContractArgsModule_Companion_ProvideConfigurationFactory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/link/injection/LinkActivityContractArgsModule_Companion_ProvideCustomerEmailFactory;
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/link/injection/LinkActivityContractArgsModule_Companion_ProvideConfigurationFactory;
+	public fun get ()Lcom/stripe/android/link/LinkPaymentLauncher$Configuration;
 	public synthetic fun get ()Ljava/lang/Object;
-	public fun get ()Ljava/lang/String;
-	public static fun provideCustomerEmail (Lcom/stripe/android/link/LinkActivityContract$Args;)Ljava/lang/String;
+	public static fun provideConfiguration (Lcom/stripe/android/link/LinkActivityContract$Args;)Lcom/stripe/android/link/LinkPaymentLauncher$Configuration;
 }
 
-public final class com/stripe/android/link/injection/LinkActivityContractArgsModule_Companion_ProvideCustomerPhoneFactory : dagger/internal/Factory {
+public final class com/stripe/android/link/injection/LinkCommonModule_Companion_CustomerEmailFactory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/link/injection/LinkActivityContractArgsModule_Companion_ProvideCustomerPhoneFactory;
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/link/injection/LinkCommonModule_Companion_CustomerEmailFactory;
+	public static fun customerEmail (Lcom/stripe/android/link/LinkPaymentLauncher$Configuration;)Ljava/lang/String;
 	public synthetic fun get ()Ljava/lang/Object;
 	public fun get ()Ljava/lang/String;
-	public static fun provideCustomerPhone (Lcom/stripe/android/link/LinkActivityContract$Args;)Ljava/lang/String;
 }
 
-public final class com/stripe/android/link/injection/LinkActivityContractArgsModule_Companion_ProvideMerchantNameFactory : dagger/internal/Factory {
+public final class com/stripe/android/link/injection/LinkCommonModule_Companion_CustomerNameFactory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/link/injection/LinkActivityContractArgsModule_Companion_ProvideMerchantNameFactory;
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/link/injection/LinkCommonModule_Companion_CustomerNameFactory;
+	public static fun customerName (Lcom/stripe/android/link/LinkPaymentLauncher$Configuration;)Ljava/lang/String;
 	public synthetic fun get ()Ljava/lang/Object;
 	public fun get ()Ljava/lang/String;
-	public static fun provideMerchantName (Lcom/stripe/android/link/LinkActivityContract$Args;)Ljava/lang/String;
 }
 
-public final class com/stripe/android/link/injection/LinkActivityContractArgsModule_Companion_ProvideStripeIntentFactory : dagger/internal/Factory {
+public final class com/stripe/android/link/injection/LinkCommonModule_Companion_CustomerPhoneFactory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/link/injection/LinkActivityContractArgsModule_Companion_ProvideStripeIntentFactory;
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/link/injection/LinkCommonModule_Companion_CustomerPhoneFactory;
+	public static fun customerPhone (Lcom/stripe/android/link/LinkPaymentLauncher$Configuration;)Ljava/lang/String;
+	public synthetic fun get ()Ljava/lang/Object;
+	public fun get ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/link/injection/LinkCommonModule_Companion_MerchantNameFactory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/link/injection/LinkCommonModule_Companion_MerchantNameFactory;
+	public synthetic fun get ()Ljava/lang/Object;
+	public fun get ()Ljava/lang/String;
+	public static fun merchantName (Lcom/stripe/android/link/LinkPaymentLauncher$Configuration;)Ljava/lang/String;
+}
+
+public final class com/stripe/android/link/injection/LinkCommonModule_Companion_StripeIntentFactory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;)Lcom/stripe/android/link/injection/LinkCommonModule_Companion_StripeIntentFactory;
 	public fun get ()Lcom/stripe/android/model/StripeIntent;
 	public synthetic fun get ()Ljava/lang/Object;
-	public static fun provideStripeIntent (Lcom/stripe/android/link/LinkActivityContract$Args;)Lcom/stripe/android/model/StripeIntent;
+	public static fun stripeIntent (Lcom/stripe/android/link/LinkPaymentLauncher$Configuration;)Lcom/stripe/android/model/StripeIntent;
 }
 
 public final class com/stripe/android/link/injection/NamedConstantsKt {

--- a/link/src/main/java/com/stripe/android/link/LinkActivityContract.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivityContract.kt
@@ -9,9 +9,8 @@ import androidx.core.os.bundleOf
 import com.stripe.android.core.injection.InjectorKey
 import com.stripe.android.link.LinkActivityResult.Canceled.Reason.BackPressed
 import com.stripe.android.model.PaymentMethodCreateParams
-import com.stripe.android.model.StripeIntent
-import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.view.ActivityStarter
+import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -30,26 +29,34 @@ class LinkActivityContract :
     /**
      * Arguments for launching [LinkActivity] to confirm a payment with Link.
      *
-     * @param stripeIntent The Stripe Intent that is being processed
-     * @param merchantName The customer-facing business name.
-     * @param customerEmail Email of the customer, used to pre-fill the form.
-     * @param customerPhone Phone number of the customer, used to pre-fill the form.
-     * @param shippingValues The initial shipping values for [FormController]
+     * @param configuration Configuration values
      * @param prefilledCardParams The payment method information prefilled by the user.
      * @param injectionParams Parameters needed to perform dependency injection.
      *                        If null, a new dependency graph will be created.
      */
     @Parcelize
     data class Args internal constructor(
-        internal val stripeIntent: StripeIntent,
-        internal val merchantName: String,
-        internal val customerEmail: String? = null,
-        internal val customerPhone: String? = null,
-        internal val customerName: String? = null,
-        internal val shippingValues: Map<IdentifierSpec, String?>? = null,
+        internal val configuration: LinkPaymentLauncher.Configuration,
         internal val prefilledCardParams: PaymentMethodCreateParams? = null,
         internal val injectionParams: InjectionParams? = null
     ) : ActivityStarter.Args {
+        @IgnoredOnParcel
+        internal val stripeIntent = configuration.stripeIntent
+
+        @IgnoredOnParcel
+        internal val merchantName = configuration.merchantName
+
+        @IgnoredOnParcel
+        internal val customerEmail = configuration.customerEmail
+
+        @IgnoredOnParcel
+        internal val customerPhone = configuration.customerPhone
+
+        @IgnoredOnParcel
+        internal val customerName = configuration.customerName
+
+        @IgnoredOnParcel
+        internal val shippingValues = configuration.shippingValues
 
         companion object {
             internal fun fromIntent(intent: Intent): Args? {

--- a/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
@@ -87,18 +87,20 @@ class LinkPaymentLauncher @Inject internal constructor(
         getLinkPaymentLauncherComponent(configuration).linkAccountManager.accountStatus
 
     /**
-     * Launch the Link UI to process the Stripe Intent sent in [setup].
+     * Launch the Link UI to process a payment.
      *
+     * @param configuration The payment and customer settings
+     * @param activityResultLauncher Launcher that will receive the payment result.
      * @param prefilledNewCardParams The card information prefilled by the user. If non null, Link
      *  will launch into adding a new card, with the card information pre-filled.
      */
     fun present(
+        configuration: Configuration,
         activityResultLauncher: ActivityResultLauncher<LinkActivityContract.Args>,
         prefilledNewCardParams: PaymentMethodCreateParams? = null
     ) {
-        val component = requireNotNull(component) { "Must call setup before presenting" }
         val args = LinkActivityContract.Args(
-            component.configuration,
+            configuration,
             prefilledNewCardParams,
             LinkActivityContract.Args.InjectionParams(
                 injectorKey,
@@ -108,7 +110,7 @@ class LinkPaymentLauncher @Inject internal constructor(
                 stripeAccountIdProvider()
             )
         )
-        buildLinkComponent(component, args)
+        buildLinkComponent(getLinkPaymentLauncherComponent(configuration), args)
         activityResultLauncher.launch(args)
     }
 

--- a/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
@@ -13,14 +13,10 @@ import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.injection.UIContext
 import com.stripe.android.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
-import com.stripe.android.link.account.LinkAccountManager
-import com.stripe.android.link.analytics.LinkEventsReporter
 import com.stripe.android.link.injection.DaggerLinkPaymentLauncherComponent
 import com.stripe.android.link.injection.LinkComponent
 import com.stripe.android.link.injection.LinkPaymentLauncherComponent
-import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.cardedit.CardEditViewModel
-import com.stripe.android.link.ui.inline.InlineSignupViewModel
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.link.ui.paymentmethod.PaymentMethodViewModel
 import com.stripe.android.link.ui.paymentmethod.SupportedPaymentMethod
@@ -37,9 +33,6 @@ import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.ui.core.forms.resources.ResourceRepository
 import com.stripe.android.ui.core.injection.NonFallbackInjectable
 import com.stripe.android.ui.core.injection.NonFallbackInjector
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 import javax.inject.Named
@@ -62,7 +55,6 @@ class LinkPaymentLauncher @Inject internal constructor(
     stripeRepository: StripeRepository,
     addressResourceRepository: ResourceRepository<AddressRepository>
 ) : NonFallbackInjectable {
-    private var configuration: Configuration? = null
     private val launcherComponentBuilder = DaggerLinkPaymentLauncherComponent.builder()
         .context(context)
         .ioContext(ioContext)
@@ -81,50 +73,18 @@ class LinkPaymentLauncher @Inject internal constructor(
         requireNotNull(LinkPaymentLauncher::class.simpleName)
     )
 
-    private lateinit var linkComponentBuilder: LinkComponent.Builder
+    /**
+     * The dependency injector Component for all injectable classes in Link while in an embedded
+     * environment.
+     */
+    internal var component: LinkPaymentLauncherComponent? = null
 
     /**
-     * The dependency injector for all injectable classes in Link.
-     * This is safe to hold here because [LinkPaymentLauncher] lives only for as long as
-     * PaymentSheet's ViewModel is alive.
+     * Fetch the customer's account status, initializing the dependencies if they haven't been
+     * initialized yet.
      */
-    internal var injector: NonFallbackInjector? = null
-
-    /**
-     * The [LinkAccountManager], exposed here so that classes that are not injected (like LinkButton
-     * or LinkInlineSignup) can access it and share the account status with all other components.
-     */
-    internal lateinit var linkAccountManager: LinkAccountManager
-
-    internal lateinit var linkEventsReporter: LinkEventsReporter
-
-    /**
-     * Publicly visible account status, used by PaymentSheet to display the correct UI.
-     */
-    lateinit var accountStatus: StateFlow<AccountStatus>
-
-    /**
-     * Sets up Link to process the given [Configuration.stripeIntent].
-     *
-     * This will fetch the user's account if they're already logged in, or lookup the email passed
-     * in during instantiation.
-     *
-     * @param configuration the [LinkPaymentLauncher.Configuration], containing the parameters
-     *                      required to process a payment.
-     * @param coroutineScope the coroutine scope used to collect the account status flow.
-     */
-    suspend fun setup(
-        configuration: Configuration,
-        coroutineScope: CoroutineScope
-    ): AccountStatus {
-        val component = buildLinkPaymentLauncherComponent(configuration)
-        accountStatus = component.linkAccountManager.accountStatus.stateIn(coroutineScope)
-        linkAccountManager = component.linkAccountManager
-        linkEventsReporter = component.linkEventsReporter
-        linkComponentBuilder = component.linkComponentBuilder
-        this.configuration = configuration
-        return accountStatus.value
-    }
+    fun getAccountStatusFlow(configuration: Configuration) =
+        getLinkPaymentLauncherComponent(configuration).linkAccountManager.accountStatus
 
     /**
      * Launch the Link UI to process the Stripe Intent sent in [setup].
@@ -136,15 +96,9 @@ class LinkPaymentLauncher @Inject internal constructor(
         activityResultLauncher: ActivityResultLauncher<LinkActivityContract.Args>,
         prefilledNewCardParams: PaymentMethodCreateParams? = null
     ) {
-        val configuration = requireNotNull(configuration) { "Must call setup before presenting" }
-
+        val component = requireNotNull(component) { "Must call setup before presenting" }
         val args = LinkActivityContract.Args(
-            configuration.stripeIntent,
-            configuration.merchantName,
-            configuration.customerEmail,
-            configuration.customerPhone,
-            configuration.customerName,
-            configuration.shippingValues,
+            component.configuration,
             prefilledNewCardParams,
             LinkActivityContract.Args.InjectionParams(
                 injectorKey,
@@ -154,7 +108,7 @@ class LinkPaymentLauncher @Inject internal constructor(
                 stripeAccountIdProvider()
             )
         )
-        buildLinkComponent(args)
+        buildLinkComponent(component, args)
         activityResultLauncher.launch(args)
     }
 
@@ -162,8 +116,13 @@ class LinkPaymentLauncher @Inject internal constructor(
      * Trigger Link sign in with the input collected from the user inline in PaymentSheet, whether
      * it's a new or existing account.
      */
-    suspend fun signInWithUserInput(userInput: UserInput) =
-        linkAccountManager.signInWithUserInput(userInput).map { true }
+    suspend fun signInWithUserInput(
+        configuration: Configuration,
+        userInput: UserInput
+    ) = getLinkPaymentLauncherComponent(configuration)
+        .linkAccountManager
+        .signInWithUserInput(userInput)
+        .map { true }
 
     /**
      * Attach a new Card to the currently signed in Link account.
@@ -172,48 +131,34 @@ class LinkPaymentLauncher @Inject internal constructor(
      *          PaymentDetails.
      */
     suspend fun attachNewCardToAccount(
+        configuration: Configuration,
         paymentMethodCreateParams: PaymentMethodCreateParams
     ): Result<LinkPaymentDetails.New> =
-        linkAccountManager.createCardPaymentDetails(
-            paymentMethodCreateParams
-        )
+        getLinkPaymentLauncherComponent(configuration)
+            .linkAccountManager
+            .createCardPaymentDetails(paymentMethodCreateParams)
 
     /**
-     * Set up [LinkPaymentLauncherComponent], responsible for injecting into classes used by inline
-     * sign up.
+     * Create or get the existing [LinkPaymentLauncherComponent], responsible for injecting all
+     * injectable classes in Link while in an embedded environment.
      */
-    private fun buildLinkPaymentLauncherComponent(
-        configuration: Configuration
-    ): LinkPaymentLauncherComponent {
-        val component = launcherComponentBuilder
-            .merchantName(configuration.merchantName)
-            .customerEmail(configuration.customerEmail)
-            .customerPhone(configuration.customerPhone)
-            .customerName(configuration.customerName)
-            .stripeIntent(configuration.stripeIntent)
-            .build()
-
-        val injector = object : NonFallbackInjector {
-            override fun inject(injectable: Injectable<*>) {
-                when (injectable) {
-                    is VerificationViewModel.Factory -> component.inject(injectable)
-                    is InlineSignupViewModel.Factory -> component.inject(injectable)
-                    else -> {
-                        throw IllegalArgumentException("invalid Injectable $injectable requested in $this")
-                    }
+    private fun getLinkPaymentLauncherComponent(configuration: Configuration) =
+        component?.takeIf { it.configuration == configuration }
+            ?: launcherComponentBuilder
+                .configuration(configuration)
+                .build()
+                .also {
+                    component = it
                 }
-            }
-        }
-
-        this.injector = injector
-        return component
-    }
 
     /**
      * Set up [LinkComponent], responsible for injecting all dependencies into the Link app.
      */
-    private fun buildLinkComponent(args: LinkActivityContract.Args) {
-        val linkComponent = linkComponentBuilder.starterArgs(args).build()
+    private fun buildLinkComponent(
+        component: LinkPaymentLauncherComponent,
+        args: LinkActivityContract.Args
+    ) {
+        val linkComponent = component.linkComponentBuilder.starterArgs(args).build()
         val injector = object : NonFallbackInjector {
             override fun inject(injectable: Injectable<*>) {
                 when (injectable) {
@@ -232,14 +177,24 @@ class LinkPaymentLauncher @Inject internal constructor(
         WeakMapInjectorRegistry.register(injector, injectorKey)
     }
 
+    /**
+     * Arguments for launching [LinkActivity] to confirm a payment with Link.
+     *
+     * @param stripeIntent The Stripe Intent that is being processed
+     * @param merchantName The customer-facing business name.
+     * @param customerName Name of the customer, used to pre-fill the form.
+     * @param customerEmail Email of the customer, used to pre-fill the form.
+     * @param customerPhone Phone number of the customer, used to pre-fill the form.
+     * @param shippingValues The initial shipping values for [FormController].
+     */
     @Parcelize
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class Configuration(
         val stripeIntent: StripeIntent,
         val merchantName: String,
+        val customerName: String?,
         val customerEmail: String?,
         val customerPhone: String?,
-        val customerName: String?,
         val shippingValues: Map<IdentifierSpec, String?>?
     ) : Parcelable
 

--- a/link/src/main/java/com/stripe/android/link/injection/LinkActivityContractArgsModule.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/LinkActivityContractArgsModule.kt
@@ -4,7 +4,6 @@ import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.ui.core.injection.FormControllerSubcomponent
 import dagger.Module
 import dagger.Provides
-import javax.inject.Named
 import javax.inject.Singleton
 
 /**
@@ -21,22 +20,6 @@ internal interface LinkActivityContractArgsModule {
     companion object {
         @Provides
         @Singleton
-        @Named(LINK_INTENT)
-        fun provideStripeIntent(args: LinkActivityContract.Args) = args.stripeIntent
-
-        @Provides
-        @Singleton
-        @Named(MERCHANT_NAME)
-        fun provideMerchantName(args: LinkActivityContract.Args) = args.merchantName
-
-        @Provides
-        @Singleton
-        @Named(CUSTOMER_EMAIL)
-        fun provideCustomerEmail(args: LinkActivityContract.Args) = args.customerEmail
-
-        @Provides
-        @Singleton
-        @Named(CUSTOMER_PHONE)
-        fun provideCustomerPhone(args: LinkActivityContract.Args) = args.customerPhone
+        fun provideConfiguration(args: LinkActivityContract.Args) = args.configuration
     }
 }

--- a/link/src/main/java/com/stripe/android/link/injection/LinkCommonModule.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/LinkCommonModule.kt
@@ -1,11 +1,15 @@
 package com.stripe.android.link.injection
 
+import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.analytics.DefaultLinkEventsReporter
 import com.stripe.android.link.analytics.LinkEventsReporter
 import com.stripe.android.link.repositories.LinkApiRepository
 import com.stripe.android.link.repositories.LinkRepository
+import com.stripe.android.model.StripeIntent
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
+import javax.inject.Named
 import javax.inject.Singleton
 
 @Module
@@ -17,4 +21,36 @@ internal interface LinkCommonModule {
     @Binds
     @Singleton
     fun bindLinkEventsReporter(linkEventsReporter: DefaultLinkEventsReporter): LinkEventsReporter
+
+    companion object {
+        @Provides
+        @Singleton
+        @Named(MERCHANT_NAME)
+        fun merchantName(configuration: LinkPaymentLauncher.Configuration): String =
+            configuration.merchantName
+
+        @Provides
+        @Singleton
+        @Named(CUSTOMER_EMAIL)
+        fun customerEmail(configuration: LinkPaymentLauncher.Configuration): String? =
+            configuration.customerEmail
+
+        @Provides
+        @Singleton
+        @Named(CUSTOMER_PHONE)
+        fun customerPhone(configuration: LinkPaymentLauncher.Configuration): String? =
+            configuration.customerPhone
+
+        @Provides
+        @Singleton
+        @Named(CUSTOMER_NAME)
+        fun customerName(configuration: LinkPaymentLauncher.Configuration): String? =
+            configuration.customerName
+
+        @Provides
+        @Singleton
+        @Named(LINK_INTENT)
+        fun stripeIntent(configuration: LinkPaymentLauncher.Configuration): StripeIntent =
+            configuration.stripeIntent
+    }
 }

--- a/link/src/main/java/com/stripe/android/link/injection/LinkPaymentLauncherComponent.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/LinkPaymentLauncherComponent.kt
@@ -4,20 +4,22 @@ import android.content.Context
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
+import com.stripe.android.core.injection.Injectable
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.injection.UIContext
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
+import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.analytics.LinkEventsReporter
 import com.stripe.android.link.ui.inline.InlineSignupViewModel
 import com.stripe.android.link.ui.verification.VerificationViewModel
-import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.ui.core.address.AddressRepository
 import com.stripe.android.ui.core.forms.resources.ResourceRepository
+import com.stripe.android.ui.core.injection.NonFallbackInjector
 import dagger.BindsInstance
 import dagger.Component
 import javax.inject.Named
@@ -39,26 +41,31 @@ internal abstract class LinkPaymentLauncherComponent {
     abstract val linkAccountManager: LinkAccountManager
     abstract val linkEventsReporter: LinkEventsReporter
     abstract val linkComponentBuilder: LinkComponent.Builder
+    abstract val configuration: LinkPaymentLauncher.Configuration
 
     abstract fun inject(factory: VerificationViewModel.Factory)
     abstract fun inject(factory: InlineSignupViewModel.Factory)
 
+    val injector: NonFallbackInjector = object : NonFallbackInjector {
+        override fun inject(injectable: Injectable<*>) {
+            when (injectable) {
+                is VerificationViewModel.Factory ->
+                    this@LinkPaymentLauncherComponent.inject(injectable)
+                is InlineSignupViewModel.Factory ->
+                    this@LinkPaymentLauncherComponent.inject(injectable)
+                else -> {
+                    throw IllegalArgumentException(
+                        "invalid Injectable $injectable requested in $this"
+                    )
+                }
+            }
+        }
+    }
+
     @Component.Builder
     interface Builder {
         @BindsInstance
-        fun merchantName(@Named(MERCHANT_NAME) merchantName: String): Builder
-
-        @BindsInstance
-        fun customerEmail(@Named(CUSTOMER_EMAIL) customerEmail: String?): Builder
-
-        @BindsInstance
-        fun customerPhone(@Named(CUSTOMER_PHONE) customerPhone: String?): Builder
-
-        @BindsInstance
-        fun customerName(@Named(CUSTOMER_NAME) customerName: String?): Builder
-
-        @BindsInstance
-        fun stripeIntent(@Named(LINK_INTENT) stripeIntent: StripeIntent): Builder
+        fun configuration(configuration: LinkPaymentLauncher.Configuration): Builder
 
         @BindsInstance
         fun context(context: Context): Builder

--- a/link/src/main/java/com/stripe/android/link/ui/LinkButtonView.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/LinkButtonView.kt
@@ -59,13 +59,15 @@ private fun LinkButton(
     enabled: Boolean,
     onClick: () -> Unit
 ) {
-    val account = linkPaymentLauncher.linkAccountManager.linkAccount.collectAsState()
+    linkPaymentLauncher.component?.let { component ->
+        val account = component.linkAccountManager.linkAccount.collectAsState()
 
-    LinkButton(
-        enabled = enabled,
-        email = account.value?.email,
-        onClick = onClick
-    )
+        LinkButton(
+            enabled = enabled,
+            email = account.value?.email,
+            onClick = onClick
+        )
+    }
 }
 
 @Composable

--- a/link/src/main/java/com/stripe/android/link/ui/LinkButtonView.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/LinkButtonView.kt
@@ -57,7 +57,7 @@ private fun LinkButton() {
 private fun LinkButton(
     linkPaymentLauncher: LinkPaymentLauncher,
     enabled: Boolean,
-    onClick: () -> Unit
+    onClick: (LinkPaymentLauncher.Configuration) -> Unit
 ) {
     linkPaymentLauncher.component?.let { component ->
         val account = component.linkAccountManager.linkAccount.collectAsState()
@@ -65,7 +65,9 @@ private fun LinkButton(
         LinkButton(
             enabled = enabled,
             email = account.value?.email,
-            onClick = onClick
+            onClick = {
+                onClick(component.configuration)
+            }
         )
     }
 }
@@ -150,7 +152,7 @@ class LinkButtonView @JvmOverloads constructor(
         private set
 
     var linkPaymentLauncher: LinkPaymentLauncher? = null
-    var onClick by mutableStateOf({})
+    var onClick by mutableStateOf<(LinkPaymentLauncher.Configuration) -> Unit>({})
     private var isEnabledState by mutableStateOf(isEnabled)
 
     override fun setEnabled(enabled: Boolean) {

--- a/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignup.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignup.kt
@@ -81,7 +81,7 @@ private fun Preview() {
 fun LinkInlineSignup(
     linkPaymentLauncher: LinkPaymentLauncher,
     enabled: Boolean,
-    onStateChanged: (InlineSignupViewState) -> Unit,
+    onStateChanged: (LinkPaymentLauncher.Configuration, InlineSignupViewState) -> Unit,
     modifier: Modifier = Modifier
 ) {
     linkPaymentLauncher.component?.let { component ->
@@ -93,7 +93,7 @@ fun LinkInlineSignup(
         val errorMessage by viewModel.errorMessage.collectAsState()
 
         LaunchedEffect(viewState) {
-            onStateChanged(viewState)
+            onStateChanged(component.configuration, viewState)
         }
 
         val focusManager = LocalFocusManager.current

--- a/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignup.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignup.kt
@@ -84,9 +84,9 @@ fun LinkInlineSignup(
     onStateChanged: (InlineSignupViewState) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    linkPaymentLauncher.injector?.let { injector ->
+    linkPaymentLauncher.component?.let { component ->
         val viewModel: InlineSignupViewModel = viewModel(
-            factory = InlineSignupViewModel.Factory(injector)
+            factory = InlineSignupViewModel.Factory(component.injector)
         )
 
         val viewState by viewModel.viewState.collectAsState()

--- a/link/src/main/java/com/stripe/android/link/ui/verification/VerificationDialog.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/verification/VerificationDialog.kt
@@ -52,9 +52,9 @@ fun LinkVerificationDialog(
         composable(LinkScreen.VerificationDialog.route) {
             var openDialog by remember { mutableStateOf(true) }
 
-            val injector = requireNotNull(linkLauncher.injector)
-            val linkAccount = linkLauncher.linkAccountManager.linkAccount.collectAsState()
-            val linkEventsReporter = linkLauncher.linkEventsReporter
+            val component = requireNotNull(linkLauncher.component)
+            val linkAccount = component.linkAccountManager.linkAccount.collectAsState()
+            val linkEventsReporter = component.linkEventsReporter
 
             val onDismiss = {
                 openDialog = false
@@ -101,7 +101,7 @@ fun LinkVerificationDialog(
                                         messageStringResId = R.string.verification_message,
                                         showChangeEmailMessage = false,
                                         linkAccount = account,
-                                        injector = injector,
+                                        injector = component.injector,
                                         onVerificationCompleted = {
                                             openDialog = false
                                             verificationCallback(true)

--- a/link/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
@@ -21,13 +21,17 @@ class LinkActivityContractTest {
             "stripeAccountId"
         )
 
-        val args = LinkActivityContract.Args(
+        val config = LinkPaymentLauncher.Configuration(
             StripeIntentFixtures.PI_SUCCEEDED,
             "Merchant, Inc",
+            "Name",
             "customer@email.com",
             "1234567890",
-            "Name",
             null,
+        )
+
+        val args = LinkActivityContract.Args(
+            config,
             null,
             injectionParams
         )

--- a/link/src/test/java/com/stripe/android/link/LinkActivityTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkActivityTest.kt
@@ -32,11 +32,15 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class LinkActivityTest {
     private val context = ApplicationProvider.getApplicationContext<Context>()
-    private val args = LinkActivityContract.Args(
+    private val config = LinkPaymentLauncher.Configuration(
         StripeIntentFixtures.PI_SUCCEEDED,
         "Example, Inc.",
-        "email@stripe.com"
+        "Name",
+        "email@stripe.com",
+        null,
+        null
     )
+    private val args = LinkActivityContract.Args(config)
     private val intent = LinkActivityContract().createIntent(context, args)
 
     private val linkAccountManager = mock<LinkAccountManager>().apply {

--- a/link/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
@@ -1,28 +1,29 @@
 package com.stripe.android.link
 
 import android.content.Context
-import androidx.activity.result.ActivityResultLauncher
 import androidx.test.core.app.ApplicationProvider
-import com.stripe.android.core.injection.WeakMapInjectorRegistry
+import com.google.common.truth.Truth.assertThat
 import com.stripe.android.link.model.StripeIntentFixtures
 import com.stripe.android.link.utils.FakeAndroidKeyStore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.job
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.kotlin.argWhere
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 class LinkPaymentLauncherTest {
     private val context = ApplicationProvider.getApplicationContext<Context>()
-    private val mockHostActivityLauncher = mock<ActivityResultLauncher<LinkActivityContract.Args>>()
+    private val config = LinkPaymentLauncher.Configuration(
+        StripeIntentFixtures.PI_SUCCEEDED,
+        MERCHANT_NAME,
+        CUSTOMER_NAME,
+        CUSTOMER_EMAIL,
+        CUSTOMER_PHONE,
+        null
+    )
 
     private var linkPaymentLauncher = LinkPaymentLauncher(
         context,
@@ -43,42 +44,18 @@ class LinkPaymentLauncherTest {
     }
 
     @Test
-    fun `verify present() launches LinkActivity with correct arguments`() =
-        runTest {
-            launch {
-                val stripeIntent = StripeIntentFixtures.PI_SUCCEEDED
-                linkPaymentLauncher.present(
-                    LinkPaymentLauncher.Configuration(
-                        stripeIntent,
-                        MERCHANT_NAME,
-                        CUSTOMER_NAME,
-                        CUSTOMER_EMAIL,
-                        CUSTOMER_PHONE,
-                        null
-                    ),
-                    mockHostActivityLauncher
-                )
+    fun `verify component is reused for same configuration`() {
+        val component = linkPaymentLauncher.component
+        linkPaymentLauncher.getAccountStatusFlow(config)
+        assertThat(linkPaymentLauncher.component).isEqualTo(component)
+    }
 
-                verify(mockHostActivityLauncher).launch(
-                    argWhere { arg ->
-                        arg.stripeIntent == stripeIntent &&
-                            arg.merchantName == MERCHANT_NAME &&
-                            arg.customerEmail == CUSTOMER_EMAIL &&
-                            arg.customerPhone == CUSTOMER_PHONE &&
-                            arg.customerName == CUSTOMER_NAME &&
-                            arg.injectionParams != null &&
-                            arg.injectionParams.productUsage == setOf(PRODUCT_USAGE) &&
-                            arg.injectionParams.injectorKey == LinkPaymentLauncher::class.simpleName + WeakMapInjectorRegistry.CURRENT_REGISTER_KEY.get() &&
-                            arg.injectionParams.enableLogging &&
-                            arg.injectionParams.publishableKey == PUBLISHABLE_KEY &&
-                            arg.injectionParams.stripeAccountId.equals(STRIPE_ACCOUNT_ID)
-                    }
-                )
-
-                // Need to cancel because the coroutine scope is still collecting the account status
-                this.coroutineContext.job.cancel()
-            }
-        }
+    @Test
+    fun `verify component is recreated for different configuration`() {
+        val component = linkPaymentLauncher.component
+        linkPaymentLauncher.getAccountStatusFlow(config.copy(merchantName = "anotherName"))
+        assertThat(linkPaymentLauncher.component).isNotEqualTo(component)
+    }
 
     companion object {
         const val PRODUCT_USAGE = "productUsage"

--- a/link/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
@@ -47,18 +47,17 @@ class LinkPaymentLauncherTest {
         runTest {
             launch {
                 val stripeIntent = StripeIntentFixtures.PI_SUCCEEDED
-                linkPaymentLauncher.setup(
-                    configuration = LinkPaymentLauncher.Configuration(
+                linkPaymentLauncher.present(
+                    LinkPaymentLauncher.Configuration(
                         stripeIntent,
                         MERCHANT_NAME,
+                        CUSTOMER_NAME,
                         CUSTOMER_EMAIL,
                         CUSTOMER_PHONE,
-                        CUSTOMER_NAME,
                         null
                     ),
-                    coroutineScope = this
+                    mockHostActivityLauncher
                 )
-                linkPaymentLauncher.present(mockHostActivityLauncher)
 
                 verify(mockHostActivityLauncher).launch(
                     argWhere { arg ->

--- a/link/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkPaymentLauncherTest.kt
@@ -4,9 +4,11 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.link.model.StripeIntentFixtures
+import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.link.utils.FakeAndroidKeyStore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
@@ -44,9 +46,10 @@ class LinkPaymentLauncherTest {
     }
 
     @Test
-    fun `verify component is reused for same configuration`() {
-        val component = linkPaymentLauncher.component
+    fun `verify component is reused for same configuration`() = runTest {
         linkPaymentLauncher.getAccountStatusFlow(config)
+        val component = linkPaymentLauncher.component
+        linkPaymentLauncher.signInWithUserInput(config, mock<UserInput.SignIn>())
         assertThat(linkPaymentLauncher.component).isEqualTo(component)
     }
 

--- a/link/src/test/java/com/stripe/android/link/ui/signup/SignUpViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/signup/SignUpViewModelTest.kt
@@ -8,6 +8,7 @@ import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.Injectable
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.link.LinkActivityContract
+import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.LinkScreen
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.analytics.LinkEventsReporter
@@ -51,13 +52,16 @@ import kotlin.test.BeforeTest
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 class SignUpViewModelTest {
-    private val defaultArgs = LinkActivityContract.Args(
+    val config = LinkPaymentLauncher.Configuration(
         StripeIntentFixtures.PI_SUCCEEDED,
         MERCHANT_NAME,
+        CUSTOMER_NAME,
         CUSTOMER_EMAIL,
         CUSTOMER_PHONE,
-        CUSTOMER_NAME,
         null,
+    )
+    private val defaultArgs = LinkActivityContract.Args(
+        config,
         null,
         LinkActivityContract.Args.InjectionParams(
             INJECTOR_KEY,
@@ -362,10 +366,12 @@ class SignUpViewModelTest {
         countryCode: CountryCode = CountryCode.US
     ): SignUpViewModel {
         val argsWithCountryCode = args.copy(
-            stripeIntent = when (val intent = args.stripeIntent) {
-                is PaymentIntent -> intent.copy(countryCode = countryCode.value)
-                is SetupIntent -> intent.copy(countryCode = countryCode.value)
-            }
+            configuration = config.copy(
+                stripeIntent = when (val intent = args.stripeIntent) {
+                    is PaymentIntent -> intent.copy(countryCode = countryCode.value)
+                    is SetupIntent -> intent.copy(countryCode = countryCode.value)
+                }
+            )
         )
         return SignUpViewModel(
             args = argsWithCountryCode,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
@@ -36,6 +36,7 @@ import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.forms.resources.LpmRepository.SupportedPaymentMethod
 import com.stripe.android.utils.AnimationConstants
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 internal abstract class BaseAddPaymentMethodFragment : Fragment() {
@@ -77,7 +78,7 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
                     LinkInlineSignup(
                         linkPaymentLauncher = sheetViewModel.linkLauncher,
                         enabled = !processing,
-                        onStateChanged = { viewState ->
+                        onStateChanged = { config, viewState ->
                             sheetViewModel.updatePrimaryButtonUIState(
                                 if (viewState.useLink) {
                                     val userInput = viewState.userInput
@@ -88,7 +89,10 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
                                         PrimaryButton.UIState(
                                             label = null,
                                             onClick = {
-                                                sheetViewModel.payWithLinkInline(userInput)
+                                                sheetViewModel.payWithLinkInline(
+                                                    config,
+                                                    userInput
+                                                )
                                             },
                                             enabled = true,
                                             visible = true
@@ -224,7 +228,10 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
                 sheetViewModel.stripeIntent.value
                     ?.linkFundingSources?.contains(PaymentMethod.Type.Card.code) ?: false &&
                 selectedPaymentMethod.code == PaymentMethod.Type.Card.code &&
-                sheetViewModel.getLinkAccountStatus() == AccountStatus.SignedOut
+                sheetViewModel.linkConfiguration.value
+                ?.let {
+                    sheetViewModel.linkLauncher.getAccountStatusFlow(it).first()
+                } == AccountStatus.SignedOut
 
             viewBinding.linkInlineSignup.isVisible = showLinkInlineSignup.value
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
@@ -17,6 +17,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.asFlow
+import androidx.lifecycle.lifecycleScope
 import com.stripe.android.core.injection.InjectorKey
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.inline.LinkInlineSignup
@@ -35,6 +36,7 @@ import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.forms.resources.LpmRepository.SupportedPaymentMethod
 import com.stripe.android.utils.AnimationConstants
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 
 internal abstract class BaseAddPaymentMethodFragment : Fragment() {
     abstract val viewModelFactory: ViewModelProvider.Factory
@@ -217,13 +219,15 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
     }
 
     private fun updateLinkInlineSignupVisibility(selectedPaymentMethod: SupportedPaymentMethod) {
-        showLinkInlineSignup.value = sheetViewModel.isLinkEnabled.value == true &&
-            sheetViewModel.stripeIntent.value
-                ?.linkFundingSources?.contains(PaymentMethod.Type.Card.code) ?: false &&
-            selectedPaymentMethod.code == PaymentMethod.Type.Card.code &&
-            sheetViewModel.linkLauncher.accountStatus.value == AccountStatus.SignedOut
+        lifecycleScope.launch {
+            showLinkInlineSignup.value = sheetViewModel.isLinkEnabled.value == true &&
+                sheetViewModel.stripeIntent.value
+                    ?.linkFundingSources?.contains(PaymentMethod.Type.Card.code) ?: false &&
+                selectedPaymentMethod.code == PaymentMethod.Type.Card.code &&
+                sheetViewModel.getLinkAccountStatus() == AccountStatus.SignedOut
 
-        viewBinding.linkInlineSignup.isVisible = showLinkInlineSignup.value
+            viewBinding.linkInlineSignup.isVisible = showLinkInlineSignup.value
+        }
     }
 
     private fun fragmentForPaymentMethod(paymentMethod: SupportedPaymentMethod) =

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -35,6 +35,7 @@ import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.ui.core.address.AddressRepository
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.ui.core.forms.resources.ResourceRepository
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Provider
@@ -169,7 +170,10 @@ internal class PaymentOptionsViewModel @Inject constructor(
             stripeIntent.paymentMethodTypes.contains(PaymentMethod.Type.Link.code)
         ) {
             viewModelScope.launch {
-                val accountStatus = linkLauncher.setup(createLinkConfiguration(stripeIntent), this)
+                val configuration = createLinkConfiguration(stripeIntent).also {
+                    _linkConfiguration.value = it
+                }
+                val accountStatus = linkLauncher.getAccountStatusFlow(configuration).first()
                 when (accountStatus) {
                     AccountStatus.Verified,
                     AccountStatus.VerificationStarted,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -137,7 +137,9 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
         setupTopContainer()
 
         linkButton.apply {
-            onClick = { viewModel.launchLink(launchedDirectly = false) }
+            onClick = { config ->
+                viewModel.launchLink(config, launchedDirectly = false)
+            }
             linkPaymentLauncher = viewModel.linkLauncher
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -441,12 +441,12 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                 .isNotEmpty()
         ) {
             viewModelScope.launch {
-                val configuration = createLinkConfiguration(stripeIntent).also {
+                val linkConfig = createLinkConfiguration(stripeIntent).also {
                     _linkConfiguration.value = it
                 }
-                val accountStatus = linkLauncher.getAccountStatusFlow(configuration).first()
+                val accountStatus = linkLauncher.getAccountStatusFlow(linkConfig).first()
                 when (accountStatus) {
-                    AccountStatus.Verified -> launchLink(configuration, launchedDirectly = true)
+                    AccountStatus.Verified -> launchLink(linkConfig, launchedDirectly = true)
                     AccountStatus.VerificationStarted,
                     AccountStatus.NeedsVerification -> {
                         linkVerificationCallback = { success ->
@@ -454,7 +454,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                             _showLinkVerificationDialog.value = false
 
                             if (success) {
-                                launchLink(configuration, launchedDirectly = true)
+                                launchLink(linkConfig, launchedDirectly = true)
                             }
                         }
                         _showLinkVerificationDialog.value = true

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -446,7 +446,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                 }
                 val accountStatus = linkLauncher.getAccountStatusFlow(configuration).first()
                 when (accountStatus) {
-                    AccountStatus.Verified -> launchLink(launchedDirectly = true)
+                    AccountStatus.Verified -> launchLink(configuration, launchedDirectly = true)
                     AccountStatus.VerificationStarted,
                     AccountStatus.NeedsVerification -> {
                         linkVerificationCallback = { success ->
@@ -454,7 +454,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                             _showLinkVerificationDialog.value = false
 
                             if (success) {
-                                launchLink(launchedDirectly = true)
+                                launchLink(configuration, launchedDirectly = true)
                             }
                         }
                         _showLinkVerificationDialog.value = true
@@ -475,7 +475,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         isReturningUser: Boolean
     ) {
         if (isReturningUser) {
-            launchLink(launchedDirectly = false, paymentMethodCreateParams)
+            launchLink(configuration, launchedDirectly = false, paymentMethodCreateParams)
         } else {
             super.completeLinkInlinePayment(
                 configuration,
@@ -486,12 +486,14 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     }
 
     fun launchLink(
+        configuration: LinkPaymentLauncher.Configuration,
         launchedDirectly: Boolean,
         paymentMethodCreateParams: PaymentMethodCreateParams? = null
     ) {
         launchedLinkDirectly = launchedDirectly
         linkActivityResultLauncher?.let { activityResultLauncher ->
             linkLauncher.present(
+                configuration,
                 activityResultLauncher,
                 paymentMethodCreateParams
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -62,6 +62,7 @@ import com.stripe.android.ui.core.forms.resources.ResourceRepository
 import dagger.Lazy
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -474,7 +475,7 @@ internal class DefaultFlowController @Inject internal constructor(
                     it.ephemeralKeySecret
                 )?.email
             }
-            val accountStatus = linkLauncher.setup(
+            val accountStatus = linkLauncher.getAccountStatusFlow(
                 configuration = LinkPaymentLauncher.Configuration(
                     stripeIntent = initData.stripeIntent,
                     merchantName = config.merchantDisplayName,
@@ -482,9 +483,8 @@ internal class DefaultFlowController @Inject internal constructor(
                     customerPhone = customerPhone,
                     customerName = config.defaultBillingDetails?.name,
                     shippingValues = shippingAddress
-                ),
-                coroutineScope = lifecycleScope
-            )
+                )
+            ).first()
             // If a returning user is paying with a new card inline, launch Link to complete payment
             (paymentSelection as? PaymentSelection.New.LinkInline)?.takeIf {
                 accountStatus == AccountStatus.Verified

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -475,25 +475,24 @@ internal class DefaultFlowController @Inject internal constructor(
                     it.ephemeralKeySecret
                 )?.email
             }
-            val accountStatus = linkLauncher.getAccountStatusFlow(
-                configuration = LinkPaymentLauncher.Configuration(
-                    stripeIntent = initData.stripeIntent,
-                    merchantName = config.merchantDisplayName,
-                    customerEmail = customerEmail,
-                    customerPhone = customerPhone,
-                    customerName = config.defaultBillingDetails?.name,
-                    shippingValues = shippingAddress
-                )
-            ).first()
+            val linkConfig = LinkPaymentLauncher.Configuration(
+                stripeIntent = initData.stripeIntent,
+                merchantName = config.merchantDisplayName,
+                customerEmail = customerEmail,
+                customerPhone = customerPhone,
+                customerName = config.defaultBillingDetails?.name,
+                shippingValues = shippingAddress
+            )
+            val accountStatus = linkLauncher.getAccountStatusFlow(linkConfig).first()
             // If a returning user is paying with a new card inline, launch Link to complete payment
             (paymentSelection as? PaymentSelection.New.LinkInline)?.takeIf {
                 accountStatus == AccountStatus.Verified
             }?.linkPaymentDetails?.originalParams?.let {
-                linkLauncher.present(linkActivityResultLauncher, it)
+                linkLauncher.present(linkConfig, linkActivityResultLauncher, it)
             } ?: run {
                 if (paymentSelection is PaymentSelection.Link) {
                     // User selected Link as the payment method, not inline
-                    linkLauncher.present(linkActivityResultLauncher)
+                    linkLauncher.present(linkConfig, linkActivityResultLauncher)
                 } else {
                     // New user paying inline, complete without launching Link
                     confirmPaymentSelection(paymentSelection, initData)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -507,12 +507,12 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
             updatePrimaryButtonState(PrimaryButton.State.StartProcessing)
 
             viewModelScope.launch {
-                val configuration = requireNotNull(linkConfiguration.value)
-                when (linkLauncher.getAccountStatusFlow(configuration).first()) {
+                val linkConfig = requireNotNull(linkConfiguration.value)
+                when (linkLauncher.getAccountStatusFlow(linkConfig).first()) {
                     AccountStatus.Verified -> {
                         activeLinkSession.value = true
                         completeLinkInlinePayment(
-                            configuration,
+                            linkConfig,
                             params,
                             userInput is UserInput.SignIn
                         )
@@ -526,7 +526,7 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
 
                             if (success) {
                                 completeLinkInlinePayment(
-                                    configuration,
+                                    linkConfig,
                                     params,
                                     userInput is UserInput.SignIn
                                 )
@@ -539,7 +539,7 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
                     }
                     AccountStatus.SignedOut -> {
                         activeLinkSession.value = false
-                        linkLauncher.signInWithUserInput(configuration, userInput).fold(
+                        linkLauncher.signInWithUserInput(linkConfig, userInput).fold(
                             onSuccess = {
                                 // If successful, the account was fetched or created, so try again
                                 payWithLinkInline(userInput)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -95,6 +95,10 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
 
     internal val activeLinkSession = MutableLiveData(false)
 
+    protected val _linkConfiguration =
+        savedStateHandle.getLiveData<LinkPaymentLauncher.Configuration>(LINK_CONFIGURATION)
+    internal val linkConfiguration: LiveData<LinkPaymentLauncher.Configuration> = _linkConfiguration
+
     private val _stripeIntent = savedStateHandle.getLiveData<StripeIntent>(SAVE_STRIPE_INTENT)
     internal val stripeIntent: LiveData<StripeIntent?> = _stripeIntent
 
@@ -462,6 +466,11 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
      */
     abstract fun setupLink(stripeIntent: StripeIntent)
 
+    suspend fun getLinkAccountStatus(): AccountStatus? =
+        linkConfiguration.value?.let {
+            linkLauncher.getAccountStatusFlow(it).first()
+        }
+
     protected suspend fun createLinkConfiguration(
         stripeIntent: StripeIntent
     ): LinkPaymentLauncher.Configuration {
@@ -497,31 +506,40 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
             savedStateHandle[SAVE_PROCESSING] = true
             updatePrimaryButtonState(PrimaryButton.State.StartProcessing)
 
-            when (linkLauncher.accountStatus.value) {
-                AccountStatus.Verified -> {
-                    activeLinkSession.value = true
-                    completeLinkInlinePayment(params, userInput is UserInput.SignIn)
-                }
-                AccountStatus.VerificationStarted,
-                AccountStatus.NeedsVerification -> {
-                    linkVerificationCallback = { success ->
-                        activeLinkSession.value = success
-                        linkVerificationCallback = null
-                        _showLinkVerificationDialog.value = false
-
-                        if (success) {
-                            completeLinkInlinePayment(params, userInput is UserInput.SignIn)
-                        } else {
-                            savedStateHandle[SAVE_PROCESSING] = false
-                            updatePrimaryButtonState(PrimaryButton.State.Ready)
-                        }
+            viewModelScope.launch {
+                val configuration = requireNotNull(linkConfiguration.value)
+                when (linkLauncher.getAccountStatusFlow(configuration).first()) {
+                    AccountStatus.Verified -> {
+                        activeLinkSession.value = true
+                        completeLinkInlinePayment(
+                            configuration,
+                            params,
+                            userInput is UserInput.SignIn
+                        )
                     }
-                    _showLinkVerificationDialog.value = true
-                }
-                AccountStatus.SignedOut -> {
-                    activeLinkSession.value = false
-                    viewModelScope.launch {
-                        linkLauncher.signInWithUserInput(userInput).fold(
+                    AccountStatus.VerificationStarted,
+                    AccountStatus.NeedsVerification -> {
+                        linkVerificationCallback = { success ->
+                            activeLinkSession.value = success
+                            linkVerificationCallback = null
+                            _showLinkVerificationDialog.value = false
+
+                            if (success) {
+                                completeLinkInlinePayment(
+                                    configuration,
+                                    params,
+                                    userInput is UserInput.SignIn
+                                )
+                            } else {
+                                savedStateHandle[SAVE_PROCESSING] = false
+                                updatePrimaryButtonState(PrimaryButton.State.Ready)
+                            }
+                        }
+                        _showLinkVerificationDialog.value = true
+                    }
+                    AccountStatus.SignedOut -> {
+                        activeLinkSession.value = false
+                        linkLauncher.signInWithUserInput(configuration, userInput).fold(
                             onSuccess = {
                                 // If successful, the account was fetched or created, so try again
                                 payWithLinkInline(userInput)
@@ -539,12 +557,16 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
     }
 
     internal open fun completeLinkInlinePayment(
+        configuration: LinkPaymentLauncher.Configuration,
         paymentMethodCreateParams: PaymentMethodCreateParams,
         isReturningUser: Boolean
     ) {
         viewModelScope.launch {
             onLinkPaymentDetailsCollected(
-                linkLauncher.attachNewCardToAccount(paymentMethodCreateParams).getOrNull()
+                linkLauncher.attachNewCardToAccount(
+                    configuration,
+                    paymentMethodCreateParams
+                ).getOrNull()
             )
         }
     }
@@ -608,5 +630,6 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
         internal const val SAVE_GOOGLE_PAY_READY = "google_pay_ready"
         internal const val SAVE_RESOURCE_REPOSITORY_READY = "resource_repository_ready"
         internal const val SAVE_STATE_LIVE_MODE = "save_state_live_mode"
+        internal const val LINK_CONFIGURATION = "link_configuration"
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -39,6 +39,7 @@ import com.stripe.android.utils.TestUtils.viewModelFactoryFor
 import com.stripe.android.utils.injectableActivityScenario
 import com.stripe.android.view.ActivityStarter
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Rule
 import org.junit.Test
@@ -452,7 +453,7 @@ class PaymentOptionsActivityTest {
             ApplicationProvider.getApplicationContext<Application>().resources
         )
         val linkPaymentLauncher = mock<LinkPaymentLauncher>().stub {
-            onBlocking { setup(any(), any()) }.thenReturn(AccountStatus.SignedOut)
+            onBlocking { getAccountStatusFlow(any()) }.thenReturn(flowOf(AccountStatus.SignedOut))
         }
         return PaymentOptionsViewModel(
             args = args,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -53,6 +53,7 @@ import com.stripe.android.view.ActivityScenarioFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -1012,7 +1013,7 @@ internal class PaymentSheetActivityTest {
         whenever(lpmRepository.serverSpecLoadingState).thenReturn(LpmRepository.ServerSpecState.Uninitialized)
 
         val linkPaymentLauncher = mock<LinkPaymentLauncher>().stub {
-            onBlocking { setup(any(), any()) }.thenReturn(AccountStatus.SignedOut)
+            onBlocking { getAccountStatusFlow(any()) }.thenReturn(flowOf(AccountStatus.SignedOut))
         }
 
         PaymentSheetViewModel(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -56,6 +56,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
@@ -638,6 +639,7 @@ internal class DefaultFlowControllerTest {
 
     @Test
     fun `confirmPaymentSelection() with link payment method should launch LinkPaymentLauncher`() = runTest {
+        whenever(linkPaymentLauncher.getAccountStatusFlow(any())).thenReturn(flowOf(AccountStatus.Verified))
         val flowController = createFlowController(
             savedSelection = SavedSelection.Link,
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
@@ -657,7 +659,7 @@ internal class DefaultFlowControllerTest {
 
     @Test
     fun `confirmPaymentSelection() with LinkInline and user signed in should launch LinkPaymentLauncher`() = runTest {
-        whenever(linkPaymentLauncher.setup(any(), any())).thenReturn(AccountStatus.Verified)
+        whenever(linkPaymentLauncher.getAccountStatusFlow(any())).thenReturn(flowOf(AccountStatus.Verified))
 
         val flowController = createFlowController(
             savedSelection = SavedSelection.Link,
@@ -690,7 +692,7 @@ internal class DefaultFlowControllerTest {
 
     @Test
     fun `confirmPaymentSelection() with LinkInline and user not signed in should confirm with PaymentLauncher`() = runTest {
-        whenever(linkPaymentLauncher.setup(any(), any())).thenReturn(AccountStatus.SignedOut)
+        whenever(linkPaymentLauncher.getAccountStatusFlow(any())).thenReturn(flowOf(AccountStatus.SignedOut))
 
         val flowController = createFlowController(
             savedSelection = SavedSelection.Link,
@@ -723,7 +725,7 @@ internal class DefaultFlowControllerTest {
 
     @Test
     fun `confirmPaymentSelection() with Link and shipping should have shipping details in confirm params`() = runTest {
-        whenever(linkPaymentLauncher.setup(any(), any())).thenReturn(AccountStatus.SignedOut)
+        whenever(linkPaymentLauncher.getAccountStatusFlow(any())).thenReturn(flowOf(AccountStatus.SignedOut))
 
         val flowController = createFlowController(
             savedSelection = SavedSelection.Link,
@@ -769,7 +771,7 @@ internal class DefaultFlowControllerTest {
 
     @Test
     fun `confirmPaymentSelection() with Link and no shipping should not have shipping details in confirm params`() = runTest {
-        whenever(linkPaymentLauncher.setup(any(), any())).thenReturn(AccountStatus.SignedOut)
+        whenever(linkPaymentLauncher.getAccountStatusFlow(any())).thenReturn(flowOf(AccountStatus.SignedOut))
 
         val flowController = createFlowController(
             savedSelection = SavedSelection.Link,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -654,7 +654,7 @@ internal class DefaultFlowControllerTest {
 
         flowController.confirm()
 
-        verify(linkPaymentLauncher).present(any(), eq(null))
+        verify(linkPaymentLauncher).present(any(), any(), eq(null))
     }
 
     @Test
@@ -687,7 +687,7 @@ internal class DefaultFlowControllerTest {
 
         flowController.confirm()
 
-        verify(linkPaymentLauncher).present(any(), eq(PaymentMethodCreateParamsFixtures.DEFAULT_CARD))
+        verify(linkPaymentLauncher).present(any(), any(), eq(PaymentMethodCreateParamsFixtures.DEFAULT_CARD))
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
`LinkPaymentLauncher` must receive the `LinkPaymentLauncher.Configuration` parameters before it can be used.
This was done on `setup`, but `LinkPaymentLauncher` wouldn't recover its state when the caller Activity is destroyed and then recreated.
Make it stateless by receiving the `LinkPaymentLauncher.Configuration` as a parameter to the methods that are used while it's in the embedded state.
`BaseSheetViewModel` stores the `LinkPaymentLauncher.Configuration` in its `SavedStateHandle` so it's recovered when the Activity is recreated.
`LinkPaymentLauncher` cannot store its own state in a `SavedStateHandle` because it can live past the lifecycle of the caller Activity.
Also clean up the `LinkPaymentLauncher` interface, moving the objects that are used by the embedded views into the `LinkPaymentLauncherComponent`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix crash when host Activity is recreated.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified