### PR TITLE
Add `IntentStatusPoller` for UPI polling

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -7254,6 +7254,14 @@ public final class com/stripe/android/payments/paymentlauncher/StripePaymentLaun
 	public static fun newInstance (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Landroidx/activity/result/ActivityResultLauncher;Landroid/content/Context;ZLkotlin/coroutines/CoroutineContext;Lkotlin/coroutines/CoroutineContext;Lcom/stripe/android/networking/StripeRepository;Lcom/stripe/android/networking/PaymentAnalyticsRequestFactory;Ljava/util/Set;)Lcom/stripe/android/payments/paymentlauncher/StripePaymentLauncher;
 }
 
+public final class com/stripe/android/polling/DefaultIntentStatusPoller_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/polling/DefaultIntentStatusPoller_Factory;
+	public fun get ()Lcom/stripe/android/polling/DefaultIntentStatusPoller;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Lcom/stripe/android/networking/StripeRepository;Ljavax/inject/Provider;Lcom/stripe/android/polling/IntentStatusPoller$Config;Lkotlinx/coroutines/CoroutineDispatcher;)Lcom/stripe/android/polling/DefaultIntentStatusPoller;
+}
+
 public abstract class com/stripe/android/view/ActivityStarter {
 	public static final field $stable I
 	public final fun startForResult (Lcom/stripe/android/view/ActivityStarter$Args;)V

--- a/payments-core/src/main/java/com/stripe/android/polling/DefaultIntentStatusPoller.kt
+++ b/payments-core/src/main/java/com/stripe/android/polling/DefaultIntentStatusPoller.kt
@@ -1,0 +1,83 @@
+package com.stripe.android.polling
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.networking.StripeRepository
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Provider
+import kotlin.math.pow
+
+private const val MILLIS_PER_SECOND = 1_000L
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class DefaultIntentStatusPoller @Inject constructor(
+    private val stripeRepository: StripeRepository,
+    private val paymentConfigProvider: Provider<PaymentConfiguration>,
+    private val config: IntentStatusPoller.Config,
+    private val dispatcher: CoroutineDispatcher,
+) : IntentStatusPoller {
+
+    private var attempts: Int = 0
+    private var pollingJob: Job? = null
+
+    private val _state = MutableStateFlow<StripeIntent.Status?>(null)
+    override val state: StateFlow<StripeIntent.Status?> = _state
+
+    override fun startPolling(scope: CoroutineScope) {
+        pollingJob = scope.launch(dispatcher) {
+            performPoll()
+        }
+    }
+
+    private suspend fun performPoll(force: Boolean = false) {
+        if (force || attempts < config.maxAttempts) {
+            attempts += 1
+
+            _state.value = fetchIntentStatus()
+
+            val canTryAgain = attempts < config.maxAttempts
+            if (canTryAgain) {
+                val delayInMillis = calculateDelayInMillis(attempts)
+                delay(delayInMillis)
+                performPoll()
+            }
+        }
+    }
+
+    private suspend fun fetchIntentStatus(): StripeIntent.Status? {
+        val paymentConfig = paymentConfigProvider.get()
+        val paymentIntent = runCatching {
+            stripeRepository.retrievePaymentIntent(
+                clientSecret = config.clientSecret,
+                options = ApiRequest.Options(
+                    publishableKeyProvider = { paymentConfig.publishableKey },
+                    stripeAccountIdProvider = { paymentConfig.stripeAccountId },
+                ),
+            )
+        }
+        return paymentIntent.getOrNull()?.status
+    }
+
+    override suspend fun forcePoll() {
+        performPoll(force = true)
+    }
+
+    override fun stopPolling() {
+        pollingJob?.cancel()
+        pollingJob = null
+    }
+}
+
+internal fun calculateDelayInMillis(attempts: Int): Long {
+    val seconds = (1.0 + attempts).pow(2)
+    return seconds.toLong() * MILLIS_PER_SECOND
+}

--- a/payments-core/src/main/java/com/stripe/android/polling/IntentStatusPoller.kt
+++ b/payments-core/src/main/java/com/stripe/android/polling/IntentStatusPoller.kt
@@ -1,0 +1,21 @@
+package com.stripe.android.polling
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.model.StripeIntent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.StateFlow
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+interface IntentStatusPoller {
+    val state: StateFlow<StripeIntent.Status?>
+
+    fun startPolling(scope: CoroutineScope)
+    suspend fun forcePoll()
+    fun stopPolling()
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class Config(
+        val clientSecret: String,
+        val maxAttempts: Int,
+    )
+}

--- a/payments-core/src/test/java/com/stripe/android/polling/DefaultIntentStatusPollerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/polling/DefaultIntentStatusPollerTest.kt
@@ -1,0 +1,137 @@
+package com.stripe.android.polling
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.StripeIntent.Status.RequiresAction
+import com.stripe.android.model.StripeIntent.Status.RequiresCapture
+import com.stripe.android.model.StripeIntent.Status.RequiresConfirmation
+import com.stripe.android.model.StripeIntent.Status.RequiresPaymentMethod
+import com.stripe.android.model.StripeIntent.Status.Succeeded
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DefaultIntentStatusPollerTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @Test
+    fun `Updates state when polling result changes`() = runTest(testDispatcher) {
+        val statuses = listOf(
+            RequiresAction,
+            RequiresCapture,
+            Succeeded,
+        )
+
+        val poller = createIntentStatusPoller(
+            enqueuedStatuses = statuses,
+            dispatcher = testDispatcher
+        )
+
+        val nextDelay = exponentialDelayProvider()
+
+        assertThat(poller.state.value).isNull()
+
+        poller.startPolling(scope = this@runTest)
+        assertThat(poller.state.value).isEqualTo(RequiresAction)
+
+        advanceTimeBy(nextDelay())
+        assertThat(poller.state.value).isEqualTo(RequiresCapture)
+
+        advanceTimeBy(nextDelay())
+        assertThat(poller.state.value).isEqualTo(Succeeded)
+    }
+
+    @Test
+    fun `Stops when reaching max attempts`() = runTest(testDispatcher) {
+        val poller = createIntentStatusPoller(
+            maxAttempts = 3,
+            enqueuedStatuses = listOf(
+                RequiresPaymentMethod,
+                RequiresConfirmation,
+                RequiresAction,
+                Succeeded,
+            ),
+            dispatcher = testDispatcher,
+        )
+
+        val nextDelay = exponentialDelayProvider()
+
+        assertThat(poller.state.value).isNull()
+
+        poller.startPolling(scope = this@runTest)
+        assertThat(poller.state.value).isEqualTo(RequiresPaymentMethod)
+
+        advanceTimeBy(nextDelay())
+        assertThat(poller.state.value).isEqualTo(RequiresConfirmation)
+
+        advanceTimeBy(nextDelay())
+        assertThat(poller.state.value).isEqualTo(RequiresAction)
+
+        advanceTimeBy(nextDelay())
+
+        // The state should be unchanged
+        assertThat(poller.state.value).isEqualTo(RequiresAction)
+    }
+
+    @Test
+    fun `Canceling polling makes poller not emit any more states`() = runTest(testDispatcher) {
+        val poller = createIntentStatusPoller(
+            enqueuedStatuses = listOf(
+                RequiresAction,
+                Succeeded,
+            ),
+            dispatcher = testDispatcher
+        )
+
+        assertThat(poller.state.value).isNull()
+
+        poller.startPolling(scope = this@runTest)
+        assertThat(poller.state.value).isEqualTo(RequiresAction)
+
+        // Advance partially into the current delay
+        advanceTimeBy(1_000L)
+
+        poller.stopPolling()
+
+        // A random large delay to show that no other status was emitted
+        // while polling is stopped
+        advanceTimeBy(10_000L)
+
+        // The state should be unchanged
+        assertThat(poller.state.value).isEqualTo(RequiresAction)
+    }
+
+    @Test
+    fun `Pausing makes poller not emit any more states until resumed`() = runTest(testDispatcher) {
+        val poller = createIntentStatusPoller(
+            enqueuedStatuses = listOf(
+                RequiresAction,
+                Succeeded
+            ),
+            dispatcher = testDispatcher
+        )
+
+        assertThat(poller.state.value).isNull()
+
+        poller.startPolling(scope = this@runTest)
+        assertThat(poller.state.value).isEqualTo(RequiresAction)
+
+        // Advance partially into the current delay
+        advanceTimeBy(1_000L)
+
+        poller.stopPolling()
+
+        // A random large delay to show that no other status was emitted
+        // while polling is stopped
+        advanceTimeBy(10_000L)
+
+        // The state should be unchanged
+        assertThat(poller.state.value).isEqualTo(RequiresAction)
+
+        poller.startPolling(scope = this@runTest)
+        assertThat(poller.state.value).isEqualTo(Succeeded)
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/polling/PollingTestUtils.kt
+++ b/payments-core/src/test/java/com/stripe/android/polling/PollingTestUtils.kt
@@ -1,0 +1,59 @@
+package com.stripe.android.polling
+
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.networking.AbsFakeStripeRepository
+import kotlinx.coroutines.CoroutineDispatcher
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+internal fun exponentialDelayProvider(): () -> Long {
+    var attempt = 1
+    return {
+        // Add a minor offset so that we run after the delay has finished,
+        // not when it's just about to finish.
+        val offset = if (attempt == 1) 1 else 0
+        calculateDelayInMillis(attempts = attempt++) + offset
+    }
+}
+
+internal fun createIntentStatusPoller(
+    enqueuedStatuses: List<StripeIntent.Status?>,
+    dispatcher: CoroutineDispatcher,
+    maxAttempts: Int = 10,
+): DefaultIntentStatusPoller {
+    return DefaultIntentStatusPoller(
+        stripeRepository = FakeStripeRepository(enqueuedStatuses),
+        paymentConfigProvider = {
+            PaymentConfiguration(
+                publishableKey = "key",
+                stripeAccountId = "account_id",
+            )
+        },
+        config = IntentStatusPoller.Config(
+            clientSecret = "secret",
+            maxAttempts = maxAttempts,
+        ),
+        dispatcher = dispatcher,
+    )
+}
+
+private class FakeStripeRepository(
+    enqueuedStatuses: List<StripeIntent.Status?>
+) : AbsFakeStripeRepository() {
+
+    private val queue = enqueuedStatuses.toMutableList()
+
+    override suspend fun retrievePaymentIntent(
+        clientSecret: String,
+        options: ApiRequest.Options,
+        expandFields: List<String>
+    ): PaymentIntent {
+        val intentStatus = queue.removeFirst()
+        return mock {
+            on { status } doReturn intentStatus
+        }
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds the `IntentStatusPoller` and its implementation `DefaultIntentStatusPoller`, which we will use for the UPI integration into payment sheet.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

UPI in Payment Sheet.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
N/A

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

_Nothing to add._
