### PR TITLE
[BANKCON-5303] Success Pane polish.

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetState.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetState.kt
@@ -4,7 +4,6 @@ import com.airbnb.mvrx.MavericksState
 import com.airbnb.mvrx.PersistState
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityArgs
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityResult
-import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetForDataContract
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 
 /**
@@ -14,7 +13,7 @@ internal data class FinancialConnectionsSheetState(
     val initialArgs: FinancialConnectionsSheetActivityArgs,
     val activityRecreated: Boolean = false,
     @PersistState val manifest: FinancialConnectionsSessionManifest? = null,
-    @PersistState val authFlowActive: Boolean = false,
+    @PersistState val webAuthFlowActive: Boolean = false,
     val viewEffect: FinancialConnectionsSheetViewEffect? = null
 ) : MavericksState {
 
@@ -52,7 +51,7 @@ internal sealed class FinancialConnectionsSheetViewEffect {
     ) : FinancialConnectionsSheetViewEffect()
 
     /**
-     * Finish [FinancialConnectionsSheetActivity] with a given [FinancialConnectionsSheetForDataContract.Result]
+     * Finish [FinancialConnectionsSheetActivity] with the given FinancialConnectionsSheetActivityResult]
      */
     data class FinishWithResult(
         val result: FinancialConnectionsSheetActivityResult

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/FetchFinancialConnectionsSessionForToken.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/FetchFinancialConnectionsSessionForToken.kt
@@ -3,8 +3,6 @@ package com.stripe.android.financialconnections.domain
 import com.stripe.android.financialconnections.model.FinancialConnectionsSession
 import com.stripe.android.financialconnections.repository.FinancialConnectionsRepository
 import com.stripe.android.model.Token
-import com.stripe.android.model.parsers.TokenJsonParser
-import org.json.JSONObject
 import javax.inject.Inject
 
 internal class FetchFinancialConnectionsSessionForToken @Inject constructor(
@@ -20,8 +18,7 @@ internal class FetchFinancialConnectionsSessionForToken @Inject constructor(
      */
     suspend operator fun invoke(clientSecret: String): Pair<FinancialConnectionsSession, Token> {
         val session = connectionsRepository.getFinancialConnectionsSession(clientSecret)
-        val parsedToken =
-            session.bankAccountToken?.let { TokenJsonParser().parse(JSONObject(it)) }
+        val parsedToken = session.parsedToken
         requireNotNull(parsedToken) { "Could not extract Token from FinancialConnectionsSession." }
         return session to parsedToken
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/NativeAuthFlowCoordinator.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.domain
 
+import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityResult
 import kotlinx.coroutines.flow.MutableSharedFlow
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -29,6 +30,8 @@ internal class NativeAuthFlowCoordinator @Inject constructor() {
          * Ensures partner web auth status gets cleared after the current session is finished.
          */
         object ClearPartnerWebAuth : Message
-        object Finish : Message
+        data class Finish(
+            val result: FinancialConnectionsSheetActivityResult
+        ) : Message
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
@@ -111,7 +111,8 @@ private fun AccountPickerContent(
                 // if account selection should be skipped.
                 true -> AccountPickerLoading()
                 false -> AccountPickerLoaded(
-                    loading = state.isLoading,
+                    submitEnabled = state.submitEnabled,
+                    submitLoading = state.submitLoading,
                     accounts = payload().accounts,
                     selectedIds = state.selectedIds,
                     onAccountClicked = onAccountClicked,
@@ -149,7 +150,8 @@ private fun AccountPickerLoading() {
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun AccountPickerLoaded(
-    loading: Boolean,
+    submitEnabled: Boolean,
+    submitLoading: Boolean,
     accounts: List<PartnerAccountUI>,
     accessibleDataCalloutModel: AccessibleDataCalloutModel?,
     selectionMode: SelectionMode,
@@ -194,7 +196,8 @@ private fun AccountPickerLoaded(
         accessibleDataCalloutModel?.let { AccessibleDataCallout(it) }
         Spacer(modifier = Modifier.size(12.dp))
         FinancialConnectionsButton(
-            loading = loading,
+            enabled = submitEnabled,
+            loading = submitLoading,
             onClick = onSelectAccounts,
             modifier = Modifier
                 .fillMaxWidth()

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
@@ -176,8 +176,11 @@ internal data class AccountPickerState(
     val selectedIds: Set<String> = emptySet()
 ) : MavericksState {
 
-    val isLoading: Boolean
+    val submitLoading: Boolean
         get() = payload is Loading || selectAccounts is Loading
+
+    val submitEnabled: Boolean
+        get() = selectedIds.isNotEmpty()
 
     data class Payload(
         val skipAccountSelection: Boolean,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
@@ -147,13 +147,15 @@ private fun LoadedContent(
             )
         }
         Spacer(modifier = Modifier.size(16.dp))
-        FinancialConnectionsSearchRow(
-            query = query,
-            searchMode = searchMode,
-            onQueryChanged = onQueryChanged,
-            onSearchFocused = onSearchFocused,
-            onCancelSearchClick = onCancelSearchClick
-        )
+        if (payload()?.searchDisabled == false) {
+            FinancialConnectionsSearchRow(
+                query = query,
+                searchMode = searchMode,
+                onQueryChanged = onQueryChanged,
+                onSearchFocused = onSearchFocused,
+                onCancelSearchClick = onCancelSearchClick
+            )
+        }
         if (query.isNotEmpty()) {
             SearchInstitutionsList(
                 institutionsProvider = institutionsProvider,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerStates.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerStates.kt
@@ -69,7 +69,8 @@ internal class InstitutionPickerStates :
 
         private fun payload() = InstitutionPickerState.Payload(
             featuredInstitutions = institutionResponse(),
-            allowManualEntry = true
+            allowManualEntry = true,
+            searchDisabled = false
         )
         private fun institutionResponse() = InstitutionResponse(
             listOf(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerViewModel.kt
@@ -49,6 +49,7 @@ internal class InstitutionPickerViewModel @Inject constructor(
                 featuredInstitutions = featuredInstitutions(
                     clientSecret = configuration.financialConnectionsSessionClientSecret
                 ),
+                searchDisabled = manifest.institutionSearchDisabled,
                 allowManualEntry = kotlin
                     .runCatching { manifest.allowManualEntry }
                     .getOrElse { false }
@@ -151,6 +152,7 @@ internal data class InstitutionPickerState(
 ) : MavericksState {
     data class Payload(
         val featuredInstitutions: InstitutionResponse,
-        val allowManualEntry: Boolean
+        val allowManualEntry: Boolean,
+        val searchDisabled: Boolean
     )
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryScreen.kt
@@ -48,9 +48,9 @@ internal fun ManualEntryScreen() {
     val state: State<ManualEntryState> = viewModel.collectAsState()
 
     ManualEntryContent(
-        routing = state.value.routing,
-        account = state.value.account,
-        accountConfirm = state.value.accountConfirm,
+        routing = state.value.routing to state.value.routingError,
+        account = state.value.account to state.value.accountError,
+        accountConfirm = state.value.accountConfirm to state.value.accountConfirmError,
         isValidForm = state.value.isValidForm,
         verifyWithMicrodeposits = state.value.verifyWithMicrodeposits,
         linkPaymentAccountStatus = state.value.linkPaymentAccount,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessScreen.kt
@@ -51,7 +51,7 @@ internal fun ManualEntrySuccessScreen(
     val viewModel: ManualEntrySuccessViewModel = mavericksViewModel()
     BackHandler(true) {}
     val completeAuthSessionAsync = viewModel
-        .collectAsState(ManualEntrySuccessState::completeAuthSession)
+        .collectAsState(ManualEntrySuccessState::completeSession)
     ManualEntrySuccessContent(
         microdepositVerificationMethod = microdepositVerificationMethod,
         last4 = last4,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessViewModel.kt
@@ -28,7 +28,7 @@ internal class ManualEntrySuccessViewModel @Inject constructor(
     }
 
     private fun logErrors() {
-        onAsync(ManualEntrySuccessState::completeAuthSession, onFail = {
+        onAsync(ManualEntrySuccessState::completeSession, onFail = {
             logger.error("Error completing session", it)
         })
     }
@@ -42,7 +42,7 @@ internal class ManualEntrySuccessViewModel @Inject constructor(
                 )
                 nativeAuthFlowCoordinator().emit(Finish(result))
             }
-        }.execute { copy(completeAuthSession = it) }
+        }.execute { copy(completeSession = it) }
     }
 
     companion object :
@@ -64,5 +64,5 @@ internal class ManualEntrySuccessViewModel @Inject constructor(
 }
 
 internal data class ManualEntrySuccessState(
-    val completeAuthSession: Async<FinancialConnectionsSession> = Uninitialized
+    val completeSession: Async<FinancialConnectionsSession> = Uninitialized
 ) : MavericksState

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentrysuccess/ManualEntrySuccessViewModel.kt
@@ -10,6 +10,7 @@ import com.stripe.android.core.Logger
 import com.stripe.android.financialconnections.domain.CompleteFinancialConnectionsSession
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message.Finish
+import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityResult.Completed
 import com.stripe.android.financialconnections.model.FinancialConnectionsSession
 import com.stripe.android.financialconnections.ui.FinancialConnectionsSheetNativeActivity
 import javax.inject.Inject
@@ -35,7 +36,11 @@ internal class ManualEntrySuccessViewModel @Inject constructor(
     fun onSubmit() {
         suspend {
             completeFinancialConnectionsSession().also {
-                nativeAuthFlowCoordinator().emit(Finish)
+                val result = Completed(
+                    financialConnectionsSession = it,
+                    token = it.parsedToken
+                )
+                nativeAuthFlowCoordinator().emit(Finish(result))
             }
         }.execute { copy(completeAuthSession = it) }
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessScreen.kt
@@ -117,9 +117,8 @@ private fun SuccessContent(
             Spacer(modifier = Modifier.weight(1f))
             if (showLinkAnotherAccount) {
                 FinancialConnectionsButton(
-                    loading = loading,
-                    type = FinancialConnectionsButton.Type.Secondary,
                     enabled = loading.not(),
+                    type = FinancialConnectionsButton.Type.Secondary,
                     onClick = onLinkAnotherAccountClick,
                     modifier = Modifier
                         .fillMaxWidth()
@@ -129,7 +128,6 @@ private fun SuccessContent(
             }
             FinancialConnectionsButton(
                 loading = loading,
-                enabled = loading.not(),
                 onClick = onDoneClick,
                 modifier = Modifier
                     .fillMaxWidth()

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessViewModel.kt
@@ -14,6 +14,7 @@ import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message
 import com.stripe.android.financialconnections.features.common.AccessibleDataCalloutModel
 import com.stripe.android.financialconnections.features.consent.FinancialConnectionsUrlResolver
+import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityResult.Completed
 import com.stripe.android.financialconnections.model.FinancialConnectionsSession
 import com.stripe.android.financialconnections.model.PartnerAccountsList
 import com.stripe.android.financialconnections.navigation.NavigationDirections
@@ -61,7 +62,11 @@ internal class SuccessViewModel @Inject constructor(
     fun onDoneClick() {
         suspend {
             completeFinancialConnectionsSession().also {
-                nativeAuthFlowCoordinator().emit(Message.Finish)
+                val result = Completed(
+                    financialConnectionsSession = it,
+                    token = it.parsedToken
+                )
+                nativeAuthFlowCoordinator().emit(Message.Finish(result))
             }
         }.execute { copy(completeSession = it) }
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsSession.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsSession.kt
@@ -5,9 +5,12 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeModel
 import com.stripe.android.financialconnections.model.serializer.JsonAsStringSerializer
 import com.stripe.android.financialconnections.model.serializer.PaymentAccountSerializer
+import com.stripe.android.model.Token
+import com.stripe.android.model.parsers.TokenJsonParser
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import org.json.JSONObject
 
 /**
  *
@@ -51,6 +54,9 @@ data class FinancialConnectionsSession internal constructor(
 
     val accounts: FinancialConnectionsAccountList
         get() = accountsNew ?: accountsOld!!
+
+    internal val parsedToken: Token?
+        get() = bankAccountToken?.let { TokenJsonParser().parse(JSONObject(it)) }
 }
 
 @Serializable(with = PaymentAccountSerializer::class)

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsSessionManifest.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsSessionManifest.kt
@@ -1,3 +1,5 @@
+@file:SuppressWarnings("unused")
+
 package com.stripe.android.financialconnections.model
 
 import android.os.Parcelable
@@ -42,7 +44,6 @@ import kotlinx.serialization.Serializable
  * @param modalCustomization
  * @param paymentMethodType
  * @param successUrl
- * @param theme
  */
 @Suppress("MaxLineLength")
 @Serializable
@@ -146,7 +147,13 @@ internal data class FinancialConnectionsSessionManifest(
     val paymentMethodType: SupportedPaymentMethodTypes? = null,
 
     @SerialName(value = "success_url")
-    val successUrl: String
+    val successUrl: String,
+
+    /**
+     * TODO@carlosmuvi mock manifest field to simulate experiment-based authFlow.
+     */
+    @kotlinx.serialization.Transient
+    val nativeAuthFlowEnabled: Boolean = true
 
 ) : Parcelable {
 
@@ -213,6 +220,7 @@ internal data class FinancialConnectionsSessionManifest(
      * OPAL,PAYMENT_FLOWS,RESERVE_APPEALS,STANDARD_ONBOARDING,STRIPE_CARD,SUPPORT_SITE
      */
     @Serializable
+    @Suppress("unused")
     enum class Product(val value: String) {
         @SerialName(value = "billpay")
         BILLPAY("billpay"),
@@ -332,7 +340,7 @@ internal data class FinancialConnectionsSessionManifest(
     ) : Parcelable {
 
         @Serializable
-        enum class Flow(val value: kotlin.String?) {
+        enum class Flow(val value: String?) {
             @SerialName("direct")
             DIRECT("direct"),
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
@@ -147,7 +147,6 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
                     logger.error("Error completing session before closing", it)
                 }
                 .onSuccess {
-                    FinancialConnectionsSheetActivityResult.Completed()
                     setState { copy(viewEffect = Finish(Canceled)) }
                 }
         }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
@@ -23,12 +23,12 @@ import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator
 import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.Message
 import com.stripe.android.financialconnections.exception.WebAuthFlowCancelledException
 import com.stripe.android.financialconnections.exception.WebAuthFlowFailedException
+import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityResult
+import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityResult.Canceled
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetNativeActivityArgs
 import com.stripe.android.financialconnections.presentation.FinancialConnectionsSheetNativeViewEffect.Finish
 import com.stripe.android.financialconnections.presentation.FinancialConnectionsSheetNativeViewEffect.OpenUrl
 import com.stripe.android.financialconnections.utils.UriComparator
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -55,8 +55,8 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
                         val manifest = getManifest()
                         setState { copy(viewEffect = OpenUrl(manifest.hostedAuthUrl)) }
                     }
-                    Message.Finish -> {
-                        setState { copy(viewEffect = Finish) }
+                    is Message.Finish -> {
+                        setState { copy(viewEffect = Finish(message.result)) }
                     }
                     Message.ClearPartnerWebAuth -> {
                         setState { copy(webAuthFlow = Uninitialized) }
@@ -78,7 +78,7 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
             val receivedUrl: String? = intent?.data?.toString()
             when {
                 receivedUrl == null -> setState {
-                    copy(webAuthFlow = Fail(WebAuthFlowFailedException(receivedUrl)))
+                    copy(webAuthFlow = Fail(WebAuthFlowFailedException(url = null)))
                 }
                 uriComparator.compareSchemeAuthorityAndPath(receivedUrl, SUCCESS_URL) -> setState {
                     copy(webAuthFlow = Success(receivedUrl))
@@ -138,17 +138,19 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
      */
     fun onBackPressed() = close()
 
-    @OptIn(DelicateCoroutinesApi::class)
     private fun close() {
-        // Asynchronously complete the session while activity is closing.
-        // Using [GlobalScope] to prevent the call from cancel while activity finishes.
         logger.debug("User intentionally closed the AuthFlow.")
-        GlobalScope.launch {
+        viewModelScope.launch {
             kotlin
                 .runCatching { completeFinancialConnectionsSession() }
-                .onFailure { logger.error("Error completing session before closing", it) }
+                .onFailure {
+                    logger.error("Error completing session before closing", it)
+                }
+                .onSuccess {
+                    FinancialConnectionsSheetActivityResult.Completed()
+                    setState { copy(viewEffect = Finish(Canceled)) }
+                }
         }
-        setState { copy(viewEffect = Finish) }
     }
 
     companion object :
@@ -208,5 +210,7 @@ internal sealed interface FinancialConnectionsSheetNativeViewEffect {
     /**
      * Finish the container activity.
      */
-    object Finish : FinancialConnectionsSheetNativeViewEffect
+    data class Finish(
+        val result: FinancialConnectionsSheetActivityResult
+    ) : FinancialConnectionsSheetNativeViewEffect
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
@@ -84,8 +84,11 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), Ma
                             uri = Uri.parse(viewEffect.url)
                         )
                     )
-                    Finish -> {
-                        setResult(Activity.RESULT_OK)
+                    is Finish -> {
+                        setResult(
+                            Activity.RESULT_OK,
+                            Intent().putExtra(EXTRA_RESULT, viewEffect.result)
+                        )
                         finish()
                     }
                 }
@@ -183,6 +186,10 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), Ma
                 inclusive = true
             }
         }
+    }
+
+    internal companion object {
+        internal const val EXTRA_RESULT = "result"
     }
 }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/Button.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/Button.kt
@@ -33,7 +33,7 @@ internal fun FinancialConnectionsButton(
     content: @Composable (RowScope.() -> Unit)
 ) {
     Button(
-        onClick =  { if (!loading) onClick() },
+        onClick = { if (!loading) onClick() },
         modifier = modifier,
         enabled = enabled,
         shape = RoundedCornerShape(size = size.radius),

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/Button.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/components/Button.kt
@@ -33,7 +33,7 @@ internal fun FinancialConnectionsButton(
     content: @Composable (RowScope.() -> Unit)
 ) {
     Button(
-        onClick = onClick,
+        onClick =  { if (!loading) onClick() },
         modifier = modifier,
         enabled = enabled,
         shape = RoundedCornerShape(size = size.radius),

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/utils/Intent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/utils/Intent.kt
@@ -1,0 +1,10 @@
+package com.stripe.android.financialconnections.utils
+
+import android.content.Intent
+import android.os.Build.VERSION.SDK_INT
+import android.os.Parcelable
+
+internal inline fun <reified T : Parcelable> Intent.parcelable(key: String): T? = when {
+    SDK_INT >= 33 -> getParcelableExtra(key, T::class.java)
+    else -> @Suppress("DEPRECATION") getParcelableExtra(key) as? T
+}

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/utils/Intent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/utils/Intent.kt
@@ -2,9 +2,10 @@ package com.stripe.android.financialconnections.utils
 
 import android.content.Intent
 import android.os.Build.VERSION.SDK_INT
+import android.os.Build.VERSION_CODES.TIRAMISU
 import android.os.Parcelable
 
 internal inline fun <reified T : Parcelable> Intent.parcelable(key: String): T? = when {
-    SDK_INT >= 33 -> getParcelableExtra(key, T::class.java)
+    SDK_INT >= TIRAMISU -> getParcelableExtra(key, T::class.java)
     else -> @Suppress("DEPRECATION") getParcelableExtra(key) as? T
 }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
@@ -48,7 +48,9 @@ class FinancialConnectionsSheetViewModelTest {
         ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
     )
 
-    private val manifest = sessionManifest()
+    private val manifest = sessionManifest().copy(
+        nativeAuthFlowEnabled = false
+    )
 
     private val fetchFinancialConnectionsSession = mock<FetchFinancialConnectionsSession>()
     private val fetchFinancialConnectionsSessionForToken =
@@ -116,7 +118,7 @@ class FinancialConnectionsSheetViewModelTest {
 
             // Then
             withState(viewModel) {
-                assertThat(it.authFlowActive).isFalse()
+                assertThat(it.webAuthFlowActive).isFalse()
                 val viewEffect = it.viewEffect as FinishWithResult
                 assertThat(viewEffect.result).isEqualTo(
                     Completed(linkedAccountId = linkedAccountId)
@@ -129,7 +131,6 @@ class FinancialConnectionsSheetViewModelTest {
     fun `handleOnNewIntent - on Link flows with invalid account, error is thrown`() {
         runTest {
             // Given
-            val linkedAccountId = "1234"
             whenever(generateFinancialConnectionsSessionManifest(any(), any())).thenReturn(manifest)
             val viewModel = createViewModel(
                 defaultInitialState.copy(initialArgs = ForLink(configuration))
@@ -181,7 +182,7 @@ class FinancialConnectionsSheetViewModelTest {
 
             // Then
             withState(viewModel) {
-                assertThat(it.authFlowActive).isFalse()
+                assertThat(it.webAuthFlowActive).isFalse()
                 assertThat(it.viewEffect).isEqualTo(FinishWithResult(Canceled))
             }
         }
@@ -199,7 +200,7 @@ class FinancialConnectionsSheetViewModelTest {
 
             // Then
             withState(viewModel) {
-                assertThat(it.authFlowActive).isFalse()
+                assertThat(it.webAuthFlowActive).isFalse()
                 val viewEffect = it.viewEffect as FinishWithResult
                 assertThat(viewEffect.result).isInstanceOf(Failed::class.java)
             }
@@ -221,7 +222,7 @@ class FinancialConnectionsSheetViewModelTest {
 
             // Then
             withState(viewModel) {
-                assertThat(it.authFlowActive).isFalse()
+                assertThat(it.webAuthFlowActive).isFalse()
                 val viewEffect = it.viewEffect as FinishWithResult
                 assertThat(viewEffect.result).isEqualTo(
                     Completed(financialConnectionsSession = expectedSession)
@@ -244,7 +245,7 @@ class FinancialConnectionsSheetViewModelTest {
 
             // Then
             withState(viewModel) {
-                assertThat(it.authFlowActive).isFalse()
+                assertThat(it.webAuthFlowActive).isFalse()
                 val viewEffect = it.viewEffect as FinishWithResult
                 assertThat(viewEffect.result).isEqualTo(Failed(apiException))
             }
@@ -264,7 +265,7 @@ class FinancialConnectionsSheetViewModelTest {
             // Then
             // Then
             withState(viewModel) {
-                assertThat(it.authFlowActive).isFalse()
+                assertThat(it.webAuthFlowActive).isFalse()
                 val viewEffect = it.viewEffect as FinishWithResult
                 assertThat(viewEffect.result).isEqualTo(Failed(APIException()))
             }
@@ -283,7 +284,7 @@ class FinancialConnectionsSheetViewModelTest {
 
             // Then
             withState(viewModel) {
-                assertThat(it.authFlowActive).isTrue()
+                assertThat(it.webAuthFlowActive).isTrue()
                 val viewEffect = it.viewEffect as FinishWithResult
                 assertThat(viewEffect.result).isEqualTo(Canceled)
             }
@@ -297,7 +298,7 @@ class FinancialConnectionsSheetViewModelTest {
             val viewModel = createViewModel(
                 defaultInitialState.copy(
                     manifest = manifest,
-                    authFlowActive = true
+                    webAuthFlowActive = true
                 )
             )
 
@@ -309,7 +310,7 @@ class FinancialConnectionsSheetViewModelTest {
 
             // Then
             withState(viewModel) {
-                assertThat(it.authFlowActive).isTrue()
+                assertThat(it.webAuthFlowActive).isTrue()
                 val viewEffect = it.viewEffect as FinishWithResult
                 assertThat(viewEffect.result).isEqualTo(Canceled)
             }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/presentation/InstitutionPickerViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/presentation/InstitutionPickerViewModelTest.kt
@@ -13,8 +13,10 @@ import com.stripe.android.financialconnections.domain.UpdateLocalManifest
 import com.stripe.android.financialconnections.features.institutionpicker.InstitutionPickerState
 import com.stripe.android.financialconnections.features.institutionpicker.InstitutionPickerViewModel
 import com.stripe.android.financialconnections.model.FinancialConnectionsInstitution
+import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.model.InstitutionResponse
 import com.stripe.android.financialconnections.navigation.NavigationManager
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -24,6 +26,7 @@ import org.mockito.kotlin.whenever
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
+@ExperimentalCoroutinesApi
 internal class InstitutionPickerViewModelTest {
 
     @get:Rule
@@ -66,6 +69,8 @@ internal class InstitutionPickerViewModelTest {
                 )
             )
         )
+
+        givenManifestReturns(ApiKeyFixtures.sessionManifest())
         givenFeaturedInstitutionsReturns(institutionResponse)
 
         val viewModel = buildViewModel(InstitutionPickerState())
@@ -103,6 +108,8 @@ internal class InstitutionPickerViewModelTest {
                 )
             )
         )
+
+        givenManifestReturns(ApiKeyFixtures.sessionManifest())
         givenFeaturedInstitutionsReturns(featuredResults)
         givenSearchInstitutionsReturns(query, searchResults)
 
@@ -114,6 +121,10 @@ internal class InstitutionPickerViewModelTest {
             assertEquals(state.payload()!!.featuredInstitutions.data, featuredResults.data)
             assertEquals(state.searchInstitutions()!!.data, searchResults.data)
         }
+    }
+
+    private suspend fun givenManifestReturns(manifest: FinancialConnectionsSessionManifest) {
+        whenever(getManifest()).thenReturn(manifest)
     }
 
     private suspend fun givenSearchInstitutionsReturns(


### PR DESCRIPTION
# Summary
- 5191419ac Disables search bar based on manifest.
- 4ae6408e1 Show loading without disabled style button on success.
- 256218616 Disable button when no accounts selected.
- 71824e6ac Manual entry: validate fields asynchronously to avoid delays.
- 12fb9e23d Uses session complete response as result instead of fetching it afterwards for native.
