### PR TITLE
Validate Card is accepted

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/StripeIntentValidator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/StripeIntentValidator.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.model
 
 import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import javax.inject.Inject
@@ -46,6 +47,14 @@ internal class StripeIntentValidator @Inject constructor() {
                     """
                         PaymentSheet cannot set up a SetupIntent in status '${stripeIntent.status}'.
                         See https://stripe.com/docs/api/setup_intents/object#setup_intent_object-status
+                    """.trimIndent()
+                )
+            }
+            !stripeIntent.paymentMethodTypes.contains(PaymentMethod.Type.Card.code) -> {
+                error(
+                    """
+                        Payment method type 'card' is required.
+                        Accepted payment methods: (${stripeIntent.paymentMethodTypes})."
                     """.trimIndent()
                 )
             }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/StripeIntentValidatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/StripeIntentValidatorTest.kt
@@ -34,6 +34,17 @@ class StripeIntentValidatorTest {
     }
 
     @Test
+    fun `requireValid() requires card is accepted`() {
+        assertFails {
+            validator.requireValid(
+                PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                    paymentMethodTypes = listOf("link", "us_bank_account")
+                )
+            )
+        }
+    }
+
+    @Test
     fun `requireValid() Succeeded is not valid`() {
         assertFails {
             validator.requireValid(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Validate that Card is accepted in the Payment / Setup Intent, and fail early with a proper error message.
Payment Sheet expects that Card is accepted, and might crash in some points of the payment flow if it's not.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Better error handling

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified