### PR TITLE
Fix issue with authenticators launching activity in background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [FIXED][5701](https://github.com/stripe/stripe-android/pull/5701) Treat blank fields as invalid in `ShippingInfoWidget`.
 * [FIXED][5715](https://github.com/stripe/stripe-android/pull/5715) Postal codes for countries other than US and Canada are no longer limited to a single character.
+* [FIXED][5667](https://github.com/stripe/stripe-android/pull/5667) Completed payments are no longer incorrectly reported as having failed if the app is backgrounded during confirmation on Android 10 and 11.
 
 ## 20.15.0 - 2022-10-11
 

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -6830,11 +6830,6 @@ public final class com/stripe/android/payments/core/authentication/OxxoAuthentic
 	public static fun newInstance (Lcom/stripe/android/payments/core/authentication/WebIntentAuthenticator;Lcom/stripe/android/payments/core/authentication/NoOpIntentAuthenticator;)Lcom/stripe/android/payments/core/authentication/OxxoAuthenticator;
 }
 
-public final class com/stripe/android/payments/core/authentication/PaymentAuthenticator$DefaultImpls {
-	public static fun onLauncherInvalidated (Lcom/stripe/android/payments/core/authentication/PaymentAuthenticator;)V
-	public static fun onNewActivityResultCaller (Lcom/stripe/android/payments/core/authentication/PaymentAuthenticator;Landroidx/activity/result/ActivityResultCaller;Landroidx/activity/result/ActivityResultCallback;)V
-}
-
 public final class com/stripe/android/payments/core/authentication/PaymentAuthenticatorRegistry$DefaultImpls {
 	public static fun onLauncherInvalidated (Lcom/stripe/android/payments/core/authentication/PaymentAuthenticatorRegistry;)V
 	public static fun onNewActivityResultCaller (Lcom/stripe/android/payments/core/authentication/PaymentAuthenticatorRegistry;Landroidx/activity/result/ActivityResultCaller;Landroidx/activity/result/ActivityResultCallback;)V

--- a/payments-core/build.gradle
+++ b/payments-core/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     testImplementation "com.google.truth:truth:$truthVersion"
     testImplementation "androidx.arch.core:core-testing:$androidxArchCoreVersion"
     testImplementation "androidx.fragment:fragment-testing:$androidxFragmentVersion"
+    testImplementation "androidx.lifecycle:lifecycle-runtime-testing:$androidxLifecycleVersion"
     testImplementation testLibs.turbine
 
     androidTestImplementation "androidx.test.espresso:espresso-core:$espressoVersion"

--- a/payments-core/src/main/java/com/stripe/android/PaymentBrowserAuthStarter.kt
+++ b/payments-core/src/main/java/com/stripe/android/PaymentBrowserAuthStarter.kt
@@ -23,14 +23,13 @@ internal interface PaymentBrowserAuthStarter :
                 .copy(statusBarColor = host.statusBarColor)
                 .toBundle()
 
-            host.startActivityForResult(
-                when (args.hasDefaultReturnUrl(defaultReturnUrl) || args.isInstantApp) {
-                    true -> StripeBrowserLauncherActivity::class.java
-                    false -> PaymentAuthWebViewActivity::class.java
-                },
-                extras,
-                args.requestCode
-            )
+            val destination = if (args.hasDefaultReturnUrl(defaultReturnUrl) || args.isInstantApp) {
+                StripeBrowserLauncherActivity::class.java
+            } else {
+                PaymentAuthWebViewActivity::class.java
+            }
+
+            host.startActivityForResult(destination, extras, args.requestCode)
         }
     }
 

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticator.kt
@@ -4,7 +4,6 @@ import com.stripe.android.PaymentRelayStarter
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.view.AuthActivityStarterHost
-import com.stripe.android.view.runWhenResumed
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -15,19 +14,17 @@ import javax.inject.Singleton
 @JvmSuppressWildcards
 internal class NoOpIntentAuthenticator @Inject constructor(
     private val paymentRelayStarterFactory: (AuthActivityStarterHost) -> PaymentRelayStarter
-) : PaymentAuthenticator<StripeIntent> {
+) : PaymentAuthenticator<StripeIntent>() {
 
-    override suspend fun authenticate(
+    override suspend fun performAuthentication(
         host: AuthActivityStarterHost,
         authenticatable: StripeIntent,
         requestOptions: ApiRequest.Options
     ) {
-        host.runWhenResumed {
-            val args = PaymentRelayStarter.Args.create(
-                stripeIntent = authenticatable,
-                stripeAccountId = requestOptions.stripeAccount,
-            )
-            paymentRelayStarterFactory(host).start(args)
-        }
+        val args = PaymentRelayStarter.Args.create(
+            stripeIntent = authenticatable,
+            stripeAccountId = requestOptions.stripeAccount,
+        )
+        paymentRelayStarterFactory(host).start(args)
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticator.kt
@@ -1,9 +1,11 @@
 package com.stripe.android.payments.core.authentication
 
+import android.util.Log
 import com.stripe.android.PaymentRelayStarter
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.view.AuthActivityStarterHost
+import com.stripe.android.view.runWhenResumed
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -21,12 +23,15 @@ internal class NoOpIntentAuthenticator @Inject constructor(
         authenticatable: StripeIntent,
         requestOptions: ApiRequest.Options
     ) {
-        paymentRelayStarterFactory(host)
-            .start(
-                PaymentRelayStarter.Args.create(
-                    authenticatable,
-                    requestOptions.stripeAccount
-                )
+        Log.d("RelayBug", "Running NoOpIntentAuthenticator.authenticate")
+
+        host.runWhenResumed {
+            Log.d("RelayBug", "Lifecycle resumed, so launching RelayActivity")
+            val args = PaymentRelayStarter.Args.create(
+                stripeIntent = authenticatable,
+                stripeAccountId = requestOptions.stripeAccount,
             )
+            paymentRelayStarterFactory(host).start(args)
+        }
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticator.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.payments.core.authentication
 
-import android.util.Log
 import com.stripe.android.PaymentRelayStarter
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.StripeIntent
@@ -23,10 +22,7 @@ internal class NoOpIntentAuthenticator @Inject constructor(
         authenticatable: StripeIntent,
         requestOptions: ApiRequest.Options
     ) {
-        Log.d("RelayBug", "Running NoOpIntentAuthenticator.authenticate")
-
         host.runWhenResumed {
-            Log.d("RelayBug", "Lifecycle resumed, so launching RelayActivity")
             val args = PaymentRelayStarter.Args.create(
                 stripeIntent = authenticatable,
                 stripeAccountId = requestOptions.stripeAccount,

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/OxxoAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/OxxoAuthenticator.kt
@@ -16,8 +16,8 @@ import javax.inject.Singleton
 internal class OxxoAuthenticator @Inject constructor(
     private val webIntentAuthenticator: WebIntentAuthenticator,
     private val noOpIntentAuthenticator: NoOpIntentAuthenticator
-) : PaymentAuthenticator<StripeIntent> {
-    override suspend fun authenticate(
+) : PaymentAuthenticator<StripeIntent>() {
+    override suspend fun performAuthentication(
         host: AuthActivityStarterHost,
         authenticatable: StripeIntent,
         requestOptions: ApiRequest.Options

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/PaymentAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/PaymentAuthenticator.kt
@@ -2,7 +2,6 @@ package com.stripe.android.payments.core.authentication
 
 import android.app.Activity
 import androidx.annotation.RestrictTo
-import androidx.annotation.VisibleForTesting
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.whenResumed
@@ -39,8 +38,7 @@ abstract class PaymentAuthenticator<Authenticatable> : ActivityResultLauncherHos
         }
     }
 
-    @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
-    abstract suspend fun performAuthentication(
+    protected abstract suspend fun performAuthentication(
         host: AuthActivityStarterHost,
         authenticatable: Authenticatable,
         requestOptions: ApiRequest.Options

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/PaymentAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/PaymentAuthenticator.kt
@@ -3,17 +3,20 @@ package com.stripe.android.payments.core.authentication
 import android.app.Activity
 import androidx.annotation.RestrictTo
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.whenResumed
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.Source
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.core.ActivityResultLauncherHost
 import com.stripe.android.view.AuthActivityStarterHost
+import kotlinx.coroutines.launch
 
 /**
  * A class to authenticate a [StripeIntent] or [Source].
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-interface PaymentAuthenticator<Authenticatable> : ActivityResultLauncherHost {
+abstract class PaymentAuthenticator<Authenticatable> : ActivityResultLauncherHost {
 
     /**
      * Authenticates a [StripeIntent] or [Source].
@@ -23,6 +26,19 @@ interface PaymentAuthenticator<Authenticatable> : ActivityResultLauncherHost {
      * @param requestOptions configurations for the API request which triggers the authentication
      */
     suspend fun authenticate(
+        host: AuthActivityStarterHost,
+        authenticatable: Authenticatable,
+        requestOptions: ApiRequest.Options
+    ) {
+        val lifecycleOwner = host.lifecycleOwner
+        lifecycleOwner.lifecycleScope.launch {
+            lifecycleOwner.whenResumed {
+                performAuthentication(host, authenticatable, requestOptions)
+            }
+        }
+    }
+
+    protected abstract suspend fun performAuthentication(
         host: AuthActivityStarterHost,
         authenticatable: Authenticatable,
         requestOptions: ApiRequest.Options

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/PaymentAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/PaymentAuthenticator.kt
@@ -2,6 +2,7 @@ package com.stripe.android.payments.core.authentication
 
 import android.app.Activity
 import androidx.annotation.RestrictTo
+import androidx.annotation.VisibleForTesting
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.whenResumed
@@ -38,7 +39,8 @@ abstract class PaymentAuthenticator<Authenticatable> : ActivityResultLauncherHos
         }
     }
 
-    protected abstract suspend fun performAuthentication(
+    @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
+    abstract suspend fun performAuthentication(
         host: AuthActivityStarterHost,
         authenticatable: Authenticatable,
         requestOptions: ApiRequest.Options

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/SourceAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/SourceAuthenticator.kt
@@ -14,7 +14,6 @@ import com.stripe.android.networking.PaymentAnalyticsEvent
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.payments.core.injection.IS_INSTANT_APP
 import com.stripe.android.view.AuthActivityStarterHost
-import com.stripe.android.view.runWhenResumed
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Named
@@ -35,23 +34,21 @@ internal class SourceAuthenticator @Inject constructor(
     @UIContext private val uiContext: CoroutineContext,
     @Named(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String,
     @Named(IS_INSTANT_APP) private val isInstantApp: Boolean
-) : PaymentAuthenticator<Source> {
+) : PaymentAuthenticator<Source>() {
 
-    override suspend fun authenticate(
+    override suspend fun performAuthentication(
         host: AuthActivityStarterHost,
         authenticatable: Source,
         requestOptions: ApiRequest.Options
     ) {
-        host.runWhenResumed {
-            if (authenticatable.flow == Source.Flow.Redirect) {
-                startSourceAuth(
-                    paymentBrowserAuthStarterFactory(host),
-                    authenticatable,
-                    requestOptions
-                )
-            } else {
-                bypassAuth(host, authenticatable, requestOptions.stripeAccount)
-            }
+        if (authenticatable.flow == Source.Flow.Redirect) {
+            startSourceAuth(
+                paymentBrowserAuthStarterFactory(host),
+                authenticatable,
+                requestOptions
+            )
+        } else {
+            bypassAuth(host, authenticatable, requestOptions.stripeAccount)
         }
     }
 

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/UnsupportedAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/UnsupportedAuthenticator.kt
@@ -7,7 +7,6 @@ import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.getRequestCode
 import com.stripe.android.view.AuthActivityStarterHost
-import com.stripe.android.view.runWhenResumed
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -19,8 +18,8 @@ import javax.inject.Singleton
 @JvmSuppressWildcards
 internal class UnsupportedAuthenticator @Inject constructor(
     private val paymentRelayStarterFactory: (AuthActivityStarterHost) -> PaymentRelayStarter
-) : PaymentAuthenticator<StripeIntent> {
-    override suspend fun authenticate(
+) : PaymentAuthenticator<StripeIntent>() {
+    override suspend fun performAuthentication(
         host: AuthActivityStarterHost,
         authenticatable: StripeIntent,
         requestOptions: ApiRequest.Options
@@ -39,15 +38,13 @@ internal class UnsupportedAuthenticator @Inject constructor(
             )
         }
 
-        host.runWhenResumed {
-            paymentRelayStarterFactory(host)
-                .start(
-                    PaymentRelayStarter.Args.ErrorArgs(
-                        exception = exception,
-                        requestCode = authenticatable.getRequestCode()
-                    )
+        paymentRelayStarterFactory(host)
+            .start(
+                PaymentRelayStarter.Args.ErrorArgs(
+                    exception = exception,
+                    requestCode = authenticatable.getRequestCode()
                 )
-        }
+            )
     }
 
     internal companion object {

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/UnsupportedAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/UnsupportedAuthenticator.kt
@@ -7,6 +7,7 @@ import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.getRequestCode
 import com.stripe.android.view.AuthActivityStarterHost
+import com.stripe.android.view.runWhenResumed
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -38,13 +39,15 @@ internal class UnsupportedAuthenticator @Inject constructor(
             )
         }
 
-        paymentRelayStarterFactory(host)
-            .start(
-                PaymentRelayStarter.Args.ErrorArgs(
-                    exception = exception,
-                    requestCode = authenticatable.getRequestCode()
+        host.runWhenResumed {
+            paymentRelayStarterFactory(host)
+                .start(
+                    PaymentRelayStarter.Args.ErrorArgs(
+                        exception = exception,
+                        requestCode = authenticatable.getRequestCode()
+                    )
                 )
-            )
+        }
     }
 
     internal companion object {

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticator.kt
@@ -13,7 +13,6 @@ import com.stripe.android.networking.PaymentAnalyticsEvent
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.payments.core.injection.IS_INSTANT_APP
 import com.stripe.android.view.AuthActivityStarterHost
-import com.stripe.android.view.runWhenResumed
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Named
@@ -34,9 +33,9 @@ internal class WebIntentAuthenticator @Inject constructor(
     private val threeDs1IntentReturnUrlMap: MutableMap<String, String>,
     @Named(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String,
     @Named(IS_INSTANT_APP) private val isInstantApp: Boolean
-) : PaymentAuthenticator<StripeIntent> {
+) : PaymentAuthenticator<StripeIntent>() {
 
-    override suspend fun authenticate(
+    override suspend fun performAuthentication(
         host: AuthActivityStarterHost,
         authenticatable: StripeIntent,
         requestOptions: ApiRequest.Options
@@ -87,19 +86,17 @@ internal class WebIntentAuthenticator @Inject constructor(
                 throw IllegalArgumentException("WebAuthenticator can't process nextActionData: $nextActionData")
         }
 
-        host.runWhenResumed {
-            beginWebAuth(
-                host,
-                authenticatable,
-                StripePaymentController.getRequestCode(authenticatable),
-                authenticatable.clientSecret.orEmpty(),
-                authUrl,
-                requestOptions.stripeAccount,
-                returnUrl = returnUrl,
-                shouldCancelSource = shouldCancelSource,
-                shouldCancelIntentOnUserNavigation = shouldCancelIntentOnUserNavigation
-            )
-        }
+        beginWebAuth(
+            host,
+            authenticatable,
+            StripePaymentController.getRequestCode(authenticatable),
+            authenticatable.clientSecret.orEmpty(),
+            authUrl,
+            requestOptions.stripeAccount,
+            returnUrl = returnUrl,
+            shouldCancelSource = shouldCancelSource,
+            shouldCancelIntentOnUserNavigation = shouldCancelIntentOnUserNavigation
+        )
     }
 
     private suspend fun beginWebAuth(

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticator.kt
@@ -13,6 +13,7 @@ import com.stripe.android.networking.PaymentAnalyticsEvent
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.payments.core.injection.IS_INSTANT_APP
 import com.stripe.android.view.AuthActivityStarterHost
+import com.stripe.android.view.runWhenResumed
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Named
@@ -86,17 +87,19 @@ internal class WebIntentAuthenticator @Inject constructor(
                 throw IllegalArgumentException("WebAuthenticator can't process nextActionData: $nextActionData")
         }
 
-        beginWebAuth(
-            host,
-            authenticatable,
-            StripePaymentController.getRequestCode(authenticatable),
-            authenticatable.clientSecret.orEmpty(),
-            authUrl,
-            requestOptions.stripeAccount,
-            returnUrl = returnUrl,
-            shouldCancelSource = shouldCancelSource,
-            shouldCancelIntentOnUserNavigation = shouldCancelIntentOnUserNavigation
-        )
+        host.runWhenResumed {
+            beginWebAuth(
+                host,
+                authenticatable,
+                StripePaymentController.getRequestCode(authenticatable),
+                authenticatable.clientSecret.orEmpty(),
+                authUrl,
+                requestOptions.stripeAccount,
+                returnUrl = returnUrl,
+                shouldCancelSource = shouldCancelSource,
+                shouldCancelIntentOnUserNavigation = shouldCancelIntentOnUserNavigation
+            )
+        }
     }
 
     private suspend fun beginWebAuth(

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3DS2Authenticator.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3DS2Authenticator.kt
@@ -29,7 +29,7 @@ internal class Stripe3DS2Authenticator @Inject constructor(
     @InjectorKey private val injectorKey: String,
     @Named(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String,
     @Named(PRODUCT_USAGE) private val productUsage: Set<String>
-) : PaymentAuthenticator<StripeIntent> {
+) : PaymentAuthenticator<StripeIntent>() {
 
     /**
      * [stripe3ds2CompletionLauncher] is mutable and might be updated during
@@ -60,7 +60,7 @@ internal class Stripe3DS2Authenticator @Inject constructor(
         stripe3ds2CompletionLauncher = null
     }
 
-    override suspend fun authenticate(
+    override suspend fun performAuthentication(
         host: AuthActivityStarterHost,
         authenticatable: StripeIntent,
         requestOptions: ApiRequest.Options

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.payments.paymentlauncher
 
 import android.app.Application
+import android.util.Log
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.VisibleForTesting
@@ -36,6 +37,7 @@ import com.stripe.android.payments.core.injection.IS_PAYMENT_INTENT
 import com.stripe.android.payments.core.injection.PaymentLauncherViewModelSubcomponent
 import com.stripe.android.view.AuthActivityStarterHost
 import dagger.Lazy
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -117,6 +119,9 @@ internal class PaymentLauncherViewModel @Inject constructor(
                             }
                         }
                     }
+                    Log.d("RelayBug", "Confirmed Stripe Intent. Will launch authenticator soon…")
+                    delay(2_000L)
+                    Log.d("RelayBug", "Launching authenticator now")
                     authenticatorRegistry.getAuthenticator(intent).authenticate(
                         host,
                         intent,

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.payments.paymentlauncher
 
 import android.app.Application
-import android.util.Log
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.VisibleForTesting
@@ -37,7 +36,6 @@ import com.stripe.android.payments.core.injection.IS_PAYMENT_INTENT
 import com.stripe.android.payments.core.injection.PaymentLauncherViewModelSubcomponent
 import com.stripe.android.view.AuthActivityStarterHost
 import dagger.Lazy
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -119,9 +117,6 @@ internal class PaymentLauncherViewModel @Inject constructor(
                             }
                         }
                     }
-                    Log.d("RelayBug", "Confirmed Stripe Intent. Will launch authenticator soon…")
-                    delay(2_000L)
-                    Log.d("RelayBug", "Launching authenticator now")
                     authenticatorRegistry.getAuthenticator(intent).authenticate(
                         host,
                         intent,

--- a/payments-core/src/main/java/com/stripe/android/view/AuthActivityStarterHost.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/AuthActivityStarterHost.kt
@@ -90,8 +90,8 @@ sealed class AuthActivityStarterHost {
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun AuthActivityStarterHost.runWhenResumed(block: suspend CoroutineScope.() -> Unit) {
     val lifecycleOwner = when (this) {
-        is AuthActivityStarterHost.ActivityHost -> activity
-        is AuthActivityStarterHost.FragmentHost -> fragment.viewLifecycleOwner
+        is ActivityHost -> activity
+        is FragmentHost -> fragment.viewLifecycleOwner
     }
 
     Log.d("RelayBug", "Current lifecycle state of host: ${lifecycleOwner.lifecycle.currentState}")

--- a/payments-core/src/main/java/com/stripe/android/view/AuthActivityStarterHost.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/AuthActivityStarterHost.kt
@@ -2,7 +2,6 @@ package com.stripe.android.view
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.annotation.RestrictTo
 import androidx.fragment.app.Fragment
@@ -91,10 +90,8 @@ sealed class AuthActivityStarterHost {
 fun AuthActivityStarterHost.runWhenResumed(block: suspend CoroutineScope.() -> Unit) {
     val lifecycleOwner = when (this) {
         is ActivityHost -> activity
-        is FragmentHost -> fragment.viewLifecycleOwner
+        is FragmentHost -> fragment.requireActivity()
     }
-
-    Log.d("RelayBug", "Current lifecycle state of host: ${lifecycleOwner.lifecycle.currentState}")
 
     lifecycleOwner.lifecycleScope.launch {
         lifecycleOwner.whenResumed(block)

--- a/payments-core/src/main/java/com/stripe/android/view/AuthActivityStarterHost.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/AuthActivityStarterHost.kt
@@ -49,7 +49,7 @@ sealed class AuthActivityStarterHost {
         override val statusBarColor: Int?
     ) : AuthActivityStarterHost() {
 
-        override val lifecycleOwner: LifecycleOwner = fragment.requireActivity()
+        override val lifecycleOwner: LifecycleOwner = fragment
 
         @Suppress("DEPRECATION")
         override fun startActivityForResult(

--- a/payments-core/src/main/java/com/stripe/android/view/AuthActivityStarterHost.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/AuthActivityStarterHost.kt
@@ -2,9 +2,16 @@ package com.stripe.android.view
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.annotation.RestrictTo
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.whenResumed
+import com.stripe.android.view.AuthActivityStarterHost.ActivityHost
+import com.stripe.android.view.AuthActivityStarterHost.FragmentHost
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 /**
  * A representation of an Android component (i.e. [ComponentActivity] or [Fragment]) that can start
@@ -77,5 +84,19 @@ sealed class AuthActivityStarterHost {
                 statusBarColor = activity.window?.statusBarColor
             )
         }
+    }
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun AuthActivityStarterHost.runWhenResumed(block: suspend CoroutineScope.() -> Unit) {
+    val lifecycleOwner = when (this) {
+        is AuthActivityStarterHost.ActivityHost -> activity
+        is AuthActivityStarterHost.FragmentHost -> fragment.viewLifecycleOwner
+    }
+
+    Log.d("RelayBug", "Current lifecycle state of host: ${lifecycleOwner.lifecycle.currentState}")
+
+    lifecycleOwner.lifecycleScope.launch {
+        lifecycleOwner.whenResumed(block)
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/view/AuthActivityStarterHost.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/AuthActivityStarterHost.kt
@@ -6,12 +6,8 @@ import androidx.activity.ComponentActivity
 import androidx.annotation.RestrictTo
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.whenResumed
 import com.stripe.android.view.AuthActivityStarterHost.ActivityHost
 import com.stripe.android.view.AuthActivityStarterHost.FragmentHost
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 
 /**
  * A representation of an Android component (i.e. [ComponentActivity] or [Fragment]) that can start

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/GenericAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/GenericAuthenticatorTest.kt
@@ -1,0 +1,72 @@
+package com.stripe.android.payments.core.authentication
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.testing.TestLifecycleOwner
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.view.AuthActivityStarterHost
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class GenericAuthenticatorTest {
+
+    private val lifecycleOwner = TestLifecycleOwner()
+
+    private val host = mock<AuthActivityStarterHost> {
+        on { lifecycleOwner } doReturn lifecycleOwner
+    }
+
+    @Test
+    fun `Only starts authentication flow once lifecycle changes to resumed`() = runTest {
+        val authenticator = TestAuthenticator()
+        lifecycleOwner.currentState = Lifecycle.State.CREATED
+
+        authenticator.authenticate(
+            host = host,
+            authenticatable = mock(),
+            requestOptions = mock(),
+        )
+
+        assertThat(authenticator.wasInvoked).isFalse()
+
+        lifecycleOwner.currentState = Lifecycle.State.RESUMED
+
+        assertThat(authenticator.wasInvoked).isTrue()
+    }
+
+    @Test
+    fun `Immediately starts authentication flow if lifecycle already resumed`() = runTest {
+        val authenticator = TestAuthenticator()
+        lifecycleOwner.currentState = Lifecycle.State.RESUMED
+
+        authenticator.authenticate(
+            host = host,
+            authenticatable = mock(),
+            requestOptions = mock(),
+        )
+
+        assertThat(authenticator.wasInvoked).isTrue()
+    }
+}
+
+private class TestAuthenticator : PaymentAuthenticator<StripeIntent>() {
+
+    var wasInvoked: Boolean = false
+        private set
+
+    override suspend fun performAuthentication(
+        host: AuthActivityStarterHost,
+        authenticatable: StripeIntent,
+        requestOptions: ApiRequest.Options
+    ) {
+        wasInvoked = true
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticatorTest.kt
@@ -16,7 +16,6 @@ import com.stripe.android.view.AuthActivityStarterHost
 import com.stripe.android.view.PaymentRelayActivity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.KArgumentCaptor
@@ -55,7 +54,7 @@ class NoOpIntentAuthenticatorTest {
             )
         )
 
-        authenticator.authenticate(
+        authenticator.performAuthentication(
             host,
             PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR,
             REQUEST_OPTIONS
@@ -79,7 +78,7 @@ class NoOpIntentAuthenticatorTest {
                 host
             )
         )
-        authenticator.authenticate(
+        authenticator.performAuthentication(
             host,
             PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR,
             REQUEST_OPTIONS

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticatorTest.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.payments.core.authentication
 
 import android.os.Bundle
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.testing.TestLifecycleOwner
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.FakeActivityResultLauncher
@@ -19,6 +21,7 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -27,7 +30,9 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 @ExperimentalCoroutinesApi
 class NoOpIntentAuthenticatorTest {
-    private val host = mock<AuthActivityStarterHost>()
+    private val host = mock<AuthActivityStarterHost> {
+        on { lifecycleOwner } doReturn TestLifecycleOwner(initialState = Lifecycle.State.RESUMED)
+    }
 
     private val paymentRelayStarterFactory =
         mock<(AuthActivityStarterHost) -> PaymentRelayStarter>()
@@ -46,7 +51,7 @@ class NoOpIntentAuthenticatorTest {
             )
         )
 
-        authenticator.performAuthentication(
+        authenticator.authenticate(
             host,
             PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR,
             REQUEST_OPTIONS
@@ -70,7 +75,7 @@ class NoOpIntentAuthenticatorTest {
                 host
             )
         )
-        authenticator.performAuthentication(
+        authenticator.authenticate(
             host,
             PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR,
             REQUEST_OPTIONS

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticatorTest.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.payments.core.authentication
 
 import android.os.Bundle
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.testing.TestLifecycleOwner
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.FakeActivityResultLauncher
@@ -14,11 +16,13 @@ import com.stripe.android.view.AuthActivityStarterHost
 import com.stripe.android.view.PaymentRelayActivity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -27,7 +31,12 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 @ExperimentalCoroutinesApi
 class NoOpIntentAuthenticatorTest {
-    private val host = mock<AuthActivityStarterHost>()
+
+    private val lifecycleOwner = TestLifecycleOwner(initialState = Lifecycle.State.RESUMED)
+
+    private val host = mock<AuthActivityStarterHost> {
+        on { lifecycleOwner } doReturn lifecycleOwner
+    }
 
     private val paymentRelayStarterFactory =
         mock<(AuthActivityStarterHost) -> PaymentRelayStarter>()
@@ -37,64 +46,63 @@ class NoOpIntentAuthenticatorTest {
     )
 
     @Test
-    fun verifyModernPaymentRelayStarter() =
-        runTest {
-            val launcher = FakeActivityResultLauncher(PaymentRelayContract())
+    fun verifyModernPaymentRelayStarter() = runTest {
+        val launcher = FakeActivityResultLauncher(PaymentRelayContract())
 
-            whenever(paymentRelayStarterFactory(any())).thenReturn(
-                PaymentRelayStarter.Modern(
-                    launcher
+        whenever(paymentRelayStarterFactory(any())).thenReturn(
+            PaymentRelayStarter.Modern(
+                launcher
+            )
+        )
+
+        authenticator.authenticate(
+            host,
+            PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR,
+            REQUEST_OPTIONS
+        )
+
+        assertThat(launcher.launchArgs)
+            .containsExactly(
+                PaymentRelayStarter.Args.PaymentIntentArgs(
+                    PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR
                 )
             )
-            authenticator.authenticate(
-                host,
-                PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR,
-                REQUEST_OPTIONS
-            )
-
-            assertThat(launcher.launchArgs)
-                .containsExactly(
-                    PaymentRelayStarter.Args.PaymentIntentArgs(
-                        PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR
-                    )
-                )
-        }
+    }
 
     @Test
-    fun verifyLegacyPaymentRelayStarter() =
-        runTest {
-            val classArgumentCaptor: KArgumentCaptor<Class<*>> = argumentCaptor()
-            val bundleArgumentCaptor: KArgumentCaptor<Bundle> = argumentCaptor()
-            val requestCodeArgumentCaptor: KArgumentCaptor<Int> = argumentCaptor()
-            whenever(paymentRelayStarterFactory(any())).thenReturn(
-                PaymentRelayStarter.Legacy(
-                    host
-                )
+    fun verifyLegacyPaymentRelayStarter() = runTest {
+        val classArgumentCaptor: KArgumentCaptor<Class<*>> = argumentCaptor()
+        val bundleArgumentCaptor: KArgumentCaptor<Bundle> = argumentCaptor()
+        val requestCodeArgumentCaptor: KArgumentCaptor<Int> = argumentCaptor()
+        whenever(paymentRelayStarterFactory(any())).thenReturn(
+            PaymentRelayStarter.Legacy(
+                host
             )
-            authenticator.authenticate(
-                host,
-                PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR,
-                REQUEST_OPTIONS
-            )
+        )
+        authenticator.authenticate(
+            host,
+            PaymentIntentFixtures.PI_WITH_LAST_PAYMENT_ERROR,
+            REQUEST_OPTIONS
+        )
 
-            verify(host).startActivityForResult(
-                classArgumentCaptor.capture(),
-                bundleArgumentCaptor.capture(),
-                requestCodeArgumentCaptor.capture()
-            )
+        verify(host).startActivityForResult(
+            classArgumentCaptor.capture(),
+            bundleArgumentCaptor.capture(),
+            requestCodeArgumentCaptor.capture()
+        )
 
-            assertThat(classArgumentCaptor.firstValue).isEqualTo(PaymentRelayActivity::class.java)
+        assertThat(classArgumentCaptor.firstValue).isEqualTo(PaymentRelayActivity::class.java)
 
-            assertThat(bundleArgumentCaptor.firstValue.get("extra_args")).isInstanceOf(
-                PaymentFlowResult.Unvalidated::class.java
-            )
-            val result =
-                bundleArgumentCaptor.firstValue.get("extra_args") as PaymentFlowResult.Unvalidated
-            assertThat(result.stripeAccountId).isNull()
-            assertThat(result.clientSecret).isEqualTo("pi_1F7J1aCRMbs6FrXfaJcvbxF6_secret_mIuDLsSfoo1m6s")
+        assertThat(bundleArgumentCaptor.firstValue.get("extra_args")).isInstanceOf(
+            PaymentFlowResult.Unvalidated::class.java
+        )
+        val result =
+            bundleArgumentCaptor.firstValue.get("extra_args") as PaymentFlowResult.Unvalidated
+        assertThat(result.stripeAccountId).isNull()
+        assertThat(result.clientSecret).isEqualTo("pi_1F7J1aCRMbs6FrXfaJcvbxF6_secret_mIuDLsSfoo1m6s")
 
-            assertThat(requestCodeArgumentCaptor.firstValue).isEqualTo(PAYMENT_REQUEST_CODE)
-        }
+        assertThat(requestCodeArgumentCaptor.firstValue).isEqualTo(PAYMENT_REQUEST_CODE)
+    }
 
     private companion object {
         private val REQUEST_OPTIONS = ApiRequest.Options(

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/NoOpIntentAuthenticatorTest.kt
@@ -1,8 +1,6 @@
 package com.stripe.android.payments.core.authentication
 
 import android.os.Bundle
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.testing.TestLifecycleOwner
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.FakeActivityResultLauncher
@@ -21,7 +19,6 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -30,12 +27,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 @ExperimentalCoroutinesApi
 class NoOpIntentAuthenticatorTest {
-
-    private val lifecycleOwner = TestLifecycleOwner(initialState = Lifecycle.State.RESUMED)
-
-    private val host = mock<AuthActivityStarterHost> {
-        on { lifecycleOwner } doReturn lifecycleOwner
-    }
+    private val host = mock<AuthActivityStarterHost>()
 
     private val paymentRelayStarterFactory =
         mock<(AuthActivityStarterHost) -> PaymentRelayStarter>()

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/SourceAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/SourceAuthenticatorTest.kt
@@ -2,6 +2,8 @@ package com.stripe.android.payments.core.authentication
 
 import android.content.Context
 import androidx.activity.ComponentActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleRegistry
 import androidx.test.core.app.ApplicationProvider
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentBrowserAuthStarter
@@ -19,6 +21,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.argWhere
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -27,7 +30,11 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 @ExperimentalCoroutinesApi
 class SourceAuthenticatorTest {
-    private val activity: ComponentActivity = mock()
+    private val activity: ComponentActivity = mock {
+        on { lifecycle } doReturn LifecycleRegistry(mock).apply {
+            currentState = Lifecycle.State.RESUMED
+        }
+    }
     private val host = AuthActivityStarterHost.create(activity)
     private val paymentBrowserAuthStarterFactory =
         mock<(AuthActivityStarterHost) -> PaymentBrowserAuthStarter>()
@@ -57,7 +64,7 @@ class SourceAuthenticatorTest {
     @Test
     fun authenticate_withNoneFlowSource_shouldBypassAuth() =
         runTest {
-            authenticator.performAuthentication(
+            authenticator.authenticate(
                 host = host,
                 authenticatable = SourceFixtures.SOURCE_WITH_SOURCE_ORDER.copy(
                     flow = Source.Flow.None

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/SourceAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/SourceAuthenticatorTest.kt
@@ -57,7 +57,7 @@ class SourceAuthenticatorTest {
     @Test
     fun authenticate_withNoneFlowSource_shouldBypassAuth() =
         runTest {
-            authenticator.authenticate(
+            authenticator.performAuthentication(
                 host = host,
                 authenticatable = SourceFixtures.SOURCE_WITH_SOURCE_ORDER.copy(
                     flow = Source.Flow.None

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/Stripe3DS2AuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/Stripe3DS2AuthenticatorTest.kt
@@ -45,7 +45,7 @@ class Stripe3DS2AuthenticatorTest {
         runTest {
             val paymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2
 
-            authenticator.authenticate(
+            authenticator.performAuthentication(
                 host,
                 paymentIntent,
                 REQUEST_OPTIONS
@@ -69,7 +69,7 @@ class Stripe3DS2AuthenticatorTest {
             authenticator.stripe3ds2CompletionLauncher = mockLauncher
 
             val paymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2
-            authenticator.authenticate(
+            authenticator.performAuthentication(
                 host,
                 paymentIntent,
                 REQUEST_OPTIONS

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/Stripe3DS2AuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/Stripe3DS2AuthenticatorTest.kt
@@ -2,6 +2,8 @@ package com.stripe.android.payments.core.authentication
 
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleRegistry
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentAuthConfig
 import com.stripe.android.core.injection.DUMMY_INJECTOR_KEY
@@ -15,6 +17,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.argWhere
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -23,7 +26,12 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 @ExperimentalCoroutinesApi
 class Stripe3DS2AuthenticatorTest {
-    private val activity: ComponentActivity = mock()
+    private val activity: ComponentActivity = mock {
+        on { lifecycle } doReturn LifecycleRegistry(mock).apply {
+            currentState = Lifecycle.State.RESUMED
+        }
+    }
+
     private val host = AuthActivityStarterHost.create(activity)
 
     private val paymentAuthConfig = PaymentAuthConfig.Builder().set3ds2Config(
@@ -45,7 +53,7 @@ class Stripe3DS2AuthenticatorTest {
         runTest {
             val paymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2
 
-            authenticator.performAuthentication(
+            authenticator.authenticate(
                 host,
                 paymentIntent,
                 REQUEST_OPTIONS
@@ -69,7 +77,7 @@ class Stripe3DS2AuthenticatorTest {
             authenticator.stripe3ds2CompletionLauncher = mockLauncher
 
             val paymentIntent = PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2
-            authenticator.performAuthentication(
+            authenticator.authenticate(
                 host,
                 paymentIntent,
                 REQUEST_OPTIONS

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/UnsupportedAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/UnsupportedAuthenticatorTest.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.payments.core.authentication
 
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.testing.TestLifecycleOwner
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.FakeActivityResultLauncher
@@ -19,6 +21,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
@@ -33,6 +36,10 @@ class UnsupportedAuthenticatorTest {
         paymentRelayStarterFactory
     )
 
+    private val host = mock<AuthActivityStarterHost> {
+        on { lifecycleOwner } doReturn TestLifecycleOwner(initialState = Lifecycle.State.RESUMED)
+    }
+
     private val launcher = FakeActivityResultLauncher(PaymentRelayContract())
 
     @Before
@@ -46,8 +53,8 @@ class UnsupportedAuthenticatorTest {
 
     @Test
     fun verifyWeChat() = runTest {
-        authenticator.performAuthentication(
-            mock(),
+        authenticator.authenticate(
+            host,
             PaymentIntentFixtures.PI_REQUIRES_WECHAT_PAY_AUTHORIZE,
             REQUEST_OPTIONS
         )
@@ -70,8 +77,8 @@ class UnsupportedAuthenticatorTest {
 
     @Test
     fun verifyNullNextActionType() = runTest {
-        authenticator.performAuthentication(
-            mock(),
+        authenticator.authenticate(
+            host,
             PI_SUCCEEDED,
             REQUEST_OPTIONS
         )

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/UnsupportedAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/UnsupportedAuthenticatorTest.kt
@@ -46,7 +46,7 @@ class UnsupportedAuthenticatorTest {
 
     @Test
     fun verifyWeChat() = runTest {
-        authenticator.authenticate(
+        authenticator.performAuthentication(
             mock(),
             PaymentIntentFixtures.PI_REQUIRES_WECHAT_PAY_AUTHORIZE,
             REQUEST_OPTIONS
@@ -70,7 +70,7 @@ class UnsupportedAuthenticatorTest {
 
     @Test
     fun verifyNullNextActionType() = runTest {
-        authenticator.authenticate(
+        authenticator.performAuthentication(
             mock(),
             PI_SUCCEEDED,
             REQUEST_OPTIONS

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticatorTest.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.payments.core.authentication
 
 import android.content.Context
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
@@ -27,6 +29,7 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -45,7 +48,9 @@ class WebIntentAuthenticatorTest {
     )
 
     private val testDispatcher = UnconfinedTestDispatcher()
-    private val host = mock<AuthActivityStarterHost>()
+    private val host = mock<AuthActivityStarterHost> {
+        on { lifecycleOwner } doReturn TestLifecycleOwner(initialState = Lifecycle.State.RESUMED)
+    }
 
     private val paymentBrowserWebStarter = mock<PaymentBrowserAuthStarter>()
 
@@ -138,7 +143,7 @@ class WebIntentAuthenticatorTest {
         expectedShouldCancelIntentOnUserNavigation: Boolean = true,
         expectedAnalyticsEvent: PaymentAnalyticsEvent?
     ) = runTest {
-        authenticator.performAuthentication(
+        authenticator.authenticate(
             host,
             stripeIntent,
             REQUEST_OPTIONS

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/WebIntentAuthenticatorTest.kt
@@ -138,7 +138,7 @@ class WebIntentAuthenticatorTest {
         expectedShouldCancelIntentOnUserNavigation: Boolean = true,
         expectedAnalyticsEvent: PaymentAnalyticsEvent?
     ) = runTest {
-        authenticator.authenticate(
+        authenticator.performAuthentication(
             host,
             stripeIntent,
             REQUEST_OPTIONS

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingAuthenticator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingAuthenticator.kt
@@ -15,11 +15,11 @@ private const val UPI_INITIAL_DELAY_IN_SECONDS = 5
 private const val UPI_MAX_ATTEMPTS = 12
 
 @Singleton
-internal class PollingAuthenticator : PaymentAuthenticator<StripeIntent> {
+internal class PollingAuthenticator : PaymentAuthenticator<StripeIntent>() {
 
     private var pollingLauncher: ActivityResultLauncher<PollingContract.Args>? = null
 
-    override suspend fun authenticate(
+    override suspend fun performAuthentication(
         host: AuthActivityStarterHost,
         authenticatable: StripeIntent,
         requestOptions: ApiRequest.Options

--- a/wechatpay/build.gradle
+++ b/wechatpay/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
     testImplementation "org.mockito:mockito-inline:$mockitoCoreVersion"
     testImplementation "androidx.test:core-ktx:$androidTestVersion"
+    testImplementation "androidx.lifecycle:lifecycle-runtime-testing:$androidxLifecycleVersion"
 
     ktlint "com.pinterest:ktlint:$ktlintVersion"
 }

--- a/wechatpay/src/main/java/com/stripe/android/payments/wechatpay/WeChatPayAuthenticator.kt
+++ b/wechatpay/src/main/java/com/stripe/android/payments/wechatpay/WeChatPayAuthenticator.kt
@@ -18,7 +18,7 @@ import com.stripe.android.view.AuthActivityStarterHost
  * [PaymentAuthenticator] implementation to authenticate through WeChatPay SDK.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class WeChatPayAuthenticator : PaymentAuthenticator<StripeIntent> {
+class WeChatPayAuthenticator : PaymentAuthenticator<StripeIntent>() {
     /**
      * [weChatPayAuthLauncher] is mutable and might be updated during
      * through [onNewActivityResultCaller]

--- a/wechatpay/src/main/java/com/stripe/android/payments/wechatpay/WeChatPayAuthenticator.kt
+++ b/wechatpay/src/main/java/com/stripe/android/payments/wechatpay/WeChatPayAuthenticator.kt
@@ -52,7 +52,7 @@ class WeChatPayAuthenticator : PaymentAuthenticator<StripeIntent> {
         weChatPayAuthLauncher = null
     }
 
-    override suspend fun authenticate(
+    override suspend fun performAuthentication(
         host: AuthActivityStarterHost,
         authenticatable: StripeIntent,
         requestOptions: ApiRequest.Options

--- a/wechatpay/src/test/java/com/stripe/android/payments/wechatpay/WeChatPayAuthenticatorTest.kt
+++ b/wechatpay/src/test/java/com/stripe/android/payments/wechatpay/WeChatPayAuthenticatorTest.kt
@@ -1,8 +1,11 @@
 package com.stripe.android.payments.wechatpay
 
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.testing.TestLifecycleOwner
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.WeChat
 import com.stripe.android.payments.wechatpay.reflection.WeChatPayReflectionHelper
+import com.stripe.android.view.AuthActivityStarterHost
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -10,6 +13,7 @@ import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.argWhere
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -27,6 +31,10 @@ class WeChatPayAuthenticatorTest {
         it.reflectionHelper = mockReflectionHelper
     }
 
+    private val host = mock<AuthActivityStarterHost> {
+        on { lifecycleOwner } doReturn TestLifecycleOwner(initialState = Lifecycle.State.RESUMED)
+    }
+
     @Before
     fun setUpMocks() {
         whenever(mockReflectionHelper.isWeChatPayAvailable()).thenReturn(true)
@@ -41,8 +49,8 @@ class WeChatPayAuthenticatorTest {
                 "WeChatPay dependency is not found, add " +
                     "${WeChatPayReflectionHelper.WECHAT_PAY_GRADLE_DEP} in app's build.gradle"
             ) {
-                authenticator.performAuthentication(
-                    mock(),
+                authenticator.authenticate(
+                    host,
                     PaymentIntentFixtures.PI_REQUIRES_BLIK_AUTHORIZE,
                     REQUEST_OPTIONS
                 )
@@ -56,8 +64,8 @@ class WeChatPayAuthenticatorTest {
                 "stripeIntent.nextActionData should be WeChatPayRedirect, " +
                     "instead it is BlikAuthorize"
             ) {
-                authenticator.performAuthentication(
-                    mock(),
+                authenticator.authenticate(
+                    host,
                     PaymentIntentFixtures.PI_REQUIRES_BLIK_AUTHORIZE,
                     REQUEST_OPTIONS
                 )
@@ -71,8 +79,8 @@ class WeChatPayAuthenticatorTest {
                 "stripeIntent.nextActionData should be WeChatPayRedirect, " +
                     "instead it is null"
             ) {
-                authenticator.performAuthentication(
-                    mock(),
+                authenticator.authenticate(
+                    host,
                     PaymentIntentFixtures.PI_NO_NEXT_ACTION_DATA,
                     REQUEST_OPTIONS
                 )
@@ -83,8 +91,8 @@ class WeChatPayAuthenticatorTest {
     @Ignore("Flaky mockito behavior: https://github.com/mockito/mockito/issues/2026")
     fun `wechatPayAuthStarter should start when stripeIntent is WeChatPay`() =
         runTest {
-            authenticator.performAuthentication(
-                mock(),
+            authenticator.authenticate(
+                host,
                 PaymentIntentFixtures.PI_REQUIRES_WECHAT_PAY_AUTHORIZE,
                 REQUEST_OPTIONS
             )

--- a/wechatpay/src/test/java/com/stripe/android/payments/wechatpay/WeChatPayAuthenticatorTest.kt
+++ b/wechatpay/src/test/java/com/stripe/android/payments/wechatpay/WeChatPayAuthenticatorTest.kt
@@ -41,7 +41,7 @@ class WeChatPayAuthenticatorTest {
                 "WeChatPay dependency is not found, add " +
                     "${WeChatPayReflectionHelper.WECHAT_PAY_GRADLE_DEP} in app's build.gradle"
             ) {
-                authenticator.authenticate(
+                authenticator.performAuthentication(
                     mock(),
                     PaymentIntentFixtures.PI_REQUIRES_BLIK_AUTHORIZE,
                     REQUEST_OPTIONS
@@ -56,7 +56,7 @@ class WeChatPayAuthenticatorTest {
                 "stripeIntent.nextActionData should be WeChatPayRedirect, " +
                     "instead it is BlikAuthorize"
             ) {
-                authenticator.authenticate(
+                authenticator.performAuthentication(
                     mock(),
                     PaymentIntentFixtures.PI_REQUIRES_BLIK_AUTHORIZE,
                     REQUEST_OPTIONS
@@ -71,7 +71,7 @@ class WeChatPayAuthenticatorTest {
                 "stripeIntent.nextActionData should be WeChatPayRedirect, " +
                     "instead it is null"
             ) {
-                authenticator.authenticate(
+                authenticator.performAuthentication(
                     mock(),
                     PaymentIntentFixtures.PI_NO_NEXT_ACTION_DATA,
                     REQUEST_OPTIONS
@@ -83,7 +83,7 @@ class WeChatPayAuthenticatorTest {
     @Ignore("Flaky mockito behavior: https://github.com/mockito/mockito/issues/2026")
     fun `wechatPayAuthStarter should start when stripeIntent is WeChatPay`() =
         runTest {
-            authenticator.authenticate(
+            authenticator.performAuthentication(
                 mock(),
                 PaymentIntentFixtures.PI_REQUIRES_WECHAT_PAY_AUTHORIZE,
                 REQUEST_OPTIONS


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Resolves: https://github.com/stripe/stripe-android/issues/5508

This pull request fixes an issue where launching a `PaymentAuthenticator` while in the background resulted in the payment being considered a failure in the SDK, even if the payment was successful. The problem seems to be limited to Android 10 and 11.

Instead of launching the authentication activity right away, we now observe the lifecycle of `AuthActivityStarterHost` and only start the activity when it’s resumed.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Bugfix.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
N/A.

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

Completed payments are no longer incorrectly reported as having failed if the app is backgrounded during confirmation on Android 10 and 11.
