### PR TITLE
Limit to 3 completion loop images

### DIFF
--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationFlow.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationFlow.kt
@@ -43,7 +43,7 @@ internal abstract class CardImageVerificationFlow(
         /**
          * The maximum number of frames to process
          */
-        const val MAX_COMPLETION_LOOP_FRAMES = 5
+        const val MAX_COMPLETION_LOOP_FRAMES = 3
     }
 
     /**

--- a/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationFlowTest.kt
+++ b/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationFlowTest.kt
@@ -22,15 +22,15 @@ class CardImageVerificationFlowTest {
         }
 
         val frameMap = mapOf(
-            SavedFrameType(hasCard = true, hasOcr = true) to listOf("A", "B", "C"),
-            SavedFrameType(hasCard = true, hasOcr = false) to listOf("D", "E", "F"),
-            SavedFrameType(hasCard = false, hasOcr = true) to listOf("G", "H", "I"),
-            SavedFrameType(hasCard = false, hasOcr = false) to listOf("J", "K", "L")
+            SavedFrameType(hasCard = true, hasOcr = true) to listOf("A", "B"),
+            SavedFrameType(hasCard = true, hasOcr = false) to listOf("D", "E"),
+            SavedFrameType(hasCard = false, hasOcr = true) to listOf("G", "H"),
+            SavedFrameType(hasCard = false, hasOcr = false) to listOf("J", "K")
         )
 
         val selectedFrames = flow.selectCompletionLoopFrames(frameMap)
         assertEquals(
-            listOf("A", "B", "C", "G", "H"),
+            listOf("A", "B", "G"),
             selectedFrames
         )
     }


### PR DESCRIPTION
# Summary
Limit the completion loop images to 3 frames instead of 5. This will remove the oversized payload issues we're seeing on our lambdas.

# Motivation
Improve the stability of the CIV scanner

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified