### PR TITLE
Add autofill in payment sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### PaymentSheet
 * [ADDED][6306](https://github.com/stripe/stripe-android/pull/6306) Added support for Cash App Pay.
 * [FIXED][6326](https://github.com/stripe/stripe-android/pull/6326) Fixed an issue where the primary button would lose its padding on configuration changes.
+* [ADDED][5672](https://github.com/stripe/stripe-android/pull/5672) Added support for credit card autofill.
 
 ## 20.19.5 - 2023-03-06
 
@@ -16,7 +17,6 @@
 
 ### PaymentSheet
 * [ADDED][6283](https://github.com/stripe/stripe-android/pull/6283) Added support for Zip payments.
-* [ADDED][5672](https://github.com/stripe/stripe-android/pull/5672) Added support for credit card autofill.
 
 ### Identity
 * [ADDED] ID/Address verification

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### PaymentSheet
 * [ADDED][6283](https://github.com/stripe/stripe-android/pull/6283) Added support for Zip payments.
+* [ADDED][5672](https://github.com/stripe/stripe-android/pull/5672) Added support for credit card autofill.
 
 ### Identity
 * [ADDED] ID/Address verification

--- a/identity/detekt-baseline.xml
+++ b/identity/detekt-baseline.xml
@@ -66,7 +66,6 @@
     <ID>ReturnCount:AddressSection.kt$private fun isValidAddress(addressMap: Map&lt;IdentifierSpec, FormFieldEntry>): Boolean</ID>
     <ID>ReturnCount:IDNumberSection.kt$BRVisualTransformation.&lt;no name provided>$override fun originalToTransformed(offset: Int): Int</ID>
     <ID>ReturnCount:IDNumberSection.kt$BRVisualTransformation.&lt;no name provided>$override fun transformedToOriginal(offset: Int): Int</ID>
-    <ID>SpreadOperator:AddressSection.kt$( it.errorMessage, *args )</ID>
     <ID>SwallowedException:IdentityTheme.kt$e: ReflectiveOperationException</ID>
     <ID>ThrowsCount:DefaultIdentityRepository.kt$DefaultIdentityRepository$private suspend fun &lt;Response : StripeModel> executeRequestWithModelJsonParser( request: StripeRequest, responseJsonParser: ModelJsonParser&lt;Response>, onSuccessExecutionTimeBlock: (Long) -> Unit = {} ): Response</ID>
     <ID>TooManyFunctions:IdentityAnalyticsRequestFactory.kt$IdentityAnalyticsRequestFactory</ID>

--- a/link/src/androidTest/java/com/stripe/android/link/ui/inline/LinkInlineSignupViewTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/inline/LinkInlineSignupViewTest.kt
@@ -13,7 +13,7 @@ import com.stripe.android.link.ui.ErrorMessage
 import com.stripe.android.link.ui.progressIndicatorTestTag
 import com.stripe.android.link.ui.signup.SignUpState
 import com.stripe.android.uicore.elements.EmailConfig
-import com.stripe.android.ui.core.elements.NameConfig
+import com.stripe.android.uicore.elements.NameConfig
 import com.stripe.android.uicore.elements.PhoneNumberController
 import com.stripe.android.uicore.elements.SimpleTextFieldController
 import org.junit.Rule

--- a/link/src/androidTest/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/signup/SignUpScreenTest.kt
@@ -12,7 +12,7 @@ import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.link.ui.ErrorMessage
 import com.stripe.android.link.ui.progressIndicatorTestTag
 import com.stripe.android.uicore.elements.EmailConfig
-import com.stripe.android.ui.core.elements.NameConfig
+import com.stripe.android.uicore.elements.NameConfig
 import com.stripe.android.uicore.elements.PhoneNumberController
 import org.junit.Rule
 import org.junit.Test

--- a/link/src/androidTest/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
+++ b/link/src/androidTest/java/com/stripe/android/link/ui/wallet/WalletScreenTest.kt
@@ -41,7 +41,7 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.CvcCheck
 import com.stripe.android.ui.core.elements.CvcController
-import com.stripe.android.ui.core.elements.DateConfig
+import com.stripe.android.uicore.elements.DateConfig
 import com.stripe.android.uicore.elements.SimpleTextFieldController
 import com.stripe.android.uicore.elements.TextFieldController
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/link/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewModel.kt
@@ -17,8 +17,8 @@ import com.stripe.android.link.ui.signup.SignUpState
 import com.stripe.android.link.ui.signup.SignUpViewModel
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
-import com.stripe.android.ui.core.elements.NameConfig
 import com.stripe.android.uicore.elements.EmailConfig
+import com.stripe.android.uicore.elements.NameConfig
 import com.stripe.android.uicore.elements.PhoneNumberController
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted

--- a/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignup.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignup.kt
@@ -50,9 +50,9 @@ import com.stripe.android.link.ui.ErrorText
 import com.stripe.android.link.ui.LinkTerms
 import com.stripe.android.link.ui.signup.EmailCollectionSection
 import com.stripe.android.link.ui.signup.SignUpState
-import com.stripe.android.ui.core.elements.NameConfig
 import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.elements.EmailConfig
+import com.stripe.android.uicore.elements.NameConfig
 import com.stripe.android.uicore.elements.PhoneNumberCollectionSection
 import com.stripe.android.uicore.elements.PhoneNumberController
 import com.stripe.android.uicore.elements.TextFieldController

--- a/link/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/signup/SignUpScreen.kt
@@ -41,8 +41,8 @@ import com.stripe.android.link.ui.PrimaryButton
 import com.stripe.android.link.ui.PrimaryButtonState
 import com.stripe.android.link.ui.ScrollableTopLevelColumn
 import com.stripe.android.link.ui.progressIndicatorTestTag
-import com.stripe.android.ui.core.elements.NameConfig
 import com.stripe.android.uicore.elements.EmailConfig
+import com.stripe.android.uicore.elements.NameConfig
 import com.stripe.android.uicore.elements.PhoneNumberCollectionSection
 import com.stripe.android.uicore.elements.PhoneNumberController
 import com.stripe.android.uicore.elements.TextFieldController

--- a/link/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/signup/SignUpViewModel.kt
@@ -18,8 +18,8 @@ import com.stripe.android.link.ui.getErrorMessage
 import com.stripe.android.model.ConsumerSignUpConsentAction
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
-import com.stripe.android.ui.core.elements.NameConfig
 import com.stripe.android.uicore.elements.EmailConfig
+import com.stripe.android.uicore.elements.NameConfig
 import com.stripe.android.uicore.elements.PhoneNumberController
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -63,7 +63,7 @@ import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.CvcCheck
 import com.stripe.android.ui.core.elements.CvcController
 import com.stripe.android.ui.core.elements.CvcElement
-import com.stripe.android.ui.core.elements.DateConfig
+import com.stripe.android.uicore.elements.DateConfig
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.RowController
 import com.stripe.android.uicore.elements.RowElement

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -30,8 +30,8 @@ import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.ui.core.FieldValuesToParamsMapConverter
 import com.stripe.android.ui.core.address.toConfirmPaymentIntentShipping
 import com.stripe.android.ui.core.elements.CvcController
-import com.stripe.android.ui.core.elements.DateConfig
 import com.stripe.android.ui.core.elements.createExpiryDateFormFieldValues
+import com.stripe.android.uicore.elements.DateConfig
 import com.stripe.android.uicore.elements.SimpleTextFieldController
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -432,10 +432,6 @@ public final class com/stripe/android/ui/core/elements/MandateTextSpec$Companion
 public final class com/stripe/android/ui/core/elements/MandateTextUIKt {
 }
 
-public final class com/stripe/android/ui/core/elements/NameConfig$Companion {
-	public final fun createController (Ljava/lang/String;)Lcom/stripe/android/uicore/elements/SimpleTextFieldController;
-}
-
 public final class com/stripe/android/ui/core/elements/NameSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/ui/core/elements/NameSpec$$serializer;

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -284,10 +284,6 @@ public final class com/stripe/android/ui/core/elements/CountrySpec$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/stripe/android/ui/core/elements/DateConfig$Companion {
-	public final fun determineTextFieldState (IIII)Lcom/stripe/android/uicore/elements/TextFieldState;
-}
-
 public final class com/stripe/android/ui/core/elements/DisplayField : java/lang/Enum {
 	public static final field Companion Lcom/stripe/android/ui/core/elements/DisplayField$Companion;
 	public static final field Country Lcom/stripe/android/ui/core/elements/DisplayField;

--- a/payments-ui-core/detekt-baseline.xml
+++ b/payments-ui-core/detekt-baseline.xml
@@ -38,10 +38,6 @@
     <ID>MagicNumber:CardNumberVisualTransformation.kt$CardNumberVisualTransformation.&lt;no name provided>$4</ID>
     <ID>MagicNumber:CardNumberVisualTransformation.kt$CardNumberVisualTransformation.&lt;no name provided>$7</ID>
     <ID>MagicNumber:CardNumberVisualTransformation.kt$CardNumberVisualTransformation.&lt;no name provided>$9</ID>
-    <ID>MagicNumber:DateConfig.kt$DateConfig$4</ID>
-    <ID>MagicNumber:DateConfig.kt$DateConfig.Companion$100</ID>
-    <ID>MagicNumber:DateConfig.kt$DateConfig.Companion$12</ID>
-    <ID>MagicNumber:DateConfig.kt$DateConfig.Companion$50</ID>
     <ID>MagicNumber:IbanConfig.kt$IbanConfig$10</ID>
     <ID>MagicNumber:IbanConfig.kt$IbanConfig$4</ID>
     <ID>MagicNumber:LpmRepository.kt$LpmRepository$20</ID>
@@ -70,7 +66,6 @@
     <ID>ReturnCount:CardNumberVisualTransformation.kt$CardNumberVisualTransformation.&lt;no name provided>$override fun transformedToOriginal(offset: Int): Int</ID>
     <ID>ReturnCount:IbanConfig.kt$IbanConfig$override fun determineState(input: String): TextFieldState</ID>
     <ID>SpreadOperator:BsbElementUI.kt$( it.errorMessage, *args )</ID>
-    <ID>SpreadOperator:SectionElementUI.kt$( it.errorMessage, *args )</ID>
     <ID>TooGenericExceptionCaught:LpmSerializer.kt$LpmSerializer$e: Exception</ID>
     <ID>TooGenericExceptionCaught:PlacesClientProxy.kt$DefaultPlacesClientProxy$e: Exception</ID>
     <ID>UnnecessaryAbstractClass:FormControllerModule.kt$FormControllerModule$FormControllerModule</ID>

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusDirection
+import com.stripe.android.uicore.elements.DateConfig
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.RowController
 import com.stripe.android.uicore.elements.RowElement

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
@@ -5,6 +5,7 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionFieldErrorController
 import com.stripe.android.uicore.elements.SectionMultiFieldElement
+import com.stripe.android.uicore.elements.convertTo4DigitDate
 import com.stripe.android.uicore.forms.FormFieldEntry
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
@@ -34,7 +34,7 @@ internal sealed class CardNumberController : TextFieldController, SectionFieldEr
     abstract val cardScanEnabled: Boolean
 
     @OptIn(ExperimentalComposeUiApi::class)
-    override val autofillTypes: List<AutofillType> = listOf(AutofillType.CreditCardNumber)
+    override val autofillType: AutofillType = AutofillType.CreditCardNumber
 
     fun onCardScanResult(cardScanSheetResult: CardScanSheetResult) {
         // Don't need to populate the card number if the result is Canceled or Failed

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
@@ -2,6 +2,8 @@ package com.stripe.android.ui.core.elements
 
 import android.content.Context
 import androidx.annotation.VisibleForTesting
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.autofill.AutofillType
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import com.stripe.android.cards.CardAccountRangeRepository
@@ -30,6 +32,9 @@ internal sealed class CardNumberController : TextFieldController, SectionFieldEr
     abstract val cardBrandFlow: Flow<CardBrand>
 
     abstract val cardScanEnabled: Boolean
+
+    @OptIn(ExperimentalComposeUiApi::class)
+    override val autofillTypes: List<AutofillType> = listOf(AutofillType.CreditCardNumber)
 
     fun onCardScanResult(cardScanSheetResult: CardScanSheetResult) {
         // Don't need to populate the card number if the result is Canceled or Failed

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcController.kt
@@ -41,7 +41,7 @@ class CvcController constructor(
     override val debugLabel = cvcTextFieldConfig.debugLabel
 
     @OptIn(ExperimentalComposeUiApi::class)
-    override val autofillTypes: List<AutofillType> = listOf(AutofillType.CreditCardSecurityCode)
+    override val autofillType: AutofillType = AutofillType.CreditCardSecurityCode
 
     private val _fieldValue = MutableStateFlow("")
     override val fieldValue: Flow<String> = _fieldValue

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcController.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.autofill.AutofillType
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import com.stripe.android.model.CardBrand
@@ -37,6 +39,9 @@ class CvcController constructor(
     override val label: Flow<Int> = _label
 
     override val debugLabel = cvcTextFieldConfig.debugLabel
+
+    @OptIn(ExperimentalComposeUiApi::class)
+    override val autofillTypes: List<AutofillType> = listOf(AutofillType.CreditCardSecurityCode)
 
     private val _fieldValue = MutableStateFlow("")
     override val fieldValue: Flow<String> = _fieldValue

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/DateConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/DateConfigTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.ui.core.elements
 
 import com.google.common.truth.Truth
 import com.stripe.android.ui.core.R
+import com.stripe.android.uicore.elements.DateConfig
 import com.stripe.android.uicore.elements.TextFieldStateConstants
 import org.junit.Test
 import java.util.Calendar

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/ExpiryDateVisualTransformationTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/ExpiryDateVisualTransformationTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.ui.core.elements
 
 import androidx.compose.ui.text.AnnotatedString
 import com.google.common.truth.Truth
+import com.stripe.android.uicore.elements.ExpiryDateVisualTransformation
 import org.junit.Test
 
 internal class ExpiryDateVisualTransformationTest {

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/NameConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/NameConfigTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.ui.core.elements
 
 import com.google.common.truth.Truth
+import com.stripe.android.uicore.elements.NameConfig
 import com.stripe.android.uicore.elements.TextFieldStateConstants.Error.Blank
 import com.stripe.android.uicore.elements.TextFieldStateConstants.Valid.Limitless
 import org.junit.Test

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/TransformSpecToElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/TransformSpecToElementTest.kt
@@ -15,7 +15,6 @@ import com.stripe.android.ui.core.elements.EmailElement
 import com.stripe.android.ui.core.elements.EmailSpec
 import com.stripe.android.ui.core.elements.EmptyFormElement
 import com.stripe.android.ui.core.elements.KeyboardType
-import com.stripe.android.ui.core.elements.NameConfig
 import com.stripe.android.ui.core.elements.NameSpec
 import com.stripe.android.ui.core.elements.SimpleDropdownElement
 import com.stripe.android.ui.core.elements.SimpleTextSpec
@@ -30,6 +29,7 @@ import com.stripe.android.uicore.elements.CountryConfig
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.EmailConfig
 import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.NameConfig
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SimpleTextElement
 import kotlinx.coroutines.flow.first

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -43,7 +43,6 @@
     <ID>MagicNumber:PrimaryButtonUiStateMapper.kt$PrimaryButtonUiStateMapper$5</ID>
     <ID>MagicNumber:USBankAccountFormFragment.kt$USBankAccountFormFragment$0.5f</ID>
     <ID>MaxLineLength:BillingAddressViewTest.kt$BillingAddressViewTest$fun</ID>
-    <ID>MaxLineLength:ConfirmPaymentIntentParamsFactoryTest.kt$ConfirmPaymentIntentParamsFactoryTest$fun</ID>
     <ID>MaxLineLength:CustomerRepositoryTest.kt$CustomerRepositoryTest$onBlocking { detachPaymentMethod(anyString(), any(), anyString(), any()) }.doThrow(InvalidParameterException("error"))</ID>
     <ID>MaxLineLength:DefaultFlowControllerTest.kt$DefaultFlowControllerTest$fun</ID>
     <ID>MaxLineLength:FlowControllerConfigurationHandlerTest.kt$FlowControllerConfigurationHandlerTest$.</ID>
@@ -67,7 +66,6 @@
     <ID>ThrowsCount:PaymentSheetConfigurationKtx.kt$internal fun PaymentSheet.Configuration.validate()</ID>
     <ID>TooManyFunctions:DefaultFlowController.kt$DefaultFlowController : FlowControllerNonFallbackInjector</ID>
     <ID>TooManyFunctions:PaymentOption.kt$DelegateDrawable : Drawable</ID>
-    <ID>TooManyFunctions:PaymentOptionsViewModel.kt$PaymentOptionsViewModel : BaseSheetViewModel</ID>
     <ID>TooManyFunctions:PaymentSheetViewModel.kt$PaymentSheetViewModel : BaseSheetViewModel</ID>
     <ID>UnnecessaryAbstractClass:PaymentSheetCommonModule.kt$PaymentSheetCommonModule$PaymentSheetCommonModule</ID>
     <ID>UnnecessaryAbstractClass:PaymentSheetLauncherModule.kt$PaymentSheetLauncherModule$PaymentSheetLauncherModule</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -129,6 +129,12 @@ internal class DefaultEventReporter @Inject internal constructor(
         )
     }
 
+    override fun onAutofill(type: String) {
+        fireEvent(
+            PaymentSheetEvent.AutofillEvent(type)
+        )
+    }
+
     private fun fireEvent(event: PaymentSheetEvent) {
         CoroutineScope(workContext).launch {
             analyticsRequestExecutor.executeAsync(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -37,6 +37,8 @@ internal interface EventReporter {
 
     fun onLpmSpecFailure()
 
+    fun onAutofill(type: String)
+
     enum class Mode(val code: String) {
         Complete("complete"),
         Custom("custom");

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -164,6 +164,17 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         override val eventName: String = "luxe_serialize_failure"
     }
 
+    class AutofillEvent(type: String) : PaymentSheetEvent() {
+        private fun String.toSnakeCase() = replace(
+            "(?<=.)(?=\\p{Upper})".toRegex(),
+            "_"
+        ).lowercase()
+
+        override val additionalParams: Map<String, Any?>
+            get() = emptyMap()
+        override val eventName: String = "autofill_${type.toSnakeCase()}"
+    }
+
     internal companion object {
         private fun analyticsValue(
             paymentSelection: PaymentSelection?

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -38,10 +38,10 @@ import com.stripe.android.paymentsheet.model.create
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.di.DaggerUSBankAccountFormComponent
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.di.USBankAccountFormViewModelSubcomponent
-import com.stripe.android.ui.core.elements.NameConfig
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
 import com.stripe.android.ui.core.elements.SaveForFutureUseSpec
 import com.stripe.android.uicore.elements.EmailConfig
+import com.stripe.android.uicore.elements.NameConfig
 import com.stripe.android.uicore.elements.TextFieldController
 import com.stripe.android.utils.requireApplication
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/stripe-ui-core/api/stripe-ui-core.api
+++ b/stripe-ui-core/api/stripe-ui-core.api
@@ -161,10 +161,6 @@ public final class com/stripe/android/uicore/elements/IdentifierSpec$Creator : a
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/uicore/elements/NameConfig$Companion {
-	public final fun createController (Ljava/lang/String;)Lcom/stripe/android/uicore/elements/SimpleTextFieldController;
-}
-
 public final class com/stripe/android/uicore/elements/PhoneNumberState$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }

--- a/stripe-ui-core/api/stripe-ui-core.api
+++ b/stripe-ui-core/api/stripe-ui-core.api
@@ -100,6 +100,12 @@ public final class com/stripe/android/uicore/elements/ComposableSingletons$Secti
 	public final fun getLambda-1$stripe_ui_core_release ()Lkotlin/jvm/functions/Function2;
 }
 
+public final class com/stripe/android/uicore/elements/ConvertTo4DigitDateKt {
+}
+
+public final class com/stripe/android/uicore/elements/DateConfig$Companion {
+}
+
 public final class com/stripe/android/uicore/elements/DropdownConfig$DefaultImpls {
 	public static fun getDisableDropdownWithSingleElement (Lcom/stripe/android/uicore/elements/DropdownConfig;)Z
 	public static fun getTinyMode (Lcom/stripe/android/uicore/elements/DropdownConfig;)Z

--- a/stripe-ui-core/api/stripe-ui-core.api
+++ b/stripe-ui-core/api/stripe-ui-core.api
@@ -100,9 +100,6 @@ public final class com/stripe/android/uicore/elements/ComposableSingletons$Secti
 	public final fun getLambda-1$stripe_ui_core_release ()Lkotlin/jvm/functions/Function2;
 }
 
-public final class com/stripe/android/uicore/elements/DateConfig$Companion {
-}
-
 public final class com/stripe/android/uicore/elements/DropdownConfig$DefaultImpls {
 	public static fun getDisableDropdownWithSingleElement (Lcom/stripe/android/uicore/elements/DropdownConfig;)Z
 	public static fun getTinyMode (Lcom/stripe/android/uicore/elements/DropdownConfig;)Z

--- a/stripe-ui-core/api/stripe-ui-core.api
+++ b/stripe-ui-core/api/stripe-ui-core.api
@@ -100,9 +100,6 @@ public final class com/stripe/android/uicore/elements/ComposableSingletons$Secti
 	public final fun getLambda-1$stripe_ui_core_release ()Lkotlin/jvm/functions/Function2;
 }
 
-public final class com/stripe/android/uicore/elements/ConvertTo4DigitDateKt {
-}
-
 public final class com/stripe/android/uicore/elements/DateConfig$Companion {
 }
 
@@ -165,6 +162,10 @@ public final class com/stripe/android/uicore/elements/IdentifierSpec$Creator : a
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/uicore/elements/IdentifierSpec;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/uicore/elements/NameConfig$Companion {
+	public final fun createController (Ljava/lang/String;)Lcom/stripe/android/uicore/elements/SimpleTextFieldController;
 }
 
 public final class com/stripe/android/uicore/elements/PhoneNumberState$Companion {

--- a/stripe-ui-core/detekt-baseline.xml
+++ b/stripe-ui-core/detekt-baseline.xml
@@ -8,14 +8,17 @@
     <ID>CyclomaticComplexMethod:Html.kt$@Composable @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun annotatedStringResource( text: String, imageGetter: Map&lt;String, EmbeddableImage> = emptyMap(), urlSpanStyle: SpanStyle = SpanStyle(textDecoration = TextDecoration.Underline) ): AnnotatedString</ID>
     <ID>CyclomaticComplexMethod:IdentifierSpec.kt$IdentifierSpec.Companion$@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) fun get(value: String)</ID>
     <ID>CyclomaticComplexMethod:StripeTheme.kt$@Composable @ReadOnlyComposable @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun StripeTypography.toComposeTypography(): Typography</ID>
-    <ID>CyclomaticComplexMethod:TextFieldUI.kt$@Composable fun TextField( textFieldController: TextFieldController, enabled: Boolean, imeAction: ImeAction, modifier: Modifier = Modifier, onTextStateChanged: (TextFieldState?) -> Unit = {}, nextFocusDirection: FocusDirection = FocusDirection.Next, previousFocusDirection: FocusDirection = FocusDirection.Previous )</ID>
+    <ID>CyclomaticComplexMethod:TextFieldUI.kt$@OptIn(ExperimentalComposeUiApi::class) @Composable fun TextField( textFieldController: TextFieldController, enabled: Boolean, imeAction: ImeAction, modifier: Modifier = Modifier, onTextStateChanged: (TextFieldState?) -> Unit = {}, nextFocusDirection: FocusDirection = FocusDirection.Next, previousFocusDirection: FocusDirection = FocusDirection.Previous )</ID>
     <ID>EmptyFunctionBlock:DrawablePainter.kt$EmptyPainter${}</ID>
     <ID>FunctionParameterNaming:IdentifierSpec.kt$IdentifierSpec.Companion$_value: String</ID>
     <ID>LongMethod:DropdownFieldUI.kt$@Composable @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun DropDown( controller: DropdownFieldController, enabled: Boolean, modifier: Modifier = Modifier )</ID>
     <ID>LongMethod:Html.kt$@Composable @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun annotatedStringResource( text: String, imageGetter: Map&lt;String, EmbeddableImage> = emptyMap(), urlSpanStyle: SpanStyle = SpanStyle(textDecoration = TextDecoration.Underline) ): AnnotatedString</ID>
-    <ID>LongMethod:OTPElementUI.kt$@OptIn(ExperimentalMaterialApi::class) @Composable @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun OTPElementUI( enabled: Boolean, element: OTPElement, modifier: Modifier = Modifier, colors: OTPElementColors = OTPElementColors( selectedBorder = MaterialTheme.colors.primary, placeholder = MaterialTheme.stripeColors.placeholderText ), focusRequester: FocusRequester = remember { FocusRequester() } )</ID>
     <ID>LongMethod:PhoneNumberElementUI.kt$@Composable @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun PhoneNumberElementUI( enabled: Boolean, controller: PhoneNumberController, requestFocusWhenShown: Boolean = false, imeAction: ImeAction = ImeAction.Done )</ID>
-    <ID>LongMethod:TextFieldUI.kt$@Composable fun TextField( textFieldController: TextFieldController, enabled: Boolean, imeAction: ImeAction, modifier: Modifier = Modifier, onTextStateChanged: (TextFieldState?) -> Unit = {}, nextFocusDirection: FocusDirection = FocusDirection.Next, previousFocusDirection: FocusDirection = FocusDirection.Previous )</ID>
+    <ID>LongMethod:TextFieldUI.kt$@OptIn(ExperimentalComposeUiApi::class) @Composable fun TextField( textFieldController: TextFieldController, enabled: Boolean, imeAction: ImeAction, modifier: Modifier = Modifier, onTextStateChanged: (TextFieldState?) -> Unit = {}, nextFocusDirection: FocusDirection = FocusDirection.Next, previousFocusDirection: FocusDirection = FocusDirection.Previous )</ID>
+    <ID>MagicNumber:DateConfig.kt$DateConfig$4</ID>
+    <ID>MagicNumber:DateConfig.kt$DateConfig.Companion$100</ID>
+    <ID>MagicNumber:DateConfig.kt$DateConfig.Companion$12</ID>
+    <ID>MagicNumber:DateConfig.kt$DateConfig.Companion$50</ID>
     <ID>MagicNumber:DrawablePainter.kt$DrawablePainter$255</ID>
     <ID>MagicNumber:DropdownFieldUI.kt$.8f</ID>
     <ID>MagicNumber:DropdownFieldUI.kt$.9f</ID>

--- a/stripe-ui-core/res/values/totranslate.xml
+++ b/stripe-ui-core/res/values/totranslate.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="stripe_paymentsheet_address_element_same_as_shipping">Billing address is same as shipping</string>
+
+    <string name="expiration_date_hint">MM / YY</string>
+    <string name="incomplete_expiry_date">Your card\'s expiration date is incomplete.</string>
+    <string name="invalid_expiry_year">Your card\'s expiration year is invalid.</string>
+    <string name="invalid_expiry_month">Your card\'s expiration month is invalid.</string>
 </resources>

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldController.kt
@@ -37,7 +37,7 @@ class AddressTextFieldController(
     override val debugLabel = config.debugLabel
 
     @ExperimentalComposeUiApi
-    override val autofillTypes: List<AutofillType> = listOf()
+    override val autofillType: AutofillType? = null
 
     /** This is all the information that can be observed on the element */
     private val _fieldValue = MutableStateFlow("")

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldController.kt
@@ -2,7 +2,9 @@ package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.autofill.AutofillType
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
@@ -33,6 +35,9 @@ class AddressTextFieldController(
 
     override val label = MutableStateFlow(config.label)
     override val debugLabel = config.debugLabel
+
+    @ExperimentalComposeUiApi
+    override val autofillTypes: List<AutofillType> = listOf()
 
     /** This is all the information that can be observed on the element */
     private val _fieldValue = MutableStateFlow("")

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/ConvertTo4DigitDate.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/ConvertTo4DigitDate.kt
@@ -1,8 +1,9 @@
+@file:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun convertTo4DigitDate(input: String) =
     "0$input".takeIf {
         (input.isNotBlank() && !(input[0] == '0' || input[0] == '1')) ||

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/ConvertTo4DigitDate.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/ConvertTo4DigitDate.kt
@@ -1,6 +1,9 @@
-package com.stripe.android.ui.core.elements
+package com.stripe.android.uicore.elements
 
-internal fun convertTo4DigitDate(input: String) =
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun convertTo4DigitDate(input: String) =
     "0$input".takeIf {
         (input.isNotBlank() && !(input[0] == '0' || input[0] == '1')) ||
             ((input.length > 1) && (input[0] == '1' && requireNotNull(input[1].digitToInt()) > 2))

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DateConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DateConfig.kt
@@ -55,6 +55,7 @@ class DateConfig : TextFieldConfig {
         }
     }
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
         @VisibleForTesting
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DateConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DateConfig.kt
@@ -1,14 +1,11 @@
-package com.stripe.android.ui.core.elements
+package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
-import com.stripe.android.ui.core.R
-import com.stripe.android.uicore.elements.TextFieldConfig
-import com.stripe.android.uicore.elements.TextFieldIcon
-import com.stripe.android.uicore.elements.TextFieldState
+import com.stripe.android.uicore.R
 import com.stripe.android.uicore.elements.TextFieldStateConstants.Error
 import com.stripe.android.uicore.elements.TextFieldStateConstants.Valid
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -21,7 +18,7 @@ class DateConfig : TextFieldConfig {
     override val debugLabel = "date"
 
     @StringRes
-    override val label = R.string.stripe_paymentsheet_expiration_date_hint
+    override val label = R.string.expiration_date_hint
     override val keyboard = KeyboardType.NumberPassword
     override val visualTransformation = ExpiryDateVisualTransformation()
     override val trailingIcon: StateFlow<TextFieldIcon?> = MutableStateFlow(null)
@@ -60,6 +57,7 @@ class DateConfig : TextFieldConfig {
 
     companion object {
         @VisibleForTesting
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         fun determineTextFieldState(
             month1Based: Int,
             twoDigitYear: Int,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/ExpiryDateVisualTransformation.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/ExpiryDateVisualTransformation.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.ui.core.elements
+package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
 import androidx.compose.ui.text.AnnotatedString

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/NameConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/NameConfig.kt
@@ -33,7 +33,9 @@ class NameConfig : TextFieldConfig {
     override fun convertToRaw(displayName: String) = displayName
     override fun convertFromRaw(rawValue: String) = rawValue
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         fun createController(initialValue: String?) = SimpleTextFieldController(
             NameConfig(),
             initialValue = initialValue

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/NameConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/NameConfig.kt
@@ -1,15 +1,11 @@
-package com.stripe.android.ui.core.elements
+package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
 import androidx.annotation.StringRes
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
-import com.stripe.android.ui.core.R
-import com.stripe.android.uicore.elements.SimpleTextFieldController
-import com.stripe.android.uicore.elements.TextFieldConfig
-import com.stripe.android.uicore.elements.TextFieldIcon
-import com.stripe.android.uicore.elements.TextFieldState
+import com.stripe.android.uicore.R
 import com.stripe.android.uicore.elements.TextFieldStateConstants.Error
 import com.stripe.android.uicore.elements.TextFieldStateConstants.Valid
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldController.kt
@@ -26,7 +26,7 @@ interface TextFieldController : InputController, SectionFieldComposable {
     fun onValueChange(displayFormatted: String): TextFieldState?
     fun onFocusChange(newHasFocus: Boolean)
 
-    val autofillTypes: List<AutofillType>
+    val autofillType: AutofillType?
     val debugLabel: String
     val trailingIcon: Flow<TextFieldIcon?>
     val capitalization: KeyboardCapitalization
@@ -116,15 +116,12 @@ class SimpleTextFieldController constructor(
     override val debugLabel = textFieldConfig.debugLabel
 
     @OptIn(ExperimentalComposeUiApi::class)
-    override val autofillTypes: List<AutofillType> = when (textFieldConfig) {
-        is DateConfig -> listOf(
-            AutofillType.CreditCardExpirationDate
-        )
-        is PostalCodeConfig -> listOf(
-            AutofillType.PostalCode
-        )
-        is EmailConfig -> listOf(AutofillType.EmailAddress)
-        else -> listOf()
+    override val autofillType: AutofillType? = when (textFieldConfig) {
+        is DateConfig -> AutofillType.CreditCardExpirationDate
+        is PostalCodeConfig -> AutofillType.PostalCode
+        is EmailConfig -> AutofillType.EmailAddress
+        is NameConfig -> AutofillType.PersonFullName
+        else -> null
     }
 
     override val placeHolder = MutableStateFlow(textFieldConfig.placeHolder)

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldController.kt
@@ -4,7 +4,9 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.RestrictTo
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.autofill.AutofillType
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -18,11 +20,13 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 
+@OptIn(ExperimentalComposeUiApi::class)
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 interface TextFieldController : InputController, SectionFieldComposable {
     fun onValueChange(displayFormatted: String): TextFieldState?
     fun onFocusChange(newHasFocus: Boolean)
 
+    val autofillTypes: List<AutofillType>
     val debugLabel: String
     val trailingIcon: Flow<TextFieldIcon?>
     val capitalization: KeyboardCapitalization
@@ -110,6 +114,18 @@ class SimpleTextFieldController constructor(
 
     override val label = MutableStateFlow(textFieldConfig.label)
     override val debugLabel = textFieldConfig.debugLabel
+
+    @OptIn(ExperimentalComposeUiApi::class)
+    override val autofillTypes: List<AutofillType> = when (textFieldConfig) {
+        is DateConfig -> listOf(
+            AutofillType.CreditCardExpirationDate
+        )
+        is PostalCodeConfig -> listOf(
+            AutofillType.PostalCode
+        )
+        is EmailConfig -> listOf(AutofillType.EmailAddress)
+        else -> listOf()
+    }
 
     override val placeHolder = MutableStateFlow(textFieldConfig.placeHolder)
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
@@ -22,16 +22,23 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.autofill.AutofillNode
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalAutofill
+import androidx.compose.ui.platform.LocalAutofillTree
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -92,6 +99,7 @@ fun TextFieldSection(
  * attribute of [textFieldController] is also taken into account to decide if the UI should be
  * enabled.
  */
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun TextField(
     textFieldController: TextFieldController,
@@ -124,6 +132,19 @@ fun TextField(
         }
     }
 
+    val autofillNode = remember {
+        AutofillNode(
+            autofillTypes = textFieldController.autofillTypes,
+            onFill = { textFieldController.onValueChange(it) }
+        )
+    }
+    val autofill = LocalAutofill.current
+    val autofillTree = LocalAutofillTree.current
+
+    LaunchedEffect(autofillNode) {
+        autofillTree += autofillNode
+    }
+
     TextField(
         value = value,
         onValueChange = { newValue ->
@@ -150,11 +171,21 @@ fun TextField(
                     false
                 }
             }
+            .onGloballyPositioned {
+                autofillNode.boundingBox = it.boundsInWindow()
+            }
             .onFocusChanged {
                 if (hasFocus != it.isFocused) {
                     textFieldController.onFocusChange(it.isFocused)
                 }
                 hasFocus = it.isFocused
+                autofill?.run {
+                    if (it.isFocused) {
+                        requestAutofillForNode(autofillNode)
+                    } else {
+                        cancelAutofillForNode(autofillNode)
+                    }
+                }
             }
             .semantics {
                 this.contentDescription = contentDescription


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

- Add support for credit card autofill in PaymentSheet. Supports card number, card expiration, and card cvc.
- Move `DateConfig` to stripe-ui-core

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Better user experience when a user has a saved credit card on their device. CardFormView, CardInputWidget, CardMultilineWidget all support autofill, so we should also support this feature in PaymentSheet.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

|   | Suggestion | Confirmation | Autofill |
|---|------------|---------------|----------|
|   | <img src="https://user-images.githubusercontent.com/99316447/222864273-679b9488-4fbe-4584-aebf-3cb7db95b1cc.png" height=400/>          | <img src="https://user-images.githubusercontent.com/99316447/222864325-1f183db6-4630-4258-ac4a-cd890af2925d.png" height=400/>             | <img src="https://user-images.githubusercontent.com/99316447/222864437-c13fe1d9-5bb6-4683-bf04-07ff5a3570b3.png" height=400 />        |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

- [ADDED] Added support for credit card autofill.