### PR TITLE
Fix checkbox visibility and inline signup issues

### DIFF
--- a/link/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/InlineSignupViewModel.kt
@@ -177,6 +177,7 @@ internal class InlineSignupViewModel @Inject constructor(
 
     private suspend fun lookupConsumerEmail(email: String) {
         clearError()
+        linkAccountManager.logout()
         linkAccountManager.lookupConsumer(email, startSession = false).fold(
             onSuccess = {
                 if (it != null) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
@@ -60,17 +60,20 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ) = ComposeView(requireContext()).apply {
+        val showCheckboxFlow = MutableStateFlow(false)
+
         setContent {
             PaymentsTheme {
-                AddPaymentMethod()
+                AddPaymentMethod(showCheckboxFlow)
             }
         }
     }
 
     @Composable
-    internal fun AddPaymentMethod() {
-        val showCheckboxFlow = MutableStateFlow(false)
-        val isRepositoryReady by sheetViewModel.isResourceRepositoryReady.observeAsState(false)
+    internal fun AddPaymentMethod(
+        showCheckboxFlow: MutableStateFlow<Boolean>
+    ) {
+        val isRepositoryReady by sheetViewModel.isResourceRepositoryReady.observeAsState()
         val processing by sheetViewModel.processing.observeAsState(false)
 
         val linkConfig by sheetViewModel.linkConfiguration.observeAsState()
@@ -80,22 +83,19 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
 
         if (isRepositoryReady == true) {
             var selectedPaymentMethodCode: String by rememberSaveable {
-                mutableStateOf(
-                    sheetViewModel.newPaymentSelection?.paymentMethodCreateParams?.typeCode
-                        ?: sheetViewModel.supportedPaymentMethods.first().code
-                )
+                mutableStateOf(getInitiallySelectedPaymentMethodType())
             }
+
             val selectedItem = remember(selectedPaymentMethodCode) {
                 sheetViewModel.supportedPaymentMethods.first {
                     it.code == selectedPaymentMethodCode
                 }
             }
 
-            val showLinkInlineSignup = sheetViewModel.isLinkEnabled.value == true &&
-                sheetViewModel.stripeIntent.value
-                ?.linkFundingSources?.contains(PaymentMethod.Type.Card.code) == true &&
-                selectedItem.code == PaymentMethod.Type.Card.code &&
-                linkAccountStatus == AccountStatus.SignedOut
+            val showLinkInlineSignup = showLinkInlineSignupView(
+                selectedPaymentMethodCode,
+                linkAccountStatus
+            )
 
             val arguments = remember(selectedItem, showLinkInlineSignup) {
                 createFormArguments(selectedItem, showLinkInlineSignup)
@@ -199,6 +199,34 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
         )
     }
 
+    private fun getInitiallySelectedPaymentMethodType() =
+        when (val selection = sheetViewModel.newPaymentSelection) {
+            is PaymentSelection.New.LinkInline -> PaymentMethod.Type.Card.code
+            is PaymentSelection.New.Card,
+            is PaymentSelection.New.USBankAccount,
+            is PaymentSelection.New.GenericPaymentMethod ->
+                selection.paymentMethodCreateParams.typeCode
+            else -> sheetViewModel.supportedPaymentMethods.first().code
+        }
+
+    private fun showLinkInlineSignupView(
+        paymentMethodCode: String,
+        linkAccountStatus: AccountStatus?
+    ): Boolean {
+        return sheetViewModel.isLinkEnabled.value == true &&
+            sheetViewModel.stripeIntent.value
+                ?.linkFundingSources?.contains(PaymentMethod.Type.Card.code) == true &&
+            paymentMethodCode == PaymentMethod.Type.Card.code &&
+            (
+                linkAccountStatus in setOf(
+                    AccountStatus.NeedsVerification,
+                    AccountStatus.VerificationStarted,
+                    AccountStatus.SignedOut
+                ) ||
+                    sheetViewModel.newPaymentSelection is PaymentSelection.New.LinkInline
+                )
+    }
+
     private fun onLinkSignupStateChanged(
         config: LinkPaymentLauncher.Configuration,
         viewState: InlineSignupViewState
@@ -294,7 +322,7 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
             amount: Amount? = null,
             @InjectorKey injectorKey: String,
             newLpm: PaymentSelection.New?,
-            isShowingLinkInlineSignup: Boolean = false
+            isShowingLinkInlineSignup: Boolean
         ): FormFragmentArguments {
             val layoutFormDescriptor = showPaymentMethod.getPMAddForm(stripeIntent, config)
 
@@ -311,15 +339,19 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
                 shippingDetails = config?.shippingDetails,
                 injectorKey = injectorKey,
                 initialPaymentMethodCreateParams =
-                newLpm?.paymentMethodCreateParams?.typeCode?.takeIf {
-                    it == showPaymentMethod.code
-                }?.let {
-                    when (newLpm) {
-                        is PaymentSelection.New.GenericPaymentMethod ->
-                            newLpm.paymentMethodCreateParams
-                        is PaymentSelection.New.Card ->
-                            newLpm.paymentMethodCreateParams
-                        else -> null
+                if (newLpm is PaymentSelection.New.LinkInline) {
+                    newLpm.linkPaymentDetails.originalParams
+                } else {
+                    newLpm?.paymentMethodCreateParams?.typeCode?.takeIf {
+                        it == showPaymentMethod.code
+                    }?.let {
+                        when (newLpm) {
+                            is PaymentSelection.New.GenericPaymentMethod ->
+                                newLpm.paymentMethodCreateParams
+                            is PaymentSelection.New.Card ->
+                                newLpm.paymentMethodCreateParams
+                            else -> null
+                        }
                     }
                 }
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
@@ -215,7 +215,7 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
     ): Boolean {
         return sheetViewModel.isLinkEnabled.value == true &&
             sheetViewModel.stripeIntent.value
-                ?.linkFundingSources?.contains(PaymentMethod.Type.Card.code) == true &&
+            ?.linkFundingSources?.contains(PaymentMethod.Type.Card.code) == true &&
             paymentMethodCode == PaymentMethod.Type.Card.code &&
             (
                 linkAccountStatus in setOf(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
@@ -322,7 +322,7 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
             amount: Amount? = null,
             @InjectorKey injectorKey: String,
             newLpm: PaymentSelection.New?,
-            isShowingLinkInlineSignup: Boolean
+            isShowingLinkInlineSignup: Boolean = false
         ): FormFragmentArguments {
             val layoutFormDescriptor = showPaymentMethod.getPMAddForm(stripeIntent, config)
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet
 
-import android.app.Application
 import android.content.Context
 import android.content.Intent
 import android.content.res.ColorStateList
@@ -18,6 +17,9 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.DUMMY_INJECTOR_KEY
+import com.stripe.android.core.injection.Injectable
+import com.stripe.android.core.injection.Injector
+import com.stripe.android.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.model.PaymentMethod
@@ -26,10 +28,18 @@ import com.stripe.android.paymentsheet.PaymentOptionsViewModel.TransitionTarget
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.PAYMENT_OPTIONS_CONTRACT_ARGS
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.databinding.PrimaryButtonBinding
+import com.stripe.android.paymentsheet.forms.FormViewModel
+import com.stripe.android.paymentsheet.forms.PaymentMethodRequirements
+import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
+import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.address.AddressRepository
+import com.stripe.android.ui.core.elements.EmailSpec
+import com.stripe.android.ui.core.elements.LayoutSpec
+import com.stripe.android.ui.core.elements.SaveForFutureUseSpec
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.ui.core.forms.resources.StaticAddressResourceRepository
 import com.stripe.android.ui.core.forms.resources.StaticLpmResourceRepository
@@ -39,6 +49,7 @@ import com.stripe.android.utils.TestUtils.viewModelFactoryFor
 import com.stripe.android.utils.injectableActivityScenario
 import com.stripe.android.view.ActivityStarter
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Rule
@@ -47,18 +58,41 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.stub
+import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
+import javax.inject.Provider
 import kotlin.test.BeforeTest
 
 @ExperimentalCoroutinesApi
+@FlowPreview
 @RunWith(RobolectricTestRunner::class)
-class PaymentOptionsActivityTest {
+internal class PaymentOptionsActivityTest {
     @get:Rule
     val rule = InstantTaskExecutorRule()
 
+    private val context = ApplicationProvider.getApplicationContext<Context>()
     private val testDispatcher = UnconfinedTestDispatcher()
 
     private val eventReporter = mock<EventReporter>()
+    private lateinit var injector: Injector
+    private val addressRepository = AddressRepository(context.resources)
+    private val lpmRepository = mock<LpmRepository>().apply {
+        whenever(fromCode(any())).thenReturn(
+            LpmRepository.SupportedPaymentMethod(
+                PaymentMethod.Type.Card.code,
+                false,
+                com.stripe.android.ui.core.R.string.stripe_paymentsheet_payment_method_card,
+                com.stripe.android.ui.core.R.drawable.stripe_ic_paymentsheet_pm_card,
+                true,
+                PaymentMethodRequirements(emptySet(), emptySet(), true),
+                LayoutSpec.create(
+                    EmailSpec(),
+                    SaveForFutureUseSpec()
+                )
+            )
+        )
+    }
+
     private val viewModel = createViewModel()
 
     private val primaryButtonUIState = PrimaryButton.UIState(
@@ -444,17 +478,10 @@ class PaymentOptionsActivityTest {
     private fun createViewModel(
         args: PaymentOptionContract.Args = PAYMENT_OPTIONS_CONTRACT_ARGS
     ): PaymentOptionsViewModel {
-        val lpmRepository = LpmRepository(
-            LpmRepository.LpmRepositoryArguments(ApplicationProvider.getApplicationContext<Application>().resources)
-        ).apply {
-            this.forceUpdate(listOf(PaymentMethod.Type.Card.code, PaymentMethod.Type.USBankAccount.code), null)
-        }
-        val addressRepository = AddressRepository(
-            ApplicationProvider.getApplicationContext<Application>().resources
-        )
         val linkPaymentLauncher = mock<LinkPaymentLauncher>().stub {
             onBlocking { getAccountStatusFlow(any()) }.thenReturn(flowOf(AccountStatus.SignedOut))
         }
+        registerFormViewModelInjector()
         return PaymentOptionsViewModel(
             args = args,
             prefsRepositoryFactory = { FakePrefsRepository() },
@@ -464,14 +491,62 @@ class PaymentOptionsActivityTest {
             application = ApplicationProvider.getApplicationContext(),
             logger = Logger.noop(),
             injectorKey = DUMMY_INJECTOR_KEY,
-            lpmResourceRepository = StaticLpmResourceRepository(
-                lpmRepository
-            ),
-            addressResourceRepository = StaticAddressResourceRepository(
-                addressRepository
-            ),
+            lpmResourceRepository = StaticLpmResourceRepository(mock<LpmRepository>().apply {
+                whenever(fromCode(any())).thenReturn(
+                    LpmRepository.SupportedPaymentMethod(
+                        PaymentMethod.Type.Card.code,
+                        false,
+                        com.stripe.android.ui.core.R.string.stripe_paymentsheet_payment_method_card,
+                        com.stripe.android.ui.core.R.drawable.stripe_ic_paymentsheet_pm_card,
+                        true,
+                        PaymentMethodRequirements(emptySet(), emptySet(), true),
+                        LayoutSpec.create(
+                            EmailSpec(),
+                            SaveForFutureUseSpec()
+                        )
+                    )
+                )
+            }),
+            addressResourceRepository = StaticAddressResourceRepository(addressRepository),
             savedStateHandle = SavedStateHandle(),
             linkLauncher = linkPaymentLauncher
         )
+    }
+
+    fun registerFormViewModelInjector() {
+        val formViewModel = FormViewModel(
+            context = context,
+            formFragmentArguments = FormFragmentArguments(
+                PaymentMethod.Type.Card.code,
+                showCheckbox = true,
+                showCheckboxControlledFields = true,
+                merchantName = "Merchant, Inc.",
+                amount = Amount(50, "USD"),
+                injectorKey = "injectorTestKeyFormFragmentArgumentTest",
+                initialPaymentMethodCreateParams = null
+            ),
+            lpmResourceRepository = StaticLpmResourceRepository(lpmRepository),
+            addressResourceRepository = StaticAddressResourceRepository(addressRepository),
+            showCheckboxFlow = mock()
+        )
+
+        val mockFormBuilder = mock<FormViewModelSubcomponent.Builder>()
+        val mockFormSubcomponent = mock<FormViewModelSubcomponent>()
+        val mockFormSubComponentBuilderProvider =
+            mock<Provider<FormViewModelSubcomponent.Builder>>()
+        whenever(mockFormBuilder.build()).thenReturn(mockFormSubcomponent)
+        whenever(mockFormBuilder.formFragmentArguments(any())).thenReturn(mockFormBuilder)
+        whenever(mockFormBuilder.showCheckboxFlow(any())).thenReturn(mockFormBuilder)
+        whenever(mockFormSubcomponent.viewModel).thenReturn(formViewModel)
+        whenever(mockFormSubComponentBuilderProvider.get()).thenReturn(mockFormBuilder)
+
+        injector = object : Injector {
+            override fun inject(injectable: Injectable<*>) {
+                (injectable as? FormViewModel.Factory)?.let {
+                    injectable.subComponentBuilderProvider = mockFormSubComponentBuilderProvider
+                }
+            }
+        }
+        WeakMapInjectorRegistry.register(injector, DUMMY_INJECTOR_KEY)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -61,6 +61,7 @@ import org.mockito.kotlin.stub
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import javax.inject.Provider
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 
 @ExperimentalCoroutinesApi
@@ -108,6 +109,11 @@ internal class PaymentOptionsActivityTest {
             ApplicationProvider.getApplicationContext(),
             ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
         )
+    }
+
+    @AfterTest
+    fun cleanup() {
+        WeakMapInjectorRegistry.clear()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -491,22 +491,7 @@ internal class PaymentOptionsActivityTest {
             application = ApplicationProvider.getApplicationContext(),
             logger = Logger.noop(),
             injectorKey = DUMMY_INJECTOR_KEY,
-            lpmResourceRepository = StaticLpmResourceRepository(mock<LpmRepository>().apply {
-                whenever(fromCode(any())).thenReturn(
-                    LpmRepository.SupportedPaymentMethod(
-                        PaymentMethod.Type.Card.code,
-                        false,
-                        com.stripe.android.ui.core.R.string.stripe_paymentsheet_payment_method_card,
-                        com.stripe.android.ui.core.R.drawable.stripe_ic_paymentsheet_pm_card,
-                        true,
-                        PaymentMethodRequirements(emptySet(), emptySet(), true),
-                        LayoutSpec.create(
-                            EmailSpec(),
-                            SaveForFutureUseSpec()
-                        )
-                    )
-                )
-            }),
+            lpmResourceRepository = StaticLpmResourceRepository(lpmRepository),
             addressResourceRepository = StaticAddressResourceRepository(addressRepository),
             savedStateHandle = SavedStateHandle(),
             linkLauncher = linkPaymentLauncher

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAddPaymentMethodFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAddPaymentMethodFragmentTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.FragmentConfigFixtures
 import com.stripe.android.ui.core.forms.resources.LpmRepository
+import com.stripe.android.utils.FakeAndroidKeyStore
 import com.stripe.android.utils.TestUtils
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -36,6 +37,7 @@ internal class PaymentOptionsAddPaymentMethodFragmentTest : PaymentOptionsViewMo
 
     @Before
     fun setup() {
+        FakeAndroidKeyStore.setup()
         PaymentConfiguration.init(
             ApplicationProvider.getApplicationContext(),
             ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
@@ -77,7 +79,6 @@ internal class PaymentOptionsAddPaymentMethodFragmentTest : PaymentOptionsViewMo
         registerInjector: Boolean = true,
         onReady: (
             PaymentOptionsAddPaymentMethodFragment,
-
             PaymentOptionsViewModel
         ) -> Unit
     ): FragmentScenario<PaymentOptionsAddPaymentMethodFragment> {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTestInjection.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTestInjection.kt
@@ -10,6 +10,8 @@ import com.stripe.android.core.injection.Injectable
 import com.stripe.android.core.injection.Injector
 import com.stripe.android.core.injection.InjectorKey
 import com.stripe.android.core.injection.WeakMapInjectorRegistry
+import com.stripe.android.link.LinkPaymentLauncher
+import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.forms.FormViewModel
@@ -24,6 +26,7 @@ import com.stripe.android.ui.core.forms.resources.StaticAddressResourceRepositor
 import com.stripe.android.ui.core.forms.resources.StaticLpmResourceRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.After
@@ -78,7 +81,9 @@ internal open class PaymentOptionsViewModelTestInjection {
             savedStateHandle = SavedStateHandle().apply {
                 set(BaseSheetViewModel.SAVE_RESOURCE_REPOSITORY_READY, true)
             },
-            linkLauncher = mock()
+            linkLauncher = mock<LinkPaymentLauncher>().apply {
+                whenever(getAccountStatusFlow(any())).thenReturn(flowOf(AccountStatus.Verified))
+            }
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -14,6 +14,9 @@ import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.DUMMY_INJECTOR_KEY
+import com.stripe.android.core.injection.Injectable
+import com.stripe.android.core.injection.Injector
+import com.stripe.android.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContract
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
@@ -33,16 +36,26 @@ import com.stripe.android.paymentsheet.PaymentSheetViewModel.CheckoutIdentifier
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.databinding.PrimaryButtonBinding
 import com.stripe.android.paymentsheet.databinding.StripeGooglePayButtonBinding
+import com.stripe.android.paymentsheet.forms.FormViewModel
+import com.stripe.android.paymentsheet.forms.PaymentMethodRequirements
+import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
 import com.stripe.android.paymentsheet.model.FragmentConfigFixtures
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
 import com.stripe.android.paymentsheet.model.StripeIntentValidator
+import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
 import com.stripe.android.paymentsheet.repositories.StripeIntentRepository
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.ui.PrimaryButtonAnimator
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
+import com.stripe.android.ui.core.Amount
+import com.stripe.android.ui.core.address.AddressRepository
+import com.stripe.android.ui.core.elements.EmailSpec
+import com.stripe.android.ui.core.elements.LayoutSpec
+import com.stripe.android.ui.core.elements.SaveForFutureUseSpec
 import com.stripe.android.ui.core.forms.resources.LpmRepository
+import com.stripe.android.ui.core.forms.resources.StaticAddressResourceRepository
 import com.stripe.android.ui.core.forms.resources.StaticLpmResourceRepository
 import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.TestUtils.getOrAwaitValue
@@ -53,6 +66,7 @@ import com.stripe.android.view.ActivityScenarioFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -66,10 +80,12 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.stub
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
+import javax.inject.Provider
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 
 @ExperimentalCoroutinesApi
+@FlowPreview
 @RunWith(RobolectricTestRunner::class)
 internal class PaymentSheetActivityTest {
     @get:Rule
@@ -77,6 +93,7 @@ internal class PaymentSheetActivityTest {
 
     private val context = ApplicationProvider.getApplicationContext<Context>()
     private val testDispatcher = UnconfinedTestDispatcher()
+    private lateinit var injector: Injector
 
     private val eventReporter = mock<EventReporter>()
     private val googlePayPaymentMethodLauncherFactory =
@@ -1016,6 +1033,8 @@ internal class PaymentSheetActivityTest {
             onBlocking { getAccountStatusFlow(any()) }.thenReturn(flowOf(AccountStatus.SignedOut))
         }
 
+        registerFormViewModelInjector()
+
         PaymentSheetViewModel(
             ApplicationProvider.getApplicationContext(),
             PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY,
@@ -1051,6 +1070,60 @@ internal class PaymentSheetActivityTest {
                 return googlePayPaymentMethodLauncher
             }
         }
+
+    fun registerFormViewModelInjector() {
+        val lpmRepository = mock<LpmRepository>().apply {
+            whenever(fromCode(any())).thenReturn(
+                LpmRepository.SupportedPaymentMethod(
+                    PaymentMethod.Type.Card.code,
+                    false,
+                    com.stripe.android.ui.core.R.string.stripe_paymentsheet_payment_method_card,
+                    com.stripe.android.ui.core.R.drawable.stripe_ic_paymentsheet_pm_card,
+                    true,
+                    PaymentMethodRequirements(emptySet(), emptySet(), true),
+                    LayoutSpec.create(
+                        EmailSpec(),
+                        SaveForFutureUseSpec()
+                    )
+                )
+            )
+        }
+
+        val formViewModel = FormViewModel(
+            context = context,
+            formFragmentArguments = FormFragmentArguments(
+                PaymentMethod.Type.Card.code,
+                showCheckbox = true,
+                showCheckboxControlledFields = true,
+                merchantName = "Merchant, Inc.",
+                amount = Amount(50, "USD"),
+                injectorKey = "injectorTestKeyFormFragmentArgumentTest",
+                initialPaymentMethodCreateParams = null
+            ),
+            lpmResourceRepository = StaticLpmResourceRepository(lpmRepository),
+            addressResourceRepository = StaticAddressResourceRepository(AddressRepository(context.resources)),
+            showCheckboxFlow = mock()
+        )
+
+        val mockFormBuilder = mock<FormViewModelSubcomponent.Builder>()
+        val mockFormSubcomponent = mock<FormViewModelSubcomponent>()
+        val mockFormSubComponentBuilderProvider =
+            mock<Provider<FormViewModelSubcomponent.Builder>>()
+        whenever(mockFormBuilder.build()).thenReturn(mockFormSubcomponent)
+        whenever(mockFormBuilder.formFragmentArguments(any())).thenReturn(mockFormBuilder)
+        whenever(mockFormBuilder.showCheckboxFlow(any())).thenReturn(mockFormBuilder)
+        whenever(mockFormSubcomponent.viewModel).thenReturn(formViewModel)
+        whenever(mockFormSubComponentBuilderProvider.get()).thenReturn(mockFormBuilder)
+
+        injector = object : Injector {
+            override fun inject(injectable: Injectable<*>) {
+                (injectable as? FormViewModel.Factory)?.let {
+                    injectable.subComponentBuilderProvider = mockFormSubComponentBuilderProvider
+                }
+            }
+        }
+        WeakMapInjectorRegistry.register(injector, DUMMY_INJECTOR_KEY)
+    }
 
     private companion object {
         private val PAYMENT_INTENT = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -131,6 +131,7 @@ internal class PaymentSheetActivityTest {
 
     @AfterTest
     fun cleanup() {
+        WeakMapInjectorRegistry.clear()
         Dispatchers.resetMain()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeAndroidKeyStore.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeAndroidKeyStore.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2020 Appmattus Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stripe.android.utils
+
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.io.InputStream
+import java.io.OutputStream
+import java.security.Key
+import java.security.KeyStore
+import java.security.KeyStoreSpi
+import java.security.Provider
+import java.security.SecureRandom
+import java.security.Security
+import java.security.cert.Certificate
+import java.security.spec.AlgorithmParameterSpec
+import java.util.Date
+import java.util.Enumeration
+import javax.crypto.KeyGenerator
+import javax.crypto.KeyGeneratorSpi
+import javax.crypto.SecretKey
+
+/**
+ * Add a fake AndroidKeyStore provider, used by EncryptedSharedPreferences.
+ *
+ * Extended from https://proandroiddev.com/testing-jetpack-security-with-robolectric-9f9cf2aa4f61
+ */
+object FakeAndroidKeyStore {
+
+    fun setup() {
+        Security.addProvider(object : Provider("AndroidKeyStore", 1.0, "") {
+            init {
+                put("KeyStore.AndroidKeyStore", FakeKeyStore::class.java.name)
+                put("KeyGenerator.AES", FakeAesKeyGenerator::class.java.name)
+            }
+        })
+    }
+
+    @Suppress("unused")
+    class FakeKeyStore : KeyStoreSpi() {
+        private val wrapped = KeyStore.getInstance(KeyStore.getDefaultType())
+        private val secretKey = mock<SecretKey>().also {
+            whenever(it.encoded).thenReturn("encoded".toByteArray())
+        }
+
+        override fun engineIsKeyEntry(alias: String?): Boolean = wrapped.isKeyEntry(alias)
+        override fun engineIsCertificateEntry(alias: String?): Boolean =
+            wrapped.isCertificateEntry(alias)
+
+        override fun engineGetCertificate(alias: String?): Certificate =
+            wrapped.getCertificate(alias)
+
+        override fun engineGetCreationDate(alias: String?): Date = wrapped.getCreationDate(alias)
+        override fun engineDeleteEntry(alias: String?) = wrapped.deleteEntry(alias)
+        override fun engineSetKeyEntry(
+            alias: String?,
+            key: Key?,
+            password: CharArray?,
+            chain: Array<out Certificate>?
+        ) =
+            wrapped.setKeyEntry(alias, key, password, chain)
+
+        override fun engineSetKeyEntry(
+            alias: String?,
+            key: ByteArray?,
+            chain: Array<out Certificate>?
+        ) = wrapped.setKeyEntry(alias, key, chain)
+
+        override fun engineStore(stream: OutputStream?, password: CharArray?) =
+            wrapped.store(stream, password)
+
+        override fun engineSize(): Int = wrapped.size()
+        override fun engineAliases(): Enumeration<String> = wrapped.aliases()
+        override fun engineContainsAlias(alias: String?): Boolean = wrapped.containsAlias(alias)
+        override fun engineLoad(stream: InputStream?, password: CharArray?) =
+            wrapped.load(stream, password)
+
+        override fun engineGetCertificateChain(alias: String?): Array<Certificate> =
+            wrapped.getCertificateChain(alias)
+
+        override fun engineSetCertificateEntry(alias: String?, cert: Certificate?) =
+            wrapped.setCertificateEntry(alias, cert)
+
+        override fun engineGetCertificateAlias(cert: Certificate?): String =
+            wrapped.getCertificateAlias(cert)
+
+        override fun engineGetKey(alias: String?, password: CharArray?): Key = secretKey
+    }
+
+    @Suppress("unused")
+    class FakeAesKeyGenerator : KeyGeneratorSpi() {
+        private val wrapped = KeyGenerator.getInstance("AES")
+
+        override fun engineInit(random: SecureRandom?) = Unit
+        override fun engineInit(params: AlgorithmParameterSpec?, random: SecureRandom?) = Unit
+        override fun engineInit(keysize: Int, random: SecureRandom?) = Unit
+        override fun engineGenerateKey(): SecretKey = wrapped.generateKey()
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
- Checkbox visibility was not being updated because the `MutableStateFlow` was being created at every recomposition.
- When user returns after entering a new card in custom flow and using Link inline signup, treat the `PaymentSelection` as a Card, so that the form is repopulated.
- When user completes inline signup before filling in card details, button would not be enabled once the card form is complete.
- Logout before looking up a new email in inline signup to avoid being in an inconsistent state when the user cancels authentication and enters a different email.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix inline signup issues

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified