### PR TITLE
Do not request focus after invalid OTP

### DIFF
--- a/link/src/main/AndroidManifest.xml
+++ b/link/src/main/AndroidManifest.xml
@@ -7,7 +7,8 @@
             android:name=".LinkActivity"
             android:theme="@style/LinkBaseTheme"
             android:exported="false"
-            android:label="@string/link" />
+            android:label="@string/link"
+            android:windowSoftInputMode="adjustResize" />
     </application>
 
 </manifest>

--- a/link/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -77,8 +77,6 @@ internal class LinkActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // TODO(brnunes-stripe): Migrate to androidx.compose.foundation 1.2.0 when out of beta
-        window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
         overridePendingTransition(R.anim.slide_up, 0)
 
         setContent {

--- a/link/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -3,7 +3,6 @@ package com.stripe.android.link
 import android.content.Intent
 import android.os.Bundle
 import android.view.ViewTreeObserver
-import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent

--- a/link/src/main/java/com/stripe/android/link/ui/verification/VerificationViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/verification/VerificationViewModel.kt
@@ -16,7 +16,6 @@ import com.stripe.android.link.ui.getErrorMessage
 import com.stripe.android.ui.core.elements.OTPSpec
 import com.stripe.android.ui.core.injection.NonFallbackInjectable
 import com.stripe.android.ui.core.injection.NonFallbackInjector
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -90,16 +89,11 @@ internal class VerificationViewModel @Inject constructor(
                     onVerificationCompleted()
                 },
                 onFailure = {
-                    onError(it)
                     linkEventsReporter.on2FAFailure()
-                    viewModelScope.launch {
-                        delay(50)
-                        for (i in 0 until otpElement.controller.otpLength) {
-                            delay(10)
-                            otpElement.controller.onValueChanged(i, "")
-                        }
-                        _requestFocus.value = true
+                    for (i in 0 until otpElement.controller.otpLength) {
+                        otpElement.controller.onValueChanged(i, "")
                     }
+                    onError(it)
                 }
             )
         }

--- a/link/src/test/java/com/stripe/android/link/ui/verification/VerificationViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/verification/VerificationViewModelTest.kt
@@ -19,7 +19,6 @@ import com.stripe.android.ui.core.injection.NonFallbackInjector
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -112,7 +111,7 @@ class VerificationViewModelTest {
         }
 
     @Test
-    fun `When confirmVerification fails then code is cleared and focus requested`() =
+    fun `When confirmVerification fails then code is cleared`() =
         runTest {
             whenever(linkAccountManager.confirmVerification(any()))
                 .thenReturn(Result.failure(RuntimeException("Error")))
@@ -124,18 +123,9 @@ class VerificationViewModelTest {
             }
 
             for (i in 0 until viewModel.otpElement.controller.otpLength) {
-                viewModel.otpElement.controller.onValueChanged(i, i.toString())
+                viewModel.otpElement.controller.onValueChanged(i, "1")
             }
-            assertThat(otp).isEqualTo("012345")
 
-            viewModel.onFocusRequested()
-            assertThat(viewModel.requestFocus.value).isFalse()
-            viewModel.onVerificationCodeEntered("code")
-
-            // Advance past animation
-            advanceTimeBy(1000)
-
-            assertThat(viewModel.requestFocus.value).isTrue()
             assertThat(otp).isEqualTo("")
         }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
After an OTP is entered, the keyboard is dismissed. If the OTP is incorrect, an error message is shown. After that, the OTP would request focus, causing the keyboard to cover the error message.
Fix that by not requesting focus on the second time.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Make sure error message is visible.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

https://user-images.githubusercontent.com/77990083/194211659-044cd2f0-4093-4d77-90df-cf5f7edfc321.mp4
