### PR TITLE
Get completion loop frame count from initialize client

### DIFF
--- a/stripecardscan/api/stripecardscan.api
+++ b/stripecardscan/api/stripecardscan.api
@@ -59,8 +59,8 @@ public final class com/stripe/android/stripecardscan/cardimageverification/CardI
 }
 
 public abstract class com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration$StrictModeFrameCount : android/os/Parcelable {
-	public synthetic fun <init> (ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getCount ()I
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getCount ()Lkotlin/jvm/functions/Function1;
 }
 
 public final class com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration$StrictModeFrameCount$High : com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet$Configuration$StrictModeFrameCount {

--- a/stripecardscan/src/androidTest/java/com/stripe/android/stripecardscan/framework/api/dto/CardImageVerificationDetailsTest.kt
+++ b/stripecardscan/src/androidTest/java/com/stripe/android/stripecardscan/framework/api/dto/CardImageVerificationDetailsTest.kt
@@ -22,18 +22,20 @@ class CardImageVerificationDetailsTest {
                   "image_size": [
                     1080,
                     1920
-                  ]
+                  ],
+                  "image_count": 5
                 },
                 "format_settings": {
                   "heic": {
-                    "compression_ratio": 0.5
+                    "compression_ratio": 0.5,
+                    "image_count": 3
                   },
                   "webp": {
                     "compression_ratio": 0.7
                     "image_size": [
                         2160,
                         1920
-                  ]
+                    ]
                   }
                 },
                 "preferred_formats": [
@@ -51,31 +53,21 @@ class CardImageVerificationDetailsTest {
         val result = Json.decodeFromString<CardImageVerificationDetailsResult>(json)
         assertNotNull(result.acceptedImageConfigs)
 
-        result.acceptedImageConfigs?.let {
-            val acceptedImageConfigs = AcceptedImageConfigs(it)
-            val heicSettings = acceptedImageConfigs.imageSettings(ImageFormat.HEIC)
-            assertNotNull(heicSettings)
+        val acceptedImageConfigs = AcceptedImageConfigs(result.acceptedImageConfigs)
 
-            heicSettings?.let {
-                assertEquals(it.first, 0.5)
-                assertEquals(it.second, Size(1080, 1920))
-            }
+        val heicSettings = acceptedImageConfigs.getImageSettings(ImageFormat.HEIC)
+        assertEquals(heicSettings.compressionRatio, 0.5)
+        assertEquals(heicSettings.imageSize, Size(1080, 1920))
+        assertEquals(heicSettings.imageCount, 3)
 
-            val jpegSettings = acceptedImageConfigs.imageSettings(ImageFormat.JPEG)
-            assertNotNull(jpegSettings)
+        val jpegSettings = acceptedImageConfigs.getImageSettings(ImageFormat.JPEG)
+        assertEquals(jpegSettings.compressionRatio, 0.8)
+        assertEquals(jpegSettings.imageSize, Size(1080, 1920))
+        assertEquals(jpegSettings.imageCount, 5)
 
-            jpegSettings?.let {
-                assertEquals(it.first, 0.8)
-                assertEquals(it.second, Size(1080, 1920))
-            }
-
-            val webpSettings = acceptedImageConfigs.imageSettings(ImageFormat.WEBP)
-            assertNotNull(webpSettings)
-
-            webpSettings?.let {
-                assertEquals(it.first, 0.7)
-                assertEquals(it.second, Size(2160, 1920))
-            }
-        }
+        val webpSettings = acceptedImageConfigs.getImageSettings(ImageFormat.WEBP)
+        assertEquals(webpSettings.compressionRatio, 0.7)
+        assertEquals(webpSettings.imageSize, Size(2160, 1920))
+        assertEquals(webpSettings.imageCount, 5)
     }
 }

--- a/stripecardscan/src/androidTest/java/com/stripe/android/stripecardscan/framework/api/dto/CardImageVerificationDetailsTest.kt
+++ b/stripecardscan/src/androidTest/java/com/stripe/android/stripecardscan/framework/api/dto/CardImageVerificationDetailsTest.kt
@@ -4,8 +4,7 @@ import android.util.Size
 import androidx.test.filters.SmallTest
 import com.stripe.android.stripecardscan.framework.util.AcceptedImageConfigs
 import com.stripe.android.stripecardscan.framework.util.ImageFormat
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.json.Json
+import com.stripe.android.stripecardscan.framework.util.decodeFromJson
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -23,7 +22,8 @@ class CardImageVerificationDetailsTest {
                     1080,
                     1920
                   ],
-                  "image_count": 5
+                  "image_count": 5,
+                  "unknown_field": "test"
                 },
                 "format_settings": {
                   "heic": {
@@ -50,7 +50,7 @@ class CardImageVerificationDetailsTest {
               }
             }"""
 
-        val result = Json.decodeFromString<CardImageVerificationDetailsResult>(json)
+        val result = decodeFromJson(CardImageVerificationDetailsResult.serializer(), json)
         assertNotNull(result.acceptedImageConfigs)
 
         val acceptedImageConfigs = AcceptedImageConfigs(result.acceptedImageConfigs)

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationActivity.kt
@@ -233,7 +233,7 @@ internal open class CardImageVerificationActivity :
                     cameraAdapter.unbindFromLifecycle(this@CardImageVerificationActivity)
                     resultListener.cardReadyForVerification(
                         pan = result.pan,
-                        frames = scanFlow.selectCompletionLoopFrames(result.savedFrames)
+                        frames = scanFlow.selectCompletionLoopFrames(result.savedFrames, imageConfigs)
                     )
                 }.let { }
             }

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationActivity.kt
@@ -366,7 +366,7 @@ internal open class CardImageVerificationActivity :
                     CardVerificationFlowParameters(
                         cardIssuer = getIssuerByDisplayName(expectedCard.issuer),
                         lastFour = expectedCard.lastFour,
-                        strictModeFrames = params.configuration.strictModeFrames.count
+                        strictModeFrames = params.configuration.strictModeFrames.count(imageConfigs.getImageSettings().second.imageCount)
                     )
                 } else {
                     launch(Dispatchers.Main) {
@@ -648,7 +648,7 @@ internal open class CardImageVerificationActivity :
             appDetails = AppDetails.fromContext(this),
             scanStatistics = ScanStatistics.fromStats(),
             scanConfig = ScanConfig(
-                strictModeFrameCount = params.configuration.strictModeFrames.count
+                strictModeFrameCount = params.configuration.strictModeFrames.count(imageConfigs.getImageSettings().second.imageCount)
             ),
             payloadInfo = currentScanPayloadInfo
         )

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationActivity.kt
@@ -233,7 +233,10 @@ internal open class CardImageVerificationActivity :
                     cameraAdapter.unbindFromLifecycle(this@CardImageVerificationActivity)
                     resultListener.cardReadyForVerification(
                         pan = result.pan,
-                        frames = scanFlow.selectCompletionLoopFrames(result.savedFrames, imageConfigs)
+                        frames = scanFlow.selectCompletionLoopFrames(
+                            result.savedFrames,
+                            imageConfigs
+                        )
                     )
                 }.let { }
             }
@@ -366,7 +369,9 @@ internal open class CardImageVerificationActivity :
                     CardVerificationFlowParameters(
                         cardIssuer = getIssuerByDisplayName(expectedCard.issuer),
                         lastFour = expectedCard.lastFour,
-                        strictModeFrames = params.configuration.strictModeFrames.count(imageConfigs.getImageSettings().second.imageCount)
+                        strictModeFrames = params.configuration.strictModeFrames.count(
+                            imageConfigs.getImageSettings().second.imageCount
+                        )
                     )
                 } else {
                     launch(Dispatchers.Main) {
@@ -648,7 +653,9 @@ internal open class CardImageVerificationActivity :
             appDetails = AppDetails.fromContext(this),
             scanStatistics = ScanStatistics.fromStats(),
             scanConfig = ScanConfig(
-                strictModeFrameCount = params.configuration.strictModeFrames.count(imageConfigs.getImageSettings().second.imageCount)
+                strictModeFrameCount = params.configuration.strictModeFrames.count(
+                    imageConfigs.getImageSettings().second.imageCount
+                )
             ),
             payloadInfo = currentScanPayloadInfo
         )

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationFlow.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationFlow.kt
@@ -13,6 +13,7 @@ import com.stripe.android.camera.scanui.ScanFlow
 import com.stripe.android.stripecardscan.cardimageverification.analyzer.MainLoopAnalyzer
 import com.stripe.android.stripecardscan.cardimageverification.result.MainLoopAggregator
 import com.stripe.android.stripecardscan.cardimageverification.result.MainLoopState
+import com.stripe.android.stripecardscan.framework.util.AcceptedImageConfigs
 import com.stripe.android.stripecardscan.payment.ml.CardDetect
 import com.stripe.android.stripecardscan.payment.ml.CardDetectModelManager
 import com.stripe.android.stripecardscan.payment.ml.SSDOcr
@@ -38,13 +39,6 @@ internal abstract class CardImageVerificationFlow(
     private val scanErrorListener: AnalyzerLoopErrorListener
 ) : ScanFlow<CardVerificationFlowParameters?, CameraPreviewImage<Bitmap>>,
     AggregateResultListener<MainLoopAggregator.InterimResult, MainLoopAggregator.FinalResult> {
-
-    companion object {
-        /**
-         * The maximum number of frames to process
-         */
-        const val MAX_COMPLETION_LOOP_FRAMES = 3
-    }
 
     /**
      * If this is true, do not start the flow.
@@ -151,7 +145,8 @@ internal abstract class CardImageVerificationFlow(
      * Select which frames to use in the completion loop.
      */
     fun <SavedFrame> selectCompletionLoopFrames(
-        frames: Map<SavedFrameType, List<SavedFrame>>
+        frames: Map<SavedFrameType, List<SavedFrame>>,
+        imageConfigs: AcceptedImageConfigs
     ): Collection<SavedFrame> {
         fun getFrames(frameType: SavedFrameType) = frames[frameType] ?: emptyList()
 
@@ -159,6 +154,6 @@ internal abstract class CardImageVerificationFlow(
         val pan = getFrames(SavedFrameType(hasCard = false, hasOcr = true))
         val card = getFrames(SavedFrameType(hasCard = true, hasOcr = false))
 
-        return (cardAndPan + pan + card).take(MAX_COMPLETION_LOOP_FRAMES)
+        return (cardAndPan + pan + card).take(imageConfigs.getImageSettings().second.imageCount)
     }
 }

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationSheet.kt
@@ -8,7 +8,6 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.ActivityResultRegistry
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.fragment.app.Fragment
-import com.stripe.android.stripecardscan.cardimageverification.CardImageVerificationFlow.Companion.MAX_COMPLETION_LOOP_FRAMES
 import com.stripe.android.stripecardscan.cardimageverification.exception.UnknownScanException
 import com.stripe.android.stripecardscan.payment.card.ScannedCard
 import com.stripe.android.stripecardscan.scanui.CancellationReason
@@ -59,14 +58,14 @@ class CardImageVerificationSheet private constructor(
          */
         val enableCannotScanButton: Boolean = true
     ) : Parcelable {
-        sealed class StrictModeFrameCount(val count: Int) : Parcelable {
-            @Parcelize object None : StrictModeFrameCount(0)
+        sealed class StrictModeFrameCount(val count: (maxCompletionLoopFrames: Int) -> Int) : Parcelable {
+            @Parcelize object None : StrictModeFrameCount({ 0 })
 
-            @Parcelize object Low : StrictModeFrameCount(1)
+            @Parcelize object Low : StrictModeFrameCount({ 1 })
 
-            @Parcelize object Medium : StrictModeFrameCount(MAX_COMPLETION_LOOP_FRAMES / 2)
+            @Parcelize object Medium : StrictModeFrameCount({ maxCompletionLoopFrames -> maxCompletionLoopFrames / 2 })
 
-            @Parcelize object High : StrictModeFrameCount(MAX_COMPLETION_LOOP_FRAMES)
+            @Parcelize object High : StrictModeFrameCount({ maxCompletionLoopFrames -> maxCompletionLoopFrames })
         }
     }
 

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/api/dto/CardImageVerificationDetails.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/api/dto/CardImageVerificationDetails.kt
@@ -38,7 +38,8 @@ internal enum class CardImageVerificationDetailsFormat {
 @Serializable
 internal data class CardImageVerificationDetailsImageSettings(
     @SerialName("compression_ratio") val compressionRatio: Double? = null,
-    @SerialName("image_size") val imageSize: DoubleArray? = null
+    @SerialName("image_size") val imageSize: List<Double>? = null,
+    @SerialName("image_count") val imageCount: Int? = null
 )
 
 @Serializable
@@ -52,5 +53,5 @@ internal data class CardImageVerificationDetailsAcceptedImageConfigs(
             CardImageVerificationDetailsImageSettings?>? = null,
 
     @SerialName("preferred_formats")
-    val preferredFormats: Array<CardImageVerificationDetailsFormat>? = null
+    val preferredFormats: List<CardImageVerificationDetailsFormat>? = null
 )

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/api/dto/ClientStats.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/api/dto/ClientStats.kt
@@ -96,5 +96,7 @@ internal data class ConfigurationStats(
 internal data class PayloadInfo(
     @SerialName("image_compression_type") val imageCompressionType: String,
     @SerialName("image_compression_quality") val imageCompressionQuality: Float,
-    @SerialName("image_payload_size") val imagePayloadSizeInBytes: Int
+    @SerialName("image_payload_size") val imagePayloadSizeInBytes: Int,
+    @SerialName("image_payload_count") val imagePayloadCount: Int,
+    @SerialName("image_payload_max_count") val imagePayloadMaxCount: Int
 )

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/image/BitmapExtensions.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/image/BitmapExtensions.kt
@@ -11,6 +11,7 @@ import com.stripe.android.camera.framework.image.toJpeg
 import com.stripe.android.camera.framework.image.toWebP
 import com.stripe.android.camera.framework.util.scaleAndCenterWithin
 import com.stripe.android.stripecardscan.framework.util.ImageFormat
+import com.stripe.android.stripecardscan.framework.util.ImageSettings
 
 /**
  * Convert a [Bitmap] to an [MLImage] for use in ML models.
@@ -27,10 +28,10 @@ internal fun Bitmap.toMLImage(mean: ImageTransformValues, std: ImageTransformVal
 
 internal fun Bitmap.toImageFormat(
     format: ImageFormat,
-    imageSettings: Pair<Double, Size>
+    imageSettings: ImageSettings
 ): Pair<ByteArray, Rect> {
     // Size and crop the image per the settings.
-    val maxImageSize = imageSettings.second
+    val maxImageSize = imageSettings.imageSize
 
     val cropRect = maxImageSize
         .scaleAndCenterWithin(this.size())
@@ -40,7 +41,7 @@ internal fun Bitmap.toImageFormat(
         .constrainToSize(maxImageSize)
 
     // Now convert formats with the compression ratio from settings.
-    val compressionRatio = imageSettings.first
+    val compressionRatio = imageSettings.compressionRatio
 
     // Convert to 0..100
     val convertedRatio = compressionRatio.times(100.0).toInt()

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/image/BitmapExtensions.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/image/BitmapExtensions.kt
@@ -2,7 +2,6 @@ package com.stripe.android.stripecardscan.framework.image
 
 import android.graphics.Bitmap
 import android.graphics.Rect
-import android.util.Size
 import androidx.annotation.CheckResult
 import com.stripe.android.camera.framework.image.constrainToSize
 import com.stripe.android.camera.framework.image.crop

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/util/ToVerificationFrameData.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/util/ToVerificationFrameData.kt
@@ -44,7 +44,9 @@ internal fun Collection<SavedFrame>.toVerificationFrameData(
     val payloadInfo = PayloadInfo(
         imageCompressionType = imageFormat.string,
         imageCompressionQuality = imageSettings.compressionRatio.toFloat(),
-        imagePayloadSizeInBytes = imagePayloadSize
+        imagePayloadSizeInBytes = imagePayloadSize,
+        imagePayloadCount = verificationFramesData.size,
+        imagePayloadMaxCount = imageSettings.imageCount
     )
 
     return Pair(verificationFramesData, payloadInfo)

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/util/ToVerificationFrameData.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/framework/util/ToVerificationFrameData.kt
@@ -11,18 +11,17 @@ import com.stripe.android.stripecardscan.framework.api.dto.ViewFinderMargins
 import com.stripe.android.stripecardscan.framework.image.toImageFormat
 
 @CheckResult
-internal suspend fun Collection<SavedFrame>.toVerificationFrameData(
+internal fun Collection<SavedFrame>.toVerificationFrameData(
     imageConfigs: AcceptedImageConfigs
 ): Pair<List<VerificationFrameData>, PayloadInfo> {
     // Attempt to get image data using the configs from the server.
-    val format = imageConfigs.preferredFormats?.first() ?: ImageFormat.JPEG
-    var imageSettings = imageConfigs.imageSettings(format)
+    val (imageFormat, imageSettings) = imageConfigs.getImageSettings()
     var imagePayloadSize = 0
 
     val verificationFramesData = this.map { savedFrame ->
         val image = savedFrame.frame.cameraPreviewImage.image
 
-        val imageDataAndCropRect = image.toImageFormat(format, imageSettings)
+        val imageDataAndCropRect = image.toImageFormat(imageFormat, imageSettings)
         val b64ImageData = b64Encode(imageDataAndCropRect.first)
 
         imagePayloadSize += b64ImageData.length
@@ -43,8 +42,8 @@ internal suspend fun Collection<SavedFrame>.toVerificationFrameData(
     }
 
     val payloadInfo = PayloadInfo(
-        imageCompressionType = format.string,
-        imageCompressionQuality = imageSettings.first.toFloat(),
+        imageCompressionType = imageFormat.string,
+        imageCompressionQuality = imageSettings.compressionRatio.toFloat(),
         imagePayloadSizeInBytes = imagePayloadSize
     )
 

--- a/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationFlowTest.kt
+++ b/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationFlowTest.kt
@@ -3,6 +3,8 @@ package com.stripe.android.stripecardscan.cardimageverification
 import androidx.test.filters.SmallTest
 import com.stripe.android.camera.framework.AnalyzerLoopErrorListener
 import com.stripe.android.stripecardscan.cardimageverification.result.MainLoopAggregator
+import com.stripe.android.stripecardscan.framework.util.AcceptedImageConfigs
+import com.stripe.android.stripecardscan.framework.util.OptionalImageSettings
 import org.junit.Test
 import kotlin.test.assertEquals
 
@@ -28,7 +30,11 @@ class CardImageVerificationFlowTest {
             SavedFrameType(hasCard = false, hasOcr = false) to listOf("J", "K")
         )
 
-        val selectedFrames = flow.selectCompletionLoopFrames(frameMap)
+        val imageConfigs = AcceptedImageConfigs(
+            defaultSettings = OptionalImageSettings(null, null, 5)
+        )
+
+        val selectedFrames = flow.selectCompletionLoopFrames(frameMap, imageConfigs)
         assertEquals(
             listOf("A", "B", "G"),
             selectedFrames

--- a/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationFlowTest.kt
+++ b/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardimageverification/CardImageVerificationFlowTest.kt
@@ -36,7 +36,7 @@ class CardImageVerificationFlowTest {
 
         val selectedFrames = flow.selectCompletionLoopFrames(frameMap, imageConfigs)
         assertEquals(
-            listOf("A", "B", "G"),
+            listOf("A", "B", "G", "H", "D"),
             selectedFrames
         )
     }


### PR DESCRIPTION
# Summary
Get the completion loop frame count for CIV from the call to initialize_client

# Motivation
We've been seeing elevated 4xx errors due to verification payloads being too large. This reduces the number of images sent.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified