### PR TITLE
Fix padding and payment method card

### DIFF
--- a/paymentsheet/res/layout/fragment_paymentsheet_payment_methods_list.xml
+++ b/paymentsheet/res/layout/fragment_paymentsheet_payment_methods_list.xml
@@ -13,7 +13,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:clipToPadding="false"
-        android:layout_marginTop="7dp"
         android:paddingHorizontal="17dp" />
 
 </LinearLayout>

--- a/paymentsheet/res/values/dimens.xml
+++ b/paymentsheet/res/values/dimens.xml
@@ -19,8 +19,8 @@
     <dimen name="stripe_paymentsheet_card_elevation">2dp</dimen>
     <dimen name="stripe_paymentsheet_paymentoption_card_height">25dp</dimen>
     <dimen name="stripe_paymentsheet_paymentoption_card_width">35dp</dimen>
-    <dimen name="stripe_paymentsheet_paymentoptions_margin_top">10dp</dimen>
-    <dimen name="stripe_paymentsheet_paymentoptions_margin_bottom">26dp</dimen>
+    <dimen name="stripe_paymentsheet_paymentoptions_margin_top">8dp</dimen>
+    <dimen name="stripe_paymentsheet_paymentoptions_margin_bottom">20dp</dimen>
     <dimen name="stripe_paymentsheet_form_textsize">14sp</dimen>
     <dimen name="stripe_paymentsheet_error_textsize">13sp</dimen>
     <!-- Default app bar elevation from https://material.io/design/environment/elevation.html -->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentMethodsUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentMethodsUI.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.selection.selectable
+import androidx.compose.material.Card
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -27,8 +28,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.stripe.android.paymentsheet.ui.LpmSelectorText
 import com.stripe.android.ui.core.MeasureComposableWidth
-import com.stripe.android.ui.core.elements.SectionCard
 import com.stripe.android.ui.core.forms.resources.LpmRepository.SupportedPaymentMethod
+import com.stripe.android.ui.core.getBorderStroke
 import com.stripe.android.ui.core.paymentsColors
 
 internal const val ADD_PM_DEFAULT_PADDING = 12.0f
@@ -138,8 +139,7 @@ internal fun PaymentMethodUI(
     }
 
     MeasureComposableWidth(composable = lpmTextSelector) { lpmSelectorTextWidth ->
-        SectionCard(
-            isSelected = isSelected,
+        Card(
             modifier = modifier
                 .alpha(alpha = if (isEnabled) 1.0F else 0.6F)
                 .height(60.dp)
@@ -151,7 +151,11 @@ internal fun PaymentMethodUI(
                             ADD_PM_DEFAULT_PADDING.dp
                     )
                 )
-                .padding(horizontal = CARD_HORIZONTAL_PADDING.dp)
+                .padding(horizontal = CARD_HORIZONTAL_PADDING.dp),
+            shape = MaterialTheme.shapes.medium,
+            backgroundColor = MaterialTheme.paymentsColors.component,
+            border = MaterialTheme.getBorderStroke(isSelected),
+            elevation = if (isSelected) 1.5.dp else 0.dp
         ) {
             Column(
                 modifier = Modifier

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/GooglePayDivider.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/GooglePayDivider.kt
@@ -26,7 +26,7 @@ internal fun GooglePayDividerUi(
         contentAlignment = Alignment.Center,
         modifier = Modifier
             .fillMaxWidth()
-            .padding(top = 16.dp)
+            .padding(top = 18.dp)
     ) {
         GooglePayDividerLine()
         Text(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fix vertical padding of the divider between the wallet buttons and saved payment methods.
Also fix the border of the payment method card, which would occasionally not be updated when the selection changed.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
UI fixes from Link design review.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/77990083/194446635-6200f9e6-d44f-49b8-85c3-5e31ad98619c.png) | ![image](https://user-images.githubusercontent.com/77990083/194446506-bf99b954-f761-4c26-8b85-87eb0cce6747.png) |
