### PR TITLE
Show "Pay using" on header when wallet buttons are visible

### DIFF
--- a/paymentsheet/res/values-b+es+419/strings.xml
+++ b/paymentsheet/res/values-b+es+419/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">O pagar con tarjeta</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Pagar</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Pagar con</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Procesando...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-ca-rES/strings.xml
+++ b/paymentsheet/res/values-ca-rES/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">O pagar amb una targeta</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Pagar</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Paga amb</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Processant...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-cs-rCZ/strings.xml
+++ b/paymentsheet/res/values-cs-rCZ/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Nebo zaplatit kartou</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Zaplatit</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Zaplatit pomocí</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Zpracování...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-da/strings.xml
+++ b/paymentsheet/res/values-da/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Eller betal med et kort</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Betal</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Betal med</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Behandler...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-de/strings.xml
+++ b/paymentsheet/res/values-de/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Oder mit Karte bezahlen</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Zahlen</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Zahlen mit</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Wird verarbeitet …</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-el-rGR/strings.xml
+++ b/paymentsheet/res/values-el-rGR/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Ή πληρωμή με κάρτα</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Πληρωμή</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Πληρωμή μέσω</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Επεξεργασία…</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-en-rGB/strings.xml
+++ b/paymentsheet/res/values-en-rGB/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Or pay with a card</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Pay</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Pay using</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Processing…</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-es/strings.xml
+++ b/paymentsheet/res/values-es/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">O paga con tarjeta</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Pagar</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Pagar con</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Procesando...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-et-rEE/strings.xml
+++ b/paymentsheet/res/values-et-rEE/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Või makske kaardiga</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Maksa</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Kasuta makseviisi</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Töötlemine ...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-fi/strings.xml
+++ b/paymentsheet/res/values-fi/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Tai maksa kortilla</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Maksa</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Käytä maksutapaa</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Käsitellään...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-fil/strings.xml
+++ b/paymentsheet/res/values-fil/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">O magbayad gamit ang kard</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Magbayad</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Magbayad gamit ang</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Pinoproseso...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-fr-rCA/strings.xml
+++ b/paymentsheet/res/values-fr-rCA/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Ou payez par carte</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Payer</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Payer avec</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Traitement en cours...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-fr/strings.xml
+++ b/paymentsheet/res/values-fr/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Ou payez par carte bancaire</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Payer</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Payer avec</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Traitement en cours...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-hr/strings.xml
+++ b/paymentsheet/res/values-hr/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Ili plati karticom</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Plati</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Platite koristeći</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Obrađuje se...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-hu/strings.xml
+++ b/paymentsheet/res/values-hu/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Vagy fizetés kártyával</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Fizetés:</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Fizetés a következővel:</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Feldolgozás...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-in/strings.xml
+++ b/paymentsheet/res/values-in/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Atau bayar dengan kartu</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Bayar</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Bayar menggunakan</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Memproses...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-it/strings.xml
+++ b/paymentsheet/res/values-it/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Oppure paga con carta</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Paga</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Paga con</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Elaborazione in corso...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-ja/strings.xml
+++ b/paymentsheet/res/values-ja/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">または、カードで支払う</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">支払う: </string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">下記の方法で支払う</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">処理中...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-ko/strings.xml
+++ b/paymentsheet/res/values-ko/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">또는 카드 결제</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">결제</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">사용할 결제 수단</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">처리 중...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-lt-rLT/strings.xml
+++ b/paymentsheet/res/values-lt-rLT/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Arba mokėti kortele</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Mokėti</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Mokėkite naudodami</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Apdorojama...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-lv-rLV/strings.xml
+++ b/paymentsheet/res/values-lv-rLV/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Vai maksāt ar karti</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Maksāt</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Maksāt, izmantojot</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Apstrādā…</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-ms-rMY/strings.xml
+++ b/paymentsheet/res/values-ms-rMY/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Atau bayar dengan kad</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Bayar</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Bayar menggunakan</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Sedang diproses...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-mt/strings.xml
+++ b/paymentsheet/res/values-mt/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Jew ħallas bil-kard</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Ħallas</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Ħallas b\'dal-metodu tal-pagament:</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Qed jiġi pproċessat...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-nb/strings.xml
+++ b/paymentsheet/res/values-nb/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Eller betal med et kort</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Betal</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Betal ved å bruke</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Behandler …</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-nl/strings.xml
+++ b/paymentsheet/res/values-nl/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Of met een kaart betalen</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Betaal</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Betalen met</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Verwerken...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-nn-rNO/strings.xml
+++ b/paymentsheet/res/values-nn-rNO/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Eller betal med eit kort</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Betal</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Betal gjennom</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Behandlar …</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-pl-rPL/strings.xml
+++ b/paymentsheet/res/values-pl-rPL/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Lub zapłać kartą</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Zapłać</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Zapłać, korzystając z</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Przetwarzanie…</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-pt-rBR/strings.xml
+++ b/paymentsheet/res/values-pt-rBR/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Ou pagar com cartão</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Pagar</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Pagar com</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Processando…</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-pt-rPT/strings.xml
+++ b/paymentsheet/res/values-pt-rPT/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Ou pagar com um cartão</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Pagar</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Pagar com</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">A processar…</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-ro-rRO/strings.xml
+++ b/paymentsheet/res/values-ro-rRO/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Sau folosiți ca metodă de plată un card</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Plătiți</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Plătiți folosind</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Se procesează...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-ru/strings.xml
+++ b/paymentsheet/res/values-ru/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Или оплатить картой</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Оплатить</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Оплатить с помощью</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Идет обработка...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-sk-rSK/strings.xml
+++ b/paymentsheet/res/values-sk-rSK/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Alebo zaplaťte kartou</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Zaplatiť</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Zaplatiť pomocou</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Prebieha spracovanie…</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-sl-rSI/strings.xml
+++ b/paymentsheet/res/values-sl-rSI/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Ali pa plačajte s kartico</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Plačaj</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Za plačilo uporabite</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Obdelovanje ...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-sv/strings.xml
+++ b/paymentsheet/res/values-sv/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Eller betala med ett kort</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Betala</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Betala med</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Bearbetar ...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-th/strings.xml
+++ b/paymentsheet/res/values-th/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">หรือชำระเงินด้วยบัตร</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">ชำระเงิน</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">ชำระโดยใช้</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">กำลังประมวลผล...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-tr/strings.xml
+++ b/paymentsheet/res/values-tr/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Ya da kartla ödeyin</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Öde</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Ödeme seçeneği</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">İşleniyor...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-vi/strings.xml
+++ b/paymentsheet/res/values-vi/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Hoặc thanh toán bằng thẻ</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Thanh toán</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Thanh toán bằng</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Đang xử lý...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-zh-rHK/strings.xml
+++ b/paymentsheet/res/values-zh-rHK/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">或用銀行卡支付</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">支付</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">支付方式</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">正在處理...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-zh-rTW/strings.xml
+++ b/paymentsheet/res/values-zh-rTW/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">或用金融卡支付</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">支付</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">支付方式</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">正在處理...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values-zh/strings.xml
+++ b/paymentsheet/res/values-zh/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">或用银行卡支付</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">支付</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">用以下方式支付</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">正在处理...</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -21,6 +21,8 @@
   <string name="stripe_paymentsheet_or_pay_with_card">Or pay with a card</string>
   <!-- Label for a button that starts processing the payment. -->
   <string name="stripe_paymentsheet_pay_button_label">Pay</string>
+  <!-- Title shown above a section containing various payment options -->
+  <string name="stripe_paymentsheet_pay_using">Pay using</string>
   <!-- Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text -->
   <string name="stripe_paymentsheet_primary_button_processing">Processing…</string>
   <!-- Content for alert popup prompting to confirm removing saved payment method. -->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
@@ -67,13 +67,6 @@ internal abstract class BasePaymentMethodsListFragment(
         isEditing = savedInstanceState?.getBoolean(IS_EDITING) ?: false
     }
 
-    override fun onResume() {
-        super.onResume()
-
-        sheetViewModel.headerText.value =
-            getString(R.string.stripe_paymentsheet_select_payment_method)
-    }
-
     @Deprecated("Deprecated in Java")
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         inflater.inflate(R.menu.paymentsheet_payment_methods_list, menu)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsListFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsListFragment.kt
@@ -31,6 +31,13 @@ internal class PaymentOptionsListFragment() : BasePaymentMethodsListFragment(
         sheetViewModel.resolveTransitionTarget(config)
     }
 
+    override fun onResume() {
+        super.onResume()
+
+        sheetViewModel.headerText.value =
+            getString(R.string.stripe_paymentsheet_select_payment_method)
+    }
+
     override fun transitionToAddPaymentMethod() {
         /**
          * Only the [PaymentOptionsViewModel.TransitionTarget.AddPaymentMethodFull] will add

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetListFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetListFragment.kt
@@ -25,4 +25,19 @@ internal class PaymentSheetListFragment() : BasePaymentMethodsListFragment(
             PaymentSheetViewModel.TransitionTarget.AddPaymentMethodFull(config)
         )
     }
+
+    override fun onResume() {
+        super.onResume()
+
+        sheetViewModel.headerText.value = getString(
+            if (
+                sheetViewModel.isLinkEnabled.value == true ||
+                sheetViewModel.isGooglePayReady.value == true
+            ) {
+                R.string.stripe_paymentsheet_pay_using
+            } else {
+                R.string.stripe_paymentsheet_select_payment_method
+            }
+        )
+    }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Show "Pay using" on header when wallet buttons are visible, keep showing "Select your payment method" when showing only saved payment methods.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Link design feedback

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| With wallet buttons  | Without wallet buttons |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/77990083/194457328-ed09511f-fbc2-4f0d-85fd-a548db870d5a.png) | ![image](https://user-images.githubusercontent.com/77990083/194457348-cd73fbfe-274f-4e3c-9fe4-adb786d7e267.png) |
