### PR TITLE
[Research + Code] Render images from CDN


### DIFF
--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -286,6 +286,14 @@ public final class com/stripe/android/financialconnections/di/FinancialConnectio
 	public static fun providesFinancialConnectionsManifestRepository (Lcom/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule;Lcom/stripe/android/financialconnections/network/FinancialConnectionsRequestExecutor;Lcom/stripe/android/financialconnections/FinancialConnectionsSheet$Configuration;Lcom/stripe/android/core/networking/ApiRequest$Factory;Lcom/stripe/android/core/networking/ApiRequest$Options;Lcom/stripe/android/core/Logger;Lcom/stripe/android/financialconnections/model/FinancialConnectionsSessionManifest;)Lcom/stripe/android/financialconnections/repository/FinancialConnectionsManifestRepository;
 }
 
+public final class com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule_ProvidesImageLoaderFactory : dagger/internal/Factory {
+	public fun <init> (Lcom/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule;Ljavax/inject/Provider;)V
+	public static fun create (Lcom/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule;Ljavax/inject/Provider;)Lcom/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule_ProvidesImageLoaderFactory;
+	public fun get ()Lcom/stripe/android/uicore/image/StripeImageLoader;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun providesImageLoader (Lcom/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule;Landroid/app/Application;)Lcom/stripe/android/uicore/image/StripeImageLoader;
+}
+
 public final class com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule_ProvidesNavigationManagerFactory : dagger/internal/Factory {
 	public fun <init> (Lcom/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule;)V
 	public static fun create (Lcom/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule;)Lcom/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule_ProvidesNavigationManagerFactory;
@@ -536,13 +544,15 @@ public final class com/stripe/android/financialconnections/features/accountpicke
 
 public final class com/stripe/android/financialconnections/features/accountpicker/ComposableSingletons$AccountPickerScreenKt {
 	public static final field INSTANCE Lcom/stripe/android/financialconnections/features/accountpicker/ComposableSingletons$AccountPickerScreenKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
 	public static field lambda-2 Lkotlin/jvm/functions/Function2;
 	public static field lambda-3 Lkotlin/jvm/functions/Function2;
+	public static field lambda-4 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
-	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-2$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-3$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-4$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class com/stripe/android/financialconnections/features/attachpayment/AttachPaymentViewModel_Factory : dagger/internal/Factory {
@@ -562,15 +572,17 @@ public final class com/stripe/android/financialconnections/features/attachpaymen
 
 public final class com/stripe/android/financialconnections/features/common/ComposableSingletons$AccessibleDataCalloutKt {
 	public static final field INSTANCE Lcom/stripe/android/financialconnections/features/common/ComposableSingletons$AccessibleDataCalloutKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
 	public static field lambda-2 Lkotlin/jvm/functions/Function2;
 	public static field lambda-3 Lkotlin/jvm/functions/Function2;
 	public static field lambda-4 Lkotlin/jvm/functions/Function2;
+	public static field lambda-5 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
-	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-2$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-3$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-4$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-5$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class com/stripe/android/financialconnections/features/common/ComposableSingletons$CloseDialogKt {
@@ -590,25 +602,27 @@ public final class com/stripe/android/financialconnections/features/common/Compo
 
 public final class com/stripe/android/financialconnections/features/common/ComposableSingletons$ErrorContentKt {
 	public static final field INSTANCE Lcom/stripe/android/financialconnections/features/common/ComposableSingletons$ErrorContentKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function2;
-	public static field lambda-2 Lkotlin/jvm/functions/Function3;
-	public static field lambda-3 Lkotlin/jvm/functions/Function2;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-10 Lkotlin/jvm/functions/Function2;
+	public static field lambda-2 Lkotlin/jvm/functions/Function2;
+	public static field lambda-3 Lkotlin/jvm/functions/Function3;
 	public static field lambda-4 Lkotlin/jvm/functions/Function2;
-	public static field lambda-5 Lkotlin/jvm/functions/Function3;
-	public static field lambda-6 Lkotlin/jvm/functions/Function2;
+	public static field lambda-5 Lkotlin/jvm/functions/Function2;
+	public static field lambda-6 Lkotlin/jvm/functions/Function3;
 	public static field lambda-7 Lkotlin/jvm/functions/Function2;
-	public static field lambda-8 Lkotlin/jvm/functions/Function3;
-	public static field lambda-9 Lkotlin/jvm/functions/Function2;
+	public static field lambda-8 Lkotlin/jvm/functions/Function2;
+	public static field lambda-9 Lkotlin/jvm/functions/Function3;
 	public fun <init> ()V
-	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-2$financial_connections_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-3$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-10$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-2$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-3$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-4$financial_connections_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-5$financial_connections_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-6$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-5$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-6$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-7$financial_connections_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-8$financial_connections_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-9$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-8$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-9$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/stripe/android/financialconnections/features/consent/ComposableSingletons$ConsentScreenKt {
@@ -633,10 +647,12 @@ public final class com/stripe/android/financialconnections/features/institutionp
 	public static field lambda-1 Lkotlin/jvm/functions/Function2;
 	public static field lambda-2 Lkotlin/jvm/functions/Function3;
 	public static field lambda-3 Lkotlin/jvm/functions/Function3;
+	public static field lambda-4 Lkotlin/jvm/functions/Function3;
 	public fun <init> ()V
 	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-2$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-3$financial_connections_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-4$financial_connections_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/stripe/android/financialconnections/features/institutionpicker/ComposableSingletons$SearchFooterKt {
@@ -699,10 +715,12 @@ public final class com/stripe/android/financialconnections/features/manualentrys
 public final class com/stripe/android/financialconnections/features/partnerauth/ComposableSingletons$PartnerAuthScreenKt {
 	public static final field INSTANCE Lcom/stripe/android/financialconnections/features/partnerauth/ComposableSingletons$PartnerAuthScreenKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function3;
-	public static field lambda-2 Lkotlin/jvm/functions/Function2;
+	public static field lambda-2 Lkotlin/jvm/functions/Function3;
+	public static field lambda-3 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
 	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-2$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-2$financial_connections_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-3$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class com/stripe/android/financialconnections/features/partnerauth/PartnerAuthScreenKt {
@@ -1492,6 +1510,14 @@ public final class com/stripe/android/financialconnections/model/GetFinancialCon
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/financialconnections/model/Image$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/model/Image;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/financialconnections/model/Image;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/financialconnections/model/OwnershipRefresh : android/os/Parcelable, com/stripe/android/core/model/StripeModel {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
@@ -1623,8 +1649,9 @@ public final class com/stripe/android/financialconnections/ui/ComposableSingleto
 }
 
 public final class com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity_MembersInjector : dagger/MembersInjector {
-	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;)V
-	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;)Ldagger/MembersInjector;
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Ldagger/MembersInjector;
+	public static fun injectImageLoader (Lcom/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity;Lcom/stripe/android/uicore/image/StripeImageLoader;)V
 	public static fun injectLogger (Lcom/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity;Lcom/stripe/android/core/Logger;)V
 	public fun injectMembers (Lcom/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity;)V
 	public synthetic fun injectMembers (Ljava/lang/Object;)V

--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -544,15 +544,13 @@ public final class com/stripe/android/financialconnections/features/accountpicke
 
 public final class com/stripe/android/financialconnections/features/accountpicker/ComposableSingletons$AccountPickerScreenKt {
 	public static final field INSTANCE Lcom/stripe/android/financialconnections/features/accountpicker/ComposableSingletons$AccountPickerScreenKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
 	public static field lambda-2 Lkotlin/jvm/functions/Function2;
 	public static field lambda-3 Lkotlin/jvm/functions/Function2;
-	public static field lambda-4 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
-	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-2$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-3$financial_connections_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-4$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class com/stripe/android/financialconnections/features/attachpayment/AttachPaymentViewModel_Factory : dagger/internal/Factory {
@@ -572,17 +570,15 @@ public final class com/stripe/android/financialconnections/features/attachpaymen
 
 public final class com/stripe/android/financialconnections/features/common/ComposableSingletons$AccessibleDataCalloutKt {
 	public static final field INSTANCE Lcom/stripe/android/financialconnections/features/common/ComposableSingletons$AccessibleDataCalloutKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
 	public static field lambda-2 Lkotlin/jvm/functions/Function2;
 	public static field lambda-3 Lkotlin/jvm/functions/Function2;
 	public static field lambda-4 Lkotlin/jvm/functions/Function2;
-	public static field lambda-5 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
-	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-2$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-3$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-4$financial_connections_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-5$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class com/stripe/android/financialconnections/features/common/ComposableSingletons$CloseDialogKt {
@@ -602,27 +598,25 @@ public final class com/stripe/android/financialconnections/features/common/Compo
 
 public final class com/stripe/android/financialconnections/features/common/ComposableSingletons$ErrorContentKt {
 	public static final field INSTANCE Lcom/stripe/android/financialconnections/features/common/ComposableSingletons$ErrorContentKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function3;
-	public static field lambda-10 Lkotlin/jvm/functions/Function2;
-	public static field lambda-2 Lkotlin/jvm/functions/Function2;
-	public static field lambda-3 Lkotlin/jvm/functions/Function3;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public static field lambda-2 Lkotlin/jvm/functions/Function3;
+	public static field lambda-3 Lkotlin/jvm/functions/Function2;
 	public static field lambda-4 Lkotlin/jvm/functions/Function2;
-	public static field lambda-5 Lkotlin/jvm/functions/Function2;
-	public static field lambda-6 Lkotlin/jvm/functions/Function3;
+	public static field lambda-5 Lkotlin/jvm/functions/Function3;
+	public static field lambda-6 Lkotlin/jvm/functions/Function2;
 	public static field lambda-7 Lkotlin/jvm/functions/Function2;
-	public static field lambda-8 Lkotlin/jvm/functions/Function2;
-	public static field lambda-9 Lkotlin/jvm/functions/Function3;
+	public static field lambda-8 Lkotlin/jvm/functions/Function3;
+	public static field lambda-9 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
-	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-10$financial_connections_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-2$financial_connections_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-3$financial_connections_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-2$financial_connections_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-3$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-4$financial_connections_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-5$financial_connections_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-6$financial_connections_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-5$financial_connections_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-6$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-7$financial_connections_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-8$financial_connections_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-9$financial_connections_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-8$financial_connections_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-9$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class com/stripe/android/financialconnections/features/consent/ComposableSingletons$ConsentScreenKt {
@@ -715,12 +709,10 @@ public final class com/stripe/android/financialconnections/features/manualentrys
 public final class com/stripe/android/financialconnections/features/partnerauth/ComposableSingletons$PartnerAuthScreenKt {
 	public static final field INSTANCE Lcom/stripe/android/financialconnections/features/partnerauth/ComposableSingletons$PartnerAuthScreenKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function3;
-	public static field lambda-2 Lkotlin/jvm/functions/Function3;
-	public static field lambda-3 Lkotlin/jvm/functions/Function2;
+	public static field lambda-2 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
 	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-2$financial_connections_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-3$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-2$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class com/stripe/android/financialconnections/features/partnerauth/PartnerAuthScreenKt {

--- a/financial-connections/build.gradle
+++ b/financial-connections/build.gradle
@@ -25,6 +25,7 @@ shot {
 
 dependencies {
     api project(":stripe-core")
+    api project(":stripe-ui-core")
     api project(":payments-model")
 
     implementation "androidx.activity:activity-ktx:$androidxActivityVersion"

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.di
 
+import android.app.Application
 import com.stripe.android.core.Logger
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
@@ -17,6 +18,7 @@ import com.stripe.android.financialconnections.network.FinancialConnectionsReque
 import com.stripe.android.financialconnections.repository.FinancialConnectionsAccountsRepository
 import com.stripe.android.financialconnections.repository.FinancialConnectionsInstitutionsRepository
 import com.stripe.android.financialconnections.repository.FinancialConnectionsManifestRepository
+import com.stripe.android.uicore.image.StripeImageLoader
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineScope
@@ -43,6 +45,14 @@ internal class FinancialConnectionsSheetNativeModule {
     @Provides
     fun providesNavigationManager() = NavigationManager(
         CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    )
+
+    @Singleton
+    @Provides
+    fun providesImageLoader(
+        context: Application
+    ) = StripeImageLoader(
+        context = context
     )
 
     @Singleton

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
@@ -52,7 +52,8 @@ internal class FinancialConnectionsSheetNativeModule {
     fun providesImageLoader(
         context: Application
     ) = StripeImageLoader(
-        context = context
+        context = context,
+        diskCache = null,
     )
 
     @Singleton

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
@@ -345,14 +345,15 @@ private fun AccountDropdownItem(
 
 @Composable
 private fun InstitutionIcon(institutionIcon: String?) {
+    val modifier = Modifier
+        .size(36.dp)
+        .clip(RoundedCornerShape(6.dp))
     StripeImage(
         url = institutionIcon ?: "",
-        errorContent = { InstitutionPlaceholder() },
+        errorContent = { InstitutionPlaceholder(modifier) },
         imageLoader = LocalImageLoader.current,
         contentDescription = null,
-        modifier = Modifier
-            .size(36.dp)
-            .clip(RoundedCornerShape(6.dp))
+        modifier = modifier
     )
 }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
@@ -3,7 +3,6 @@
 package com.stripe.android.financialconnections.features.accountpicker
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -39,7 +38,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -57,6 +55,7 @@ import com.stripe.android.financialconnections.features.accountpicker.AccountPic
 import com.stripe.android.financialconnections.features.accountpicker.AccountPickerState.SelectionMode
 import com.stripe.android.financialconnections.features.common.AccessibleDataCallout
 import com.stripe.android.financialconnections.features.common.AccessibleDataCalloutModel
+import com.stripe.android.financialconnections.features.common.InstitutionPlaceholder
 import com.stripe.android.financialconnections.features.common.LoadingContent
 import com.stripe.android.financialconnections.features.common.NoAccountsAvailableErrorContent
 import com.stripe.android.financialconnections.features.common.NoSupportedPaymentMethodTypeAccountsErrorContent
@@ -64,12 +63,14 @@ import com.stripe.android.financialconnections.features.common.UnclassifiedError
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
 import com.stripe.android.financialconnections.model.PartnerAccount
 import com.stripe.android.financialconnections.presentation.parentViewModel
+import com.stripe.android.financialconnections.ui.LocalImageLoader
 import com.stripe.android.financialconnections.ui.TextResource
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsButton
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsOutlinedTextField
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsScaffold
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsTopAppBar
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
+import com.stripe.android.uicore.image.StripeImage
 import java.text.NumberFormat
 import java.util.Currency
 
@@ -255,10 +256,9 @@ private fun DropdownContent(
     onAccountClicked: (PartnerAccount) -> Unit
 ) {
     var expanded by remember { mutableStateOf(false) }
-    val selectedOptionText: String? = remember(selectedIds) {
+    val selectedOption: PartnerAccountUI? = remember(selectedIds) {
         accounts
             .firstOrNull { selectedIds.contains(it.account.id) }
-            ?.let { "${it.account.name} ${it.account.encryptedNumbers}" }
     }
     Spacer(modifier = Modifier.size(12.dp))
     ExposedDropdownMenuBox(
@@ -269,10 +269,12 @@ private fun DropdownContent(
     ) {
         FinancialConnectionsOutlinedTextField(
             readOnly = true,
-            value = selectedOptionText
+            value = selectedOption?.let { "${it.account.name} ${it.account.encryptedNumbers}" }
                 ?: stringResource(id = R.string.stripe_account_picker_dropdown_hint),
             onValueChange = { },
-            leadingIcon = { if (selectedOptionText != null) InstitutionIcon() },
+            leadingIcon = {
+                if (selectedOption != null) InstitutionIcon(selectedOption.institutionIcon)
+            },
             trailingIcon = {
                 ExposedDropdownMenuDefaults.TrailingIcon(
                     expanded = expanded
@@ -312,7 +314,7 @@ private fun AccountDropdownItem(
         }
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
-            InstitutionIcon()
+            InstitutionIcon(account.institutionIcon)
             Spacer(modifier = Modifier.size(8.dp))
             val (title, subtitle) = getAccountTexts(
                 account = account.account,
@@ -342,9 +344,11 @@ private fun AccountDropdownItem(
 }
 
 @Composable
-private fun InstitutionIcon() {
-    Image(
-        painter = painterResource(id = R.drawable.stripe_ic_brandicon_institution),
+private fun InstitutionIcon(institutionIcon: String?) {
+    StripeImage(
+        url = institutionIcon ?: "",
+        errorContent = { InstitutionPlaceholder() },
+        imageLoader = LocalImageLoader.current,
         contentDescription = null,
         modifier = Modifier
             .size(36.dp)

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerStates.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerStates.kt
@@ -80,7 +80,8 @@ internal class AccountPickerStates : PreviewParameterProvider<AccountPickerState
                     subcategory = FinancialConnectionsAccount.Subcategory.CHECKING,
                     supportedPaymentMethodTypes = emptyList()
                 ),
-                enabled = true
+                enabled = true,
+                institutionIcon = null
             ),
             PartnerAccountUI(
                 PartnerAccount(
@@ -91,7 +92,8 @@ internal class AccountPickerStates : PreviewParameterProvider<AccountPickerState
                     subcategory = FinancialConnectionsAccount.Subcategory.SAVINGS,
                     supportedPaymentMethodTypes = emptyList()
                 ),
-                enabled = true
+                enabled = true,
+                institutionIcon = null
             ),
             PartnerAccountUI(
                 PartnerAccount(
@@ -103,7 +105,8 @@ internal class AccountPickerStates : PreviewParameterProvider<AccountPickerState
                     subcategory = FinancialConnectionsAccount.Subcategory.CREDIT_CARD,
                     supportedPaymentMethodTypes = emptyList()
                 ),
-                enabled = false
+                enabled = false,
+                institutionIcon = null
             ),
             PartnerAccountUI(
                 PartnerAccount(
@@ -115,7 +118,8 @@ internal class AccountPickerStates : PreviewParameterProvider<AccountPickerState
                     subcategory = FinancialConnectionsAccount.Subcategory.CHECKING,
                     supportedPaymentMethodTypes = emptyList()
                 ),
-                enabled = false
+                enabled = false,
+                institutionIcon = null
             )
         )
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
@@ -49,6 +49,7 @@ internal class AccountPickerViewModel @Inject constructor(
         suspend {
             val state = awaitState()
             val manifest = getManifest()
+            val activeInstitution = manifest.activeInstitution
             val partnerAccountList = pollAuthorizationSessionAccounts(
                 manifest = manifest,
                 canRetry = state.canRetry
@@ -56,6 +57,7 @@ internal class AccountPickerViewModel @Inject constructor(
             val accounts = partnerAccountList.data.map { account ->
                 AccountPickerState.PartnerAccountUI(
                     account = account,
+                    institutionIcon = activeInstitution?.icon?.default,
                     enabled = account.enabled(manifest)
                 )
             }.sortedBy { it.enabled }
@@ -287,7 +289,8 @@ internal data class AccountPickerState(
 
     data class PartnerAccountUI(
         val account: PartnerAccount,
-        val enabled: Boolean
+        val enabled: Boolean,
+        val institutionIcon: String?
     )
 
     enum class SelectionMode {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/AccessibleDataCallout.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/AccessibleDataCallout.kt
@@ -300,6 +300,8 @@ internal fun AccessibleDataCalloutWithManyAccountsPreview() {
                 name = "name",
                 url = "url",
                 featured = true,
+                icon = null,
+                logo = null,
                 featuredOrder = null,
                 mobileHandoffCapable = false
             )
@@ -350,6 +352,8 @@ internal fun AccessibleDataCalloutWithMultipleAccountsPreview() {
                 name = "name",
                 url = "url",
                 featured = true,
+                icon = null,
+                logo = null,
                 featuredOrder = null,
                 mobileHandoffCapable = false
             )
@@ -392,6 +396,8 @@ internal fun AccessibleDataCalloutWithOneAccountPreview() {
                 url = "url",
                 featured = true,
                 featuredOrder = null,
+                icon = null,
+                logo = null,
                 mobileHandoffCapable = false
             )
         )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/AccessibleDataCallout.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/AccessibleDataCallout.kt
@@ -2,7 +2,6 @@
 
 package com.stripe.android.financialconnections.features.common
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -22,7 +21,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalUriHandler
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -34,10 +32,12 @@ import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
 import com.stripe.android.financialconnections.model.FinancialConnectionsInstitution
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 import com.stripe.android.financialconnections.model.PartnerAccount
+import com.stripe.android.financialconnections.ui.LocalImageLoader
 import com.stripe.android.financialconnections.ui.TextResource
 import com.stripe.android.financialconnections.ui.components.AnnotatedText
 import com.stripe.android.financialconnections.ui.components.StringAnnotation
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
+import com.stripe.android.uicore.image.StripeImage
 
 private const val COLLAPSE_ACCOUNTS_THRESHOLD = 5
 
@@ -60,6 +60,7 @@ internal fun AccessibleDataCalloutWithAccounts(
         Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
             if (accounts.count() >= COLLAPSE_ACCOUNTS_THRESHOLD) {
                 AccountRow(
+                    iconUrl = institution.icon?.default,
                     text = institution.name,
                     subText = stringResource(
                         id = R.string.stripe_success_infobox_accounts,
@@ -67,7 +68,12 @@ internal fun AccessibleDataCalloutWithAccounts(
                     )
                 )
             } else {
-                accounts.forEach { AccountRow(it.fullName) }
+                accounts.forEach {
+                    AccountRow(
+                        iconUrl = institution.icon?.default,
+                        text = it.fullName
+                    )
+                }
             }
 
             Divider(color = FinancialConnectionsTheme.colors.backgroundBackdrop)
@@ -79,7 +85,8 @@ internal fun AccessibleDataCalloutWithAccounts(
 @Composable
 private fun AccountRow(
     text: String,
-    subText: String? = null
+    subText: String? = null,
+    iconUrl: String?
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -90,8 +97,10 @@ private fun AccountRow(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            Image(
-                painter = painterResource(id = R.drawable.stripe_ic_brandicon_institution),
+            StripeImage(
+                url = iconUrl ?: "",
+                imageLoader = LocalImageLoader.current,
+                errorContent = { InstitutionPlaceholder() },
                 contentDescription = null,
                 modifier = Modifier
                     .size(24.dp)

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/AccessibleDataCallout.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/AccessibleDataCallout.kt
@@ -100,11 +100,11 @@ private fun AccountRow(
             StripeImage(
                 url = iconUrl ?: "",
                 imageLoader = LocalImageLoader.current,
-                errorContent = { InstitutionPlaceholder() },
                 contentDescription = null,
                 modifier = Modifier
                     .size(24.dp)
-                    .clip(RoundedCornerShape(4.dp))
+                    .clip(RoundedCornerShape(4.dp)),
+                errorContent = { InstitutionPlaceholder() }
             )
             Text(
                 text,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/AccessibleDataCallout.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/AccessibleDataCallout.kt
@@ -97,14 +97,15 @@ private fun AccountRow(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
+            val modifier = Modifier
+                .size(24.dp)
+                .clip(RoundedCornerShape(4.dp))
             StripeImage(
                 url = iconUrl ?: "",
                 imageLoader = LocalImageLoader.current,
                 contentDescription = null,
-                modifier = Modifier
-                    .size(24.dp)
-                    .clip(RoundedCornerShape(4.dp)),
-                errorContent = { InstitutionPlaceholder() }
+                modifier = modifier,
+                errorContent = { InstitutionPlaceholder(modifier) }
             )
             Text(
                 text,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ErrorContent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ErrorContent.kt
@@ -51,7 +51,7 @@ internal fun UnclassifiedErrorContent(
     onCloseFromErrorClick: (Throwable) -> Unit
 ) {
     ErrorContent(
-        null, //TODO show warning icon.
+        null, // TODO show warning icon.
         title = stringResource(R.string.stripe_error_generic_title),
         content = stringResource(R.string.stripe_error_generic_desc),
         primaryCta = stringResource(R.string.stripe_error_cta_close) to {
@@ -65,7 +65,7 @@ internal fun InstitutionUnknownErrorContent(
     onSelectAnotherBank: () -> Unit
 ) {
     ErrorContent(
-        iconUrl = null, //TODO show institution icon.
+        iconUrl = null, // TODO show institution icon.
         title = stringResource(R.string.stripe_error_generic_title),
         content = stringResource(R.string.stripe_error_unplanned_downtime_desc),
         primaryCta = Pair(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ErrorContent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ErrorContent.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.intl.Locale
@@ -320,15 +321,16 @@ private fun BadgedInstitutionImage(
         modifier = Modifier
             .size(40.dp)
     ) {
+        val modifier = Modifier
+            .size(36.dp)
+            .align(Alignment.BottomStart)
+            .clip(RoundedCornerShape(6.dp))
         StripeImage(
             url = institutionIconUrl ?: "",
             imageLoader = LocalImageLoader.current,
-            errorContent = { InstitutionPlaceholder() },
+            errorContent = { InstitutionPlaceholder(modifier) },
             contentDescription = null,
-            modifier = Modifier
-                .size(36.dp)
-                .align(Alignment.BottomStart)
-                .clip(RoundedCornerShape(6.dp))
+            modifier = modifier
         )
         Icon(
             painter = badge.first,
@@ -420,9 +422,11 @@ internal fun NoAccountsAvailableErrorContentPreview() {
 }
 
 @Composable
-internal fun InstitutionPlaceholder() {
+internal fun InstitutionPlaceholder(modifier: Modifier) {
     Image(
+        modifier = modifier,
         painter = painterResource(id = R.drawable.stripe_ic_brandicon_institution),
-        contentDescription = "Bank icon placeholder"
+        contentDescription = "Bank icon placeholder",
+        contentScale = ContentScale.Crop
     )
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ErrorContent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ErrorContent.kt
@@ -420,7 +420,7 @@ internal fun NoAccountsAvailableErrorContentPreview() {
 }
 
 @Composable
-private fun InstitutionPlaceholder() {
+internal fun InstitutionPlaceholder() {
     Image(
         painter = painterResource(id = R.drawable.stripe_ic_brandicon_institution),
         contentDescription = "Bank icon placeholder"

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ErrorContent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/ErrorContent.kt
@@ -37,10 +37,12 @@ import com.stripe.android.financialconnections.exception.InstitutionUnplannedExc
 import com.stripe.android.financialconnections.exception.NoAccountsAvailableException
 import com.stripe.android.financialconnections.exception.NoSupportedPaymentMethodTypeAccountsException
 import com.stripe.android.financialconnections.model.FinancialConnectionsInstitution
+import com.stripe.android.financialconnections.ui.LocalImageLoader
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsButton
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsScaffold
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsTopAppBar
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
+import com.stripe.android.uicore.image.StripeImage
 import java.text.SimpleDateFormat
 
 @Composable
@@ -49,7 +51,7 @@ internal fun UnclassifiedErrorContent(
     onCloseFromErrorClick: (Throwable) -> Unit
 ) {
     ErrorContent(
-        painterResource(id = R.drawable.stripe_ic_brandicon_institution),
+        null, //TODO show warning icon.
         title = stringResource(R.string.stripe_error_generic_title),
         content = stringResource(R.string.stripe_error_generic_desc),
         primaryCta = stringResource(R.string.stripe_error_cta_close) to {
@@ -63,7 +65,7 @@ internal fun InstitutionUnknownErrorContent(
     onSelectAnotherBank: () -> Unit
 ) {
     ErrorContent(
-        iconPainter = painterResource(id = R.drawable.stripe_ic_brandicon_institution),
+        iconUrl = null, //TODO show institution icon.
         title = stringResource(R.string.stripe_error_generic_title),
         content = stringResource(R.string.stripe_error_unplanned_downtime_desc),
         primaryCta = Pair(
@@ -80,7 +82,7 @@ internal fun InstitutionUnplannedDowntimeErrorContent(
     onEnterDetailsManually: () -> Unit
 ) {
     ErrorContent(
-        iconPainter = painterResource(id = R.drawable.stripe_ic_brandicon_institution),
+        iconUrl = exception.institution.icon?.default ?: "",
         title = stringResource(
             R.string.stripe_error_unplanned_downtime_title,
             exception.institution.name
@@ -112,7 +114,7 @@ internal fun InstitutionPlannedDowntimeErrorContent(
         SimpleDateFormat("dd/MM/yyyy HH:mm", javaLocale).format(exception.backUpAt)
     }
     ErrorContent(
-        iconPainter = painterResource(id = R.drawable.stripe_ic_brandicon_institution),
+        iconUrl = exception.institution.icon?.default ?: "",
         title = stringResource(
             R.string.stripe_error_planned_downtime_title,
             exception.institution.name
@@ -143,7 +145,7 @@ internal fun NoSupportedPaymentMethodTypeAccountsErrorContent(
     onEnterDetailsManually: () -> Unit
 ) {
     ErrorContent(
-        painterResource(id = R.drawable.stripe_ic_brandicon_institution),
+        iconUrl = exception.institution.icon?.default ?: "",
         title = stringResource(
             R.string.stripe_account_picker_error_no_payment_method_title
         ),
@@ -207,7 +209,7 @@ internal fun NoAccountsAvailableErrorContent(
     }
 
     ErrorContent(
-        painterResource(id = R.drawable.stripe_ic_brandicon_institution),
+        iconUrl = exception.institution.icon?.default ?: "",
         title = stringResource(
             R.string.stripe_account_picker_error_no_account_available_title,
             exception.institution.name
@@ -225,7 +227,7 @@ internal fun AccountNumberRetrievalErrorContent(
     onEnterDetailsManually: () -> Unit
 ) {
     ErrorContent(
-        painterResource(id = R.drawable.stripe_ic_brandicon_institution),
+        iconUrl = exception.institution.icon?.default ?: "",
         title = stringResource(
             R.string.stripe_attachlinkedpaymentaccount_error_title
         ),
@@ -252,7 +254,7 @@ internal fun AccountNumberRetrievalErrorContent(
 
 @Composable
 internal fun ErrorContent(
-    iconPainter: Painter,
+    iconUrl: String?,
     badge: Pair<Painter, Shape> = Pair(
         painterResource(id = R.drawable.stripe_ic_warning_circle),
         CircleShape
@@ -273,7 +275,7 @@ internal fun ErrorContent(
                 .weight(1f)
                 .verticalScroll(scrollState)
         ) {
-            BadgedImage(iconPainter, badge)
+            BadgedInstitutionImage(iconUrl, badge)
             Spacer(modifier = Modifier.size(16.dp))
             Text(
                 text = title,
@@ -310,16 +312,18 @@ internal fun ErrorContent(
 }
 
 @Composable
-private fun BadgedImage(
-    iconPainter: Painter,
+private fun BadgedInstitutionImage(
+    institutionIconUrl: String?,
     badge: Pair<Painter, Shape>
 ) {
     Box(
         modifier = Modifier
             .size(40.dp)
     ) {
-        Image(
-            painter = iconPainter,
+        StripeImage(
+            url = institutionIconUrl ?: "",
+            imageLoader = LocalImageLoader.current,
+            errorContent = { InstitutionPlaceholder() },
             contentDescription = null,
             modifier = Modifier
                 .size(36.dp)
@@ -368,6 +372,8 @@ internal fun InstitutionPlannedDowntimeErrorContentPreview() {
                         url = "RandomInstitution url",
                         featured = false,
                         featuredOrder = null,
+                        icon = null,
+                        logo = null,
                         mobileHandoffCapable = false
                     ),
                     allowManualEntry = true,
@@ -397,6 +403,8 @@ internal fun NoAccountsAvailableErrorContentPreview() {
                         url = "RandomInstitution url",
                         featured = false,
                         featuredOrder = null,
+                        icon = null,
+                        logo = null,
                         mobileHandoffCapable = false
                     ),
                     allowManualEntry = true,
@@ -409,4 +417,12 @@ internal fun NoAccountsAvailableErrorContentPreview() {
             )
         }
     }
+}
+
+@Composable
+private fun InstitutionPlaceholder() {
+    Image(
+        painter = painterResource(id = R.drawable.stripe_ic_brandicon_institution),
+        contentDescription = "Bank icon placeholder"
+    )
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/LoadingContent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/LoadingContent.kt
@@ -25,7 +25,7 @@ import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsThem
 
 @Composable
 @Suppress("MagicNumber")
-fun LoadingShimmerEffect(
+internal fun LoadingShimmerEffect(
     content: @Composable (Brush) -> Unit
 ) {
     val gradient = listOf(
@@ -103,7 +103,7 @@ internal fun LoadingSpinner() {
 private const val LOADING_SPINNER_ROTATION_MS = 1000
 
 @Composable
-@Preview()
+@Preview
 internal fun LoadingSpinnerPreview() {
     LoadingSpinner()
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/LoadingContent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/LoadingContent.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.features.common
 
+import androidx.compose.animation.core.FastOutLinearInEasing
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
@@ -13,12 +14,46 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
+
+@Composable
+@Suppress("MagicNumber")
+fun LoadingShimmerEffect(
+    content: @Composable (Brush) -> Unit
+) {
+    val gradient = listOf(
+        FinancialConnectionsTheme.colors.backgroundContainer,
+        FinancialConnectionsTheme.colors.textWhite,
+        FinancialConnectionsTheme.colors.backgroundContainer
+    )
+    val transition = rememberInfiniteTransition()
+    val translateAnimation = transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1000f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(
+                durationMillis = 1000,
+                easing = FastOutLinearInEasing
+            )
+        )
+    )
+    val brush = Brush.linearGradient(
+        colors = gradient,
+        start = Offset(200f, 200f),
+        end = Offset(
+            x = translateAnimation.value,
+            y = translateAnimation.value
+        )
+    )
+    content(brush)
+}
 
 @Composable
 internal fun LoadingContent(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
@@ -1,8 +1,9 @@
-@file:Suppress("TooManyFunctions")
+@file:Suppress("TooManyFunctions", "LongMethod")
 
 package com.stripe.android.financialconnections.features.institutionpicker
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -50,6 +51,7 @@ import com.airbnb.mvrx.compose.collectAsState
 import com.airbnb.mvrx.compose.mavericksViewModel
 import com.stripe.android.financialconnections.R
 import com.stripe.android.financialconnections.features.common.InstitutionPlaceholder
+import com.stripe.android.financialconnections.features.common.LoadingShimmerEffect
 import com.stripe.android.financialconnections.features.common.LoadingSpinner
 import com.stripe.android.financialconnections.features.institutionpicker.InstitutionPickerState.Payload
 import com.stripe.android.financialconnections.model.FinancialConnectionsInstitution
@@ -337,15 +339,16 @@ private fun InstitutionResultTile(
                 horizontal = 16.dp
             )
     ) {
+        val modifier = Modifier
+            .size(36.dp)
+            .clip(RoundedCornerShape(6.dp))
         StripeImage(
             url = institution.icon?.default ?: "",
             imageLoader = LocalImageLoader.current,
             contentDescription = null,
-            modifier = Modifier
-                .size(36.dp)
-                .clip(RoundedCornerShape(6.dp)),
+            modifier = modifier,
             contentScale = ContentScale.Crop,
-            errorContent = { InstitutionPlaceholder() }
+            errorContent = { InstitutionPlaceholder(modifier) }
         )
         Spacer(modifier = Modifier.size(8.dp))
         Column {
@@ -403,10 +406,24 @@ private fun FeaturedInstitutionsGrid(
                             .clickable { onInstitutionSelected(institution) }
                     ) {
                         StripeImage(
-                            modifier = Modifier.fillMaxSize(),
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(8.dp),
                             url = institution.logo?.default ?: "",
                             imageLoader = LocalImageLoader.current,
-                            contentScale = ContentScale.Crop,
+                            contentScale = ContentScale.Fit,
+                            loadingContent = {
+                                LoadingShimmerEffect { shimmer ->
+                                    Spacer(
+                                        modifier = Modifier
+                                            .align(Alignment.Center)
+                                            .height(20.dp)
+                                            .clip(RoundedCornerShape(10.dp))
+                                            .fillMaxWidth(fraction = 0.5f)
+                                            .background(shimmer)
+                                    )
+                                }
+                            },
                             errorContent = {
                                 Text(
                                     modifier = Modifier.align(Alignment.Center),

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
@@ -339,14 +339,13 @@ private fun InstitutionResultTile(
     ) {
         StripeImage(
             url = institution.icon?.default ?: "",
-            errorContent = { InstitutionPlaceholder() },
-            contentScale = ContentScale.Crop,
-            contentDescription = null,
             imageLoader = LocalImageLoader.current,
+            contentDescription = null,
             modifier = Modifier
                 .size(36.dp)
-                .clip(RoundedCornerShape(6.dp))
-
+                .clip(RoundedCornerShape(6.dp)),
+            contentScale = ContentScale.Crop,
+            errorContent = { InstitutionPlaceholder() }
         )
         Spacer(modifier = Modifier.size(8.dp))
         Column {
@@ -410,6 +409,7 @@ private fun FeaturedInstitutionsGrid(
                             contentScale = ContentScale.Crop,
                             errorContent = {
                                 Text(
+                                    modifier = Modifier.align(Alignment.Center),
                                     text = institution.name,
                                     color = FinancialConnectionsTheme.colors.textPrimary,
                                     style = FinancialConnectionsTheme.typography.bodyEmphasized,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -54,12 +55,14 @@ import com.stripe.android.financialconnections.features.institutionpicker.Instit
 import com.stripe.android.financialconnections.model.FinancialConnectionsInstitution
 import com.stripe.android.financialconnections.model.InstitutionResponse
 import com.stripe.android.financialconnections.presentation.parentViewModel
+import com.stripe.android.financialconnections.ui.LocalImageLoader
 import com.stripe.android.financialconnections.ui.TextResource
 import com.stripe.android.financialconnections.ui.components.AnnotatedText
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsOutlinedTextField
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsScaffold
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsTopAppBar
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
+import com.stripe.android.uicore.image.StripeImage
 
 @Composable
 internal fun InstitutionPickerScreen() {
@@ -334,9 +337,17 @@ private fun InstitutionResultTile(
                 horizontal = 16.dp
             )
     ) {
-        Image(
-            painter = painterResource(id = R.drawable.stripe_ic_brandicon_institution),
+        StripeImage(
+            url = institution.icon?.default ?: "",
+            errorContent = {
+                Image(
+                    painter = painterResource(id = R.drawable.stripe_ic_brandicon_institution),
+                    contentDescription = "Bank icon placeholder"
+                )
+            },
+            contentScale = ContentScale.Crop,
             contentDescription = null,
+            imageLoader = LocalImageLoader.current,
             modifier = Modifier
                 .size(36.dp)
                 .clip(RoundedCornerShape(6.dp))
@@ -389,19 +400,28 @@ private fun FeaturedInstitutionsGrid(
                         modifier = Modifier
                             .height(80.dp)
                             .fillMaxWidth()
+                            .clip(RoundedCornerShape(6.dp))
                             .border(
                                 width = 1.dp,
                                 color = FinancialConnectionsTheme.colors.borderDefault,
                                 shape = RoundedCornerShape(4.dp)
                             )
                             .clickable { onInstitutionSelected(institution) }
-                            .padding(8.dp)
                     ) {
-                        Text(
-                            text = institution.name,
-                            color = FinancialConnectionsTheme.colors.textPrimary,
-                            style = FinancialConnectionsTheme.typography.bodyEmphasized,
-                            textAlign = TextAlign.Center
+                        StripeImage(
+                            modifier = Modifier.fillMaxSize(),
+                            url = institution.logo?.default ?: "",
+                            imageLoader = LocalImageLoader.current,
+                            contentScale = ContentScale.Crop,
+                            errorContent = {
+                                Text(
+                                    text = institution.name,
+                                    color = FinancialConnectionsTheme.colors.textPrimary,
+                                    style = FinancialConnectionsTheme.typography.bodyEmphasized,
+                                    textAlign = TextAlign.Center
+                                )
+                            },
+                            contentDescription = "Institution logo"
                         )
                     }
                 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerScreen.kt
@@ -3,7 +3,6 @@
 package com.stripe.android.financialconnections.features.institutionpicker
 
 import androidx.activity.compose.BackHandler
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -50,6 +49,7 @@ import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.compose.collectAsState
 import com.airbnb.mvrx.compose.mavericksViewModel
 import com.stripe.android.financialconnections.R
+import com.stripe.android.financialconnections.features.common.InstitutionPlaceholder
 import com.stripe.android.financialconnections.features.common.LoadingSpinner
 import com.stripe.android.financialconnections.features.institutionpicker.InstitutionPickerState.Payload
 import com.stripe.android.financialconnections.model.FinancialConnectionsInstitution
@@ -339,12 +339,7 @@ private fun InstitutionResultTile(
     ) {
         StripeImage(
             url = institution.icon?.default ?: "",
-            errorContent = {
-                Image(
-                    painter = painterResource(id = R.drawable.stripe_ic_brandicon_institution),
-                    contentDescription = "Bank icon placeholder"
-                )
-            },
+            errorContent = { InstitutionPlaceholder() },
             contentScale = ContentScale.Crop,
             contentDescription = null,
             imageLoader = LocalImageLoader.current,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerStates.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerStates.kt
@@ -80,6 +80,8 @@ internal class InstitutionPickerStates :
                     url = "institution 1 url",
                     featured = false,
                     featuredOrder = null,
+                    icon = null,
+                    logo = null,
                     mobileHandoffCapable = false
                 ),
                 FinancialConnectionsInstitution(
@@ -88,6 +90,8 @@ internal class InstitutionPickerStates :
                     url = "Institution 2 url",
                     featured = false,
                     featuredOrder = null,
+                    icon = null,
+                    logo = null,
                     mobileHandoffCapable = false
                 ),
                 FinancialConnectionsInstitution(
@@ -96,6 +100,8 @@ internal class InstitutionPickerStates :
                     url = "Institution 3 url",
                     featured = false,
                     featuredOrder = null,
+                    icon = null,
+                    logo = null,
                     mobileHandoffCapable = false
                 )
             )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthScreen.kt
@@ -191,14 +191,15 @@ private fun PrePaneContent(
                 bottom = 16.dp
             )
     ) {
+        val modifier = Modifier
+            .size(36.dp)
+            .clip(RoundedCornerShape(6.dp))
         StripeImage(
             url = institution.icon?.default ?: "",
             contentDescription = null,
             imageLoader = LocalImageLoader.current,
-            errorContent = { InstitutionPlaceholder() },
-            modifier = Modifier
-                .size(36.dp)
-                .clip(RoundedCornerShape(6.dp))
+            errorContent = { InstitutionPlaceholder(modifier) },
+            modifier = modifier
         )
         Spacer(modifier = Modifier.size(16.dp))
         Text(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
@@ -19,6 +19,7 @@ import com.stripe.android.financialconnections.domain.PollAuthorizationSessionOA
 import com.stripe.android.financialconnections.domain.PostAuthorizationSession
 import com.stripe.android.financialconnections.exception.WebAuthFlowCancelledException
 import com.stripe.android.financialconnections.features.partnerauth.PartnerAuthState.Payload
+import com.stripe.android.financialconnections.model.FinancialConnectionsInstitution
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.FinancialConnectionsAuthorizationSession.Flow
 import com.stripe.android.financialconnections.navigation.NavigationDirections
 import com.stripe.android.financialconnections.navigation.NavigationManager
@@ -46,14 +47,14 @@ internal class PartnerAuthViewModel @Inject constructor(
         suspend {
             val manifest = getManifest()
             val authSession = createAuthorizationSession(
-                institution = manifest.activeInstitution!!,
+                institution = requireNotNull(manifest.activeInstitution),
                 allowManualEntry = manifest.allowManualEntry
             )
             Payload(
                 flow = authSession.flow,
                 showPrepane = authSession.flow?.isOAuth() ?: true,
                 showPartnerDisclosure = authSession.showPartnerDisclosure ?: false,
-                institutionName = manifest.activeInstitution.name
+                institution = manifest.activeInstitution
             )
         }.execute {
             copy(payload = it)
@@ -194,7 +195,7 @@ internal data class PartnerAuthState(
     val authenticationStatus: Async<String> = Uninitialized
 ) : MavericksState {
     data class Payload(
-        val institutionName: String,
+        val institution: FinancialConnectionsInstitution,
         val flow: Flow?,
         val showPartnerDisclosure: Boolean,
         val showPrepane: Boolean

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessScreen.kt
@@ -233,6 +233,8 @@ internal fun SuccessScreenPreview() {
                 url = "url",
                 featured = true,
                 featuredOrder = null,
+                icon = null,
+                logo = null,
                 mobileHandoffCapable = false
             )
         )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsInstitution.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsInstitution.kt
@@ -33,7 +33,7 @@ internal data class FinancialConnectionsInstitution(
 
     // TODO@carlosmuvi remove hardcoded images.
     // @SerialName(value = "logo")
-    val logo: Image? = null,
+    val logo: Image? = Image("https://play-lh.googleusercontent.com/KFPSKyRk3oZQvTPR1BJ2nzGQZFcAfsNWUZ-MQQM_ixEbxs4_-MYHo4cVQOlDU8lrG3BE"),
 
     @SerialName(value = "featured_order") val featuredOrder: Int? = null,
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsInstitution.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsInstitution.kt
@@ -27,8 +27,24 @@ internal data class FinancialConnectionsInstitution(
 
     @SerialName(value = "name") val name: String,
 
+    // TODO@carlosmuvi remove hardcoded images.
+    // @SerialName(value = "icon")
+    val icon: Image? = Image("https://pbs.twimg.com/profile_images/748885874516094980/ywt_aKRx_400x400.jpg"),
+
+    // TODO@carlosmuvi remove hardcoded images.
+    // @SerialName(value = "logo")
+    val logo: Image? = Image("https://play-lh.googleusercontent.com/KFPSKyRk3oZQvTPR1BJ2nzGQZFcAfsNWUZ-MQQM_ixEbxs4_-MYHo4cVQOlDU8lrG3BE"),
+
     @SerialName(value = "featured_order") val featuredOrder: Int? = null,
 
     @SerialName(value = "url") val url: String? = null
+
+) : Parcelable
+
+@Serializable
+@Parcelize
+internal data class Image(
+
+    @SerialName(value = "default") val default: String
 
 ) : Parcelable

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsInstitution.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsInstitution.kt
@@ -33,7 +33,7 @@ internal data class FinancialConnectionsInstitution(
 
     // TODO@carlosmuvi remove hardcoded images.
     // @SerialName(value = "logo")
-    val logo: Image? = Image("https://play-lh.googleusercontent.com/KFPSKyRk3oZQvTPR1BJ2nzGQZFcAfsNWUZ-MQQM_ixEbxs4_-MYHo4cVQOlDU8lrG3BE"),
+    val logo: Image? = null,
 
     @SerialName(value = "featured_order") val featuredOrder: Int? = null,
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsInstitution.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/FinancialConnectionsInstitution.kt
@@ -27,13 +27,11 @@ internal data class FinancialConnectionsInstitution(
 
     @SerialName(value = "name") val name: String,
 
-    // TODO@carlosmuvi remove hardcoded images.
-    // @SerialName(value = "icon")
-    val icon: Image? = Image("https://pbs.twimg.com/profile_images/748885874516094980/ywt_aKRx_400x400.jpg"),
+    @SerialName(value = "icon")
+    val icon: Image? = null,
 
-    // TODO@carlosmuvi remove hardcoded images.
-    // @SerialName(value = "logo")
-    val logo: Image? = Image("https://play-lh.googleusercontent.com/KFPSKyRk3oZQvTPR1BJ2nzGQZFcAfsNWUZ-MQQM_ixEbxs4_-MYHo4cVQOlDU8lrG3BE"),
+    @SerialName(value = "logo")
+    val logo: Image? = null,
 
     @SerialName(value = "featured_order") val featuredOrder: Int? = null,
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/FinancialConnectionsSheetNativeActivity.kt
@@ -45,6 +45,7 @@ import com.stripe.android.financialconnections.presentation.FinancialConnections
 import com.stripe.android.financialconnections.presentation.FinancialConnectionsSheetNativeViewEffect.OpenUrl
 import com.stripe.android.financialconnections.presentation.FinancialConnectionsSheetNativeViewModel
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
+import com.stripe.android.uicore.image.StripeImageLoader
 import javax.inject.Inject
 
 internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), MavericksView {
@@ -56,6 +57,9 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), Ma
 
     @Inject
     lateinit var logger: Logger
+
+    @Inject
+    lateinit var imageLoader: StripeImageLoader
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -114,6 +118,7 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), Ma
         NavigationEffect(navController)
         CompositionLocalProvider(
             LocalNavHostController provides navController,
+            LocalImageLoader provides imageLoader,
         ) {
             NavHost(navController, startDestination = initialDestination) {
                 composable(NavigationDirections.consent.destination) {
@@ -205,4 +210,8 @@ internal class FinancialConnectionsSheetNativeActivity : AppCompatActivity(), Ma
 
 internal val LocalNavHostController = staticCompositionLocalOf<NavHostController> {
     error("No NavHostController provided")
+}
+
+internal val LocalImageLoader = staticCompositionLocalOf<StripeImageLoader> {
+    error("No ImageLoader provided")
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/StripeImage.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/StripeImage.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp.Companion.Infinity
 import androidx.compose.ui.unit.IntSize.Companion.Zero
+import com.stripe.android.uicore.image.StripeImageState.Error
+import com.stripe.android.uicore.image.StripeImageState.Loading
 import com.stripe.android.uicore.image.StripeImageState.Success
 import kotlinx.coroutines.launch
 
@@ -41,14 +43,14 @@ fun StripeImage(
     imageLoader: StripeImageLoader,
     contentDescription: String?,
     modifier: Modifier = Modifier,
+    contentScale: ContentScale = ContentScale.Fit,
     errorContent: @Composable BoxWithConstraintsScope.() -> Unit = {},
-    loadingContent: @Composable BoxWithConstraintsScope.() -> Unit = {},
-    contentScale: ContentScale = ContentScale.Fit
+    loadingContent: @Composable BoxWithConstraintsScope.() -> Unit = {}
 ) {
     BoxWithConstraints(modifier) {
         val (width, height) = calculateBoxSize()
         val state: MutableState<StripeImageState> =
-            remember { mutableStateOf(StripeImageState.Loading) }
+            remember { mutableStateOf(Loading) }
         LaunchedEffect(url) {
             launch {
                 imageLoader
@@ -57,13 +59,13 @@ fun StripeImage(
                         state.value = Success(BitmapPainter(bitmap.asImageBitmap()))
                     }
                     .onFailure {
-                        state.value = StripeImageState.Error
+                        state.value = Error
                     }
             }
         }
         when (val result = state.value) {
-            StripeImageState.Error -> errorContent()
-            StripeImageState.Loading -> loadingContent()
+            Error -> errorContent()
+            Loading -> loadingContent()
             is Success -> Image(
                 modifier = modifier,
                 contentDescription = contentDescription,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/StripeImage.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/StripeImage.kt
@@ -102,7 +102,7 @@ private fun BoxWithConstraintsScope.calculateBoxSize(): Pair<Int, Int> {
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-sealed class StripeImageState {
+private sealed class StripeImageState {
     object Loading : StripeImageState()
     data class Success(val painter: Painter) : StripeImageState()
     object Error : StripeImageState()

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/StripeImage.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/StripeImage.kt
@@ -41,8 +41,8 @@ fun StripeImage(
     imageLoader: StripeImageLoader,
     contentDescription: String?,
     modifier: Modifier = Modifier,
-    errorContent: @Composable () -> Unit = {},
-    loadingContent: @Composable () -> Unit = {},
+    errorContent: @Composable BoxWithConstraintsScope.() -> Unit = {},
+    loadingContent: @Composable BoxWithConstraintsScope.() -> Unit = {},
     contentScale: ContentScale = ContentScale.Fit
 ) {
     BoxWithConstraints(modifier) {


### PR DESCRIPTION
cc @scottmathews


# Summary
<!-- Simple summary of what was changed. -->
- d9f438482 Adds placeholders and fixes error content on featured institutions.
- d4f641a23 Adds images to account picker and success.
- 24f09f656 Renders image on prepane.
- e370c6bd5 Renders images across AuthFlow.

# Motivation
:notebook_with_decorative_cover: &nbsp;**[Research + Code] Render images from CDN**
:globe_with_meridians: &nbsp;[BANKCON-5306](https://jira.corp.stripe.com/browse/BANKCON-5306)
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Screenshots

https://user-images.githubusercontent.com/99293320/194967509-564d09e4-e7e2-4fd3-af0a-13d68f0b2317.mp4