### PR TITLE
[Bug] Zero argument constructor crash on FinancialConnectionsState


### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetState.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetState.kt
@@ -4,7 +4,6 @@ import com.airbnb.mvrx.MavericksState
 import com.airbnb.mvrx.PersistState
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityArgs
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityResult
-import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetForDataContract
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
 
 /**

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetState.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetState.kt
@@ -11,7 +11,7 @@ import com.stripe.android.financialconnections.model.FinancialConnectionsSession
  *  Class containing all of the data needed to represent the screen.
  */
 internal data class FinancialConnectionsSheetState(
-    val initialArgs: FinancialConnectionsSheetActivityArgs,
+    val initialArgs: FinancialConnectionsSheetActivityArgs = emptyArgs(),
     val activityRecreated: Boolean = false,
     @PersistState val manifest: FinancialConnectionsSessionManifest? = null,
     @PersistState val authFlowActive: Boolean = false,
@@ -27,6 +27,17 @@ internal data class FinancialConnectionsSheetState(
     constructor(args: FinancialConnectionsSheetActivityArgs) : this(
         initialArgs = args
     )
+
+    private companion object {
+        fun emptyArgs(): FinancialConnectionsSheetActivityArgs {
+            return FinancialConnectionsSheetActivityArgs.ForData(
+                FinancialConnectionsSheet.Configuration(
+                    financialConnectionsSessionClientSecret = "",
+                    publishableKey = ""
+                )
+            )
+        }
+    }
 }
 
 /**
@@ -44,7 +55,7 @@ internal sealed class FinancialConnectionsSheetViewEffect {
     ) : FinancialConnectionsSheetViewEffect()
 
     /**
-     * Finish [FinancialConnectionsSheetActivity] with a given [FinancialConnectionsSheetForDataContract.Result]
+     * Finish [FinancialConnectionsSheetActivity] with a given [FinancialConnectionsSheetActivityResult]
      */
     data class FinishWithResult(
         val result: FinancialConnectionsSheetActivityResult

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetActivityArgs.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetActivityArgs.kt
@@ -50,6 +50,8 @@ sealed class FinancialConnectionsSheetActivityArgs constructor(
         }
     }
 
+    internal fun isValid(): Boolean = kotlin.runCatching { validate() }.isSuccess
+
     companion object {
         internal fun fromIntent(intent: Intent): FinancialConnectionsSheetActivityArgs? {
             return intent.getParcelableExtra(Mavericks.KEY_ARG)

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsApiRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsApiRepository.kt
@@ -41,10 +41,12 @@ internal class FinancialConnectionsApiRepository @Inject constructor(
         encodeDefaults = true
     }
 
-    private val options = ApiRequest.Options(
-        apiKey = publishableKey,
-        stripeAccount = stripeAccountId
-    )
+    private val options by lazy {
+        ApiRequest.Options(
+            apiKey = publishableKey,
+            stripeAccount = stripeAccountId
+        )
+    }
 
     override suspend fun getFinancialConnectionsAccounts(
         getFinancialConnectionsAcccountsParams: GetFinancialConnectionsAcccountsParams


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

- `FinancialConnectionsActivity` gets opened without configuration arguments. Check the Github issue for more info - https://github.com/stripe/stripe-android/issues/5629
- While figuring out what's triggering the activity to open, prevent from crashing and just finishing gracefully with a Failure state.

# Motivation
:notebook_with_decorative_cover: &nbsp;**[Bug] Zero argument constructor crash on FinancialConnectionsState**
:globe_with_meridians: &nbsp;[BANKCON-5498](https://jira.corp.stripe.com/browse/BANKCON-5498)

>
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
