### PR TITLE
Add `PollingViewModel` and tests

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/polling/IntentStatusPoller.kt
+++ b/payments-core/src/main/java/com/stripe/android/polling/IntentStatusPoller.kt
@@ -10,7 +10,7 @@ interface IntentStatusPoller {
     val state: StateFlow<StripeIntent.Status?>
 
     fun startPolling(scope: CoroutineScope)
-    suspend fun forcePoll()
+    suspend fun forcePoll(): StripeIntent.Status?
     fun stopPolling()
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/payments-core/src/test/java/com/stripe/android/polling/PollingTestUtils.kt
+++ b/payments-core/src/test/java/com/stripe/android/polling/PollingTestUtils.kt
@@ -15,7 +15,7 @@ internal fun exponentialDelayProvider(): () -> Long {
         // Add a minor offset so that we run after the delay has finished,
         // not when it's just about to finish.
         val offset = if (attempt == 1) 1 else 0
-        calculateDelay(attempts = attempt++) + offset
+        calculateDelay(attempts = attempt++).inWholeMilliseconds + offset
     }
 }
 

--- a/payments-core/src/test/java/com/stripe/android/polling/PollingTestUtils.kt
+++ b/payments-core/src/test/java/com/stripe/android/polling/PollingTestUtils.kt
@@ -15,7 +15,7 @@ internal fun exponentialDelayProvider(): () -> Long {
         // Add a minor offset so that we run after the delay has finished,
         // not when it's just about to finish.
         val offset = if (attempt == 1) 1 else 0
-        calculateDelayInMillis(attempts = attempt++) + offset
+        calculateDelay(attempts = attempt++) + offset
     }
 }
 

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -1528,12 +1528,28 @@ public final class com/stripe/android/paymentsheet/paymentdatacollection/polling
 	public final fun getLambda-2$paymentsheet_release ()Lkotlin/jvm/functions/Function2;
 }
 
+public final class com/stripe/android/paymentsheet/paymentdatacollection/polling/DefaultTimeProvider_Factory : dagger/internal/Factory {
+	public fun <init> ()V
+	public static fun create ()Lcom/stripe/android/paymentsheet/paymentdatacollection/polling/DefaultTimeProvider_Factory;
+	public fun get ()Lcom/stripe/android/paymentsheet/paymentdatacollection/polling/DefaultTimeProvider;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance ()Lcom/stripe/android/paymentsheet/paymentdatacollection/polling/DefaultTimeProvider;
+}
+
 public final class com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingContract$Args$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/paymentdatacollection/polling/PollingContract$Args;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/paymentdatacollection/polling/PollingContract$Args;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModel_Factory : dagger/internal/Factory {
+	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
+	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModel_Factory;
+	public fun get ()Lcom/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModel;
+	public synthetic fun get ()Ljava/lang/Object;
+	public static fun newInstance (Lcom/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModel$Args;Lcom/stripe/android/polling/IntentStatusPoller;Lcom/stripe/android/paymentsheet/paymentdatacollection/polling/TimeProvider;Lkotlinx/coroutines/CoroutineDispatcher;Landroidx/lifecycle/SavedStateHandle;)Lcom/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModel;
 }
 
 public final class com/stripe/android/paymentsheet/repositories/CustomerApiRepository_Factory : dagger/internal/Factory {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModel.kt
@@ -1,0 +1,190 @@
+package com.stripe.android.paymentsheet.paymentdatacollection.polling
+
+import android.os.SystemClock
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.stripe.android.core.injection.DUMMY_INJECTOR_KEY
+import com.stripe.android.core.injection.InjectorKey
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.polling.IntentStatusPoller
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.ZERO
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+private const val KEY_CURRENT_POLLING_START_TIME = "KEY_CURRENT_POLLING_START_TIME"
+
+internal interface TimeProvider {
+    fun currentTimeInMillis(): Long
+}
+
+internal class DefaultTimeProvider @Inject constructor() : TimeProvider {
+    override fun currentTimeInMillis(): Long {
+        return SystemClock.elapsedRealtime()
+    }
+}
+
+internal enum class PollingState {
+    Active,
+    Success,
+    Failed,
+    Canceled,
+}
+
+internal data class PollingUiState(
+    val durationRemaining: Duration,
+    val pollingState: PollingState = PollingState.Active,
+)
+
+internal class PollingViewModel @Inject constructor(
+    private val args: Args,
+    private val poller: IntentStatusPoller,
+    private val timeProvider: TimeProvider,
+    private val dispatcher: CoroutineDispatcher,
+    private val savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(PollingUiState(durationRemaining = args.timeLimit))
+    val uiState: StateFlow<PollingUiState> = _uiState
+
+    init {
+        val timeRemaining = computeTimeRemaining()
+
+        viewModelScope.launch(dispatcher) {
+            observeCountdown(timeRemaining)
+        }
+
+        viewModelScope.launch(dispatcher) {
+            observePollingResults()
+        }
+
+        viewModelScope.launch(dispatcher) {
+            // Wait until the deadline arrives
+            // TODO: Need to use timeRemaining?
+            delay(args.timeLimit)
+            handleTimeLimitReached()
+        }
+
+        viewModelScope.launch(dispatcher) {
+            delay(args.initialDelay)
+            poller.startPolling(scope = this)
+        }
+    }
+
+    private suspend fun handleTimeLimitReached() {
+        poller.stopPolling()
+        delay(3.seconds)
+        performOneOffPoll()
+    }
+
+    private suspend fun performOneOffPoll() {
+        val intentStatus = poller.forcePoll()
+        if (intentStatus == StripeIntent.Status.Succeeded) {
+            _uiState.update {
+                it.copy(pollingState = PollingState.Success)
+            }
+        } else {
+            _uiState.update {
+                it.copy(pollingState = PollingState.Failed)
+            }
+        }
+    }
+
+    private fun computeTimeRemaining(): Duration {
+        val originalStartTime = savedStateHandle.get<Long>(KEY_CURRENT_POLLING_START_TIME)
+
+        if (originalStartTime == null) {
+            savedStateHandle[KEY_CURRENT_POLLING_START_TIME] = timeProvider.currentTimeInMillis()
+        }
+
+        return if (originalStartTime != null) {
+            // We were polling before the process death, so let's use the previous attempt's
+            // start time.
+            val deadline = originalStartTime + args.timeLimit.inWholeMilliseconds
+            val currentTimeInMillis = timeProvider.currentTimeInMillis()
+            val millisRemaining = deadline - currentTimeInMillis
+            maxOf(millisRemaining.milliseconds, ZERO)
+        } else {
+            args.timeLimit
+        }
+    }
+
+    fun pausePolling() {
+        poller.stopPolling()
+    }
+
+    fun resumePolling() {
+        viewModelScope.launch(dispatcher) {
+            delay(args.initialDelay)
+            poller.startPolling(viewModelScope)
+        }
+    }
+
+    fun handleCancel() {
+        _uiState.update {
+            it.copy(pollingState = PollingState.Canceled)
+        }
+        poller.stopPolling()
+    }
+
+    private suspend fun observeCountdown(timeLimit: Duration) {
+        countdownFlow(timeLimit).collect { secondsRemaining ->
+            _uiState.update {
+                it.copy(durationRemaining = secondsRemaining)
+            }
+        }
+    }
+
+    private suspend fun observePollingResults() {
+        poller.state
+            .map { it?.toPollingState() ?: PollingState.Active }
+            .collect(this::updatePollingState)
+    }
+
+    private fun updatePollingState(pollingState: PollingState) {
+        _uiState.update {
+            it.copy(pollingState = pollingState)
+        }
+    }
+
+    data class Args(
+        val clientSecret: String,
+        val timeLimit: Duration,
+        val initialDelay: Duration,
+        val maxAttempts: Int,
+        @InjectorKey internal val injectorKey: String = DUMMY_INJECTOR_KEY
+    )
+}
+
+private fun countdownFlow(duration: Duration) = flow {
+    var remainingDuration = duration
+    emit(remainingDuration)
+
+    while (remainingDuration.inWholeSeconds > 0) {
+        delay(1.seconds)
+        remainingDuration = duration.minus(1.seconds)
+        emit(remainingDuration)
+    }
+}
+
+private fun StripeIntent.Status.toPollingState(): PollingState {
+    return when (this) {
+        StripeIntent.Status.RequiresAction -> PollingState.Active
+        StripeIntent.Status.Succeeded -> PollingState.Success
+        StripeIntent.Status.Canceled,
+        StripeIntent.Status.Processing,
+        StripeIntent.Status.RequiresConfirmation,
+        StripeIntent.Status.RequiresPaymentMethod,
+        StripeIntent.Status.RequiresCapture -> PollingState.Failed
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModel.kt
@@ -69,9 +69,7 @@ internal class PollingViewModel @Inject constructor(
         }
 
         viewModelScope.launch(dispatcher) {
-            // Wait until the deadline arrives
-            // TODO: Need to use timeRemaining?
-            delay(args.timeLimit)
+            delay(timeRemaining)
             handleTimeLimitReached()
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModel.kt
@@ -136,9 +136,9 @@ internal class PollingViewModel @Inject constructor(
     }
 
     private suspend fun observeCountdown(timeLimit: Duration) {
-        countdownFlow(timeLimit).collect { secondsRemaining ->
+        countdownFlow(timeLimit).collect { duration ->
             _uiState.update {
-                it.copy(durationRemaining = secondsRemaining)
+                it.copy(durationRemaining = duration)
             }
         }
     }
@@ -168,9 +168,9 @@ private fun countdownFlow(duration: Duration) = flow {
     var remainingDuration = duration
     emit(remainingDuration)
 
-    while (remainingDuration.inWholeSeconds > 0) {
+    while (remainingDuration > ZERO) {
         delay(1.seconds)
-        remainingDuration = duration.minus(1.seconds)
+        remainingDuration -= 1.seconds
         emit(remainingDuration)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingTestUtils.kt
@@ -1,0 +1,47 @@
+package com.stripe.android.paymentsheet.paymentdatacollection.polling
+
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.polling.IntentStatusPoller
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+internal class FakeIntentStatusPoller : IntentStatusPoller {
+
+    private val _state = MutableStateFlow<StripeIntent.Status?>(null)
+    override val state: StateFlow<StripeIntent.Status?> = _state
+
+    private val forcePollChannel = Channel<StripeIntent.Status?>(capacity = 1)
+
+    var isActive: Boolean = false
+        private set
+
+    override fun startPolling(scope: CoroutineScope) {
+        isActive = true
+    }
+
+    override suspend fun forcePoll(): StripeIntent.Status? {
+        return forcePollChannel.receive()
+    }
+
+    override fun stopPolling() {
+        isActive = false
+    }
+
+    fun enqueueForcePollResult(status: StripeIntent.Status?) {
+        forcePollChannel.trySend(status)
+    }
+
+    fun emitNextPollResult(status: StripeIntent.Status?) {
+        _state.value = status
+    }
+}
+
+internal class FakeTimeProvider(
+    private val timeInMillis: Long = System.currentTimeMillis(),
+) : TimeProvider {
+    override fun currentTimeInMillis(): Long {
+        return timeInMillis
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModelTest.kt
@@ -5,11 +5,14 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.polling.IntentStatusPoller
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
@@ -19,7 +22,7 @@ class PollingViewModelTest {
     private val testDispatcher = UnconfinedTestDispatcher()
 
     @Test
-    fun `Emits provided time limit as remaining duration`() = runBlocking {
+    fun `Emits provided time limit as remaining duration`() = runTest(testDispatcher) {
         val timeLimit = 5.minutes
 
         val viewModel = createPollingViewModel(
@@ -31,7 +34,7 @@ class PollingViewModelTest {
     }
 
     @Test
-    fun `Remaining time is updated every second`() = runBlocking {
+    fun `Remaining time is updated every second`() = runTest(testDispatcher) {
         val timeLimit = 5.minutes
 
         val viewModel = createPollingViewModel(
@@ -41,17 +44,17 @@ class PollingViewModelTest {
 
         assertThat(viewModel.uiState.value.durationRemaining).isEqualTo(timeLimit)
 
-        testDispatcher.scheduler.advanceTimeBy(1.seconds.inWholeMilliseconds + 1)
+        advanceTimeBy(1.seconds + 1.milliseconds)
 
         assertThat(viewModel.uiState.value.durationRemaining).isEqualTo(timeLimit - 1.seconds)
 
-        testDispatcher.scheduler.advanceTimeBy(1.seconds.inWholeMilliseconds)
+        advanceTimeBy(1.seconds)
 
         assertThat(viewModel.uiState.value.durationRemaining).isEqualTo(timeLimit - 2.seconds)
     }
 
     @Test
-    fun `Reflects cancellation in UI state`() = runBlocking {
+    fun `Reflects cancellation in UI state`() = runTest(testDispatcher) {
         val fakePoller = FakeIntentStatusPoller()
 
         val viewModel = createPollingViewModel(
@@ -68,7 +71,7 @@ class PollingViewModelTest {
     }
 
     @Test
-    fun `Reflects failure in UI state`() = runBlocking {
+    fun `Reflects failure in UI state`() = runTest(testDispatcher) {
         val fakePoller = FakeIntentStatusPoller()
 
         val viewModel = createPollingViewModel(
@@ -84,7 +87,7 @@ class PollingViewModelTest {
     }
 
     @Test
-    fun `Performs one-off poll when time limit has been exceeded`() {
+    fun `Performs one-off poll when time limit has been exceeded`() = runTest(testDispatcher) {
         val fakePoller = FakeIntentStatusPoller().apply {
             emitNextPollResult(StripeIntent.Status.RequiresAction)
         }
@@ -99,17 +102,17 @@ class PollingViewModelTest {
 
         fakePoller.enqueueForcePollResult(StripeIntent.Status.RequiresCapture)
 
-        testDispatcher.scheduler.advanceTimeBy(10.seconds.inWholeMilliseconds + 1)
+        advanceTimeBy(10.seconds + 1.milliseconds)
 
         assertThat(fakePoller.isActive).isFalse()
 
-        testDispatcher.scheduler.advanceTimeBy(3.seconds.inWholeMilliseconds + 1)
+        advanceTimeBy(3.seconds)
 
         assertThat(viewModel.uiState.value.pollingState).isEqualTo(PollingState.Failed)
     }
 
     @Test
-    fun `Pausing stops the poller and doesn't emit new state`() = runBlocking {
+    fun `Pausing stops the poller and doesn't emit new state`() = runTest(testDispatcher) {
         val fakePoller = FakeIntentStatusPoller()
 
         val viewModel = createPollingViewModel(
@@ -117,21 +120,21 @@ class PollingViewModelTest {
             dispatcher = testDispatcher,
         )
 
-        testDispatcher.scheduler.advanceTimeBy(5.seconds.inWholeMilliseconds + 1)
+        advanceTimeBy(5.seconds + 1.milliseconds)
 
         assertThat(fakePoller.isActive).isTrue()
         assertThat(viewModel.uiState.value.pollingState).isEqualTo(PollingState.Active)
 
         viewModel.pausePolling()
 
-        testDispatcher.scheduler.advanceTimeBy(1.minutes.inWholeMilliseconds + 1)
+        advanceTimeBy(1.minutes)
 
         assertThat(fakePoller.isActive).isFalse()
         assertThat(viewModel.uiState.value.pollingState).isEqualTo(PollingState.Active)
     }
 
     @Test
-    fun `Continues polling after pausing and resuming`() = runBlocking {
+    fun `Continues polling after pausing and resuming`() = runTest(testDispatcher) {
         val fakePoller = FakeIntentStatusPoller()
 
         val viewModel = createPollingViewModel(
@@ -139,7 +142,7 @@ class PollingViewModelTest {
             dispatcher = testDispatcher,
         )
 
-        testDispatcher.scheduler.advanceTimeBy(5.seconds.inWholeMilliseconds + 1)
+        advanceTimeBy(5.seconds + 1.milliseconds)
 
         assertThat(fakePoller.isActive).isTrue()
 
@@ -149,22 +152,23 @@ class PollingViewModelTest {
 
         viewModel.resumePolling()
 
-        testDispatcher.scheduler.advanceTimeBy(5.seconds.inWholeMilliseconds + 1)
+        advanceTimeBy(5.seconds + 1.milliseconds)
 
         assertThat(fakePoller.isActive).isTrue()
     }
 
     @Test
-    fun `Emits correct time limit when restoring from process death`() = runBlocking {
+    fun `Emits correct time limit when restoring from process death`() = runTest(testDispatcher) {
         val currentTime = System.currentTimeMillis()
         val timeProvider = FakeTimeProvider(timeInMillis = currentTime)
 
+        val timeLimit = 10.minutes
+        val alreadyPassed = 2.minutes
+
         val savedStateHandle = SavedStateHandle().apply {
-            val mockedStartTime = currentTime - 2.minutes.inWholeMilliseconds
+            val mockedStartTime = currentTime - alreadyPassed.inWholeMilliseconds
             this["KEY_CURRENT_POLLING_START_TIME"] = mockedStartTime
         }
-
-        val timeLimit = 10.minutes
 
         val viewModel = createPollingViewModel(
             timeLimit = timeLimit,
@@ -173,7 +177,8 @@ class PollingViewModelTest {
             dispatcher = testDispatcher,
         )
 
-        assertThat(viewModel.uiState.value.durationRemaining).isEqualTo(8.minutes)
+        val remainingTime = timeLimit - alreadyPassed
+        assertThat(viewModel.uiState.value.durationRemaining).isEqualTo(remainingTime)
     }
 }
 
@@ -199,4 +204,9 @@ private fun createPollingViewModel(
         dispatcher = dispatcher,
         savedStateHandle = savedStateHandle,
     )
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+private fun TestScope.advanceTimeBy(duration: Duration) {
+    advanceTimeBy(duration.inWholeMilliseconds)
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModelTest.kt
@@ -1,0 +1,182 @@
+package com.stripe.android.paymentsheet.paymentdatacollection.polling
+
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.polling.IntentStatusPoller
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.Test
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PollingViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @Test
+    fun `Emits provided time limit as remaining duration`() = runBlocking {
+        val timeLimit = 5.minutes
+
+        val viewModel = createPollingViewModel(
+            timeLimit = timeLimit,
+            dispatcher = testDispatcher,
+        )
+
+        assertThat(viewModel.uiState.value.durationRemaining).isEqualTo(timeLimit)
+    }
+
+    @Test
+    fun `Reflects cancellation in UI state`() = runBlocking {
+        val fakePoller = FakeIntentStatusPoller()
+
+        val viewModel = createPollingViewModel(
+            poller = fakePoller,
+            dispatcher = testDispatcher,
+        )
+
+        assertThat(viewModel.uiState.value.pollingState).isEqualTo(PollingState.Active)
+
+        viewModel.handleCancel()
+
+        assertThat(fakePoller.isActive).isFalse()
+        assertThat(viewModel.uiState.value.pollingState).isEqualTo(PollingState.Canceled)
+    }
+
+    @Test
+    fun `Reflects failure in UI state`() = runBlocking {
+        val fakePoller = FakeIntentStatusPoller()
+
+        val viewModel = createPollingViewModel(
+            poller = fakePoller,
+            dispatcher = testDispatcher,
+        )
+
+        assertThat(viewModel.uiState.value.pollingState).isEqualTo(PollingState.Active)
+
+        fakePoller.emitNextPollResult(StripeIntent.Status.Canceled)
+
+        assertThat(viewModel.uiState.value.pollingState).isEqualTo(PollingState.Failed)
+    }
+
+    @Test
+    fun `Performs one-off poll when time limit has been exceeded`() {
+        val fakePoller = FakeIntentStatusPoller().apply {
+            emitNextPollResult(StripeIntent.Status.RequiresAction)
+        }
+
+        val viewModel = createPollingViewModel(
+            poller = fakePoller,
+            timeLimit = 10.seconds,
+            dispatcher = testDispatcher,
+        )
+
+        assertThat(viewModel.uiState.value.pollingState).isEqualTo(PollingState.Active)
+
+        fakePoller.enqueueForcePollResult(StripeIntent.Status.RequiresCapture)
+
+        testDispatcher.scheduler.advanceTimeBy(10.seconds.inWholeMilliseconds + 1)
+
+        assertThat(fakePoller.isActive).isFalse()
+
+        testDispatcher.scheduler.advanceTimeBy(3.seconds.inWholeMilliseconds + 1)
+
+        assertThat(viewModel.uiState.value.pollingState).isEqualTo(PollingState.Failed)
+    }
+
+    @Test
+    fun `Pausing stops the poller and doesn't emit new state`() = runBlocking {
+        val fakePoller = FakeIntentStatusPoller()
+
+        val viewModel = createPollingViewModel(
+            poller = fakePoller,
+            dispatcher = testDispatcher,
+        )
+
+        testDispatcher.scheduler.advanceTimeBy(5.seconds.inWholeMilliseconds + 1)
+
+        assertThat(fakePoller.isActive).isTrue()
+        assertThat(viewModel.uiState.value.pollingState).isEqualTo(PollingState.Active)
+
+        viewModel.pausePolling()
+
+        testDispatcher.scheduler.advanceTimeBy(1.minutes.inWholeMilliseconds + 1)
+
+        assertThat(fakePoller.isActive).isFalse()
+        assertThat(viewModel.uiState.value.pollingState).isEqualTo(PollingState.Active)
+    }
+
+    @Test
+    fun `Continues polling after pausing and resuming`() = runBlocking {
+        val fakePoller = FakeIntentStatusPoller()
+
+        val viewModel = createPollingViewModel(
+            poller = fakePoller,
+            dispatcher = testDispatcher,
+        )
+
+        testDispatcher.scheduler.advanceTimeBy(5.seconds.inWholeMilliseconds + 1)
+
+        assertThat(fakePoller.isActive).isTrue()
+
+        viewModel.pausePolling()
+
+        assertThat(fakePoller.isActive).isFalse()
+
+        viewModel.resumePolling()
+
+        testDispatcher.scheduler.advanceTimeBy(5.seconds.inWholeMilliseconds + 1)
+
+        assertThat(fakePoller.isActive).isTrue()
+    }
+
+    @Test
+    fun `Emits correct time limit when restoring from process death`() = runBlocking {
+        val currentTime = System.currentTimeMillis()
+        val timeProvider = FakeTimeProvider(timeInMillis = currentTime)
+
+        val savedStateHandle = SavedStateHandle().apply {
+            val mockedStartTime = currentTime - 2.minutes.inWholeMilliseconds
+            this["KEY_CURRENT_POLLING_START_TIME"] = mockedStartTime
+        }
+
+        val timeLimit = 10.minutes
+
+        val viewModel = createPollingViewModel(
+            timeLimit = timeLimit,
+            timeProvider = timeProvider,
+            savedStateHandle = savedStateHandle,
+            dispatcher = testDispatcher,
+        )
+
+        assertThat(viewModel.uiState.value.durationRemaining).isEqualTo(8.minutes)
+    }
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+private fun createPollingViewModel(
+    timeLimit: Duration = 5.minutes,
+    initialDelay: Duration = 5.seconds,
+    poller: IntentStatusPoller = FakeIntentStatusPoller(),
+    timeProvider: TimeProvider = FakeTimeProvider(),
+    savedStateHandle: SavedStateHandle = SavedStateHandle(),
+    dispatcher: TestDispatcher,
+): PollingViewModel {
+    return PollingViewModel(
+        args = PollingViewModel.Args(
+            clientSecret = "secret",
+            timeLimit = timeLimit,
+            initialDelay = initialDelay,
+            maxAttempts = 10,
+            injectorKey = "injector",
+        ),
+        poller = poller,
+        timeProvider = timeProvider,
+        dispatcher = dispatcher,
+        savedStateHandle = savedStateHandle,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModelTest.kt
@@ -31,6 +31,26 @@ class PollingViewModelTest {
     }
 
     @Test
+    fun `Remaining time is updated every second`() = runBlocking {
+        val timeLimit = 5.minutes
+
+        val viewModel = createPollingViewModel(
+            timeLimit = timeLimit,
+            dispatcher = testDispatcher,
+        )
+
+        assertThat(viewModel.uiState.value.durationRemaining).isEqualTo(timeLimit)
+
+        testDispatcher.scheduler.advanceTimeBy(1.seconds.inWholeMilliseconds + 1)
+
+        assertThat(viewModel.uiState.value.durationRemaining).isEqualTo(timeLimit - 1.seconds)
+
+        testDispatcher.scheduler.advanceTimeBy(1.seconds.inWholeMilliseconds)
+
+        assertThat(viewModel.uiState.value.durationRemaining).isEqualTo(timeLimit - 2.seconds)
+    }
+
+    @Test
     fun `Reflects cancellation in UI state`() = runBlocking {
         val fakePoller = FakeIntentStatusPoller()
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds the `PollingViewModel` and its tests. It will be used in the `PollingFragment` and:
1. start the polling
2. enforce the polling time limit
3. performing a last force-poll once the time limit is up
4. pausing and resuming polling

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Polling for UPI in payment sheet.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
N/A.

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

_Nothing to add._
