### PR TITLE
Handle blank fields in `ShippingInfoWidget`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## XX.XX.XX - 2022-XX-XX
 
+### Payments
+
+* [FIXED][5701](https://github.com/stripe/stripe-android/pull/5701) Treat empty fields as invalid in `ShippingInfoWidget`.
+
 ## 20.15.0 - 2022-10-11
 
 This release adds Link as a payment method to the SDK and fixes a minor issue with CardScan.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Payments
 
-* [FIXED][5701](https://github.com/stripe/stripe-android/pull/5701) Treat empty fields as invalid in `ShippingInfoWidget`.
+* [FIXED][5701](https://github.com/stripe/stripe-android/pull/5701) Treat blank fields as invalid in `ShippingInfoWidget`.
 
 ## 20.15.0 - 2022-10-11
 

--- a/payments-core/src/main/java/com/stripe/android/view/PostalCodeValidator.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PostalCodeValidator.kt
@@ -34,7 +34,7 @@ class PostalCodeValidator {
             return false
         }
 
-        return if (postalCode.isEmpty() &&
+        return if (postalCode.isBlank() &&
             isPostalCodeNotRequired(optionalShippingInfoFields, hiddenShippingInfoFields)
         ) {
             // user has configured postal code as optional or hidden and customer has not inputted

--- a/payments-core/src/main/java/com/stripe/android/view/ShippingInfoWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/ShippingInfoWidget.kt
@@ -184,22 +184,22 @@ class ShippingInfoWidget @JvmOverloads constructor(
         )
         postalCodeEditText.shouldShowError = !isPostalCodeValid
 
-        val requiredAddressLine1Empty = address.isEmpty() &&
+        val requiredAddressLine1Empty = address.isBlank() &&
             isFieldRequired(CustomizableShippingField.Line1)
         addressEditText.shouldShowError = requiredAddressLine1Empty
 
-        val requiredCityEmpty = city.isEmpty() &&
+        val requiredCityEmpty = city.isBlank() &&
             isFieldRequired(CustomizableShippingField.City)
         cityEditText.shouldShowError = requiredCityEmpty
 
-        val requiredNameEmpty = name.isEmpty()
+        val requiredNameEmpty = name.isBlank()
         nameEditText.shouldShowError = requiredNameEmpty
 
-        val requiredStateEmpty = state.isEmpty() &&
+        val requiredStateEmpty = state.isBlank() &&
             isFieldRequired(CustomizableShippingField.State)
         stateEditText.shouldShowError = requiredStateEmpty
 
-        val requiredPhoneNumberEmpty = phoneNumber.isEmpty() &&
+        val requiredPhoneNumberEmpty = phoneNumber.isBlank() &&
             isFieldRequired(CustomizableShippingField.Phone)
         phoneNumberEditText.shouldShowError = requiredPhoneNumberEmpty
 

--- a/payments-core/src/test/java/com/stripe/android/view/ShippingInfoWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/ShippingInfoWidgetTest.kt
@@ -194,8 +194,17 @@ class ShippingInfoWidgetTest {
             .isFalse()
         assertThat(stateTextInputLayout.isErrorEnabled)
             .isFalse()
-        postalEditText.setText("")
 
+        nameEditText.setText("      ")
+        assertThat(shippingInfoWidget.validateAllFields())
+            .isFalse()
+        assertThat(nameTextInputLayout.isErrorEnabled)
+            .isTrue()
+        nameEditText.setText("Valid Name")
+        assertThat(shippingInfoWidget.validateAllFields())
+            .isTrue()
+
+        postalEditText.setText("")
         assertThat(shippingInfoWidget.validateAllFields())
             .isFalse()
         assertThat(postalCodeTextInputLayout.isErrorEnabled)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Treat blank fields as invalid in `ShippingInfoWidget`.
Previously only fully empty fields were considered invalid.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
#5690

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

