### PR TITLE
Tweak ripple area of payment option card

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
@@ -627,9 +627,6 @@ internal fun PaymentOptionUi(
             .padding(top = 12.dp)
             .width(viewWidth)
             .alpha(alpha = if (isEnabled) 1.0F else 0.6F)
-            .selectable(selected = isSelected, enabled = isEnabled, onClick = {
-                onItemSelectedListener()
-            })
     ) {
         val (checkIcon, deleteIcon, label, card) = createRefs()
         SectionCard(
@@ -647,7 +644,13 @@ internal fun PaymentOptionUi(
             Column(
                 verticalArrangement = Arrangement.Center,
                 horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier.fillMaxSize()
+                modifier = Modifier
+                    .fillMaxSize()
+                    .selectable(
+                        selected = isSelected,
+                        enabled = isEnabled,
+                        onClick = onItemSelectedListener,
+                    ),
             ) {
                 Image(
                     painter = painterResource(iconRes),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request tweaks the ripple effect in the payment option card, limiting it to the actual card. (see screenshots below)

(Yes, this technically reduces the tappable area. However, I’d argue that users tap the card, not the text below it, so this shouldn’t have any impact in practical use.)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

UX polish.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before | After |
| ------------- | ------------- |
| <img width="608" alt="Screen Shot 2022-10-14 at 12 28 31 PM" src="https://user-images.githubusercontent.com/110940675/195896795-49b37cb0-01a3-4ed4-a832-de25c06b0065.png"> | <img width="608" alt="Screen Shot 2022-10-14 at 12 27 54 PM" src="https://user-images.githubusercontent.com/110940675/195896819-b3220d2e-dd97-4c9a-9cd5-df6bf9076d69.png"> |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

_Nothing to add._
