### PR TITLE
Fix broken Link inline signup test

### DIFF
--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestLink.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestLink.kt
@@ -58,13 +58,13 @@ class TestLink {
     }
 
     private val linkNewUser = TestParameters(
-        lpmRepository.fromCode("card")!!,
-        Customer.New,
-        LinkState.On,
-        GooglePayState.On,
-        Currency.USD,
-        IntentType.Pay,
-        Billing.Off,
+        paymentMethod = lpmRepository.fromCode("card")!!,
+        customer = Customer.Guest,
+        linkState = LinkState.On,
+        googlePayState = GooglePayState.On,
+        currency = Currency.USD,
+        intentType = IntentType.Pay,
+        billing = Billing.Off,
         shipping = Shipping.Off,
         delayed = DelayedPMs.Off,
         automatic = Automatic.Off,
@@ -77,12 +77,7 @@ class TestLink {
 
     @Test
     fun testLinkInlineCustom() {
-        testDriver.testLinkCustom(
-            linkNewUser.copy(
-                paymentMethod = lpmRepository.fromCode("card")!!,
-                customer = Customer.Guest,
-            )
-        )
+        testDriver.testLinkCustom(linkNewUser)
     }
 
     companion object {

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -21,6 +21,7 @@ import androidx.test.runner.screenshot.Screenshot
 import androidx.test.uiautomator.UiDevice
 import com.google.common.truth.Truth.assertThat
 import com.karumi.shot.ScreenshotTest
+import com.stripe.android.paymentsheet.PAYMENT_OPTION_CARD_TEST_TAG
 import com.stripe.android.paymentsheet.PaymentSheetResult
 import com.stripe.android.paymentsheet.example.playground.activity.PaymentSheetPlaygroundActivity
 import com.stripe.android.test.core.ui.BrowserUI
@@ -79,7 +80,7 @@ class PlaygroundTestDriver(
             selectors.addPaymentMethodButton.isDisplayed()
         }
 
-        composeTestRule.onNodeWithText("+ Add").apply {
+        composeTestRule.onNodeWithTag("$PAYMENT_OPTION_CARD_TEST_TAG+ Add").apply {
             assertExists()
             performClick()
         }

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -45,6 +45,10 @@ public final class com/stripe/android/paymentsheet/PaymentOptionResult$Succeeded
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/paymentsheet/PaymentOptionsAdapterKt {
+	public static final field PAYMENT_OPTION_CARD_TEST_TAG Ljava/lang/String;
+}
+
 public final class com/stripe/android/paymentsheet/PaymentOptionsViewModel_Factory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/paymentsheet/PaymentOptionsViewModel_Factory;

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
@@ -605,6 +606,9 @@ internal class PaymentOptionsAdapter(
     }
 }
 
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+const val PAYMENT_OPTION_CARD_TEST_TAG = "PAYMENT_OPTION_CARD_TEST_TAG"
+
 @Composable
 internal fun PaymentOptionUi(
     viewWidth: Dp,
@@ -646,6 +650,7 @@ internal fun PaymentOptionUi(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = Modifier
                     .fillMaxSize()
+                    .testTag(PAYMENT_OPTION_CARD_TEST_TAG + labelText)
                     .selectable(
                         selected = isSelected,
                         enabled = isEnabled,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes the Link inline signup test, which I accidentally broke with the UX tweak in https://github.com/stripe/stripe-android/pull/5707.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Working E2E tests.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
N/A.

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

_Nothing to add._
