### PR TITLE
Fix issue with limited postal code input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Payments
 
 * [FIXED][5701](https://github.com/stripe/stripe-android/pull/5701) Treat blank fields as invalid in `ShippingInfoWidget`.
+* [FIXED][5715](https://github.com/stripe/stripe-android/pull/5715) Postal codes for countries other than US and Canada are no longer limited to a single character.
 
 ## 20.15.0 - 2022-10-11
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PostalCodeConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PostalCodeConfig.kt
@@ -37,17 +37,17 @@ internal class PostalCodeConfig(
 
         override fun getError(): FieldError? {
             return when {
-                input.isNotBlank() && !isFull() && country == "US" -> {
+                input.isNotBlank() && !isValid() && country == "US" -> {
                     FieldError(R.string.address_zip_invalid)
                 }
-                input.isNotBlank() && !isFull() -> {
+                input.isNotBlank() && !isValid() -> {
                     FieldError(R.string.address_zip_postal_invalid)
                 }
                 else -> null
             }
         }
 
-        override fun isFull(): Boolean = input.length >= format.minimumLength
+        override fun isFull(): Boolean = input.length >= format.maximumLength
 
         override fun isBlank(): Boolean = input.isBlank()
     }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PostalCodeConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/PostalCodeConfigTest.kt
@@ -40,9 +40,9 @@ class PostalCodeConfigTest {
             Truth.assertThat(determineStateForInput(" ").isValid()).isFalse()
             Truth.assertThat(determineStateForInput(" ").isFull()).isFalse()
             Truth.assertThat(determineStateForInput("a").isValid()).isTrue()
-            Truth.assertThat(determineStateForInput("a").isFull()).isTrue()
+            Truth.assertThat(determineStateForInput("a").isFull()).isFalse()
             Truth.assertThat(determineStateForInput("1").isValid()).isTrue()
-            Truth.assertThat(determineStateForInput("1").isFull()).isTrue()
+            Truth.assertThat(determineStateForInput("1").isFull()).isFalse()
             Truth.assertThat(determineStateForInput("aaaaaa").isValid()).isTrue()
             Truth.assertThat(determineStateForInput("111111").isValid()).isTrue()
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where non-US and non-Canadian postal codes were limited to a single character.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Resolves: https://github.com/stripe/stripe-android/issues/5714

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

[FIXED] Postal codes for countries other than US and Canada are no longer limited to a single character.
