### PR TITLE
Add Loading and Error composable callbacks to StripeImage


### DIFF
--- a/stripe-ui-core/api/stripe-ui-core.api
+++ b/stripe-ui-core/api/stripe-ui-core.api
@@ -5,6 +5,15 @@ public final class com/stripe/android/uicore/BuildConfig {
 	public fun <init> ()V
 }
 
+public final class com/stripe/android/uicore/image/ComposableSingletons$StripeImageKt {
+	public static final field INSTANCE Lcom/stripe/android/uicore/image/ComposableSingletons$StripeImageKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-2 Lkotlin/jvm/functions/Function3;
+	public fun <init> ()V
+	public final fun getLambda-1$stripe_ui_core_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-2$stripe_ui_core_release ()Lkotlin/jvm/functions/Function3;
+}
+
 public final class com/stripe/android/uicore/image/StripeImageKt {
 }
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/NetworkImageDecoder.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/NetworkImageDecoder.kt
@@ -49,8 +49,8 @@ class NetworkImageDecoder {
 
     private fun URL.stream(): InputStream {
         val con: URLConnection = openConnection()
-        con.connectTimeout = 10_000
-        con.readTimeout = 10_000
+        con.connectTimeout = IMAGE_STREAM_TIMEOUT
+        con.readTimeout = IMAGE_STREAM_TIMEOUT
         return con.getInputStream()
     }
 
@@ -72,5 +72,9 @@ class NetworkImageDecoder {
             }
         }
         return inSampleSize
+    }
+
+    private companion object {
+        const val IMAGE_STREAM_TIMEOUT = 10_000
     }
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/StripeImage.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/StripeImage.kt
@@ -6,18 +6,19 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.BoxWithConstraintsScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.Dp.Companion.Infinity
 import androidx.compose.ui.unit.IntSize.Companion.Zero
+import com.stripe.android.uicore.image.StripeImageState.Error
+import com.stripe.android.uicore.image.StripeImageState.Loading
+import com.stripe.android.uicore.image.StripeImageState.Success
 import kotlinx.coroutines.launch
 
 /**
@@ -30,7 +31,8 @@ import kotlinx.coroutines.launch
  *  and does not represent a meaningful action that a user can take.
  * @param imageLoader The [StripeImageLoader] that will be used to execute the request.
  * @param modifier Modifier used to adjust the layout algorithm or draw decoration content.
- * @param placeholder A [Painter] that is displayed while the image is loading.
+ * @param errorContent content to render when image loading fails.
+ * @param loadingContent content to render when image loads.
  * @param contentScale Optional scale parameter used to determine the aspect ratio scaling to be
  *  used if the bounds are a different size from the intrinsic size of the painter.
  */
@@ -38,33 +40,39 @@ import kotlinx.coroutines.launch
 @Composable
 fun StripeImage(
     url: String,
-    placeholder: Painter,
     imageLoader: StripeImageLoader,
     contentDescription: String?,
     modifier: Modifier = Modifier,
-    contentScale: ContentScale = ContentScale.Fit
+    contentScale: ContentScale = ContentScale.Fit,
+    errorContent: @Composable BoxWithConstraintsScope.() -> Unit = {},
+    loadingContent: @Composable BoxWithConstraintsScope.() -> Unit = {}
 ) {
     BoxWithConstraints(modifier) {
         val (width, height) = calculateBoxSize()
-        var painter: Painter by remember {
-            mutableStateOf(BitmapPainter(ImageBitmap(width, height)))
-        }
+        val state: MutableState<StripeImageState> =
+            remember { mutableStateOf(Loading) }
         LaunchedEffect(url) {
             launch {
                 imageLoader
                     .load(url, width, height)
-                    .fold(
-                        onSuccess = { bitmap -> BitmapPainter(bitmap.asImageBitmap()) },
-                        onFailure = { placeholder }
-                    ).let { painter = it }
+                    .onSuccess { bitmap ->
+                        state.value = Success(BitmapPainter(bitmap.asImageBitmap()))
+                    }
+                    .onFailure {
+                        state.value = Error
+                    }
             }
         }
-        Image(
-            modifier = modifier,
-            contentDescription = contentDescription,
-            contentScale = contentScale,
-            painter = painter
-        )
+        when (val result = state.value) {
+            Error -> errorContent()
+            Loading -> loadingContent()
+            is Success -> Image(
+                modifier = modifier,
+                contentDescription = contentDescription,
+                contentScale = contentScale,
+                painter = result.painter
+            )
+        }
     }
 }
 
@@ -91,4 +99,10 @@ private fun BoxWithConstraintsScope.calculateBoxSize(): Pair<Int, Int> {
     if (width == -1) width = height
     if (height == -1) height = width
     return Pair(width, height)
+}
+
+private sealed class StripeImageState {
+    object Loading : StripeImageState()
+    data class Success(val painter: Painter) : StripeImageState()
+    object Error : StripeImageState()
 }


### PR DESCRIPTION
# Summary

- Replaces placeholder by error and loading composables.
- Adds timeout to image fetching (10 seconds replacing the 2 minute java.net.URL default)

# Motivation
:notebook_with_decorative_cover: &nbsp;**Add Loading and Error composable callbacks to StripeImage**
:globe_with_meridians: &nbsp;[BANKCON-5584](https://jira.corp.stripe.com/browse/BANKCON-5584)
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified - Example usage: https://github.com/stripe/stripe-android/blob/49263ece9260ef7d6ff29149f4786c278c11bc43/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt#L353

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
