### PR TITLE
move `Html` from payments-ui-core to stripe-ui-core

### DIFF
--- a/link/build.gradle
+++ b/link/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation project(':stripe-core')
     implementation project(':payments-ui-core')
     implementation project(':financial-connections')
-//    implementation project(':stripe-ui-core')
+    implementation project(':stripe-ui-core')
 
     implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"
     implementation "androidx.constraintlayout:constraintlayout:$androidxConstraintlayoutVersion"

--- a/link/build.gradle
+++ b/link/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation project(':stripe-core')
     implementation project(':payments-ui-core')
     implementation project(':financial-connections')
+//    implementation project(':stripe-ui-core')
 
     implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"
     implementation "androidx.constraintlayout:constraintlayout:$androidxConstraintlayoutVersion"

--- a/link/src/main/java/com/stripe/android/link/ui/LinkTerms.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/LinkTerms.kt
@@ -8,8 +8,8 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import com.stripe.android.link.R
-import com.stripe.android.ui.core.elements.Html
 import com.stripe.android.ui.core.paymentsColors
+import com.stripe.android.uicore.text.Html
 
 @Preview
 @Composable

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -63,7 +63,6 @@ import com.stripe.android.model.CvcCheck
 import com.stripe.android.ui.core.elements.CvcController
 import com.stripe.android.ui.core.elements.CvcElement
 import com.stripe.android.ui.core.elements.DateConfig
-import com.stripe.android.ui.core.elements.Html
 import com.stripe.android.ui.core.elements.IdentifierSpec
 import com.stripe.android.ui.core.elements.RowController
 import com.stripe.android.ui.core.elements.RowElement
@@ -74,6 +73,7 @@ import com.stripe.android.ui.core.elements.SimpleTextElement
 import com.stripe.android.ui.core.elements.SimpleTextFieldController
 import com.stripe.android.ui.core.elements.TextFieldController
 import com.stripe.android.ui.core.injection.NonFallbackInjector
+import com.stripe.android.uicore.text.Html
 import kotlinx.coroutines.flow.flowOf
 import java.util.UUID
 

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -544,9 +544,6 @@ public final class com/stripe/android/ui/core/elements/H4TextKt {
 public final class com/stripe/android/ui/core/elements/H6TextKt {
 }
 
-public final class com/stripe/android/ui/core/elements/HtmlKt {
-}
-
 public final class com/stripe/android/ui/core/elements/HyperlinkedTextKt {
 }
 

--- a/payments-ui-core/build.gradle
+++ b/payments-ui-core/build.gradle
@@ -7,6 +7,7 @@ apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 dependencies {
     implementation project(":stripe-core")
     implementation project(":payments-core")
+    implementation project(":stripe-ui-core")
     compileOnly project(":stripecardscan")
     compileOnly "com.google.android.libraries.places:places:$placesVersion"
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AffirmElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AffirmElementUI.kt
@@ -9,8 +9,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.paymentsColors
-import com.stripe.android.uicore.text.Html
 import com.stripe.android.uicore.text.EmbeddableImage
+import com.stripe.android.uicore.text.Html
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AffirmElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AffirmElementUI.kt
@@ -9,6 +9,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.paymentsColors
+import com.stripe.android.uicore.text.Html
+import com.stripe.android.uicore.text.EmbeddableImage
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayElementUI.kt
@@ -15,8 +15,8 @@ import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.AfterpayClearpayHeaderElement.Companion.isClearpay
 import com.stripe.android.ui.core.paymentsColors
 import com.stripe.android.ui.core.shouldUseDarkDynamicColor
-import com.stripe.android.uicore.text.Html
 import com.stripe.android.uicore.text.EmbeddableImage
+import com.stripe.android.uicore.text.Html
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayElementUI.kt
@@ -15,6 +15,8 @@ import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.AfterpayClearpayHeaderElement.Companion.isClearpay
 import com.stripe.android.ui.core.paymentsColors
 import com.stripe.android.ui.core.shouldUseDarkDynamicColor
+import com.stripe.android.uicore.text.Html
+import com.stripe.android.uicore.text.EmbeddableImage
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBecsDebitMandateElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBecsDebitMandateElementUI.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.paymentsColors
+import com.stripe.android.uicore.text.Html
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation project(":link")
     implementation project(":payments-core")
     implementation project(':payments-ui-core')
+    implementation project(':stripe-ui-core')
     compileOnly project(':financial-connections')
 
     implementation "androidx.annotation:annotation:$androidxAnnotationVersion"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreen.kt
@@ -43,10 +43,10 @@ import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.ui.AddressOptionsAppBar
 import com.stripe.android.ui.core.darken
 import com.stripe.android.ui.core.elements.TextFieldSection
-import com.stripe.android.ui.core.elements.annotatedStringResource
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.ui.core.injection.NonFallbackInjector
 import com.stripe.android.ui.core.paymentsColors
+import com.stripe.android.uicore.text.annotatedStringResource
 
 @VisibleForTesting
 internal const val TEST_TAG_ATTRIBUTION_DRAWABLE = "AutocompleteAttributionDrawable"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -41,10 +41,10 @@ import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.PaymentsThemeDefaults
 import com.stripe.android.ui.core.createTextSpanFromTextStyle
 import com.stripe.android.ui.core.elements.H4Text
-import com.stripe.android.ui.core.elements.Html
 import com.stripe.android.ui.core.getBackgroundColor
 import com.stripe.android.ui.core.isSystemDarkTheme
 import com.stripe.android.ui.core.paymentsColors
+import com.stripe.android.uicore.text.Html
 import com.stripe.android.utils.AnimationConstants
 import com.stripe.android.view.KeyboardController
 import kotlin.math.roundToInt

--- a/stripe-ui-core/api/stripe-ui-core.api
+++ b/stripe-ui-core/api/stripe-ui-core.api
@@ -21,3 +21,9 @@ public final class com/stripe/android/uicore/image/DrawablePainterKt {
 public final class com/stripe/android/uicore/image/StripeImageKt {
 }
 
+public final class com/stripe/android/uicore/image/UiUtilsKt {
+}
+
+public final class com/stripe/android/uicore/text/HtmlKt {
+}
+

--- a/stripe-ui-core/build.gradle
+++ b/stripe-ui-core/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     implementation "com.jakewharton:disklrucache:2.0.2"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
+    implementation "androidx.compose.material:material:$androidxComposeVersion"
+    implementation "androidx.core:core-ktx:$androidxCoreVersion"
 
     testImplementation "junit:junit:$junitVersion"
     testImplementation "com.google.truth:truth:$truthVersion"

--- a/stripe-ui-core/detekt-baseline.xml
+++ b/stripe-ui-core/detekt-baseline.xml
@@ -2,11 +2,14 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
+    <ID>ComplexMethod:Html.kt$@Composable @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun annotatedStringResource( text: String, imageGetter: Map&lt;String, EmbeddableImage> = emptyMap(), urlSpanStyle: SpanStyle = SpanStyle(textDecoration = TextDecoration.Underline) ): AnnotatedString</ID>
     <ID>EmptyFunctionBlock:DrawablePainter.kt$EmptyPainter${}</ID>
+    <ID>LongMethod:Html.kt$@Composable @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun annotatedStringResource( text: String, imageGetter: Map&lt;String, EmbeddableImage> = emptyMap(), urlSpanStyle: SpanStyle = SpanStyle(textDecoration = TextDecoration.Underline) ): AnnotatedString</ID>
     <ID>MagicNumber:DrawablePainter.kt$DrawablePainter$255</ID>
+    <ID>MagicNumber:Html.kt$0.1f</ID>
     <ID>MaxLineLength:DrawablePainter.kt$*</ID>
     <ID>MaxLineLength:UiUtils.kt$*</ID>
-    <ID>ReturnCount:UiUtils.kt$internal fun Context.getDrawableFromUri(uri: Uri): Drawable?</ID>
+    <ID>ReturnCount:UiUtils.kt$@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun Context.getDrawableFromUri(uri: Uri): Drawable?</ID>
     <ID>ThrowsCount:UiUtils.kt$@SuppressLint("DiscouragedApi") internal fun Context.getResourceId(uri: Uri): Pair&lt;Resources, Int></ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/UiUtils.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/UiUtils.kt
@@ -55,7 +55,7 @@ internal fun Context.getResourceId(uri: Uri): Pair<Resources, Int> {
  * This method is partially borrowed from [ImageView#getDrawableFromUri].
  * @see <a href="https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/widget/ImageView.java#1002">source</a>
  */
-internal fun Context.getDrawableFromUri(uri: Uri): Drawable? {
+fun Context.getDrawableFromUri(uri: Uri): Drawable? {
     val scheme = uri.scheme
     if (ContentResolver.SCHEME_ANDROID_RESOURCE == scheme) {
         try {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/UiUtils.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/UiUtils.kt
@@ -10,6 +10,7 @@ import android.net.Uri
 import android.text.TextUtils
 import android.util.Log
 import androidx.annotation.DrawableRes
+import androidx.annotation.RestrictTo
 import java.io.FileNotFoundException
 import java.io.IOException
 
@@ -55,6 +56,7 @@ internal fun Context.getResourceId(uri: Uri): Pair<Resources, Int> {
  * This method is partially borrowed from [ImageView#getDrawableFromUri].
  * @see <a href="https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/widget/ImageView.java#1002">source</a>
  */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun Context.getDrawableFromUri(uri: Uri): Drawable? {
     val scheme = uri.scheme
     if (ContentResolver.SCHEME_ANDROID_RESOURCE == scheme) {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/text/Html.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/text/Html.kt
@@ -101,11 +101,11 @@ fun Html(
     val context = LocalContext.current
     ClickableText(
         annotatedText,
+        color = color,
+        style = style,
         modifier = modifier
             .semantics(mergeDescendants = true) {}, // makes it a separate accessible item,
         inlineContent = inlineContentMap,
-        color = color,
-        style = style,
         onClick = {
             if (enabled) {
                 // Position is the position of the tag in the string
@@ -212,10 +212,10 @@ fun annotatedStringResource(
 @Composable
 private fun ClickableText(
     text: AnnotatedString,
-    modifier: Modifier = Modifier,
-    inlineContent: Map<String, InlineTextContent> = mapOf(),
     color: Color,
     style: TextStyle,
+    modifier: Modifier = Modifier,
+    inlineContent: Map<String, InlineTextContent> = mapOf(),
     softWrap: Boolean = true,
     overflow: TextOverflow = TextOverflow.Clip,
     maxLines: Int = Int.MAX_VALUE,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/text/Html.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/text/Html.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.uicore.text
 
-
 import android.content.Intent
 import android.graphics.Typeface
 import android.net.Uri

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/text/Html.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/text/Html.kt
@@ -1,4 +1,5 @@
-package com.stripe.android.ui.core.elements
+package com.stripe.android.uicore.text
+
 
 import android.content.Intent
 import android.graphics.Typeface
@@ -18,6 +19,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.foundation.text.appendInlineContent
+import androidx.compose.material.LocalTextStyle
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
@@ -41,7 +43,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.core.text.HtmlCompat
-import com.stripe.android.ui.core.paymentsColors
 
 private const val LINK_TAG = "URL"
 
@@ -61,10 +62,10 @@ data class EmbeddableImage(
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun Html(
     html: String,
-    imageGetter: Map<String, EmbeddableImage>,
-    color: Color,
-    style: TextStyle,
     modifier: Modifier = Modifier,
+    imageGetter: Map<String, EmbeddableImage> = emptyMap(),
+    color: Color = Color.Unspecified,
+    style: TextStyle = LocalTextStyle.current,
     enabled: Boolean = true,
     urlSpanStyle: SpanStyle = SpanStyle(textDecoration = TextDecoration.Underline),
     imageAlign: PlaceholderVerticalAlign = PlaceholderVerticalAlign.AboveBaseline
@@ -214,8 +215,8 @@ private fun ClickableText(
     text: AnnotatedString,
     modifier: Modifier = Modifier,
     inlineContent: Map<String, InlineTextContent> = mapOf(),
-    color: Color = MaterialTheme.paymentsColors.subtitle,
-    style: TextStyle = MaterialTheme.typography.body2,
+    color: Color,
+    style: TextStyle,
     softWrap: Boolean = true,
     overflow: TextOverflow = TextOverflow.Clip,
     maxLines: Int = Int.MAX_VALUE,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Reuse html from other modules.

There are two changes introduced to `Html`
1. the default param value of `color` and `style` passed to `ClickableText` is removed and replaced with `Color.Unspecified` and `LocalTextStyle.current`. atm all calling site of `Html` is not relying on the default value of these two params anyway. The new default value matches the ones used in `Text`
2. the order of `modifier` parameter is changed as suggested by ide

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Share code

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
