### PR TITLE
Wait for the preview to post before starting the camera

### DIFF
--- a/stripecardscan-example/src/main/res/layout/activity_card_scan_fragment_demo.xml
+++ b/stripecardscan-example/src/main/res/layout/activity_card_scan_fragment_demo.xml
@@ -18,7 +18,7 @@
             android:layout_height="0dp"
             android:layout_marginTop="64dp"
             android:visibility="gone"
-            app:layout_constraintDimensionRatio="200:160"
+            app:layout_constraintDimensionRatio="1:1"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"/>

--- a/stripecardscan/api/stripecardscan.api
+++ b/stripecardscan/api/stripecardscan.api
@@ -369,14 +369,11 @@ public final class com/stripe/android/stripecardscan/cardscan/exception/UnknownS
 }
 
 public final class com/stripe/android/stripecardscan/databinding/ActivityCardscanBinding : androidx/viewbinding/ViewBinding {
+	public final field cameraView Lcom/stripe/android/camera/scanui/CameraView;
 	public final field closeButton Landroid/widget/ImageView;
 	public final field instructions Landroid/widget/TextView;
-	public final field previewFrame Landroid/widget/FrameLayout;
 	public final field swapCameraButton Landroid/widget/ImageView;
 	public final field torchButton Landroid/widget/ImageView;
-	public final field viewFinderBackground Lcom/stripe/android/camera/scanui/ViewFinderBackground;
-	public final field viewFinderBorder Landroid/widget/ImageView;
-	public final field viewFinderWindow Landroid/view/View;
 	public static fun bind (Landroid/view/View;)Lcom/stripe/android/stripecardscan/databinding/ActivityCardscanBinding;
 	public synthetic fun getRoot ()Landroid/view/View;
 	public fun getRoot ()Landroidx/constraintlayout/widget/ConstraintLayout;
@@ -385,13 +382,12 @@ public final class com/stripe/android/stripecardscan/databinding/ActivityCardsca
 }
 
 public final class com/stripe/android/stripecardscan/databinding/FragmentCardscanBinding : androidx/viewbinding/ViewBinding {
+	public final field cameraView Lcom/stripe/android/camera/scanui/CameraView;
 	public final field closeButton Landroid/widget/ImageView;
 	public final field instructions Landroid/widget/TextView;
-	public final field previewFrame Landroid/widget/FrameLayout;
+	public final field swapCameraButton Landroid/widget/ImageView;
 	public final field title Landroid/widget/TextView;
-	public final field viewFinderBackground Lcom/stripe/android/camera/scanui/ViewFinderBackground;
-	public final field viewFinderBorder Landroid/widget/ImageView;
-	public final field viewFinderWindow Landroid/view/View;
+	public final field torchButton Landroid/widget/ImageView;
 	public static fun bind (Landroid/view/View;)Lcom/stripe/android/stripecardscan/databinding/FragmentCardscanBinding;
 	public synthetic fun getRoot ()Landroid/view/View;
 	public fun getRoot ()Landroidx/constraintlayout/widget/ConstraintLayout;

--- a/stripecardscan/res/layout/activity_cardscan.xml
+++ b/stripecardscan/res/layout/activity_cardscan.xml
@@ -6,42 +6,12 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     tools:context=".cardscan.CardScanActivity">
 
-    <FrameLayout
-        android:id="@+id/preview_frame"
+    <com.stripe.android.camera.scanui.CameraView
+        android:id="@+id/camera_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
-    </FrameLayout>
-
-    <com.stripe.android.camera.scanui.ViewFinderBackground
-        android:id="@+id/view_finder_background"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" />
-
-    <View
-        android:id="@+id/view_finder_window"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintVertical_bias="0.5"
-        app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintDimensionRatio="200:126"/>
-
-    <ImageView
-        android:id="@+id/view_finder_border"
-        android:contentDescription="@string/stripe_card_view_finder_description"
-        android:background="@drawable/stripe_card_border_not_found"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintVertical_bias="0.5"
-        app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintDimensionRatio="200:126"/>
+        android:layout_height="match_parent"
+        app:borderDrawable="@drawable/stripe_card_border_not_found"
+        app:viewFinderType="creditCard" />
 
     <ImageView
         android:id="@+id/close_button"
@@ -95,7 +65,7 @@
         android:layout_marginTop="16dp"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
-        app:layout_constraintBottom_toTopOf="@id/view_finder_window"
+        app:layout_constraintTop_toBottomOf="@id/swap_camera_button"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>
 

--- a/stripecardscan/res/layout/fragment_cardscan.xml
+++ b/stripecardscan/res/layout/fragment_cardscan.xml
@@ -6,53 +6,39 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     tools:context=".cardscan.CardScanFragment">
 
-    <FrameLayout
-        android:id="@+id/preview_frame"
+    <com.stripe.android.camera.scanui.CameraView
+        android:id="@+id/camera_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
-    </FrameLayout>
-
-    <com.stripe.android.camera.scanui.ViewFinderBackground
-        android:id="@+id/view_finder_background"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" />
-
-    <View
-        android:id="@+id/view_finder_window"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintVertical_bias="0.5"
-        app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintDimensionRatio="200:126"/>
-
-    <ImageView
-        android:id="@+id/view_finder_border"
-        android:contentDescription="@string/stripe_card_view_finder_description"
-        android:background="@drawable/stripe_paymentsheet_card_border_not_found"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintVertical_bias="0.5"
-        app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintDimensionRatio="200:126"/>
+        android:layout_height="match_parent"
+        app:viewFinderType="creditCard" />
 
     <ImageView
         android:id="@+id/close_button"
         android:contentDescription="@string/stripe_close_button_description"
-        android:src="@drawable/stripe_paymentsheet_close_button"
+        android:src="@drawable/stripe_close_button_dark"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:padding="20dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"/>
+
+    <ImageView
+        android:id="@+id/torch_button"
+        android:contentDescription="@string/stripe_torch_button_description"
+        android:src="@drawable/stripe_flash_off_dark"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <ImageView
+        android:id="@+id/swap_camera_button"
+        android:contentDescription="@string/stripe_swap_camera_button_description"
+        android:src="@drawable/stripe_camera_swap_dark"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/view_finder_window"/>
+        app:layout_constraintEnd_toEndOf="parent"/>
 
     <TextView
         android:id="@+id/title"
@@ -64,9 +50,9 @@
         android:gravity="center"
         android:textColor="@color/stripeInstructionsColorDark"
         android:layout_marginBottom="8dp"
-        app:layout_constraintBottom_toTopOf="@id/view_finder_window"
-        app:layout_constraintStart_toStartOf="@id/view_finder_window"
-        app:layout_constraintEnd_toEndOf="@id/view_finder_window" />
+        app:layout_constraintTop_toBottomOf="@id/close_button"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 
     <TextView
         android:id="@+id/instructions"
@@ -80,10 +66,9 @@
         android:layout_marginTop="16dp"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
-        app:layout_constraintTop_toTopOf="@id/view_finder_window"
-        app:layout_constraintBottom_toBottomOf="@id/view_finder_window"
-        app:layout_constraintStart_toStartOf="@id/view_finder_window"
-        app:layout_constraintEnd_toEndOf="@id/view_finder_window"
+        app:layout_constraintTop_toBottomOf="@id/title"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         android:visibility="gone"/>
 
 

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanActivity.kt
@@ -2,19 +2,20 @@ package com.stripe.android.stripecardscan.cardscan
 
 import android.annotation.SuppressLint
 import android.content.Intent
-import android.content.res.Resources
 import android.graphics.Bitmap
 import android.graphics.PointF
 import android.os.Bundle
 import android.util.Size
+import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import androidx.annotation.RestrictTo
-import androidx.core.view.updateMargins
 import com.stripe.android.camera.CameraPreviewImage
 import com.stripe.android.camera.framework.Stats
 import com.stripe.android.camera.scanui.ScanErrorListener
 import com.stripe.android.camera.scanui.ScanState
 import com.stripe.android.camera.scanui.SimpleScanStateful
+import com.stripe.android.camera.scanui.ViewFinderBackground
 import com.stripe.android.camera.scanui.util.asRect
 import com.stripe.android.camera.scanui.util.setDrawable
 import com.stripe.android.camera.scanui.util.startAnimation
@@ -34,7 +35,6 @@ import com.stripe.android.stripecardscan.scanui.CancellationReason
 import com.stripe.android.stripecardscan.scanui.ScanActivity
 import com.stripe.android.stripecardscan.scanui.ScanResultListener
 import com.stripe.android.stripecardscan.scanui.util.getColorByRes
-import com.stripe.android.stripecardscan.scanui.util.getFloatResource
 import com.stripe.android.stripecardscan.scanui.util.hide
 import com.stripe.android.stripecardscan.scanui.util.setVisible
 import com.stripe.android.stripecardscan.scanui.util.show
@@ -43,8 +43,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.math.min
-import kotlin.math.roundToInt
 
 internal const val INTENT_PARAM_REQUEST = "request"
 internal const val INTENT_PARAM_RESULT = "result"
@@ -75,7 +73,19 @@ internal class CardScanActivity : ScanActivity(), SimpleScanStateful<CardScanSta
     }
 
     override val previewFrame: ViewGroup by lazy {
-        viewBinding.previewFrame
+        viewBinding.cameraView.previewFrame
+    }
+
+    private val viewFinderWindow: View by lazy {
+        viewBinding.cameraView.viewFinderWindowView
+    }
+
+    private val viewFinderBorder: ImageView by lazy {
+        viewBinding.cameraView.viewFinderBorderView
+    }
+
+    private val viewFinderBackground: ViewFinderBackground by lazy {
+        viewBinding.cameraView.viewFinderBackgroundView
     }
 
     private val params: CardScanSheetParams by lazy {
@@ -184,8 +194,6 @@ internal class CardScanActivity : ScanActivity(), SimpleScanStateful<CardScanSta
             return
         }
 
-        setupViewFinderConstraints()
-
         viewBinding.closeButton.setOnClickListener {
             userClosedScanner()
         }
@@ -195,11 +203,11 @@ internal class CardScanActivity : ScanActivity(), SimpleScanStateful<CardScanSta
         viewBinding.swapCameraButton.setOnClickListener {
             toggleCamera()
         }
-        viewBinding.viewFinderBorder.setOnTouchListener { _, e ->
+        viewFinderBorder.setOnTouchListener { _, e ->
             setFocus(
                 PointF(
-                    e.x + viewBinding.viewFinderWindow.left,
-                    e.y + viewBinding.viewFinderWindow.top
+                    e.x + viewFinderBorder.left,
+                    e.y + viewFinderBorder.top
                 )
             )
             true
@@ -227,31 +235,6 @@ internal class CardScanActivity : ScanActivity(), SimpleScanStateful<CardScanSta
         closeScanner()
     }
 
-    /**
-     * Set up viewFinderWindowView and viewFinderBorderView centered with predefined margins
-     */
-    private fun setupViewFinderConstraints() {
-        val screenSize = Resources.getSystem().displayMetrics.let {
-            Size(it.widthPixels, it.heightPixels)
-        }
-        val viewFinderMargin = (
-            min(screenSize.width, screenSize.height) *
-                getFloatResource(R.dimen.stripeViewFinderMargin)
-            ).roundToInt()
-
-        listOf(viewBinding.viewFinderWindow, viewBinding.viewFinderBorder).forEach { view ->
-            (view.layoutParams as ViewGroup.MarginLayoutParams)
-                .updateMargins(
-                    viewFinderMargin,
-                    viewFinderMargin,
-                    viewFinderMargin,
-                    viewFinderMargin
-                )
-        }
-
-        viewBinding.viewFinderBackground.setViewFinderRect(viewBinding.viewFinderWindow.asRect())
-    }
-
     override fun onFlashSupported(supported: Boolean) {
         viewBinding.torchButton.setVisible(supported)
     }
@@ -261,9 +244,11 @@ internal class CardScanActivity : ScanActivity(), SimpleScanStateful<CardScanSta
     }
 
     override fun onCameraReady() {
-        viewBinding.viewFinderBackground
-            .setViewFinderRect(viewBinding.viewFinderWindow.asRect())
-        startCameraAdapter()
+        previewFrame.post {
+            viewFinderBackground
+                .setViewFinderRect(viewFinderWindow.asRect())
+            startCameraAdapter()
+        }
     }
 
     /**
@@ -273,7 +258,7 @@ internal class CardScanActivity : ScanActivity(), SimpleScanStateful<CardScanSta
         scanFlow.startFlow(
             context = this,
             imageStream = cameraStream,
-            viewFinder = viewBinding.viewFinderWindow.asRect(),
+            viewFinder = viewBinding.cameraView.viewFinderWindowView.asRect(),
             lifecycleOwner = this,
             coroutineScope = this,
             parameters = null
@@ -302,28 +287,28 @@ internal class CardScanActivity : ScanActivity(), SimpleScanStateful<CardScanSta
     override fun displayState(newState: CardScanState, previousState: CardScanState?) {
         when (newState) {
             is CardScanState.NotFound -> {
-                viewBinding.viewFinderBackground
+                viewFinderBackground
                     .setBackgroundColor(getColorByRes(R.color.stripeNotFoundBackground))
-                viewBinding.viewFinderWindow
+                viewFinderWindow
                     .setBackgroundResource(R.drawable.stripe_card_background_not_found)
-                viewBinding.viewFinderBorder.startAnimation(R.drawable.stripe_card_border_not_found)
+                viewFinderBorder.startAnimation(R.drawable.stripe_card_border_not_found)
                 viewBinding.instructions.setText(R.string.stripe_card_scan_instructions)
             }
             is CardScanState.Found -> {
-                viewBinding.viewFinderBackground
+                viewFinderBackground
                     .setBackgroundColor(getColorByRes(R.color.stripeFoundBackground))
-                viewBinding.viewFinderWindow
+                viewFinderWindow
                     .setBackgroundResource(R.drawable.stripe_card_background_found)
-                viewBinding.viewFinderBorder.startAnimation(R.drawable.stripe_card_border_found)
+                viewFinderBorder.startAnimation(R.drawable.stripe_card_border_found)
                 viewBinding.instructions.setText(R.string.stripe_card_scan_instructions)
                 viewBinding.instructions.show()
             }
             is CardScanState.Correct -> {
-                viewBinding.viewFinderBackground
+                viewFinderBackground
                     .setBackgroundColor(getColorByRes(R.color.stripeCorrectBackground))
-                viewBinding.viewFinderWindow
+                viewFinderWindow
                     .setBackgroundResource(R.drawable.stripe_card_background_correct)
-                viewBinding.viewFinderBorder.startAnimation(R.drawable.stripe_card_border_correct)
+                viewFinderBorder.startAnimation(R.drawable.stripe_card_border_correct)
                 viewBinding.instructions.hide()
             }
         }

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanFragment.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanFragment.kt
@@ -9,6 +9,7 @@ import android.util.Size
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import android.widget.TextView
 import androidx.core.os.bundleOf
 import androidx.core.view.updateMargins
@@ -17,6 +18,7 @@ import com.stripe.android.camera.CameraPreviewImage
 import com.stripe.android.camera.framework.Stats
 import com.stripe.android.camera.scanui.ScanErrorListener
 import com.stripe.android.camera.scanui.SimpleScanStateful
+import com.stripe.android.camera.scanui.ViewFinderBackground
 import com.stripe.android.camera.scanui.util.asRect
 import com.stripe.android.camera.scanui.util.startAnimation
 import com.stripe.android.stripecardscan.R
@@ -35,6 +37,7 @@ import com.stripe.android.stripecardscan.scanui.CancellationReason
 import com.stripe.android.stripecardscan.scanui.ScanFragment
 import com.stripe.android.stripecardscan.scanui.util.getColorByRes
 import com.stripe.android.stripecardscan.scanui.util.getFloatResource
+import com.stripe.android.stripecardscan.scanui.util.setVisible
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
@@ -55,7 +58,19 @@ class CardScanFragment : ScanFragment(), SimpleScanStateful<CardScanState> {
 
     override val instructionsText: TextView by lazy { viewBinding.instructions }
 
-    override val previewFrame: ViewGroup by lazy { viewBinding.previewFrame }
+    override val previewFrame: ViewGroup by lazy { viewBinding.cameraView.previewFrame }
+
+    private val viewFinderWindow: View by lazy {
+        viewBinding.cameraView.viewFinderWindowView
+    }
+
+    private val viewFinderBorder: ImageView by lazy {
+        viewBinding.cameraView.viewFinderBorderView
+    }
+
+    private val viewFinderBackground: ViewFinderBackground by lazy {
+        viewBinding.cameraView.viewFinderBackgroundView
+    }
 
     private val params: CardScanSheetParams by lazy {
         arguments?.getParcelable(CARD_SCAN_FRAGMENT_PARAMS_KEY) ?: CardScanSheetParams("")
@@ -170,11 +185,17 @@ class CardScanFragment : ScanFragment(), SimpleScanStateful<CardScanState> {
         viewBinding.closeButton.setOnClickListener {
             userClosedScanner()
         }
-        viewBinding.viewFinderBorder.setOnTouchListener { _, e ->
+        viewBinding.torchButton.setOnClickListener {
+            toggleFlashlight()
+        }
+        viewBinding.swapCameraButton.setOnClickListener {
+            toggleCamera()
+        }
+        viewFinderBorder.setOnTouchListener { _, e ->
             setFocus(
                 PointF(
-                    e.x + viewBinding.viewFinderWindow.left,
-                    e.y + viewBinding.viewFinderWindow.top
+                    e.x + viewFinderWindow.left,
+                    e.y + viewFinderWindow.top
                 )
             )
             true
@@ -214,7 +235,7 @@ class CardScanFragment : ScanFragment(), SimpleScanStateful<CardScanState> {
                 (context?.getFloatResource(R.dimen.stripeViewFinderMargin) ?: 0F)
             ).roundToInt()
 
-        listOf(viewBinding.viewFinderWindow, viewBinding.viewFinderBorder).forEach { view ->
+        listOf(viewFinderWindow, viewFinderBorder).forEach { view ->
             (view.layoutParams as ViewGroup.MarginLayoutParams)
                 .updateMargins(
                     viewFinderMargin,
@@ -224,20 +245,24 @@ class CardScanFragment : ScanFragment(), SimpleScanStateful<CardScanState> {
                 )
         }
 
-        viewBinding.viewFinderBackground.setViewFinderRect(viewBinding.viewFinderWindow.asRect())
+        viewFinderBackground.setViewFinderRect(viewFinderWindow.asRect())
     }
 
-    override fun onFlashSupported(supported: Boolean) {}
+    override fun onFlashSupported(supported: Boolean) {
+        viewBinding.torchButton.setVisible(supported)
+    }
 
-    override fun onSupportsMultipleCameras(supported: Boolean) {}
+    override fun onSupportsMultipleCameras(supported: Boolean) {
+        viewBinding.swapCameraButton.setVisible(supported)
+    }
 
     /**
      * Prepare to start the camera. Once the camera is ready, [onCameraReady] must be called.
      */
     override fun prepareCamera(onCameraReady: () -> Unit) {
-        viewBinding.previewFrame.post {
-            viewBinding.viewFinderBackground
-                .setViewFinderRect(viewBinding.viewFinderWindow.asRect())
+        previewFrame.post {
+            viewFinderBackground
+                .setViewFinderRect(viewFinderWindow.asRect())
             onCameraReady()
         }
     }
@@ -250,7 +275,7 @@ class CardScanFragment : ScanFragment(), SimpleScanStateful<CardScanState> {
             scanFlow.startFlow(
                 context = it,
                 imageStream = cameraStream,
-                viewFinder = viewBinding.viewFinderWindow.asRect(),
+                viewFinder = viewFinderWindow.asRect(),
                 lifecycleOwner = this,
                 coroutineScope = this,
                 parameters = null
@@ -275,26 +300,26 @@ class CardScanFragment : ScanFragment(), SimpleScanStateful<CardScanState> {
         when (newState) {
             is CardScanState.NotFound, CardScanState.Found -> {
                 context?.let {
-                    viewBinding.viewFinderBackground
+                    viewFinderBackground
                         .setBackgroundColor(
                             it.getColorByRes(R.color.stripeNotFoundBackground)
                         )
                 }
-                viewBinding.viewFinderWindow
+                viewFinderWindow
                     .setBackgroundResource(R.drawable.stripe_card_background_not_found)
-                viewBinding.viewFinderBorder
+                viewFinderBorder
                     .startAnimation(R.drawable.stripe_paymentsheet_card_border_not_found)
             }
             is CardScanState.Correct -> {
                 context?.let {
-                    viewBinding.viewFinderBackground
+                    viewFinderBackground
                         .setBackgroundColor(
                             it.getColorByRes(R.color.stripeCorrectBackground)
                         )
                 }
-                viewBinding.viewFinderWindow
+                viewFinderWindow
                     .setBackgroundResource(R.drawable.stripe_card_background_correct)
-                viewBinding.viewFinderBorder.startAnimation(R.drawable.stripe_card_border_correct)
+                viewFinderBorder.startAnimation(R.drawable.stripe_card_border_correct)
             }
         }
     }


### PR DESCRIPTION
# Summary
Prevent a crash in cardscan OCR by waiting for the preview frame to initialize before starting the camera.

# Motivation
https://github.com/stripe/stripe-android/issues/5486

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified