### PR TITLE
upload aab to EmergeTool when PRs merged to master

### DIFF
--- a/.github/workflows/identity_pull_request.yml
+++ b/.github/workflows/identity_pull_request.yml
@@ -94,4 +94,4 @@ jobs:
         with:
           artifact_path: identity-example/build/outputs/bundle/theme1Release/identity-example-theme1-release.aab
           emerge_api_key: ${{ secrets.EMERGE_API_KEY }}
-          build_type: release # Optional, change if your workflow builds a specific type
+          build_type: pull_request

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,21 @@
+name: Upload aabs on push
+# Upload aabs of example apps when changes are merged to master branch.
+# The aab is used as a base reference to compare with aab built from pull requests.
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  upload-identity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Generate Android release bundle for Identity example app
+        run: ./gradlew :identity-example:bundleRelease
+      - name: Upload artifact to Emerge
+        uses: EmergeTools/emerge-upload-action@v1.0.2
+        with:
+          artifact_path: identity-example/build/outputs/bundle/theme1Release/identity-example-theme1-release.aab
+          emerge_api_key: ${{ secrets.EMERGE_API_KEY }}
+          build_type: push


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Upload the base aab file when PRs are merged to master.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
The base will be used to compare with the aab built with PRs. (see example `apk-size-analysis` in `identity_pull_request.yml`)

add additional `upload-{your_example_app}` job for other modules.


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
