### PR TITLE
Add E2E test for UPI

### DIFF
--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestHardCodedLpms.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestHardCodedLpms.kt
@@ -6,13 +6,13 @@ import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
-import com.stripe.android.test.core.DisableAnimationsRule
 import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.Automatic
 import com.stripe.android.test.core.Billing
 import com.stripe.android.test.core.Currency
 import com.stripe.android.test.core.Customer
 import com.stripe.android.test.core.DelayedPMs
+import com.stripe.android.test.core.DisableAnimationsRule
 import com.stripe.android.test.core.GooglePayState
 import com.stripe.android.test.core.INDIVIDUAL_TEST_TIMEOUT_SECONDS
 import com.stripe.android.test.core.IntentType
@@ -246,6 +246,26 @@ class TestHardCodedLpms {
                 merchantCountryCode = "GB",
                 automatic = Automatic.Off
             )
+        )
+    }
+
+    @Test
+    fun testUpi() {
+        testDriver.confirmNewOrGuestComplete(
+            testParameters = newUser.copy(
+                paymentMethod = lpmRepository.fromCode("upi")!!,
+                currency = Currency.INR,
+                merchantCountryCode = "IN",
+                automatic = Automatic.Off,
+                authorizationAction = null,
+            ),
+            populateCustomLpmFields = {
+                composeTestRule.onNodeWithText("UPI ID").apply {
+                    performTextInput(
+                        "payment.success@stripeupi"
+                    )
+                }
+            }
         )
     }
 }

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/TestParameters.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/TestParameters.kt
@@ -102,7 +102,8 @@ enum class Currency {
     USD,
     EUR,
     AUD,
-    GBP
+    GBP,
+    INR,
 }
 
 /**


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds an end-to-end test for UPI. We can unfortunately not test the polling flow, as that test would take over 5 minutes due to limitations with using `payment.pending@stripeupi`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

UPI launch.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
N/A

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

_Nothing to add._
