### PR TITLE
Prevent multiple invocations of final result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## XX.XX.XX - 2022-XX-XX
 
+* [FIXED][5749](https://github.com/stripe/stripe-android/pull/5749) Prevent multiple invocations to `/verify_frames`
+
 ## 20.15.2 - 2022-10-25
 
 This release fixes a few bugs in `PaymentSession`, `PaymentSheet` and `CardScan`.
@@ -41,7 +43,7 @@ This release adds Link as a payment method to the SDK and fixes a minor issue wi
 
 ### CardScan
 
-* [CHANGED][5679](https://github.com/stripe/stripe-android/pull/5679) Fix oversized verification_frames payloads leading to failed scans.
+* [FIXED][5679](https://github.com/stripe/stripe-android/pull/5679) Fix oversized verification_frames payloads leading to failed scans.
 
 ## 20.14.1 - 2022-10-03
 

--- a/camera-core/src/main/java/com/stripe/android/camera/framework/Result.kt
+++ b/camera-core/src/main/java/com/stripe/android/camera/framework/Result.kt
@@ -8,6 +8,8 @@ import com.stripe.android.camera.framework.util.FrameRateTracker
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 /**
@@ -98,6 +100,8 @@ abstract class ResultAggregator<
 ) : StatefulResultHandler<DataFrame, State, AnalyzerResult, Boolean>(initialState),
     LifecycleEventObserver {
 
+    private val finalResultMutex = Mutex()
+
     private var isCanceled = false
     private var isPaused = false
     private var isFinished = false
@@ -178,16 +182,19 @@ abstract class ResultAggregator<
         else -> withContext(Dispatchers.Default) {
             frameRateTracker.trackFrameProcessed()
 
-            val (interimResult, finalResult) = aggregateResult(data, result)
+            finalResultMutex.withLock {
+                val (interimResult, finalResult) = aggregateResult(data, result)
 
-            launch { listener.onInterimResult(interimResult) }
+                aggregatorExecutionStats?.trackResult("frame_processed")
 
-            aggregatorExecutionStats?.trackResult("frame_processed")
+                launch { listener.onInterimResult(interimResult) }
 
-            finalResult?.also {
-                isFinished = true
-                launch { listener.onResult(it) }
-            } != null
+                if (!isFinished && finalResult != null) {
+                    isFinished = true
+                    launch { listener.onResult(finalResult) }
+                }
+                isFinished
+            }
         }
     }
 


### PR DESCRIPTION
# Summary
Prevent multiple invocations of the final result, which could trigger multiple calls to the `/verify_frames` endpoint

# Motivation
Elevated 500s on the `/verify_frames` endpoint

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
