### PR TITLE
Refactor Html to use StripeImage

### DIFF
--- a/example/AndroidManifest.xml
+++ b/example/AndroidManifest.xml
@@ -76,6 +76,7 @@
         <activity android:name=".activity.AlipayPaymentWebActivity"/>
         <activity android:name=".activity.ConnectUSBankAccountActivity"/>
         <activity android:name=".activity.ManualUSBankAccountPaymentMethodActivity"/>
+        <activity android:name=".activity.StripeImageActivity"/>
     </application>
 
 </manifest>

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -32,6 +32,7 @@ def getAccountId() {
 dependencies {
     implementation project(':payments')
     implementation project(':financial-connections')
+    implementation project(':stripe-ui-core')
 
     implementation("com.alipay.sdk:alipaysdk-android:15.8.11")
 

--- a/example/src/main/java/com/stripe/example/activity/LauncherActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/LauncherActivity.kt
@@ -164,6 +164,11 @@ class LauncherActivity : AppCompatActivity() {
             Item(
                 activity.getString(R.string.manual_us_bank_account_example),
                 ManualUSBankAccountPaymentMethodActivity::class.java
+            ),
+            // This is for internal use so as not to confuse the user.
+            Item(
+                "StripeImage Example",
+                StripeImageActivity::class.java
             )
         )
 

--- a/example/src/main/java/com/stripe/example/activity/StripeImageActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/StripeImageActivity.kt
@@ -1,0 +1,78 @@
+package com.stripe.example.activity
+
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.text.PlaceholderVerticalAlign
+import com.stripe.android.ui.core.R
+import com.stripe.android.uicore.image.StripeImageLoader
+import com.stripe.android.uicore.text.EmbeddableImage
+import com.stripe.android.uicore.text.Html
+
+class StripeImageActivity : AppCompatActivity() {
+    private val LocalStripeImageLoader = staticCompositionLocalOf<StripeImageLoader> {
+        error("No ImageLoader provided")
+    }
+
+    private val imageLoader by lazy {
+        StripeImageLoader(
+            context = this,
+            memoryCache = null,
+            diskCache = null
+        )
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            CompositionLocalProvider(LocalStripeImageLoader provides imageLoader) {
+                Column {
+                    Html(
+                        imageLoader = mapOf(
+                            "affirm" to EmbeddableImage.Drawable(
+                                R.drawable.stripe_ic_affirm_logo,
+                                R.string.stripe_paymentsheet_payment_method_affirm
+                            )
+                        ),
+                        html = """
+                            HTML with single local image
+                            <br/>
+                            Local image <img src="affirm"/>.
+                            <br/>
+                        """.trimIndent(),
+                        color = MaterialTheme.colors.onSurface,
+                        style = MaterialTheme.typography.body1
+                    )
+                    Html(
+                        imageLoader = mapOf(
+                            "affirm" to EmbeddableImage.Drawable(
+                                R.drawable.stripe_ic_affirm_logo,
+                                R.string.stripe_paymentsheet_payment_method_affirm
+                            )
+                        ),
+                        html = """
+                            HTML with local and remote images
+                            <br/>
+                            Local image <img src="affirm"/>.
+                            <br/>
+                            Unknown remote image <img src="https://qa-b.stripecdn.com/unknown_image.png"/>
+                            <br/>
+                            Remote images 
+                            <img src="https://qa-b.stripecdn.com/payment-method-messaging-statics-srv/assets/afterpay_logo_black.png"/>
+                            <img src="https://qa-b.stripecdn.com/payment-method-messaging-statics-srv/assets/klarna_logo_black.png"/>
+                            <br/>
+                            Paragraph text <b>bold text</b>. ⓘ
+                        """.trimIndent(),
+                        color = MaterialTheme.colors.onSurface,
+                        style = MaterialTheme.typography.body1,
+                        imageAlign = PlaceholderVerticalAlign.TextCenter
+                    )
+                }
+            }
+        }
+    }
+}

--- a/link/src/main/java/com/stripe/android/link/ui/LinkTerms.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/LinkTerms.kt
@@ -19,7 +19,6 @@ internal fun LinkTerms(
 ) {
     Html(
         html = stringResource(R.string.sign_up_terms).replaceHyperlinks(),
-        imageGetter = emptyMap(),
         color = MaterialTheme.paymentsColors.placeholderText,
         style = MaterialTheme.typography.subtitle1,
         modifier = modifier,

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -296,7 +296,6 @@ internal fun WalletBody(
         if (uiState.selectedItem is ConsumerPaymentDetails.BankAccount) {
             Html(
                 html = stringResource(R.string.wallet_bank_account_terms).replaceHyperlinks(),
-                imageGetter = emptyMap(),
                 color = MaterialTheme.colors.onSecondary,
                 style = MaterialTheme.typography.caption,
                 modifier = Modifier

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AffirmElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AffirmElementUI.kt
@@ -17,8 +17,8 @@ import com.stripe.android.uicore.text.Html
 fun AffirmElementUI() {
     Html(
         html = stringResource(id = R.string.affirm_buy_now_pay_later),
-        imageGetter = mapOf(
-            "affirm" to EmbeddableImage(
+        imageLoader = mapOf(
+            "affirm" to EmbeddableImage.Drawable(
                 R.drawable.stripe_ic_affirm_logo,
                 R.string.stripe_paymentsheet_payment_method_affirm
             )

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayElementUI.kt
@@ -31,8 +31,8 @@ fun AfterpayClearpayElementUI(
     Html(
         html = messageFormatString,
         enabled = enabled,
-        imageGetter = mapOf(
-            "afterpay" to EmbeddableImage(
+        imageLoader = mapOf(
+            "afterpay" to EmbeddableImage.Drawable(
                 if (isClearpay()) {
                     R.drawable.stripe_ic_clearpay_logo
                 } else {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBecsDebitMandateElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBecsDebitMandateElementUI.kt
@@ -18,7 +18,6 @@ fun AuBecsDebitMandateElementUI(
 ) {
     Html(
         html = stringResource(id = R.string.au_becs_mandate, element.merchantName ?: ""),
-        imageGetter = emptyMap(),
         color = MaterialTheme.paymentsColors.subtitle,
         style = MaterialTheme.typography.body2,
         modifier = Modifier.padding(vertical = 8.dp)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -292,7 +292,6 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
                     PaymentsTheme {
                         Html(
                             html = text,
-                            imageGetter = mapOf(),
                             color = MaterialTheme.paymentsColors.subtitle,
                             style = MaterialTheme.typography.body1.copy(
                                 textAlign = TextAlign.Center

--- a/stripe-ui-core/api/stripe-ui-core.api
+++ b/stripe-ui-core/api/stripe-ui-core.api
@@ -24,6 +24,35 @@ public final class com/stripe/android/uicore/image/StripeImageKt {
 public final class com/stripe/android/uicore/image/UiUtilsKt {
 }
 
+public final class com/stripe/android/uicore/text/EmbeddableImage$Bitmap : com/stripe/android/uicore/text/EmbeddableImage {
+	public static final field $stable I
+	public fun <init> (Landroid/graphics/Bitmap;)V
+	public final fun component1 ()Landroid/graphics/Bitmap;
+	public final fun copy (Landroid/graphics/Bitmap;)Lcom/stripe/android/uicore/text/EmbeddableImage$Bitmap;
+	public static synthetic fun copy$default (Lcom/stripe/android/uicore/text/EmbeddableImage$Bitmap;Landroid/graphics/Bitmap;ILjava/lang/Object;)Lcom/stripe/android/uicore/text/EmbeddableImage$Bitmap;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBitmap ()Landroid/graphics/Bitmap;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/stripe/android/uicore/text/EmbeddableImage$Drawable : com/stripe/android/uicore/text/EmbeddableImage {
+	public static final field $stable I
+	public fun <init> (IILandroidx/compose/ui/graphics/ColorFilter;)V
+	public synthetic fun <init> (IILandroidx/compose/ui/graphics/ColorFilter;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()Landroidx/compose/ui/graphics/ColorFilter;
+	public final fun copy (IILandroidx/compose/ui/graphics/ColorFilter;)Lcom/stripe/android/uicore/text/EmbeddableImage$Drawable;
+	public static synthetic fun copy$default (Lcom/stripe/android/uicore/text/EmbeddableImage$Drawable;IILandroidx/compose/ui/graphics/ColorFilter;ILjava/lang/Object;)Lcom/stripe/android/uicore/text/EmbeddableImage$Drawable;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getColorFilter ()Landroidx/compose/ui/graphics/ColorFilter;
+	public final fun getContentDescription ()I
+	public final fun getId ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/stripe/android/uicore/text/HtmlKt {
 }
 

--- a/stripe-ui-core/detekt-baseline.xml
+++ b/stripe-ui-core/detekt-baseline.xml
@@ -8,7 +8,10 @@
     <ID>MagicNumber:DrawablePainter.kt$DrawablePainter$255</ID>
     <ID>MagicNumber:Html.kt$0.1f</ID>
     <ID>MaxLineLength:DrawablePainter.kt$*</ID>
+    <ID>MaxLineLength:Html.kt$*</ID>
     <ID>MaxLineLength:UiUtils.kt$*</ID>
+    <ID>NoConsecutiveBlankLines:com.stripe.android.uicore.text.Html.kt:244</ID>
+    <ID>NoTrailingSpaces:com.stripe.android.uicore.text.Html.kt:1</ID>
     <ID>ReturnCount:UiUtils.kt$@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun Context.getDrawableFromUri(uri: Uri): Drawable?</ID>
     <ID>ThrowsCount:UiUtils.kt$@SuppressLint("DiscouragedApi") internal fun Context.getResourceId(uri: Uri): Pair&lt;Resources, Int></ID>
   </CurrentIssues>

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/NetworkImageDecoder.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/NetworkImageDecoder.kt
@@ -21,7 +21,7 @@ class NetworkImageDecoder {
         url: String,
         width: Int,
         height: Int
-    ): Bitmap {
+    ): Bitmap? {
         return BitmapFactory.Options().run {
             // First decode with inJustDecodeBounds=true to check dimensions
             inJustDecodeBounds = true
@@ -31,7 +31,15 @@ class NetworkImageDecoder {
             // Decode bitmap with inSampleSize set
             inJustDecodeBounds = false
             decodeStream(url)
-        }!!
+        }
+    }
+
+    suspend fun decode(
+        url: String
+    ): Bitmap? {
+        return BitmapFactory.Options().run {
+            decodeStream(url)
+        }
     }
 
     private suspend fun BitmapFactory.Options.decodeStream(

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/StripeImage.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/StripeImage.kt
@@ -55,8 +55,10 @@ fun StripeImage(
             launch {
                 imageLoader
                     .load(url, width, height)
-                    .onSuccess { bitmap ->
-                        state.value = Success(BitmapPainter(bitmap.asImageBitmap()))
+                    .onSuccess {
+                        it?.let { bitmap ->
+                            state.value = Success(BitmapPainter(bitmap.asImageBitmap()))
+                        }
                     }
                     .onFailure {
                         state.value = Error


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

- Refactor `Html` to use `StripeImage` to load remote images.
- Refactor `StripeImage` to load urls without width/height
- Add `onLoaded` callback in `Html`, needed for UME. It notifies the caller that the HTML is done loading. UME will need this so that we comply with the UME view contract (view is completely done loading)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

- Reuse `Html` to render HTML for UME
- If we don't know the size of image beforehand, we need a way to set the size of the image after it has been downloaded

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots

<img src="https://user-images.githubusercontent.com/99316447/198273851-d9a9006e-3d46-44eb-a78c-73058612b82b.gif" height=400/>


