### PR TITLE
Fix broken rendering of `ShippingInfoWidget` when using MaterialComponents

### DIFF
--- a/example/AndroidManifest.xml
+++ b/example/AndroidManifest.xml
@@ -36,11 +36,6 @@
         <activity
             android:name=".activity.LauncherActivity"
             android:exported="true">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
         </activity>
 
         <activity android:name=".activity.CreateCardTokenActivity" />
@@ -70,12 +65,21 @@
         <activity android:name=".activity.SimpleConfirmationActivity" />
         <activity android:name=".activity.ConnectExampleActivity" />
         <activity android:name=".activity.ComposeExampleActivity" />
-        <activity android:name=".activity.KlarnaPaymentActivity"/>
-        <activity android:name=".activity.AffirmPaymentActivity"/>
-        <activity android:name=".activity.AlipayPaymentNativeActivity"/>
-        <activity android:name=".activity.AlipayPaymentWebActivity"/>
-        <activity android:name=".activity.ConnectUSBankAccountActivity"/>
-        <activity android:name=".activity.ManualUSBankAccountPaymentMethodActivity"/>
+        <activity android:name=".activity.KlarnaPaymentActivity" />
+        <activity android:name=".activity.AffirmPaymentActivity" />
+        <activity android:name=".activity.AlipayPaymentNativeActivity" />
+        <activity android:name=".activity.AlipayPaymentWebActivity" />
+        <activity android:name=".activity.ConnectUSBankAccountActivity" />
+        <activity android:name=".activity.ManualUSBankAccountPaymentMethodActivity" />
+        <activity
+            android:name=".activity.ShippingInfoWidgetActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/example/res/layout/activity_shipping_info_widget.xml
+++ b/example/res/layout/activity_shipping_info_widget.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:orientation="vertical">
+
+        <com.stripe.android.view.ShippingInfoWidget
+            android:id="@+id/shipping_info_widget"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+    </LinearLayout>
+
+</ScrollView>

--- a/example/res/layout/activity_shipping_info_widget.xml
+++ b/example/res/layout/activity_shipping_info_widget.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -12,7 +13,8 @@
         <com.stripe.android.view.ShippingInfoWidget
             android:id="@+id/shipping_info_widget"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            app:countryTextInputExposedDropdownMenuStyle="?attr/textInputOutlinedExposedDropdownMenuStyle" />
 
     </LinearLayout>
 

--- a/example/res/layout/launcher_activity.xml
+++ b/example/res/layout/launcher_activity.xml
@@ -3,16 +3,13 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    >
+    android:layout_height="match_parent">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/examples"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:padding="8dp"
-        tools:context="com.stripe.example.activity.LauncherActivity"
-        />
+        tools:context="com.stripe.example.activity.LauncherActivity" />
 
 </FrameLayout>

--- a/example/res/values/themes.xml
+++ b/example/res/values/themes.xml
@@ -7,7 +7,13 @@
         <item name="colorControlActivated">@color/accent</item>
         <item name="titleTextColor">@color/title</item>
         <item name="android:textColorPrimary">@color/textPrimary</item>
+        <item name="textInputStyle">@style/MyTextInputStyle</item>
+        <item name="textInputFilledExposedDropdownMenuStyle">@style/MyDropdownTextInputStyle</item>
     </style>
+
+    <style name="MyTextInputStyle" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox" />
+
+    <style name="MyDropdownTextInputStyle" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu" />
 
     <style name="StripeDefaultTheme" parent="StripeBaseTheme">
         <!-- Applied to toolbar background -->

--- a/example/src/main/java/com/stripe/example/activity/LauncherActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/LauncherActivity.kt
@@ -164,7 +164,11 @@ class LauncherActivity : AppCompatActivity() {
             Item(
                 activity.getString(R.string.manual_us_bank_account_example),
                 ManualUSBankAccountPaymentMethodActivity::class.java
-            )
+            ),
+            Item(
+                "Shipping info widget",
+                ShippingInfoWidgetActivity::class.java
+            ),
         )
 
         override fun onCreateViewHolder(viewGroup: ViewGroup, i: Int): ExamplesViewHolder {

--- a/example/src/main/java/com/stripe/example/activity/ShippingInfoWidgetActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/ShippingInfoWidgetActivity.kt
@@ -1,0 +1,23 @@
+package com.stripe.example.activity
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.stripe.android.model.Address
+import com.stripe.android.model.ShippingInformation
+import com.stripe.example.databinding.ActivityShippingInfoWidgetBinding
+
+class ShippingInfoWidgetActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val viewBinding = ActivityShippingInfoWidgetBinding.inflate(layoutInflater)
+        setContentView(viewBinding.root)
+
+        viewBinding.shippingInfoWidget.populateShippingInfo(
+            shippingInformation = ShippingInformation(
+                address = Address.Builder()
+                    .setCountry("CA")
+                    .build(),
+            ),
+        )
+    }
+}

--- a/payments-core/res/layout/address_widget.xml
+++ b/payments-core/res/layout/address_widget.xml
@@ -3,11 +3,10 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <com.stripe.android.view.CountryTextInputLayout
-        android:id="@+id/country_autocomplete_aaw"
+    <FrameLayout
+        android:id="@+id/country_autocomplete_container"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="@string/address_label_country" />
+        android:layout_height="wrap_content" />
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/tl_name_aaw"

--- a/payments-core/res/values/attrs.xml
+++ b/payments-core/res/values/attrs.xml
@@ -22,6 +22,10 @@
         <attr name="countryItemLayout" format="reference" />
     </declare-styleable>
 
+    <declare-styleable name="ShippingInfoWidget">
+        <attr name="countryTextInputExposedDropdownMenuStyle" format="reference" />
+    </declare-styleable>
+
     <declare-styleable name="StripeCardFormView">
         <attr name="cardFormStyle" format="enum">
             <enum name="standard" value="0" />

--- a/payments-core/src/main/java/com/stripe/android/view/CountryTextInputLayout.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CountryTextInputLayout.kt
@@ -3,7 +3,6 @@ package com.stripe.android.view
 import android.content.Context
 import android.os.Parcelable
 import android.util.AttributeSet
-import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View.OnFocusChangeListener
 import android.widget.AdapterView
@@ -39,7 +38,7 @@ import kotlin.properties.Delegates
 class CountryTextInputLayout @JvmOverloads internal constructor(
     context: Context,
     attrs: AttributeSet? = null,
-    defStyleAttr: Int = context.determineExposedDropdownMenuStyle(),
+    defStyleAttr: Int = com.google.android.material.R.attr.textInputStyle
 ) : TextInputLayout(context, attrs, defStyleAttr) {
 
     @StyleRes
@@ -295,32 +294,4 @@ class CountryTextInputLayout @JvmOverloads internal constructor(
         val countryCode: CountryCode,
         val superState: Parcelable?
     ) : Parcelable
-}
-
-/**
- * Determines the correct text input style to use for [CountryTextInputLayout].
- *
- * A [TextInputLayout] with an [AutoCompleteTextView] requires the use of an exposed dropdown menu
- * style. Otherwise, it won't render correctly when using a MaterialComponents theme.
- *
- * Unfortunately, there's no single theme attribute for this, which requires us to manually select
- * the correct attribute based on the current [R.attr.textInputStyle].
- */
-private fun Context.determineExposedDropdownMenuStyle(): Int {
-    val typedValue = TypedValue()
-    theme.resolveAttribute(R.attr.textInputStyle, typedValue, true)
-
-    return when (val textInputStyle = typedValue.data) {
-        R.style.Widget_MaterialComponents_TextInputLayout_FilledBox,
-        R.style.Widget_MaterialComponents_TextInputLayout_FilledBox_Dense -> {
-            R.attr.textInputFilledExposedDropdownMenuStyle
-        }
-        R.style.Widget_MaterialComponents_TextInputLayout_OutlinedBox,
-        R.style.Widget_MaterialComponents_TextInputLayout_OutlinedBox_Dense -> {
-            R.attr.textInputOutlinedExposedDropdownMenuStyle
-        }
-        else -> {
-            textInputStyle
-        }
-    }
 }

--- a/payments-core/src/main/java/com/stripe/android/view/CountryTextInputLayout.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CountryTextInputLayout.kt
@@ -3,6 +3,7 @@ package com.stripe.android.view
 import android.content.Context
 import android.os.Parcelable
 import android.util.AttributeSet
+import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View.OnFocusChangeListener
 import android.widget.AdapterView
@@ -38,7 +39,7 @@ import kotlin.properties.Delegates
 class CountryTextInputLayout @JvmOverloads internal constructor(
     context: Context,
     attrs: AttributeSet? = null,
-    defStyleAttr: Int = com.google.android.material.R.attr.textInputStyle
+    defStyleAttr: Int = context.determineExposedDropdownMenuStyle(),
 ) : TextInputLayout(context, attrs, defStyleAttr) {
 
     @StyleRes
@@ -294,4 +295,32 @@ class CountryTextInputLayout @JvmOverloads internal constructor(
         val countryCode: CountryCode,
         val superState: Parcelable?
     ) : Parcelable
+}
+
+/**
+ * Determines the correct text input style to use for [CountryTextInputLayout].
+ *
+ * A [TextInputLayout] with an [AutoCompleteTextView] requires the use of an exposed dropdown menu
+ * style. Otherwise, it won't render correctly when using a MaterialComponents theme.
+ *
+ * Unfortunately, there's no single theme attribute for this, which requires us to manually select
+ * the correct attribute based on the current [R.attr.textInputStyle].
+ */
+private fun Context.determineExposedDropdownMenuStyle(): Int {
+    val typedValue = TypedValue()
+    theme.resolveAttribute(R.attr.textInputStyle, typedValue, true)
+
+    return when (val textInputStyle = typedValue.data) {
+        R.style.Widget_MaterialComponents_TextInputLayout_FilledBox,
+        R.style.Widget_MaterialComponents_TextInputLayout_FilledBox_Dense -> {
+            R.attr.textInputFilledExposedDropdownMenuStyle
+        }
+        R.style.Widget_MaterialComponents_TextInputLayout_OutlinedBox,
+        R.style.Widget_MaterialComponents_TextInputLayout_OutlinedBox_Dense -> {
+            R.attr.textInputOutlinedExposedDropdownMenuStyle
+        }
+        else -> {
+            textInputStyle
+        }
+    }
 }

--- a/payments-core/src/main/java/com/stripe/android/view/ShippingInfoWidget.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/ShippingInfoWidget.kt
@@ -8,7 +8,9 @@ import android.text.InputFilter.AllCaps
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
+import android.widget.FrameLayout
 import android.widget.LinearLayout
+import androidx.core.content.withStyledAttributes
 import com.stripe.android.R
 import com.stripe.android.core.model.Country
 import com.stripe.android.core.model.CountryUtils
@@ -19,6 +21,8 @@ import java.util.Locale
 
 /**
  * A widget used to collect address data from a user.
+ *
+ * If used with MaterialComponents, be sure to provide `countryTextInputStyle` in the XML.
  */
 class ShippingInfoWidget @JvmOverloads constructor(
     context: Context,
@@ -56,7 +60,29 @@ class ShippingInfoWidget @JvmOverloads constructor(
             countryAutoCompleteTextView.selectedCountry?.let(::updateConfigForCountry)
         }
 
-    private val countryAutoCompleteTextView = viewBinding.countryAutocompleteAaw
+    private val countryAutoCompleteTextView: CountryTextInputLayout by lazy {
+        var styleAttr = 0
+
+        context.withStyledAttributes(
+            attrs,
+            intArrayOf(R.styleable.ShippingInfoWidget_countryTextInputExposedDropdownMenuStyle)
+        ) {
+            styleAttr = getResourceId(
+                R.styleable.ShippingInfoWidget_countryTextInputExposedDropdownMenuStyle,
+                R.attr.textInputFilledExposedDropdownMenuStyle
+            )
+        }
+
+        CountryTextInputLayout(
+            context,
+            null,
+            styleAttr,
+        ).apply {
+            hint = resources.getString(R.string.address_label_country)
+        }
+    }
+
+    private val countryAutoCompleteContainer = viewBinding.countryAutocompleteContainer
     private val addressLine1TextInputLayout = viewBinding.tlAddressLine1Aaw
     private val addressLine2TextInputLayout = viewBinding.tlAddressLine2Aaw
     private val cityTextInputLayout = viewBinding.tlCityAaw
@@ -221,6 +247,14 @@ class ShippingInfoWidget @JvmOverloads constructor(
     }
 
     private fun initView() {
+        countryAutoCompleteContainer.addView(
+            countryAutoCompleteTextView,
+            FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.WRAP_CONTENT,
+            )
+        )
+
         countryAutoCompleteTextView.countryChangeCallback = ::updateConfigForCountry
 
         phoneNumberEditText.addTextChangedListener(PhoneNumberFormattingTextWatcher())

--- a/payments-core/src/test/java/com/stripe/android/view/CountryTextInputLayoutTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CountryTextInputLayoutTest.kt
@@ -2,6 +2,8 @@ package com.stripe.android.view
 
 import android.content.Context
 import android.widget.AutoCompleteTextView
+import android.widget.FrameLayout
+import androidx.core.view.children
 import androidx.test.core.app.ApplicationProvider
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.CustomerSession
@@ -61,8 +63,7 @@ class CountryTextInputLayoutTest {
             )
         ).use { activityScenario ->
             activityScenario.onActivity {
-                countryTextInputLayout = it
-                    .findViewById(R.id.country_autocomplete_aaw)
+                countryTextInputLayout = it.findCountryTextInputLayout()
                 autoCompleteTextView = countryTextInputLayout.countryAutocomplete
             }
         }
@@ -177,4 +178,9 @@ class CountryTextInputLayoutTest {
     fun teardown() {
         Locale.setDefault(Locale.US)
     }
+}
+
+private fun PaymentFlowActivity.findCountryTextInputLayout(): CountryTextInputLayout {
+    val countryTextContainer = findViewById<FrameLayout>(R.id.country_autocomplete_container)
+    return countryTextContainer.children.first() as CountryTextInputLayout
 }

--- a/payments-core/src/test/java/com/stripe/android/view/ShippingInfoWidgetTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/ShippingInfoWidgetTest.kt
@@ -2,6 +2,8 @@ package com.stripe.android.view
 
 import android.content.Context
 import android.view.View
+import android.widget.FrameLayout
+import androidx.core.view.children
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.material.textfield.TextInputLayout
 import com.google.common.truth.Truth.assertThat
@@ -83,8 +85,7 @@ class ShippingInfoWidgetTest {
                 postalEditText = shippingInfoWidget.findViewById(R.id.et_postal_code_aaw)
                 stateEditText = shippingInfoWidget.findViewById(R.id.et_state_aaw)
                 phoneEditText = shippingInfoWidget.findViewById(R.id.et_phone_number_aaw)
-                countryTextInputLayout =
-                    shippingInfoWidget.findViewById(R.id.country_autocomplete_aaw)
+                countryTextInputLayout = shippingInfoWidget.findCountryTextInputLayout()
             }
         }
     }
@@ -390,4 +391,9 @@ class ShippingInfoWidgetTest {
             "416-759-0260"
         )
     }
+}
+
+private fun ShippingInfoWidget.findCountryTextInputLayout(): CountryTextInputLayout {
+    val countryTextContainer = findViewById<FrameLayout>(R.id.country_autocomplete_container)
+    return countryTextContainer.children.first() as CountryTextInputLayout
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where the country text field was rendered incorrectly when using a MaterialComponents theme.

### Why was it broken?

Unlike all the other text fields, which are a `TextInputLayout` wrapping a `StripeEditText`, the country text field is a `TextInputLayout` wrapping an `AutoCompleteTextView`. In order for those to render correctly in a MaterialComponents theme, the style of the surrounding `TextInputLayout` must inherit from a `Widget.MaterialComponents.TextInputLayout.*.ExposedDropdownMenu`.

### Why can’t we use a theme attribute?

There exists no such theme attribute. The theme exposes `textInputFilledExposedDropdownMenuStyle` and `textInputOutlinedExposedDropdownMenuStyle`, but no general `textInputExposedDropdownMenuStyle` (which it does for `textInputStyle`). As a consequence, we don’t know which to choose.

### Why can’t we determine the dropdown style based on the theme’s `textInputStyle`?

That was my first approach: If `textInputStyle` is filled, then use the filled dropdown style; otherwise, use the outlined one. However, this stops working if the `textInputStyle` is a style inheriting from `Widget.MaterialComponents.TextInputLayout.*`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
