### PR TITLE
Fix mandate text issue

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CheckboxElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CheckboxElementUI.kt
@@ -20,11 +20,12 @@ import com.stripe.android.ui.core.elements.menu.Checkbox
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun CheckboxElementUI(
+    modifier: Modifier = Modifier,
     automationTestTag: String = "",
     isChecked: Boolean = false,
     label: String? = null,
     isEnabled: Boolean = false,
-    onValueChange: (Boolean) -> Unit
+    onValueChange: (Boolean) -> Unit,
 ) {
     val accessibilityDescription = stringResource(
         if (isChecked) {
@@ -35,7 +36,7 @@ fun CheckboxElementUI(
     )
 
     Row(
-        modifier = Modifier
+        modifier = modifier
             .padding(vertical = 4.dp)
             .semantics {
                 testTag = automationTestTag

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SaveForFutureUseElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SaveForFutureUseElementUI.kt
@@ -4,6 +4,7 @@ import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 
 const val SAVE_FOR_FUTURE_CHECKBOX_TEST_TAG = "SAVE_FOR_FUTURE_CHECKBOX_TEST_TAG"
@@ -12,7 +13,8 @@ const val SAVE_FOR_FUTURE_CHECKBOX_TEST_TAG = "SAVE_FOR_FUTURE_CHECKBOX_TEST_TAG
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun SaveForFutureUseElementUI(
     enabled: Boolean,
-    element: SaveForFutureUseElement
+    element: SaveForFutureUseElement,
+    modifier: Modifier = Modifier,
 ) {
     val controller = element.controller
     val checked by controller.saveForFutureUse.collectAsState(true)
@@ -24,8 +26,9 @@ fun SaveForFutureUseElementUI(
         isChecked = checked,
         label = label?.let { resources.getString(it, element.merchantName) },
         isEnabled = enabled,
+        modifier = modifier,
         onValueChange = {
             controller.onValueChange(!checked)
-        }
+        },
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormFragment.kt
@@ -58,6 +58,7 @@ import com.stripe.android.ui.core.elements.SectionCard
 import com.stripe.android.ui.core.elements.SimpleDialogElementUI
 import com.stripe.android.ui.core.elements.TextFieldSection
 import com.stripe.android.ui.core.paymentsColors
+import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.launch
 
 /**
@@ -191,20 +192,23 @@ internal class USBankAccountFormFragment : Fragment() {
                 }
             }
         }
+
         lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.saveForFutureUse.collect { saved ->
-                    updateMandateText(
-                        if (saved) {
-                            getString(
-                                R.string.stripe_paymentsheet_ach_save_mandate,
-                                viewModel.formattedMerchantName()
-                            )
-                        } else {
-                            ACHText.getContinueMandateText(requireContext())
-                        }
-                    )
-                }
+                viewModel.saveForFutureUse
+                    .filterNot { viewModel.currentScreenState.value is NameAndEmailCollection }
+                    .collect { saved ->
+                        updateMandateText(
+                            if (saved) {
+                                getString(
+                                    R.string.stripe_paymentsheet_ach_save_mandate,
+                                    viewModel.formattedMerchantName()
+                                )
+                            } else {
+                                ACHText.getContinueMandateText(requireContext())
+                            }
+                        )
+                    }
             }
         }
 
@@ -412,10 +416,11 @@ internal class USBankAccountFormFragment : Fragment() {
             }
             if (formArgs.showCheckbox) {
                 SaveForFutureUseElementUI(
-                    true,
-                    viewModel.saveForFutureUseElement.apply {
+                    enabled = true,
+                    element = viewModel.saveForFutureUseElement.apply {
                         this.controller.onValueChange(saveForFutureUsage)
-                    }
+                    },
+                    modifier = Modifier.padding(top = 8.dp)
                 )
             }
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where the US bank account form would briefly show the mandate text when selected. It also adds some more padding above the `Save for future use` checkbox.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
N/A

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

_Nothing to add._
