### PR TITLE
Add `allowsPaymentMethodsRequiringShippingAddress` to config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### PaymentSheet
 
 * [ADDED][5676](https://github.com/stripe/stripe-android/pull/5676) Added `AddressLauncher`, an [activity](https://stripe.com/docs/elements/address-element?platform=android) that collects local and international addresses for your customers.
-* [ADDED][5769](https://github.com/stripe/stripe-android/pull/5769) Added `PaymentSheet.Configuration.allowsPaymentMethodsRequiringShippingAddress`. Previously, to allow payment methods that require a shipping address (e.g. Afterpay and Affirm) in `PaymentSheet`, you attached a shipping address to the PaymentIntent before initializing `PaymentSheet`. Now, you can instead set this property to `true` and update `PaymentSheet.FlowController.shippingDetails` whenever your customer’s shipping address becomes available. The shipping address will be attached to the PaymentIntent when the customer completes the checkout.
+* [ADDED][5769](https://github.com/stripe/stripe-android/pull/5769) Added `PaymentSheet.Configuration.allowsPaymentMethodsRequiringShippingAddress`. Previously, to allow payment methods that require a shipping address (e.g. Afterpay and Affirm) in `PaymentSheet`, you attached a shipping address to the PaymentIntent before initializing `PaymentSheet`. Now, you can instead set this property to `true` and set `PaymentSheet.Configuration.shippingDetails` or `PaymentSheet.FlowController.shippingDetails` whenever your customer’s shipping address becomes available. The shipping address will be attached to the PaymentIntent when the customer completes the checkout.
 
 ## 20.15.4 - 2022-11-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### PaymentSheet
 
 * [ADDED][5676](https://github.com/stripe/stripe-android/pull/5676) Added `AddressLauncher`, an [activity](https://stripe.com/docs/elements/address-element?platform=android) that collects local and international addresses for your customers.
-* [ADDED][5769](https://github.com/stripe/stripe-android/pull/5769) Added support for showing payment methods that require a shipping address via `PaymentSheet.Configuration.allowsPaymentMethodsRequiringShippingAddress`. If set to `true`, PaymentSheet displays these payment methods even if no `shippingDetails` are passed in.
+* [ADDED][5769](https://github.com/stripe/stripe-android/pull/5769) Added `PaymentSheet.Configuration.allowsPaymentMethodsRequiringShippingAddress`. Previously, to allow payment methods that require a shipping address (e.g. Afterpay and Affirm) in `PaymentSheet`, you attached a shipping address to the PaymentIntent before initializing `PaymentSheet`. Now, you can instead set this property to `true` and update `PaymentSheet.FlowController.shippingDetails` whenever your customer’s shipping address becomes available. The shipping address will be attached to the PaymentIntent when the customer completes the checkout.
 
 ## 20.15.4 - 2022-11-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,19 +3,23 @@
 ## XX.XX.XX - 2022-XX-XX
 
 ### Payments
+
 * [CHANGED][5789](https://github.com/stripe/stripe-android/pull/5789) We now disable the back button while confirming intents with `PaymentLauncher` to prevent them from incorrectly being displayed as failed.
 
 ### PaymentSheet
 
 * [ADDED][5676](https://github.com/stripe/stripe-android/pull/5676) Added `AddressLauncher`, an [activity](https://stripe.com/docs/elements/address-element?platform=android) that collects local and international addresses for your customers.
+* [ADDED][5769](https://github.com/stripe/stripe-android/pull/5769) Added support for showing payment methods that require a shipping address via `PaymentSheet.Configuration.allowsPaymentMethodsRequiringShippingAddress`. If set to `true`, PaymentSheet displays these payment methods even if no `shippingDetails` are passed in.
 
 ## 20.15.4 - 2022-11-07
 
 ### CardScan
+
 * [FIXED][5768](https://github.com/stripe/stripe-android/pull/5768) Fixed SDK version reporting in cardscan scan stats
 
 ### Identity
-* [FIXED][5762](https://github.com/stripe/stripe-android/pull/5762) Use a custom implementation of FileProvider to avoid collision with client app. 
+
+* [FIXED][5762](https://github.com/stripe/stripe-android/pull/5762) Use a custom implementation of FileProvider to avoid collision with client app.
 
 ## 20.15.3 - 2022-10-31
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
@@ -9,6 +9,12 @@ enum class CheckoutMode(val value: String) {
     PaymentWithSetup("payment_with_setup")
 }
 
+enum class Shipping(val value: String) {
+    On("on"),
+    OnWithDefaults("on_with_defaults"),
+    Off("off"),
+}
+
 data class CheckoutCurrency(val value: String) {
     companion object {
         val USD = CheckoutCurrency("usd")
@@ -24,7 +30,7 @@ data class SavedToggles(
     val currency: String,
     val merchantCountryCode: String,
     val mode: String,
-    val setShippingAddress: Boolean,
+    val shippingAddress: String,
     val setAutomaticPaymentMethods: Boolean,
     val setDelayedPaymentMethods: Boolean,
     val setDefaultBillingAddress: Boolean,
@@ -38,7 +44,7 @@ enum class Toggle(val key: String, val default: Any) {
     Currency("currency", CheckoutCurrency.USD.value),
     MerchantCountryCode("merchantCountry", "US"),
     Mode("mode", CheckoutMode.Payment.value),
-    SetShippingAddress("setShippingAddress", true),
+    ShippingAddress("shippingAddress", Shipping.On.value),
     SetDefaultBillingAddress("setDefaultBillingAddress", true),
     SetAutomaticPaymentMethods("setAutomaticPaymentMethods", true),
     SetDelayedPaymentMethods("setDelayedPaymentMethods", false)

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/viewmodel/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/viewmodel/PaymentSheetPlaygroundViewModel.kt
@@ -46,7 +46,7 @@ class PaymentSheetPlaygroundViewModel(
         currency: String,
         merchantCountryCode: String,
         mode: String,
-        setShippingAddress: Boolean,
+        shipping: String,
         setDefaultBillingAddress: Boolean,
         setAutomaticPaymentMethods: Boolean,
         setDelayedPaymentMethods: Boolean,
@@ -63,7 +63,7 @@ class PaymentSheetPlaygroundViewModel(
         editor.putString(Toggle.Currency.key, currency)
         editor.putString(Toggle.MerchantCountryCode.key, merchantCountryCode)
         editor.putString(Toggle.Mode.key, mode)
-        editor.putBoolean(Toggle.SetShippingAddress.key, setShippingAddress)
+        editor.putString(Toggle.ShippingAddress.key, shipping)
         editor.putBoolean(Toggle.SetDefaultBillingAddress.key, setDefaultBillingAddress)
         editor.putBoolean(Toggle.SetAutomaticPaymentMethods.key, setAutomaticPaymentMethods)
         editor.putBoolean(Toggle.SetDelayedPaymentMethods.key, setDelayedPaymentMethods)
@@ -96,9 +96,9 @@ class PaymentSheetPlaygroundViewModel(
             Toggle.Mode.key,
             Toggle.Mode.default.toString()
         )
-        val setShippingAddress = sharedPreferences.getBoolean(
-            Toggle.SetShippingAddress.key,
-            Toggle.SetShippingAddress.default as Boolean
+        val shippingAddress = sharedPreferences.getString(
+            Toggle.ShippingAddress.key,
+            Toggle.ShippingAddress.default as String
         )
         val setAutomaticPaymentMethods = sharedPreferences.getBoolean(
             Toggle.SetAutomaticPaymentMethods.key,
@@ -123,7 +123,7 @@ class PaymentSheetPlaygroundViewModel(
             currency = currency.toString(),
             merchantCountryCode = merchantCountryCode.toString(),
             mode = mode.toString(),
-            setShippingAddress = setShippingAddress,
+            shippingAddress = shippingAddress!!,
             setAutomaticPaymentMethods = setAutomaticPaymentMethods,
             setDelayedPaymentMethods = setDelayedPaymentMethods,
             setDefaultBillingAddress = setDefaultBillingAddress,

--- a/paymentsheet-example/src/main/res/layout/activity_payment_sheet_playground.xml
+++ b/paymentsheet-example/src/main/res/layout/activity_payment_sheet_playground.xml
@@ -262,7 +262,14 @@
 
             <RadioButton
                 android:id="@+id/shipping_on_button"
-                android:text="@string/on"
+                android:text="On"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:checked="false" />
+
+            <RadioButton
+                android:id="@+id/shipping_on_with_defaults_button"
+                android:text="On w/ defaults"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:checked="true" />

--- a/paymentsheet-example/src/main/res/layout/activity_payment_sheet_playground.xml
+++ b/paymentsheet-example/src/main/res/layout/activity_payment_sheet_playground.xml
@@ -218,24 +218,26 @@
 
         <RadioGroup
             android:id="@+id/default_billing_radio_group"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
             android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
             app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/default_billing_address">
 
             <RadioButton
                 android:id="@+id/default_billing_on_button"
                 android:text="@string/on"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:checked="false" />
 
             <RadioButton
                 android:id="@+id/default_billing_off_button"
                 android:text="@string/off"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:checked="true" />
         </RadioGroup>
@@ -245,39 +247,41 @@
             android:text="@string/shipping_address"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="16dp"
+            android:layout_marginStart="16dp"
             android:layout_marginTop="8dp"
-            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintHorizontal_chainStyle="packed"
-            app:layout_constraintTop_toBottomOf="@+id/google_pay_radio_group" />
+            app:layout_constraintTop_toBottomOf="@+id/default_billing_radio_group" />
 
         <RadioGroup
             android:id="@+id/shipping_radio_group"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
             android:layout_marginEnd="16dp"
+            android:layout_marginStart="16dp"
             app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/shipping_address">
 
             <RadioButton
                 android:id="@+id/shipping_on_button"
-                android:text="On"
-                android:layout_width="match_parent"
+                android:text="@string/on"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:checked="false" />
 
             <RadioButton
                 android:id="@+id/shipping_on_with_defaults_button"
-                android:text="On w/ defaults"
-                android:layout_width="match_parent"
+                android:text="@string/on_with_defaults"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:checked="true" />
 
             <RadioButton
                 android:id="@+id/shipping_off_button"
                 android:text="@string/off"
-                android:layout_width="match_parent"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:checked="false" />
         </RadioGroup>
@@ -291,7 +295,7 @@
             android:layout_marginTop="8dp"
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/default_billing_radio_group" />
+            app:layout_constraintTop_toBottomOf="@+id/shipping_radio_group" />
 
         <RadioGroup
             android:id="@+id/allowsDelayedPaymentMethods_radio_group"

--- a/paymentsheet-example/src/main/res/values/strings.xml
+++ b/paymentsheet-example/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="link">Link</string>
     <string name="google_pay">Google Pay</string>
     <string name="on">On</string>
+    <string name="on_with_defaults">On w/ defaults</string>
     <string name="off">Off</string>
     <string name="checkout_mode">Checkout Mode</string>
     <string name="payment">Pay</string>

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -275,23 +275,26 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration : 
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;)V
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;)V
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;Z)V
-	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;)V
-	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZ)V
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;)V
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
 	public final fun component2 ()Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;
 	public final fun component3 ()Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
 	public final fun component4 ()Landroid/content/res/ColorStateList;
 	public final fun component5 ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;
 	public final fun component6 ()Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;
 	public final fun component7 ()Z
-	public final fun component8 ()Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;
-	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
+	public final fun component8 ()Z
+	public final fun component9 ()Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;
+	public final fun copy (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAllowsDelayedPaymentMethods ()Z
+	public final fun getAllowsPaymentMethodsRequiringShippingAddress ()Z
 	public final fun getAppearance ()Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;
 	public final fun getCustomer ()Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;
 	public final fun getDefaultBillingDetails ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;
@@ -309,6 +312,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration$Bu
 	public static final field $stable I
 	public fun <init> (Ljava/lang/String;)V
 	public final fun allowsDelayedPaymentMethods (Z)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
+	public final fun allowsPaymentMethodsRequiringShippingAddress (Z)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun appearance (Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun build ()Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
 	public final fun customer (Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -148,6 +148,20 @@ class PaymentSheet internal constructor(
          */
         val allowsDelayedPaymentMethods: Boolean = false,
 
+
+        /**
+         * If true, allows payment methods that require a shipping address, like Afterpay and
+         * Affirm. Defaults to false.
+         *
+         * Set this to true if you collect shipping addresses and set [shippingDetails] or set
+         * `shipping` details directly on the PaymentIntent.
+         *
+         * Note: PaymentSheet considers this property `true` and allows payment methods that require
+         * a shipping address if `shipping` details are present on the PaymentIntent when
+         * PaymentSheet loads.
+         */
+        val allowsPaymentMethodsRequiringShippingAddress: Boolean = false,
+
         /**
          * Describes the appearance of Payment Sheet.
          */
@@ -173,6 +187,7 @@ class PaymentSheet internal constructor(
             private var defaultBillingDetails: BillingDetails? = null
             private var shippingDetails: AddressDetails? = null
             private var allowsDelayedPaymentMethods: Boolean = false
+            private var allowsPaymentMethodsRequiringShippingAddress: Boolean = false
             private var appearance: Appearance = Appearance()
 
             fun merchantDisplayName(merchantDisplayName: String) =
@@ -203,6 +218,13 @@ class PaymentSheet internal constructor(
             fun allowsDelayedPaymentMethods(allowsDelayedPaymentMethods: Boolean) =
                 apply { this.allowsDelayedPaymentMethods = allowsDelayedPaymentMethods }
 
+            fun allowsPaymentMethodsRequiringShippingAddress(
+                allowsPaymentMethodsRequiringShippingAddress: Boolean,
+            ) = apply {
+                this.allowsPaymentMethodsRequiringShippingAddress =
+                    allowsPaymentMethodsRequiringShippingAddress
+            }
+
             fun appearance(appearance: Appearance) =
                 apply { this.appearance = appearance }
 
@@ -214,6 +236,7 @@ class PaymentSheet internal constructor(
                 defaultBillingDetails,
                 shippingDetails,
                 allowsDelayedPaymentMethods,
+                allowsPaymentMethodsRequiringShippingAddress,
                 appearance
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -148,7 +148,6 @@ class PaymentSheet internal constructor(
          */
         val allowsDelayedPaymentMethods: Boolean = false,
 
-
         /**
          * If true, allows payment methods that require a shipping address, like Afterpay and
          * Affirm. Defaults to false.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -149,15 +149,14 @@ class PaymentSheet internal constructor(
         val allowsDelayedPaymentMethods: Boolean = false,
 
         /**
-         * If true, allows payment methods that require a shipping address, like Afterpay and
-         * Affirm. Defaults to false.
+         * If `true`, allows payment methods that require a shipping address, like Afterpay and
+         * Affirm. Defaults to `false`.
          *
-         * Set this to true if you collect shipping addresses and set [shippingDetails] or set
-         * `shipping` details directly on the PaymentIntent.
+         * Set this to `true` if you collect shipping addresses via [shippingDetails] or
+         * [FlowController.shippingDetails].
          *
-         * Note: PaymentSheet considers this property `true` and allows payment methods that require
-         * a shipping address if `shipping` details are present on the PaymentIntent when
-         * PaymentSheet loads.
+         * **Note**: PaymentSheet considers this property `true` if `shipping` details are present
+         * on the PaymentIntent when PaymentSheet loads.
          */
         val allowsPaymentMethodsRequiringShippingAddress: Boolean = false,
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -860,7 +860,6 @@ internal class PaymentSheetViewModelTest {
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
                 config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config?.copy(
-                    shippingDetails = null,
                     allowsPaymentMethodsRequiringShippingAddress = true,
                 )
             )
@@ -869,6 +868,7 @@ internal class PaymentSheetViewModelTest {
         viewModel.setStripeIntent(
             PaymentIntentFixtures.PI_WITH_SHIPPING.copy(
                 paymentMethodTypes = listOf("afterpay_clearpay"),
+                shipping = null,
             )
         )
 
@@ -881,14 +881,6 @@ internal class PaymentSheetViewModelTest {
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
                 config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config?.copy(
-                    shippingDetails = AddressDetails(
-                        name = "Test Name",
-                        address = PaymentSheet.Address(
-                            line1 = "123 Main Street",
-                            postalCode = "12345",
-                            country = "US",
-                        ),
-                    ),
                     allowsPaymentMethodsRequiringShippingAddress = false,
                 )
             )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

API Review: [Here](https://paper.dropbox.com/doc/2022-09-27-PaymentSheet-allowsPaymentMethodsRequiringShippingAddress-Mobile-API-Review--BsP7QOt4M8qm5JPu5mdzGve~Ag-edaX1GjfvA0ywHC73Ozsr)

This pull request adds support for displaying Affirm and Afterpay as payment options even when not providing `shippingDetails` in the payment sheet configuration. We achieve this by adding a property `allowsPaymentMethodsRequiringShippingAddress` that merchants can set to `true`.

Test the flow in the playground: Set `Shipping address` to `On` (instead of `On w/ defaults`), then open the custom flow and confirm that Affirm and Afterpay are visible.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Enable the use case where shipping information is collected _after_ the payment intent is created.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screen recording

https://user-images.githubusercontent.com/110940675/199551526-628ccf6d-d592-4182-a0b2-a0ca0a9047cb.mp4

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

~[Added] Added support for showing payment methods that require a shipping address via `PaymentSheet.Configuration.allowsPaymentMethodsRequiringShippingAddress`. If set to `true`, PaymentSheet displays these payment methods even if no `shippingDetails` are passed in.~

[ADDED] Added `PaymentSheet.Configuration.allowsPaymentMethodsRequiringShippingAddress`. Previously, to allow payment methods that require a shipping address (e.g. Afterpay and Affirm) in `PaymentSheet`, you attached a shipping address to the PaymentIntent before initializing `PaymentSheet`. Now, you can instead set this property to `true` and set `PaymentSheet.Configuration.shippingDetails` or `PaymentSheet.FlowController.shippingDetails` whenever your customer’s shipping address becomes available. The shipping address will be attached to the PaymentIntent when the customer completes the checkout.