### PR TITLE
[Identity] Add liveMode in analytics

### DIFF
--- a/identity/api/identity.api
+++ b/identity/api/identity.api
@@ -259,6 +259,9 @@ public final class com/stripe/android/identity/injection/IdentityCommonModule_Co
 	public static fun provideStripeNetworkClient ()Lcom/stripe/android/core/networking/StripeNetworkClient;
 }
 
+public abstract interface annotation class com/stripe/android/identity/injection/IdentityVerificationScope : java/lang/annotation/Annotation {
+}
+
 public final class com/stripe/android/identity/navigation/IdentityFragmentFactory_Factory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/identity/navigation/IdentityFragmentFactory_Factory;

--- a/identity/api/identity.api
+++ b/identity/api/identity.api
@@ -259,9 +259,6 @@ public final class com/stripe/android/identity/injection/IdentityCommonModule_Co
 	public static fun provideStripeNetworkClient ()Lcom/stripe/android/core/networking/StripeNetworkClient;
 }
 
-public abstract interface annotation class com/stripe/android/identity/injection/IdentityVerificationScope : java/lang/annotation/Annotation {
-}
-
 public final class com/stripe/android/identity/navigation/IdentityFragmentFactory_Factory : dagger/internal/Factory {
 	public fun <init> (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)V
 	public static fun create (Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;Ljavax/inject/Provider;)Lcom/stripe/android/identity/navigation/IdentityFragmentFactory_Factory;

--- a/identity/src/main/java/com/stripe/android/identity/analytics/FPSTracker.kt
+++ b/identity/src/main/java/com/stripe/android/identity/analytics/FPSTracker.kt
@@ -2,6 +2,7 @@ package com.stripe.android.identity.analytics
 
 import com.stripe.android.camera.framework.time.Clock
 import com.stripe.android.camera.framework.time.ClockMark
+import com.stripe.android.identity.injection.IdentityVerificationScope
 import com.stripe.android.identity.networking.IdentityRepository
 import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
@@ -9,6 +10,7 @@ import javax.inject.Inject
 /**
  * Tracker for frames processed per second.
  */
+@IdentityVerificationScope
 internal class FPSTracker @Inject constructor(
     private val identityAnalyticsRequestFactory: IdentityAnalyticsRequestFactory,
     private val identityRepository: IdentityRepository

--- a/identity/src/main/java/com/stripe/android/identity/analytics/IdentityAnalyticsRequestFactory.kt
+++ b/identity/src/main/java/com/stripe/android/identity/analytics/IdentityAnalyticsRequestFactory.kt
@@ -4,17 +4,21 @@ import android.content.Context
 import com.stripe.android.core.networking.AnalyticsRequestV2
 import com.stripe.android.core.networking.AnalyticsRequestV2Factory
 import com.stripe.android.identity.IdentityVerificationSheetContract
+import com.stripe.android.identity.injection.IdentityVerificationScope
 import com.stripe.android.identity.networking.models.DocumentUploadParam
+import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.states.IdentityScanState
 import javax.inject.Inject
 
 /**
  * Factory for creating [AnalyticsRequestV2] for Identity.
  */
+@IdentityVerificationScope
 internal class IdentityAnalyticsRequestFactory @Inject constructor(
     context: Context,
     private val args: IdentityVerificationSheetContract.Args
 ) {
+    lateinit var verificationPage: VerificationPage
     private val requestFactory = AnalyticsRequestV2Factory(
         context = context,
         clientId = CLIENT_ID,
@@ -24,12 +28,18 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
     private fun additionalParamWithEventMetadata(vararg pairs: Pair<String, *>) =
         mapOf(
             PARAM_VERIFICATION_SESSION to args.verificationSessionId,
-            PARAM_EVENT_META_DATA to mapOf(*pairs)
+            PARAM_EVENT_META_DATA to
+                mapOf(
+                    PARAM_LIVE_MODE to verificationPage.livemode,
+                    *pairs
+                )
         )
 
     fun sheetPresented() = requestFactory.createRequest(
         EVENT_SHEET_PRESENTED,
-        additionalParams = additionalParamWithEventMetadata()
+        mapOf(
+            PARAM_VERIFICATION_SESSION to args.verificationSessionId
+        )
     )
 
     fun sheetClosed(sessionResult: String) = requestFactory.createRequest(
@@ -311,6 +321,7 @@ internal class IdentityAnalyticsRequestFactory @Inject constructor(
         const val PARAM_ID = "id"
         const val PARAM_FILE_NAME = "file_name"
         const val PARAM_FILE_SIZE = "file_size"
+        const val PARAM_LIVE_MODE = "live_mode"
 
         const val SCREEN_NAME_CONSENT = "consent"
         const val SCREEN_NAME_DOC_SELECT = "document_select"

--- a/identity/src/main/java/com/stripe/android/identity/analytics/ScreenTracker.kt
+++ b/identity/src/main/java/com/stripe/android/identity/analytics/ScreenTracker.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.stripe.android.camera.framework.StatTracker
 import com.stripe.android.camera.framework.time.Clock
 import com.stripe.android.camera.framework.time.ClockMark
+import com.stripe.android.identity.injection.IdentityVerificationScope
 import com.stripe.android.identity.networking.IdentityRepository
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -12,6 +13,7 @@ import javax.inject.Inject
 /**
  * Tracker for screen transition.
  */
+@IdentityVerificationScope
 internal class ScreenTracker @Inject constructor(
     private val identityAnalyticsRequestFactory: IdentityAnalyticsRequestFactory,
     private val identityRepository: IdentityRepository

--- a/identity/src/main/java/com/stripe/android/identity/injection/IdentityActivitySubcomponent.kt
+++ b/identity/src/main/java/com/stripe/android/identity/injection/IdentityActivitySubcomponent.kt
@@ -16,6 +16,7 @@ import com.stripe.android.identity.utils.IdentityIO
 import dagger.BindsInstance
 import dagger.Subcomponent
 
+@IdentityVerificationScope
 @Subcomponent
 internal interface IdentityActivitySubcomponent {
     val identityFragmentFactory: IdentityFragmentFactory

--- a/identity/src/main/java/com/stripe/android/identity/injection/IdentityVerificationScope.kt
+++ b/identity/src/main/java/com/stripe/android/identity/injection/IdentityVerificationScope.kt
@@ -1,0 +1,10 @@
+package com.stripe.android.identity.injection
+
+import javax.inject.Scope
+
+/**
+ * Scope for an verification, used for [IdentityActivitySubcomponent].
+ */
+@Scope
+@Retention
+annotation class IdentityVerificationScope

--- a/identity/src/main/java/com/stripe/android/identity/injection/IdentityVerificationScope.kt
+++ b/identity/src/main/java/com/stripe/android/identity/injection/IdentityVerificationScope.kt
@@ -7,4 +7,4 @@ import javax.inject.Scope
  */
 @Scope
 @Retention
-annotation class IdentityVerificationScope
+internal annotation class IdentityVerificationScope

--- a/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
@@ -3,7 +3,6 @@ package com.stripe.android.identity.navigation
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
@@ -56,6 +55,15 @@ internal class ConsentFragment(
                             requireSelfie = verificationPage.requireSelfie()
                         )
                     }
+                    lifecycleScope.launch(identityViewModel.workContext) {
+                        identityViewModel.screenTracker.screenTransitionFinish(SCREEN_NAME_CONSENT)
+                    }
+
+                    identityViewModel.sendAnalyticsRequest(
+                        identityViewModel.identityAnalyticsRequestFactory.screenPresented(
+                            screenName = SCREEN_NAME_CONSENT
+                        )
+                    )
                 },
                 onFallbackUrl = this@ConsentFragment::logErrorAndLaunchFallback,
                 onError = this@ConsentFragment::logErrorAndNavigateToError,
@@ -63,19 +71,6 @@ internal class ConsentFragment(
                 onConsentDeclined = this@ConsentFragment::declineConsentAndPost
             )
         }
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        lifecycleScope.launch(identityViewModel.workContext) {
-            identityViewModel.screenTracker.screenTransitionFinish(SCREEN_NAME_CONSENT)
-        }
-
-        identityViewModel.sendAnalyticsRequest(
-            identityViewModel.identityAnalyticsRequestFactory.screenPresented(
-                screenName = SCREEN_NAME_CONSENT
-            )
-        )
     }
 
     private fun logErrorAndLaunchFallback(fallbackUrl: String) {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
@@ -50,7 +50,10 @@ internal class DocSelectionFragment(
         setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
         setContent {
             val verificationPage by identityViewModel.verificationPage.observeAsState()
-            DocSelectionScreen(verificationPage, ::postVerificationPageDataAndNavigate)
+            DocSelectionScreen(
+                verificationPage,
+                ::postVerificationPageDataAndNavigate
+            )
         }
     }
 

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityFragmentFactory.kt
@@ -7,6 +7,7 @@ import com.stripe.android.camera.AppSettingsOpenable
 import com.stripe.android.camera.CameraPermissionEnsureable
 import com.stripe.android.identity.FallbackUrlLauncher
 import com.stripe.android.identity.VerificationFlowFinishable
+import com.stripe.android.identity.injection.IdentityVerificationScope
 import com.stripe.android.identity.utils.IdentityIO
 import com.stripe.android.identity.viewmodel.IdentityScanViewModel
 import javax.inject.Inject
@@ -14,6 +15,7 @@ import javax.inject.Inject
 /**
  * Factory for creating Identity fragments.
  */
+@IdentityVerificationScope
 internal class IdentityFragmentFactory @Inject constructor(
     private val cameraPermissionEnsureable: CameraPermissionEnsureable,
     private val appSettingsOpenable: AppSettingsOpenable,

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
@@ -670,6 +670,7 @@ internal class IdentityViewModel constructor(
             }.fold(
                 onSuccess = {
                     _verificationPage.postValue(Resource.success(it))
+                    identityAnalyticsRequestFactory.verificationPage = it
                     if (shouldRetrieveModel) {
                         downloadModelAndPost(
                             it.documentCapture.models.idDetectorUrl,
@@ -690,7 +691,7 @@ internal class IdentityViewModel constructor(
                     "Failed to retrieve verification page with " +
                         (
                             "sessionID: ${verificationArgs.verificationSessionId} and ephemeralKey: " +
-                                "${verificationArgs.ephemeralKeySecret}"
+                                verificationArgs.ephemeralKeySecret
                             ).let { msg ->
                             _verificationPage.postValue(
                                 Resource.error(

--- a/identity/src/test/java/com/stripe/android/identity/IdentityActivityTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/IdentityActivityTest.kt
@@ -50,7 +50,9 @@ internal class IdentityActivityTest {
             IdentityAnalyticsRequestFactory(
                 context = ApplicationProvider.getApplicationContext(),
                 args = ARGS
-            )
+            ).also {
+                it.verificationPage = mock()
+            }
         )
         on { verificationPage }.thenReturn(mock())
         on { screenTracker }.thenReturn(mock())

--- a/identity/src/test/java/com/stripe/android/identity/navigation/CameraPermissionDeniedFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/CameraPermissionDeniedFragmentTest.kt
@@ -49,7 +49,9 @@ class CameraPermissionDeniedFragmentTest {
             IdentityAnalyticsRequestFactory(
                 context = ApplicationProvider.getApplicationContext(),
                 args = mock()
-            )
+            ).also {
+                it.verificationPage = mock()
+            }
         on { screenTracker } doReturn mockScreenTracker
         on { uiContext } doReturn testDispatcher
         on { workContext } doReturn testDispatcher

--- a/identity/src/test/java/com/stripe/android/identity/navigation/ConfirmationFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/ConfirmationFragmentTest.kt
@@ -40,7 +40,9 @@ class ConfirmationFragmentTest {
             IdentityAnalyticsRequestFactory(
                 context = ApplicationProvider.getApplicationContext(),
                 args = mock()
-            )
+            ).also {
+                it.verificationPage = mock()
+            }
         )
         on { uiContext } doReturn testDispatcher
         on { workContext } doReturn testDispatcher

--- a/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/ConsentFragmentTest.kt
@@ -75,7 +75,9 @@ internal class ConsentFragmentTest {
             IdentityAnalyticsRequestFactory(
                 context = ApplicationProvider.getApplicationContext(),
                 args = ARGS
-            )
+            ).also {
+                it.verificationPage = mock()
+            }
         )
         on { screenTracker }.thenReturn(mockScreenTracker)
         on { uiContext } doReturn testDispatcher

--- a/identity/src/test/java/com/stripe/android/identity/navigation/CouldNotCaptureFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/CouldNotCaptureFragmentTest.kt
@@ -50,7 +50,9 @@ internal class CouldNotCaptureFragmentTest {
             IdentityAnalyticsRequestFactory(
                 context = ApplicationProvider.getApplicationContext(),
                 args = mock()
-            )
+            ).also {
+                it.verificationPage = mock()
+            }
 
         on { screenTracker } doReturn mockScreenTracker
         on { uiContext } doReturn testDispatcher

--- a/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/DocSelectionFragmentTest.kt
@@ -67,7 +67,9 @@ internal class DocSelectionFragmentTest {
             IdentityAnalyticsRequestFactory(
                 context = ApplicationProvider.getApplicationContext(),
                 args = mock()
-            )
+            ).also {
+                it.verificationPage = mock()
+            }
         )
         on { screenTracker }.thenReturn(mockScreenTracker)
         on { uiContext } doReturn testDispatcher

--- a/identity/src/test/java/com/stripe/android/identity/navigation/DriverLicenseScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/DriverLicenseScanFragmentTest.kt
@@ -94,7 +94,9 @@ internal class DriverLicenseScanFragmentTest {
             IdentityAnalyticsRequestFactory(
                 context = ApplicationProvider.getApplicationContext(),
                 args = mock()
-            )
+            ).also {
+                it.verificationPage = mock()
+            }
         on { it.fpsTracker } doReturn mock()
         on { it.screenTracker } doReturn mockScreenTracker
         on { uiContext } doReturn testDispatcher

--- a/identity/src/test/java/com/stripe/android/identity/navigation/ErrorFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/ErrorFragmentTest.kt
@@ -50,7 +50,9 @@ class ErrorFragmentTest {
             IdentityAnalyticsRequestFactory(
                 context = ApplicationProvider.getApplicationContext(),
                 args = mock()
-            )
+            ).also {
+                it.verificationPage = mock()
+            }
 
         on { screenTracker } doReturn mockScreenTracker
         on { uiContext } doReturn testDispatcher

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IDScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IDScanFragmentTest.kt
@@ -97,7 +97,9 @@ internal class IDScanFragmentTest {
             IdentityAnalyticsRequestFactory(
                 context = ApplicationProvider.getApplicationContext(),
                 args = mock()
-            )
+            ).also {
+                it.verificationPage = mock()
+            }
         on { it.fpsTracker } doReturn mockFPSTracker
         on { it.screenTracker } doReturn mockScreenTracker
         on { uiContext } doReturn testDispatcher

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IdentityDocumentScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IdentityDocumentScanFragmentTest.kt
@@ -78,7 +78,9 @@ class IdentityDocumentScanFragmentTest {
             IdentityAnalyticsRequestFactory(
                 context = ApplicationProvider.getApplicationContext(),
                 args = mock()
-            )
+            ).also {
+                it.verificationPage = mock()
+            }
             )
         on { it.fpsTracker } doReturn mock()
         on { screenTracker } doReturn mock()

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IdentityUploadFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IdentityUploadFragmentTest.kt
@@ -113,7 +113,9 @@ class IdentityUploadFragmentTest {
             IdentityAnalyticsRequestFactory(
                 context = ApplicationProvider.getApplicationContext(),
                 args = mock()
-            )
+            ).also {
+                it.verificationPage = mock()
+            }
         )
         whenever(it.screenTracker).thenReturn(mockScreenTracker)
         whenever(it.uiContext).thenReturn(testDispatcher)

--- a/identity/src/test/java/com/stripe/android/identity/navigation/PassportScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/PassportScanFragmentTest.kt
@@ -91,7 +91,9 @@ class PassportScanFragmentTest {
             IdentityAnalyticsRequestFactory(
                 context = ApplicationProvider.getApplicationContext(),
                 args = mock()
-            )
+            ).also {
+                it.verificationPage = mock()
+            }
         on { fpsTracker } doReturn mock()
         on { screenTracker } doReturn mockScreenTracker
         on { uiContext } doReturn testDispatcher

--- a/identity/src/test/java/com/stripe/android/identity/navigation/PassportUploadFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/PassportUploadFragmentTest.kt
@@ -88,7 +88,9 @@ class PassportUploadFragmentTest {
             IdentityAnalyticsRequestFactory(
                 context = ApplicationProvider.getApplicationContext(),
                 args = mock()
-            )
+            ).also {
+                it.verificationPage = mock()
+            }
         )
         whenever(it.screenTracker).thenReturn(mockScreenTracker)
         whenever(it.uiContext).thenReturn(testDispatcher)

--- a/identity/src/test/java/com/stripe/android/identity/navigation/SelfieFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/SelfieFragmentTest.kt
@@ -112,7 +112,9 @@ internal class SelfieFragmentTest {
             IdentityAnalyticsRequestFactory(
                 context = ApplicationProvider.getApplicationContext(),
                 args = mock()
-            )
+            ).also {
+                it.verificationPage = mock()
+            }
         on { fpsTracker } doReturn mockFPSTracker
         on { screenTracker } doReturn mockScreenTracker
         on { uiContext } doReturn testDispatcher


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add live mode in the analytics.
Live mode information is only available after a fetch of `VerificagionPage` returns. Set that up as a `lateinit var` as `IdentityAnalyticsRequestFactory` has to be created during initialization.

Also fix a bug that multiple `IdentityAnalyticsRequestFactory`s are created by adding the correct scope to the subcomponent it belongs to

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
