### PR TITLE
Switch to using `ViewModelProvider.Factory` directly instead of via subclasses

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityActivity.kt
@@ -52,7 +52,6 @@ internal class IdentityActivity :
     @VisibleForTesting
     internal var viewModelFactory: ViewModelProvider.Factory =
         IdentityViewModel.IdentityViewModelFactory(
-            this,
             { uiContext },
             { workContext },
             { subcomponent }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityUploadFragment.kt
@@ -84,10 +84,7 @@ internal abstract class IdentityUploadFragment(
 
     @VisibleForTesting
     internal var identityUploadViewModelFactory: ViewModelProvider.Factory =
-        IdentityUploadViewModel.FrontBackUploadViewModelFactory(
-            { this },
-            identityIO
-        )
+        IdentityUploadViewModel.FrontBackUploadViewModelFactory(identityIO)
 
     private val identityUploadViewModel: IdentityUploadViewModel by viewModels {
         identityUploadViewModelFactory

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityUploadViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityUploadViewModel.kt
@@ -4,10 +4,11 @@ import android.content.Context
 import android.net.Uri
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
-import androidx.lifecycle.AbstractSavedStateViewModelFactory
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.savedstate.SavedStateRegistryOwner
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.identity.utils.IdentityIO
 import com.stripe.android.identity.utils.ImageChooser
 import com.stripe.android.identity.utils.PhotoTaker
@@ -93,17 +94,15 @@ internal class IdentityUploadViewModel(
     }
 
     internal class FrontBackUploadViewModelFactory(
-        ownerProvider: () -> SavedStateRegistryOwner,
         private val identityIO: IdentityIO
-    ) : AbstractSavedStateViewModelFactory(ownerProvider(), null) {
+    ) : ViewModelProvider.Factory {
 
         @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel> create(
-            key: String,
-            modelClass: Class<T>,
-            handle: SavedStateHandle
-        ): T {
-            return IdentityUploadViewModel(identityIO, handle) as T
+        override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
+            return IdentityUploadViewModel(
+                identityIO = identityIO,
+                savedStateHandle = extras.createSavedStateHandle(),
+            ) as T
         }
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
@@ -4,15 +4,16 @@ import android.graphics.Bitmap
 import android.net.Uri
 import android.util.Log
 import androidx.annotation.VisibleForTesting
-import androidx.lifecycle.AbstractSavedStateViewModelFactory
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
-import androidx.savedstate.SavedStateRegistryOwner
+import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.camera.framework.image.longerEdge
 import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.exception.APIException
@@ -828,19 +829,16 @@ internal class IdentityViewModel constructor(
     }
 
     internal class IdentityViewModelFactory(
-        savedStateRegistryOwner: SavedStateRegistryOwner,
         private val uiContextSupplier: () -> CoroutineContext,
         private val workContextSupplier: () -> CoroutineContext,
         private val subcomponentSupplier: () -> IdentityActivitySubcomponent
-    ) : AbstractSavedStateViewModelFactory(savedStateRegistryOwner, null) {
+    ) : ViewModelProvider.Factory {
 
         @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel> create(
-            key: String,
-            modelClass: Class<T>,
-            handle: SavedStateHandle
-        ): T {
+        override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
             val subcomponent = subcomponentSupplier()
+            val savedStateHandle = extras.createSavedStateHandle()
+
             return IdentityViewModel(
                 subcomponent.verificationArgs,
                 subcomponent.identityRepository,
@@ -849,7 +847,7 @@ internal class IdentityViewModel constructor(
                 subcomponent.identityAnalyticsRequestFactory,
                 subcomponent.fpsTracker,
                 subcomponent.screenTracker,
-                handle,
+                savedStateHandle,
                 uiContextSupplier(),
                 workContextSupplier()
             ) as T

--- a/link/src/main/java/com/stripe/android/link/LinkActivity.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivity.kt
@@ -59,11 +59,9 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalMaterialApi::class)
 internal class LinkActivity : ComponentActivity() {
     @VisibleForTesting
-    internal var viewModelFactory: ViewModelProvider.Factory =
-        LinkActivityViewModel.Factory(
-            applicationSupplier = { application },
-            starterArgsSupplier = { starterArgs }
-        )
+    internal var viewModelFactory: ViewModelProvider.Factory = LinkActivityViewModel.Factory {
+        starterArgs
+    }
 
     private val viewModel: LinkActivityViewModel by viewModels { viewModelFactory }
 

--- a/link/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -1,10 +1,10 @@
 package com.stripe.android.link
 
 import android.app.Application
-import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.CreationExtras
+import androidx.lifecycle.viewmodel.MutableCreationExtras
 import androidx.navigation.NavHostController
-import androidx.savedstate.SavedStateRegistry
-import androidx.savedstate.SavedStateRegistryOwner
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.injection.Injectable
@@ -29,7 +29,6 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.spy
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
@@ -38,6 +37,7 @@ import kotlin.test.assertNotNull
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 class LinkActivityViewModelTest {
+
     private val config = LinkPaymentLauncher.Configuration(
         stripeIntent = StripeIntentFixtures.PI_SUCCEEDED,
         merchantName = MERCHANT_NAME,
@@ -109,8 +109,12 @@ class LinkActivityViewModelTest {
 
         val factory = LinkActivityViewModel.Factory { defaultArgs }
         val factorySpy = spy(factory)
-        val createdViewModel = factorySpy.create(LinkActivityViewModel::class.java)
-        verify(factorySpy, times(0)).fallbackInitialize(any())
+
+        val createdViewModel = factorySpy.create(
+            modelClass = LinkActivityViewModel::class.java,
+            extras = fakeCreationExtras(),
+        )
+        verify(factorySpy, never()).fallbackInitialize(any())
         assertThat(createdViewModel).isEqualTo(vmToBeReturned)
 
         WeakMapInjectorRegistry.staticCacheMap.clear()
@@ -118,22 +122,19 @@ class LinkActivityViewModelTest {
 
     @Test
     fun `Factory gets initialized with fallback when no Injector is available`() = runTest {
-        val mockSavedStateRegistryOwner = mock<SavedStateRegistryOwner>()
-        val mockSavedStateRegistry = mock<SavedStateRegistry>()
-        val mockLifeCycle = mock<Lifecycle>()
-
-        whenever(mockSavedStateRegistryOwner.savedStateRegistry).thenReturn(mockSavedStateRegistry)
-        whenever(mockSavedStateRegistryOwner.lifecycle).thenReturn(mockLifeCycle)
-        whenever(mockLifeCycle.currentState).thenReturn(Lifecycle.State.CREATED)
-
-        val context = ApplicationProvider.getApplicationContext<Application>()
+        val application = ApplicationProvider.getApplicationContext<Application>()
         val factory = LinkActivityViewModel.Factory { defaultArgs }
         val factorySpy = spy(factory)
 
-        assertNotNull(factorySpy.create(LinkActivityViewModel::class.java))
+        val viewModel = factorySpy.create(
+            modelClass = LinkActivityViewModel::class.java,
+            extras = fakeCreationExtras(),
+        )
+        assertNotNull(viewModel)
+
         verify(factorySpy).fallbackInitialize(
             argWhere {
-                it.application == context
+                it.application == application
             }
         )
     }
@@ -206,6 +207,13 @@ class LinkActivityViewModelTest {
         }
         whenever(navigator.userNavigationEnabled).thenReturn(userNavigationEnabled)
         whenever(navigator.navigationController).thenReturn(mockNavController)
+    }
+
+    private fun fakeCreationExtras(): CreationExtras {
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        return MutableCreationExtras().apply {
+            set(ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY, application)
+        }
     }
 
     private companion object {

--- a/link/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkActivityViewModelTest.kt
@@ -107,10 +107,7 @@ class LinkActivityViewModelTest {
         }
         WeakMapInjectorRegistry.register(injector, INJECTOR_KEY)
 
-        val factory = LinkActivityViewModel.Factory(
-            { ApplicationProvider.getApplicationContext() },
-            { defaultArgs }
-        )
+        val factory = LinkActivityViewModel.Factory { defaultArgs }
         val factorySpy = spy(factory)
         val createdViewModel = factorySpy.create(LinkActivityViewModel::class.java)
         verify(factorySpy, times(0)).fallbackInitialize(any())
@@ -130,10 +127,7 @@ class LinkActivityViewModelTest {
         whenever(mockLifeCycle.currentState).thenReturn(Lifecycle.State.CREATED)
 
         val context = ApplicationProvider.getApplicationContext<Application>()
-        val factory = LinkActivityViewModel.Factory(
-            { ApplicationProvider.getApplicationContext() },
-            { defaultArgs }
-        )
+        val factory = LinkActivityViewModel.Factory { defaultArgs }
         val factorySpy = spy(factory)
 
         assertNotNull(factorySpy.create(LinkActivityViewModel::class.java))

--- a/payments-core/src/main/java/com/stripe/android/PaymentSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/PaymentSession.kt
@@ -1,7 +1,6 @@
 package com.stripe.android
 
 import android.app.Activity
-import android.app.Application
 import android.content.Context
 import android.content.Intent
 import androidx.activity.ComponentActivity
@@ -14,7 +13,6 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.OnLifecycleEvent
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
-import androidx.savedstate.SavedStateRegistryOwner
 import com.stripe.android.PaymentSession.PaymentSessionListener
 import com.stripe.android.view.ActivityStarter
 import com.stripe.android.view.PaymentFlowActivity
@@ -34,10 +32,8 @@ import com.stripe.android.view.PaymentMethodsActivityStarter
  */
 class PaymentSession @VisibleForTesting internal constructor(
     private val context: Context,
-    application: Application,
     viewModelStoreOwner: ViewModelStoreOwner,
     private val lifecycleOwner: LifecycleOwner,
-    savedStateRegistryOwner: SavedStateRegistryOwner,
     private val config: PaymentSessionConfig,
     customerSession: CustomerSession,
     private val paymentMethodsActivityStarter:
@@ -50,8 +46,6 @@ class PaymentSession @VisibleForTesting internal constructor(
         ViewModelProvider(
             viewModelStoreOwner,
             PaymentSessionViewModel.Factory(
-                application,
-                savedStateRegistryOwner,
                 paymentSessionData,
                 customerSession
             )
@@ -102,8 +96,6 @@ class PaymentSession @VisibleForTesting internal constructor(
      */
     constructor(activity: ComponentActivity, config: PaymentSessionConfig) : this(
         activity.applicationContext,
-        activity.application,
-        activity,
         activity,
         activity,
         config,
@@ -122,8 +114,6 @@ class PaymentSession @VisibleForTesting internal constructor(
      */
     constructor(fragment: Fragment, config: PaymentSessionConfig) : this(
         fragment.requireActivity().applicationContext,
-        fragment.requireActivity().application,
-        fragment,
         fragment,
         fragment,
         config,

--- a/payments-core/src/main/java/com/stripe/android/PaymentSessionViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/PaymentSessionViewModel.kt
@@ -240,7 +240,6 @@ internal class PaymentSessionViewModel(
         private val customerSession: CustomerSession
     ) : ViewModelProvider.Factory {
 
-
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
             return PaymentSessionViewModel(

--- a/payments-core/src/main/java/com/stripe/android/PaymentSessionViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/PaymentSessionViewModel.kt
@@ -2,16 +2,18 @@ package com.stripe.android
 
 import android.app.Application
 import androidx.annotation.IntRange
-import androidx.lifecycle.AbstractSavedStateViewModelFactory
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.savedstate.SavedStateRegistryOwner
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.core.StripeError
 import com.stripe.android.model.Customer
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.utils.requireApplication
 import com.stripe.android.view.PaymentMethodsActivityStarter
 
 internal class PaymentSessionViewModel(
@@ -234,19 +236,16 @@ internal class PaymentSessionViewModel(
     }
 
     internal class Factory(
-        private val application: Application,
-        owner: SavedStateRegistryOwner,
         private val paymentSessionData: PaymentSessionData,
         private val customerSession: CustomerSession
-    ) : AbstractSavedStateViewModelFactory(owner, null) {
-        override fun <T : ViewModel?> create(
-            key: String,
-            modelClass: Class<T>,
-            handle: SavedStateHandle
-        ): T {
+    ) : ViewModelProvider.Factory {
+
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
             return PaymentSessionViewModel(
-                application,
-                handle,
+                extras.requireApplication(),
+                extras.createSavedStateHandle(),
                 paymentSessionData,
                 customerSession
             ) as T

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherActivity.kt
@@ -34,11 +34,7 @@ import org.json.JSONObject
  */
 internal class GooglePayLauncherActivity : AppCompatActivity() {
     private val viewModel: GooglePayLauncherViewModel by viewModels {
-        GooglePayLauncherViewModel.Factory(
-            application,
-            args,
-            this
-        )
+        GooglePayLauncherViewModel.Factory(args)
     }
 
     private lateinit var args: GooglePayLauncherContract.Args

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
@@ -1,16 +1,15 @@
 package com.stripe.android.googlepaylauncher
 
-import android.app.Application
 import android.content.Intent
-import android.os.Bundle
 import androidx.annotation.VisibleForTesting
-import androidx.lifecycle.AbstractSavedStateViewModelFactory
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.distinctUntilChanged
 import androidx.lifecycle.viewModelScope
-import androidx.savedstate.SavedStateRegistryOwner
+import androidx.lifecycle.viewmodel.CreationExtras
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.wallet.PaymentData
 import com.google.android.gms.wallet.PaymentDataRequest
@@ -31,6 +30,7 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.networking.StripeApiRepository
 import com.stripe.android.networking.StripeRepository
+import com.stripe.android.utils.requireApplication
 import com.stripe.android.view.AuthActivityStarterHost
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
@@ -219,19 +219,15 @@ internal class GooglePayLauncherViewModel(
         }.getOrElse { GooglePayLauncher.Result.Failed(it) }
 
     internal class Factory(
-        private val application: Application,
         private val args: GooglePayLauncherContract.Args,
-        owner: SavedStateRegistryOwner,
         private val enableLogging: Boolean = false,
         private val workContext: CoroutineContext = Dispatchers.IO,
-        defaultArgs: Bundle? = null
-    ) : AbstractSavedStateViewModelFactory(owner, defaultArgs) {
+    ) : ViewModelProvider.Factory {
+
         @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel> create(
-            key: String,
-            modelClass: Class<T>,
-            handle: SavedStateHandle
-        ): T {
+        override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
+            val application = extras.requireApplication()
+
             val googlePayEnvironment = args.config.environment
             val logger = Logger.getInstance(enableLogging)
 
@@ -284,7 +280,7 @@ internal class GooglePayLauncherViewModel(
                     isJcbEnabled = args.config.isJcbEnabled
                 ),
                 googlePayRepository,
-                handle
+                extras.createSavedStateHandle()
             ) as T
         }
     }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherActivity.kt
@@ -30,11 +30,7 @@ import kotlinx.coroutines.launch
  */
 internal class GooglePayPaymentMethodLauncherActivity : AppCompatActivity() {
     private val viewModel: GooglePayPaymentMethodLauncherViewModel by viewModels {
-        GooglePayPaymentMethodLauncherViewModel.Factory(
-            application,
-            args,
-            this
-        )
+        GooglePayPaymentMethodLauncherViewModel.Factory(args)
     }
 
     private lateinit var args: GooglePayPaymentMethodLauncherContract.Args

--- a/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherActivity.kt
@@ -24,10 +24,7 @@ import com.stripe.android.view.PaymentAuthWebViewActivity
  */
 internal class StripeBrowserLauncherActivity : AppCompatActivity() {
     private val viewModel: StripeBrowserLauncherViewModel by viewModels {
-        StripeBrowserLauncherViewModel.Factory(
-            application,
-            this
-        )
+        StripeBrowserLauncherViewModel.Factory()
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherViewModel.kt
@@ -1,14 +1,14 @@
 package com.stripe.android.payments
 
-import android.app.Application
 import android.content.Intent
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabColorSchemeParams
 import androidx.browser.customtabs.CustomTabsIntent
-import androidx.lifecycle.AbstractSavedStateViewModelFactory
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.savedstate.SavedStateRegistryOwner
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
 import com.stripe.android.auth.PaymentBrowserAuthContract
@@ -18,6 +18,7 @@ import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
 import com.stripe.android.networking.PaymentAnalyticsEvent
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
+import com.stripe.android.utils.requireApplication
 import kotlin.properties.Delegates
 
 internal class StripeBrowserLauncherViewModel(
@@ -97,17 +98,13 @@ internal class StripeBrowserLauncherViewModel(
         )
     }
 
-    class Factory(
-        private val application: Application,
-        owner: SavedStateRegistryOwner
-    ) : AbstractSavedStateViewModelFactory(owner, null) {
+    class Factory : ViewModelProvider.Factory {
 
         @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel?> create(
-            key: String,
-            modelClass: Class<T>,
-            handle: SavedStateHandle
-        ): T {
+        override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
+            val application = extras.requireApplication()
+            val savedStateHandle = extras.createSavedStateHandle()
+
             val config = PaymentConfiguration.getInstance(application)
             val browserCapabilitiesSupplier = BrowserCapabilitiesSupplier(application)
 
@@ -119,7 +116,7 @@ internal class StripeBrowserLauncherViewModel(
                 ),
                 browserCapabilitiesSupplier.get(),
                 application.getString(R.string.stripe_verify_your_payment),
-                handle
+                savedStateHandle
             ) as T
         }
     }

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountActivity.kt
@@ -23,7 +23,6 @@ internal class CollectBankAccountActivity : AppCompatActivity() {
     private lateinit var financialConnectionsPaymentsProxy: FinancialConnectionsPaymentsProxy
 
     private val viewModel: CollectBankAccountViewModel by viewModels {
-        // TODO: Do we need to add defaultArgs to CreationExtras?
         CollectBankAccountViewModel.Factory {
             requireNotNull(starterArgs)
         }

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountActivity.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountContract
 import com.stripe.android.payments.bankaccount.ui.CollectBankAccountViewEffect.FinishWithResult
@@ -23,15 +22,12 @@ internal class CollectBankAccountActivity : AppCompatActivity() {
 
     private lateinit var financialConnectionsPaymentsProxy: FinancialConnectionsPaymentsProxy
 
-    internal var viewModelFactory: ViewModelProvider.Factory =
-        CollectBankAccountViewModel.Factory(
-            { application },
-            { requireNotNull(starterArgs) },
-            this,
-            intent?.extras
-        )
-
-    private val viewModel: CollectBankAccountViewModel by viewModels { viewModelFactory }
+    private val viewModel: CollectBankAccountViewModel by viewModels {
+        // TODO: Do we need to add defaultArgs to CreationExtras?
+        CollectBankAccountViewModel.Factory {
+            requireNotNull(starterArgs)
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountViewModel.kt
@@ -1,12 +1,11 @@
 package com.stripe.android.payments.bankaccount.ui
 
-import android.app.Application
-import android.os.Bundle
-import androidx.lifecycle.AbstractSavedStateViewModelFactory
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
-import androidx.savedstate.SavedStateRegistryOwner
+import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.core.Logger
 import com.stripe.android.financialconnections.FinancialConnectionsSheetResult
 import com.stripe.android.financialconnections.model.FinancialConnectionsSession
@@ -23,6 +22,7 @@ import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResu
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResult.Cancelled
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResult.Completed
 import com.stripe.android.payments.bankaccount.ui.CollectBankAccountViewEffect.OpenConnectionsFlow
+import com.stripe.android.utils.requireApplication
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
@@ -169,21 +169,17 @@ internal class CollectBankAccountViewModel @Inject constructor(
     }
 
     class Factory(
-        private val applicationSupplier: () -> Application,
         private val argsSupplier: () -> CollectBankAccountContract.Args,
-        owner: SavedStateRegistryOwner,
-        defaultArgs: Bundle? = null
-    ) : AbstractSavedStateViewModelFactory(owner, defaultArgs) {
+    ) : ViewModelProvider.Factory {
 
         @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel> create(
-            key: String,
-            modelClass: Class<T>,
-            savedStateHandle: SavedStateHandle
-        ): T {
+        override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
+            val application = extras.requireApplication()
+            val savedStateHandle = extras.createSavedStateHandle()
+
             return DaggerCollectBankAccountComponent.builder()
                 .savedStateHandle(savedStateHandle)
-                .application(applicationSupplier())
+                .application(application)
                 .viewEffect(MutableSharedFlow())
                 .configuration(argsSupplier()).build()
                 .viewModel as T

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionActivity.kt
@@ -35,12 +35,7 @@ internal class Stripe3ds2TransactionActivity : AppCompatActivity() {
     lateinit var args: Stripe3ds2TransactionContract.Args
 
     @VisibleForTesting
-    internal var viewModelFactory: ViewModelProvider.Factory =
-        Stripe3ds2TransactionViewModelFactory(
-            { application },
-            this,
-            { args }
-        )
+    internal var viewModelFactory: ViewModelProvider.Factory = Stripe3ds2TransactionViewModelFactory { args }
 
     public override fun onCreate(savedInstanceState: Bundle?) {
         val argsResult = runCatching {

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
@@ -22,12 +22,9 @@ internal class PaymentLauncherConfirmationActivity : AppCompatActivity() {
     }
 
     @VisibleForTesting
-    internal var viewModelFactory: ViewModelProvider.Factory =
-        PaymentLauncherViewModel.Factory(
-            { requireNotNull(starterArgs) },
-            { application },
-            this
-        )
+    internal var viewModelFactory: ViewModelProvider.Factory = PaymentLauncherViewModel.Factory {
+        requireNotNull(starterArgs)
+    }
 
     @VisibleForTesting
     internal val viewModel: PaymentLauncherViewModel by viewModels { viewModelFactory }

--- a/payments-core/src/main/java/com/stripe/android/utils/CreationExtrasKtx.kt
+++ b/payments-core/src/main/java/com/stripe/android/utils/CreationExtrasKtx.kt
@@ -1,3 +1,5 @@
+@file:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+
 package com.stripe.android.utils
 
 import android.app.Application

--- a/payments-core/src/main/java/com/stripe/android/utils/CreationExtrasKtx.kt
+++ b/payments-core/src/main/java/com/stripe/android/utils/CreationExtrasKtx.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.utils
+
+import android.app.Application
+import androidx.annotation.RestrictTo
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.CreationExtras
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun CreationExtras.requireApplication(): Application {
+    return requireNotNull(this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY])
+}

--- a/payments-core/src/test/java/com/stripe/android/PaymentSessionTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentSessionTest.kt
@@ -323,8 +323,6 @@ class PaymentSessionTest {
     ): PaymentSession {
         return PaymentSession(
             activity,
-            activity.application,
-            activity,
             activity,
             activity,
             config,

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
@@ -30,6 +30,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.networking.AbsFakeStripeRepository
+import com.stripe.android.utils.fakeCreationExtras
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
@@ -162,6 +163,7 @@ class GooglePayPaymentMethodLauncherViewModelTest {
             }
             val injectorKey = "testInjectorKey"
             WeakMapInjectorRegistry.register(injector, injectorKey)
+
             val factory = GooglePayPaymentMethodLauncherViewModel.Factory(
                 GooglePayPaymentMethodLauncherContract.Args(
                     mock(),
@@ -177,9 +179,13 @@ class GooglePayPaymentMethodLauncherViewModelTest {
                     )
                 )
             )
+
             val factorySpy = spy(factory)
-            val createdViewModel =
-                factorySpy.create(GooglePayPaymentMethodLauncherViewModel::class.java)
+            val createdViewModel = factorySpy.create(
+                modelClass = GooglePayPaymentMethodLauncherViewModel::class.java,
+                extras = fragment.fakeCreationExtras(),
+            )
+
             verify(factorySpy, times(0)).fallbackInitialize(any())
             assertThat(createdViewModel).isEqualTo(viewModel)
 
@@ -190,10 +196,10 @@ class GooglePayPaymentMethodLauncherViewModelTest {
     @Test
     fun `Factory gets initialized with fallback when no Injector is available`() {
         scenario.onFragment { fragment ->
-            val context = ApplicationProvider.getApplicationContext<Application>()
+            val application = ApplicationProvider.getApplicationContext<Application>()
             val productUsage = setOf("TestProductUsage")
             val publishableKey = "publishable_key"
-            PaymentConfiguration.init(context, publishableKey)
+            PaymentConfiguration.init(application, publishableKey)
 
             val factory = GooglePayPaymentMethodLauncherViewModel.Factory(
                 GooglePayPaymentMethodLauncherContract.Args(
@@ -214,11 +220,19 @@ class GooglePayPaymentMethodLauncherViewModelTest {
                     )
                 )
             )
+
             val factorySpy = spy(factory)
-            assertNotNull(factorySpy.create(GooglePayPaymentMethodLauncherViewModel::class.java))
+
+            assertNotNull(
+                factorySpy.create(
+                    modelClass = GooglePayPaymentMethodLauncherViewModel::class.java,
+                    extras = fragment.fakeCreationExtras(),
+                )
+            )
+
             verify(factorySpy).fallbackInitialize(
                 argWhere {
-                    it.application == context &&
+                    it.application == application &&
                         it.productUsage == productUsage &&
                         it.publishableKey == publishableKey
                 }

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
@@ -163,7 +163,6 @@ class GooglePayPaymentMethodLauncherViewModelTest {
             val injectorKey = "testInjectorKey"
             WeakMapInjectorRegistry.register(injector, injectorKey)
             val factory = GooglePayPaymentMethodLauncherViewModel.Factory(
-                ApplicationProvider.getApplicationContext(),
                 GooglePayPaymentMethodLauncherContract.Args(
                     mock(),
                     "usd",
@@ -176,8 +175,7 @@ class GooglePayPaymentMethodLauncherViewModelTest {
                         "key",
                         null
                     )
-                ),
-                fragment
+                )
             )
             val factorySpy = spy(factory)
             val createdViewModel =
@@ -198,7 +196,6 @@ class GooglePayPaymentMethodLauncherViewModelTest {
             PaymentConfiguration.init(context, publishableKey)
 
             val factory = GooglePayPaymentMethodLauncherViewModel.Factory(
-                context,
                 GooglePayPaymentMethodLauncherContract.Args(
                     GooglePayPaymentMethodLauncher.Config(
                         GooglePayEnvironment.Test,
@@ -215,8 +212,7 @@ class GooglePayPaymentMethodLauncherViewModelTest {
                         publishableKey,
                         null
                     )
-                ),
-                fragment
+                )
             )
             val factorySpy = spy(factory)
             assertNotNull(factorySpy.create(GooglePayPaymentMethodLauncherViewModel::class.java))

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelTest.kt
@@ -25,6 +25,7 @@ import com.stripe.android.stripe3ds2.init.ui.StripeUiCustomization
 import com.stripe.android.stripe3ds2.service.StripeThreeDs2ServiceImpl
 import com.stripe.android.stripe3ds2.transaction.MessageVersionRegistry
 import com.stripe.android.stripe3ds2.transaction.SdkTransactionId
+import com.stripe.android.utils.fakeCreationExtras
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -91,25 +92,8 @@ class Stripe3ds2TransactionViewModelTest {
 
     @Test
     fun `Stripe3ds2TransactionViewModel gets initialized by Injector when Injector is available`() {
-        scenario.onFragment { savedStateRegistryOwner ->
-            // The reason the ViewModel cannot be mocked here is because
-            // TODO
-            // AbstractSavedStateViewModelFactory will call viewModel.setTagIfAbsent, which accesses
-            // ViewModel.mBagOfTags that's initialized in base class.
-            // Mocking it would leave this field null, causing an NPE.
-            val viewModel = Stripe3ds2TransactionViewModel(
-                ARGS,
-                mock(),
-                mock(),
-                mock(),
-                mock(),
-                mock(),
-                mock(),
-                mock(),
-                mock(),
-                mock(),
-                false
-            )
+        scenario.onFragment { fragment ->
+            val viewModel: Stripe3ds2TransactionViewModel = mock()
             val mockBuilder = mock<Stripe3ds2TransactionViewModelSubcomponent.Builder>()
             val mockSubcomponent = mock<Stripe3ds2TransactionViewModelSubcomponent>()
 
@@ -129,8 +113,12 @@ class Stripe3ds2TransactionViewModelTest {
 
             val factory = Stripe3ds2TransactionViewModelFactory { ARGS }
             val factorySpy = spy(factory)
-            val createdViewModel =
-                factorySpy.create(Stripe3ds2TransactionViewModel::class.java)
+
+            val createdViewModel = factorySpy.create(
+                modelClass = Stripe3ds2TransactionViewModel::class.java,
+                extras = fragment.fakeCreationExtras(),
+            )
+
             verify(factorySpy, times(0)).fallbackInitialize(any())
             assertThat(createdViewModel).isEqualTo(viewModel)
 
@@ -140,12 +128,18 @@ class Stripe3ds2TransactionViewModelTest {
 
     @Test
     fun `Stripe3ds2TransactionViewModel gets initialized with fallback when no Injector is available`() {
-        scenario.onFragment { savedStateRegistryOwner ->
+        scenario.onFragment { fragment ->
             val application = ApplicationProvider.getApplicationContext<Application>()
             val factory = Stripe3ds2TransactionViewModelFactory { ARGS }
             val factorySpy = spy(factory)
 
-            assertNotNull(factorySpy.create(Stripe3ds2TransactionViewModel::class.java))
+            assertNotNull(
+                factorySpy.create(
+                    modelClass = Stripe3ds2TransactionViewModel::class.java,
+                    extras = fragment.fakeCreationExtras(),
+                )
+            )
+
             verify(factorySpy).fallbackInitialize(
                 argWhere {
                     it.application == application &&

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModelTest.kt
@@ -93,6 +93,7 @@ class Stripe3ds2TransactionViewModelTest {
     fun `Stripe3ds2TransactionViewModel gets initialized by Injector when Injector is available`() {
         scenario.onFragment { savedStateRegistryOwner ->
             // The reason the ViewModel cannot be mocked here is because
+            // TODO
             // AbstractSavedStateViewModelFactory will call viewModel.setTagIfAbsent, which accesses
             // ViewModel.mBagOfTags that's initialized in base class.
             // Mocking it would leave this field null, causing an NPE.
@@ -126,11 +127,7 @@ class Stripe3ds2TransactionViewModelTest {
             }
             WeakMapInjectorRegistry.register(injector, INJECTOR_KEY)
 
-            val factory = Stripe3ds2TransactionViewModelFactory(
-                { ApplicationProvider.getApplicationContext() },
-                savedStateRegistryOwner,
-                { ARGS }
-            )
+            val factory = Stripe3ds2TransactionViewModelFactory { ARGS }
             val factorySpy = spy(factory)
             val createdViewModel =
                 factorySpy.create(Stripe3ds2TransactionViewModel::class.java)
@@ -145,11 +142,7 @@ class Stripe3ds2TransactionViewModelTest {
     fun `Stripe3ds2TransactionViewModel gets initialized with fallback when no Injector is available`() {
         scenario.onFragment { savedStateRegistryOwner ->
             val application = ApplicationProvider.getApplicationContext<Application>()
-            val factory = Stripe3ds2TransactionViewModelFactory(
-                { application },
-                savedStateRegistryOwner,
-                { ARGS }
-            )
+            val factory = Stripe3ds2TransactionViewModelFactory { ARGS }
             val factorySpy = spy(factory)
 
             assertNotNull(factorySpy.create(Stripe3ds2TransactionViewModel::class.java))

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModelTest.kt
@@ -445,6 +445,7 @@ class PaymentLauncherViewModelTest {
         val mockBuilder = mock<PaymentLauncherViewModelSubcomponent.Builder>()
         val mockSubComponent = mock<PaymentLauncherViewModelSubcomponent>()
         // The reason the ViewModel cannot be mocked here is because
+        // TODO
         // AbstractSavedStateViewModelFactory will call viewmodel.setTagIfAbsent, which accesses
         // ViewModel.mBagOfTags that's initialized in base class.
         // Mocking it would leave this field null, causing an NPE.
@@ -471,20 +472,16 @@ class PaymentLauncherViewModelTest {
         }
         val injectorKey = WeakMapInjectorRegistry.nextKey("testKey")
         WeakMapInjectorRegistry.register(injector, injectorKey)
-        val factory = PaymentLauncherViewModel.Factory(
-            {
-                PaymentLauncherContract.Args.IntentConfirmationArgs(
-                    injectorKey,
-                    ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-                    TEST_STRIPE_ACCOUNT_ID,
-                    false,
-                    PRODUCT_USAGE,
-                    mock<ConfirmPaymentIntentParams>()
-                )
-            },
-            { ApplicationProvider.getApplicationContext() },
-            mockSavedStateRegistryOwner
-        )
+        val factory = PaymentLauncherViewModel.Factory {
+            PaymentLauncherContract.Args.IntentConfirmationArgs(
+                injectorKey,
+                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                TEST_STRIPE_ACCOUNT_ID,
+                false,
+                PRODUCT_USAGE,
+                mock<ConfirmPaymentIntentParams>()
+            )
+        }
         val factorySpy = spy(factory)
         val createdViewModel = factorySpy.create(PaymentLauncherViewModel::class.java)
         verify(factorySpy, times(0)).fallbackInitialize(any())
@@ -495,29 +492,17 @@ class PaymentLauncherViewModelTest {
 
     @Test
     fun `Factory gets initialized with fallback when no Injector is available`() = runTest {
-        val mockSavedStateRegistryOwner = mock<SavedStateRegistryOwner>()
-        val mockSavedStateRegistry = mock<SavedStateRegistry>()
-        val mockLifeCycle = mock<Lifecycle>()
-
-        whenever(mockSavedStateRegistryOwner.savedStateRegistry).thenReturn(mockSavedStateRegistry)
-        whenever(mockSavedStateRegistryOwner.lifecycle).thenReturn(mockLifeCycle)
-        whenever(mockLifeCycle.currentState).thenReturn(Lifecycle.State.CREATED)
-
         val context = ApplicationProvider.getApplicationContext<Application>()
-        val factory = PaymentLauncherViewModel.Factory(
-            {
-                PaymentLauncherContract.Args.IntentConfirmationArgs(
-                    DUMMY_INJECTOR_KEY,
-                    ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-                    TEST_STRIPE_ACCOUNT_ID,
-                    false,
-                    PRODUCT_USAGE,
-                    mock<ConfirmPaymentIntentParams>()
-                )
-            },
-            { ApplicationProvider.getApplicationContext() },
-            mockSavedStateRegistryOwner
-        )
+        val factory = PaymentLauncherViewModel.Factory {
+            PaymentLauncherContract.Args.IntentConfirmationArgs(
+                DUMMY_INJECTOR_KEY,
+                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                TEST_STRIPE_ACCOUNT_ID,
+                false,
+                PRODUCT_USAGE,
+                mock<ConfirmPaymentIntentParams>()
+            )
+        }
         val factorySpy = spy(factory)
 
         assertNotNull(factorySpy.create(PaymentLauncherViewModel::class.java))

--- a/payments-core/src/test/java/com/stripe/android/utils/CreationExtrasUtils.kt
+++ b/payments-core/src/test/java/com/stripe/android/utils/CreationExtrasUtils.kt
@@ -1,0 +1,14 @@
+package com.stripe.android.utils
+
+import androidx.lifecycle.HasDefaultViewModelProviderFactory
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.CreationExtras
+import androidx.lifecycle.viewmodel.MutableCreationExtras
+
+internal fun HasDefaultViewModelProviderFactory.fakeCreationExtras(): CreationExtras {
+    return MutableCreationExtras(
+        initialExtras = defaultViewModelCreationExtras,
+    ).apply {
+        set(ViewModelProvider.NewInstanceFactory.VIEW_MODEL_KEY, "some_key")
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
@@ -53,7 +53,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 
 @FlowPreview
 internal abstract class BaseAddPaymentMethodFragment : Fragment() {
-    abstract val viewModelFactory: ViewModelProvider.Factory
     abstract val sheetViewModel: BaseSheetViewModel<*>
 
     override fun onCreateView(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidViewBinding
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.inline.InlineSignupViewState

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -38,13 +38,9 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
     }
 
     @VisibleForTesting
-    internal var viewModelFactory: ViewModelProvider.Factory =
-        PaymentOptionsViewModel.Factory(
-            { application },
-            { requireNotNull(starterArgs) },
-            this,
-            intent?.extras
-        )
+    internal var viewModelFactory: ViewModelProvider.Factory = PaymentOptionsViewModel.Factory {
+        requireNotNull(starterArgs)
+    }
 
     override val viewModel: PaymentOptionsViewModel by viewModels { viewModelFactory }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAddPaymentMethodFragment.kt
@@ -1,21 +1,15 @@
 package com.stripe.android.paymentsheet
 
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.activityViewModels
-import androidx.lifecycle.ViewModelProvider
+import kotlinx.coroutines.FlowPreview
 
+@FlowPreview
 internal class PaymentOptionsAddPaymentMethodFragment : BaseAddPaymentMethodFragment() {
-    override val viewModelFactory: ViewModelProvider.Factory = PaymentOptionsViewModel.Factory(
-        { requireActivity().application },
-        {
+    override val sheetViewModel by activityViewModels<PaymentOptionsViewModel> {
+        PaymentOptionsViewModel.Factory {
             requireNotNull(
                 requireArguments().getParcelable(PaymentOptionsActivity.EXTRA_STARTER_ARGS)
             )
-        },
-        (activity as? AppCompatActivity) ?: this
-    )
-
-    override val sheetViewModel by activityViewModels<PaymentOptionsViewModel> {
-        viewModelFactory
+        }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsListFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsListFragment.kt
@@ -2,22 +2,17 @@ package com.stripe.android.paymentsheet
 
 import android.os.Bundle
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.activityViewModels
 
 internal class PaymentOptionsListFragment() : BasePaymentMethodsListFragment(
     canClickSelectedItem = true
 ) {
     private val activityViewModel by activityViewModels<PaymentOptionsViewModel> {
-        PaymentOptionsViewModel.Factory(
-            { requireActivity().application },
-            {
-                requireNotNull(
-                    requireArguments().getParcelable(PaymentOptionsActivity.EXTRA_STARTER_ARGS)
-                )
-            },
-            (activity as? AppCompatActivity) ?: this
-        )
+        PaymentOptionsViewModel.Factory {
+            requireNotNull(
+                requireArguments().getParcelable(PaymentOptionsActivity.EXTRA_STARTER_ARGS)
+            )
+        }
     }
 
     override val sheetViewModel: PaymentOptionsViewModel by lazy { activityViewModel }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -42,13 +42,9 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
     }
 
     @VisibleForTesting
-    internal var viewModelFactory: ViewModelProvider.Factory =
-        PaymentSheetViewModel.Factory(
-            { application },
-            { requireNotNull(starterArgs) },
-            this,
-            intent?.extras
-        )
+    internal var viewModelFactory: ViewModelProvider.Factory = PaymentSheetViewModel.Factory {
+        requireNotNull(starterArgs)
+    }
 
     override val viewModel: PaymentSheetViewModel by viewModels { viewModelFactory }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddPaymentMethodFragment.kt
@@ -2,24 +2,16 @@ package com.stripe.android.paymentsheet
 
 import android.os.Bundle
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.activityViewModels
-import androidx.lifecycle.ViewModelProvider
+import kotlinx.coroutines.FlowPreview
 
+@OptIn(FlowPreview::class)
 internal class PaymentSheetAddPaymentMethodFragment() : BaseAddPaymentMethodFragment() {
-    override val viewModelFactory: ViewModelProvider.Factory = PaymentSheetViewModel.Factory(
-        { requireActivity().application },
-        {
-            requireNotNull(
-                requireArguments().getParcelable(PaymentSheetActivity.EXTRA_STARTER_ARGS)
-            )
-        },
-        (activity as? AppCompatActivity) ?: this,
-        (activity as? AppCompatActivity)?.intent?.extras
-    )
 
     override val sheetViewModel by activityViewModels<PaymentSheetViewModel> {
-        viewModelFactory
+        PaymentSheetViewModel.Factory {
+            requireNotNull(requireArguments().getParcelable(PaymentSheetActivity.EXTRA_STARTER_ARGS))
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetListFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetListFragment.kt
@@ -1,21 +1,16 @@
 package com.stripe.android.paymentsheet
 
-import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.activityViewModels
 
 internal class PaymentSheetListFragment() : BasePaymentMethodsListFragment(
     canClickSelectedItem = false
 ) {
     private val activityViewModel by activityViewModels<PaymentSheetViewModel> {
-        PaymentSheetViewModel.Factory(
-            { requireActivity().application },
-            {
-                requireNotNull(
-                    requireArguments().getParcelable(PaymentSheetActivity.EXTRA_STARTER_ARGS)
-                )
-            },
-            (activity as? AppCompatActivity) ?: this
-        )
+        PaymentSheetViewModel.Factory {
+            requireNotNull(
+                requireArguments().getParcelable(PaymentSheetActivity.EXTRA_STARTER_ARGS)
+            )
+        }
     }
 
     override val sheetViewModel: PaymentSheetViewModel by lazy { activityViewModel }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -705,25 +705,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             return viewModel as T
         }
 
-//        @Suppress("UNCHECKED_CAST")
-//        override fun <T : ViewModel> create(
-//            key: String,
-//            modelClass: Class<T>,
-//            savedStateHandle: SavedStateHandle
-//        ): T {
-//            val args = starterArgsSupplier()
-//
-//            val injector = injectWithFallback(args.injectorKey, FallbackInitializeParam(applicationSupplier()))
-//
-//            val subcomponent = subComponentBuilderProvider.get()
-//                .paymentSheetViewModelModule(PaymentSheetViewModelModule(args))
-//                .savedStateHandle(savedStateHandle)
-//                .build()
-//            val viewModel = subcomponent.viewModel
-//            viewModel.injector = requireNotNull(injector as NonFallbackInjector)
-//            return viewModel as T
-//        }
-
         override fun fallbackInitialize(arg: FallbackInitializeParam): Injector {
             val component = DaggerPaymentSheetLauncherComponent
                 .builder()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -73,29 +72,19 @@ internal class USBankAccountFormFragment : Fragment() {
     }
 
     private val paymentSheetViewModelFactory: ViewModelProvider.Factory by lazy {
-        PaymentSheetViewModel.Factory(
-            { requireActivity().application },
-            {
-                requireNotNull(
-                    requireArguments().getParcelable(PaymentSheetActivity.EXTRA_STARTER_ARGS)
-                )
-            },
-            (activity as? AppCompatActivity) ?: this,
-            (activity as? AppCompatActivity)?.intent?.extras
-        )
+        PaymentSheetViewModel.Factory {
+            requireNotNull(
+                requireArguments().getParcelable(PaymentSheetActivity.EXTRA_STARTER_ARGS)
+            )
+        }
     }
 
     private val paymentOptionsViewModelFactory: ViewModelProvider.Factory by lazy {
-        PaymentOptionsViewModel.Factory(
-            { requireActivity().application },
-            {
-                requireNotNull(
-                    requireArguments().getParcelable(PaymentOptionsActivity.EXTRA_STARTER_ARGS)
-                )
-            },
-            (activity as? AppCompatActivity) ?: this,
-            (activity as? AppCompatActivity)?.intent?.extras
-        )
+        PaymentOptionsViewModel.Factory {
+            requireNotNull(
+                requireArguments().getParcelable(PaymentOptionsActivity.EXTRA_STARTER_ARGS)
+            )
+        }
     }
 
     private val sheetViewModel: BaseSheetViewModel<*>? by lazy {
@@ -129,29 +118,25 @@ internal class USBankAccountFormFragment : Fragment() {
     }
 
     private val viewModel by activityViewModels<USBankAccountFormViewModel> {
-        USBankAccountFormViewModel.Factory(
-            applicationSupplier = { requireActivity().application },
-            argsSupplier = {
-                val savedPaymentMethod =
-                    sheetViewModel?.newPaymentSelection as? PaymentSelection.New.USBankAccount
+        USBankAccountFormViewModel.Factory {
+            val savedPaymentMethod =
+                sheetViewModel?.newPaymentSelection as? PaymentSelection.New.USBankAccount
 
-                USBankAccountFormViewModel.Args(
-                    formArgs = formArgs,
-                    isCompleteFlow = sheetViewModel is PaymentSheetViewModel,
-                    clientSecret = clientSecret,
-                    savedPaymentMethod = savedPaymentMethod,
-                    shippingDetails = sheetViewModel?.config?.shippingDetails,
-                    onConfirmStripeIntent = { params ->
-                        (sheetViewModel as? PaymentSheetViewModel)?.confirmStripeIntent(params)
-                    },
-                    onUpdateSelectionAndFinish = { paymentSelection ->
-                        sheetViewModel?.updateSelection(paymentSelection)
-                        sheetViewModel?.onFinish()
-                    }
-                )
-            },
-            owner = this
-        )
+            USBankAccountFormViewModel.Args(
+                formArgs = formArgs,
+                isCompleteFlow = sheetViewModel is PaymentSheetViewModel,
+                clientSecret = clientSecret,
+                savedPaymentMethod = savedPaymentMethod,
+                shippingDetails = sheetViewModel?.config?.shippingDetails,
+                onConfirmStripeIntent = { params ->
+                    (sheetViewModel as? PaymentSheetViewModel)?.confirmStripeIntent(params)
+                },
+                onUpdateSelectionAndFinish = { paymentSelection ->
+                    sheetViewModel?.updateSelection(paymentSelection)
+                    sheetViewModel?.onFinish()
+                }
+            )
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingFragment.kt
@@ -30,18 +30,14 @@ internal class PollingFragment : BottomSheetDialogFragment() {
     }
 
     private val viewModel by viewModels<PollingViewModel> {
-        PollingViewModel.Factory(
-            applicationSupplier = { requireActivity().application },
-            argsSupplier = {
-                PollingViewModel.Args(
-                    clientSecret = args.clientSecret,
-                    timeLimit = args.timeLimitInSeconds.seconds,
-                    initialDelay = args.initialDelayInSeconds.seconds,
-                    maxAttempts = args.maxAttempts,
-                )
-            },
-            owner = this,
-        )
+        PollingViewModel.Factory {
+            PollingViewModel.Args(
+                clientSecret = args.clientSecret,
+                timeLimit = args.timeLimitInSeconds.seconds,
+                initialDelay = args.initialDelayInSeconds.seconds,
+                maxAttempts = args.maxAttempts,
+            )
+        }
     }
 
     override fun onCreateView(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingViewModel.kt
@@ -1,13 +1,13 @@
 package com.stripe.android.paymentsheet.paymentdatacollection.polling
 
 import android.app.Application
-import android.os.Bundle
 import android.os.SystemClock
-import androidx.lifecycle.AbstractSavedStateViewModelFactory
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
-import androidx.savedstate.SavedStateRegistryOwner
+import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.core.injection.DUMMY_INJECTOR_KEY
 import com.stripe.android.core.injection.Injectable
 import com.stripe.android.core.injection.Injector
@@ -17,6 +17,7 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.paymentdatacollection.polling.di.DaggerPollingComponent
 import com.stripe.android.paymentsheet.paymentdatacollection.polling.di.PollingViewModelSubcomponent
 import com.stripe.android.polling.IntentStatusPoller
+import com.stripe.android.utils.requireApplication
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -175,12 +176,8 @@ internal class PollingViewModel @Inject constructor(
     }
 
     internal class Factory(
-        private val applicationSupplier: () -> Application,
         private val argsSupplier: () -> Args,
-        owner: SavedStateRegistryOwner,
-        defaultArgs: Bundle? = null
-    ) : AbstractSavedStateViewModelFactory(owner, defaultArgs),
-        Injectable<Factory.FallbackInitializeParam> {
+    ) : ViewModelProvider.Factory, Injectable<Factory.FallbackInitializeParam> {
         internal data class FallbackInitializeParam(
             val application: Application
         )
@@ -189,14 +186,13 @@ internal class PollingViewModel @Inject constructor(
         lateinit var subcomponentBuilderProvider: Provider<PollingViewModelSubcomponent.Builder>
 
         @Suppress("UNCHECKED_CAST")
-        override fun <T : ViewModel> create(
-            key: String,
-            modelClass: Class<T>,
-            savedStateHandle: SavedStateHandle
-        ): T {
+        override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
             val args = argsSupplier()
 
-            injectWithFallback(args.injectorKey, FallbackInitializeParam(applicationSupplier()))
+            val application = extras.requireApplication()
+            val savedStateHandle = extras.createSavedStateHandle()
+
+            injectWithFallback(args.injectorKey, FallbackInitializeParam(application))
 
             return subcomponentBuilderProvider.get()
                 .args(args)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
@@ -31,7 +31,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
-import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
@@ -285,11 +284,7 @@ internal class PaymentSheetListFragmentTest : PaymentSheetViewModelTestInjection
         fragment: PaymentSheetListFragment
     ): PaymentSheetViewModel {
         return fragment.activityViewModels<PaymentSheetViewModel> {
-            PaymentSheetViewModel.Factory(
-                { fragment.requireActivity().application },
-                { PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY },
-                mock()
-            )
+            PaymentSheetViewModel.Factory { PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY }
         }.value
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request makes use the of new `create(modelClass, extras)` method in `ViewModelProvider.Factory`, allowing us to move away from subclassing `AbstractSavedStateViewModelFactory`. This means we no longer have to provide `Application`, `SavedStateRegistryOwner`, and such when constructing the factory.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Simplify factory construction.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
N/A

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A
