### PR TITLE
Prevent back during payment intent confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 2022-XX-XX
 
+### Payments
+* [CHANGED][5789](https://github.com/stripe/stripe-android/pull/5789) We now disable the back button while confirming intents with `PaymentLauncher` to prevent them from incorrectly being displayed as failed.
+
 ## 20.15.4 - 2022-11-07
 
 ### CardScan

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
@@ -45,6 +46,10 @@ internal class PaymentLauncherConfirmationActivity : AppCompatActivity() {
         }.getOrElse {
             finishWithResult(PaymentResult.Failed(it))
             return
+        }
+
+        onBackPressedDispatcher.addCallback {
+            // Prevent back presses while confirming payment
         }
 
         args.statusBarColor?.let {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where a payment was incorrectly displayed as `failed` when pressing the back button while confirming the payment intent.

We now ignore back presses in the `PaymentLauncherConfirmationActivity`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Resolves https://github.com/stripe/stripe-android/issues/5771

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
N/A

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

[CHANGED] We now disable the back button while confirming intents via `PaymentLauncher` to prevent them from incorrectly being displayed as failed.
