### PR TITLE
Backend driven account selection


### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerScreen.kt
@@ -323,12 +323,11 @@ private fun AccountDropdownItem(
             Spacer(modifier = Modifier.size(8.dp))
             val (title, subtitle) = getAccountTexts(
                 account = account.account,
-                enabled = account.enabled
             )
             Column {
                 Text(
                     text = title,
-                    color = if (account.enabled) {
+                    color = if (account.account.allowSelection) {
                         FinancialConnectionsTheme.colors.textPrimary
                     } else {
                         FinancialConnectionsTheme.colors.textDisabled
@@ -377,7 +376,6 @@ private fun SingleSelectContent(
                 selected = selectedIds.contains(account.account.id),
                 onAccountClicked = onAccountClicked,
                 account = account.account,
-                enabled = account.enabled
             ) {
                 RadioButton(
                     selected = selectedIds.contains(account.account.id),
@@ -407,11 +405,12 @@ private fun MultiSelectContent(
     ) {
         item("select_all_accounts") {
             AccountItem(
-                enabled = true,
                 selected = allAccountsSelected,
                 onAccountClicked = { onSelectAllAccountsClicked() },
                 account = PartnerAccount(
                     id = "select_all_accounts",
+                    allowSelection = true,
+                    allowSelectionMessage = "",
                     authorization = "",
                     category = FinancialConnectionsAccount.Category.UNKNOWN,
                     subcategory = FinancialConnectionsAccount.Subcategory.UNKNOWN,
@@ -432,7 +431,6 @@ private fun MultiSelectContent(
         }
         items(accounts, key = { it.account.id }) { account ->
             AccountItem(
-                enabled = account.enabled,
                 selected = selectedIds.contains(account.account.id),
                 onAccountClicked = onAccountClicked,
                 account = account.account
@@ -453,7 +451,6 @@ private fun MultiSelectContent(
 
 @Composable
 private fun AccountItem(
-    enabled: Boolean,
     selected: Boolean,
     onAccountClicked: (PartnerAccount) -> Unit,
     account: PartnerAccount,
@@ -472,7 +469,7 @@ private fun AccountItem(
                 },
                 shape = RoundedCornerShape(8.dp)
             )
-            .clickable(enabled = enabled) { onAccountClicked(account) }
+            .clickable(enabled = account.allowSelection) { onAccountClicked(account) }
             .padding(padding)
     ) {
         Row(
@@ -482,13 +479,12 @@ private fun AccountItem(
             selectorContent()
             val (title, subtitle) = getAccountTexts(
                 account = account,
-                enabled = enabled
             )
             Spacer(modifier = Modifier.size(16.dp))
             Column {
                 Text(
                     text = title,
-                    color = if (enabled) {
+                    color = if (account.allowSelection) {
                         FinancialConnectionsTheme.colors.textPrimary
                     } else {
                         FinancialConnectionsTheme.colors.textDisabled
@@ -511,7 +507,6 @@ private fun AccountItem(
 @Composable
 private fun getAccountTexts(
     account: PartnerAccount,
-    enabled: Boolean
 ): Pair<String, String?> {
     val balance = if (account.balanceAmount != null && account.currency != null) {
         NumberFormat
@@ -524,7 +519,7 @@ private fun getAccountTexts(
         else -> account.name
     }
     val subtitle = when {
-        enabled.not() -> stringResource(id = R.string.stripe_account_picker_must_be_bank_account)
+        account.allowSelection.not() -> account.allowSelectionMessage
         balance != null -> balance
         account.encryptedNumbers.isNotEmpty() -> account.encryptedNumbers
         else -> null

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerStates.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerStates.kt
@@ -77,10 +77,11 @@ internal class AccountPickerStates : PreviewParameterProvider<AccountPickerState
                     balanceAmount = 1000,
                     displayableAccountNumbers = "1234",
                     currency = "$",
+                    allowSelection = true,
+                    allowSelectionMessage = "",
                     subcategory = FinancialConnectionsAccount.Subcategory.CHECKING,
                     supportedPaymentMethodTypes = emptyList()
                 ),
-                enabled = true,
                 institutionIcon = null
             ),
             PartnerAccountUI(
@@ -89,10 +90,11 @@ internal class AccountPickerStates : PreviewParameterProvider<AccountPickerState
                     category = FinancialConnectionsAccount.Category.CASH,
                     id = "id2",
                     name = "Account 2 - no acct numbers",
+                    allowSelection = true,
+                    allowSelectionMessage = "",
                     subcategory = FinancialConnectionsAccount.Subcategory.SAVINGS,
                     supportedPaymentMethodTypes = emptyList()
                 ),
-                enabled = true,
                 institutionIcon = null
             ),
             PartnerAccountUI(
@@ -103,9 +105,10 @@ internal class AccountPickerStates : PreviewParameterProvider<AccountPickerState
                     name = "Account 3",
                     displayableAccountNumbers = "1234",
                     subcategory = FinancialConnectionsAccount.Subcategory.CREDIT_CARD,
+                    allowSelection = false,
+                    allowSelectionMessage = "Cannot be selected",
                     supportedPaymentMethodTypes = emptyList()
                 ),
-                enabled = false,
                 institutionIcon = null
             ),
             PartnerAccountUI(
@@ -116,9 +119,10 @@ internal class AccountPickerStates : PreviewParameterProvider<AccountPickerState
                     name = "Account 4",
                     displayableAccountNumbers = "1234",
                     subcategory = FinancialConnectionsAccount.Subcategory.CHECKING,
+                    allowSelection = false,
+                    allowSelectionMessage = "Cannot be selected",
                     supportedPaymentMethodTypes = emptyList()
                 ),
-                enabled = false,
                 institutionIcon = null
             )
         )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/accountpicker/AccountPickerViewModel.kt
@@ -77,9 +77,8 @@ internal class AccountPickerViewModel @Inject constructor(
                 AccountPickerState.PartnerAccountUI(
                     account = account,
                     institutionIcon = activeInstitution?.icon?.default,
-                    enabled = account.enabled(manifest)
                 )
-            }.sortedBy { it.enabled }
+            }.sortedBy { it.account.allowSelection }
 
             AccountPickerState.Payload(
                 skipAccountSelection = activeAuthSession.skipAccountSelection == true,
@@ -122,7 +121,7 @@ internal class AccountPickerViewModel @Inject constructor(
                 payload.selectionMode == SelectionMode.DROPDOWN -> setState {
                     copy(
                         selectedIds = setOfNotNull(
-                            payload.accounts.firstOrNull { it.enabled }?.account?.id
+                            payload.accounts.firstOrNull { it.account.allowSelection }?.account?.id
                         )
                     )
                 }
@@ -167,11 +166,6 @@ internal class AccountPickerViewModel @Inject constructor(
 
             else -> SelectionMode.CHECKBOXES
         }
-
-    private fun PartnerAccount.enabled(
-        manifest: FinancialConnectionsSessionManifest
-    ) = manifest.paymentMethodType == null ||
-        supportedPaymentMethodTypes.contains(manifest.paymentMethodType)
 
     fun onAccountClicked(account: PartnerAccount) {
         withState { state ->
@@ -309,7 +303,7 @@ internal data class AccountPickerState(
     ) {
 
         val selectableAccounts
-            get() = accounts.filter { it.enabled }
+            get() = accounts.filter { it.account.allowSelection }
 
         val subtitle: TextResource?
             get() = when {
@@ -331,7 +325,6 @@ internal data class AccountPickerState(
 
     data class PartnerAccountUI(
         val account: PartnerAccount,
-        val enabled: Boolean,
         val institutionIcon: String?
     )
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/AccessibleDataCallout.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/common/AccessibleDataCallout.kt
@@ -282,6 +282,8 @@ internal fun AccessibleDataCalloutWithManyAccountsPreview() {
                     category = FinancialConnectionsAccount.Category.CASH,
                     id = "id1",
                     name = "Account 1 - no acct numbers",
+                    allowSelection = true,
+                    allowSelectionMessage = "",
                     subcategory = FinancialConnectionsAccount.Subcategory.CHECKING,
                     supportedPaymentMethodTypes = emptyList()
                 ),
@@ -290,6 +292,8 @@ internal fun AccessibleDataCalloutWithManyAccountsPreview() {
                     category = FinancialConnectionsAccount.Category.CASH,
                     id = "id2",
                     name = "Account 2 - no acct numbers",
+                    allowSelection = true,
+                    allowSelectionMessage = "",
                     subcategory = FinancialConnectionsAccount.Subcategory.SAVINGS,
                     supportedPaymentMethodTypes = emptyList()
                 ),
@@ -298,6 +302,8 @@ internal fun AccessibleDataCalloutWithManyAccountsPreview() {
                     category = FinancialConnectionsAccount.Category.CASH,
                     id = "id3",
                     name = "Account 3 - no acct numbers",
+                    allowSelection = true,
+                    allowSelectionMessage = "",
                     subcategory = FinancialConnectionsAccount.Subcategory.SAVINGS,
                     supportedPaymentMethodTypes = emptyList()
                 ),
@@ -306,6 +312,8 @@ internal fun AccessibleDataCalloutWithManyAccountsPreview() {
                     category = FinancialConnectionsAccount.Category.CASH,
                     id = "id4",
                     name = "Account 4 - no acct numbers",
+                    allowSelection = true,
+                    allowSelectionMessage = "",
                     subcategory = FinancialConnectionsAccount.Subcategory.SAVINGS,
                     supportedPaymentMethodTypes = emptyList()
                 ),
@@ -314,6 +322,8 @@ internal fun AccessibleDataCalloutWithManyAccountsPreview() {
                     category = FinancialConnectionsAccount.Category.CASH,
                     id = "id5",
                     name = "Account 5 - no acct numbers",
+                    allowSelection = true,
+                    allowSelectionMessage = "",
                     subcategory = FinancialConnectionsAccount.Subcategory.SAVINGS,
                     supportedPaymentMethodTypes = emptyList()
                 )
@@ -360,6 +370,8 @@ internal fun AccessibleDataCalloutWithMultipleAccountsPreview() {
                     displayableAccountNumbers = "1234",
                     currency = "$",
                     subcategory = FinancialConnectionsAccount.Subcategory.CHECKING,
+                    allowSelection = true,
+                    allowSelectionMessage = "",
                     supportedPaymentMethodTypes = emptyList()
                 ),
                 PartnerAccount(
@@ -368,6 +380,8 @@ internal fun AccessibleDataCalloutWithMultipleAccountsPreview() {
                     id = "id2",
                     name = "Account 2 - no acct numbers",
                     subcategory = FinancialConnectionsAccount.Subcategory.SAVINGS,
+                    allowSelection = true,
+                    allowSelectionMessage = "",
                     supportedPaymentMethodTypes = emptyList()
                 )
             ),
@@ -412,6 +426,8 @@ internal fun AccessibleDataCalloutWithOneAccountPreview() {
                     displayableAccountNumbers = "1234",
                     currency = "$",
                     subcategory = FinancialConnectionsAccount.Subcategory.CHECKING,
+                    allowSelection = true,
+                    allowSelectionMessage = "",
                     supportedPaymentMethodTypes = emptyList()
                 )
             ),

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/success/SuccessScreen.kt
@@ -207,6 +207,8 @@ internal fun SuccessScreenPreview() {
                     category = FinancialConnectionsAccount.Category.CASH,
                     id = "id2",
                     name = "Account 2 - no acct numbers",
+                    allowSelection = true,
+                    allowSelectionMessage = "",
                     subcategory = FinancialConnectionsAccount.Subcategory.SAVINGS,
                     supportedPaymentMethodTypes = emptyList()
                 ),
@@ -215,6 +217,8 @@ internal fun SuccessScreenPreview() {
                     category = FinancialConnectionsAccount.Category.CASH,
                     id = "id3",
                     name = "Account 3",
+                    allowSelection = true,
+                    allowSelectionMessage = "",
                     displayableAccountNumbers = "1234",
                     subcategory = FinancialConnectionsAccount.Subcategory.CREDIT_CARD,
                     supportedPaymentMethodTypes = emptyList()
@@ -224,6 +228,8 @@ internal fun SuccessScreenPreview() {
                     category = FinancialConnectionsAccount.Category.CASH,
                     id = "id4",
                     name = "Account 4",
+                    allowSelection = true,
+                    allowSelectionMessage = "",
                     displayableAccountNumbers = "1234",
                     subcategory = FinancialConnectionsAccount.Subcategory.CHECKING,
                     supportedPaymentMethodTypes = emptyList()

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/PartnerAccountsList.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/PartnerAccountsList.kt
@@ -79,6 +79,10 @@ internal data class PartnerAccount(
 
     @SerialName(value = "institution_name") val institutionName: String? = null,
 
+    @SerialName(value = "allow_selection") val allowSelection: Boolean,
+
+    @SerialName(value = "allow_selection_message") val allowSelectionMessage: String? = null,
+
     @SerialName(value = "institution_url") val institutionUrl: String? = null,
 
     @SerialName(value = "linked_account_id") val linkedAccountId: String? = null,


### PR DESCRIPTION
# Summary

- Removes client logic determining wether or not an account can be selected.
- Consumes it from API.

# Motivation
:notebook_with_decorative_cover: &nbsp;**Backend driven account selection**
:globe_with_meridians: &nbsp;[BANKCON-5590](https://jira.corp.stripe.com/browse/BANKCON-5590)

> <https://docs.google.com/spreadsheets/d/1xJI0sAVFpwVU7UzCvACsgSb_nFFaNhKmJ-1RdW34-NQ/edit#gid=0>
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->