### PR TITLE
Remove `Context` usage from PaymentSheet view models

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/Amount.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/Amount.kt
@@ -3,6 +3,9 @@ package com.stripe.android.ui.core
 import android.content.res.Resources
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.ResolvableString
+import com.stripe.android.core.resolvableString
+import com.stripe.android.core.resolve
 import kotlinx.parcelize.Parcelize
 
 /**
@@ -15,9 +18,15 @@ data class Amount(val value: Long, val currencyCode: String) : Parcelable {
     /**
      * Builds a localized label in the format "Pay $10.99".
      */
-    fun buildPayButtonLabel(resources: Resources) =
-        resources.getString(
+    fun buildPayButtonLabel(resources: Resources): String = buildPayButtonLabel().resolve(resources)
+
+    /**
+     * Builds a localized label in the format "Pay $10.99".
+     */
+    fun buildPayButtonLabel(): ResolvableString {
+        return resolvableString(
             R.string.stripe_pay_button_amount,
             CurrencyFormatter.format(value, currencyCode)
         )
+    }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/model/TransformGoogleToStripeAddress.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/model/TransformGoogleToStripeAddress.kt
@@ -188,6 +188,7 @@ class DefaultTransformGoogleToStripeAddress @Inject constructor(
     private val context: Context,
 ) : TransformGoogleToStripeAddress {
 
+    @Suppress("LongMethod", "ComplexMethod")
     override fun invoke(place: Place): com.stripe.android.model.Address {
         var address = Address()
         val addressLine1 = AddressLine1()

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/autocomplete/model/DefaultTransformGoogleToStripeAddressTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/autocomplete/model/DefaultTransformGoogleToStripeAddressTest.kt
@@ -10,7 +10,8 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-class TransformGoogleToStripeAddressTest {
+@Suppress("LongMethod")
+class DefaultTransformGoogleToStripeAddressTest {
 
     private val context = ApplicationProvider.getApplicationContext<Context>()
 
@@ -65,7 +66,8 @@ class TransformGoogleToStripeAddressTest {
             """.trimIndent()
         )
 
-        val stripeAddress = place.transformGoogleToStripeAddress(context)
+        val transform = DefaultTransformGoogleToStripeAddress(context)
+        val stripeAddress = transform(place)
 
         assertThat(stripeAddress).isEqualTo(
             Address(
@@ -130,7 +132,8 @@ class TransformGoogleToStripeAddressTest {
             """.trimIndent()
         )
 
-        val stripeAddress = place.transformGoogleToStripeAddress(context)
+        val transform = DefaultTransformGoogleToStripeAddress(context)
+        val stripeAddress = transform(place)
 
         assertThat(stripeAddress).isEqualTo(
             Address(
@@ -190,7 +193,8 @@ class TransformGoogleToStripeAddressTest {
             """.trimIndent()
         )
 
-        val stripeAddress = place.transformGoogleToStripeAddress(context)
+        val transform = DefaultTransformGoogleToStripeAddress(context)
+        val stripeAddress = transform(place)
 
         assertThat(stripeAddress).isEqualTo(
             Address(
@@ -250,7 +254,8 @@ class TransformGoogleToStripeAddressTest {
             """.trimIndent()
         )
 
-        val stripeAddress = place.transformGoogleToStripeAddress(context)
+        val transform = DefaultTransformGoogleToStripeAddress(context)
+        val stripeAddress = transform(place)
 
         assertThat(stripeAddress).isEqualTo(
             Address(
@@ -320,7 +325,8 @@ class TransformGoogleToStripeAddressTest {
             """.trimIndent()
         )
 
-        val stripeAddress = place.transformGoogleToStripeAddress(context)
+        val transform = DefaultTransformGoogleToStripeAddress(context)
+        val stripeAddress = transform(place)
 
         assertThat(stripeAddress).isEqualTo(
             Address(
@@ -385,7 +391,8 @@ class TransformGoogleToStripeAddressTest {
             """.trimIndent()
         )
 
-        val stripeAddress = place.transformGoogleToStripeAddress(context)
+        val transform = DefaultTransformGoogleToStripeAddress(context)
+        val stripeAddress = transform(place)
 
         assertThat(stripeAddress).isEqualTo(
             Address(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
@@ -12,7 +12,10 @@ import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherE
 import com.stripe.android.paymentsheet.addresselement.analytics.DefaultAddressLauncherEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
+import com.stripe.android.ui.core.elements.autocomplete.model.DefaultTransformGoogleToStripeAddress
+import com.stripe.android.ui.core.elements.autocomplete.model.TransformGoogleToStripeAddress
 import com.stripe.android.ui.core.injection.FormControllerSubcomponent
+import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import javax.inject.Named
@@ -26,53 +29,62 @@ import javax.inject.Singleton
         FormControllerSubcomponent::class
     ]
 )
-internal class AddressElementViewModelModule {
-    @Provides
-    @Singleton
-    fun provideEventReporterMode(): EventReporter.Mode = EventReporter.Mode.Custom
+internal abstract class AddressElementViewModelModule {
 
-    /**
-     * This module is only used when the app is recovered from a killed process,
-     * where no [Injector] is available. Returns a dummy key instead.
-     */
-    @Provides
-    @InjectorKey
-    fun provideDummyInjectorKey(): String = DUMMY_INJECTOR_KEY
+    @Binds
+    abstract fun bindsTransformGoogleToStripeAddress(
+        impl: DefaultTransformGoogleToStripeAddress,
+    ): TransformGoogleToStripeAddress
 
-    @Provides
-    @Named(PUBLISHABLE_KEY)
-    @Singleton
-    fun providesPublishableKey(
-        args: AddressElementActivityContract.Args
-    ): String = args.publishableKey
+    companion object {
 
-    @Provides
-    @Singleton
-    internal fun provideAnalyticsRequestFactory(
-        context: Context,
-        @Named(PUBLISHABLE_KEY) publishableKey: String
-    ): AnalyticsRequestFactory = AnalyticsRequestFactory(
-        packageManager = context.packageManager,
-        packageName = context.packageName.orEmpty(),
-        packageInfo = context.packageInfo,
-        publishableKeyProvider = { publishableKey }
-    )
+        @Provides
+        @Singleton
+        fun provideEventReporterMode(): EventReporter.Mode = EventReporter.Mode.Custom
 
-    @Provides
-    @Singleton
-    internal fun provideGooglePlacesClient(
-        context: Context,
-        args: AddressElementActivityContract.Args
-    ): PlacesClientProxy? = args.config?.googlePlacesApiKey?.let {
-        PlacesClientProxy.create(
-            context,
-            it
+        /**
+         * This module is only used when the app is recovered from a killed process,
+         * where no [Injector] is available. Returns a dummy key instead.
+         */
+        @Provides
+        @InjectorKey
+        fun provideDummyInjectorKey(): String = DUMMY_INJECTOR_KEY
+
+        @Provides
+        @Named(PUBLISHABLE_KEY)
+        @Singleton
+        fun providesPublishableKey(
+            args: AddressElementActivityContract.Args
+        ): String = args.publishableKey
+
+        @Provides
+        @Singleton
+        internal fun provideAnalyticsRequestFactory(
+            context: Context,
+            @Named(PUBLISHABLE_KEY) publishableKey: String
+        ): AnalyticsRequestFactory = AnalyticsRequestFactory(
+            packageManager = context.packageManager,
+            packageName = context.packageName.orEmpty(),
+            packageInfo = context.packageInfo,
+            publishableKeyProvider = { publishableKey }
         )
-    }
 
-    @Provides
-    @Singleton
-    fun provideEventReporter(
-        defaultAddressLauncherEventReporter: DefaultAddressLauncherEventReporter
-    ): AddressLauncherEventReporter = defaultAddressLauncherEventReporter
+        @Provides
+        @Singleton
+        internal fun provideGooglePlacesClient(
+            context: Context,
+            args: AddressElementActivityContract.Args
+        ): PlacesClientProxy? = args.config?.googlePlacesApiKey?.let {
+            PlacesClientProxy.create(
+                context,
+                it
+            )
+        }
+
+        @Provides
+        @Singleton
+        fun provideEventReporter(
+            defaultAddressLauncherEventReporter: DefaultAddressLauncherEventReporter
+        ): AddressLauncherEventReporter = defaultAddressLauncherEventReporter
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.injection
 
+import android.app.Application
 import android.content.Context
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.injection.ENABLE_LOGGING
@@ -18,6 +19,8 @@ import dagger.Provides
 import javax.inject.Named
 import javax.inject.Provider
 import javax.inject.Singleton
+
+internal const val APPLICATION_NAME_PROVIDER = "APPLICATION_NAME_PROVIDER"
 
 @Module
 internal abstract class PaymentSheetCommonModule {
@@ -56,12 +59,23 @@ internal abstract class PaymentSheetCommonModule {
 
         @Provides
         @Named(STRIPE_ACCOUNT_ID)
-        fun provideStripeAccountId(paymentConfiguration: Provider<PaymentConfiguration>):
-            () -> String? = { paymentConfiguration.get().stripeAccountId }
+        fun provideStripeAccountId(
+            paymentConfiguration: Provider<PaymentConfiguration>,
+        ): () -> String? = { paymentConfiguration.get().stripeAccountId }
 
         @Provides
         @Singleton
         @Named(ENABLE_LOGGING)
         fun provideEnabledLogging(): Boolean = BuildConfig.DEBUG
+
+        @Provides
+        @Singleton
+        @Named(APPLICATION_NAME_PROVIDER)
+        fun provideApplicationNameProvider(appContext: Context): () -> String {
+            return {
+                val application = appContext as Application
+                application.applicationInfo.loadLabel(application.packageManager).toString()
+            }
+        }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.model
 
 import android.content.res.Resources
+import com.stripe.android.core.resolve
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.ui.createCardLabel
 import com.stripe.android.paymentsheet.ui.getCardBrandIcon
@@ -55,7 +56,7 @@ internal class PaymentOptionFactory(
             is PaymentSelection.New.USBankAccount -> {
                 PaymentOption(
                     drawableResourceId = selection.iconResource,
-                    label = selection.labelResource
+                    label = selection.labelResource.resolve(resources),
                 )
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.model
 
 import android.os.Parcelable
 import androidx.annotation.DrawableRes
+import com.stripe.android.core.ResolvableString
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConsumerPaymentDetails
@@ -50,7 +51,7 @@ internal sealed class PaymentSelection : Parcelable {
 
         @Parcelize
         data class USBankAccount(
-            val labelResource: String,
+            val labelResource: ResolvableString,
             @DrawableRes val iconResource: Int,
             val bankName: String,
             val last4: String,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/ACHText.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/ACHText.kt
@@ -1,18 +1,25 @@
 package com.stripe.android.paymentsheet.paymentdatacollection.ach
 
-import android.content.Context
+import com.stripe.android.core.ResolvableString
+import com.stripe.android.core.resolvableString
 import com.stripe.android.paymentsheet.R
 
 /**
  * Temporary hack to get mandate text to display properly until translations are fixed
  */
 internal object ACHText {
-    fun getContinueMandateText(context: Context): String {
-        return context.getString(
-            R.string.stripe_paymentsheet_ach_continue_mandate
-        ).replace(
-            "<terms>",
-            "<a href=\"https://stripe.com/ach-payments/authorization\">"
-        ).replace("</terms>", "</a>")
+    fun getContinueMandateText(): ResolvableString {
+        return resolvableString(
+            id = R.string.stripe_paymentsheet_ach_continue_mandate,
+            transform = {
+                it.replace(
+                    oldValue = "<terms>",
+                    newValue = "<a href=\"https://stripe.com/ach-payments/authorization\">",
+                ).replace(
+                    oldValue = "</terms>",
+                    newValue = "</a>",
+                )
+            }
+        )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormFragment.kt
@@ -36,6 +36,10 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import com.stripe.android.core.ResolvableString
+import com.stripe.android.core.resolvableString
+import com.stripe.android.core.resolve
+import com.stripe.android.core.toResolvableString
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.paymentsheet.PaymentOptionsActivity
@@ -185,12 +189,12 @@ internal class USBankAccountFormFragment : Fragment() {
                     .collect { saved ->
                         updateMandateText(
                             if (saved) {
-                                getString(
+                                resolvableString(
                                     R.string.stripe_paymentsheet_ach_save_mandate,
                                     viewModel.formattedMerchantName()
                                 )
                             } else {
-                                ACHText.getContinueMandateText(requireContext())
+                                ACHText.getContinueMandateText()
                             }
                         )
                     }
@@ -437,7 +441,7 @@ internal class USBankAccountFormFragment : Fragment() {
     }
 
     private fun updatePrimaryButton(
-        text: String?,
+        text: ResolvableString?,
         onClick: () -> Unit,
         shouldShowProcessingWhenClicked: Boolean = true,
         enabled: Boolean = true,
@@ -466,7 +470,7 @@ internal class USBankAccountFormFragment : Fragment() {
         )
     }
 
-    private fun updateMandateText(mandateText: String?) {
+    private fun updateMandateText(mandateText: ResolvableString?) {
         val microdepositsText =
             if (viewModel.currentScreenState.value
                 is USBankAccountFormScreenState.VerifyWithMicrodeposits
@@ -478,13 +482,15 @@ internal class USBankAccountFormFragment : Fragment() {
             } else {
                 ""
             }
+
         val updatedText = mandateText?.let {
             """
                 $microdepositsText
                 
-                $mandateText
+                ${mandateText.resolve(requireContext())}
             """.trimIndent()
-        } ?: run { null }
-        sheetViewModel?.updateBelowButtonText(updatedText)
+        }
+
+        sheetViewModel?.updateBelowButtonText(updatedText?.toResolvableString())
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormScreenState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormScreenState.kt
@@ -1,23 +1,24 @@
 package com.stripe.android.paymentsheet.paymentdatacollection.ach
 
 import androidx.annotation.StringRes
+import com.stripe.android.core.ResolvableString
 import com.stripe.android.financialconnections.model.BankAccount
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
 
 internal sealed class USBankAccountFormScreenState(
     @StringRes open val error: Int? = null
 ) {
-    abstract val primaryButtonText: String?
-    abstract val mandateText: String?
+    abstract val primaryButtonText: ResolvableString?
+    abstract val mandateText: ResolvableString?
 
     class NameAndEmailCollection(
         @StringRes override val error: Int? = null,
         val name: String,
         val email: String?,
-        override val primaryButtonText: String?
+        override val primaryButtonText: ResolvableString?
     ) : USBankAccountFormScreenState() {
 
-        override val mandateText: String? = null
+        override val mandateText: ResolvableString? = null
 
         override fun updateInputs(name: String, email: String?, saveForFutureUsage: Boolean) =
             NameAndEmailCollection(
@@ -34,8 +35,8 @@ internal sealed class USBankAccountFormScreenState(
         val paymentAccount: FinancialConnectionsAccount,
         val financialConnectionsSessionId: String,
         val intentId: String,
-        override val primaryButtonText: String?,
-        override val mandateText: String?,
+        override val primaryButtonText: ResolvableString?,
+        override val mandateText: ResolvableString?,
         val saveForFutureUsage: Boolean
     ) : USBankAccountFormScreenState() {
         override fun updateInputs(name: String, email: String?, saveForFutureUsage: Boolean) =
@@ -48,8 +49,8 @@ internal sealed class USBankAccountFormScreenState(
         val paymentAccount: BankAccount,
         val financialConnectionsSessionId: String,
         val intentId: String,
-        override val primaryButtonText: String?,
-        override val mandateText: String?,
+        override val primaryButtonText: ResolvableString?,
+        override val mandateText: ResolvableString?,
         val saveForFutureUsage: Boolean
     ) : USBankAccountFormScreenState() {
         override fun updateInputs(name: String, email: String?, saveForFutureUsage: Boolean) =
@@ -63,8 +64,8 @@ internal sealed class USBankAccountFormScreenState(
         val intentId: String,
         val bankName: String,
         val last4: String?,
-        override val primaryButtonText: String?,
-        override val mandateText: String?,
+        override val primaryButtonText: ResolvableString?,
+        override val mandateText: ResolvableString?,
         val saveForFutureUsage: Boolean
     ) : USBankAccountFormScreenState() {
         override fun updateInputs(name: String, email: String?, saveForFutureUsage: Boolean) =

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -11,12 +11,14 @@ import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ResolvableString
 import com.stripe.android.core.injection.DUMMY_INJECTOR_KEY
 import com.stripe.android.core.injection.Injectable
 import com.stripe.android.core.injection.Injector
 import com.stripe.android.core.injection.InjectorKey
 import com.stripe.android.core.injection.injectWithFallback
 import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.core.resolvableString
 import com.stripe.android.financialconnections.model.BankAccount
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
 import com.stripe.android.model.ConfirmStripeIntentParams
@@ -55,7 +57,6 @@ import javax.inject.Provider
 
 internal class USBankAccountFormViewModel @Inject internal constructor(
     private val args: Args,
-    private val application: Application,
     private val stripeRepository: StripeRepository,
     private val lazyPaymentConfig: Provider<PaymentConfiguration>,
     private val savedStateHandle: SavedStateHandle
@@ -80,9 +81,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
             USBankAccountFormScreenState.NameAndEmailCollection(
                 name = name.value,
                 email = email.value,
-                primaryButtonText = application.getString(
-                    R.string.stripe_continue_button_label
-                )
+                primaryButtonText = resolvableString(R.string.stripe_continue_button_label),
             )
         )
     val currentScreenState: StateFlow<USBankAccountFormScreenState>
@@ -259,9 +258,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
                 error = error,
                 name = name.value,
                 email = email.value,
-                primaryButtonText = application.getString(
-                    R.string.stripe_continue_button_label
-                )
+                primaryButtonText = resolvableString(R.string.stripe_continue_button_label),
             )
         }
     }
@@ -354,7 +351,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
                     }
 
                     val paymentSelection = PaymentSelection.New.USBankAccount(
-                        labelResource = application.getString(
+                        labelResource = resolvableString(
                             R.string.paymentsheet_payment_method_item_card_number,
                             last4
                         ),
@@ -417,31 +414,27 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         }
     }
 
-    private fun buildPrimaryButtonText(): String? {
+    private fun buildPrimaryButtonText(): ResolvableString? {
         return when {
             args.isCompleteFlow -> {
                 if (args.clientSecret is PaymentIntentClientSecret) {
-                    args.formArgs.amount?.buildPayButtonLabel(application.resources)
+                    args.formArgs.amount?.buildPayButtonLabel()
                 } else {
-                    application.getString(
-                        R.string.stripe_setup_button_label
-                    )
+                    resolvableString(R.string.stripe_setup_button_label)
                 }
             }
-            else -> application.getString(
-                R.string.stripe_continue_button_label
-            )
+            else -> resolvableString(R.string.stripe_continue_button_label)
         }
     }
 
-    private fun buildMandateText(): String {
+    private fun buildMandateText(): ResolvableString {
         return if (saveForFutureUse.value) {
-            application.getString(
+            resolvableString(
                 R.string.stripe_paymentsheet_ach_save_mandate,
                 formattedMerchantName()
             )
         } else {
-            ACHText.getContinueMandateText(application)
+            ACHText.getContinueMandateText()
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -32,6 +32,7 @@ import androidx.core.view.isVisible
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.stripe.android.core.resolve
 import com.stripe.android.link.ui.verification.LinkVerificationDialog
 import com.stripe.android.paymentsheet.BottomSheetController
 import com.stripe.android.paymentsheet.R
@@ -214,7 +215,7 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
         userMessage?.message.let { message ->
             viewModel.config?.appearance?.let {
                 messageView.text = createTextSpanFromTextStyle(
-                    text = message,
+                    text = message?.resolve(this),
                     context = this,
                     fontSizeDp = (
                         it.typography.sizeScaleFactor
@@ -256,7 +257,7 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
                 primaryButton.setOnClickListener {
                     state.onClick?.invoke()
                 }
-                primaryButton.setLabel(state.label)
+                primaryButton.setLabel(state.label?.resolve(this))
                 primaryButton.isVisible = state.visible
                 bottomSpacer.isVisible = state.visible
             } ?: run {
@@ -291,7 +292,7 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
                 notesView.setContent {
                     PaymentsTheme {
                         Html(
-                            html = text,
+                            html = text.resolve(this),
                             color = MaterialTheme.paymentsColors.subtitle,
                             style = MaterialTheme.typography.body1.copy(
                                 textAlign = TextAlign.Center

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
@@ -18,6 +18,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.withStyledAttributes
 import androidx.core.view.isVisible
 import androidx.core.view.setPadding
+import com.stripe.android.core.ResolvableString
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.databinding.PrimaryButtonBinding
 import com.stripe.android.ui.core.PaymentsTheme
@@ -220,7 +221,7 @@ internal class PrimaryButton @JvmOverloads constructor(
      * Used to override the current UI state of the Primary Button
      */
     internal data class UIState(
-        val label: String?,
+        val label: ResolvableString?,
         val onClick: (() -> Unit)?,
         val enabled: Boolean,
         val visible: Boolean

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -20,6 +20,8 @@ import com.stripe.android.core.injection.DUMMY_INJECTOR_KEY
 import com.stripe.android.core.injection.Injectable
 import com.stripe.android.core.injection.NonFallbackInjector
 import com.stripe.android.core.injection.WeakMapInjectorRegistry
+import com.stripe.android.core.resolvableString
+import com.stripe.android.core.toResolvableString
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.model.PaymentIntentFixtures
@@ -99,7 +101,7 @@ internal class PaymentOptionsActivityTest {
     private val viewModel = createViewModel()
 
     private val primaryButtonUIState = PrimaryButton.UIState(
-        label = "Test",
+        label = "Test".toResolvableString(),
         onClick = {},
         enabled = true,
         visible = true
@@ -378,7 +380,7 @@ internal class PaymentOptionsActivityTest {
             it.onActivity { activity ->
                 viewModel.updatePrimaryButtonUIState(
                     primaryButtonUIState.copy(
-                        label = "Some text"
+                        label = "Some text".toResolvableString()
                     )
                 )
                 assertThat(activity.viewBinding.continueButton.externalLabel).isEqualTo("Some text")
@@ -395,7 +397,7 @@ internal class PaymentOptionsActivityTest {
             it.onActivity { activity ->
                 viewModel.updatePrimaryButtonUIState(
                     primaryButtonUIState.copy(
-                        label = "Some text",
+                        label = "Some text".toResolvableString(),
                         enabled = false
                     )
                 )
@@ -417,7 +419,7 @@ internal class PaymentOptionsActivityTest {
         ).use {
             it.onActivity { activity ->
                 viewModel.updateBelowButtonText(
-                    ApplicationProvider.getApplicationContext<Context>().getString(
+                    resolvableString(
                         com.stripe.android.paymentsheet.R.string.stripe_paymentsheet_payment_method_us_bank_account
                     )
                 )
@@ -513,7 +515,7 @@ internal class PaymentOptionsActivityTest {
             eventReporter = eventReporter,
             customerRepository = FakeCustomerRepository(),
             workContext = testDispatcher,
-            application = ApplicationProvider.getApplicationContext(),
+            applicationNameProvider = { "AppName" },
             logger = Logger.noop(),
             injectorKey = DUMMY_INJECTOR_KEY,
             lpmResourceRepository = StaticLpmResourceRepository(lpmRepository),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet
 import androidx.appcompat.app.AppCompatActivity
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.SavedStateHandle
-import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.DUMMY_INJECTOR_KEY
@@ -297,13 +296,13 @@ internal class PaymentOptionsViewModelTest {
         eventReporter = eventReporter,
         customerRepository = customerRepository,
         workContext = testDispatcher,
-        application = ApplicationProvider.getApplicationContext(),
         logger = Logger.noop(),
         injectorKey = DUMMY_INJECTOR_KEY,
         lpmResourceRepository = lpmResourceRepository,
         addressResourceRepository = mock(),
         savedStateHandle = SavedStateHandle(),
-        linkLauncher = linkLauncher
+        linkLauncher = linkLauncher,
+        applicationNameProvider = { "AppName" },
     )
 
     private companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTestInjection.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTestInjection.kt
@@ -81,7 +81,7 @@ internal open class PaymentOptionsViewModelTestInjection {
             eventReporter = eventReporter,
             customerRepository = FakeCustomerRepository(paymentMethods),
             workContext = testDispatcher,
-            application = ApplicationProvider.getApplicationContext(),
+            applicationNameProvider = { "AppName" },
             logger = Logger.noop(),
             injectorKey = injectorKey,
             lpmResourceRepository = StaticLpmResourceRepository(lpmRepository),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -17,6 +17,8 @@ import com.stripe.android.core.injection.DUMMY_INJECTOR_KEY
 import com.stripe.android.core.injection.Injectable
 import com.stripe.android.core.injection.NonFallbackInjector
 import com.stripe.android.core.injection.WeakMapInjectorRegistry
+import com.stripe.android.core.resolvableString
+import com.stripe.android.core.toResolvableString
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContract
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
@@ -132,7 +134,7 @@ internal class PaymentSheetActivityTest {
     )
 
     private val primaryButtonUIState = PrimaryButton.UIState(
-        label = "Test",
+        label = "Test".toResolvableString(),
         onClick = {},
         enabled = true,
         visible = true
@@ -775,7 +777,7 @@ internal class PaymentSheetActivityTest {
             viewModel.checkoutIdentifier = CheckoutIdentifier.SheetTopGooglePay
             val errorMessage = "Error message"
             viewModel._viewState.value =
-                PaymentSheetViewState.Reset(BaseSheetViewModel.UserErrorMessage(errorMessage))
+                PaymentSheetViewState.Reset(BaseSheetViewModel.UserErrorMessage(errorMessage.toResolvableString()))
 
             assertThat(activity.viewBinding.topMessage.isVisible).isTrue()
             assertThat(activity.viewBinding.topMessage.text.toString()).isEqualTo(errorMessage)
@@ -796,7 +798,7 @@ internal class PaymentSheetActivityTest {
 
             val errorMessage = "Error message"
             viewModel._viewState.value =
-                PaymentSheetViewState.Reset(BaseSheetViewModel.UserErrorMessage(errorMessage))
+                PaymentSheetViewState.Reset(BaseSheetViewModel.UserErrorMessage(errorMessage.toResolvableString()))
 
             assertThat(activity.viewBinding.message.isVisible).isTrue()
             assertThat(activity.viewBinding.message.text.toString()).isEqualTo(errorMessage)
@@ -812,7 +814,7 @@ internal class PaymentSheetActivityTest {
 
             viewModel.checkoutIdentifier = CheckoutIdentifier.SheetTopGooglePay
             viewModel._viewState.value =
-                PaymentSheetViewState.Reset(BaseSheetViewModel.UserErrorMessage(errorMessage))
+                PaymentSheetViewState.Reset(BaseSheetViewModel.UserErrorMessage(errorMessage.toResolvableString()))
 
             assertThat(activity.viewBinding.message.isVisible).isFalse()
             assertThat(activity.viewBinding.message.text.isNullOrEmpty()).isTrue()
@@ -842,7 +844,7 @@ internal class PaymentSheetActivityTest {
 
             val errorMessage = "Error message"
             viewModel._viewState.value =
-                PaymentSheetViewState.Reset(BaseSheetViewModel.UserErrorMessage(errorMessage))
+                PaymentSheetViewState.Reset(BaseSheetViewModel.UserErrorMessage(errorMessage.toResolvableString()))
 
             assertThat(activity.viewBinding.message.isVisible).isTrue()
             assertThat(activity.viewBinding.message.text.toString()).isEqualTo(errorMessage)
@@ -858,7 +860,7 @@ internal class PaymentSheetActivityTest {
 
             viewModel.checkoutIdentifier = CheckoutIdentifier.SheetTopGooglePay
             viewModel._viewState.value =
-                PaymentSheetViewState.Reset(BaseSheetViewModel.UserErrorMessage(errorMessage))
+                PaymentSheetViewState.Reset(BaseSheetViewModel.UserErrorMessage(errorMessage.toResolvableString()))
 
             assertThat(activity.viewBinding.message.isVisible).isFalse()
             assertThat(activity.viewBinding.message.text.isNullOrEmpty()).isTrue()
@@ -939,7 +941,7 @@ internal class PaymentSheetActivityTest {
 
             viewModel.updatePrimaryButtonUIState(
                 primaryButtonUIState.copy(
-                    label = "Some text"
+                    label = "Some text".toResolvableString()
                 )
             )
             assertThat(activity.viewBinding.buyButton.externalLabel).isEqualTo("Some text")
@@ -957,7 +959,7 @@ internal class PaymentSheetActivityTest {
 
             viewModel.updatePrimaryButtonUIState(
                 primaryButtonUIState.copy(
-                    label = "Some text",
+                    label = "Some text".toResolvableString(),
                     enabled = false
                 )
             )
@@ -979,7 +981,7 @@ internal class PaymentSheetActivityTest {
             idleLooper()
 
             viewModel.updateBelowButtonText(
-                context.getString(
+                resolvableString(
                     R.string.stripe_paymentsheet_payment_method_us_bank_account
                 )
             )
@@ -1049,12 +1051,12 @@ internal class PaymentSheetActivityTest {
         registerFormViewModelInjector()
 
         PaymentSheetViewModel(
-            ApplicationProvider.getApplicationContext(),
             PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY,
             eventReporter,
             { PaymentConfiguration(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY) },
             StripeIntentRepository.Static(paymentIntent),
             StripeIntentValidator(),
+            applicationNameProvider = { "AppName" },
             FakeCustomerRepository(paymentMethods),
             FakePrefsRepository(),
             StaticLpmResourceRepository(lpmRepository),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTestInjection.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTestInjection.kt
@@ -88,12 +88,12 @@ internal open class PaymentSheetViewModelTestInjection {
         args: PaymentSheetContract.Args = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY
     ): PaymentSheetViewModel = runBlocking {
         PaymentSheetViewModel(
-            ApplicationProvider.getApplicationContext(),
             args,
             eventReporter,
             { PaymentConfiguration(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY) },
             StripeIntentRepository.Static(stripeIntent),
             StripeIntentValidator(),
+            applicationNameProvider = { "AppName" },
             FakeCustomerRepository(customerRepositoryPMs),
             FakePrefsRepository(),
             lpmResourceRepository = StaticLpmResourceRepository(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AutocompleteViewModelTest.kt
@@ -1,10 +1,9 @@
 package com.stripe.android.paymentsheet.addresselement
 
-import android.app.Application
 import android.text.SpannableString
 import androidx.lifecycle.viewModelScope
-import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.Address
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
 import com.stripe.android.ui.core.elements.TextFieldIcon
@@ -13,6 +12,7 @@ import com.stripe.android.ui.core.elements.autocomplete.model.AutocompletePredic
 import com.stripe.android.ui.core.elements.autocomplete.model.FetchPlaceResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import com.stripe.android.ui.core.elements.autocomplete.model.Place
+import com.stripe.android.ui.core.elements.autocomplete.model.TransformGoogleToStripeAddress
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.stateIn
@@ -40,20 +40,23 @@ import kotlin.test.BeforeTest
 class AutocompleteViewModelTest {
     private val args = mock<AddressElementActivityContract.Args>()
     private val navigator = mock<AddressElementNavigator>()
-    private val application = ApplicationProvider.getApplicationContext<Application>()
     private val mockClient = mock<PlacesClientProxy>()
     private val mockEventReporter = mock<AddressLauncherEventReporter>()
+
+    private val transformGoogleToStripeAddress = object : TransformGoogleToStripeAddress {
+        override fun invoke(place: Place): Address {
+            return Address()
+        }
+    }
 
     private fun createViewModel() =
         AutocompleteViewModel(
             args,
             navigator,
             mockClient,
-            AutocompleteViewModel.Args(
-                "US"
-            ),
+            AutocompleteViewModel.Args("US"),
             mockEventReporter,
-            application
+            transformGoogleToStripeAddress,
         )
 
     @BeforeTest

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -2,10 +2,10 @@ package com.stripe.android.paymentsheet.paymentdatacollection.ach
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
-import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.toResolvableString
 import com.stripe.android.financialconnections.model.BankAccount
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
 import com.stripe.android.financialconnections.model.FinancialConnectionsSession
@@ -290,7 +290,7 @@ class USBankAccountFormViewModelTest {
             val viewModel = createViewModel(
                 defaultArgs.copy(
                     savedPaymentMethod = PaymentSelection.New.USBankAccount(
-                        labelResource = "Test",
+                        labelResource = "Test".toResolvableString(),
                         iconResource = 0,
                         bankName = "Test",
                         last4 = "Test",
@@ -321,7 +321,6 @@ class USBankAccountFormViewModelTest {
         )
         return USBankAccountFormViewModel(
             args = args,
-            application = ApplicationProvider.getApplicationContext(),
             stripeRepository = stripeRepository,
             lazyPaymentConfig = { paymentConfiguration },
             savedStateHandle = savedStateHandle

--- a/stripe-core/src/main/java/com/stripe/android/core/ResolvableString.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/ResolvableString.kt
@@ -41,16 +41,6 @@ fun ResolvableString.resolve(resources: Resources): String {
     }
 }
 
-//@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-//fun resolvableString(text: String): ResolvableString {
-//    return ResolvableString.Value(text)
-//}
-
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-fun String.toResolvableString(): ResolvableString {
-    return ResolvableString.Value(this)
-}
-
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun resolvableString(
     @StringRes id: Int,
@@ -58,4 +48,9 @@ fun resolvableString(
     transform: (String) -> String = { it }
 ): ResolvableString {
     return ResolvableString.Resource(id, args.toList(), transform)
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun String.toResolvableString(): ResolvableString {
+    return ResolvableString.Value(this)
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/ResolvableString.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/ResolvableString.kt
@@ -1,0 +1,61 @@
+package com.stripe.android.core
+
+import android.content.Context
+import android.content.res.Resources
+import android.os.Parcelable
+import androidx.annotation.RestrictTo
+import androidx.annotation.StringRes
+import kotlinx.parcelize.Parcelize
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+sealed interface ResolvableString : Parcelable {
+
+    @Parcelize
+    data class Value internal constructor(
+        val text: String,
+    ) : ResolvableString
+
+    @Parcelize
+    data class Resource internal constructor(
+        @StringRes val id: Int,
+        val args: List<String>,
+        val transform: (String) -> String = { it },
+    ) : ResolvableString
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun ResolvableString.resolve(context: Context): String {
+    return resolve(context.resources)
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun ResolvableString.resolve(resources: Resources): String {
+    return when (this) {
+        is ResolvableString.Resource -> {
+            val text = resources.getString(id, *args.toTypedArray())
+            transform(text)
+        }
+        is ResolvableString.Value -> {
+            text
+        }
+    }
+}
+
+//@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+//fun resolvableString(text: String): ResolvableString {
+//    return ResolvableString.Value(text)
+//}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun String.toResolvableString(): ResolvableString {
+    return ResolvableString.Value(this)
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun resolvableString(
+    @StringRes id: Int,
+    vararg args: String,
+    transform: (String) -> String = { it }
+): ResolvableString {
+    return ResolvableString.Resource(id, args.toList(), transform)
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Various view models in the `paymentsheet` module have been subclasses of `AndroidViewModel`. This makes unit testing more tedious and requires us to use `Robolectric`.

With this pull request, all view models extend `ViewModel`. Whenever a `Context` is required, we inject an interface whose implementation takes a `Context`. For unit tests, we can simply swap for a fake implementation.

For resolving string resources, this pull request adds `ResolvableString`, a representation of text that can be backed by either a string or a resource (including format arguments). With this, resolving a string can be delayed until we reach the view layer and have access to a `Context`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
