### PR TITLE
Move CurrencyFormatter to stripe-ui-core


### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/Amount.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/Amount.kt
@@ -3,6 +3,7 @@ package com.stripe.android.ui.core
 import android.content.res.Resources
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
+import com.stripe.android.uicore.format.CurrencyFormatter
 import kotlinx.parcelize.Parcelize
 
 /**

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement.kt
@@ -4,9 +4,9 @@ import android.content.res.Resources
 import androidx.annotation.RestrictTo
 import androidx.compose.ui.text.intl.Locale
 import com.stripe.android.ui.core.Amount
-import com.stripe.android.uicore.format.CurrencyFormatter
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.forms.FormFieldEntry
+import com.stripe.android.uicore.format.CurrencyFormatter
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement.kt
@@ -4,7 +4,7 @@ import android.content.res.Resources
 import androidx.annotation.RestrictTo
 import androidx.compose.ui.text.intl.Locale
 import com.stripe.android.ui.core.Amount
-import com.stripe.android.ui.core.CurrencyFormatter
+import com.stripe.android.uicore.format.CurrencyFormatter
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.forms.FormFieldEntry
 import kotlinx.coroutines.flow.Flow

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/format/CurrencyFormatter.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/format/CurrencyFormatter.kt
@@ -8,82 +8,79 @@ import java.util.Locale
 import kotlin.math.pow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class CurrencyFormatter {
+object CurrencyFormatter {
 
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    companion object {
-        private const val MAJOR_UNIT_BASE = 10.0
-        private val SERVER_DECIMAL_DIGITS =
-            mapOf(
-                setOf("UGX", "AFN", "ALL", "AMD", "COP", "IDR", "ISK", "PKR", "LBP") to 2
-            )
-
-        fun format(
-            amount: Long,
-            amountCurrencyCode: String,
-            targetLocale: Locale = Locale.getDefault()
-        ) = format(
-            amount,
-            Currency.getInstance(amountCurrencyCode.uppercase()),
-            targetLocale
+    private const val MAJOR_UNIT_BASE = 10.0
+    private val SERVER_DECIMAL_DIGITS =
+        mapOf(
+            setOf("UGX", "AFN", "ALL", "AMD", "COP", "IDR", "ISK", "PKR", "LBP") to 2
         )
 
-        fun format(
-            amount: Long,
-            amountCurrency: Currency,
-            targetLocale: Locale = Locale.getDefault()
-        ): String {
-            val amountCurrencyDecimalDigits = getDefaultDecimalDigits(amountCurrency)
-            val majorUnitAmount =
-                amount / MAJOR_UNIT_BASE.pow(amountCurrencyDecimalDigits.toDouble())
+    fun format(
+        amount: Long,
+        amountCurrencyCode: String,
+        targetLocale: Locale = Locale.getDefault()
+    ) = format(
+        amount,
+        Currency.getInstance(amountCurrencyCode.uppercase()),
+        targetLocale
+    )
 
-            /**
-             * The currencyFormat for a country and region specifies many things including:
-             * - do they use decimal places (e.g. Korea's is whole numbers only)
-             * - what is the symbol for the currency
-             * - where does the symbol go (right or left of the number)
-             * - how do they format decimal separators (e.g. France uses commas)
-             * - how do they separate thousand digits (e.g. France uses spaces)
-             * When you get the [NumberFormat#getCurrencyInstance] you are getting all this information.
-             *
-             * Some fields not used here, but might be relevant in other scenarios:
-             * - positive and negative numbers
-             *
-             * Among other things the currency format of the amount might have decimal places
-             * even if the targetLocale's currency does not, so below we will do a sort of merge of
-             * the targetLocale and amount currency. We will start with the currency format of the
-             * targetLocale, this sets, most notably, the number decimal and thousands separators,
-             * where the currency symbol should be placed relative to the number. Then we find the
-             * currency symbol of the amount for the targetLocale, and use that. Finally, we set the
-             * number of decimal places used by the amount currency.
-             *
-             * See the [NumberFormat] for why we use a try block.
-             */
-            val currencyFormat = NumberFormat.getCurrencyInstance(targetLocale)
+    fun format(
+        amount: Long,
+        amountCurrency: Currency,
+        targetLocale: Locale = Locale.getDefault()
+    ): String {
+        val amountCurrencyDecimalDigits = getDefaultDecimalDigits(amountCurrency)
+        val majorUnitAmount =
+            amount / MAJOR_UNIT_BASE.pow(amountCurrencyDecimalDigits.toDouble())
 
-            runCatching {
-                val decimalFormatSymbols =
-                    (currencyFormat as DecimalFormat).decimalFormatSymbols
-                decimalFormatSymbols.currency = amountCurrency
-                decimalFormatSymbols.currencySymbol = amountCurrency.getSymbol(targetLocale)
-                currencyFormat.minimumFractionDigits = amountCurrencyDecimalDigits
-                currencyFormat.decimalFormatSymbols = decimalFormatSymbols
-            }
+        /**
+         * The currencyFormat for a country and region specifies many things including:
+         * - do they use decimal places (e.g. Korea's is whole numbers only)
+         * - what is the symbol for the currency
+         * - where does the symbol go (right or left of the number)
+         * - how do they format decimal separators (e.g. France uses commas)
+         * - how do they separate thousand digits (e.g. France uses spaces)
+         * When you get the [NumberFormat#getCurrencyInstance] you are getting all this information.
+         *
+         * Some fields not used here, but might be relevant in other scenarios:
+         * - positive and negative numbers
+         *
+         * Among other things the currency format of the amount might have decimal places
+         * even if the targetLocale's currency does not, so below we will do a sort of merge of
+         * the targetLocale and amount currency. We will start with the currency format of the
+         * targetLocale, this sets, most notably, the number decimal and thousands separators,
+         * where the currency symbol should be placed relative to the number. Then we find the
+         * currency symbol of the amount for the targetLocale, and use that. Finally, we set the
+         * number of decimal places used by the amount currency.
+         *
+         * See the [NumberFormat] for why we use a try block.
+         */
+        val currencyFormat = NumberFormat.getCurrencyInstance(targetLocale)
 
-            return currencyFormat.format(majorUnitAmount)
+        runCatching {
+            val decimalFormatSymbols =
+                (currencyFormat as DecimalFormat).decimalFormatSymbols
+            decimalFormatSymbols.currency = amountCurrency
+            decimalFormatSymbols.currencySymbol = amountCurrency.getSymbol(targetLocale)
+            currencyFormat.minimumFractionDigits = amountCurrencyDecimalDigits
+            currencyFormat.decimalFormatSymbols = decimalFormatSymbols
         }
 
-        private fun getDefaultDecimalDigits(currency: Currency): Int {
-            /**
-             * Handle special cases where the client's default fractional digits for a given currency
-             * don't match the Stripe backend's assumption.
-             */
-            return SERVER_DECIMAL_DIGITS
-                .filter { entry ->
-                    entry.key.contains(currency.currencyCode.uppercase())
-                }.map {
-                    it.value
-                }.firstOrNull() ?: currency.defaultFractionDigits
-        }
+        return currencyFormat.format(majorUnitAmount)
+    }
+
+    private fun getDefaultDecimalDigits(currency: Currency): Int {
+        /**
+         * Handle special cases where the client's default fractional digits for a given currency
+         * don't match the Stripe backend's assumption.
+         */
+        return SERVER_DECIMAL_DIGITS
+            .filter { entry ->
+                entry.key.contains(currency.currencyCode.uppercase())
+            }.map {
+                it.value
+            }.firstOrNull() ?: currency.defaultFractionDigits
     }
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/format/CurrencyFormatter.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/format/CurrencyFormatter.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.ui.core
+package com.stripe.android.uicore.format
 
 import androidx.annotation.RestrictTo
 import java.text.DecimalFormat

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/format/CurrencyFormatterTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/format/CurrencyFormatterTest.kt
@@ -94,7 +94,7 @@ class CurrencyFormatterTest {
                 it.currencyCode
             }
             .forEach {
-                print(String.format("%s, ", it.currencyCode))
+                print(String.format(Locale.getDefault(), "%s, ", it.currencyCode))
             }
     }
 

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/format/CurrencyFormatterTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/format/CurrencyFormatterTest.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.ui.core
+package com.stripe.android.uicore.format
 
 import android.icu.text.NumberFormat
 import com.google.common.truth.Truth.assertThat


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

- Moves currency formatter to core module so that all sdks can use it.

# Motivation

Being able to use currency formatting in Financial Connections.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
