### PR TITLE
[Identity] Wait for VerificaionPage response to return when process is killed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@
 * [CHANGED][5789](https://github.com/stripe/stripe-android/pull/5789) We now disable the back button while confirming intents with `PaymentLauncher` to prevent them from incorrectly being displayed as failed.
 
 ### PaymentSheet
-
 * [ADDED][5676](https://github.com/stripe/stripe-android/pull/5676) Added `AddressLauncher`, an [activity](https://stripe.com/docs/elements/address-element?platform=android) that collects local and international addresses for your customers.
+
+### Identtiy
+* [FIXED][5816](https://github.com/stripe/stripe-android/pull/5816) Wait for VerificaionPage response to return when process is killed.
 
 ## 20.15.4 - 2022-11-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
 ### PaymentSheet
 * [ADDED][5676](https://github.com/stripe/stripe-android/pull/5676) Added `AddressLauncher`, an [activity](https://stripe.com/docs/elements/address-element?platform=android) that collects local and international addresses for your customers.
 
-### Identtiy
-* [FIXED][5816](https://github.com/stripe/stripe-android/pull/5816) Wait for VerificaionPage response to return when process is killed.
+### Identity
+* [FIXED][5816](https://github.com/stripe/stripe-android/pull/5816) Fixed an issue where the SDK would crash when recovering from process death.
 
 ## 20.15.4 - 2022-11-07
 

--- a/identity/detekt-baseline.xml
+++ b/identity/detekt-baseline.xml
@@ -6,13 +6,14 @@
     <ID>ComplexMethod:IdentityCameraScanFragment.kt$IdentityCameraScanFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
     <ID>ComplexMethod:IdentityFragmentFactory.kt$IdentityFragmentFactory$override fun instantiate(classLoader: ClassLoader, className: String): Fragment</ID>
     <ID>ComplexMethod:NavigationUtils.kt$internal fun Int.fragmentIdToScreenName(): String</ID>
-    <ID>ComplexMethod:UploadScreen.kt$@Composable internal fun UploadScreen( identityViewModel: IdentityViewModel, title: String, context: String, frontInfo: DocumentUploadSideInfo, backInfo: DocumentUploadSideInfo?, onContinueClicked: () -> Unit )</ID>
+    <ID>ComplexMethod:UploadScreen.kt$@Composable internal fun UploadScreen( identityViewModel: IdentityViewModel, title: String, context: String, frontInfo: DocumentUploadSideInfo, backInfo: DocumentUploadSideInfo?, onComposeFinish: () -> Unit, onContinueClicked: () -> Unit )</ID>
     <ID>EmptyFunctionBlock:IdentityCameraScanFragmentTest.kt$IdentityCameraScanFragmentTest.TestFragment${ }</ID>
     <ID>EmptyFunctionBlock:IdentityCameraScanFragmentTest.kt$IdentityCameraScanFragmentTest.TestFragment${}</ID>
     <ID>FunctionOnlyReturningConstant:FaceDetectorTransitioner.kt$FaceDetectorTransitioner$private fun isFaceFocused(): Boolean</ID>
     <ID>LargeClass:DriverLicenseScanFragmentTest.kt$DriverLicenseScanFragmentTest</ID>
+    <ID>LargeClass:IDScanFragmentTest.kt$IDScanFragmentTest</ID>
     <ID>LargeClass:IdentityViewModel.kt$IdentityViewModel : ViewModel</ID>
-    <ID>LongMethod:ConfirmationScreen.kt$@Composable internal fun ConfirmationScreen( verificationPageState: Resource&lt;VerificationPage>?, onConfirmed: () -> Unit )</ID>
+    <ID>LongMethod:ConfirmationScreen.kt$@Composable internal fun ConfirmationScreen( verificationPageState: Resource&lt;VerificationPage>, onError: (Throwable) -> Unit, onComposeFinish: (VerificationPage) -> Unit, onConfirmed: () -> Unit )</ID>
     <ID>LongMethod:ConsentScreen.kt$@Composable private fun SuccessUI( merchantLogoUri: Uri, verificationPage: VerificationPage, onConsentAgreed: () -> Unit, onConsentDeclined: () -> Unit )</ID>
     <ID>LongMethod:DriverLicenseScanFragmentTest.kt$DriverLicenseScanFragmentTest$@Test fun `front scanned and uploaded - response is missing back - back UI is on - back scanned and uploaded - not require selfie - submit`()</ID>
     <ID>LongMethod:DriverLicenseScanFragmentTest.kt$DriverLicenseScanFragmentTest$@Test fun `front scanned and uploaded - response is missing back - back UI is on - back scanned and uploaded - require selfie - to selfie`()</ID>
@@ -30,8 +31,7 @@
     <ID>LongMethod:PassportScanFragmentTest.kt$PassportScanFragmentTest$@Test fun `front scanned and uploaded - not require selfie - submit`()</ID>
     <ID>LongMethod:PassportScanFragmentTest.kt$PassportScanFragmentTest$@Test fun `front scanned and uploaded - require selfie - to selfie`()</ID>
     <ID>LongMethod:SelfieFragment.kt$SelfieFragment$private fun collectUploadedStateAndUploadForCollectedSelfies()</ID>
-    <ID>LongMethod:UploadScreen.kt$@Composable internal fun UploadImageDialog( uploadInfo: DocumentUploadSideInfo, onDismissRequest: () -> Unit, onUploadMethodSelected: () -> Unit )</ID>
-    <ID>LongMethod:UploadScreen.kt$@Composable internal fun UploadScreen( identityViewModel: IdentityViewModel, title: String, context: String, frontInfo: DocumentUploadSideInfo, backInfo: DocumentUploadSideInfo?, onContinueClicked: () -> Unit )</ID>
+    <ID>LongMethod:UploadScreen.kt$@Composable internal fun UploadScreen( identityViewModel: IdentityViewModel, title: String, context: String, frontInfo: DocumentUploadSideInfo, backInfo: DocumentUploadSideInfo?, onComposeFinish: () -> Unit, onContinueClicked: () -> Unit )</ID>
     <ID>MagicNumber:DefaultIdentityIO.kt$DefaultIdentityIO$100</ID>
     <ID>MagicNumber:DefaultIdentityIO.kt$DefaultIdentityIO$5</ID>
     <ID>MagicNumber:FaceDetectorAnalyzer.kt$FaceDetectorAnalyzer$3</ID>

--- a/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
@@ -49,7 +49,7 @@ internal class ConsentFragment(
             ConsentScreen(
                 merchantLogoUri = identityViewModel.verificationArgs.brandLogo,
                 verificationState = verificationState,
-                onSuccess = { verificationPage ->
+                onComposeFinish = { verificationPage ->
                     identityViewModel.updateAnalyticsState { oldState ->
                         oldState.copy(
                             requireSelfie = verificationPage.requireSelfie()

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityDocumentScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityDocumentScanFragment.kt
@@ -75,15 +75,19 @@ internal abstract class IdentityDocumentScanFragment(
             identityViewModel.resetDocumentUploadedState()
         }
         super.onViewCreated(view, savedInstanceState)
-
-        lifecycleScope.launch(identityViewModel.workContext) {
-            identityViewModel.screenTracker.screenTransitionFinish(fragmentId.fragmentIdToScreenName())
-        }
-        identityViewModel.sendAnalyticsRequest(
-            identityViewModel.identityAnalyticsRequestFactory.screenPresented(
-                scanType = frontScanType,
-                screenName = fragmentId.fragmentIdToScreenName()
-            )
+        identityViewModel.observeForVerificationPage(
+            this,
+            onSuccess = {
+                lifecycleScope.launch(identityViewModel.workContext) {
+                    identityViewModel.screenTracker.screenTransitionFinish(fragmentId.fragmentIdToScreenName())
+                }
+                identityViewModel.sendAnalyticsRequest(
+                    identityViewModel.identityAnalyticsRequestFactory.screenPresented(
+                        scanType = frontScanType,
+                        screenName = fragmentId.fragmentIdToScreenName()
+                    )
+                )
+            }
         )
     }
 

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityUploadFragment.kt
@@ -186,7 +186,9 @@ internal abstract class IdentityUploadFragment(
                         this@IdentityUploadFragment,
                         onSuccess = {
                             lifecycleScope.launch(identityViewModel.workContext) {
-                                identityViewModel.screenTracker.screenTransitionFinish(fragmentId.fragmentIdToScreenName())
+                                identityViewModel.screenTracker.screenTransitionFinish(
+                                    fragmentId.fragmentIdToScreenName()
+                                )
                             }
                             identityViewModel.sendAnalyticsRequest(
                                 identityViewModel.identityAnalyticsRequestFactory.screenPresented(

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityUploadFragment.kt
@@ -180,6 +180,22 @@ internal abstract class IdentityUploadFragment(
                     }
                 } else {
                     null
+                },
+                onComposeFinish = {
+                    identityViewModel.observeForVerificationPage(
+                        this@IdentityUploadFragment,
+                        onSuccess = {
+                            lifecycleScope.launch(identityViewModel.workContext) {
+                                identityViewModel.screenTracker.screenTransitionFinish(fragmentId.fragmentIdToScreenName())
+                            }
+                            identityViewModel.sendAnalyticsRequest(
+                                identityViewModel.identityAnalyticsRequestFactory.screenPresented(
+                                    scanType = frontScanType,
+                                    screenName = fragmentId.fragmentIdToScreenName()
+                                )
+                            )
+                        }
+                    )
                 }
             ) {
                 identityViewModel.observeForVerificationPage(
@@ -205,16 +221,6 @@ internal abstract class IdentityUploadFragment(
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         collectedUploadState()
-
-        lifecycleScope.launch(identityViewModel.workContext) {
-            identityViewModel.screenTracker.screenTransitionFinish(fragmentId.fragmentIdToScreenName())
-        }
-        identityViewModel.sendAnalyticsRequest(
-            identityViewModel.identityAnalyticsRequestFactory.screenPresented(
-                scanType = frontScanType,
-                screenName = fragmentId.fragmentIdToScreenName()
-            )
-        )
     }
 
     /**

--- a/identity/src/main/java/com/stripe/android/identity/ui/DocSelectionScreen.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/DocSelectionScreen.kt
@@ -30,7 +30,6 @@ import com.google.android.material.composethemeadapter.MdcTheme
 import com.stripe.android.identity.R
 import com.stripe.android.identity.navigation.DocSelectionFragment.Companion.SELECTION_NONE
 import com.stripe.android.identity.networking.Resource
-import com.stripe.android.identity.networking.Status
 import com.stripe.android.identity.networking.models.CollectedDataParam.Type
 import com.stripe.android.identity.networking.models.VerificationPage
 
@@ -39,50 +38,54 @@ internal const val singleSelectionTag = "SingleSelection"
 
 @Composable
 internal fun DocSelectionScreen(
-    verificationPageState: Resource<VerificationPage>?,
+    verificationPageState: Resource<VerificationPage>,
+    onError: (Throwable) -> Unit,
+    onComposeFinish: (VerificationPage) -> Unit,
     onDocTypeSelected: (Type) -> Unit
 ) {
     MdcTheme {
-        require(verificationPageState != null && verificationPageState.status == Status.SUCCESS) {
-            "verificationPageState.status is not SUCCESS"
-        }
-        val documentSelect =
-            remember { requireNotNull(verificationPageState.data).documentSelect }
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(
-                    horizontal = dimensionResource(id = R.dimen.page_horizontal_margin),
-                    vertical = dimensionResource(id = R.dimen.page_vertical_margin)
-                )
+        CheckVerificationPageAndCompose(
+            verificationPageResource = verificationPageState,
+            onError = onError
         ) {
-            Text(
-                text = documentSelect.title,
+            val documentSelect = remember { it.documentSelect }
+            Column(
                 modifier = Modifier
-                    .fillMaxWidth()
+                    .fillMaxSize()
                     .padding(
-                        top = 58.dp,
-                        bottom = 32.dp
+                        horizontal = dimensionResource(id = R.dimen.page_horizontal_margin),
+                        vertical = dimensionResource(id = R.dimen.page_vertical_margin)
                     )
-                    .semantics {
-                        testTag = docSelectionTitleTag
-                    },
-                fontSize = 24.sp,
-                fontWeight = FontWeight.Bold
-            )
-            if (documentSelect.idDocumentTypeAllowlist.count() > 1) {
-                MultiSelection(
-                    documentSelect.idDocumentTypeAllowlist,
-                    onDocTypeSelected = onDocTypeSelected
+            ) {
+                Text(
+                    text = documentSelect.title,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(
+                            top = 58.dp,
+                            bottom = 32.dp
+                        )
+                        .semantics {
+                            testTag = docSelectionTitleTag
+                        },
+                    fontSize = 24.sp,
+                    fontWeight = FontWeight.Bold
                 )
-            } else {
-                SingleSelection(
-                    allowedType = documentSelect.idDocumentTypeAllowlist.entries.first().key,
-                    buttonText = documentSelect.buttonText,
-                    bodyText = documentSelect.body,
-                    onDocTypeSelected = onDocTypeSelected
-                )
+                if (documentSelect.idDocumentTypeAllowlist.count() > 1) {
+                    MultiSelection(
+                        documentSelect.idDocumentTypeAllowlist,
+                        onDocTypeSelected = onDocTypeSelected
+                    )
+                } else {
+                    SingleSelection(
+                        allowedType = documentSelect.idDocumentTypeAllowlist.entries.first().key,
+                        buttonText = documentSelect.buttonText,
+                        bodyText = documentSelect.body,
+                        onDocTypeSelected = onDocTypeSelected
+                    )
+                }
             }
+            onComposeFinish(it)
         }
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/ui/LoadingScreen.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/LoadingScreen.kt
@@ -1,0 +1,64 @@
+package com.stripe.android.identity.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.stripe.android.identity.R
+import com.stripe.android.identity.networking.Resource
+import com.stripe.android.identity.networking.Status
+import com.stripe.android.identity.networking.models.VerificationPage
+
+@Composable
+internal fun LoadingScreen() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .semantics {
+                testTag = LOADING_SCREEN_TAG
+            },
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        CircularProgressIndicator(modifier = Modifier.padding(bottom = 32.dp))
+        Text(text = stringResource(id = R.string.loading), fontSize = 24.sp)
+    }
+}
+
+@Composable
+internal fun CheckVerificationPageAndCompose(
+    verificationPageResource: Resource<VerificationPage>,
+    onError: (Throwable) -> Unit,
+    onSuccess: @Composable (VerificationPage) -> Unit
+) {
+    when (verificationPageResource.status) {
+        Status.SUCCESS -> {
+            onSuccess(requireNotNull(verificationPageResource.data))
+        }
+        Status.ERROR -> {
+            LaunchedEffect(Unit) {
+                onError(
+                    verificationPageResource.throwable
+                        ?: IllegalStateException("Failed to get verificationPage")
+                )
+            }
+        }
+        Status.LOADING -> {
+            LoadingScreen()
+        }
+        Status.IDLE -> {
+            // no-op
+        }
+    }
+}

--- a/identity/src/main/java/com/stripe/android/identity/ui/UploadScreen.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/UploadScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.material.contentColorFor
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -66,6 +67,7 @@ internal fun UploadScreen(
     context: String,
     frontInfo: DocumentUploadSideInfo,
     backInfo: DocumentUploadSideInfo?,
+    onComposeFinish: () -> Unit,
     onContinueClicked: () -> Unit
 ) {
     val frontUploadState by identityViewModel.documentFrontUploadedState.collectAsState()
@@ -206,6 +208,9 @@ internal fun UploadScreen(
                 continueButtonState = LoadingButtonState.Loading
                 onContinueClicked()
             }
+        }
+        LaunchedEffect(Unit) {
+            onComposeFinish()
         }
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
@@ -687,7 +687,9 @@ internal class IdentityViewModel constructor(
     fun observeForVerificationPage(
         owner: LifecycleOwner,
         onSuccess: (VerificationPage) -> Unit,
-        onFailure: (Throwable) -> Unit
+        onFailure: (Throwable) -> Unit = {
+            Log.d(TAG, "Failed to get VerificationPage")
+        }
     ) {
         verificationPage.observe(owner) { resource ->
             when (resource.status) {

--- a/identity/src/test/java/com/stripe/android/identity/navigation/DriverLicenseScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/DriverLicenseScanFragmentTest.kt
@@ -138,6 +138,13 @@ internal class DriverLicenseScanFragmentTest {
             runBlocking {
                 mockScreenTracker.screenTransitionFinish(eq(SCREEN_NAME_LIVE_CAPTURE_DRIVER_LICENSE))
             }
+            val successCaptor = argumentCaptor<(VerificationPage) -> Unit>()
+            verify(mockIdentityViewModel).observeForVerificationPage(
+                any(),
+                successCaptor.capture(),
+                any()
+            )
+            successCaptor.lastValue.invoke(verificationPageNotRequireSelfie)
             verify(mockIdentityViewModel).sendAnalyticsRequest(
                 argThat {
                     eventName == EVENT_SCREEN_PRESENTED &&
@@ -171,6 +178,7 @@ internal class DriverLicenseScanFragmentTest {
                 whenever(mockIdentityScanViewModel.targetScanType).thenReturn(IdentityScanState.ScanType.DL_FRONT)
                 verifyUploadedWithFinalResult(
                     mockFrontFinalResult,
+                    time = 2,
                     targetType = IdentityScanState.ScanType.DL_FRONT
                 )
 
@@ -194,7 +202,7 @@ internal class DriverLicenseScanFragmentTest {
 
                 // observeForVerificationPage - trigger onSuccess
                 val successCaptor = argumentCaptor<(VerificationPage) -> Unit>()
-                verify(mockIdentityViewModel, times(2)).observeForVerificationPage(
+                verify(mockIdentityViewModel, times(3)).observeForVerificationPage(
                     any(),
                     successCaptor.capture(),
                     any()
@@ -257,6 +265,7 @@ internal class DriverLicenseScanFragmentTest {
                 finalResultLiveData.postValue(mockFrontFinalResult)
                 verifyUploadedWithFinalResult(
                     mockFrontFinalResult,
+                    time = 2,
                     targetType = IdentityScanState.ScanType.DL_FRONT
                 )
 
@@ -281,7 +290,7 @@ internal class DriverLicenseScanFragmentTest {
 
                 // observeForVerificationPage - trigger onSuccess
                 val successCaptor = argumentCaptor<(VerificationPage) -> Unit>()
-                verify(mockIdentityViewModel, times(2)).observeForVerificationPage(
+                verify(mockIdentityViewModel, times(3)).observeForVerificationPage(
                     any(),
                     successCaptor.capture(),
                     any()
@@ -316,7 +325,7 @@ internal class DriverLicenseScanFragmentTest {
                 finalResultLiveData.postValue(mockBackFinalResult)
                 verifyUploadedWithFinalResult(
                     mockBackFinalResult,
-                    time = 3,
+                    time = 4,
                     targetType = IdentityScanState.ScanType.DL_BACK
                 )
 
@@ -324,7 +333,7 @@ internal class DriverLicenseScanFragmentTest {
                 binding.kontinue.findViewById<Button>(R.id.button).callOnClick()
                 documentBackUploadState.update { backUploadedState }
 
-                verify(mockIdentityViewModel, times(4)).observeForVerificationPage(
+                verify(mockIdentityViewModel, times(5)).observeForVerificationPage(
                     any(),
                     successCaptor.capture(),
                     any()
@@ -373,6 +382,7 @@ internal class DriverLicenseScanFragmentTest {
                 finalResultLiveData.postValue(mockFrontFinalResult)
                 verifyUploadedWithFinalResult(
                     mockFrontFinalResult,
+                    time = 2,
                     targetType = IdentityScanState.ScanType.DL_FRONT
                 )
 
@@ -397,7 +407,7 @@ internal class DriverLicenseScanFragmentTest {
 
                 // observeForVerificationPage - trigger onSuccess
                 val successCaptor = argumentCaptor<(VerificationPage) -> Unit>()
-                verify(mockIdentityViewModel, times(2)).observeForVerificationPage(
+                verify(mockIdentityViewModel, times(3)).observeForVerificationPage(
                     any(),
                     successCaptor.capture(),
                     any()
@@ -432,7 +442,7 @@ internal class DriverLicenseScanFragmentTest {
                 finalResultLiveData.postValue(mockBackFinalResult)
                 verifyUploadedWithFinalResult(
                     mockBackFinalResult,
-                    time = 3,
+                    time = 4,
                     targetType = IdentityScanState.ScanType.DL_BACK
                 )
 
@@ -440,7 +450,7 @@ internal class DriverLicenseScanFragmentTest {
                 binding.kontinue.findViewById<Button>(R.id.button).callOnClick()
                 documentBackUploadState.update { backUploadedState }
 
-                verify(mockIdentityViewModel, times(4)).observeForVerificationPage(
+                verify(mockIdentityViewModel, times(5)).observeForVerificationPage(
                     any(),
                     successCaptor.capture(),
                     any()
@@ -489,6 +499,7 @@ internal class DriverLicenseScanFragmentTest {
                 finalResultLiveData.postValue(mockFrontFinalResult)
                 verifyUploadedWithFinalResult(
                     mockFrontFinalResult,
+                    time = 2,
                     targetType = IdentityScanState.ScanType.DL_FRONT
                 )
 
@@ -513,7 +524,7 @@ internal class DriverLicenseScanFragmentTest {
 
                 // observeForVerificationPage - trigger onSuccess
                 val successCaptor = argumentCaptor<(VerificationPage) -> Unit>()
-                verify(mockIdentityViewModel, times(2)).observeForVerificationPage(
+                verify(mockIdentityViewModel, times(3)).observeForVerificationPage(
                     any(),
                     successCaptor.capture(),
                     any()
@@ -562,6 +573,7 @@ internal class DriverLicenseScanFragmentTest {
                 finalResultLiveData.postValue(mockFrontFinalResult)
                 verifyUploadedWithFinalResult(
                     mockFrontFinalResult,
+                    time = 2,
                     targetType = IdentityScanState.ScanType.DL_FRONT
                 )
 
@@ -586,7 +598,7 @@ internal class DriverLicenseScanFragmentTest {
 
                 // observeForVerificationPage - trigger onSuccess
                 val successCaptor = argumentCaptor<(VerificationPage) -> Unit>()
-                verify(mockIdentityViewModel, times(2)).observeForVerificationPage(
+                verify(mockIdentityViewModel, times(3)).observeForVerificationPage(
                     any(),
                     successCaptor.capture(),
                     any()

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IDScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IDScanFragmentTest.kt
@@ -141,6 +141,13 @@ internal class IDScanFragmentTest {
             runBlocking {
                 mockScreenTracker.screenTransitionFinish(eq(SCREEN_NAME_LIVE_CAPTURE_ID))
             }
+            val successCaptor = argumentCaptor<(VerificationPage) -> Unit>()
+            verify(mockIdentityViewModel).observeForVerificationPage(
+                any(),
+                successCaptor.capture(),
+                any()
+            )
+            successCaptor.lastValue.invoke(verificationPageNotRequireSelfie)
             verify(mockIdentityViewModel).sendAnalyticsRequest(
                 argThat {
                     eventName == EVENT_SCREEN_PRESENTED &&
@@ -177,6 +184,7 @@ internal class IDScanFragmentTest {
                 whenever(mockIdentityScanViewModel.targetScanType).thenReturn(IdentityScanState.ScanType.ID_FRONT)
                 verifyUploadedWithFinalResult(
                     mockFrontFinalResult,
+                    time = 2,
                     targetType = IdentityScanState.ScanType.ID_FRONT
                 )
 
@@ -200,7 +208,7 @@ internal class IDScanFragmentTest {
 
                 // observeForVerificationPage - trigger onSuccess
                 val successCaptor = argumentCaptor<(VerificationPage) -> Unit>()
-                verify(mockIdentityViewModel, times(2)).observeForVerificationPage(
+                verify(mockIdentityViewModel, times(3)).observeForVerificationPage(
                     any(),
                     successCaptor.capture(),
                     any()
@@ -264,6 +272,7 @@ internal class IDScanFragmentTest {
                 finalResultLiveData.postValue(mockFrontFinalResult)
                 verifyUploadedWithFinalResult(
                     mockFrontFinalResult,
+                    time = 2,
                     targetType = IdentityScanState.ScanType.ID_FRONT
                 )
 
@@ -288,7 +297,7 @@ internal class IDScanFragmentTest {
 
                 // observeForVerificationPage - trigger onSuccess
                 val successCaptor = argumentCaptor<(VerificationPage) -> Unit>()
-                verify(mockIdentityViewModel, times(2)).observeForVerificationPage(
+                verify(mockIdentityViewModel, times(3)).observeForVerificationPage(
                     any(),
                     successCaptor.capture(),
                     any()
@@ -323,7 +332,7 @@ internal class IDScanFragmentTest {
                 finalResultLiveData.postValue(mockBackFinalResult)
                 verifyUploadedWithFinalResult(
                     mockBackFinalResult,
-                    time = 3,
+                    time = 4,
                     targetType = IdentityScanState.ScanType.ID_BACK
                 )
 
@@ -331,7 +340,7 @@ internal class IDScanFragmentTest {
                 binding.kontinue.findViewById<Button>(R.id.button).callOnClick()
                 documentBackUploadState.update { backUploadedState }
 
-                verify(mockIdentityViewModel, times(4)).observeForVerificationPage(
+                verify(mockIdentityViewModel, times(5)).observeForVerificationPage(
                     any(),
                     successCaptor.capture(),
                     any()
@@ -380,6 +389,7 @@ internal class IDScanFragmentTest {
                 finalResultLiveData.postValue(mockFrontFinalResult)
                 verifyUploadedWithFinalResult(
                     mockFrontFinalResult,
+                    time = 2,
                     targetType = IdentityScanState.ScanType.ID_FRONT
                 )
 
@@ -404,7 +414,7 @@ internal class IDScanFragmentTest {
 
                 // observeForVerificationPage - trigger onSuccess
                 val successCaptor = argumentCaptor<(VerificationPage) -> Unit>()
-                verify(mockIdentityViewModel, times(2)).observeForVerificationPage(
+                verify(mockIdentityViewModel, times(3)).observeForVerificationPage(
                     any(),
                     successCaptor.capture(),
                     any()
@@ -439,7 +449,7 @@ internal class IDScanFragmentTest {
                 finalResultLiveData.postValue(mockBackFinalResult)
                 verifyUploadedWithFinalResult(
                     mockBackFinalResult,
-                    time = 3,
+                    time = 4,
                     targetType = IdentityScanState.ScanType.ID_BACK
                 )
 
@@ -447,7 +457,7 @@ internal class IDScanFragmentTest {
                 binding.kontinue.findViewById<Button>(R.id.button).callOnClick()
                 documentBackUploadState.update { backUploadedState }
 
-                verify(mockIdentityViewModel, times(4)).observeForVerificationPage(
+                verify(mockIdentityViewModel, times(5)).observeForVerificationPage(
                     any(),
                     successCaptor.capture(),
                     any()
@@ -496,6 +506,7 @@ internal class IDScanFragmentTest {
                 finalResultLiveData.postValue(mockFrontFinalResult)
                 verifyUploadedWithFinalResult(
                     mockFrontFinalResult,
+                    time = 2,
                     targetType = IdentityScanState.ScanType.ID_FRONT
                 )
 
@@ -520,7 +531,7 @@ internal class IDScanFragmentTest {
 
                 // observeForVerificationPage - trigger onSuccess
                 val successCaptor = argumentCaptor<(VerificationPage) -> Unit>()
-                verify(mockIdentityViewModel, times(2)).observeForVerificationPage(
+                verify(mockIdentityViewModel, times(3)).observeForVerificationPage(
                     any(),
                     successCaptor.capture(),
                     any()
@@ -569,6 +580,7 @@ internal class IDScanFragmentTest {
                 finalResultLiveData.postValue(mockFrontFinalResult)
                 verifyUploadedWithFinalResult(
                     mockFrontFinalResult,
+                    time = 2,
                     targetType = IdentityScanState.ScanType.ID_FRONT
                 )
 
@@ -593,7 +605,7 @@ internal class IDScanFragmentTest {
 
                 // observeForVerificationPage - trigger onSuccess
                 val successCaptor = argumentCaptor<(VerificationPage) -> Unit>()
-                verify(mockIdentityViewModel, times(2)).observeForVerificationPage(
+                verify(mockIdentityViewModel, times(3)).observeForVerificationPage(
                     any(),
                     successCaptor.capture(),
                     any()

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IdentityDocumentScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IdentityDocumentScanFragmentTest.kt
@@ -209,12 +209,12 @@ class IdentityDocumentScanFragmentTest {
             )
 
             val successCaptor: KArgumentCaptor<(VerificationPage) -> Unit> = argumentCaptor()
-            verify(mockIdentityViewModel).observeForVerificationPage(
+            verify(mockIdentityViewModel, times(2)).observeForVerificationPage(
                 any(),
                 successCaptor.capture(),
                 any()
             )
-            successCaptor.firstValue(SUCCESS_VERIFICATION_PAGE_NOT_REQUIRE_LIVE_CAPTURE)
+            successCaptor.lastValue(SUCCESS_VERIFICATION_PAGE_NOT_REQUIRE_LIVE_CAPTURE)
 
             verify(mockScanFlow).resetFlow()
             assertThat(testFragment.cameraAdapter.isBoundToLifecycle()).isFalse()
@@ -255,12 +255,12 @@ class IdentityDocumentScanFragmentTest {
             )
 
             val successCaptor: KArgumentCaptor<(VerificationPage) -> Unit> = argumentCaptor()
-            verify(mockIdentityViewModel).observeForVerificationPage(
+            verify(mockIdentityViewModel, times(2)).observeForVerificationPage(
                 any(),
                 successCaptor.capture(),
                 any()
             )
-            successCaptor.firstValue(SUCCESS_VERIFICATION_PAGE_REQUIRE_LIVE_CAPTURE)
+            successCaptor.lastValue(SUCCESS_VERIFICATION_PAGE_REQUIRE_LIVE_CAPTURE)
 
             verify(mockScanFlow).resetFlow()
             assertThat(testFragment.cameraAdapter.isBoundToLifecycle()).isFalse()

--- a/identity/src/test/java/com/stripe/android/identity/navigation/PassportScanFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/PassportScanFragmentTest.kt
@@ -128,6 +128,13 @@ class PassportScanFragmentTest {
             runBlocking {
                 mockScreenTracker.screenTransitionFinish(eq(SCREEN_NAME_LIVE_CAPTURE_PASSPORT))
             }
+            val successCaptor = argumentCaptor<(VerificationPage) -> Unit>()
+            verify(mockIdentityViewModel).observeForVerificationPage(
+                any(),
+                successCaptor.capture(),
+                any()
+            )
+            successCaptor.lastValue.invoke(verificationPageRequireSelfie)
             verify(mockIdentityViewModel).sendAnalyticsRequest(
                 argThat {
                     eventName == EVENT_SCREEN_PRESENTED &&
@@ -161,7 +168,7 @@ class PassportScanFragmentTest {
                 finalResultLiveData.postValue(mockFrontFinalResult)
 
                 val successCaptor = argumentCaptor<(VerificationPage) -> Unit>()
-                verify(mockIdentityViewModel).observeForVerificationPage(
+                verify(mockIdentityViewModel, times(2)).observeForVerificationPage(
                     any(),
                     successCaptor.capture(),
                     any()
@@ -195,7 +202,7 @@ class PassportScanFragmentTest {
                 )
 
                 // observeForVerificationPage - trigger onSuccess
-                verify(mockIdentityViewModel, times(2)).observeForVerificationPage(
+                verify(mockIdentityViewModel, times(3)).observeForVerificationPage(
                     any(),
                     successCaptor.capture(),
                     any()
@@ -241,7 +248,7 @@ class PassportScanFragmentTest {
                 finalResultLiveData.postValue(mockFrontFinalResult)
 
                 val successCaptor = argumentCaptor<(VerificationPage) -> Unit>()
-                verify(mockIdentityViewModel).observeForVerificationPage(
+                verify(mockIdentityViewModel, times(2)).observeForVerificationPage(
                     any(),
                     successCaptor.capture(),
                     any()
@@ -275,7 +282,7 @@ class PassportScanFragmentTest {
                 )
 
                 // observeForVerificationPage - trigger onSuccess
-                verify(mockIdentityViewModel, times(2)).observeForVerificationPage(
+                verify(mockIdentityViewModel, times(3)).observeForVerificationPage(
                     any(),
                     successCaptor.capture(),
                     any()

--- a/identity/src/test/java/com/stripe/android/identity/navigation/SelfieFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/SelfieFragmentTest.kt
@@ -48,14 +48,12 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
 import org.junit.runner.RunWith
-import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 
@@ -124,6 +122,23 @@ internal class SelfieFragmentTest {
     @Test
     fun `when initialized UI is reset and bound`() {
         launchSelfieFragment { binding, _, _ ->
+
+            val successCaptor = argumentCaptor<(VerificationPage) -> Unit>()
+
+            val mockSelfieCapture = mock<VerificationPageStaticContentSelfieCapturePage> {
+                on { consentText } doReturn CONSENT_TEXT
+            }
+            verify(mockIdentityViewModel).observeForVerificationPage(
+                any(),
+                successCaptor.capture(),
+                any()
+            )
+            successCaptor.lastValue(
+                mock {
+                    on { selfieCapture } doReturn mockSelfieCapture
+                }
+            )
+
             runBlocking {
                 verify(mockScreenTracker).screenTransitionFinish(eq(SCREEN_NAME_SELFIE))
             }
@@ -131,24 +146,6 @@ internal class SelfieFragmentTest {
                 argThat {
                     eventName == EVENT_SCREEN_PRESENTED &&
                         (params[PARAM_EVENT_META_DATA] as Map<*, *>)[PARAM_SCREEN_NAME] == SCREEN_NAME_SELFIE
-                }
-            )
-
-            val successCaptor: KArgumentCaptor<(VerificationPage) -> Unit> = argumentCaptor()
-            verify(
-                mockIdentityViewModel,
-                times(1)
-            ).observeForVerificationPage(
-                any(),
-                successCaptor.capture(),
-                any()
-            )
-            val mockSelfieCapture = mock<VerificationPageStaticContentSelfieCapturePage> {
-                on { consentText } doReturn CONSENT_TEXT
-            }
-            successCaptor.lastValue(
-                mock {
-                    on { selfieCapture } doReturn mockSelfieCapture
                 }
             )
 

--- a/identity/src/test/java/com/stripe/android/identity/ui/ConfirmationScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/ConfirmationScreenTest.kt
@@ -26,6 +26,8 @@ class ConfirmationScreenTest {
     val composeTestRule = createComposeRule()
 
     private val onConfirmedMock = mock<() -> Unit>()
+    private val onError = mock<(Throwable) -> Unit>()
+    private val onComposeFinish = mock<(VerificationPage) -> Unit>()
 
     private val verificationPage = mock<VerificationPage>().also {
         whenever(it.success).thenReturn(
@@ -57,6 +59,8 @@ class ConfirmationScreenTest {
         composeTestRule.setContent {
             ConfirmationScreen(
                 verificationPageState = verificationState,
+                onError = onError,
+                onComposeFinish = onComposeFinish,
                 onConfirmed = onConfirmedMock
             )
         }

--- a/identity/src/test/java/com/stripe/android/identity/ui/ConsentScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/ConsentScreenTest.kt
@@ -168,7 +168,7 @@ class ConsentScreenTest {
             ConsentScreen(
                 merchantLogoUri = merchantLogoUri,
                 verificationState = verificationState,
-                onSuccess = onSuccessMock,
+                onComposeFinish = onSuccessMock,
                 onFallbackUrl = onFallbackMock,
                 onError = onErrorMock,
                 onConsentAgreed = onConsentAgreedMock,

--- a/identity/src/test/java/com/stripe/android/identity/ui/DocSelectScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/DocSelectScreenTest.kt
@@ -31,6 +31,8 @@ class DocSelectScreenTest {
     val composeTestRule = createComposeRule()
 
     private val onDocTypeSelectedMock = mock<(CollectedDataParam.Type) -> Unit>()
+    private val onError = mock<(Throwable) -> Unit>()
+    private val onComposeFinish = mock<(VerificationPage) -> Unit>()
 
     private val verificationPageWithMultiChoice = mock<VerificationPage> {
         on { it.documentSelect } doReturn DOC_SELECT_MULTI_CHOICE
@@ -86,6 +88,8 @@ class DocSelectScreenTest {
         composeTestRule.setContent {
             DocSelectionScreen(
                 verificationPageState = verificationState,
+                onError = onError,
+                onComposeFinish = onComposeFinish,
                 onDocTypeSelected = onDocTypeSelectedMock
             )
         }

--- a/identity/src/test/java/com/stripe/android/identity/ui/UploadScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/UploadScreenTest.kt
@@ -37,6 +37,7 @@ class UploadScreenTest {
     private val onContinueClicked = mock<() -> Unit>()
     private val onDismissRequest = mock<() -> Unit>()
     private val onUploadMethodSelected = mock<() -> Unit>()
+    private val onComposeFinish = mock<() -> Unit>()
 
     private val documentFrontUploadState = MutableStateFlow(IDLE_STATE)
     private val documentBackUploadState = MutableStateFlow(IDLE_STATE)
@@ -184,6 +185,7 @@ class UploadScreenTest {
                 } else {
                     null
                 },
+                onComposeFinish = onComposeFinish,
                 onContinueClicked = onContinueClicked
             )
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
When activity is killed by system, another API request is made to fetch `Resource<VerificationPage>`.

The compose screens(`ConfirmationScreen`, `UploadScreen`, `DocSelectionScreen`) can't use `requireNotNull` as the request is still pending. Refactor the compose method to draw a Loading screen when the request is pending.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Recover from process kill


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
