### PR TITLE
Add shouldCache to StripeRequest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,7 @@ ext {
     placesVersion = '2.6.0'
     playServicesVersion = '1.6.4'
     leakCanaryVersion = '2.9.1'
+    okhttpVersion = '4.10.0'
 
     androidTestVersion = '1.4.0'
     androidTestJunitVersion = '1.1.3'

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsApiRepositoryTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsApiRepositoryTest.kt
@@ -139,7 +139,7 @@ class FinancialConnectionsApiRepositoryTest {
 
     private suspend fun givenGetRequestReturns(successBody: String) {
         val mock = mock<ApiRequest>()
-        whenever(apiRequestFactory.createGet(any(), any(), any())).thenReturn(mock)
+        whenever(apiRequestFactory.createGet(any(), any(), any(), any())).thenReturn(mock)
         whenever(mockStripeNetworkClient.executeRequest(any())).thenReturn(
             StripeResponse(
                 code = HttpURLConnection.HTTP_OK,

--- a/payments-core/detekt-baseline.xml
+++ b/payments-core/detekt-baseline.xml
@@ -69,6 +69,8 @@
     <ID>MagicNumber:FraudDetectionDataRequestParamsFactory.kt$FraudDetectionDataRequestParamsFactory.Companion$60</ID>
     <ID>MagicNumber:PaymentAuthConfig.kt$PaymentAuthConfig.Stripe3ds2Config$5</ID>
     <ID>MagicNumber:PaymentAuthConfig.kt$PaymentAuthConfig.Stripe3ds2Config$99</ID>
+    <ID>MagicNumber:StripeApiRepository.kt$StripeApiRepository$10</ID>
+    <ID>MagicNumber:StripeApiRepository.kt$StripeApiRepository$1024</ID>
     <ID>MagicNumber:StripeColorUtils.kt$StripeColorUtils.Companion$0.114</ID>
     <ID>MagicNumber:StripeColorUtils.kt$StripeColorUtils.Companion$0.299</ID>
     <ID>MagicNumber:StripeColorUtils.kt$StripeColorUtils.Companion$0.5</ID>
@@ -201,9 +203,7 @@
     <ID>TooGenericExceptionThrown:PaymentFlowViewModelTest.kt$PaymentFlowViewModelTest.ThrowingShippingMethodsFactory$throw RuntimeException("Always throws an exception")</ID>
     <ID>TooManyFunctions:AccountParams.kt$AccountParams.BusinessTypeParams.Company$Builder : ObjectBuilder</ID>
     <ID>TooManyFunctions:AccountParams.kt$AccountParams.BusinessTypeParams.Individual$Builder : ObjectBuilder</ID>
-    <ID>TooManyFunctions:AddPaymentMethodActivity.kt$AddPaymentMethodActivity : StripeActivity</ID>
     <ID>TooManyFunctions:AuthenticationComponent.kt$AuthenticationComponent$Builder</ID>
-    <ID>TooManyFunctions:CardFormView.kt$CardFormView : LinearLayout</ID>
     <ID>TooManyFunctions:CardInputWidget.kt$CardInputWidget : LinearLayoutCardWidget</ID>
     <ID>TooManyFunctions:CardMultilineWidget.kt$CardMultilineWidget : LinearLayoutCardWidget</ID>
     <ID>TooManyFunctions:CardWidget.kt$CardWidget</ID>
@@ -211,17 +211,12 @@
     <ID>TooManyFunctions:CustomerSession.kt$CustomerSession</ID>
     <ID>TooManyFunctions:PaymentAnalyticsRequestFactory.kt$PaymentAnalyticsRequestFactory : AnalyticsRequestFactory</ID>
     <ID>TooManyFunctions:PaymentController.kt$PaymentController</ID>
-    <ID>TooManyFunctions:PaymentFlowActivity.kt$PaymentFlowActivity : StripeActivity</ID>
-    <ID>TooManyFunctions:PaymentFlowResultProcessor.kt$PaymentFlowResultProcessor&lt;T : StripeIntent, out S : StripeIntentResult&lt;T>></ID>
     <ID>TooManyFunctions:PaymentMethod.kt$PaymentMethod$Builder : ObjectBuilder</ID>
     <ID>TooManyFunctions:PaymentMethodCreateParams.kt$PaymentMethodCreateParams$Companion</ID>
-    <ID>TooManyFunctions:PaymentMethodsActivity.kt$PaymentMethodsActivity : AppCompatActivity</ID>
     <ID>TooManyFunctions:PaymentMethodsActivityStarter.kt$PaymentMethodsActivityStarter.Args$Builder : ObjectBuilder</ID>
     <ID>TooManyFunctions:PaymentMethodsAdapter.kt$PaymentMethodsAdapter : Adapter</ID>
     <ID>TooManyFunctions:PaymentSessionConfig.kt$PaymentSessionConfig$Builder : ObjectBuilder</ID>
-    <ID>TooManyFunctions:PaymentSessionViewModel.kt$PaymentSessionViewModel : AndroidViewModel</ID>
     <ID>TooManyFunctions:PersonTokenParams.kt$PersonTokenParams$Builder : ObjectBuilder</ID>
-    <ID>TooManyFunctions:ShippingInfoWidget.kt$ShippingInfoWidget : LinearLayout</ID>
     <ID>TooManyFunctions:SourceParams.kt$SourceParams$Companion</ID>
     <ID>TooManyFunctions:Stripe.kt$Stripe</ID>
     <ID>TooManyFunctions:StripeApiRepository.kt$StripeApiRepository : StripeRepository</ID>

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -162,7 +162,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
     init {
         fireFraudDetectionDataRequest()
 
-        CoroutineScope(Dispatchers.IO).launch {
+        CoroutineScope(workContext).launch {
             val httpCacheDir = File(context.cacheDir, "stripe_api_repository_cache")
             val httpCacheSize = (10 * 1024 * 1024).toLong() // 10 MiB
             HttpResponseCache.install(httpCacheDir, httpCacheSize)

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.networking
 
 import android.content.Context
+import android.net.http.HttpResponseCache
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.DefaultFraudDetectionDataRepository
@@ -90,8 +91,11 @@ import com.stripe.android.model.parsers.Stripe3ds2AuthResultJsonParser
 import com.stripe.android.model.parsers.TokenJsonParser
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.utils.StripeUrlUtils
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import org.json.JSONException
+import java.io.File
 import java.io.IOException
 import java.net.HttpURLConnection
 import java.security.Security
@@ -157,6 +161,12 @@ class StripeApiRepository @JvmOverloads internal constructor(
 
     init {
         fireFraudDetectionDataRequest()
+
+        CoroutineScope(Dispatchers.IO).launch {
+            val httpCacheDir = File(context.cacheDir, "stripe_api_repository_cache")
+            val httpCacheSize = (10 * 1024 * 1024).toLong() // 10 MiB
+            HttpResponseCache.install(httpCacheDir, httpCacheSize)
+        }
     }
 
     override suspend fun retrieveStripeIntent(

--- a/stripe-core/build.gradle
+++ b/stripe-core/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     testImplementation "androidx.arch.core:core-testing:$androidxArchCoreVersion"
     testImplementation "androidx.fragment:fragment-testing:$androidxFragmentVersion"
     testImplementation "androidx.test:runner:$androidTestVersion"
+    testImplementation "com.squareup.okhttp3:mockwebserver:$okhttpVersion"
 
     ktlint "com.pinterest:ktlint:$ktlintVersion"
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/ApiRequest.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/ApiRequest.kt
@@ -28,7 +28,7 @@ data class ApiRequest internal constructor(
     private val appInfo: AppInfo? = null,
     private val apiVersion: String = ApiVersion.get().code,
     private val sdkVersion: String = StripeSdkVersion.VERSION,
-    override var shouldCache: Boolean = false
+    override val shouldCache: Boolean = false
 ) : StripeRequest() {
     private val query: String = QueryStringFactory.createFromParamsWithEmptyValues(params)
 

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/ApiRequest.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/ApiRequest.kt
@@ -27,7 +27,8 @@ data class ApiRequest internal constructor(
     val options: Options,
     private val appInfo: AppInfo? = null,
     private val apiVersion: String = ApiVersion.get().code,
-    private val sdkVersion: String = StripeSdkVersion.VERSION
+    private val sdkVersion: String = StripeSdkVersion.VERSION,
+    override var shouldCache: Boolean = false
 ) : StripeRequest() {
     private val query: String = QueryStringFactory.createFromParamsWithEmptyValues(params)
 
@@ -142,7 +143,8 @@ data class ApiRequest internal constructor(
         fun createGet(
             url: String,
             options: Options,
-            params: Map<String, *>? = null
+            params: Map<String, *>? = null,
+            shouldCache: Boolean = false,
         ): ApiRequest {
             return ApiRequest(
                 method = Method.GET,
@@ -151,14 +153,16 @@ data class ApiRequest internal constructor(
                 options = options,
                 appInfo = appInfo,
                 apiVersion = apiVersion,
-                sdkVersion = sdkVersion
+                sdkVersion = sdkVersion,
+                shouldCache = shouldCache
             )
         }
 
         fun createPost(
             url: String,
             options: Options,
-            params: Map<String, *>? = null
+            params: Map<String, *>? = null,
+            shouldCache: Boolean = false,
         ): ApiRequest {
             return ApiRequest(
                 method = Method.POST,
@@ -167,7 +171,8 @@ data class ApiRequest internal constructor(
                 options = options,
                 appInfo = appInfo,
                 apiVersion = apiVersion,
-                sdkVersion = sdkVersion
+                sdkVersion = sdkVersion,
+                shouldCache = shouldCache
             )
         }
 

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/ConnectionFactory.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/ConnectionFactory.kt
@@ -47,7 +47,7 @@ interface ConnectionFactory {
             return (URL(request.url).openConnection() as HttpURLConnection).apply {
                 connectTimeout = CONNECT_TIMEOUT
                 readTimeout = READ_TIMEOUT
-                useCaches = false
+                useCaches = request.shouldCache
                 requestMethod = request.method.code
 
                 request.headers.forEach { (key, value) ->

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/StripeRequest.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/StripeRequest.kt
@@ -39,6 +39,11 @@ abstract class StripeRequest {
     open var postHeaders: Map<String, String>? = null
 
     /**
+     * Whether the response should be cached or not
+     */
+    open var shouldCache = false
+
+    /**
      * Writes the body of a POST request with [OutputStream], left empty for non-POST requests
      */
     open fun writePostBody(outputStream: OutputStream) {}

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/StripeRequest.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/StripeRequest.kt
@@ -41,7 +41,7 @@ abstract class StripeRequest {
     /**
      * Whether the response should be cached or not
      */
-    open var shouldCache = false
+    open val shouldCache = false
 
     /**
      * Writes the body of a POST request with [OutputStream], left empty for non-POST requests

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/StripeResponse.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/StripeResponse.kt
@@ -24,6 +24,7 @@ data class StripeResponse<ResponseBody>(
      * the response body
      */
     val body: ResponseBody?,
+
     /**
      * the response headers
      */

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/DefaultStripeNetworkClientTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/DefaultStripeNetworkClientTest.kt
@@ -1,11 +1,14 @@
 package com.stripe.android.core.networking
 
+import android.net.http.HttpResponseCache
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.APIConnectionException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
@@ -16,7 +19,12 @@ import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import java.io.File
 import java.io.InputStream
+import java.net.CacheRequest
+import java.net.CacheResponse
 import java.net.HttpURLConnection
+import java.net.ResponseCache
+import java.net.URI
+import java.net.URLConnection
 import java.net.UnknownHostException
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -184,13 +192,76 @@ internal class DefaultStripeNetworkClientTest {
             assertThat(response.code).isEqualTo(TEST_NON_RETRY_CODES_END)
         }
 
-    private class FakeStripeRequest : StripeRequest() {
-        override val method: Method = Method.POST
-        override val url: String = TEST_HOST
-        override val mimeType: MimeType = MimeType.Form
-        override val headers = emptyMap<String, String>()
-        override val retryResponseCodes = TEST_RETRY_CODES
+    @Test
+    fun `request that should cache creates a connection that uses cache`() = runTest {
+        val server = MockWebServer()
+
+        server.enqueue(MockResponse().setBody("response1"))
+        server.enqueue(MockResponse().setBody("response2"))
+        server.enqueue(MockResponse().setBody("response3"))
+
+        server.start()
+
+        var getCacheCount = 0
+        var putCacheCount = 0
+        HttpResponseCache.setDefault(object : ResponseCache() {
+            override fun get(
+                uri: URI?,
+                rqstMethod: String?,
+                rqstHeaders: MutableMap<String, MutableList<String>>?
+            ): CacheResponse? {
+                getCacheCount++
+                return null
+            }
+
+            override fun put(uri: URI?, conn: URLConnection?): CacheRequest? {
+                putCacheCount++
+                return null
+            }
+        })
+
+        val executor = DefaultStripeNetworkClient(
+            workContext = testDispatcher,
+            connectionFactory = ConnectionFactory.Default
+        )
+
+        val url = server.url("").toString()
+
+        val requestWithCache = FakeStripeRequest(
+            shouldCache = true,
+            method = StripeRequest.Method.GET,
+            url = url
+        )
+
+        val requestWithoutCache = FakeStripeRequest(
+            shouldCache = false,
+            method = StripeRequest.Method.GET,
+            url = url
+        )
+
+        executor.executeRequest(requestWithCache)
+        assertThat(getCacheCount).isEqualTo(1)
+        assertThat(putCacheCount).isEqualTo(1)
+
+        executor.executeRequest(requestWithCache)
+        assertThat(getCacheCount).isEqualTo(2)
+        assertThat(putCacheCount).isEqualTo(2)
+
+        executor.executeRequest(requestWithoutCache)
+        assertThat(getCacheCount).isEqualTo(2)
+        assertThat(putCacheCount).isEqualTo(2)
+
+        server.shutdown()
     }
+
+    private class FakeStripeRequest(
+        override val url: String = TEST_HOST,
+        override val shouldCache: Boolean = false,
+        override val method: Method = Method.POST,
+        override val mimeType: MimeType = MimeType.Form,
+        override val headers: Map<String, String> = emptyMap(),
+        override val retryResponseCodes: Iterable<Int> = TEST_RETRY_CODES
+    ) : StripeRequest()
 
     private class RetryCountConnectionFactory(
         private val stripeConnection: (Int) -> StripeConnection<String>


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

- Add `shouldCache` to `StripeRequest`
- Add default `shouldCache` to get and post methods for `ApiRequest`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

This is needed for UME. UME resources are likely to be requested more than other stripe api calls. The backend for UME will utilize cache-control headers which our network stack currently does not support.

This PR adds a network cache to the `StripeApiRepository` to cache the response and automatically cache the response if needed.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

https://user-images.githubusercontent.com/99316447/201730107-1a99d818-67db-4a9f-85f6-0a289ed0ed97.mov

