### PR TITLE
Force 1:1 aspect ratio for cardscan fragment

### DIFF
--- a/stripecardscan/res/layout/fragment_cardscan.xml
+++ b/stripecardscan/res/layout/fragment_cardscan.xml
@@ -2,14 +2,17 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     tools:context=".cardscan.CardScanFragment">
 
     <com.stripe.android.camera.scanui.CameraView
         android:id="@+id/camera_view"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintDimensionRatio="1:1"
         app:viewFinderType="creditCard" />
 

--- a/stripecardscan/res/layout/fragment_cardscan.xml
+++ b/stripecardscan/res/layout/fragment_cardscan.xml
@@ -9,7 +9,8 @@
     <com.stripe.android.camera.scanui.CameraView
         android:id="@+id/camera_view"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintDimensionRatio="1:1"
         app:viewFinderType="creditCard" />
 
     <ImageView


### PR DESCRIPTION
# Summary
Force the fragment aspect ratio to 1:1 to ensure correct display and view calculation

# Motivation
https://github.com/stripe/stripe-android/issues/5779

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

Tested using a fragment container that can scroll up and out of view.

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
