### PR TITLE
New consent drawer - Android


### DIFF
--- a/financial-connections/api/financial-connections.api
+++ b/financial-connections/api/financial-connections.api
@@ -655,9 +655,13 @@ public final class com/stripe/android/financialconnections/features/common/Compo
 
 public final class com/stripe/android/financialconnections/features/consent/ComposableSingletons$ConsentScreenKt {
 	public static final field INSTANCE Lcom/stripe/android/financialconnections/features/consent/ComposableSingletons$ConsentScreenKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-2 Lkotlin/jvm/functions/Function2;
+	public static field lambda-3 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
-	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-1$financial_connections_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-2$financial_connections_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-3$financial_connections_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class com/stripe/android/financialconnections/features/consent/ConsentViewModel_Factory : dagger/internal/Factory {
@@ -1542,6 +1546,22 @@ public final class com/stripe/android/financialconnections/model/Image$Creator :
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/model/Image;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/financialconnections/model/Image;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/financialconnections/model/LegalDetailsBody$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/model/LegalDetailsBody;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/financialconnections/model/LegalDetailsBody;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/financialconnections/model/LegalDetailsNotice$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/financialconnections/model/LegalDetailsNotice;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/financialconnections/model/LegalDetailsNotice;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/MarkdownParser.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/MarkdownParser.kt
@@ -32,7 +32,7 @@ internal object MarkdownParser {
             bullets = pane.body.bullets.map { bullet ->
                 Bullet(
                     icon = bullet.icon,
-                    content = toHtml(bullet.content),
+                    content = bullet.content?.let { toHtml(it) },
                     title = bullet.title?.let { toHtml(it) }
                 )
             }
@@ -46,7 +46,7 @@ internal object MarkdownParser {
                 bullets = pane.dataAccessNotice.body.bullets.map { bullet ->
                     Bullet(
                         icon = bullet.icon,
-                        content = toHtml(bullet.content),
+                        content = bullet.content?.let { toHtml(it) },
                         title = bullet.title?.let { toHtml(it) }
                     )
                 }
@@ -61,7 +61,7 @@ internal object MarkdownParser {
                 bullets = pane.legalDetailsNotice.body.bullets.map { bullet ->
                     Bullet(
                         icon = bullet.icon,
-                        content = toHtml(bullet.content),
+                        content = bullet.content?.let { toHtml(it) },
                         title = bullet.title?.let { toHtml(it) }
                     )
                 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/MarkdownParser.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/MarkdownParser.kt
@@ -5,6 +5,8 @@ import com.stripe.android.financialconnections.model.ConsentPane
 import com.stripe.android.financialconnections.model.ConsentPaneBody
 import com.stripe.android.financialconnections.model.DataAccessNotice
 import com.stripe.android.financialconnections.model.DataAccessNoticeBody
+import com.stripe.android.financialconnections.model.LegalDetailsBody
+import com.stripe.android.financialconnections.model.LegalDetailsNotice
 
 internal object MarkdownParser {
     private val markDownToHtmlRegex = listOf(
@@ -52,6 +54,20 @@ internal object MarkdownParser {
             learnMore = toHtml(pane.dataAccessNotice.learnMore),
             cta = toHtml(pane.dataAccessNotice.cta),
             connectedAccountNotice = pane.dataAccessNotice.connectedAccountNotice?.let { toHtml(it) }
+        ),
+        legalDetailsNotice = LegalDetailsNotice(
+            title = toHtml(pane.legalDetailsNotice.title),
+            body = LegalDetailsBody(
+                bullets = pane.legalDetailsNotice.body.bullets.map { bullet ->
+                    Bullet(
+                        icon = bullet.icon,
+                        content = toHtml(bullet.content),
+                        title = bullet.title?.let { toHtml(it) }
+                    )
+                }
+            ),
+            cta = toHtml(pane.legalDetailsNotice.cta),
+            learnMore = toHtml(pane.legalDetailsNotice.learnMore)
         )
     )
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentScreen.kt
@@ -474,23 +474,30 @@ private fun ConsentBottomSheetBullet(
         ConsentBulletIcon(iconUrl = iconUrl)
         Spacer(modifier = Modifier.size(8.dp))
         Column {
-            title?.let {
+            if (title != null && description != null) {
                 Text(
                     text = title.toText().toString(),
                     style = typography.bodyEmphasized.copy(
                         color = colors.textPrimary
                     )
                 )
-            }
-            if (title != null && description != null) Spacer(modifier = Modifier.size(2.dp))
-            description?.let {
+                Spacer(modifier = Modifier.size(2.dp))
                 Text(
                     text = description.toText().toString(),
                     style = typography.caption.copy(
                         color = colors.textSecondary
                     )
                 )
+            } else {
+                val text = title ?: description ?: TextResource.Text("")
+                Text(
+                    text = text.toText().toString(),
+                    style = typography.body.copy(
+                        color = colors.textPrimary
+                    )
+                )
             }
+
         }
     }
 }
@@ -528,9 +535,12 @@ private fun ConsentBulletIcon(iconUrl: String?) {
         .size(16.dp)
         .offset(y = 2.dp)
     if (iconUrl == null) {
-        val color = colors.textSecondary
+        val color = colors.textPrimary
         Canvas(
-            modifier = Modifier.size(16.dp).padding(6.dp),
+            modifier = Modifier
+                .size(16.dp)
+                .padding(6.dp)
+                .offset(y = 2.dp),
             onDraw = { drawCircle(color = color) }
         )
     } else {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentScreen.kt
@@ -145,7 +145,13 @@ private fun ConsentMainContent(
         TextResource.Text(fromHtml(consent.title))
     }
     val bullets = remember(consent.body.bullets) {
-        consent.body.bullets.map { it.icon to TextResource.Text(fromHtml(it.content)) }
+        consent.body.bullets.map { bullet ->
+            Triple(
+                first = bullet.icon,
+                second = bullet.title?.let { TextResource.Text(fromHtml(it)) },
+                third = bullet.content?.let { TextResource.Text(fromHtml(it)) },
+            )
+        }
     }
     FinancialConnectionsScaffold(
         topBar = {
@@ -180,11 +186,15 @@ private fun ConsentMainContent(
                     )
                 )
                 Spacer(modifier = Modifier.size(24.dp))
-                bullets.forEach { (iconUrl, text) ->
-                    ConsentBulletRow(iconUrl?.default, text) { onClickableTextClick(it) }
+                bullets.forEach { (iconUrl, title, description) ->
                     Spacer(modifier = Modifier.size(16.dp))
+                    ConsentBottomSheetBullet(
+                        iconUrl = iconUrl?.default,
+                        title = title,
+                        description = description,
+                        onClickableTextClick = onClickableTextClick
+                    )
                 }
-
                 Spacer(modifier = Modifier.weight(1f))
             }
             ConsentFooter(
@@ -329,7 +339,7 @@ private fun LegalDetailsBottomSheetContent(
             Triple(
                 first = body.icon,
                 second = body.title?.let { TextResource.Text(fromHtml(body.title)) },
-                third = TextResource.Text(fromHtml(body.content))
+                third = body.content?.let { TextResource.Text(fromHtml(body.content)) }
             )
         }
     }
@@ -360,11 +370,11 @@ private fun DataAccessBottomSheetContent(
         dataDialog.connectedAccountNotice?.let { TextResource.Text(fromHtml(it)) }
     }
     val bullets = remember(dataDialog.body.bullets) {
-        dataDialog.body.bullets.map { body ->
+        dataDialog.body.bullets.map { bullet ->
             Triple(
-                first = body.icon,
-                second = body.title?.let { TextResource.Text(fromHtml(body.title)) },
-                third = TextResource.Text(fromHtml(body.content))
+                first = bullet.icon,
+                second = bullet.title?.let { TextResource.Text(fromHtml(it)) },
+                third = bullet.content?.let { TextResource.Text(fromHtml(it)) }
             )
         }
     }
@@ -383,7 +393,7 @@ private fun DataAccessBottomSheetContent(
 private fun ConsentBottomSheetContent(
     title: TextResource.Text,
     onClickableTextClick: (String) -> Unit,
-    bullets: List<Triple<Image?, TextResource?, TextResource>>,
+    bullets: List<Triple<Image?, TextResource?, TextResource?>>,
     connectedAccountNotice: TextResource?,
     cta: String,
     learnMore: TextResource,
@@ -409,7 +419,8 @@ private fun ConsentBottomSheetContent(
                 ConsentBottomSheetBullet(
                     iconUrl = iconUrl?.default,
                     title = title,
-                    description = description
+                    description = description,
+                    onClickableTextClick = onClickableTextClick
                 )
             }
         }
@@ -468,64 +479,86 @@ private fun ConsentBottomSheetContent(
 private fun ConsentBottomSheetBullet(
     title: TextResource?,
     description: TextResource?,
-    iconUrl: String?
+    iconUrl: String?,
+    onClickableTextClick: (String) -> Unit
 ) {
     Row {
         ConsentBulletIcon(iconUrl = iconUrl)
         Spacer(modifier = Modifier.size(8.dp))
         Column {
-            if (title != null && description != null) {
-                Text(
-                    text = title.toText().toString(),
-                    style = typography.bodyEmphasized.copy(
-                        color = colors.textPrimary
+            when {
+                // title + content
+                title != null && description != null -> {
+                    AnnotatedText(
+                        text = title,
+                        defaultStyle = typography.body.copy(
+                            color = colors.textPrimary
+                        ),
+                        annotationStyles = mapOf(
+                            StringAnnotation.CLICKABLE to typography.bodyEmphasized
+                                .toSpanStyle()
+                                .copy(color = colors.textBrand),
+                            StringAnnotation.BOLD to typography.bodyEmphasized
+                                .toSpanStyle()
+                                .copy(color = colors.textPrimary),
+                        ),
+                        onClickableTextClick = onClickableTextClick
                     )
-                )
-                Spacer(modifier = Modifier.size(2.dp))
-                Text(
-                    text = description.toText().toString(),
-                    style = typography.caption.copy(
-                        color = colors.textSecondary
+                    Spacer(modifier = Modifier.size(2.dp))
+                    AnnotatedText(
+                        text = description,
+                        defaultStyle = typography.detail.copy(
+                            color = colors.textSecondary
+                        ),
+                        annotationStyles = mapOf(
+                            StringAnnotation.CLICKABLE to typography.detailEmphasized
+                                .toSpanStyle()
+                                .copy(color = colors.textBrand),
+                            StringAnnotation.BOLD to typography.detailEmphasized
+                                .toSpanStyle()
+                                .copy(color = colors.textSecondary),
+                        ),
+                        onClickableTextClick = onClickableTextClick
                     )
-                )
-            } else {
-                val text = title ?: description ?: TextResource.Text("")
-                Text(
-                    text = text.toText().toString(),
-                    style = typography.body.copy(
-                        color = colors.textPrimary
+                }
+                // only title
+                title != null -> {
+                    AnnotatedText(
+                        text = title,
+                        defaultStyle = typography.body.copy(
+                            color = colors.textPrimary
+                        ),
+                        annotationStyles = mapOf(
+                            StringAnnotation.CLICKABLE to typography.bodyEmphasized
+                                .toSpanStyle()
+                                .copy(color = colors.textBrand),
+                            StringAnnotation.BOLD to typography.bodyEmphasized
+                                .toSpanStyle()
+                                .copy(color = colors.textPrimary),
+                        ),
+                        onClickableTextClick = {}
                     )
-                )
+                }
+                // only content
+                description != null -> {
+                    AnnotatedText(
+                        text = description,
+                        defaultStyle = typography.body.copy(
+                            color = colors.textSecondary
+                        ),
+                        annotationStyles = mapOf(
+                            StringAnnotation.CLICKABLE to typography.bodyEmphasized
+                                .toSpanStyle()
+                                .copy(color = colors.textBrand),
+                            StringAnnotation.BOLD to typography.bodyEmphasized
+                                .toSpanStyle()
+                                .copy(color = colors.textSecondary),
+                        ),
+                        onClickableTextClick = {}
+                    )
+                }
             }
-
         }
-    }
-}
-
-@Composable
-private fun ConsentBulletRow(
-    iconUrl: String?,
-    text: TextResource,
-    onClickableTextClick: ((String) -> Unit)? = null
-) {
-    Row {
-        ConsentBulletIcon(iconUrl = iconUrl)
-        Spacer(modifier = Modifier.size(8.dp))
-        AnnotatedText(
-            text,
-            onClickableTextClick = { onClickableTextClick?.invoke(it) },
-            defaultStyle = typography.body.copy(
-                color = colors.textSecondary
-            ),
-            annotationStyles = mapOf(
-                StringAnnotation.CLICKABLE to typography.bodyEmphasized
-                    .toSpanStyle()
-                    .copy(color = colors.textBrand),
-                StringAnnotation.BOLD to typography.bodyEmphasized
-                    .toSpanStyle()
-                    .copy(color = colors.textSecondary)
-            )
-        )
     }
 }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentScreen.kt
@@ -3,7 +3,6 @@
 
 package com.stripe.android.financialconnections.features.consent
 
-import android.net.Uri
 import android.os.Build
 import android.text.Html
 import android.text.Spanned
@@ -34,7 +33,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -55,7 +54,6 @@ import com.stripe.android.financialconnections.model.DataAccessNotice
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.NextPane
 import com.stripe.android.financialconnections.model.Image
 import com.stripe.android.financialconnections.model.LegalDetailsNotice
-import com.stripe.android.financialconnections.presentation.CreateBrowserIntentForUrl
 import com.stripe.android.financialconnections.presentation.parentViewModel
 import com.stripe.android.financialconnections.ui.FinancialConnectionsPreview
 import com.stripe.android.financialconnections.ui.LocalImageLoader
@@ -79,7 +77,7 @@ internal fun ConsentScreen() {
     val parentViewModel = parentViewModel()
     val state = viewModel.collectAsState()
 
-    val context = LocalContext.current
+    val uriHandler = LocalUriHandler.current
     val scope = rememberCoroutineScope()
     val bottomSheetState = rememberModalBottomSheetState(
         ModalBottomSheetValue.Hidden,
@@ -93,13 +91,7 @@ internal fun ConsentScreen() {
     state.value.viewEffect?.let { viewEffect ->
         LaunchedEffect(viewEffect) {
             when (viewEffect) {
-                is OpenUrl -> context.startActivity(
-                    CreateBrowserIntentForUrl(
-                        context = context,
-                        uri = Uri.parse(viewEffect.url)
-                    )
-                )
-
+                is OpenUrl -> uriHandler.openUri(viewEffect.url)
                 is OpenBottomSheet -> bottomSheetState.show()
             }
             viewModel.onViewEffectLaunched()

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentScreen.kt
@@ -98,6 +98,7 @@ internal fun ConsentScreen() {
                     uri = Uri.parse(viewEffect.url)
                 )
             )
+
             is ViewEffect.OpenBottomSheet -> bottomSheetState.show()
             null -> Unit
         }
@@ -188,7 +189,7 @@ private fun ConsentMainContent(
                 )
                 Spacer(modifier = Modifier.size(24.dp))
                 bullets.forEach { (iconUrl, text) ->
-                    ConsentBullet(iconUrl.default, text) { onClickableTextClick(it) }
+                    ConsentBullet(iconUrl?.default, text) { onClickableTextClick(it) }
                     Spacer(modifier = Modifier.size(16.dp))
                 }
 
@@ -227,11 +228,13 @@ private fun LoadedContent(
                     onConfirmModalClick = onConfirmModalClick,
                     onClickableTextClick = onClickableTextClick
                 )
+
                 ConsentState.BottomSheetContent.DATA -> DataAccessBottomSheetContent(
                     dataDialog = consent.dataAccessNotice,
                     onConfirmModalClick = onConfirmModalClick,
                     onClickableTextClick = onClickableTextClick
                 )
+
                 null -> {}
             }
         },
@@ -388,7 +391,7 @@ private fun DataAccessBottomSheetContent(
 private fun ConsentBottomSheetContent(
     title: TextResource.Text,
     onClickableTextClick: (String) -> Unit,
-    bullets: List<Triple<Image, TextResource?, TextResource>>,
+    bullets: List<Triple<Image?, TextResource?, TextResource>>,
     connectedAccountNotice: TextResource?,
     cta: String,
     learnMore: TextResource,
@@ -412,7 +415,7 @@ private fun ConsentBottomSheetContent(
             bullets.forEach { (iconUrl, title, description) ->
                 Spacer(modifier = Modifier.size(16.dp))
                 ConsentBottomSheetBullet(
-                    iconUrl = iconUrl.default,
+                    iconUrl = iconUrl?.default,
                     title = title,
                     description = description
                 )
@@ -473,13 +476,13 @@ private fun ConsentBottomSheetContent(
 private fun ConsentBottomSheetBullet(
     title: TextResource?,
     description: TextResource?,
-    iconUrl: String
+    iconUrl: String?
 ) {
-    Column {
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            val modifier = Modifier.size(16.dp)
+    val icon: @Composable () -> Unit = {
+        val modifier = Modifier.size(16.dp)
+        iconUrl?.let {
             StripeImage(
-                url = iconUrl,
+                url = it,
                 colorFilter = ColorFilter.tint(colors.textSuccess),
                 errorContent = { InstitutionPlaceholder(modifier) },
                 imageLoader = LocalImageLoader.current,
@@ -487,19 +490,32 @@ private fun ConsentBottomSheetBullet(
                 modifier = modifier
             )
             Spacer(modifier = Modifier.size(8.dp))
-            title?.let {
+        }
+    }
+    Column {
+        if (title != null) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                icon()
                 Text(
-                    text = it.toText().toString(),
+                    text = title.toText().toString(),
                     style = typography.bodyEmphasized.copy(
                         color = colors.textPrimary
                     )
                 )
             }
+            Spacer(modifier = Modifier.size(2.dp))
         }
-        Spacer(modifier = Modifier.size(2.dp))
-        Row {
-            Spacer(modifier = Modifier.size(24.dp))
-            description?.let {
+        if (description != null) {
+            Row {
+                if (iconUrl != null) {
+                    if (title == null) {
+                        // draw icon on the description row instead of the title row.
+                        icon()
+                    } else {
+                        // draw a space to match the space taken by the icon in the title row.
+                        Spacer(modifier = Modifier.size(24.dp))
+                    }
+                }
                 Text(
                     text = description.toText().toString(),
                     style = typography.caption.copy(
@@ -513,7 +529,7 @@ private fun ConsentBottomSheetBullet(
 
 @Composable
 private fun ConsentBullet(
-    iconUrl: String,
+    iconUrl: String?,
     text: TextResource,
     onClickableTextClick: ((String) -> Unit)? = null
 ) {
@@ -521,14 +537,16 @@ private fun ConsentBullet(
         val modifier = Modifier
             .size(16.dp)
             .offset(y = 2.dp)
-        StripeImage(
-            url = iconUrl,
-            colorFilter = ColorFilter.tint(colors.textSecondary),
-            imageLoader = LocalImageLoader.current,
-            contentDescription = null,
-            errorContent = { InstitutionPlaceholder(modifier) },
-            modifier = modifier
-        )
+        iconUrl?.let {
+            StripeImage(
+                url = iconUrl,
+                colorFilter = ColorFilter.tint(colors.textSecondary),
+                imageLoader = LocalImageLoader.current,
+                contentDescription = null,
+                errorContent = { InstitutionPlaceholder(modifier) },
+                modifier = modifier
+            )
+        }
         Spacer(modifier = Modifier.size(8.dp))
         AnnotatedText(
             text,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentScreen.kt
@@ -510,7 +510,7 @@ private fun ConsentBottomSheetBullet(
                                 .toSpanStyle()
                                 .copy(color = colors.textPrimary),
                         ),
-                        onClickableTextClick = {}
+                        onClickableTextClick = onClickableTextClick
                     )
                 }
                 // only content
@@ -528,7 +528,7 @@ private fun ConsentBottomSheetBullet(
                                 .toSpanStyle()
                                 .copy(color = colors.textSecondary),
                         ),
-                        onClickableTextClick = {}
+                        onClickableTextClick = onClickableTextClick
                     )
                 }
             }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentState.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentState.kt
@@ -7,9 +7,15 @@ import com.stripe.android.financialconnections.model.ConsentPane
 
 internal data class ConsentState(
     val consent: Async<ConsentPane> = Uninitialized,
+    val currentBottomSheet: BottomSheetContent? = null,
     val acceptConsent: Async<Unit> = Uninitialized,
     val viewEffect: ViewEffect? = null
 ) : MavericksState {
+
+    enum class BottomSheetContent {
+        LEGAL,
+        DATA
+    }
 
     sealed class ViewEffect {
         data class OpenUrl(
@@ -25,5 +31,6 @@ internal data class ConsentState(
 
 internal enum class ConsentClickableText(val value: String) {
     DATA("stripe://data-access-notice"),
+    LEGAL_DETAILS("stripe://legal-details-notice"),
     MANUAL_ENTRY("stripe://manual-entry"),
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentState.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentState.kt
@@ -7,7 +7,7 @@ import com.stripe.android.financialconnections.model.ConsentPane
 
 internal data class ConsentState(
     val consent: Async<ConsentPane> = Uninitialized,
-    val currentBottomSheet: BottomSheetContent? = null,
+    val currentBottomSheet: BottomSheetContent = BottomSheetContent.DATA,
     val acceptConsent: Async<Unit> = Uninitialized,
     val viewEffect: ViewEffect? = null
 ) : MavericksState {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentStates.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentStates.kt
@@ -24,6 +24,7 @@ internal class ConsentStates : PreviewParameterProvider<ConsentState> {
         fun canonical() = ConsentState(consent = Success(sampleConsent().copy(belowCta = null)))
         fun manualEntryPlusMicrodeposits() = ConsentState(consent = Success(sampleConsent()))
 
+        @Suppress("LongMethod")
         fun sampleConsent(): ConsentPane = ConsentPane(
             title = "Goldilocks works with Stripe to link your accounts",
             body = ConsentPaneBody(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentStates.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentStates.kt
@@ -71,22 +71,18 @@ internal class ConsentStates : PreviewParameterProvider<ConsentState> {
                 cta = "OK"
             ),
             legalDetailsNotice = LegalDetailsNotice(
-                title = "Goldilocks works with Stripe to link your accounts",
+                title = "Stripe uses your account data as described in the Terms, including:",
                 body = LegalDetailsBody(
                     bullets = listOf(
                         Bullet(
-                            icon = Image("https://www.cdn.stripe.com/12321312321.png"),
-                            title = "Account details",
-                            content = "Account number, routing number, account type, account nickname."
+                            content = "To improve our services"
                         ),
                         Bullet(
-                            icon = Image("https://www.cdn.stripe.com/12321312321.png"),
-                            title = "Account details",
-                            content = "Account number, routing number, account type, account nickname."
+                            content = "To manage fraud and loss risk of transactions"
                         ),
                     )
                 ),
-                learnMore = "Learn more about legal notice",
+                learnMore = "Learn more",
                 cta = "OK"
             ),
         )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentStates.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentStates.kt
@@ -8,6 +8,8 @@ import com.stripe.android.financialconnections.model.ConsentPaneBody
 import com.stripe.android.financialconnections.model.DataAccessNotice
 import com.stripe.android.financialconnections.model.DataAccessNoticeBody
 import com.stripe.android.financialconnections.model.Image
+import com.stripe.android.financialconnections.model.LegalDetailsBody
+import com.stripe.android.financialconnections.model.LegalDetailsNotice
 
 internal class ConsentStates : PreviewParameterProvider<ConsentState> {
     override val values = sequenceOf(
@@ -66,7 +68,26 @@ internal class ConsentStates : PreviewParameterProvider<ConsentState> {
                 learnMore = "Learn more about data access",
                 connectedAccountNotice = "Connected account placeholder",
                 cta = "OK"
-            )
+            ),
+            legalDetailsNotice = LegalDetailsNotice(
+                title = "Goldilocks works with Stripe to link your accounts",
+                body = LegalDetailsBody(
+                    bullets = listOf(
+                        Bullet(
+                            icon = Image("https://www.cdn.stripe.com/12321312321.png"),
+                            title = "Account details",
+                            content = "Account number, routing number, account type, account nickname."
+                        ),
+                        Bullet(
+                            icon = Image("https://www.cdn.stripe.com/12321312321.png"),
+                            title = "Account details",
+                            content = "Account number, routing number, account type, account nickname."
+                        ),
+                    )
+                ),
+                learnMore = "Learn more about legal notice",
+                cta = "OK"
+            ),
         )
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentViewModel.kt
@@ -14,6 +14,7 @@ import com.stripe.android.financialconnections.domain.AcceptConsent
 import com.stripe.android.financialconnections.domain.GetOrFetchSync
 import com.stripe.android.financialconnections.domain.GoNext
 import com.stripe.android.financialconnections.features.MarkdownParser
+import com.stripe.android.financialconnections.features.consent.ConsentState.BottomSheetContent
 import com.stripe.android.financialconnections.features.consent.ConsentState.ViewEffect
 import com.stripe.android.financialconnections.features.consent.ConsentState.ViewEffect.OpenUrl
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest
@@ -73,23 +74,34 @@ internal class ConsentViewModel @Inject constructor(
                 eventTracker.track(Click(eventName, pane = NextPane.CONSENT))
             }
         }
-
+        val date = Date()
         if (URLUtil.isNetworkUrl(uri)) {
-            val date = Date()
             setState { copy(viewEffect = OpenUrl(uri, date.time)) }
         } else {
             val managedUri = ConsentClickableText.values()
                 .firstOrNull { uriUtils.compareSchemeAuthorityAndPath(it.value, uri) }
             when (managedUri) {
                 ConsentClickableText.DATA -> {
-                    val date = Date()
-                    setState { copy(viewEffect = ViewEffect.OpenBottomSheet(date.time)) }
+                    setState {
+                        copy(
+                            currentBottomSheet = BottomSheetContent.DATA,
+                            viewEffect = ViewEffect.OpenBottomSheet(date.time)
+                        )
+                    }
                 }
 
                 ConsentClickableText.MANUAL_ENTRY -> {
                     navigationManager.navigate(NavigationDirections.manualEntry)
                 }
 
+                ConsentClickableText.LEGAL_DETAILS -> {
+                    setState {
+                        copy(
+                            currentBottomSheet = BottomSheetContent.LEGAL,
+                            viewEffect = ViewEffect.OpenBottomSheet(date.time)
+                        )
+                    }
+                }
                 null -> logger.error("Unrecognized clickable text: $uri")
             }
         }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/SynchronizeSessionResponse.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/SynchronizeSessionResponse.kt
@@ -36,8 +36,17 @@ internal data class ConsentPane(
     val cta: String,
     @SerialName("data_access_notice")
     val dataAccessNotice: DataAccessNotice,
+    @SerialName("legal_details_notice")
+    val legalDetailsNotice: LegalDetailsNotice,
     @SerialName("title")
     val title: String
+) : Parcelable
+
+@Serializable
+@Parcelize
+internal data class ConsentPaneBody(
+    @SerialName("bullets")
+    val bullets: List<Bullet>
 ) : Parcelable
 
 @Serializable
@@ -75,7 +84,21 @@ internal data class DataAccessNotice(
 
 @Serializable
 @Parcelize
-internal data class ConsentPaneBody(
+internal data class LegalDetailsNotice(
+    @SerialName("body")
+    val body: LegalDetailsBody,
+    @SerialName("title")
+    val title: String,
+    @SerialName("cta")
+    val cta: String,
+    @SerialName("learn_more")
+    val learnMore: String,
+
+) : Parcelable
+
+@Serializable
+@Parcelize
+internal data class LegalDetailsBody(
     @SerialName("bullets")
     val bullets: List<Bullet>
 ) : Parcelable

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/SynchronizeSessionResponse.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/SynchronizeSessionResponse.kt
@@ -60,7 +60,7 @@ internal data class DataAccessNoticeBody(
 @Parcelize
 internal data class Bullet(
     @SerialName("content")
-    val content: String,
+    val content: String? = null,
     @SerialName("icon")
     val icon: Image? = null,
     @SerialName("title")

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/SynchronizeSessionResponse.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/SynchronizeSessionResponse.kt
@@ -62,7 +62,7 @@ internal data class Bullet(
     @SerialName("content")
     val content: String,
     @SerialName("icon")
-    val icon: Image,
+    val icon: Image? = null,
     @SerialName("title")
     val title: String? = null
 ) : Parcelable

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/sdui/ServerDrivenUi.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/sdui/ServerDrivenUi.kt
@@ -1,3 +1,5 @@
+@file:Suppress("MatchingDeclarationName")
+
 package com.stripe.android.financialconnections.ui.sdui
 
 import android.os.Build

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/sdui/ServerDrivenUi.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/sdui/ServerDrivenUi.kt
@@ -1,0 +1,33 @@
+package com.stripe.android.financialconnections.ui.sdui
+
+import android.os.Build
+import android.text.Html
+import android.text.Spanned
+import com.stripe.android.financialconnections.model.Bullet
+import com.stripe.android.financialconnections.ui.TextResource
+
+/**
+ * UI model of [Bullet] where text content has been transformed to [Spanned] Text resources.
+ */
+internal data class BulletUI(
+    val title: TextResource?,
+    val content: TextResource?,
+    val icon: String?
+) {
+    companion object {
+        fun from(bullet: Bullet): BulletUI = BulletUI(
+            icon = bullet.icon?.default,
+            title = bullet.title?.let { TextResource.Text(fromHtml(it)) },
+            content = bullet.content?.let { TextResource.Text(fromHtml(it)) },
+        )
+    }
+}
+
+@SuppressWarnings("deprecation")
+internal fun fromHtml(source: String): Spanned {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        Html.fromHtml(source, Html.FROM_HTML_MODE_LEGACY)
+    } else {
+        Html.fromHtml(source)
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

- Adds legal bottom sheet to consent screen.

# Motivation
:notebook_with_decorative_cover: &nbsp;**New consent drawer - Android**
:globe_with_meridians: &nbsp;[BANKCON-5728](https://jira.corp.stripe.com/browse/BANKCON-5728)
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Screenshots

https://user-images.githubusercontent.com/99293320/202532019-d9ea653f-a3ff-443b-b254-3816b41ccf26.mp4

