### PR TITLE
[stripe-ui-core] only load valid image urls in Html

### DIFF
--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/ImageLruDiskCache.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/ImageLruDiskCache.kt
@@ -82,10 +82,13 @@ class ImageLruDiskCache(
 
     private fun compressFormatFromUrl(url: String): CompressFormat {
         return when {
-            url.endsWith("png") -> CompressFormat.PNG
-            url.endsWith("webp") -> CompressFormat.WEBP
-            url.endsWith("jpg") ||
-                url.endsWith("jpeg") -> CompressFormat.JPEG
+            url.endsWith(SupportedImageType.PNG.suffix, ignoreCase = true) -> CompressFormat.PNG
+            url.endsWith(SupportedImageType.WEBP.suffix, ignoreCase = true) -> CompressFormat.WEBP
+            url.endsWith(SupportedImageType.JPG.suffix, ignoreCase = true) ||
+                url.endsWith(
+                    SupportedImageType.JPEG.suffix,
+                    ignoreCase = true
+                ) -> CompressFormat.JPEG
             else -> throw IllegalArgumentException("Unexpected image format: $url")
         }
     }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/ImageLruDiskCache.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/ImageLruDiskCache.kt
@@ -80,18 +80,9 @@ class ImageLruDiskCache(
         }
     }
 
-    private fun compressFormatFromUrl(url: String): CompressFormat {
-        return when {
-            url.endsWith(SupportedImageType.PNG.suffix, ignoreCase = true) -> CompressFormat.PNG
-            url.endsWith(SupportedImageType.WEBP.suffix, ignoreCase = true) -> CompressFormat.WEBP
-            url.endsWith(SupportedImageType.JPG.suffix, ignoreCase = true) ||
-                url.endsWith(
-                    SupportedImageType.JPEG.suffix,
-                    ignoreCase = true
-                ) -> CompressFormat.JPEG
-            else -> throw IllegalArgumentException("Unexpected image format: $url")
-        }
-    }
+    private fun compressFormatFromUrl(url: String) =
+        ImageType.fromUrl(url)?.compressFormat
+            ?: throw throw IllegalArgumentException("Unexpected image format: $url")
 
     private fun CompressFormat.quality(): Int = when (this) {
         CompressFormat.JPEG -> JPEG_COMPRESS_QUALITY

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/UiUtils.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/UiUtils.kt
@@ -5,6 +5,7 @@ import android.content.ContentResolver
 import android.content.Context
 import android.content.res.Resources
 import android.content.res.Resources.NotFoundException
+import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.text.TextUtils
@@ -81,17 +82,42 @@ fun Context.getDrawableFromUri(uri: Uri): Drawable? {
     return null
 }
 
-internal fun String.isSupportedImageUrl(): Boolean {
-    SupportedImageType.values().forEach {
-        if (endsWith(it.suffix, ignoreCase = true)) {
-            return true
+internal fun String.isSupportedImageUrl() =
+    ImageType.values().any { imageType ->
+        imageType.suffixes.any { suffix ->
+            endsWith(suffix, ignoreCase = true)
         }
     }
-    return false
-}
 
-internal enum class SupportedImageType(val suffix: String) {
-    PNG("png"), WEBP("webp"), JPEG("jpeg"), JPG("jpg")
+internal enum class ImageType(
+    val suffixes: List<String>,
+    val compressFormat: Bitmap.CompressFormat
+) {
+    PNG(
+        suffixes = listOf("png"),
+        compressFormat = Bitmap.CompressFormat.PNG
+    ),
+    WEBP(
+        suffixes = listOf("webp"),
+        compressFormat = Bitmap.CompressFormat.WEBP
+    ),
+    JPEG(
+        suffixes = listOf("jpeg", "jpg"),
+        compressFormat = Bitmap.CompressFormat.JPEG
+    );
+
+    companion object {
+        fun fromUrl(url: String): ImageType? =
+            values()
+                .firstOrNull {
+                    it.suffixes.any { suffix ->
+                        url.endsWith(
+                            suffix,
+                            ignoreCase = true
+                        )
+                    }
+                }
+    }
 }
 
 private const val TAG = "stripe_ui_core_utils"

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/UiUtils.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/UiUtils.kt
@@ -81,4 +81,17 @@ fun Context.getDrawableFromUri(uri: Uri): Drawable? {
     return null
 }
 
+internal fun String.isSupportedImageUrl(): Boolean {
+    SupportedImageType.values().forEach {
+        if (endsWith(it.suffix, ignoreCase = true)) {
+            return true
+        }
+    }
+    return false
+}
+
+internal enum class SupportedImageType(val suffix: String) {
+    PNG("png"), WEBP("webp"), JPEG("jpeg"), JPG("jpg")
+}
+
 private const val TAG = "stripe_ui_core_utils"

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/text/Html.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/text/Html.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.unit.sp
 import androidx.core.text.HtmlCompat
 import com.stripe.android.uicore.image.StripeImage
 import com.stripe.android.uicore.image.StripeImageLoader
+import com.stripe.android.uicore.image.isSupportedImageUrl
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -146,7 +147,11 @@ private fun rememberRemoteImages(
     val remoteUrls = annotatedText.getStringAnnotations(
         start = 0,
         end = annotatedText.length
-    ).filter { !imageLoader.keys.contains(it.item) }
+    ).filter {
+        it.item.let { url ->
+            url.isSupportedImageUrl() && !imageLoader.keys.contains(url)
+        }
+    }
 
     val remoteImages = remember { MutableStateFlow<Map<String, InlineTextContent>>(emptyMap()) }
     val localDensity = LocalDensity.current


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
When the url is not image we shouldn't load them in `Html`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
