### PR TITLE
[Identity] upper case confirmation continue button

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/ui/ConfirmationScreen.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/ConfirmationScreen.kt
@@ -115,7 +115,7 @@ internal fun ConfirmationScreen(
                             testTag = confirmationConfirmButtonTag
                         }
                 ) {
-                    Text(text = successPage.buttonText)
+                    Text(text = successPage.buttonText.uppercase())
                 }
             }
             LaunchedEffect(Unit) {

--- a/identity/src/test/java/com/stripe/android/identity/ui/ConfirmationScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/ConfirmationScreenTest.kt
@@ -46,7 +46,9 @@ class ConfirmationScreenTest {
         ) {
             onNodeWithTag(confirmationTitleTag).assertTextEquals(CONFIRMATION_TITLE)
             onNodeWithTag(BODY_TAG).assertTextEquals(CONFIRMATION_BODY)
-            onNodeWithTag(confirmationConfirmButtonTag).assertTextEquals(CONFIRMATION_BUTTON_TEXT)
+            onNodeWithTag(confirmationConfirmButtonTag).assertTextEquals(
+                CONFIRMATION_BUTTON_TEXT.uppercase()
+            )
             onNodeWithTag(confirmationConfirmButtonTag).performClick()
             verify(onConfirmedMock).invoke()
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Upper case the confirmation screen continue button
# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified




# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![confirmBefore](https://user-images.githubusercontent.com/79880926/202600788-176feb71-6c31-4c86-8418-c62404b8f8a6.png)  | ![confirmAfter](https://user-images.githubusercontent.com/79880926/202600784-4f19a7a4-6ee4-4547-b323-1561b713b67d.png) |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
