### PR TITLE
Fix payment cancellation on back press during processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## XX.XX.XX - 2022-XX-XX
 
 ### PaymentSheet
-* [CHANGED][5848](https://github.com/stripe/stripe-android/pull/5848) We now disable the back button while processing intents with `BaseSheetActivity` to prevent them from incorrectly being displayed as canceled.
+* [CHANGED][5848](https://github.com/stripe/stripe-android/pull/5848) We now disable the back button while processing intents in `PaymentSheet` to prevent them from incorrectly being displayed as canceled.
 
 ### CardScan
 * [SECURITY][5798](https://github.com/stripe/stripe-android/pull/5798) URL-encode IDs used in URLs to prevent injection attacks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 2022-XX-XX
 
+### PaymentSheet
+* [CHANGED][5848](https://github.com/stripe/stripe-android/pull/5848) We now disable the back button while processing intents with `BaseSheetActivity` to prevent them from incorrectly being displayed as canceled.
+
 ### CardScan
 * [SECURITY][5798](https://github.com/stripe/stripe-android/pull/5798) URL-encode IDs used in URLs to prevent injection attacks.
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -186,12 +186,15 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
         overridePendingTransition(AnimationConstants.FADE_IN, AnimationConstants.FADE_OUT)
     }
 
+    @Deprecated("Deprecated in Java")
     override fun onBackPressed() {
-        if (supportFragmentManager.backStackEntryCount > 0) {
-            clearErrorMessages()
-            super.onBackPressed()
-        } else {
-            viewModel.onUserCancel()
+        if (viewModel.processing.value == false) {
+            if (supportFragmentManager.backStackEntryCount > 0) {
+                clearErrorMessages()
+                super.onBackPressed()
+            } else {
+                viewModel.onUserCancel()
+            }
         }
     }
 


### PR DESCRIPTION
# Summary

Fix an issue where payment gets cancelled on back press during processing in PaymentSheet.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Fixes https://github.com/stripe/stripe-android/issues/5844

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

- [CHANGED][5848](https://github.com/stripe/stripe-android/pull/5848) We now disable the back button while processing intents with `BaseSheetActivity` to prevent them from incorrectly being displayed as canceled.
