### PR TITLE
[Identity] Add a dummy Resource value

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/networking/Resource.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/Resource.kt
@@ -35,5 +35,9 @@ internal data class Resource<out T>(
         fun <T> idle(): Resource<T> {
             return Resource(Status.IDLE, null)
         }
+
+        // Integer saved as dummy values of Resource<Int> when Resource<Unit> is needed.
+        // Resource<Unit> shouldn't be used as Unit can't be parcelized.
+        internal const val DUMMY_RESOURCE = 0
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
@@ -35,6 +35,7 @@ import com.stripe.android.identity.ml.IDDetectorOutput
 import com.stripe.android.identity.networking.IdentityModelFetcher
 import com.stripe.android.identity.networking.IdentityRepository
 import com.stripe.android.identity.networking.Resource
+import com.stripe.android.identity.networking.Resource.Companion.DUMMY_RESOURCE
 import com.stripe.android.identity.networking.SelfieUploadState
 import com.stripe.android.identity.networking.SingleSideDocumentUploadState
 import com.stripe.android.identity.networking.Status
@@ -154,7 +155,7 @@ internal class IdentityViewModel constructor(
      * StateFlow to track request status of postVerificationPageData
      */
     @VisibleForTesting
-    internal val verificationPageData = MutableStateFlow<Resource<Unit>>(
+    internal val verificationPageData = MutableStateFlow<Resource<Int>>(
         savedStateHandle[VERIFICATION_PAGE_DATA] ?: run {
             Resource.idle()
         }
@@ -164,7 +165,7 @@ internal class IdentityViewModel constructor(
      * StateFlow to track request status of postVerificationPageSubmit
      */
     @VisibleForTesting
-    internal val verificationPageSubmit = MutableStateFlow<Resource<Unit>>(
+    internal val verificationPageSubmit = MutableStateFlow<Resource<Int>>(
         savedStateHandle[VERIFICATION_PAGE_SUBMIT] ?: run {
             Resource.idle()
         }
@@ -822,7 +823,7 @@ internal class IdentityViewModel constructor(
             calculateClearDataParam(collectedDataParam)
         ).let { verificationPageData ->
             this.verificationPageData.updateStateAndSave {
-                Resource.success(Unit)
+                Resource.success(DUMMY_RESOURCE)
             }
             _collectedData.updateStateAndSave { oldValue ->
                 oldValue.mergeWith(collectedDataParam)
@@ -859,7 +860,7 @@ internal class IdentityViewModel constructor(
             verificationArgs.ephemeralKeySecret
         ).let {
             verificationPageSubmit.updateStateAndSave {
-                Resource.success(Unit)
+                Resource.success(DUMMY_RESOURCE)
             }
             return it
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
`Resource<Unit>` can't be parcelized. Add a dummy value to make it parcelizable.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Make Resource parcelizable.


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
