### PR TITLE
Fix incorrect error message translations with client-side mapping

### DIFF
--- a/payments-core/res/values-DA/strings.xml
+++ b/payments-core/res/values-DA/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Dit navn er påkrævet.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Annuller</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Dit kort blev afvist</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s slutter på %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Færdig</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Rediger</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Dit kort er udløbet</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">MM/ÅÅ</string>
   <string name="expiry_label_short">Udløbsdato</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s -Offline</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Din betalingsmetode blev afvist.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">Dit korts udløbsdato er ikke fuldendt.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">Det indtastede IBAN-nummer er ugyldigt.</string>
   <string name="invalid_card_number">Nummeret på dit kort er ugyldigt.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Dit korts sikkerhedskode er ugyldig.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Kortets udløbsmåned er ugyldig.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Dit korts udløbsår er ugyldigt.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Dit navn er ugyldigt.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Ugyldig forsendelsesadresse</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Vælg bankkonto (FPX)...</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Gratis</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Der opstod en fejl under behandling af dit kort – prøv igen om et par sekunder</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Fjern</string>

--- a/payments-core/res/values-FI/strings.xml
+++ b/payments-core/res/values-FI/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Nimesi vaaditaan.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Peruuta</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Korttiasi ei hyväksytty</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s päättyy numeroihin %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Valmis</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Muokkaa</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Korttisi on vanhentunut</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">KK/VV</string>
   <string name="expiry_label_short">Vanheneminen</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - Offline-tilassa</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Maksutapasi on hylätty.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">Kortin voimassaoloaika on puutteellinen.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">Antamasi IBAN on virheellinen.</string>
   <string name="invalid_card_number">Kortin numero ei kelpaa.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Kortin turvakoodi on virheellinen.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Kortin erääntymiskuukausi ei kelpaa.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Kortin voimassaolovuosi ei kelpaa.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Nimi on virheellinen.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Toimitusosoite ei kelpaa</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Valitse pankkitili (FPX)...</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Maksuton</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Kortin käsittelyssä tapahtui virhe – kokeile uudelleen muutaman sekunnin kuluttua</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Poista</string>

--- a/payments-core/res/values-KO/strings.xml
+++ b/payments-core/res/values-KO/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">이름이 필요합니다.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">취소</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">카드가 거절되었습니다</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%2$s(으)로 끝나는 %1$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">완료</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">편집</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">카드가 만료되었습니다</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">MM/YY</string>
   <string name="expiry_label_short">만료</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - 오프라인</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">결제 방식이 거부되었습니다.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">카드의 만료 날짜가 불완전합니다.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">입력한 IBAN이 잘못되었습니다.</string>
   <string name="invalid_card_number">카드 번호가 잘못되었습니다.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">카드의 보안 코드가 유효하지 않습니다.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">카드의 만료 월이 유효하지 않습니다.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">카드의 만료 연도가 유효하지 않습니다.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">이름이 잘못되었습니다.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">잘못된 배송 주소</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">은행 계좌 선택(FPX)…</string>
   <!-- Label for free shipping method -->
   <string name="price_free">무료</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">카드를 처리하는 동안 오류가 발생했습니다. 몇 초 후에 다시 시도하십시오.</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">제거</string>

--- a/payments-core/res/values-RU/strings.xml
+++ b/payments-core/res/values-RU/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Необходимо указать ваше имя.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Отмена</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Карта отклонена</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s, оканч. на %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Готово</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Редактировать</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Срок действия карты истек</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">ММ/ГГ</string>
   <string name="expiry_label_short">Истечение срока действия</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - не в сети</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Не удалось выполнить оплату этим способом.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">Дата истечения срока действия карты введена не полностью.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">Введенный код IBAN содержит ошибку.</string>
   <string name="invalid_card_number">Номер карты недействителен.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Код CVV/CVC карты недействителен.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Недопустимый месяц окончания действия карты.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Недопустимый год окончания действия карты.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Недействительное имя.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Ошибочный адрес доставки</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Выберите банковский счет (FPX)…</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Бесплатно</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">При обработке карты произошла ошибка. Подождите несколько секунд и повторите попытку</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Удалить</string>

--- a/payments-core/res/values-SV/strings.xml
+++ b/payments-core/res/values-SV/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Namn är obligatoriskt.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Avbryt</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Ditt kort nekades</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s med slutsiffrorna %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Klar</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Redigera</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Kortet har löpt ut</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">MM/ÅÅ</string>
   <string name="expiry_label_short">Giltighetstid</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - offline</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Din betalningsmetod godkändes inte.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">Kortets utgångsdatum är ofullständigt.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">Angivet IBAN är ogiltigt.</string>
   <string name="invalid_card_number">Kortnumret är ogiltigt.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Kortets säkerhetskod är ogiltig.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Kortets utgångsmånad är ogiltig.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Kortets utgångsår är ogiltigt.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Ditt namn är ogiltigt.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Ogiltig leveransadress</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Välj bankkonto (FPX) ...</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Gratis</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Ett fel uppstod vid behandlingen av ditt kort - försök igen om ett par sekunder</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Ta bort</string>

--- a/payments-core/res/values-TR/strings.xml
+++ b/payments-core/res/values-TR/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Adınız gereklidir.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">İptal</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Kartınız reddedildi</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%2$s İle Biten %1$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Tamam</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Düzenle</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Kartınızın kullanım süresi dolmuş</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">AA/YY</string>
   <string name="expiry_label_short">Son kullanma</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - Çevrimdışı</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Ödeme yönteminiz reddedildi.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">Kartınızın son kullanma tarihi eksik.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">Girdiğiniz IBAN geçersiz.</string>
   <string name="invalid_card_number">Kart numaranız geçersiz.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Kartınızın güvenlik kodu geçersiz.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Kartınızın son kullanma ayı geçersiz.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Kartınızın son kullanma yılı geçersiz.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Adınız geçersiz.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Geçersiz Gönderi Adresi</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Banka Hesabı Seçin (FPX)...</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Ücretsiz</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Kartınızla işlem yapılırken bir hata oluştu -- birazdan tekrar deneyin</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Kaldır</string>

--- a/payments-core/res/values-b+es+419/strings.xml
+++ b/payments-core/res/values-b+es+419/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Tu nombre es obligatorio.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Cancelar</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Tu tarjeta fue rechazada.</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s terminada en %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">¡Listo!</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Editar</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Tu tarjeta ha vencido.</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">MM/AA</string>
   <string name="expiry_label_short">Vencimiento</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - Fuera de línea</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Tu método de pago fue rechazado.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">La fecha de vencimiento de la tarjeta está incompleta.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">El IBAN que ingresaste no es válido.</string>
   <string name="invalid_card_number">El número de tarjeta no es válido.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">El código de seguridad de la tarjeta no es válido.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">El mes de vencimiento de la tarjeta no es válido.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">El año de vencimiento de la tarjeta no es válido.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">El nombre no es válido.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Dirección de envío inválida</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Seleccionar cuenta bancaria (FPX)…</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Gratis</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Hubo un error al procesar tu tarjeta. Vuelve a intentar en unos segundos.</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Eliminar</string>

--- a/payments-core/res/values-ca-rES/strings.xml
+++ b/payments-core/res/values-ca-rES/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">El teu nom és obligatori.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Cancel·la</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">S\'ha rebutjat la teva targeta</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s que acaba en %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Fet</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Editar</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">La teva targeta ha caducat</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">MM / AA</string>
   <string name="expiry_label_short">Caducitat</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - Fora de línia</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">S\'ha rebutjat el mètode de pagament.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">La data de caducitat de la teva targeta no està completa.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">L\'IBAN és incorrecte.</string>
   <string name="invalid_card_number">El número de la teva targeta no és vàlid.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">El codi de seguretat de la teva targeta no és vàlid</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">El mes de caducitat de la teva targeta no és vàlid.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">L\'any de caducitat de la teva targeta no és vàlid.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">El nom no és vàlid.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Adreça d\'enviament invàlida</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Seleccionar Compte Bancari (FPX)...</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Sense cost</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Hi ha hagut un error processant la teva targeta - torna-ho a intentar en uns segons</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Eliminar</string>

--- a/payments-core/res/values-cs-rCZ/strings.xml
+++ b/payments-core/res/values-cs-rCZ/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Vaše jméno je povinný údaj.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Zrušit</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Vaše karta byla odmítnuta</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s končící za %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Hotovo</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Upravit</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Platnost Vaší karty uplynula</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">MM/RR</string>
   <string name="expiry_label_short">Konec platnosti</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - Offline</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Vaše platební metoda byla zamítnuta.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">Datum konce platnosti vaší karty je neúplné.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">Číslo IBAN, které jste zadali, je neplatné.</string>
   <string name="invalid_card_number">Číslo vaší karty je neplatné.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Bezpečnostní kód vaší karty je neplatný.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Rok konce platnosti vaší karty je neplatný.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Rok konce platnosti vaší karty je neplatný.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Vaše jméno je neplatné.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Neplatná dodací adresa</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Vyberte bankovní účet (FPX)</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Zdarma</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Při zpracování Vaší karty došlo k chybě -- zkuste to za několik sekund znovu</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Odebrat</string>

--- a/payments-core/res/values-de/strings.xml
+++ b/payments-core/res/values-de/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Ihr Name ist erforderlich.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Abbrechen</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Ihre Karte wurde abgelehnt.</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s, endend auf %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Fertig</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Bearbeiten</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Ihre Karte ist abgelaufen.</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">MM/JJ</string>
   <string name="expiry_label_short">Ablauf</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s ─ offline</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Ihre Zahlungsmethode wurde abgelehnt.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">Ablaufdatum der Karte ist unvollständig.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">Die eingegebene IBAN ist ungültig.</string>
   <string name="invalid_card_number">Die Kartennummer ist ungültig.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Sicherheitscode der Karte ist ungültig.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Der Ablaufmonat Ihrer Karte ist ungültig.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Das Ablaufjahr der Karte ist ungültig.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Ihr Name ist ungültig.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Ungültige Versandadresse</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Bankkonto (FPX) auswählen …</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Kostenlos</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Fehler bei der Verarbeitung Ihrer Karte – versuchen Sie es in ein paar Sekunden noch einmal.</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Entfernen</string>

--- a/payments-core/res/values-el-rGR/strings.xml
+++ b/payments-core/res/values-el-rGR/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Το όνομά σας απαιτείται.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Ακύρωση</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Η κάρτα σας απορρίφθηκε</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s λήγει σε %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Τέλος</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Επεξεργασία</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Η κάρτα σας έχει λήξει</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">ΜΜ/ΕΕ</string>
   <string name="expiry_label_short">Λήξη</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - Εκτός σύνδεσης</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Η μέθοδος πληρωμής σας απορρίφθηκε.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">Η ημερομηνία λήξης της κάρτας σας είναι ελλιπής.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">Ο κωδικός IBAN που εισαγάγατε δεν είναι έγκυρος.</string>
   <string name="invalid_card_number">Ο αριθμός της κάρτας σας δεν είναι έγκυρος.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Ο κωδικός ασφαλείας της κάρτας σας δεν είναι έγκυρος.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Ο μήνας λήξης της κάρτας σας δεν είναι έγκυρος.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Το έτος λήξης της κάρτας σας δεν είναι έγκυρο.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Το όνομά σας δεν είναι έγκυρο.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Μη έγκυρη διεύθυνση αποστολής</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Επιλογή τραπεζικού λογαριασμού (FPX)…</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Δωρεάν</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Προέκυψε απροσδόκητο σφάλμα κατά την επεξεργασία της κάρτας σας -- δοκιμάστε ξανά σε μερικά δευτερόλεπτα</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Αφαίρεση</string>

--- a/payments-core/res/values-en-rGB/strings.xml
+++ b/payments-core/res/values-en-rGB/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Your name is required.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Cancel</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Your card has been declined</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s ending in %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Done</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Edit</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Your card has expired</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">MM/YY</string>
   <string name="expiry_label_short">Expiry</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - Offline</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Your payment method was declined.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">Your card\'s expiration date is incomplete.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">The IBAN you entered is invalid.</string>
   <string name="invalid_card_number">Your card number is invalid.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Your card\'s security code is invalid.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Your card expiry month is invalid.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Your card\'s expiry year is invalid.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Your name is invalid.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Invalid Shipping Address</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Select Bank Account (FPX)…</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Free</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">There was an error processing your card - please try again in a few seconds</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Remove</string>

--- a/payments-core/res/values-es/strings.xml
+++ b/payments-core/res/values-es/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">El nombre es obligatorio</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Cancelar</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">La tarjeta ha sido rechazada</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s terminada en %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Listo</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Modificar</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">La tarjeta ha caducado</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">MM/AA</string>
   <string name="expiry_label_short">Caducidad</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - Fuera de línea</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Se ha rechazado tu método de pago.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">La fecha de caducidad de la tarjeta está incompleta.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">El IBAN introducido no es válido.</string>
   <string name="invalid_card_number">El número de tarjeta no es válido.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">El código de seguridad de la tarjeta no es válido.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">El mes de caducidad de la tarjeta no es válido.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">El año de caducidad de la tarjeta no es válido.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">El nombre no es válido.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Dirección de envío no válida</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Seleccionar cuenta bancaria (FPX)…</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Gratuito</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Error al procesar la tarjeta. Vuelve a intentarlo en unos segundos.</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Eliminar</string>

--- a/payments-core/res/values-et-rEE/strings.xml
+++ b/payments-core/res/values-et-rEE/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Nime esitamine on kohustuslik.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Tühista</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Kaart lükati tagasi</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s, lõpeb nr-ga %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Valmis</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Muutmine</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Kaart on aegunud</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">KK/AA</string>
   <string name="expiry_label_short">Aegumine</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - võrguühenduseta</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Teie makseviis lükati tagasi.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">Kaardi aegumiskuupäev on puudulik.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">Sisestatud IBAN on kehtetu.</string>
   <string name="invalid_card_number">Kaardi number on kehtetu.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Kaardi turvakood on kehtetu.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Kaardi aegumiskuu on kehtetu.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Kaardi aegumisaasta on kehtetu.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Teie nimi on kehtetu.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Kehtetu tarneaadress</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Valige pangakonto (FPX) ...</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Tasuta</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Kaardi töötlemisel esines tõrge – proovige mõne sekundi pärast uuesti</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Eemalda</string>

--- a/payments-core/res/values-fil/strings.xml
+++ b/payments-core/res/values-fil/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Kailangan ang iyong pangalan.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Kanselahin</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Tinanggihan ang iyong kard</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s nagtatapos sa %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Tapos Na</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">I-edit</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Napaso na ang iyong kard</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">BB / TT</string>
   <string name="expiry_label_short">Pagkapaso</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - Offline</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Tinanggihan ang iyong paraan ng pagbabayad.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">Ang petsa ng pagkapaso ng iyong kard ay di kumpleto.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">Ang IBAN na iniligay mo ay imbalido.</string>
   <string name="invalid_card_number">Ang numero ng iyong kard ay di balido.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Ang security code ng iyong kard ay di balido.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Ang buwan ng pagkapaso ng iyong kard ay di balido.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Ang taon ng pagkapaso ng iyong kard ay di balido.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Ang iyong pangalan ay imbalido.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Adres ng Nagpadala ay di balido</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Piliin ang Account sa Bangko (FPX)…</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Libre</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Nagkaroon ng kamalian sa pagproseso ng iyong kard -- subukin muli sa ilang segundo</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Alisin</string>

--- a/payments-core/res/values-fr-rCA/strings.xml
+++ b/payments-core/res/values-fr-rCA/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Votre nom est obligatoire.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Annuler</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Votre carte a été refusée</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s se terminant par %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Terminé</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Modifier</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Votre carte a expiré</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">MM/AA</string>
   <string name="expiry_label_short">Expiration</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s ─ hors ligne</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Votre moyen de paiement a été refusé.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">La date d\'expiration de votre carte est incomplète.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">L\'IBAN que vous avez saisi n\'est pas valide.</string>
   <string name="invalid_card_number">Le numéro de votre carte n\'est pas valide.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Le code de sécurité de votre carte n\'est pas valide.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Le mois d\'expiration de votre carte n\'est pas valide.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">L\'année d\'expiration de votre carte n\'est pas valide.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Votre nom n\'est pas valide.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Adresse de livraison non valide</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Sélectionner un compte bancaire (FPX)…</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Gratuit</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Une erreur est survenue lors du traitement de votre carte. Réessayez dans quelques secondes.</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Supprimer</string>

--- a/payments-core/res/values-fr/strings.xml
+++ b/payments-core/res/values-fr/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Votre nom est obligatoire.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Annuler</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Votre carte a été refusée.</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s se terminant par %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Terminé</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Modifier</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Votre carte est arrivée à expiration.</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">MM/AA</string>
   <string name="expiry_label_short">Expire le</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - Hors ligne</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Votre moyen de paiement a été refusé.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">La date d\'expiration de votre carte bancaire est incomplète.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">L\'IBAN que vous avez saisi n\'est pas valide.</string>
   <string name="invalid_card_number">Le numéro de votre carte bancaire n\'est pas valide.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Le code de sécurité de votre carte bancaire n\'est pas valide.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Le mois d\'expiration de votre carte n\'est pas valide.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">L\'année d\'expiration de votre carte n\'est pas valide.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Votre nom n\'est pas valide.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Adresse de livraison incorrecte</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Sélectionner le compte bancaire (FPX)...</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Gratuit</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Une erreur est survenue lors du traitement de votre carte. Réessayez dans quelques secondes.</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Supprimer</string>

--- a/payments-core/res/values-hr/strings.xml
+++ b/payments-core/res/values-hr/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Vaše ime je obavezno.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Otkaži</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Kartica je odbijena</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s završava na %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Gotovo</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Uredi</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Vaša kartica je istekla</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">MM/GG</string>
   <string name="expiry_label_short">Istek</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - Izvan mreže</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Vaš način plaćanja je odbijen.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">Datum isteka vaše kartice nije kompletan.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">Uneseni IBAN nije valjan.</string>
   <string name="invalid_card_number">Broj kartice nije valjan.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Sigurnosni kod vaše kartice nije valjan.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Mjesec isteka kartice nije valjan.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Godina isteka kartice nije valjana.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Vaše ime je neispravno.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Adresa za otpremu nije valjana</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Odaberite bankovni račun (FPX)...</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Besplatno</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Došlo je do pogreške u obradi vaše kartice -- pokušajte ponovno za nekoliko sekundi</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Ukloni</string>

--- a/payments-core/res/values-hu/strings.xml
+++ b/payments-core/res/values-hu/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Nevének megadása kötelező.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Mégse</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">A kártyáját elutasítottuk</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s végződése %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Kész</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Szerkesztés</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">A kártyája lejárt</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">HH/ÉÉ</string>
   <string name="expiry_label_short">Lejárat</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - offline</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Fizetési módja elutasításra került.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">A kártya lejárati dátuma hiányos.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">A beírt IBAN-szám érvénytelen.</string>
   <string name="invalid_card_number">Kártyaszáma érvénytelen.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">A kártya biztonsági kódja érvénytelen.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Kártyájának lejárati hónapja érvénytelen.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Kártyájának lejárati éve érvénytelen.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Érvénytelen név.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Érvénytelen szállítási cím</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Bankszámlaválasztás (FPX)...</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Ingyenes</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Hiba történt kártyája feldolgozása során, próbálja újra néhány másodperc múlva</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Eltávolítás</string>

--- a/payments-core/res/values-in/strings.xml
+++ b/payments-core/res/values-in/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Nama Anda harus diisi.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Batalkan</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Kartu Anda ditolak</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s berakhiran %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Selesai</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Edit</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Kartu Anda telah kedaluwarsa</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">BB/TT</string>
   <string name="expiry_label_short">Kedaluwarsa</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - Offline</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Metode pembayaran Anda ditolak.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">Tanggal kedaluwarsa kartu Anda tidak lengkap.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">IBAN yang Anda masukkan tidak valid.</string>
   <string name="invalid_card_number">Nomor kartu Anda tidak valid.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Kode keamanan kartu Anda tidak valid.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Bulan kedaluwarsa kartu Anda tidak valid.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Tahun kedaluwarsa kartu Anda tidak valid.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Nama Anda tidak valid.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Alamat Pengiriman Tidak Valid</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Pilih Rekening Bank (FPX)…</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Gratis</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Ada kesalahan saat memproses kartu Anda -- cobalah lagi dalam beberapa detik</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Hapus</string>

--- a/payments-core/res/values-it/strings.xml
+++ b/payments-core/res/values-it/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Il tuo nome è obbligatorio.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Annulla</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">La carta è stata rifiutata</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s che termina con %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Fine</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Modifica</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">La carta è scaduta</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">MM/AA</string>
   <string name="expiry_label_short">Scadenza</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - Offline</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">La tua modalità di pagamento è stata rifiutata.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">La data di scadenza della carta è incompleta.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">L\'IBAN inserito non è valido.</string>
   <string name="invalid_card_number">Il numero della carta non è valido.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Il codice di sicurezza della carta non è valido.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Il mese di scadenza della carta non è valido.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">L\'anno di scadenza della carta non è valido.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Nome non valido.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Indirizzo di spedizione non valido</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Seleziona conto bancario (FPX)…</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Gratuita</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Si è verificato un errore durante l\'elaborazione della carta. Riprova fra qualche secondo.</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Rimuovi</string>

--- a/payments-core/res/values-ja/strings.xml
+++ b/payments-core/res/values-ja/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">名前を入力してください。</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">キャンセル</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">クレジットカードが拒否されました</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">末尾が %2$s の %1$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">完了</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">編集</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">クレジットカードの有効期限が切れています</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">MM/YY</string>
   <string name="expiry_label_short">有効期限</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - オフライン</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">お客様の支払い方法が拒否されました。</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">カードの有効期限の日付に不備があります。</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">入力した IBAN が無効です。</string>
   <string name="invalid_card_number">カードの番号が無効です。</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">カードのセキュリティコードが無効です。</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">カードの有効期限の月が無効です。</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">カードの有効期限の年が無効です。</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">名前が無効です。</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">配送先住所が無効です</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">銀行口座を選択 (FPX)...</string>
   <!-- Label for free shipping method -->
   <string name="price_free">無料</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">クレジットカード情報の処理中にエラーが発生しました。数秒後にもう一度お試しください</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">削除</string>

--- a/payments-core/res/values-lt-rLT/strings.xml
+++ b/payments-core/res/values-lt-rLT/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Privaloma nurodyti vardą, pavardę.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Atšaukti</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Kortelė buvo atmesta</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s, kuri baigiasi %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Atlikta</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Redaguoti</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Kortelė baigė galioti</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">mm / MM</string>
   <string name="expiry_label_short">Galiojimo pabaigos data</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s – neprisijungęs</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Jūsų mokėjimo būdas buvo atmestas.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">Neišsami kortelės galiojimo pabaigos data.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">Įvedėte neteisingą IBAN.</string>
   <string name="invalid_card_number">Negaliojantis kortelės numeris.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Kortelės saugos kodas negalioja.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Negaliojantis kortelės galiojimo pabaigos mėnuo.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Kortelės galiojimo pabaigos metai neteisingi.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Jūsų vardas neteisingas.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Netinkamas siuntimo adresas</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Pasirinkti banko sąskaitą (FPX)...</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Nemokamai</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Įvyko kortelės apdorojimo klaida, po kelių sekundžių bandykite dar kartą</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Pašalinti</string>

--- a/payments-core/res/values-lv-rLV/strings.xml
+++ b/payments-core/res/values-lv-rLV/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Jānorāda vārds/nosaukums.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Atcelt</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Karte tika noraidīta</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s, kuras numura pēdējie cipari ir %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Gatavs</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Rediģēt</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Kartes derīguma termiņš ir beidzies</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">MM/GG</string>
   <string name="expiry_label_short">Derīguma termiņš</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s — bezsaistē</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Maksājuma veids tika noraidīts.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">Kartes derīguma termiņa datums nav pilnīgs.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">Ievadītais IBAN nav derīgs.</string>
   <string name="invalid_card_number">Kartes numurs nav derīgs.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Kartes drošības kods nav derīgs.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Kartes derīguma termiņa mēnesis nav derīgs.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Kartes derīguma termiņa gads nav derīgs.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Jūsu vārds nav derīgs.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Nederīga piegādes adrese</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Atlasīt bankas kontu (FPX)…</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Bezmaksas</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Radās kļūda, apstrādājot jūsu karti — mēģiniet vēlreiz pēc dažām sekundēm</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Noņemt</string>

--- a/payments-core/res/values-ms-rMY/strings.xml
+++ b/payments-core/res/values-ms-rMY/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Nama anda diperlukan.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Batalkan</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Kad anda telah ditolak</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s – berakhiran %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Selesai</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Edit</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Kad anda telah tamat tempoh</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">BB/TT</string>
   <string name="expiry_label_short">Tamat Tempoh</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s – Luar Talian</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Kaedah pembayaran anda ditolak.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">Tarikh tamat tempoh kad anda tidak lengkap.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">IBAN yang anda masukkan tidak sah.</string>
   <string name="invalid_card_number">Nombor kad anda tidak sah.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Kod keselamatan kad anda tidak sah.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Bulan tamat tempoh kad anda tidak sah.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Tahun tamat tempoh kad anda tidak sah.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Nama anda tidak sah.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Alamat Pengiriman Tidak Sah</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Pilih Akaun Bank (FPX)…</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Percuma</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Ada ralat semasa memproses kad anda -- cuba lagi dalam masa beberapa saat</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Alih Keluar</string>

--- a/payments-core/res/values-mt/strings.xml
+++ b/payments-core/res/values-mt/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Ismek huwa meħtieġ.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Ikkanċella</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Il-kard tiegħek ma ġietx aċċettata</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s li jispiċċa %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Bil-lest</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Editja</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Il-kard tiegħek skadiet</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">XX/SS</string>
   <string name="expiry_label_short">Skadenza</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - Offline</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Il-metodu tal-pagament tiegħek m\'għaddiex.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">Id-data tal-iskadenza tal-kard tiegħek mhijiex kompluta.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">L-IBAN li daħħalt mhux tajjeb.</string>
   <string name="invalid_card_number">In-numru tal-kard tiegħek mhux validu.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Il-kodiċi tas-sigurtà tal-kard tiegħek mhux validu.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Ix-xahar tal-iskadenza tal-kard tiegħek mhux validu.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Is-sena tal-iskadenza tal-kard tiegħek mhijiex valida.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">L-isem li daħħalt mhux tajjeb.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">L-Indirizz għat-Trasport tal-Merkanzija Mhux Validu</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Agħżel Kont Bankarju (FPX)…</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Bla ħlas</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Kien hemm żball fl-ipproċessar tal-kard tiegħek -- erġa\' pprova wara ftit sekondi</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Neħħi</string>

--- a/payments-core/res/values-nb/strings.xml
+++ b/payments-core/res/values-nb/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Navn er påkrevd.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Avbryt</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Kortet ditt ble avvist</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s som slutter på %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Ferdig</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Rediger</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Kortet ditt har utløpt</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">MM/ÅÅ</string>
   <string name="expiry_label_short">Utløp</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s – frakoblet</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Betalingsmetoden din ble avvist.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">Kortets utløpsdato er ufullstendig.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">IBAN-nummeret du la inn er ugyldig.</string>
   <string name="invalid_card_number">Kortnummeret er ugyldig.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Kortets sikkerhetskode er ugyldig.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Kortets utløpsmåned er ugyldig.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Kortets utløpsår er ugyldig.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Navnet er ugyldig.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Ugyldig leveringsadresse</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Velg bankkonto (FPX) …</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Gratis</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Det oppstod en feil ved prosessering av kortet -- prøv igjen om et par sekunder</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Fjern</string>

--- a/payments-core/res/values-nl/strings.xml
+++ b/payments-core/res/values-nl/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Je naam is vereist.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Annuleren</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Je kaart is geweigerd</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s eindigend op %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Gereed</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Bewerken</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Je kaart is vervallen</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">MM/JJ</string>
   <string name="expiry_label_short">Vervaldatum</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - offline</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Je betaalmethode is geweigerd.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">De vervaldatum van je kaart is onvolledig.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">Het opgegeven IBAN-nummer is ongeldig.</string>
   <string name="invalid_card_number">Het kaartnummer is ongeldig.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">De beveiligingscode van je kaart is ongeldig.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">De vervalmaand van de kaart is ongeldig.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Het vervaljaar van de kaart is ongeldig.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Je naam is ongeldig.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Ongeldig verzendadres</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Bankrekening selecteren (FPX)...</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Gratis</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Er is een fout met de verwerking van je kaart. Probeer het over enkele seconden opnieuw</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Verwijderen</string>

--- a/payments-core/res/values-nn-rNO/strings.xml
+++ b/payments-core/res/values-nn-rNO/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Namn er påkravd.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Avbryt</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Kortet vart avvist</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s sluttar på %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Ferdig</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Rediger</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Kortet har gått ut</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">MM/ÅÅ</string>
   <string name="expiry_label_short">Utløp</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - fråkopla</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Betalingsmåten din vart avvist.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">Utløpsdatoen til kortet er ufullstendig.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">Du skreiv inn eit ugyldig IBAN-nummer.</string>
   <string name="invalid_card_number">Kortnummeret ditt er ugyldig.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Sikkerheitskoden til kortet er ugyldig.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Utløpsmånaden på kortet er ugyldig.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Utløpsåret på kortet ditt er ugyldig.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Namnet ditt er ugyldig.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Ugyldig sendingsadresse</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Vel bankkonto (FPX)...</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Gratis</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Det oppstod ei feil under behandlinga av kortet – prøv igjen om nokre få sekund</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Fjern</string>

--- a/payments-core/res/values-pl-rPL/strings.xml
+++ b/payments-core/res/values-pl-rPL/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Wymagane jest imię i nazwisko.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Anuluj</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Karta została odrzucona</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s kończy się %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Gotowe</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Edytuj</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Ważność Twojej karty wygasła</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">MM/RR</string>
   <string name="expiry_label_short">Data ważności</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s – offline</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Twoja metoda płatności została odrzucona.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">Data ważności karty jest niepełna.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">Podany IBAN jest nieprawidłowy.</string>
   <string name="invalid_card_number">Nieprawidłowy nr karty.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Kod bezpieczeństwa karty jest nieprawidłowy.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Miesiąc daty ważności karty jest nieprawidłowy.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Rok daty ważności karty jest nieprawidłowy</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Twoje imię i nazwisko jest nieprawidłowe.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Nieprawidłowy adres dostawy</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Wybierz konto bankowe (FPX)…</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Bezpłatnie</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Podczas przetwarzania Twojej karty wystąpił błąd – spróbuj ponownie za kilka sekund</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Usuń</string>

--- a/payments-core/res/values-pt-rBR/strings.xml
+++ b/payments-core/res/values-pt-rBR/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">É obrigatório informar seu nome.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Cancelar</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">O cartão foi recusado</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s com final %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Concluído</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Editar</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">O cartão expirou</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">MM/AA</string>
   <string name="expiry_label_short">Validade</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s – Offline</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">A forma de pagamento foi recusada.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">Data de validade incompleta.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">O IBAN inserido é inválido.</string>
   <string name="invalid_card_number">Número do cartão inválido.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Código de segurança inválido.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">O mês de validade do cartão é inválido.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Ano de validade inválido.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Nome inválido.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Endereço de envio inválido</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Selecionar conta bancária (FPX)…</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Grátis</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Erro ao processar o cartão – tente novamente em alguns segundos</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Remover</string>

--- a/payments-core/res/values-pt-rPT/strings.xml
+++ b/payments-core/res/values-pt-rPT/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">O seu nome é obrigatório.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Cancelar</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">O seu cartão foi recusado</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s a terminar em %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Concluído</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Editar</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">O seu cartão expirou</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">MM/AA</string>
   <string name="expiry_label_short">Validade</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - Offline</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">O seu método de pagamento foi recusado.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">A data de validade do seu cartão está incompleta.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">O IBAN que introduziu é inválido.</string>
   <string name="invalid_card_number">O número do seu cartão é inválido.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">O código de segurança do seu cartão é inválido.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">O mês de validade do seu cartão é inválido.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">O ano de validade do seu cartão é inválido.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">O seu nome é inválido.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Endereço de envio inválido</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Selecionar conta bancária (FPX)…</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Gratuito</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Ocorreu um erro ao processar o seu cartão -- tente novamente dentro de alguns segundos</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Remover</string>

--- a/payments-core/res/values-ro-rRO/strings.xml
+++ b/payments-core/res/values-ro-rRO/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Este necesar numele dvs.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Anulare</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Cardul dvs. a fost respins</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s se termină în %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Efectuat</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Editare</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Cardul dvs. a expirat</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">LL/AA</string>
   <string name="expiry_label_short">Data de expirare</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - Offline</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Metoda dvs. de plată a fost respinsă.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">Data de expirare a cardului dvs. nu este completă.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">Codul IBAN pe care l-ați introdus nu este valid.</string>
   <string name="invalid_card_number">Numărul cardului dvs. nu este valid.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Codul de securitate al cardului dvs. nu este valid.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Luna de expirare a cardului dvs. nu este validă.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Anul de expirare al cardului dvs. nu este valid.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Numele dvs. nu este valid.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Adresa de expediere nu este validă</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Selectare cont bancar (FPX)…</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Expediere gratuită</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">A apărut o eroare la procesarea cardului dvs. -- încercați din nou în câteva secunde</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Eliminare</string>

--- a/payments-core/res/values-sk-rSK/strings.xml
+++ b/payments-core/res/values-sk-rSK/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Vyžaduje sa vaše meno.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Zrušiť</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Vaša karta bola odmietnutá</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">Karta %1$s s poslednými štyrmi číslami %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Hotovo</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Upraviť</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Platnosť vašej karty vypršala</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">MM/RR</string>
   <string name="expiry_label_short">Ukončenie platnosti</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - Offline</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Váš spôsob platby bol odmietnutý.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">Dátum vypršania platnosti vašej karty je neúplný.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">Zadaný IBAN je neplatný.</string>
   <string name="invalid_card_number">Číslo vašej karty je neplatné.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Bezpečnostný kód vašej karty je neplatný.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Mesiac vypršania platnosti vašej karty je neplatný.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Rok ukončenia platnosti vašej karty je neplatný.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Vaše meno je neplatné.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Neplatná dodacia adresa</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Zvoľte bankový účet (FPX)…</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Zdarma</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Pri spracovaní vašej karty sa vyskytla chyba -- skúste znova o niekoľko sekúnd</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Odstrániť</string>

--- a/payments-core/res/values-sl-rSI/strings.xml
+++ b/payments-core/res/values-sl-rSI/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Vaše ime je obvezno.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Prekliči</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Vaša kartica je bila zavrnjena</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s, ki se konča s/z %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Dokončano</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Uredi</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Vaša kartica je potekla</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">MM/LL</string>
   <string name="expiry_label_short">Potek</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s – ni dosegljiva</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Vaš način plačila je bil zavrnjen.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">Datum poteka vaše kartice ni popoln.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">Vnesena koda IBAN ni veljavna.</string>
   <string name="invalid_card_number">Številka vaše kartice ni veljavna.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Varnostna koda vaše kartice ni veljavna.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Mesec poteka vaše kartice ni veljaven.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Leto poteka vaše kartice ni veljavno.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Vaše ime ni veljavno.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Neveljaven dostavni naslov</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Izberite bančni račun (FPX) …</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Brezplačno</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Pri obdelavi vaše kartice je prišlo do napake. Poskusite znova čez nekaj sekund.</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Odstrani</string>

--- a/payments-core/res/values-th/strings.xml
+++ b/payments-core/res/values-th/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">ต้องระบุชื่อ</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">ยกเลิก</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">บัตรของคุณถูกปฏิเสธ</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s ลงท้ายด้วย %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">เสร็จสิ้น</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">แก้ไข</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">บัตรของคุณหมดอายุแล้ว</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">ดด/ปป</string>
   <string name="expiry_label_short">วันหมดอายุ</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - ออฟไลน์</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">การชำระเงินของคุณถูกปฏิเสธ</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">วันที่หมดอายุของบัตรไม่ครบถ้วน</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">IBAN ที่คุณป้อนไม่ถูกต้อง</string>
   <string name="invalid_card_number">หมายเลขบัตรไม่ถูกต้อง</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">รหัสความปลอดภัยของบัตรไม่ถูกต้อง</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">เดือนที่หมดอายุของบัตรไม่ถูกต้อง</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">ปีที่หมดอายุของบัตรไม่ถูกต้อง</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">ชื่อไม่ถูกต้อง</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">ที่อยู่สำหรับจัดส่งไม่ถูกต้อง</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">เลือกบัญชีธนาคาร (FPX)…</string>
   <!-- Label for free shipping method -->
   <string name="price_free">ฟรี</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">เกิดข้อผิดพลาดขณะประมวลผลบัตร โปรดลองอีกครั้งในอีกสักครู่</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">นำออก</string>

--- a/payments-core/res/values-vi/strings.xml
+++ b/payments-core/res/values-vi/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Tên của bạn là bắt buộc.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Hủy</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Thẻ bị từ chối</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s kết thúc bằng %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Xong</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Sửa</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Thẻ đã hết hạn</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">Tháng/Năm</string>
   <string name="expiry_label_short">Hết hạn</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - Ngoại tuyến</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Phương thức thanh toán của quý vị đã bị từ chối.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">Ngày hết hạn trên thẻ không hợp lệ.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">IBAN quý vị đã nhập không hợp lệ.</string>
   <string name="invalid_card_number">Số thẻ của bạn không hợp lệ.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Mã bảo mật trên thẻ không hợp lệ.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Tháng hết hạn trên thẻ của bạn không hợp lệ.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Năm hết hạn trên thẻ của bạn không hợp lệ.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Tên của quý vị không hợp lệ.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Địa chỉ vận chuyển không hợp lệ</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Chọn Tài khoản Ngân hàng (FPX)...</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Miễn phí</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">Có lỗi bất ngờ khi xử lý thẻ -- hãy thử lại sau vài giây</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Xóa</string>

--- a/payments-core/res/values-zh-rHK/strings.xml
+++ b/payments-core/res/values-zh-rHK/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">您需要填寫姓名。</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">取消</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">您的卡已被拒絕</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s - 尾號：%2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">完成</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">編輯</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">您的卡已過期</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">月份/年份</string>
   <string name="expiry_label_short">有效期</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - 線下</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">您的支付方式被拒絕了。</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">您的銀行卡的不完整。</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">您輸入的 IBAN 無效。</string>
   <string name="invalid_card_number">您的卡號無效。</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">您的銀行卡安全碼無效。</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">您的銀行卡的到期月份無效。</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">您的銀行卡的到期年份無效。</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">您的姓名無效。</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">收货地址無效</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">選擇銀行帳戶 (FPX)… </string>
   <!-- Label for free shipping method -->
   <string name="price_free">免費</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">處理您的卡時發生了錯誤 -- 請稍候再試</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">移除</string>

--- a/payments-core/res/values-zh-rTW/strings.xml
+++ b/payments-core/res/values-zh-rTW/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">您需要填寫姓名。</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">取消</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">您的卡已被拒絕</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s - 尾號：%2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">完成</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">編輯</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">您的卡已過期</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">月份/年份</string>
   <string name="expiry_label_short">有效期</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - 線下</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">您的支付方式被拒絕了。</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">您的卡的不完整。</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">您輸入的 IBAN 無效。</string>
   <string name="invalid_card_number">您的卡號無效。</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">您的金融卡安全碼無效。</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">您的金融卡的到期月份無效。</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">您的金融卡的到期年份無效。</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">您的名稱無效。</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">送貨地址無效</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">選擇銀行帳戶 (FPX)… </string>
   <!-- Label for free shipping method -->
   <string name="price_free">免費</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">處理您的卡時發生錯誤 -- 請等待幾秒後再試</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">移除</string>

--- a/payments-core/res/values-zh/strings.xml
+++ b/payments-core/res/values-zh/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">您需要填写姓名。</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">取消</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">您的卡已被拒绝</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s - 尾号：%2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">完成</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">编辑</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">您的银行卡已过期</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">月份/年份</string>
   <string name="expiry_label_short">有效期</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - 线下</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">您的支付方式被拒绝了。</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">您的银行卡的不完整。</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">您输入的 IBAN 无效。</string>
   <string name="invalid_card_number">您的卡号无效。</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">您的银行卡安全码无效。</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">您的银行卡的到期月份无效。</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">您的银行卡的到期年份无效。</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">您的姓名无效。</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">无效的送货地址</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">选择银行账户 (FPX)…</string>
   <!-- Label for free shipping method -->
   <string name="price_free">免费</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">处理您的卡时发生错误 —— 请稍后再试</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">移除</string>

--- a/payments-core/res/values/strings.xml
+++ b/payments-core/res/values/strings.xml
@@ -110,6 +110,8 @@
   <string name="becs_widget_name_required">Your name is required.</string>
   <!-- Button title to cancel action in an alert -->
   <string name="cancel">Cancel</string>
+  <!-- Error when the card was declined by the credit card networks -->
+  <string name="card_declined">Your card was declined</string>
   <!-- Details of a saved card. &apos;{card brand} ending in {last 4}&apos; e.g. &apos;VISA ending in 4242&apos; -->
   <string name="card_ending_in">%1$s ending in %2$s</string>
   <!-- Text for close button -->
@@ -121,13 +123,19 @@
   <string name="done">Done</string>
   <!-- Button title to enter editing mode -->
   <string name="edit">Edit</string>
+  <!-- Error when the card has already expired -->
+  <string name="expired_card">Your card has expired</string>
   <!-- label for text field to enter card expiry -->
   <string name="expiry_date_hint">MM/YY</string>
   <string name="expiry_label_short">Expiry</string>
   <!-- Label that will show that an FPX bank is offline. For example, &quot;AmBank - Offline&quot; -->
   <string name="fpx_bank_offline">%s - Offline</string>
+  <!-- Error message when a payment method gets declined. -->
+  <string name="generic_decline">Your payment method was declined.</string>
   <!-- Error message for card details form when expiration date isn&apos;t entered completely -->
   <string name="incomplete_expiry_date">Your card\'s expiration date is incomplete.</string>
+  <!-- An error message displayed when the customer's iban is invalid. -->
+  <string name="invalid_bank_account_iban">The IBAN you entered is invalid.</string>
   <string name="invalid_card_number">Your card\'s number is invalid.</string>
   <!-- Error message for card entry form when CVC/CVV is invalid -->
   <string name="invalid_cvc">Your card\'s security code is invalid.</string>
@@ -135,6 +143,8 @@
   <string name="invalid_expiry_month">Your card\'s expiration month is invalid.</string>
   <!-- String to describe an invalid year in expiry date. -->
   <string name="invalid_expiry_year">Your card\'s expiration year is invalid.</string>
+  <!-- Error when customer's name is invalid -->
+  <string name="invalid_owner_name">Your name is invalid.</string>
   <!-- Shipping form error message -->
   <string name="invalid_shipping_information">Invalid Shipping Address</string>
   <!-- Error message for when postal code in form is incomplete -->
@@ -143,6 +153,8 @@
   <string name="payment_method_add_new_fpx">Select Bank Account (FPX)…</string>
   <!-- Label for free shipping method -->
   <string name="price_free">Free</string>
+  <!-- Error when there is a problem processing the credit card -->
+  <string name="processing_error">There was an error processing your card -- try again in a few seconds</string>
   <!-- Button title for confirmation alert to remove a saved payment method
    Text for remove button -->
   <string name="remove">Remove</string>

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -109,7 +109,7 @@ import kotlin.coroutines.CoroutineContext
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 class StripeApiRepository @JvmOverloads internal constructor(
-    context: Context,
+    private val context: Context,
     publishableKeyProvider: () -> String,
     private val appInfo: AppInfo? = Stripe.appInfo,
     private val logger: Logger = Logger.noop(),
@@ -1750,7 +1750,11 @@ class StripeApiRepository @JvmOverloads internal constructor(
     private fun handleApiError(response: StripeResponse<String>) {
         val requestId = response.requestId?.value
         val responseCode = response.code
-        val stripeError = StripeErrorJsonParser().parse(response.responseJson())
+
+        val stripeError = StripeErrorJsonParser()
+            .parse(response.responseJson())
+            .withLocalizedMessage(context)
+
         when (responseCode) {
             HttpURLConnection.HTTP_BAD_REQUEST, HttpURLConnection.HTTP_NOT_FOUND -> {
                 throw InvalidRequestException(

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeErrorMapping.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeErrorMapping.kt
@@ -1,0 +1,26 @@
+package com.stripe.android.networking
+
+import android.content.Context
+import com.stripe.android.R
+import com.stripe.android.core.StripeError
+
+internal fun StripeError.withLocalizedMessage(context: Context): StripeError {
+    val messageResourceId = when (code) {
+        "incorrect_number" -> R.string.invalid_card_number
+        "invalid_number" -> R.string.invalid_card_number
+        "invalid_expiry_month" -> R.string.invalid_expiry_month
+        "invalid_expiry_year" -> R.string.invalid_expiry_year
+        "invalid_cvc" -> R.string.invalid_cvc
+        "expired_card" -> R.string.expired_card
+        "incorrect_cvc" -> R.string.invalid_cvc
+        "card_declined" -> R.string.card_declined
+        "processing_error" -> R.string.processing_error
+        "invalid_owner_name" -> R.string.invalid_owner_name
+        "invalid_bank_account_iban" -> R.string.invalid_bank_account_iban
+        "generic_decline" -> R.string.generic_decline
+        else -> null
+    }
+
+    val newMessage = messageResourceId?.let { context.getString(it) } ?: message
+    return copy(message = newMessage)
+}

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeErrorMapping.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeErrorMapping.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.stripe.android.R
 import com.stripe.android.core.StripeError
 
+@Suppress("ComplexMethod")
 internal fun StripeError.withLocalizedMessage(context: Context): StripeError {
     val messageResourceId = when (code) {
         "incorrect_number" -> R.string.invalid_card_number

--- a/payments-core/src/test/java/com/stripe/android/StripeTest.java
+++ b/payments-core/src/test/java/com/stripe/android/StripeTest.java
@@ -1025,7 +1025,7 @@ public class StripeTest {
                 CardException.class,
                 () -> defaultStripe.createCardTokenSynchronous(cardParams)
         );
-        assertEquals("Your card number is incorrect.", cardException.getMessage());
+        assertEquals("Your card's number is invalid.", cardException.getMessage());
     }
 
     @Test

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IbanConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IbanConfig.kt
@@ -101,7 +101,7 @@ class IbanConfig : TextFieldConfig {
             }
         } else {
             TextFieldStateConstants.Error.Incomplete(
-                R.string.stripe_error_invalid_bank_account_iban
+                R.string.invalid_bank_account_iban
             )
         }
     }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IbanConfig.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IbanConfig.kt
@@ -101,7 +101,7 @@ class IbanConfig : TextFieldConfig {
             }
         } else {
             TextFieldStateConstants.Error.Incomplete(
-                R.string.iban_invalid
+                R.string.stripe_error_invalid_bank_account_iban
             )
         }
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes incorrect translations for error messages.

We’re following iOS’s example and use client-side error messages for this, because we can’t rely on the response’s localized message.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Resolves https://github.com/stripe/stripe-android/issues/2915
Resolves https://github.com/stripe/stripe-android/issues/5058
Resolves https://github.com/stripe/stripe-android/issues/5074

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![Screenshot_20221122_095620](https://user-images.githubusercontent.com/110940675/203346251-a5aaca88-1dba-4737-a35a-2d09c8be3e77.png) | ![Screenshot_20221122_095400](https://user-images.githubusercontent.com/110940675/203345832-6a71ff56-ff9e-4631-955e-d354ea5886e5.png) |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A
