### PR TITLE
Fix MMK being shown as zero-decimal currency

### DIFF
--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/format/CurrencyFormatter.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/format/CurrencyFormatter.kt
@@ -13,7 +13,7 @@ object CurrencyFormatter {
     private const val MAJOR_UNIT_BASE = 10.0
     private val SERVER_DECIMAL_DIGITS =
         mapOf(
-            setOf("UGX", "AFN", "ALL", "AMD", "COP", "IDR", "ISK", "PKR", "LBP") to 2
+            setOf("UGX", "AFN", "ALL", "AMD", "COP", "IDR", "ISK", "PKR", "LBP", "MMK") to 2
         )
 
     fun format(

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/format/CurrencyFormatterTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/format/CurrencyFormatterTest.kt
@@ -222,6 +222,13 @@ class CurrencyFormatterTest {
             .isEqualTo("US$ 1,234.12")
     }
 
+    @Test
+    fun `Treats MMK as a two-decimal currency`() {
+        val currency = Currency.getInstance("MMK")
+        val formattedAmount = CurrencyFormatter.format(5099L, currency)
+        assertThat(formattedAmount).isEqualTo("MMK50.99")
+    }
+
     companion object {
         val LOCALE_ICELAND_LANGUAGE_ONLY = Locale("IS")
         val LOCALE_AUSTRALIA_LANGUAGE_COUNTRY = Locale("en-AU", "AU")


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where we displayed an incorrect amount when using MMK.

Just like for other currencies, we need to override the currency’s `defaultFractionDigits` and return 2 instead of 0.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Internal ticket: RUN_MOBILESDK-975.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

Tested by sending `MMK` as the currency code to the test backend.

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![Screenshot_20221122_131959](https://user-images.githubusercontent.com/110940675/203392234-89616d3d-a1e3-4b5d-bb37-20e0bb7b8710.png) | ![Screenshot_20221122_131909](https://user-images.githubusercontent.com/110940675/203392161-2909e4c7-7e4b-4791-acd3-8c0c91919722.png) |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A
