### PR TITLE
[Identity] Navigate when Fragment's lifecycle owner is in Resumed

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/navigation/CameraPermissionDeniedFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/CameraPermissionDeniedFragment.kt
@@ -8,13 +8,13 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.ViewModelProvider
-import androidx.navigation.fragment.findNavController
 import com.stripe.android.camera.AppSettingsOpenable
 import com.stripe.android.identity.R
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_ERROR
 import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.ui.ErrorScreen
 import com.stripe.android.identity.ui.ErrorScreenButton
+import com.stripe.android.identity.utils.navigateOnResume
 import com.stripe.android.identity.utils.navigateToUploadFragment
 
 /**
@@ -57,7 +57,7 @@ internal class CameraPermissionDeniedFragment(
                     appSettingsOpenable.openAppSettings()
                     // navigate back to DocSelectFragment, so that when user is back to the app from settings
                     // the camera permission check can be triggered again from there.
-                    findNavController().navigate(R.id.action_cameraPermissionDeniedFragment_to_docSelectionFragment)
+                    navigateOnResume(R.id.action_cameraPermissionDeniedFragment_to_docSelectionFragment)
                 }
             )
         }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
@@ -12,7 +12,6 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
-import androidx.navigation.fragment.findNavController
 import com.stripe.android.identity.FallbackUrlLauncher
 import com.stripe.android.identity.R
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_CONSENT
@@ -20,6 +19,7 @@ import com.stripe.android.identity.networking.Resource
 import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.networking.models.VerificationPage.Companion.requireSelfie
 import com.stripe.android.identity.ui.ConsentScreen
+import com.stripe.android.identity.utils.navigateOnResume
 import com.stripe.android.identity.utils.navigateToErrorFragmentWithFailedReason
 import com.stripe.android.identity.utils.postVerificationPageDataAndMaybeSubmit
 import com.stripe.android.identity.viewmodel.IdentityViewModel
@@ -114,7 +114,7 @@ internal class ConsentFragment(
                 collectedDataParam,
                 fromFragment = R.id.consentFragment,
                 notSubmitBlock = {
-                    findNavController().navigate(R.id.action_consentFragment_to_docSelectionFragment)
+                    navigateOnResume(R.id.action_consentFragment_to_docSelectionFragment)
                 }
             )
         }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/CouldNotCaptureFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/CouldNotCaptureFragment.kt
@@ -9,13 +9,13 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.stringResource
 import androidx.core.os.bundleOf
 import androidx.lifecycle.ViewModelProvider
-import androidx.navigation.fragment.findNavController
 import com.stripe.android.identity.R
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_ERROR
 import com.stripe.android.identity.navigation.IdentityDocumentScanFragment.Companion.ARG_SHOULD_START_FROM_BACK
 import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.ui.ErrorScreen
 import com.stripe.android.identity.ui.ErrorScreenButton
+import com.stripe.android.identity.utils.navigateOnResume
 import com.stripe.android.identity.utils.navigateToUploadFragment
 
 /**
@@ -70,7 +70,7 @@ internal class CouldNotCaptureFragment(
                     identityViewModel.screenTracker.screenTransitionStart(
                         SCREEN_NAME_ERROR
                     )
-                    findNavController().navigate(
+                    navigateOnResume(
                         scanType.toScanDestinationId(),
                         bundleOf(
                             ARG_SHOULD_START_FROM_BACK to scanType.toShouldStartFromBack()

--- a/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
@@ -14,7 +14,6 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
-import androidx.navigation.fragment.findNavController
 import com.stripe.android.camera.CameraPermissionEnsureable
 import com.stripe.android.identity.R
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_DOC_SELECT
@@ -24,6 +23,7 @@ import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.networking.models.CollectedDataParam.Type
 import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.ui.DocSelectionScreen
+import com.stripe.android.identity.utils.navigateOnResume
 import com.stripe.android.identity.utils.navigateToDefaultErrorFragment
 import com.stripe.android.identity.utils.navigateToUploadFragment
 import com.stripe.android.identity.utils.postVerificationPageDataAndMaybeSubmit
@@ -91,7 +91,7 @@ internal class DocSelectionFragment(
                                 when (modelResource.status) {
                                     // model ready, camera permission is granted -> navigate to scan
                                     Status.SUCCESS -> {
-                                        findNavController().navigate(type.toScanDestinationId())
+                                        navigateOnResume(type.toScanDestinationId())
                                     }
                                     // model not ready, camera permission is granted -> navigate to manual capture
                                     Status.ERROR -> {
@@ -151,7 +151,7 @@ internal class DocSelectionFragment(
         identityViewModel.observeForVerificationPage(
             viewLifecycleOwner,
             onSuccess = { verificationPage ->
-                findNavController().navigate(
+                navigateOnResume(
                     R.id.action_camera_permission_denied,
                     if (verificationPage.documentCapture.requireLiveCapture) {
                         null

--- a/identity/src/main/java/com/stripe/android/identity/navigation/ErrorFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ErrorFragment.kt
@@ -20,6 +20,7 @@ import com.stripe.android.identity.networking.models.VerificationPageDataRequire
 import com.stripe.android.identity.ui.ErrorScreen
 import com.stripe.android.identity.ui.ErrorScreenButton
 import com.stripe.android.identity.utils.clearDataAndNavigateUp
+import com.stripe.android.identity.utils.navigateOnResume
 
 /**
  * Fragment to show generic error.
@@ -63,7 +64,7 @@ internal class ErrorFragment(
                     } else {
                         val destination = args.getInt(ARG_GO_BACK_BUTTON_DESTINATION)
                         if (destination == UNEXPECTED_DESTINATION) {
-                            findNavController().navigate(DEFAULT_BACK_BUTTON_NAVIGATION)
+                            navigateOnResume(DEFAULT_BACK_BUTTON_NAVIGATION)
                         } else {
                             findNavController().let { navController ->
                                 var shouldContinueNavigateUp = true

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityCameraScanFragment.kt
@@ -12,7 +12,6 @@ import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
-import androidx.navigation.fragment.findNavController
 import com.stripe.android.camera.CameraAdapter
 import com.stripe.android.camera.CameraPreviewImage
 import com.stripe.android.camera.scanui.CameraView
@@ -29,6 +28,7 @@ import com.stripe.android.identity.networking.Status
 import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.states.IdentityScanState.Companion.isBack
 import com.stripe.android.identity.states.IdentityScanState.Companion.isFront
+import com.stripe.android.identity.utils.navigateOnResume
 import com.stripe.android.identity.utils.navigateToDefaultErrorFragment
 import com.stripe.android.identity.viewmodel.CameraViewModel
 import com.stripe.android.identity.viewmodel.IdentityScanViewModel
@@ -135,7 +135,7 @@ internal abstract class IdentityCameraScanFragment(
                                 )
                             }
                         }
-                        findNavController().navigate(
+                        navigateOnResume(
                             R.id.action_global_couldNotCaptureFragment,
                             bundleOf(
                                 ARG_COULD_NOT_CAPTURE_SCAN_TYPE to identityScanViewModel.targetScanType

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityDocumentScanFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityDocumentScanFragment.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
-import androidx.navigation.fragment.findNavController
 import com.stripe.android.camera.CameraAdapter
 import com.stripe.android.camera.CameraPreviewImage
 import com.stripe.android.camera.CameraXAdapter
@@ -35,6 +34,7 @@ import com.stripe.android.identity.states.IdentityScanState.Companion.isFront
 import com.stripe.android.identity.states.IdentityScanState.Companion.isNullOrFront
 import com.stripe.android.identity.ui.DocumentScanScreen
 import com.stripe.android.identity.utils.fragmentIdToScreenName
+import com.stripe.android.identity.utils.navigateOnResume
 import com.stripe.android.identity.utils.navigateToDefaultErrorFragment
 import com.stripe.android.identity.utils.postVerificationPageData
 import com.stripe.android.identity.utils.submitVerificationPageDataAndNavigate
@@ -234,7 +234,7 @@ internal abstract class IdentityDocumentScanFragment(
     internal fun collectDocumentUploadedStateAndPost(
         type: CollectedDataParam.Type,
         isFront: Boolean
-    ) = lifecycleScope.launch {
+    ) = viewLifecycleOwner.lifecycleScope.launch {
         if (isFront) {
             identityViewModel.documentFrontUploadedState
         } else {
@@ -273,7 +273,7 @@ internal abstract class IdentityDocumentScanFragment(
                                             }
                                         )
                                     } else if (verificationPageDataWithNoError.isMissingSelfie()) {
-                                        findNavController().navigate(
+                                        navigateOnResume(
                                             R.id.action_global_selfieFragment
                                         )
                                     } else {

--- a/identity/src/main/java/com/stripe/android/identity/networking/Resource.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/Resource.kt
@@ -35,5 +35,9 @@ internal data class Resource<out T>(
         fun <T> idle(): Resource<T> {
             return Resource(Status.IDLE, null)
         }
+
+        // Integer saved as dummy values of Resource<Int> when Resource<Unit> is needed.
+        // Resource<Unit> shouldn't be used as Unit can't be parcelized.
+        internal const val DUMMY_RESOURCE = 0
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/utils/NavigationUtils.kt
+++ b/identity/src/main/java/com/stripe/android/identity/utils/NavigationUtils.kt
@@ -261,7 +261,7 @@ internal fun Fragment.navigateOnResume(destinationId: Int, args: Bundle? = null)
 }
 
 private fun Fragment.repeatOnResume(block: () -> Unit) {
-    lifecycleScope.launch {
+    viewLifecycleOwner.lifecycleScope.launch {
         viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
             block()
         }

--- a/identity/src/main/java/com/stripe/android/identity/utils/NavigationUtils.kt
+++ b/identity/src/main/java/com/stripe/android/identity/utils/NavigationUtils.kt
@@ -1,9 +1,13 @@
 package com.stripe.android.identity.utils
 
+import android.os.Bundle
 import android.util.Log
 import androidx.annotation.IdRes
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.fragment.findNavController
 import com.stripe.android.identity.R
@@ -30,6 +34,7 @@ import com.stripe.android.identity.networking.models.VerificationPageData
 import com.stripe.android.identity.networking.models.VerificationPageData.Companion.hasError
 import com.stripe.android.identity.networking.models.VerificationPageDataRequirementError
 import com.stripe.android.identity.viewmodel.IdentityViewModel
+import kotlinx.coroutines.launch
 
 /**
  * A util method for a [Fragment] to post [CollectedDataParam] and resolve its [VerificationPageData].
@@ -76,7 +81,7 @@ internal suspend fun Fragment.navigateToSelfieOrSubmit(
     @IdRes fromFragment: Int
 ) {
     if (verificationPage.requireSelfie()) {
-        findNavController().navigate(R.id.action_global_selfieFragment)
+        navigateOnResume(R.id.action_global_selfieFragment)
     } else {
         submitVerificationPageDataAndNavigate(
             identityViewModel,
@@ -106,8 +111,7 @@ internal suspend fun Fragment.submitVerificationPageDataAndNavigate(
                     )
                 }
                 submittedVerificationPageData.submitted -> {
-                    findNavController()
-                        .navigate(R.id.action_global_confirmationFragment)
+                    navigateOnResume(R.id.action_global_confirmationFragment)
                 }
                 else -> {
                     "VerificationPage submit failed".let { msg ->
@@ -164,35 +168,43 @@ private fun Fragment.navigateToRequirementErrorFragment(
     @IdRes fromFragment: Int,
     requirementError: VerificationPageDataRequirementError
 ) {
-    findNavController()
-        .navigateToErrorFragmentWithRequirementError(
-            fromFragment,
-            requirementError
-        )
+    repeatOnResume {
+        findNavController()
+            .navigateToErrorFragmentWithRequirementError(
+                fromFragment,
+                requirementError
+            )
+    }
 }
 
 /**
  * Navigate to [ErrorFragment] with default values and a cause.
  */
 internal fun Fragment.navigateToDefaultErrorFragment(cause: Throwable) {
-    findNavController().navigateToErrorFragmentWithDefaultValues(requireContext(), cause)
+    repeatOnResume {
+        findNavController().navigateToErrorFragmentWithDefaultValues(requireContext(), cause)
+    }
 }
 
 /**
  * Navigate to [ErrorFragment] with default values and a message.
  */
 internal fun Fragment.navigateToDefaultErrorFragment(message: String) {
-    findNavController().navigateToErrorFragmentWithDefaultValues(
-        requireContext(),
-        IllegalStateException(message)
-    )
+    repeatOnResume {
+        findNavController().navigateToErrorFragmentWithDefaultValues(
+            requireContext(),
+            IllegalStateException(message)
+        )
+    }
 }
 
 /**
  * Navigate to [ErrorFragment] as final destination.
  */
 internal fun Fragment.navigateToErrorFragmentWithFailedReason(failedReason: Throwable) {
-    findNavController().navigateToErrorFragmentWithFailedReason(requireContext(), failedReason)
+    repeatOnResume {
+        findNavController().navigateToErrorFragmentWithFailedReason(requireContext(), failedReason)
+    }
 }
 
 /**
@@ -203,13 +215,15 @@ internal fun Fragment.navigateToUploadFragment(
     shouldShowTakePhoto: Boolean,
     shouldShowChoosePhoto: Boolean
 ) {
-    findNavController().navigate(
-        destinationId,
-        bundleOf(
-            ARG_SHOULD_SHOW_TAKE_PHOTO to shouldShowTakePhoto,
-            ARG_SHOULD_SHOW_CHOOSE_PHOTO to shouldShowChoosePhoto
+    repeatOnResume {
+        findNavController().navigate(
+            destinationId,
+            bundleOf(
+                ARG_SHOULD_SHOW_TAKE_PHOTO to shouldShowTakePhoto,
+                ARG_SHOULD_SHOW_CHOOSE_PHOTO to shouldShowChoosePhoto
+            )
         )
-    )
+    }
 }
 
 /**
@@ -234,6 +248,24 @@ internal fun NavController.clearDataAndNavigateUp(identityViewModel: IdentityVie
     }
 
     return navigateUp()
+}
+
+/**
+ * Try navigate to a destination when the fragment is in resume state.
+ * If app is backgrounded, navigate when it's brought to foreground.
+ */
+internal fun Fragment.navigateOnResume(destinationId: Int, args: Bundle? = null) {
+    repeatOnResume {
+        findNavController().navigate(destinationId, args)
+    }
+}
+
+private fun Fragment.repeatOnResume(block: () -> Unit) {
+    lifecycleScope.launch {
+        viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+            block()
+        }
+    }
 }
 
 internal fun Int.fragmentIdToRequirement(): List<Requirement> = when (this) {

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/IdentityViewModel.kt
@@ -35,6 +35,7 @@ import com.stripe.android.identity.ml.IDDetectorOutput
 import com.stripe.android.identity.networking.IdentityModelFetcher
 import com.stripe.android.identity.networking.IdentityRepository
 import com.stripe.android.identity.networking.Resource
+import com.stripe.android.identity.networking.Resource.Companion.DUMMY_RESOURCE
 import com.stripe.android.identity.networking.SelfieUploadState
 import com.stripe.android.identity.networking.SingleSideDocumentUploadState
 import com.stripe.android.identity.networking.Status
@@ -154,7 +155,7 @@ internal class IdentityViewModel constructor(
      * StateFlow to track request status of postVerificationPageData
      */
     @VisibleForTesting
-    internal val verificationPageData = MutableStateFlow<Resource<Unit>>(
+    internal val verificationPageData = MutableStateFlow<Resource<Int>>(
         savedStateHandle[VERIFICATION_PAGE_DATA] ?: run {
             Resource.idle()
         }
@@ -164,7 +165,7 @@ internal class IdentityViewModel constructor(
      * StateFlow to track request status of postVerificationPageSubmit
      */
     @VisibleForTesting
-    internal val verificationPageSubmit = MutableStateFlow<Resource<Unit>>(
+    internal val verificationPageSubmit = MutableStateFlow<Resource<Int>>(
         savedStateHandle[VERIFICATION_PAGE_SUBMIT] ?: run {
             Resource.idle()
         }
@@ -822,7 +823,7 @@ internal class IdentityViewModel constructor(
             calculateClearDataParam(collectedDataParam)
         ).let { verificationPageData ->
             this.verificationPageData.updateStateAndSave {
-                Resource.success(Unit)
+                Resource.success(DUMMY_RESOURCE)
             }
             _collectedData.updateStateAndSave { oldValue ->
                 oldValue.mergeWith(collectedDataParam)
@@ -859,7 +860,7 @@ internal class IdentityViewModel constructor(
             verificationArgs.ephemeralKeySecret
         ).let {
             verificationPageSubmit.updateStateAndSave {
-                Resource.success(Unit)
+                Resource.success(DUMMY_RESOURCE)
             }
             return it
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Use `repeatOnLifecycle` when about to call `NavigationController.navigate`


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Some navigation calls are followed by a network API roundtrip. If the app is backgrounded while the API is outstadning,  when API returns while app is in background, the navigation call is ignored.

Add the  `repeatOnLifecycle` wrapper would make sure when app is brought to foreground the navigation correctly happens


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before - stuck on loading | After - correctly navigates |
| ------------- | ------------- |
| ![navigateBefore](https://user-images.githubusercontent.com/79880926/203887463-1b48b0c3-6d26-4d2e-bb2e-c5c1e24f5b43.gif)  | ![navigateAfter](https://user-images.githubusercontent.com/79880926/203887472-a8560527-6ba8-4af7-ac4f-665acddac67a.gif) |


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
