### PR TITLE
Add `LinkState` to `PaymentSheetState`

### DIFF
--- a/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
@@ -36,11 +36,13 @@ import com.stripe.android.ui.core.forms.resources.ResourceRepository
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 import javax.inject.Named
+import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
 /**
  * Launcher for an Activity that will confirm a payment using Link.
  */
+@Singleton
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class LinkPaymentLauncher @Inject internal constructor(
     context: Context,

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/NamedConstants.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/NamedConstants.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.payments.core.injection
 
+import androidx.annotation.RestrictTo
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
@@ -18,3 +19,6 @@ const val IS_PAYMENT_INTENT = "isPaymentIntent"
  * Name to indicate whether the current app is an instant app.
  */
 const val IS_INSTANT_APP = "isInstantApp"
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+const val APP_NAME = "appName"

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -1256,6 +1256,14 @@ public final class com/stripe/android/paymentsheet/paymentdatacollection/polling
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/paymentsheet/state/LinkState$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/state/LinkState;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/state/LinkState;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/paymentsheet/state/PaymentSheetState$Full$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/state/PaymentSheetState$Full;

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -9,7 +9,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.createSavedStateHandle
-import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.IOContext
@@ -20,10 +19,7 @@ import com.stripe.android.core.injection.NonFallbackInjector
 import com.stripe.android.core.injection.injectWithFallback
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.LinkPaymentLauncher
-import com.stripe.android.link.LinkPaymentLauncher.Companion.LINK_ENABLED
-import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.injection.DaggerPaymentOptionsViewModelFactoryComponent
@@ -32,14 +28,13 @@ import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.ACHText
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
+import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.ui.core.address.AddressRepository
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.ui.core.forms.resources.ResourceRepository
 import com.stripe.android.utils.requireApplication
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
@@ -101,7 +96,15 @@ internal class PaymentOptionsViewModel @Inject constructor(
 
     init {
         savedStateHandle[SAVE_GOOGLE_PAY_READY] = args.state.isGooglePayReady
-        setupLink(args.state.stripeIntent)
+
+        val linkState = args.state.linkState
+
+        _isLinkEnabled.value = linkState != null
+        activeLinkSession.value = linkState?.loginState == LinkState.LoginState.LoggedIn
+
+        if (linkState != null) {
+            setupLink(linkState)
+        }
 
         // After recovering from don't keep activities the stripe intent will be saved,
         // calling setStripeIntent would require the repository be initialized, which
@@ -172,31 +175,12 @@ internal class PaymentOptionsViewModel @Inject constructor(
         }
     }
 
-    override fun setupLink(stripeIntent: StripeIntent) {
-        if (LINK_ENABLED &&
-            stripeIntent.paymentMethodTypes.contains(PaymentMethod.Type.Link.code)
-        ) {
-            viewModelScope.launch {
-                val configuration = createLinkConfiguration(stripeIntent).also {
-                    _linkConfiguration.value = it
-                }
-                val accountStatus = linkLauncher.getAccountStatusFlow(configuration).first()
-                when (accountStatus) {
-                    AccountStatus.Verified,
-                    AccountStatus.VerificationStarted,
-                    AccountStatus.NeedsVerification -> {
-                        // If account exists, select link by default
-                        savedStateHandle[SAVE_SELECTION] = PaymentSelection.Link
-                    }
-                    AccountStatus.SignedOut,
-                    AccountStatus.Error -> {
-                    }
-                }
-                activeLinkSession.value = accountStatus == AccountStatus.Verified
-                _isLinkEnabled.value = accountStatus != AccountStatus.Error
-            }
-        } else {
-            _isLinkEnabled.value = false
+    private fun setupLink(linkState: LinkState) {
+        _linkConfiguration.value = linkState.configuration
+
+        if (linkState.isReadyForUse) {
+            // If account exists, select Link by default
+            savedStateHandle[SAVE_SELECTION] = PaymentSelection.Link
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -33,8 +33,6 @@ import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkActivityResult.Canceled.Reason
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.LinkPaymentLauncher
-import com.stripe.android.link.LinkPaymentLauncher.Companion.LINK_ENABLED
-import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
@@ -62,6 +60,7 @@ import com.stripe.android.paymentsheet.model.StripeIntentValidator
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.ACHText
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.StripeIntentRepository
+import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentSheetLoader
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
@@ -71,7 +70,6 @@ import com.stripe.android.ui.core.forms.resources.ResourceRepository
 import com.stripe.android.utils.requireApplication
 import dagger.Lazy
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -233,7 +231,15 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
         savedStateHandle[SAVE_PAYMENT_METHODS] = state.customerPaymentMethods
         setStripeIntent(state.stripeIntent)
-        setupLink(state.stripeIntent)
+
+        val linkState = state.linkState
+
+        _isLinkEnabled.value = linkState != null
+        activeLinkSession.value = linkState?.loginState == LinkState.LoginState.LoggedIn
+
+        if (linkState != null) {
+            setupLink(linkState)
+        }
 
         resetViewState()
     }
@@ -372,33 +378,21 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         }
     }
 
-    override fun setupLink(stripeIntent: StripeIntent) {
-        if (LINK_ENABLED &&
-            stripeIntent.paymentMethodTypes.contains(PaymentMethod.Type.Link.code) &&
-            stripeIntent.linkFundingSources.intersect(LinkPaymentLauncher.supportedFundingSources)
-                .isNotEmpty()
-        ) {
-            viewModelScope.launch {
-                val linkConfig = createLinkConfiguration(stripeIntent).also {
-                    _linkConfiguration.value = it
-                }
+    private fun setupLink(state: LinkState) {
+        _linkConfiguration.value = state.configuration
+        _isLinkEnabled.value = true
+        activeLinkSession.value = state.loginState == LinkState.LoginState.LoggedIn
 
-                val accountStatus = linkLauncher.getAccountStatusFlow(linkConfig).first()
-
-                when (accountStatus) {
-                    AccountStatus.Verified -> launchLink(linkConfig, launchedDirectly = true)
-                    AccountStatus.VerificationStarted,
-                    AccountStatus.NeedsVerification -> setupLinkWithVerification(linkConfig)
-                    AccountStatus.SignedOut,
-                    AccountStatus.Error -> {
-                        // Nothing to do here
-                    }
-                }
-                activeLinkSession.value = accountStatus == AccountStatus.Verified
-                _isLinkEnabled.value = accountStatus != AccountStatus.Error
+        when (state.loginState) {
+            LinkState.LoginState.LoggedIn -> {
+                launchLink(state.configuration, launchedDirectly = true)
             }
-        } else {
-            _isLinkEnabled.value = false
+            LinkState.LoginState.NeedsVerification -> {
+                setupLinkWithVerification(state.configuration)
+            }
+            LinkState.LoginState.LoggedOut -> {
+                // Nothing to do here
+            }
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -380,8 +380,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
     private fun setupLink(state: LinkState) {
         _linkConfiguration.value = state.configuration
-        _isLinkEnabled.value = true
-        activeLinkSession.value = state.loginState == LinkState.LoginState.LoggedIn
 
         when (state.loginState) {
             LinkState.LoginState.LoggedIn -> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
@@ -1,11 +1,13 @@
 package com.stripe.android.paymentsheet.injection
 
+import android.app.Application
 import android.content.Context
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
+import com.stripe.android.payments.core.injection.APP_NAME
 import com.stripe.android.paymentsheet.BuildConfig
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -15,7 +17,9 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.repositories.CustomerApiRepository
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.StripeIntentRepository
+import com.stripe.android.paymentsheet.state.DefaultLinkAccountStatusProvider
 import com.stripe.android.paymentsheet.state.DefaultPaymentSheetLoader
+import com.stripe.android.paymentsheet.state.LinkAccountStatusProvider
 import com.stripe.android.paymentsheet.state.PaymentSheetLoader
 import dagger.Binds
 import dagger.Lazy
@@ -42,6 +46,11 @@ internal abstract class PaymentSheetCommonModule {
 
     @Binds
     abstract fun bindsPaymentSheetLoader(impl: DefaultPaymentSheetLoader): PaymentSheetLoader
+
+    @Binds
+    abstract fun bindsLinkAccountStatusProvider(
+        impl: DefaultLinkAccountStatusProvider,
+    ): LinkAccountStatusProvider
 
     companion object {
         /**
@@ -85,6 +94,16 @@ internal abstract class PaymentSheetCommonModule {
                 customerConfig?.id,
                 workContext
             )
+        }
+
+        @Provides
+        @Singleton
+        @Named(APP_NAME)
+        fun provideAppName(
+            appContext: Context,
+        ): String {
+            val application = appContext as Application
+            return application.applicationInfo.loadLabel(application.packageManager).toString()
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/LinkAccountStatusProvider.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/LinkAccountStatusProvider.kt
@@ -1,0 +1,19 @@
+package com.stripe.android.paymentsheet.state
+
+import com.stripe.android.link.LinkPaymentLauncher
+import com.stripe.android.link.model.AccountStatus
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+
+internal fun interface LinkAccountStatusProvider {
+    suspend operator fun invoke(configuration: LinkPaymentLauncher.Configuration): AccountStatus
+}
+
+internal class DefaultLinkAccountStatusProvider @Inject constructor(
+    private val linkLauncher: LinkPaymentLauncher,
+) : LinkAccountStatusProvider {
+
+    override suspend fun invoke(configuration: LinkPaymentLauncher.Configuration): AccountStatus {
+        return linkLauncher.getAccountStatusFlow(configuration).first()
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/LinkState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/LinkState.kt
@@ -1,0 +1,19 @@
+package com.stripe.android.paymentsheet.state
+
+import android.os.Parcelable
+import com.stripe.android.link.LinkPaymentLauncher
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+internal data class LinkState(
+    val configuration: LinkPaymentLauncher.Configuration,
+    val loginState: LoginState,
+) : Parcelable {
+
+    val isReadyForUse: Boolean
+        get() = loginState in setOf(LoginState.LoggedIn, LoginState.NeedsVerification)
+
+    enum class LoginState {
+        LoggedIn, NeedsVerification, LoggedOut,
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -4,11 +4,17 @@ import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayRepository
+import com.stripe.android.link.LinkPaymentLauncher
+import com.stripe.android.link.LinkPaymentLauncher.Companion.supportedFundingSources
+import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethod.Type.Link
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.payments.core.injection.APP_NAME
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PrefsRepository
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.addresselement.toIdentifierMap
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.ClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -20,9 +26,13 @@ import com.stripe.android.paymentsheet.repositories.StripeIntentRepository
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.ui.core.forms.resources.LpmRepository.ServerSpecState
 import com.stripe.android.ui.core.forms.resources.ResourceRepository
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
+import javax.inject.Named
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
@@ -45,6 +55,7 @@ internal interface PaymentSheetLoader {
 
 @Singleton
 internal class DefaultPaymentSheetLoader @Inject constructor(
+    @Named(APP_NAME) private val appName: String,
     private val prefsRepositoryFactory: @JvmSuppressWildcards (PaymentSheet.CustomerConfiguration?) -> PrefsRepository,
     private val googlePayRepositoryFactory: @JvmSuppressWildcards (GooglePayEnvironment) -> GooglePayRepository,
     private val stripeIntentRepository: StripeIntentRepository,
@@ -54,6 +65,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
     private val logger: Logger,
     private val eventReporter: EventReporter,
     @IOContext private val workContext: CoroutineContext,
+    private val accountStatusProvider: LinkAccountStatusProvider,
 ) : PaymentSheetLoader {
 
     override suspend fun load(
@@ -65,15 +77,12 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
             retrieveStripeIntent(clientSecret)
         }.fold(
             onSuccess = { stripeIntent ->
-                val isLinkReady = stripeIntent.paymentMethodTypes.contains(Link.code)
-
                 create(
                     clientSecret = clientSecret,
                     stripeIntent = stripeIntent,
                     customerConfig = paymentSheetConfiguration?.customer,
                     config = paymentSheetConfiguration,
                     isGooglePayReady = isGooglePayReady,
-                    isLinkReady = isLinkReady
                 )
             },
             onFailure = {
@@ -104,36 +113,57 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         customerConfig: PaymentSheet.CustomerConfiguration?,
         config: PaymentSheet.Configuration?,
         isGooglePayReady: Boolean,
-        isLinkReady: Boolean
     ): PaymentSheetLoader.Result {
         val prefsRepository = prefsRepositoryFactory(customerConfig)
 
-        val paymentMethods = if (customerConfig != null) {
-            retrieveCustomerPaymentMethods(
-                stripeIntent,
-                config,
-                customerConfig
-            )
-        } else {
-            emptyList()
-        }
+        val isLinkAvailable = stripeIntent.paymentMethodTypes.contains(Link.code) &&
+            stripeIntent.linkFundingSources.intersect(supportedFundingSources).isNotEmpty()
 
-        val savedSelection = retrieveSavedPaymentSelection(
-            prefsRepository,
-            isGooglePayReady,
-            isLinkReady,
-            paymentMethods
-        )
+        val paymentMethods: Deferred<List<PaymentMethod>>
+        val savedSelection: Deferred<SavedSelection>
+        val linkState: Deferred<LinkState?>
+
+        coroutineScope {
+            paymentMethods = async {
+                if (customerConfig != null) {
+                    retrieveCustomerPaymentMethods(
+                        stripeIntent,
+                        config,
+                        customerConfig
+                    )
+                } else {
+                    emptyList()
+                }
+            }
+
+            savedSelection = async {
+                retrieveSavedPaymentSelection(
+                    prefsRepository,
+                    isGooglePayReady,
+                    isLinkAvailable,
+                    paymentMethods.await()
+                )
+            }
+
+            linkState = async {
+                if (isLinkAvailable) {
+                    loadLinkState(config, stripeIntent)
+                } else {
+                    null
+                }
+            }
+        }
 
         return PaymentSheetLoader.Result.Success(
             PaymentSheetState.Full(
                 config = config,
                 clientSecret = clientSecret,
                 stripeIntent = stripeIntent,
-                customerPaymentMethods = paymentMethods,
-                savedSelection = savedSelection,
+                customerPaymentMethods = paymentMethods.await(),
+                savedSelection = savedSelection.await(),
                 isGooglePayReady = isGooglePayReady,
-                isLinkEnabled = isLinkReady,
+                linkState = linkState.await(),
+                newPaymentSelection = null,
             )
         )
     }
@@ -214,5 +244,63 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         }
 
         return stripeIntentValidator.requireValid(paymentMethodPreference.intent)
+    }
+
+    private suspend fun loadLinkState(
+        config: PaymentSheet.Configuration?,
+        stripeIntent: StripeIntent,
+    ): LinkState {
+        val linkConfig = createLinkConfiguration(config, stripeIntent)
+
+        val loginState = when (accountStatusProvider(linkConfig)) {
+            AccountStatus.Verified -> LinkState.LoginState.LoggedIn
+            AccountStatus.NeedsVerification,
+            AccountStatus.VerificationStarted -> LinkState.LoginState.NeedsVerification
+            AccountStatus.SignedOut,
+            AccountStatus.Error -> LinkState.LoginState.LoggedOut
+        }
+
+        return LinkState(
+            configuration = linkConfig,
+            loginState = loginState,
+        )
+    }
+
+    private suspend fun createLinkConfiguration(
+        config: PaymentSheet.Configuration?,
+        stripeIntent: StripeIntent,
+    ): LinkPaymentLauncher.Configuration {
+        val shippingDetails: AddressDetails? = config?.shippingDetails
+
+        val customerPhone = if (shippingDetails?.isCheckboxSelected == true) {
+            shippingDetails.phoneNumber
+        } else {
+            config?.defaultBillingDetails?.phone
+        }
+
+        val shippingAddress = if (shippingDetails?.isCheckboxSelected == true) {
+            shippingDetails.toIdentifierMap(config.defaultBillingDetails)
+        } else {
+            null
+        }
+
+        val customerEmail = config?.defaultBillingDetails?.email ?: config?.customer?.let {
+            customerRepository.retrieveCustomer(
+                it.id,
+                it.ephemeralKeySecret
+            )
+        }?.email
+
+        val merchantName = config?.merchantDisplayName ?: appName
+
+        return LinkPaymentLauncher.Configuration(
+            stripeIntent = stripeIntent,
+            merchantName = merchantName,
+            customerEmail = customerEmail,
+            customerPhone = customerPhone,
+            customerName = config?.defaultBillingDetails?.name,
+            customerBillingCountryCode = config?.defaultBillingDetails?.address?.country,
+            shippingValues = shippingAddress
+        )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetState.kt
@@ -19,15 +19,15 @@ internal sealed interface PaymentSheetState : Parcelable {
         val config: PaymentSheet.Configuration?,
         val clientSecret: ClientSecret,
         val stripeIntent: StripeIntent,
-        val customerPaymentMethods: List<PaymentMethod> = emptyList(),
-        val savedSelection: SavedSelection = SavedSelection.None,
-        val isGooglePayReady: Boolean = false,
-        val isLinkEnabled: Boolean = false,
-        val newPaymentSelection: PaymentSelection.New? = null,
+        val customerPaymentMethods: List<PaymentMethod>,
+        val savedSelection: SavedSelection,
+        val isGooglePayReady: Boolean,
+        val linkState: LinkState?,
+        val newPaymentSelection: PaymentSelection.New?,
     ) : PaymentSheetState {
 
         val hasPaymentOptions: Boolean
-            get() = isGooglePayReady || isLinkEnabled || customerPaymentMethods.isNotEmpty()
+            get() = isGooglePayReady || linkState != null || customerPaymentMethods.isNotEmpty()
 
         val initialPaymentSelection: PaymentSelection?
             get() = when (savedSelection) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -482,11 +482,6 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
         }
     }
 
-    /**
-     * Function called during initialization to setup Link.
-     */
-    abstract fun setupLink(stripeIntent: StripeIntent)
-
     protected suspend fun createLinkConfiguration(
         stripeIntent: StripeIntent
     ): LinkPaymentLauncher.Configuration {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAddPaymentMethodFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAddPaymentMethodFragmentTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.model.FragmentConfig
 import com.stripe.android.paymentsheet.model.FragmentConfigFixtures
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
+import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.utils.FakeAndroidKeyStore
@@ -71,9 +72,11 @@ internal class PaymentOptionsAddPaymentMethodFragmentTest : PaymentOptionsViewMo
                 stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 clientSecret = PaymentIntentClientSecret("secret"),
                 customerPaymentMethods = emptyList(),
+                savedSelection = SavedSelection.None,
                 config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
                 isGooglePayReady = false,
                 newPaymentSelection = null,
+                linkState = null,
             ),
             statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR,
             injectorKey = DUMMY_INJECTOR_KEY,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -9,6 +9,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.SetupIntentClientSecret
 import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
 import com.stripe.android.paymentsheet.state.PaymentSheetState
@@ -91,6 +92,8 @@ internal object PaymentSheetFixtures {
             config = CONFIG_GOOGLEPAY,
             isGooglePayReady = false,
             newPaymentSelection = null,
+            linkState = null,
+            savedSelection = SavedSelection.None,
         ),
         statusBarColor = STATUS_BAR_COLOR,
         injectorKey = DUMMY_INJECTOR_KEY,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -40,6 +40,7 @@ import com.stripe.android.paymentsheet.model.StripeIntentValidator
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.ACHText
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.StripeIntentRepository
+import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.Companion.SAVE_PROCESSING
@@ -65,7 +66,6 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -298,11 +298,13 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
-    fun `setupLink() launches Link when account status is Verified`() = runTest {
-        whenever(linkLauncher.getAccountStatusFlow(any())).thenReturn(flowOf(AccountStatus.Verified))
-        val viewModel = createViewModel()
-
-        viewModel.setupLink(PAYMENT_INTENT)
+    fun `Launches Link when user is logged in to their Link account`() = runTest {
+        val viewModel = createViewModel(
+            linkState = LinkState(
+                configuration = mock(),
+                loginState = LinkState.LoginState.LoggedIn,
+            ),
+        )
 
         assertThat(viewModel.showLinkVerificationDialog.value).isFalse()
         assertThat(viewModel.activeLinkSession.value).isTrue()
@@ -311,23 +313,13 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
-    fun `setupLink() starts verification when account status is NeedsVerification`() = runTest {
-        whenever(linkLauncher.getAccountStatusFlow(any())).thenReturn(flowOf(AccountStatus.NeedsVerification))
-        val viewModel = createViewModel()
-
-        viewModel.setupLink(PAYMENT_INTENT)
-
-        assertThat(viewModel.showLinkVerificationDialog.value).isTrue()
-        assertThat(viewModel.activeLinkSession.value).isFalse()
-        assertThat(viewModel.isLinkEnabled.value).isTrue()
-    }
-
-    @Test
-    fun `setupLink() starts verification when account status is VerificationStarted`() = runTest {
-        whenever(linkLauncher.getAccountStatusFlow(any())).thenReturn(flowOf(AccountStatus.VerificationStarted))
-        val viewModel = createViewModel()
-
-        viewModel.setupLink(PAYMENT_INTENT)
+    fun `Launches Link verification when user needs to verify their Link account`() = runTest {
+        val viewModel = createViewModel(
+            linkState = LinkState(
+                configuration = mock(),
+                loginState = LinkState.LoginState.NeedsVerification,
+            ),
+        )
 
         assertThat(viewModel.showLinkVerificationDialog.value).isTrue()
         assertThat(viewModel.activeLinkSession.value).isFalse()
@@ -335,22 +327,23 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
-    fun `setupLink() enables Link when account status is SignedOut`() = runTest {
-        whenever(linkLauncher.getAccountStatusFlow(any())).thenReturn(flowOf(AccountStatus.SignedOut))
-        val viewModel = createViewModel()
-
-        viewModel.setupLink(PAYMENT_INTENT)
+    fun `Enables Link when user is logged out of their Link account`() = runTest {
+        val viewModel = createViewModel(
+            linkState = LinkState(
+                configuration = mock(),
+                loginState = LinkState.LoginState.LoggedOut,
+            ),
+        )
 
         assertThat(viewModel.activeLinkSession.value).isFalse()
         assertThat(viewModel.isLinkEnabled.value).isTrue()
     }
 
     @Test
-    fun `setupLink() disables Link when account status is Error`() = runTest {
-        whenever(linkLauncher.getAccountStatusFlow(any())).thenReturn(flowOf(AccountStatus.Error))
-        val viewModel = createViewModel()
-
-        viewModel.setupLink(PAYMENT_INTENT)
+    fun `Does not enable Link when the Link state can't be determined`() = runTest {
+        val viewModel = createViewModel(
+            linkState = null,
+        )
 
         assertThat(viewModel.activeLinkSession.value).isFalse()
         assertThat(viewModel.isLinkEnabled.value).isFalse()
@@ -952,6 +945,7 @@ internal class PaymentSheetViewModelTest {
         stripeIntent: StripeIntent = PAYMENT_INTENT,
         customerRepository: CustomerRepository = FakeCustomerRepository(PAYMENT_METHODS),
         shouldFailLoad: Boolean = false,
+        linkState: LinkState? = null,
     ): PaymentSheetViewModel {
         val paymentConfiguration = PaymentConfiguration(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
         return PaymentSheetViewModel(
@@ -961,7 +955,11 @@ internal class PaymentSheetViewModelTest {
             { paymentConfiguration },
             StripeIntentRepository.Static(stripeIntent),
             StripeIntentValidator(),
-            FakePaymentSheetLoader(stripeIntent = stripeIntent, shouldFail = shouldFailLoad),
+            FakePaymentSheetLoader(
+                stripeIntent = stripeIntent,
+                shouldFail = shouldFailLoad,
+                linkState = linkState,
+            ),
             customerRepository,
             prefsRepository,
             lpmResourceRepository,

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
@@ -6,7 +6,8 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 
 internal class FakeCustomerRepository(
-    private val paymentMethods: List<PaymentMethod> = emptyList()
+    private val paymentMethods: List<PaymentMethod> = emptyList(),
+    private val customer: Customer? = null,
 ) : CustomerRepository {
     lateinit var savedPaymentMethod: PaymentMethod
     var error: Throwable? = null
@@ -14,7 +15,7 @@ internal class FakeCustomerRepository(
     override suspend fun retrieveCustomer(
         customerId: String,
         ephemeralKeySecret: String
-    ): Customer? = null
+    ): Customer? = customer
 
     override suspend fun getPaymentMethods(
         customerConfig: PaymentSheet.CustomerConfiguration,

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentSheetLoader.kt
@@ -6,6 +6,7 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.ClientSecret
 import com.stripe.android.paymentsheet.model.SavedSelection
+import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentSheetLoader
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import kotlinx.coroutines.delay
@@ -18,6 +19,7 @@ internal class FakePaymentSheetLoader(
     private val savedSelection: SavedSelection = SavedSelection.None,
     private val isGooglePayAvailable: Boolean = false,
     private val delay: Duration = Duration.ZERO,
+    private val linkState: LinkState? = null,
 ) : PaymentSheetLoader {
 
     fun updatePaymentMethods(paymentMethods: List<PaymentMethod>) {
@@ -40,6 +42,8 @@ internal class FakePaymentSheetLoader(
                     customerPaymentMethods = customerPaymentMethods,
                     savedSelection = savedSelection,
                     isGooglePayReady = isGooglePayAvailable,
+                    linkState = linkState,
+                    newPaymentSelection = null,
                 )
             )
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request moves Link initialization into the `PaymentSheetLoader`, which removes duplicated logic from the view models.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
N/A

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A
