### PR TITLE
Add PaymentIntent flow to Financial Connections Playground


### DIFF
--- a/financial-connections-example/build.gradle
+++ b/financial-connections-example/build.gradle
@@ -64,6 +64,7 @@ def getBackendUrl() {
 
 dependencies {
     implementation project(':financial-connections')
+    implementation project(':payments-core')
 
     implementation "androidx.activity:activity-ktx:$androidxActivityVersion"
     implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
@@ -5,10 +5,14 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Button
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.MaterialTheme
@@ -24,8 +28,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.core.content.edit
 import com.stripe.android.financialconnections.rememberFinancialConnectionsSheet
 import com.stripe.android.financialconnections.rememberFinancialConnectionsSheetForToken
@@ -134,7 +140,21 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
                     ) {
                         Text("Connect Accounts!")
                     }
-                    Text(text = state.status)
+                    LazyColumn {
+                        items(state.status) { item ->
+                            Row(Modifier.padding(8.dp), verticalAlignment = Alignment.Top) {
+                                Canvas(
+                                    modifier = Modifier
+                                        .padding(end = 8.dp, top = 6.dp)
+                                        .size(6.dp)
+                                ) {
+                                    drawCircle(Color.Black)
+                                }
+                                Text(text = item, fontSize = 12.sp)
+                            }
+                        }
+                    }
+
                 }
             }
         )
@@ -228,7 +248,7 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
     @Composable
     fun ContentPreview() {
         FinancialConnectionsContent(
-            state = FinancialConnectionsPlaygroundState(false, "pk", "Result: Pending"),
+            state = FinancialConnectionsPlaygroundState(false, "pk", listOf("Result: Pending")),
             onButtonClick = { _, _ -> }
         )
     }

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
@@ -3,11 +3,16 @@ package com.stripe.android.financialconnections.example
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import com.stripe.android.Stripe
+import com.stripe.android.confirmPaymentIntent
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.FinancialConnectionsSheetForTokenResult
 import com.stripe.android.financialconnections.FinancialConnectionsSheetResult
 import com.stripe.android.financialconnections.example.data.BackendRepository
 import com.stripe.android.financialconnections.example.data.Settings
+import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResult
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -20,9 +25,8 @@ class FinancialConnectionsPlaygroundViewModel(
 ) : AndroidViewModel(application) {
 
     private val repository = BackendRepository(Settings(application))
-
-    private val _state = MutableStateFlow(FinancialConnectionsExampleState())
-    val state: StateFlow<FinancialConnectionsExampleState> = _state
+    private val _state = MutableStateFlow(FinancialConnectionsPlaygroundState())
+    val state: StateFlow<FinancialConnectionsPlaygroundState> = _state
 
     private val _viewEffect = MutableSharedFlow<FinancialConnectionsPlaygroundViewEffect?>()
     val viewEffect: SharedFlow<FinancialConnectionsPlaygroundViewEffect?> = _viewEffect
@@ -34,8 +38,35 @@ class FinancialConnectionsPlaygroundViewModel(
         when (flow) {
             Flow.Data -> startForData(mode)
             Flow.Token -> startForToken(mode)
+            Flow.PaymentIntent -> startWithPaymentIntent()
         }
 
+    }
+
+
+    private fun startWithPaymentIntent() {
+        viewModelScope.launch {
+            showLoadingWithMessage("Fetching link account session from example backend!")
+            kotlin.runCatching { repository.createPaymentIntent("US") }
+                // Success creating session: open the financial connections sheet with received secret
+                .onSuccess {
+                    _state.update { current ->
+                        current.copy(
+                            publishableKey = it.publishableKey,
+                            loading = true,
+                            status = "Payment Intent created ${it.intentSecret}, opening FinancialConnectionsSheet."
+                        )
+                    }
+                    _viewEffect.emit(
+                        FinancialConnectionsPlaygroundViewEffect.OpenForPaymentIntent(
+                            paymentIntentSecret = it.intentSecret,
+                            publishableKey = it.publishableKey
+                        )
+                    )
+                }
+                // Error retrieving session: display error.
+                .onFailure(::showError)
+        }
     }
 
     private fun startForData(mode: Mode) {
@@ -45,6 +76,7 @@ class FinancialConnectionsPlaygroundViewModel(
                 // Success creating session: open the financial connections sheet with received secret
                 .onSuccess {
                     showLoadingWithMessage("Session created, opening FinancialConnectionsSheet.")
+                    _state.update { current -> current.copy(publishableKey = it.publishableKey) }
                     _viewEffect.emit(
                         FinancialConnectionsPlaygroundViewEffect.OpenForData(
                             configuration = FinancialConnectionsSheet.Configuration(
@@ -66,6 +98,7 @@ class FinancialConnectionsPlaygroundViewModel(
                 // Success creating session: open the financial connections sheet with received secret
                 .onSuccess {
                     showLoadingWithMessage("Session created, opening FinancialConnectionsSheet.")
+                    _state.update { current -> current.copy(publishableKey = it.publishableKey) }
                     _viewEffect.emit(
                         FinancialConnectionsPlaygroundViewEffect.OpenForToken(
                             configuration = FinancialConnectionsSheet.Configuration(
@@ -123,6 +156,38 @@ class FinancialConnectionsPlaygroundViewModel(
         }
         _state.update { it.copy(loading = false, status = statusText) }
     }
+
+    fun onCollectBankAccountLauncherResult(result: CollectBankAccountResult) {
+        _state.update { it.copy(status = it.status + "\n" + "Session attached! Confirming Intent") }
+        viewModelScope.launch {
+            val statusText = when (result) {
+                is CollectBankAccountResult.Completed -> {
+                    val confirmedIntent = stripe(
+                        _state.value.publishableKey!!
+                    ).confirmPaymentIntent(
+                        ConfirmPaymentIntentParams.create(
+                            clientSecret = requireNotNull(result.response.intent.clientSecret),
+                            paymentMethodType = PaymentMethod.Type.USBankAccount
+                        )
+                    )
+                    _state.value.status + "\n" + "Completed! ${confirmedIntent.status}"
+                }
+
+                is CollectBankAccountResult.Failed -> "Failed! ${result.error}"
+                is CollectBankAccountResult.Cancelled -> "Cancelled!"
+            }
+            _state.update { it.copy(loading = false, status = statusText) }
+        }
+
+    }
+
+    private fun stripe(publishableKey: String) = Stripe(
+        getApplication(),
+        publishableKey,
+        null,
+        true,
+        emptySet()
+    )
 }
 
 enum class Mode(val flow: String) {
@@ -130,7 +195,7 @@ enum class Mode(val flow: String) {
 }
 
 enum class Flow {
-    Data, Token
+    Data, Token, PaymentIntent
 }
 
 enum class NativeOverride {
@@ -145,4 +210,15 @@ sealed class FinancialConnectionsPlaygroundViewEffect {
     data class OpenForToken(
         val configuration: FinancialConnectionsSheet.Configuration
     ) : FinancialConnectionsPlaygroundViewEffect()
+
+    data class OpenForPaymentIntent(
+        val paymentIntentSecret: String,
+        val publishableKey: String
+    ) : FinancialConnectionsPlaygroundViewEffect()
 }
+
+data class FinancialConnectionsPlaygroundState(
+    val loading: Boolean = false,
+    val publishableKey: String? = null,
+    val status: String = ""
+)

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/BackendApiService.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/BackendApiService.kt
@@ -1,7 +1,10 @@
 package com.stripe.android.financialconnections.example.data
 
+import com.stripe.android.financialconnections.example.data.model.CreateIntentResponse
 import com.stripe.android.financialconnections.example.data.model.CreateLinkAccountSessionResponse
 import retrofit2.http.Body
+import retrofit2.http.FieldMap
+import retrofit2.http.FormUrlEncoded
 import retrofit2.http.POST
 
 interface BackendApiService {
@@ -14,6 +17,12 @@ interface BackendApiService {
     suspend fun createLinkAccountSessionForToken(
         @Body linkAccountSessionBody: LinkAccountSessionBody
     ): CreateLinkAccountSessionResponse
+
+    @FormUrlEncoded
+    @POST("create_payment_intent")
+    suspend fun createPaymentIntent(
+        @FieldMap params: MutableMap<String, String>
+    ): CreateIntentResponse
 }
 
 data class LinkAccountSessionBody(

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/BackendRepository.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/BackendRepository.kt
@@ -1,5 +1,8 @@
 package com.stripe.android.financialconnections.example.data
 
+import com.stripe.android.financialconnections.example.data.model.CreateIntentResponse
+import okhttp3.ResponseBody
+
 class BackendRepository(
     settings: Settings
 ) {
@@ -14,5 +17,24 @@ class BackendRepository(
         backendService.createLinkAccountSessionForToken(
             LinkAccountSessionBody(flow)
         )
+
+    suspend fun createPaymentIntent(
+        country: String,
+        customerId: String? = null,
+        supportedPaymentMethods: String? = null
+    ): CreateIntentResponse {
+        return backendService.createPaymentIntent(
+            mapOf("country" to country)
+                .plus(
+                    customerId?.let {
+                        mapOf("customer_id" to it)
+                    }.orEmpty()
+                ).plus(
+                    supportedPaymentMethods?.let {
+                        mapOf("supported_payment_methods" to it)
+                    }.orEmpty()
+                ).toMutableMap()
+        )
+    }
 
 }

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/model/CreateLinkAccountSessionResponse.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/model/CreateLinkAccountSessionResponse.kt
@@ -7,3 +7,9 @@ data class CreateLinkAccountSessionResponse(
     @SerializedName("las_id") val lasId: String,
     @SerializedName("publishable_key") val publishableKey: String
 )
+
+
+data class CreateIntentResponse(
+    @SerializedName("secret") val intentSecret: String,
+    @SerializedName("publishable_key") val publishableKey: String
+)


### PR DESCRIPTION
# Summary
- Adds Payment intent example: Creates a PI on sample backend, collects bank account with Financial Connections and Confirms the Intent.
- A similar example exists on the payments example app. 

# Demo

https://user-images.githubusercontent.com/99293320/204627564-baaa5504-2b94-4a96-9281-96aaa70f448d.mp4

# Motivation
:notebook_with_decorative_cover: &nbsp;**Add PaymentIntent flow to Financial Connections Playground**
:globe_with_meridians: &nbsp;[BANKCON-5815](https://jira.corp.stripe.com/browse/BANKCON-5815)
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->