### PR TITLE
Fix issue with disabled pay button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 2022-XX-XX
 
+### PaymentSheet
+* [FIXED][5888](https://github.com/stripe/stripe-android/pull/5888) The primary button no longer stays disabled when returning from the `Add payment method` to the `Saved payment methods` screen.
+
 ## 20.16.1 - 2022-11-21
 
 ### PaymentSheet

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -188,6 +188,7 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
     override fun onBackPressed() {
         if (viewModel.processing.value == false) {
             if (supportFragmentManager.backStackEntryCount > 0) {
+                viewModel.onUserBack()
                 clearErrorMessages()
                 super.onBackPressed()
             } else {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -606,6 +606,12 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
 
     abstract fun onUserCancel()
 
+    fun onUserBack() {
+        // Reset the selection to the one from before opening the add payment method screen
+        val paymentOptionsState = paymentOptionsState.value
+        updateSelection(paymentOptionsState.selectedItem?.toPaymentSelection())
+    }
+
     abstract fun onPaymentResult(paymentResult: PaymentResult)
 
     abstract fun onFinish()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -1021,6 +1021,30 @@ internal class PaymentSheetActivityTest {
         }
     }
 
+    @Test
+    fun `Enables primary button again when returning from add payment method screen`() {
+        val addPaymentMethodTarget = PaymentSheetViewModel.TransitionTarget.AddPaymentMethodFull(
+            FragmentConfigFixtures.DEFAULT
+        )
+
+        val viewModel = createViewModel()
+
+        activityScenario(viewModel).launch(intent).use { injectableScenario ->
+            injectableScenario.onActivity { activity ->
+                idleLooper()
+                assertThat(activity.viewBinding.buyButton.isEnabled).isTrue()
+
+                viewModel.transitionTo(addPaymentMethodTarget)
+                idleLooper()
+                assertThat(activity.viewBinding.buyButton.isEnabled).isFalse()
+
+                viewModel.onUserBack()
+                idleLooper()
+                assertThat(activity.viewBinding.buyButton.isEnabled).isTrue()
+            }
+        }
+    }
+
     private fun currentFragment(activity: PaymentSheetActivity) =
         activity.supportFragmentManager.findFragmentById(activity.viewBinding.fragmentContainer.id)
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -1021,30 +1021,6 @@ internal class PaymentSheetActivityTest {
         }
     }
 
-    @Test
-    fun `Enables primary button again when returning from add payment method screen`() {
-        val addPaymentMethodTarget = PaymentSheetViewModel.TransitionTarget.AddPaymentMethodFull(
-            FragmentConfigFixtures.DEFAULT
-        )
-
-        val viewModel = createViewModel()
-
-        activityScenario(viewModel).launch(intent).use { injectableScenario ->
-            injectableScenario.onActivity { activity ->
-                idleLooper()
-                assertThat(activity.viewBinding.buyButton.isEnabled).isTrue()
-
-                viewModel.transitionTo(addPaymentMethodTarget)
-                idleLooper()
-                assertThat(activity.viewBinding.buyButton.isEnabled).isFalse()
-
-                viewModel.onUserBack()
-                idleLooper()
-                assertThat(activity.viewBinding.buyButton.isEnabled).isTrue()
-            }
-        }
-    }
-
     private fun currentFragment(activity: PaymentSheetActivity) =
         activity.supportFragmentManager.findFragmentById(activity.viewBinding.fragmentContainer.id)
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where the primary button stayed disabled when returning from the `Add payment method` to the `Saved payment methods` screen.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Resolves: https://github.com/stripe/stripe-android/issues/5887

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
N/A

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

[FIXED] The primary button no longer stays disabled when returning from the `Add payment method` to the `Saved payment methods` screen.
