### PR TITLE
Pass current payment selection into PaymentOptionContract args

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -262,7 +262,9 @@ internal class DefaultFlowController @Inject internal constructor(
 
         paymentOptionActivityLauncher.launch(
             PaymentOptionContract.Args(
-                state = state,
+                state = state.copy(
+                    newPaymentSelection = viewModel.paymentSelection as? PaymentSelection.New,
+                ),
                 statusBarColor = statusBarColor(),
                 injectorKey = injectorKey,
                 enableLogging = enableLogging,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -968,6 +968,30 @@ internal class DefaultFlowControllerTest {
             )
         }
 
+    @Test
+    fun `Remembers previous new payment selection when presenting payment options again`() = runTest {
+        val flowController = createFlowController()
+
+        flowController.configureWithPaymentIntent(
+            paymentIntentClientSecret = PaymentSheetFixtures.CLIENT_SECRET,
+            callback = { _, _ -> },
+        )
+
+        val previousPaymentSelection = NEW_CARD_PAYMENT_SELECTION
+
+        flowController.onPaymentOptionResult(
+            paymentOptionResult = PaymentOptionResult.Succeeded(previousPaymentSelection),
+        )
+
+        flowController.presentPaymentOptions()
+
+        verify(paymentOptionActivityLauncher).launch(
+            argWhere {
+                it.state.newPaymentSelection == previousPaymentSelection
+            }
+        )
+    }
+
     private fun createFlowController(
         paymentMethods: List<PaymentMethod> = emptyList(),
         savedSelection: SavedSelection = SavedSelection.None,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes a regression when switching over to using `PaymentSheetState`, where `newPaymentSelection` wasn’t preserved when presenting payment options a second time.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
N/A

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A
