### PR TITLE
don't use additional jobs to report interim and final result

### DIFF
--- a/camera-core/src/main/java/com/stripe/android/camera/framework/Result.kt
+++ b/camera-core/src/main/java/com/stripe/android/camera/framework/Result.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.camera.framework.util.FrameRateTracker
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -187,11 +186,11 @@ abstract class ResultAggregator<
 
                 aggregatorExecutionStats?.trackResult("frame_processed")
 
-                launch { listener.onInterimResult(interimResult) }
+                listener.onInterimResult(interimResult)
 
                 if (!isFinished && finalResult != null) {
                     isFinished = true
-                    launch { listener.onResult(finalResult) }
+                    listener.onResult(finalResult)
                 }
                 isFinished
             }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Directly notify the listener for `onInterimResult` and `onResult`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
The job on to report `onResult` sometimes is not executed sometimes.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
