### PR TITLE
Use correct `Context` when creating `FlowController` in Fragment

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerFactory.kt
@@ -29,15 +29,15 @@ internal class FlowControllerFactory(
         paymentOptionCallback: PaymentOptionCallback,
         paymentResultCallback: PaymentSheetResultCallback
     ) : this(
-        activity,
-        activity.lifecycleScope,
-        activity,
-        activity.applicationContext,
-        activity,
-        { activity.window.statusBarColor },
-        PaymentOptionFactory(activity.resources),
-        paymentOptionCallback,
-        paymentResultCallback
+        viewModelStoreOwner = activity,
+        lifecycleScope = activity.lifecycleScope,
+        lifecycleOwner = activity,
+        appContext = activity.applicationContext,
+        activityResultCaller = activity,
+        statusBarColor = { activity.window.statusBarColor },
+        paymentOptionFactory = PaymentOptionFactory(activity.resources),
+        paymentOptionCallback = paymentOptionCallback,
+        paymentResultCallback = paymentResultCallback,
     )
 
     constructor(
@@ -45,15 +45,15 @@ internal class FlowControllerFactory(
         paymentOptionCallback: PaymentOptionCallback,
         paymentResultCallback: PaymentSheetResultCallback
     ) : this(
-        fragment,
-        fragment.lifecycleScope,
-        fragment,
-        fragment.requireContext(),
-        fragment,
-        { fragment.activity?.window?.statusBarColor },
-        PaymentOptionFactory(fragment.resources),
-        paymentOptionCallback,
-        paymentResultCallback
+        viewModelStoreOwner = fragment,
+        lifecycleScope = fragment.lifecycleScope,
+        lifecycleOwner = fragment,
+        appContext = fragment.requireContext().applicationContext,
+        activityResultCaller = fragment,
+        statusBarColor = { fragment.activity?.window?.statusBarColor },
+        paymentOptionFactory = PaymentOptionFactory(fragment.resources),
+        paymentOptionCallback = paymentOptionCallback,
+        paymentResultCallback = paymentResultCallback,
     )
 
     fun create(): PaymentSheet.FlowController =


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

With this pull request, we correctly use the application context when instantiating a `FlowController` in a Fragment. Before, we used the Activity.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
N/A

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A
