### PR TITLE
Revert "Validate Card is accepted"

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/StripeIntentValidator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/StripeIntentValidator.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet.model
 
 import com.stripe.android.model.PaymentIntent
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import javax.inject.Inject
@@ -47,14 +46,6 @@ internal class StripeIntentValidator @Inject constructor() {
                     """
                         PaymentSheet cannot set up a SetupIntent in status '${stripeIntent.status}'.
                         See https://stripe.com/docs/api/setup_intents/object#setup_intent_object-status
-                    """.trimIndent()
-                )
-            }
-            !stripeIntent.paymentMethodTypes.contains(PaymentMethod.Type.Card.code) -> {
-                error(
-                    """
-                        Payment method type 'card' is required.
-                        Accepted payment methods: (${stripeIntent.paymentMethodTypes})."
                     """.trimIndent()
                 )
             }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/StripeIntentValidatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/StripeIntentValidatorTest.kt
@@ -34,17 +34,6 @@ class StripeIntentValidatorTest {
     }
 
     @Test
-    fun `requireValid() requires card is accepted`() {
-        assertFails {
-            validator.requireValid(
-                PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-                    paymentMethodTypes = listOf("link", "us_bank_account")
-                )
-            )
-        }
-    }
-
-    @Test
     fun `requireValid() Succeeded is not valid`() {
         assertFails {
             validator.requireValid(


### PR DESCRIPTION
Reverts stripe/stripe-android#5665

I tested this with https://flax-intermediate-revolve.glitch.me/checkout (and hardcoded a few payment methods, all of which worked).

I wasn't able to see anything that failed. 