### PR TITLE
[Identity] Replace globalActions with IdentityTopLevelDestination for Jetpack compose (2 of 3)

### DIFF
--- a/identity/res/navigation/identity_nav_graph.xml
+++ b/identity/res/navigation/identity_nav_graph.xml
@@ -21,16 +21,81 @@
         app:destination="@id/couldNotCaptureFragment" />
 
     <action
+        android:id="@+id/action_global_docSelectionFragment"
+        app:destination="@id/docSelectionFragment" />
+
+    <action
+        android:id="@+id/action_global_consentFragment"
+        app:destination="@id/consentFragment" />
+
+    <action
         android:id="@+id/action_global_selfieFragment"
         app:destination="@id/selfieFragment" />
 
+    <action
+        android:id="@+id/action_global_driverLicenseScanFragment"
+        app:destination="@id/driverLicenseScanFragment" />
+
+    <action
+        android:id="@+id/action_global_driverLicenseScanPopUpToDocSelect"
+        app:destination="@id/driverLicenseScanFragment"
+        app:popUpTo="@id/docSelectionFragment"
+        app:popUpToInclusive="false" />
+
+    <action
+        android:id="@+id/action_global_passportScanFragment"
+        app:destination="@id/passportScanFragment" />
+
+    <action
+        android:id="@+id/action_global_passportScanPopUpToDocSelect"
+        app:destination="@id/passportScanFragment"
+        app:popUpTo="@id/docSelectionFragment"
+        app:popUpToInclusive="false" />
+
+    <action
+        android:id="@+id/action_global_IDScanFragment"
+        app:destination="@id/IDScanFragment" />
+
+    <action
+        android:id="@+id/action_global_IDScanPopUpToDocSelect"
+        app:destination="@id/IDScanFragment"
+        app:popUpTo="@id/docSelectionFragment"
+        app:popUpToInclusive="false" />
+
+    <action
+        android:id="@+id/action_global_passportUploadFragment"
+        app:destination="@id/passportUploadFragment" />
+
+    <action
+        android:id="@+id/action_global_passportUploadPopUpToDocSelect"
+        app:destination="@id/passportUploadFragment"
+        app:popUpTo="@id/docSelectionFragment"
+        app:popUpToInclusive="false" />
+
+    <action
+        android:id="@+id/action_global_driverLicenseUploadFragment"
+        app:destination="@id/driverLicenseUploadFragment" />
+
+    <action
+        android:id="@+id/action_global_driverLicenseUploadPopUpToDocSelect"
+        app:destination="@id/driverLicenseUploadFragment"
+        app:popUpTo="@id/docSelectionFragment"
+        app:popUpToInclusive="false" />
+
+    <action
+        android:id="@+id/action_global_IDUploadFragment"
+        app:destination="@id/IDUploadFragment" />
+
+    <action
+        android:id="@+id/action_global_IDUploadPopUpToDocSelect"
+        app:destination="@id/IDUploadFragment"
+        app:popUpTo="@id/docSelectionFragment"
+        app:popUpToInclusive="false" />
+
+
     <fragment
         android:id="@+id/consentFragment"
-        android:name="com.stripe.android.identity.navigation.ConsentFragment">
-        <action
-            android:id="@+id/action_consentFragment_to_docSelectionFragment"
-            app:destination="@id/docSelectionFragment" />
-    </fragment>
+        android:name="com.stripe.android.identity.navigation.ConsentFragment" />
     <fragment
         android:id="@+id/IDScanFragment"
         android:name="com.stripe.android.identity.navigation.IDScanFragment">
@@ -65,44 +130,13 @@
         <argument
             android:name="scanType"
             app:argType="com.stripe.android.identity.networking.models.CollectedDataParam$Type" />
-        <action
-            android:id="@+id/action_cameraPermissionDeniedFragment_to_passportUploadFragment"
-            app:destination="@id/passportUploadFragment" />
-        <action
-            android:id="@+id/action_cameraPermissionDeniedFragment_to_IDUploadFragment"
-            app:destination="@id/IDUploadFragment" />
-        <action
-            android:id="@+id/action_cameraPermissionDeniedFragment_to_driverLicenseUploadFragment"
-            app:destination="@id/driverLicenseUploadFragment" />
-        <action
-            android:id="@+id/action_cameraPermissionDeniedFragment_to_docSelectionFragment"
-            app:destination="@id/docSelectionFragment" />
     </fragment>
     <fragment
         android:id="@+id/confirmationFragment"
         android:name="com.stripe.android.identity.navigation.ConfirmationFragment" />
     <fragment
         android:id="@+id/docSelectionFragment"
-        android:name="com.stripe.android.identity.navigation.DocSelectionFragment">
-        <action
-            android:id="@+id/action_docSelectionFragment_to_passportScanFragment"
-            app:destination="@id/passportScanFragment" />
-        <action
-            android:id="@+id/action_docSelectionFragment_to_IDScanFragment"
-            app:destination="@id/IDScanFragment" />
-        <action
-            android:id="@+id/action_docSelectionFragment_to_driverLicenseScanFragment"
-            app:destination="@id/driverLicenseScanFragment" />
-        <action
-            android:id="@+id/action_docSelectionFragment_to_passportUploadFragment"
-            app:destination="@id/passportUploadFragment" />
-        <action
-            android:id="@+id/action_docSelectionFragment_to_IDUploadFragment"
-            app:destination="@id/IDUploadFragment" />
-        <action
-            android:id="@+id/action_docSelectionFragment_to_driverLicenseUploadFragment"
-            app:destination="@id/driverLicenseUploadFragment" />
-    </fragment>
+        android:name="com.stripe.android.identity.navigation.DocSelectionFragment" />
     <fragment
         android:id="@+id/errorFragment"
         android:name="com.stripe.android.identity.navigation.ErrorFragment">
@@ -122,9 +156,6 @@
             android:name="goBackButtonDestination"
             android:defaultValue="0"
             app:argType="integer" />
-        <action
-            android:id="@+id/action_errorFragment_to_consentFragment"
-            app:destination="@id/consentFragment" />
     </fragment>
     <fragment
         android:id="@+id/couldNotCaptureFragment"
@@ -132,41 +163,6 @@
         <argument
             android:name="scanType"
             app:argType="com.stripe.android.identity.states.IdentityScanState$ScanType" />
-        <action
-            android:id="@+id/action_couldNotCaptureFragment_to_passportUploadFragment"
-            app:destination="@id/passportUploadFragment"
-            app:popUpTo="@id/docSelectionFragment"
-            app:popUpToInclusive="false" />
-        <action
-            android:id="@+id/action_couldNotCaptureFragment_to_IDUploadFragment"
-            app:destination="@id/IDUploadFragment"
-            app:popUpTo="@id/docSelectionFragment"
-            app:popUpToInclusive="false" />
-        <action
-            android:id="@+id/action_couldNotCaptureFragment_to_driverLicenseUploadFragment"
-            app:destination="@id/driverLicenseUploadFragment"
-            app:popUpTo="@id/docSelectionFragment"
-            app:popUpToInclusive="false" />
-        <action
-            android:id="@+id/action_couldNotCaptureFragment_to_passportScanFragment"
-            app:destination="@id/passportScanFragment"
-            app:popUpTo="@id/docSelectionFragment"
-            app:popUpToInclusive="false" />
-        <action
-            android:id="@+id/action_couldNotCaptureFragment_to_IDScanFragment"
-            app:destination="@id/IDScanFragment"
-            app:popUpTo="@id/docSelectionFragment"
-            app:popUpToInclusive="false" />
-        <action
-            android:id="@+id/action_couldNotCaptureFragment_to_driverLicenseScanFragment"
-            app:destination="@id/driverLicenseScanFragment"
-            app:popUpTo="@id/docSelectionFragment"
-            app:popUpToInclusive="false" />
-        <action
-            android:id="@+id/action_couldNotCaptureFragment_to_selfieFragment"
-            app:destination="@id/selfieFragment"
-            app:popUpTo="@id/docSelectionFragment"
-            app:popUpToInclusive="false" />
     </fragment>
     <fragment
         android:id="@+id/selfieFragment"

--- a/identity/src/main/java/com/stripe/android/identity/navigation/CameraPermissionDeniedFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/CameraPermissionDeniedFragment.kt
@@ -86,7 +86,7 @@ internal class CameraPermissionDeniedFragment(
                 shouldShowTakePhoto,
                 shouldShowChoosePhoto
             )
-            CollectedDataParam.Type.DRIVINGLICENSE -> DriveLicenseUploadDestination(
+            CollectedDataParam.Type.DRIVINGLICENSE -> DriverLicenseUploadDestination(
                 shouldShowTakePhoto,
                 shouldShowChoosePhoto
             )

--- a/identity/src/main/java/com/stripe/android/identity/navigation/CameraPermissionDeniedFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/CameraPermissionDeniedFragment.kt
@@ -3,7 +3,6 @@ package com.stripe.android.identity.navigation
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.annotation.IdRes
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.stringResource
@@ -15,7 +14,6 @@ import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.ui.ErrorScreen
 import com.stripe.android.identity.ui.ErrorScreenButton
 import com.stripe.android.identity.utils.navigateOnResume
-import com.stripe.android.identity.utils.navigateToUploadFragment
 
 /**
  * Fragment to show user denies camera permission.
@@ -44,10 +42,11 @@ internal class CameraPermissionDeniedFragment(
                         buttonText = stringResource(id = R.string.file_upload)
                     ) {
                         identityViewModel.screenTracker.screenTransitionStart(SCREEN_NAME_ERROR)
-                        navigateToUploadFragment(
-                            it.toUploadDestinationId(),
-                            shouldShowTakePhoto = false,
-                            shouldShowChoosePhoto = true
+                        navigateOnResume(
+                            it.toUploadDestination(
+                                shouldShowTakePhoto = false,
+                                shouldShowChoosePhoto = true
+                            )
                         )
                     }
                 },
@@ -57,7 +56,7 @@ internal class CameraPermissionDeniedFragment(
                     appSettingsOpenable.openAppSettings()
                     // navigate back to DocSelectFragment, so that when user is back to the app from settings
                     // the camera permission check can be triggered again from there.
-                    navigateOnResume(R.id.action_cameraPermissionDeniedFragment_to_docSelectionFragment)
+                    navigateOnResume(DocSelectionDestination)
                 }
             )
         }
@@ -79,15 +78,22 @@ internal class CameraPermissionDeniedFragment(
     internal companion object {
         const val ARG_SCAN_TYPE = "scanType"
 
-        @IdRes
-        private fun CollectedDataParam.Type.toUploadDestinationId() =
-            when (this) {
-                CollectedDataParam.Type.IDCARD ->
-                    R.id.action_cameraPermissionDeniedFragment_to_IDUploadFragment
-                CollectedDataParam.Type.DRIVINGLICENSE ->
-                    R.id.action_cameraPermissionDeniedFragment_to_driverLicenseUploadFragment
-                CollectedDataParam.Type.PASSPORT ->
-                    R.id.action_cameraPermissionDeniedFragment_to_passportUploadFragment
-            }
+        private fun CollectedDataParam.Type.toUploadDestination(
+            shouldShowTakePhoto: Boolean,
+            shouldShowChoosePhoto: Boolean
+        ) = when (this) {
+            CollectedDataParam.Type.IDCARD -> IDUploadDestination(
+                shouldShowTakePhoto,
+                shouldShowChoosePhoto
+            )
+            CollectedDataParam.Type.DRIVINGLICENSE -> DriveLicenseUploadDestination(
+                shouldShowTakePhoto,
+                shouldShowChoosePhoto
+            )
+            CollectedDataParam.Type.PASSPORT -> PassportUploadDestination(
+                shouldShowTakePhoto,
+                shouldShowChoosePhoto
+            )
+        }
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ConsentFragment.kt
@@ -114,7 +114,7 @@ internal class ConsentFragment(
                 collectedDataParam,
                 fromFragment = R.id.consentFragment,
                 notSubmitBlock = {
-                    navigateOnResume(R.id.action_consentFragment_to_docSelectionFragment)
+                    navigateOnResume(DocSelectionDestination)
                 }
             )
         }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/CouldNotCaptureFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/CouldNotCaptureFragment.kt
@@ -89,9 +89,9 @@ internal class CouldNotCaptureFragment(
                 IdentityScanState.ScanType.ID_BACK ->
                     IDUploadDestination(shouldShowTakePhoto, shouldShowChoosePhoto, true)
                 IdentityScanState.ScanType.DL_FRONT ->
-                    DriveLicenseUploadDestination(shouldShowTakePhoto, shouldShowChoosePhoto, true)
+                    DriverLicenseUploadDestination(shouldShowTakePhoto, shouldShowChoosePhoto, true)
                 IdentityScanState.ScanType.DL_BACK ->
-                    DriveLicenseUploadDestination(shouldShowTakePhoto, shouldShowChoosePhoto, true)
+                    DriverLicenseUploadDestination(shouldShowTakePhoto, shouldShowChoosePhoto, true)
                 IdentityScanState.ScanType.PASSPORT ->
                     PassportUploadDestination(shouldShowTakePhoto, shouldShowChoosePhoto, true)
                 IdentityScanState.ScanType.SELFIE -> {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/CouldNotCaptureFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/CouldNotCaptureFragment.kt
@@ -112,12 +112,12 @@ internal class CouldNotCaptureFragment(
                         shouldPopUpToDocSelection = true
                     )
                 IdentityScanState.ScanType.DL_FRONT ->
-                    DriveLicenseScanDestination(
+                    DriverLicenseScanDestination(
                         shouldStartFromBack = false,
                         shouldPopUpToDocSelection = true
                     )
                 IdentityScanState.ScanType.DL_BACK ->
-                    DriveLicenseScanDestination(
+                    DriverLicenseScanDestination(
                         shouldStartFromBack = true,
                         shouldPopUpToDocSelection = true
                     )

--- a/identity/src/main/java/com/stripe/android/identity/navigation/CouldNotCaptureFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/CouldNotCaptureFragment.kt
@@ -3,22 +3,18 @@ package com.stripe.android.identity.navigation
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.annotation.IdRes
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.stringResource
-import androidx.core.os.bundleOf
 import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.identity.R
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_ERROR
 import com.stripe.android.identity.navigation.CouldNotCaptureDestination.Companion.ARG_COULD_NOT_CAPTURE_SCAN_TYPE
 import com.stripe.android.identity.navigation.CouldNotCaptureDestination.Companion.ARG_REQUIRE_LIVE_CAPTURE
-import com.stripe.android.identity.navigation.IdentityDocumentScanFragment.Companion.ARG_SHOULD_START_FROM_BACK
 import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.ui.ErrorScreen
 import com.stripe.android.identity.ui.ErrorScreenButton
 import com.stripe.android.identity.utils.navigateOnResume
-import com.stripe.android.identity.utils.navigateToUploadFragment
 
 /**
  * Fragment to indicate live capture failure.
@@ -58,10 +54,11 @@ internal class CouldNotCaptureFragment(
                         identityViewModel.screenTracker.screenTransitionStart(
                             SCREEN_NAME_ERROR
                         )
-                        navigateToUploadFragment(
-                            scanType.toUploadDestinationId(),
-                            shouldShowTakePhoto = true,
-                            shouldShowChoosePhoto = !args.getBoolean(ARG_REQUIRE_LIVE_CAPTURE)
+                        navigateOnResume(
+                            scanType.toUploadDestination(
+                                shouldShowTakePhoto = true,
+                                shouldShowChoosePhoto = !args.getBoolean(ARG_REQUIRE_LIVE_CAPTURE)
+                            )
                         )
                     }
                 },
@@ -73,10 +70,7 @@ internal class CouldNotCaptureFragment(
                         SCREEN_NAME_ERROR
                     )
                     navigateOnResume(
-                        scanType.toScanDestinationId(),
-                        bundleOf(
-                            ARG_SHOULD_START_FROM_BACK to scanType.toShouldStartFromBack()
-                        )
+                        scanType.toScanDestination()
                     )
                 }
             )
@@ -85,49 +79,55 @@ internal class CouldNotCaptureFragment(
 
     internal companion object {
 
-        @IdRes
-        private fun IdentityScanState.ScanType.toUploadDestinationId() =
+        private fun IdentityScanState.ScanType.toUploadDestination(
+            shouldShowTakePhoto: Boolean,
+            shouldShowChoosePhoto: Boolean
+        ) =
             when (this) {
                 IdentityScanState.ScanType.ID_FRONT ->
-                    R.id.action_couldNotCaptureFragment_to_IDUploadFragment
+                    IDUploadDestination(shouldShowTakePhoto, shouldShowChoosePhoto, true)
                 IdentityScanState.ScanType.ID_BACK ->
-                    R.id.action_couldNotCaptureFragment_to_IDUploadFragment
+                    IDUploadDestination(shouldShowTakePhoto, shouldShowChoosePhoto, true)
                 IdentityScanState.ScanType.DL_FRONT ->
-                    R.id.action_couldNotCaptureFragment_to_driverLicenseUploadFragment
+                    DriveLicenseUploadDestination(shouldShowTakePhoto, shouldShowChoosePhoto, true)
                 IdentityScanState.ScanType.DL_BACK ->
-                    R.id.action_couldNotCaptureFragment_to_driverLicenseUploadFragment
+                    DriveLicenseUploadDestination(shouldShowTakePhoto, shouldShowChoosePhoto, true)
                 IdentityScanState.ScanType.PASSPORT ->
-                    R.id.action_couldNotCaptureFragment_to_passportUploadFragment
+                    PassportUploadDestination(shouldShowTakePhoto, shouldShowChoosePhoto, true)
                 IdentityScanState.ScanType.SELFIE -> {
                     throw IllegalArgumentException("SELFIE doesn't support upload")
                 }
             }
 
-        @IdRes
-        private fun IdentityScanState.ScanType.toScanDestinationId() =
+        private fun IdentityScanState.ScanType.toScanDestination() =
             when (this) {
                 IdentityScanState.ScanType.ID_FRONT ->
-                    R.id.action_couldNotCaptureFragment_to_IDScanFragment
+                    IDScanDestination(
+                        shouldStartFromBack = false,
+                        shouldPopUpToDocSelection = true
+                    )
                 IdentityScanState.ScanType.ID_BACK ->
-                    R.id.action_couldNotCaptureFragment_to_IDScanFragment
+                    IDScanDestination(
+                        shouldStartFromBack = true,
+                        shouldPopUpToDocSelection = true
+                    )
                 IdentityScanState.ScanType.DL_FRONT ->
-                    R.id.action_couldNotCaptureFragment_to_driverLicenseScanFragment
+                    DriveLicenseScanDestination(
+                        shouldStartFromBack = false,
+                        shouldPopUpToDocSelection = true
+                    )
                 IdentityScanState.ScanType.DL_BACK ->
-                    R.id.action_couldNotCaptureFragment_to_driverLicenseScanFragment
+                    DriveLicenseScanDestination(
+                        shouldStartFromBack = true,
+                        shouldPopUpToDocSelection = true
+                    )
                 IdentityScanState.ScanType.PASSPORT ->
-                    R.id.action_couldNotCaptureFragment_to_passportScanFragment
+                    PassportScanDestination(
+                        shouldStartFromBack = false,
+                        shouldPopUpToDocSelection = true
+                    )
                 IdentityScanState.ScanType.SELFIE ->
-                    R.id.action_couldNotCaptureFragment_to_selfieFragment
-            }
-
-        private fun IdentityScanState.ScanType.toShouldStartFromBack() =
-            when (this) {
-                IdentityScanState.ScanType.ID_FRONT -> false
-                IdentityScanState.ScanType.ID_BACK -> true
-                IdentityScanState.ScanType.DL_FRONT -> false
-                IdentityScanState.ScanType.DL_BACK -> true
-                IdentityScanState.ScanType.PASSPORT -> false
-                IdentityScanState.ScanType.SELFIE -> false
+                    SelfieDestination
             }
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
@@ -196,7 +196,7 @@ internal class DocSelectionFragment(
                         shouldShowChoosePhoto
                     )
                 Type.DRIVINGLICENSE ->
-                    DriveLicenseUploadDestination(
+                    DriverLicenseUploadDestination(
                         shouldShowTakePhoto,
                         shouldShowChoosePhoto
                     )

--- a/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.annotation.IdRes
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.platform.ComposeView
@@ -24,7 +23,6 @@ import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.ui.DocSelectionScreen
 import com.stripe.android.identity.utils.navigateOnResume
 import com.stripe.android.identity.utils.navigateToDefaultErrorFragment
-import com.stripe.android.identity.utils.navigateToUploadFragment
 import com.stripe.android.identity.utils.postVerificationPageDataAndMaybeSubmit
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 import kotlinx.coroutines.launch
@@ -90,7 +88,7 @@ internal class DocSelectionFragment(
                                 when (modelResource.status) {
                                     // model ready, camera permission is granted -> navigate to scan
                                     Status.SUCCESS -> {
-                                        navigateOnResume(type.toScanDestinationId())
+                                        navigateOnResume(type.toScanDestination())
                                     }
                                     // model not ready, camera permission is granted -> navigate to manual capture
                                     Status.ERROR -> {
@@ -129,10 +127,11 @@ internal class DocSelectionFragment(
                         navigateToDefaultErrorFragment(msg)
                     }
                 } else {
-                    navigateToUploadFragment(
-                        type.toUploadDestinationId(),
-                        shouldShowTakePhoto = true,
-                        shouldShowChoosePhoto = true
+                    navigateOnResume(
+                        type.toUploadDestination(
+                            shouldShowTakePhoto = true,
+                            shouldShowChoosePhoto = true
+                        )
                     )
                 }
             },
@@ -174,20 +173,33 @@ internal class DocSelectionFragment(
         const val SELECTION_NONE = ""
         val TAG: String = DocSelectionFragment::class.java.simpleName
 
-        @IdRes
-        private fun Type.toScanDestinationId() =
+        private fun Type.toScanDestination() =
             when (this) {
-                Type.IDCARD -> R.id.action_docSelectionFragment_to_IDScanFragment
-                Type.PASSPORT -> R.id.action_docSelectionFragment_to_passportScanFragment
-                Type.DRIVINGLICENSE -> R.id.action_docSelectionFragment_to_driverLicenseScanFragment
+                Type.IDCARD -> IDScanDestination()
+                Type.PASSPORT -> PassportScanDestination()
+                Type.DRIVINGLICENSE -> DriveLicenseScanDestination()
             }
 
-        @IdRes
-        private fun Type.toUploadDestinationId() =
+        private fun Type.toUploadDestination(
+            shouldShowTakePhoto: Boolean,
+            shouldShowChoosePhoto: Boolean
+        ) =
             when (this) {
-                Type.IDCARD -> R.id.action_docSelectionFragment_to_IDUploadFragment
-                Type.PASSPORT -> R.id.action_docSelectionFragment_to_passportUploadFragment
-                Type.DRIVINGLICENSE -> R.id.action_docSelectionFragment_to_driverLicenseUploadFragment
+                Type.IDCARD ->
+                    IDUploadDestination(
+                        shouldShowTakePhoto,
+                        shouldShowChoosePhoto
+                    )
+                Type.PASSPORT ->
+                    PassportUploadDestination(
+                        shouldShowTakePhoto,
+                        shouldShowChoosePhoto
+                    )
+                Type.DRIVINGLICENSE ->
+                    DriveLicenseUploadDestination(
+                        shouldShowTakePhoto,
+                        shouldShowChoosePhoto
+                    )
             }
 
         private fun Type.toAnalyticsScanType() = when (this) {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/DocSelectionFragment.kt
@@ -177,7 +177,7 @@ internal class DocSelectionFragment(
             when (this) {
                 Type.IDCARD -> IDScanDestination()
                 Type.PASSPORT -> PassportScanDestination()
-                Type.DRIVINGLICENSE -> DriveLicenseScanDestination()
+                Type.DRIVINGLICENSE -> DriverLicenseScanDestination()
             }
 
         private fun Type.toUploadDestination(

--- a/identity/src/main/java/com/stripe/android/identity/navigation/ErrorFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ErrorFragment.kt
@@ -16,7 +16,6 @@ import com.stripe.android.identity.navigation.ErrorDestination.Companion.ARG_ERR
 import com.stripe.android.identity.navigation.ErrorDestination.Companion.ARG_GO_BACK_BUTTON_DESTINATION
 import com.stripe.android.identity.navigation.ErrorDestination.Companion.ARG_GO_BACK_BUTTON_TEXT
 import com.stripe.android.identity.navigation.ErrorDestination.Companion.ARG_SHOULD_FAIL
-import com.stripe.android.identity.navigation.ErrorDestination.Companion.DEFAULT_BACK_BUTTON_NAVIGATION
 import com.stripe.android.identity.navigation.ErrorDestination.Companion.UNEXPECTED_DESTINATION
 import com.stripe.android.identity.ui.ErrorScreen
 import com.stripe.android.identity.ui.ErrorScreenButton
@@ -65,7 +64,7 @@ internal class ErrorFragment(
                     } else {
                         val destination = args.getInt(ARG_GO_BACK_BUTTON_DESTINATION)
                         if (destination == UNEXPECTED_DESTINATION) {
-                            navigateOnResume(DEFAULT_BACK_BUTTON_NAVIGATION)
+                            navigateOnResume(ConsentDestination)
                         } else {
                             findNavController().let { navController ->
                                 var shouldContinueNavigateUp = true

--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityUploadFragment.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityUploadFragment.kt
@@ -24,8 +24,6 @@ import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.ui.DocumentUploadSideInfo
 import com.stripe.android.identity.ui.UploadMethod
 import com.stripe.android.identity.ui.UploadScreen
-import com.stripe.android.identity.utils.ARG_SHOULD_SHOW_CHOOSE_PHOTO
-import com.stripe.android.identity.utils.ARG_SHOULD_SHOW_TAKE_PHOTO
 import com.stripe.android.identity.utils.IdentityIO
 import com.stripe.android.identity.utils.fragmentIdToScreenName
 import com.stripe.android.identity.utils.navigateToDefaultErrorFragment

--- a/identity/src/main/java/com/stripe/android/identity/navigation/NavigationDestinations.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/NavigationDestinations.kt
@@ -203,28 +203,31 @@ internal class ErrorDestination(
 
 internal object ConfirmationDestination : IdentityTopLevelDestination() {
     private const val CONFIRMATION = "Confirmation"
-    override val destination = R.id.action_global_confirmationFragment
-    override val destinationRoute = object : DestinationRoute() {
+    private val ROUTE = object : DestinationRoute() {
         override val routeBase = CONFIRMATION
     }
+    override val destination = R.id.action_global_confirmationFragment
+    override val destinationRoute = ROUTE
     override val routeWithArgs = destinationRoute.route
 }
 
 internal object DocSelectionDestination : IdentityTopLevelDestination() {
     private const val DOC_SELECTION = "DocSelection"
-    override val destination = R.id.action_global_docSelectionFragment
-    override val destinationRoute = object : DestinationRoute() {
+    private val ROUTE = object : DestinationRoute() {
         override val routeBase = DOC_SELECTION
     }
+    override val destination = R.id.action_global_docSelectionFragment
+    override val destinationRoute = ROUTE
     override val routeWithArgs = destinationRoute.route
 }
 
 internal object ConsentDestination : IdentityTopLevelDestination() {
     private const val CONSENT = "Consent"
-    override val destination = R.id.action_global_consentFragment
-    override val destinationRoute = object : DestinationRoute() {
+    private val ROUTE = object : DestinationRoute() {
         override val routeBase = CONSENT
     }
+    override val destination = R.id.action_global_consentFragment
+    override val destinationRoute = ROUTE
     override val routeWithArgs = destinationRoute.route
 }
 

--- a/identity/src/main/java/com/stripe/android/identity/navigation/NavigationDestinations.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/NavigationDestinations.kt
@@ -2,7 +2,6 @@ package com.stripe.android.identity.navigation
 
 import android.os.Bundle
 import androidx.annotation.IdRes
-import androidx.annotation.VisibleForTesting
 import androidx.core.os.bundleOf
 import androidx.navigation.NamedNavArgument
 import androidx.navigation.NavController
@@ -56,7 +55,6 @@ internal abstract class IdentityTopLevelDestination {
 
 private fun String.withBracket() = "{$this}"
 
-@VisibleForTesting
 internal fun IdentityTopLevelDestination.DestinationRoute.withParams(
     vararg params: Pair<String, Any?>
 ): String {
@@ -180,9 +178,6 @@ internal class ErrorDestination(
         // If this happens, set the back button destination to [DEFAULT_BACK_BUTTON_DESTINATION]
         const val UNEXPECTED_DESTINATION = -1
 
-        val DEFAULT_BACK_BUTTON_NAVIGATION =
-            R.id.action_errorFragment_to_consentFragment
-
         val Route = object : DestinationRoute() {
             override val routeBase = ERROR
             override val arguments = listOf(
@@ -215,11 +210,20 @@ internal object ConfirmationDestination : IdentityTopLevelDestination() {
     override val routeWithArgs = destinationRoute.route
 }
 
-internal object SelfieDestination : IdentityTopLevelDestination() {
-    private const val SELFIE = "Selfie"
-    override val destination = R.id.action_global_selfieFragment
+internal object DocSelectionDestination : IdentityTopLevelDestination() {
+    private const val DOC_SELECTION = "DocSelection"
+    override val destination = R.id.action_global_docSelectionFragment
     override val destinationRoute = object : DestinationRoute() {
-        override val routeBase = SELFIE
+        override val routeBase = DOC_SELECTION
+    }
+    override val routeWithArgs = destinationRoute.route
+}
+
+internal object ConsentDestination : IdentityTopLevelDestination() {
+    private const val CONSENT = "Consent"
+    override val destination = R.id.action_global_consentFragment
+    override val destinationRoute = object : DestinationRoute() {
+        override val routeBase = CONSENT
     }
     override val routeWithArgs = destinationRoute.route
 }

--- a/identity/src/main/java/com/stripe/android/identity/navigation/ScanDestinations.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ScanDestinations.kt
@@ -1,0 +1,98 @@
+package com.stripe.android.identity.navigation
+
+import androidx.core.os.bundleOf
+import com.stripe.android.identity.R
+
+internal class PassportScanDestination(
+    shouldStartFromBack: Boolean = false,
+    shouldPopUpToDocSelection: Boolean = false
+) : IdentityTopLevelDestination() {
+    override val destinationRoute = ROUTE
+    override val destination =
+        if (shouldPopUpToDocSelection) {
+            R.id.action_global_passportScanPopUpToDocSelect
+        } else {
+            R.id.action_global_passportScanFragment
+        }
+
+    override val routeWithArgs = destinationRoute.withParams(
+        ARG_SHOULD_START_FROM_BACK to shouldStartFromBack
+    )
+
+    override val argsBundle = bundleOf(
+        ARG_SHOULD_START_FROM_BACK to shouldStartFromBack
+    )
+
+    companion object {
+        const val PASSPORT_SCAN = "PassportScan"
+        val ROUTE = object : DestinationRoute() {
+            override val routeBase = PASSPORT_SCAN
+        }
+    }
+}
+
+internal class IDScanDestination(
+    shouldStartFromBack: Boolean = false,
+    shouldPopUpToDocSelection: Boolean = false
+) : IdentityTopLevelDestination() {
+    override val destinationRoute = ROUTE
+    override val destination =
+        if (shouldPopUpToDocSelection) {
+            R.id.action_global_IDScanPopUpToDocSelect
+        } else {
+            R.id.action_global_IDScanFragment
+        }
+    override val routeWithArgs = destinationRoute.withParams(
+        ARG_SHOULD_START_FROM_BACK to shouldStartFromBack
+    )
+
+    override val argsBundle = bundleOf(
+        ARG_SHOULD_START_FROM_BACK to shouldStartFromBack
+    )
+
+    companion object {
+        const val ID_SCAN = "IDScan"
+        val ROUTE = object : DestinationRoute() {
+            override val routeBase = ID_SCAN
+        }
+    }
+}
+
+internal class DriveLicenseScanDestination(
+    shouldStartFromBack: Boolean = false,
+    shouldPopUpToDocSelection: Boolean = false
+) : IdentityTopLevelDestination() {
+    override val destinationRoute = ROUTE
+    override val destination =
+        if (shouldPopUpToDocSelection) {
+            R.id.action_global_driverLicenseScanPopUpToDocSelect
+        } else {
+            R.id.action_global_driverLicenseScanFragment
+        }
+    override val routeWithArgs = destinationRoute.withParams(
+        ARG_SHOULD_START_FROM_BACK to shouldStartFromBack
+    )
+
+    override val argsBundle = bundleOf(
+        ARG_SHOULD_START_FROM_BACK to shouldStartFromBack
+    )
+
+    companion object {
+        const val DRIVE_LICENSE_SCAN = "DriverLicenseScan"
+        val ROUTE = object : DestinationRoute() {
+            override val routeBase = DRIVE_LICENSE_SCAN
+        }
+    }
+}
+
+internal object SelfieDestination : IdentityTopLevelDestination() {
+    const val SELFIE = "Selfie"
+    private val ROUTE = object : DestinationRoute() {
+        override val routeBase = SELFIE
+    }
+    override val destination = R.id.action_global_selfieFragment
+    override val destinationRoute = ROUTE
+    override val routeWithArgs = destinationRoute.route
+}
+
+internal const val ARG_SHOULD_START_FROM_BACK = "startFromBack"

--- a/identity/src/main/java/com/stripe/android/identity/navigation/ScanDestinations.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ScanDestinations.kt
@@ -58,7 +58,7 @@ internal class IDScanDestination(
     }
 }
 
-internal class DriveLicenseScanDestination(
+internal class DriverLicenseScanDestination(
     shouldStartFromBack: Boolean = false,
     shouldPopUpToDocSelection: Boolean = false
 ) : IdentityTopLevelDestination() {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/UploadDestinations.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/UploadDestinations.kt
@@ -63,7 +63,7 @@ internal class IDUploadDestination(
     }
 }
 
-internal class DriveLicenseUploadDestination(
+internal class DriverLicenseUploadDestination(
     shouldShowTakePhoto: Boolean,
     shouldShowChoosePhoto: Boolean,
     shouldPopUpToDocSelection: Boolean = false

--- a/identity/src/main/java/com/stripe/android/identity/navigation/UploadDestinations.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/UploadDestinations.kt
@@ -1,0 +1,104 @@
+package com.stripe.android.identity.navigation
+
+import androidx.core.os.bundleOf
+import com.stripe.android.identity.R
+
+internal class PassportUploadDestination(
+    shouldShowTakePhoto: Boolean,
+    shouldShowChoosePhoto: Boolean,
+    shouldPopUpToDocSelection: Boolean = false
+) : IdentityTopLevelDestination() {
+    override val destinationRoute = ROUTE
+    override val destination =
+        if (shouldPopUpToDocSelection) {
+            R.id.action_global_passportUploadPopUpToDocSelect
+        } else {
+            R.id.action_global_passportUploadFragment
+        }
+    override val routeWithArgs = destinationRoute.withParams(
+        ARG_SHOULD_SHOW_TAKE_PHOTO to shouldShowTakePhoto,
+        ARG_SHOULD_SHOW_CHOOSE_PHOTO to shouldShowChoosePhoto
+    )
+
+    override val argsBundle = bundleOf(
+        ARG_SHOULD_SHOW_TAKE_PHOTO to shouldShowTakePhoto,
+        ARG_SHOULD_SHOW_CHOOSE_PHOTO to shouldShowChoosePhoto
+    )
+
+    companion object {
+        const val PASSPORT_UPLOAD = "PassportUpload"
+        val ROUTE = object : DestinationRoute() {
+            override val routeBase = PASSPORT_UPLOAD
+        }
+    }
+}
+
+internal class IDUploadDestination(
+    shouldShowTakePhoto: Boolean,
+    shouldShowChoosePhoto: Boolean,
+    shouldPopUpToDocSelection: Boolean = false
+) : IdentityTopLevelDestination() {
+    override val destinationRoute = ROUTE
+    override val destination =
+        if (shouldPopUpToDocSelection) {
+            R.id.action_global_IDUploadPopUpToDocSelect
+        } else {
+            R.id.action_global_IDUploadFragment
+        }
+    override val routeWithArgs = destinationRoute.withParams(
+        ARG_SHOULD_SHOW_TAKE_PHOTO to shouldShowTakePhoto,
+        ARG_SHOULD_SHOW_CHOOSE_PHOTO to shouldShowChoosePhoto
+    )
+
+    override val argsBundle = bundleOf(
+        ARG_SHOULD_SHOW_TAKE_PHOTO to shouldShowTakePhoto,
+        ARG_SHOULD_SHOW_CHOOSE_PHOTO to shouldShowChoosePhoto
+    )
+
+    companion object {
+        const val ID_UPLOAD = "IDUpload"
+        val ROUTE = object : DestinationRoute() {
+            override val routeBase = ID_UPLOAD
+        }
+    }
+}
+
+internal class DriveLicenseUploadDestination(
+    shouldShowTakePhoto: Boolean,
+    shouldShowChoosePhoto: Boolean,
+    shouldPopUpToDocSelection: Boolean = false
+) : IdentityTopLevelDestination() {
+    override val destinationRoute = ROUTE
+    override val destination =
+        if (shouldPopUpToDocSelection) {
+            R.id.action_global_driverLicenseUploadPopUpToDocSelect
+        } else {
+            R.id.action_global_driverLicenseUploadFragment
+        }
+    override val routeWithArgs = destinationRoute.withParams(
+        ARG_SHOULD_SHOW_TAKE_PHOTO to shouldShowTakePhoto,
+        ARG_SHOULD_SHOW_CHOOSE_PHOTO to shouldShowChoosePhoto
+    )
+
+    override val argsBundle = bundleOf(
+        ARG_SHOULD_SHOW_TAKE_PHOTO to shouldShowTakePhoto,
+        ARG_SHOULD_SHOW_CHOOSE_PHOTO to shouldShowChoosePhoto
+    )
+
+    companion object {
+        const val DRIVE_LICENSE_UPLOAD = "DriverLicenseUpload"
+        val ROUTE = object : DestinationRoute() {
+            override val routeBase = DRIVE_LICENSE_UPLOAD
+        }
+    }
+}
+
+/**
+ * Argument to indicate if choose photo option should be shown when picking an image.
+ */
+internal const val ARG_SHOULD_SHOW_CHOOSE_PHOTO = "shouldShowChoosePhoto"
+
+/**
+ * Argument to indicate if take photo option should be shown when picking an image.
+ */
+internal const val ARG_SHOULD_SHOW_TAKE_PHOTO = "shouldShowTakePhoto"

--- a/identity/src/main/java/com/stripe/android/identity/utils/NavigationUtils.kt
+++ b/identity/src/main/java/com/stripe/android/identity/utils/NavigationUtils.kt
@@ -1,9 +1,7 @@
 package com.stripe.android.identity.utils
 
-import android.os.Bundle
 import android.util.Log
 import androidx.annotation.IdRes
-import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -22,8 +20,6 @@ import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Com
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_LIVE_CAPTURE_ID
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_LIVE_CAPTURE_PASSPORT
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_SELFIE
-import com.stripe.android.identity.navigation.ARG_SHOULD_SHOW_CHOOSE_PHOTO
-import com.stripe.android.identity.navigation.ARG_SHOULD_SHOW_TAKE_PHOTO
 import com.stripe.android.identity.navigation.ConfirmationDestination
 import com.stripe.android.identity.navigation.ErrorFragment
 import com.stripe.android.identity.navigation.IdentityTopLevelDestination
@@ -210,25 +206,6 @@ internal fun Fragment.navigateToDefaultErrorFragment(message: String) {
 internal fun Fragment.navigateToErrorFragmentWithFailedReason(failedReason: Throwable) {
     repeatOnResume {
         findNavController().navigateToErrorScreenWithFailedReason(requireContext(), failedReason)
-    }
-}
-
-/**
- * Navigate to upload fragment with shouldShowTakePhoto argument.
- */
-internal fun Fragment.navigateToUploadFragment(
-    @IdRes destinationId: Int,
-    shouldShowTakePhoto: Boolean,
-    shouldShowChoosePhoto: Boolean
-) {
-    repeatOnResume {
-        findNavController().navigate(
-            destinationId,
-            bundleOf(
-                ARG_SHOULD_SHOW_TAKE_PHOTO to shouldShowTakePhoto,
-                ARG_SHOULD_SHOW_CHOOSE_PHOTO to shouldShowChoosePhoto
-            )
-        )
     }
 }
 

--- a/identity/src/main/java/com/stripe/android/identity/utils/NavigationUtils.kt
+++ b/identity/src/main/java/com/stripe/android/identity/utils/NavigationUtils.kt
@@ -22,6 +22,8 @@ import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Com
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_LIVE_CAPTURE_ID
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_LIVE_CAPTURE_PASSPORT
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.SCREEN_NAME_SELFIE
+import com.stripe.android.identity.navigation.ARG_SHOULD_SHOW_CHOOSE_PHOTO
+import com.stripe.android.identity.navigation.ARG_SHOULD_SHOW_TAKE_PHOTO
 import com.stripe.android.identity.navigation.ConfirmationDestination
 import com.stripe.android.identity.navigation.ErrorFragment
 import com.stripe.android.identity.navigation.IdentityTopLevelDestination
@@ -76,7 +78,7 @@ internal suspend fun Fragment.postVerificationPageDataAndMaybeSubmit(
 }
 
 /**
- * Check if selfie is required from [VerificationPage], navigate to selfie fragment if so, otherwise
+ * Check if selfie is required from [VerificationPage], navigate to Ω fragment if so, otherwise
  * submit the verification.
  */
 internal suspend fun Fragment.navigateToSelfieOrSubmit(
@@ -367,15 +369,5 @@ private val DOCUMENT_UPLOAD_SCREENS = setOf(
     R.id.passportScanFragment,
     R.id.driverLicenseScanFragment
 )
-
-/**
- * Argument to indicate if take photo option should be shown when picking an image.
- */
-internal const val ARG_SHOULD_SHOW_TAKE_PHOTO = "shouldShowTakePhoto"
-
-/**
- * Argument to indicate if choose photo option should be shown when picking an image.
- */
-internal const val ARG_SHOULD_SHOW_CHOOSE_PHOTO = "shouldShowChoosePhoto"
 
 private const val TAG = "NAVIGATION_UTIL"

--- a/identity/src/main/java/com/stripe/android/identity/utils/NavigationUtils.kt
+++ b/identity/src/main/java/com/stripe/android/identity/utils/NavigationUtils.kt
@@ -260,12 +260,6 @@ internal fun NavController.clearDataAndNavigateUp(identityViewModel: IdentityVie
  * Try navigate to a destination when the fragment is in resume state.
  * If app is backgrounded, navigate when it's brought to foreground.
  */
-internal fun Fragment.navigateOnResume(destinationId: Int, args: Bundle? = null) {
-    repeatOnResume {
-        findNavController().navigate(destinationId, args)
-    }
-}
-
 internal fun Fragment.navigateOnResume(destination: IdentityTopLevelDestination) {
     repeatOnResume {
         findNavController().navigateTo(destination)

--- a/identity/src/test/java/com/stripe/android/identity/IdentityActivityTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/IdentityActivityTest.kt
@@ -16,10 +16,10 @@ import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Com
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.EVENT_SHEET_PRESENTED
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.EVENT_VERIFICATION_CANCELED
 import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Companion.EVENT_VERIFICATION_FAILED
+import com.stripe.android.identity.navigation.ARG_SHOULD_SHOW_CHOOSE_PHOTO
+import com.stripe.android.identity.navigation.ARG_SHOULD_SHOW_TAKE_PHOTO
 import com.stripe.android.identity.navigation.ErrorDestination.Companion.ARG_CAUSE
 import com.stripe.android.identity.navigation.ErrorDestination.Companion.ARG_SHOULD_FAIL
-import com.stripe.android.identity.utils.ARG_SHOULD_SHOW_CHOOSE_PHOTO
-import com.stripe.android.identity.utils.ARG_SHOULD_SHOW_TAKE_PHOTO
 import com.stripe.android.identity.utils.InjectableActivityScenario
 import com.stripe.android.identity.utils.injectableActivityScenario
 import com.stripe.android.identity.viewmodel.IdentityViewModel

--- a/identity/src/test/java/com/stripe/android/identity/navigation/CameraPermissionDeniedFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/CameraPermissionDeniedFragmentTest.kt
@@ -18,7 +18,6 @@ import com.stripe.android.identity.analytics.IdentityAnalyticsRequestFactory.Com
 import com.stripe.android.identity.analytics.ScreenTracker
 import com.stripe.android.identity.navigation.CameraPermissionDeniedFragment.Companion.ARG_SCAN_TYPE
 import com.stripe.android.identity.networking.models.CollectedDataParam
-import com.stripe.android.identity.utils.ARG_SHOULD_SHOW_TAKE_PHOTO
 import com.stripe.android.identity.viewModelFactoryFor
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/identity/src/test/java/com/stripe/android/identity/navigation/CouldNotCaptureFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/CouldNotCaptureFragmentTest.kt
@@ -18,7 +18,6 @@ import com.stripe.android.identity.analytics.ScreenTracker
 import com.stripe.android.identity.navigation.CouldNotCaptureDestination.Companion.ARG_COULD_NOT_CAPTURE_SCAN_TYPE
 import com.stripe.android.identity.navigation.CouldNotCaptureDestination.Companion.ARG_REQUIRE_LIVE_CAPTURE
 import com.stripe.android.identity.states.IdentityScanState.ScanType
-import com.stripe.android.identity.utils.ARG_SHOULD_SHOW_CHOOSE_PHOTO
 import com.stripe.android.identity.viewModelFactoryFor
 import com.stripe.android.identity.viewmodel.IdentityViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/identity/src/test/java/com/stripe/android/identity/navigation/ErrorFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/ErrorFragmentTest.kt
@@ -160,7 +160,7 @@ class ErrorFragmentTest {
                 R.navigation.identity_nav_graph
             )
             navController.setCurrentDestination(R.id.consentFragment)
-            navController.navigate(R.id.action_consentFragment_to_docSelectionFragment)
+            navController.navigate(R.id.action_global_docSelectionFragment)
             navController.navigate(R.id.action_global_errorFragment)
 
             Navigation.setViewNavController(
@@ -192,7 +192,7 @@ class ErrorFragmentTest {
                 R.navigation.identity_nav_graph
             )
             navController.setCurrentDestination(firstEntry)
-            navController.navigate(R.id.action_consentFragment_to_docSelectionFragment)
+            navController.navigate(R.id.action_global_docSelectionFragment)
             navController.navigate(R.id.action_global_errorFragment)
 
             Navigation.setViewNavController(

--- a/identity/src/test/java/com/stripe/android/identity/navigation/IdentityUploadFragmentTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/navigation/IdentityUploadFragmentTest.kt
@@ -31,8 +31,6 @@ import com.stripe.android.identity.networking.models.Requirement
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPageStaticContentDocumentCapturePage
 import com.stripe.android.identity.states.IdentityScanState
-import com.stripe.android.identity.utils.ARG_SHOULD_SHOW_CHOOSE_PHOTO
-import com.stripe.android.identity.utils.ARG_SHOULD_SHOW_TAKE_PHOTO
 import com.stripe.android.identity.utils.IdentityIO
 import com.stripe.android.identity.viewModelFactoryFor
 import com.stripe.android.identity.viewmodel.IdentityUploadViewModel


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Prepare for NavController with Jetpack Compose

Currently Identity SDK creates a nav graph in [identity_nav_graph.xml](https://github.com/stripe/stripe-android/blob/master/identity/res/navigation/identity_nav_graph.xml) with multiple `Fragment`s and navigates between fragments by `NavController.navigate(destination, bundle)`.
In order to transition to a full Jetpack compose nav graph, we need to remove all the Fragments and use `NavController.navigate(route)` to navigates between `composable` created within a single activity.

This PR introduced the following change:
* Removed non-global actions from `identity_nav_graph` and replaced them with global actions. (non-global action could represent where the navigation is _from_, but this information is not used)
* Added `IdentityTopLevelDestination` implementations of these newly added non-global actions. 
* Replaced the old `navigateOnResume(destinationId: Int)` with `navigateOnResume(IdentityTopLevelDestination)`

Previous steps:
* Create `IdentityTopLevelDestination`: #5900


Next steps:
* Remove all Fragments, define theme as `composable`s within a NavGraph and Change the implementation of `NavController.navigateTo` from `NavController.navigate(destination, bundle)` to `NavController.navigate(route)` (3 of 3)


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
