### PR TITLE
Fail gracefully on invalid payment sheet params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 2022-XX-XX
 
+### PaymentSheet
+* [FIXED][5910](https://github.com/stripe/stripe-android/pull/5910) PaymentSheet now fails gracefully when launched with invalid arguments.
+
 ## 20.16.2 - 2022-12-05
 
 ### PaymentSheet

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -24,7 +24,6 @@ import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.utils.AnimationConstants
-import java.security.InvalidParameterException
 
 /**
  * An `Activity` for selecting a payment option.
@@ -65,20 +64,13 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
     override val bottomSpacer: View by lazy { viewBinding.bottomSpacer }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        val starterArgs = this.starterArgs
+        val starterArgs = initializeStarterArgs()
+        super.onCreate(savedInstanceState)
+
         if (starterArgs == null) {
             finish()
             return
         }
-        try {
-            starterArgs.state.config?.validate()
-            starterArgs.state.config?.appearance?.parseAppearance()
-        } catch (e: InvalidParameterException) {
-            finish()
-            return
-        }
-
-        super.onCreate(savedInstanceState)
 
         starterArgs.statusBarColor?.let {
             window.statusBarColor = it
@@ -154,6 +146,12 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
             },
             false
         )
+    }
+
+    private fun initializeStarterArgs(): PaymentOptionContract.Args? {
+        starterArgs?.state?.config?.appearance?.parseAppearance()
+        earlyExitDueToIllegalState = starterArgs == null
+        return starterArgs
     }
 
     private fun isSelectOrAddFragment() = supportFragmentManager.fragments.firstOrNull()?.let {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -81,6 +81,8 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
     abstract val primaryButton: PrimaryButton
     abstract val bottomSpacer: View
 
+    protected var earlyExitDueToIllegalState: Boolean = false
+
     abstract fun setActivityResult(result: ResultType)
 
     private val keyboardController: KeyboardController by lazy {
@@ -89,6 +91,10 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        if (earlyExitDueToIllegalState) {
+            return
+        }
 
         if (Build.VERSION.SDK_INT != Build.VERSION_CODES.O) {
             // In Oreo, Activities where `android:windowIsTranslucent=true` can't request

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -8,7 +8,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.SavedStateHandle
+import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.common.truth.Truth.assertThat
@@ -478,6 +480,13 @@ internal class PaymentOptionsActivityTest {
                 )
             }
         }
+    }
+
+    @Test
+    fun `Handles missing args correctly`() {
+        val emptyIntent = Intent(context, PaymentOptionsActivity::class.java)
+        val scenario = ActivityScenario.launchActivityForResult<PaymentOptionsActivity>(emptyIntent)
+        assertThat(scenario.state).isEqualTo(Lifecycle.State.DESTROYED)
     }
 
     private fun createIntent(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -7,6 +7,7 @@ import com.stripe.android.core.injection.DUMMY_INJECTOR_KEY
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentsheet.model.ClientSecret
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
@@ -107,6 +108,7 @@ internal object PaymentSheetFixtures {
         stripeIntent: StripeIntent = state.stripeIntent,
         config: PaymentSheet.Configuration? = state.config,
         newPaymentSelection: PaymentSelection.New? = state.newPaymentSelection,
+        clientSecret: ClientSecret = state.clientSecret,
     ): PaymentOptionContract.Args {
         return copy(
             state = state.copy(
@@ -115,6 +117,7 @@ internal object PaymentSheetFixtures {
                 stripeIntent = stripeIntent,
                 config = config,
                 newPaymentSelection = newPaymentSelection,
+                clientSecret = clientSecret,
             ),
         )
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request changes how we handle invalid payment sheet arguments, making sure that we don’t finish the activity before `super.onCreate()` has been called and making sure that we don’t access the `viewModel` in the `onDestroy()`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Resolves: https://github.com/stripe/stripe-android/issues/5906

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
N/A

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
[FIXED] PaymentSheet now fails gracefully when launched with invalid arguments.
