### PR TITLE
Make UI tests more resilient

### DIFF
--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.test.performTextInput
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
+import androidx.test.espresso.Espresso.closeSoftKeyboard
 import androidx.test.espresso.IdlingPolicies
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.runner.screenshot.Screenshot
@@ -103,7 +104,7 @@ class PlaygroundTestDriver(
             performTextInput("email@email.com")
         }
 
-        Espresso.closeSoftKeyboard()
+        closeSoftKeyboard()
 
         composeTestRule.waitUntil(timeoutMillis = 5000L) {
             selectors.continueButton.checkEnabled()
@@ -111,10 +112,7 @@ class PlaygroundTestDriver(
 
         composeTestRule.waitForIdle()
 
-        selectors.continueButton.apply {
-            scrollTo()
-            click()
-        }
+        selectors.continueButton.click()
 
         composeTestRule.waitUntil(timeoutMillis = 5000L) {
             composeTestRule.onAllNodesWithTag("OTP-0").fetchSemanticsNodes().isNotEmpty()
@@ -177,19 +175,12 @@ class PlaygroundTestDriver(
     }
 
     private fun pressMultiStepSelect() {
-        selectors.multiStepSelect.apply {
-            scrollTo()
-            click()
-        }
+        selectors.multiStepSelect.click()
         waitForNotPlaygroundActivity()
     }
 
     private fun pressContinue() {
-        selectors.continueButton.apply {
-            scrollTo()
-            click()
-        }
-
+        selectors.continueButton.click()
         waitForPlaygroundActivity()
     }
 
@@ -269,10 +260,7 @@ class PlaygroundTestDriver(
     }
 
     private fun pressBuy() {
-        selectors.buyButton.apply {
-            scrollTo()
-            click()
-        }
+        selectors.buyButton.click()
     }
 
     internal fun pressEdit() {
@@ -503,9 +491,9 @@ class PlaygroundTestDriver(
             PaymentSheetPlaygroundActivity.SUPPORTED_PAYMENT_METHODS_EXTRA,
             testParameters.supportedPaymentMethods.toTypedArray()
         )
+
         val scenario = ActivityScenario.launch<PaymentSheetPlaygroundActivity>(intent)
         scenario.onActivity { activity ->
-
             monitorCurrentActivity(activity.application)
 
             IdlingPolicies.setIdlingResourceTimeout(45, TimeUnit.SECONDS)
@@ -530,6 +518,8 @@ class PlaygroundTestDriver(
 
         launchPlayground.acquire()
         launchPlayground.release()
+
+        closeSoftKeyboard()
 
         setConfiguration(selectors)
     }

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/EspressoIdButton.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/EspressoIdButton.kt
@@ -2,18 +2,22 @@ package com.stripe.android.test.core.ui
 
 import androidx.annotation.IntegerRes
 import androidx.test.espresso.Espresso
+import androidx.test.espresso.ViewInteraction
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.matcher.ViewMatchers
 import java.security.InvalidParameterException
 
 open class EspressoIdButton(@IntegerRes val id: Int) {
-    fun click() {
-        Espresso.onView(ViewMatchers.withId(id)).perform(ViewActions.click())
-    }
 
-    fun scrollTo() {
-        Espresso.onView(ViewMatchers.withId(id)).perform(ViewActions.scrollTo())
+    fun click() {
+        val interaction = Espresso.onView(ViewMatchers.withId(id))
+
+        if (interaction.isNotVisible) {
+            interaction.perform(ViewActions.scrollTo())
+        }
+
+        interaction.perform(ViewActions.click())
     }
 
     fun isEnabled() {
@@ -39,3 +43,6 @@ open class EspressoIdButton(@IntegerRes val id: Int) {
             .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
     }
 }
+
+private val ViewInteraction.isNotVisible: Boolean
+    get() = runCatching { check(ViewAssertions.matches(ViewMatchers.isDisplayed())) }.isFailure

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/EspressoLabelIdButton.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/EspressoLabelIdButton.kt
@@ -5,7 +5,6 @@ import androidx.test.espresso.Espresso
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.matcher.ViewMatchers
-import java.security.InvalidParameterException
 
 open class EspressoLabelIdButton(@StringRes val label: Int) {
     fun click() {
@@ -13,18 +12,5 @@ open class EspressoLabelIdButton(@StringRes val label: Int) {
             .perform(ViewActions.scrollTo())
             .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
             .perform(ViewActions.click())
-    }
-
-    fun exists(): Boolean {
-        return try {
-            Espresso.onView(ViewMatchers.withText(label))
-                .withFailureHandler { _, _ ->
-                    throw InvalidParameterException("No payment selector found")
-                }
-                .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
-            true
-        } catch (e: InvalidParameterException) {
-            false
-        }
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

In our BrowserStack tests, failures regularly happen because the software keyboard is open when the test begins. 

This pull request makes sure that we close the keyboard before running our UI tests. It’s also adding code to automatically scroll to a view that needs to be clicked, instead of requiring an explicit call to `scrollTo()`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Failing BrowserStack tests.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
N/A

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A
