### PR TITLE
Maestro tests: Remove pull request trigger.

### DIFF
--- a/.github/workflows/financialconnections_nightly.yaml
+++ b/.github/workflows/financialconnections_nightly.yaml
@@ -2,8 +2,6 @@ name: financial-connections-nightly
 on:
   # Can be executed manually.
   workflow_dispatch:
-  # PRs (delete)
-  pull_request:
   # Execute hourly.
   schedule:
     - cron: '0 * * * *'


### PR DESCRIPTION
# Summary
We don't want to run maestro tests on pull requests. They're already running via a cron job.
