### PR TITLE
Reduce usage of `VisibleForTesting` in view models

### DIFF
--- a/example/src/main/java/com/stripe/example/activity/GooglePayLauncherComposeActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/GooglePayLauncherComposeActivity.kt
@@ -1,5 +1,6 @@
 package com.stripe.example.activity
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.clickable
@@ -122,6 +123,7 @@ class GooglePayLauncherComposeActivity : StripeIntentActivity() {
         )
     }
 
+    @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
     @Composable
     private fun GooglePayLauncherScreen(
         scaffoldState: ScaffoldState,

--- a/example/src/main/java/com/stripe/example/activity/GooglePayPaymentMethodLauncherComposeActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/GooglePayPaymentMethodLauncherComposeActivity.kt
@@ -1,5 +1,6 @@
 package com.stripe.example.activity
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
@@ -89,6 +90,7 @@ class GooglePayPaymentMethodLauncherComposeActivity : AppCompatActivity() {
         )
     }
 
+    @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
     @Composable
     private fun GooglePayPaymentMethodLauncherScreen(
         scaffoldState: ScaffoldState,

--- a/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
@@ -2,6 +2,7 @@ package com.stripe.android.link
 
 import android.content.Context
 import android.os.Parcelable
+import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.injection.ENABLE_LOGGING
@@ -88,18 +89,29 @@ class LinkPaymentLauncher @Inject internal constructor(
     fun getAccountStatusFlow(configuration: Configuration) =
         getLinkPaymentLauncherComponent(configuration).linkAccountManager.accountStatus
 
+    private var linkActivityResultLauncher:
+        ActivityResultLauncher<LinkActivityContract.Args>? = null
+
+    fun register(
+        activityResultCaller: ActivityResultCaller,
+        callback: (LinkActivityResult) -> Unit,
+    ) {
+        linkActivityResultLauncher = activityResultCaller.registerForActivityResult(
+            LinkActivityContract(),
+            callback,
+        )
+    }
+
     /**
      * Launch the Link UI to process a payment.
      *
      * @param configuration The payment and customer settings
-     * @param activityResultLauncher Launcher that will receive the payment result.
      * @param prefilledNewCardParams The card information prefilled by the user. If non null, Link
      *  will launch into adding a new card, with the card information pre-filled.
      */
     fun present(
         configuration: Configuration,
-        activityResultLauncher: ActivityResultLauncher<LinkActivityContract.Args>,
-        prefilledNewCardParams: PaymentMethodCreateParams? = null
+        prefilledNewCardParams: PaymentMethodCreateParams? = null,
     ) {
         val args = LinkActivityContract.Args(
             configuration,
@@ -113,7 +125,7 @@ class LinkPaymentLauncher @Inject internal constructor(
             )
         )
         buildLinkComponent(getLinkPaymentLauncherComponent(configuration), args)
-        activityResultLauncher.launch(args)
+        linkActivityResultLauncher?.launch(args)
     }
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -197,7 +197,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
     }
 
     override fun onPaymentResult(paymentResult: PaymentResult) {
-        _processing.value = false
+        savedStateHandle[SAVE_PROCESSING] = false
     }
 
     override fun updateSelection(selection: PaymentSelection?) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -28,7 +28,6 @@ import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContract
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
-import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkActivityResult.Canceled.Reason
 import com.stripe.android.link.LinkPaymentDetails
@@ -441,7 +440,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     /**
      * Method called with the result of launching the Link UI to collect a payment.
      */
-    fun onLinkActivityResult(result: LinkActivityResult) {
+    private fun onLinkActivityResult(result: LinkActivityResult) {
         val completePaymentFlow = result is LinkActivityResult.Completed
         val cancelPaymentFlow = launchedLinkDirectly &&
             result is LinkActivityResult.Canceled && result.reason == Reason.BackPressed

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -116,8 +116,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         args.config?.shippingDetails?.toConfirmPaymentIntentShipping()
     )
 
-    @VisibleForTesting
-    internal val _paymentSheetResult = MutableLiveData<PaymentSheetResult>()
+    private val _paymentSheetResult = MutableLiveData<PaymentSheetResult>()
     internal val paymentSheetResult: LiveData<PaymentSheetResult> = _paymentSheetResult
 
     private val _startConfirm = MutableLiveData<Event<ConfirmStripeIntentParams>>()
@@ -149,8 +148,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
     override var newPaymentSelection: PaymentSelection.New? = null
 
-    @VisibleForTesting
-    internal var googlePayPaymentMethodLauncher: GooglePayPaymentMethodLauncher? = null
+    private var googlePayPaymentMethodLauncher: GooglePayPaymentMethodLauncher? = null
 
     private var linkActivityResultLauncher:
         ActivityResultLauncher<LinkActivityContract.Args>? = null
@@ -449,7 +447,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     /**
      * Method called with the result of launching the Link UI to collect a payment.
      */
-    private fun onLinkActivityResult(result: LinkActivityResult) {
+    fun onLinkActivityResult(result: LinkActivityResult) {
         val completePaymentFlow = result is LinkActivityResult.Completed
         val cancelPaymentFlow = launchedLinkDirectly &&
             result is LinkActivityResult.Canceled && result.reason == Reason.BackPressed

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -150,11 +150,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
     private var googlePayPaymentMethodLauncher: GooglePayPaymentMethodLauncher? = null
 
-    private var linkActivityResultLauncher:
-        ActivityResultLauncher<LinkActivityContract.Args>? = null
-
-    @VisibleForTesting
-    internal var launchedLinkDirectly: Boolean = false
+    private var launchedLinkDirectly: Boolean = false
 
     @VisibleForTesting
     internal val googlePayLauncherConfig: GooglePayPaymentMethodLauncher.Config? =
@@ -335,9 +331,9 @@ internal class PaymentSheetViewModel @Inject internal constructor(
      * Must be called from the Activity's `onCreate`.
      */
     fun registerFromActivity(activityResultCaller: ActivityResultCaller) {
-        linkActivityResultLauncher = activityResultCaller.registerForActivityResult(
-            LinkActivityContract(),
-            ::onLinkActivityResult
+        linkLauncher.register(
+            activityResultCaller,
+            ::onLinkActivityResult,
         )
 
         paymentLauncher = paymentLauncherFactory.create(
@@ -358,7 +354,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
      */
     fun unregisterFromActivity() {
         paymentLauncher?.unregisterPollingAuthenticator()
-        linkActivityResultLauncher = null
         paymentLauncher = null
     }
 
@@ -425,14 +420,13 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         paymentMethodCreateParams: PaymentMethodCreateParams? = null
     ) {
         launchedLinkDirectly = launchedDirectly
-        linkActivityResultLauncher?.let { activityResultLauncher ->
-            linkLauncher.present(
-                configuration,
-                activityResultLauncher,
-                paymentMethodCreateParams
-            )
-            onLinkLaunched()
-        }
+
+        linkLauncher.present(
+            configuration,
+            paymentMethodCreateParams,
+        )
+
+        onLinkLaunched()
     }
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -20,7 +20,6 @@ import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContract
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
-import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.model.AccountStatus
@@ -109,8 +108,6 @@ internal class DefaultFlowController @Inject internal constructor(
     private val paymentOptionActivityLauncher: ActivityResultLauncher<PaymentOptionContract.Args>
     private val googlePayActivityLauncher:
         ActivityResultLauncher<GooglePayPaymentMethodLauncherContract.Args>
-    private val linkActivityResultLauncher:
-        ActivityResultLauncher<LinkActivityContract.Args>
 
     /**
      * [FlowControllerComponent] is hold to inject into [Activity]s and created
@@ -169,6 +166,11 @@ internal class DefaultFlowController @Inject internal constructor(
             }
         )
 
+        linkLauncher.register(
+            activityResultCaller = activityResultCaller,
+            callback = ::onLinkActivityResult,
+        )
+
         paymentOptionActivityLauncher =
             activityResultCaller.registerForActivityResult(
                 PaymentOptionContract(),
@@ -178,11 +180,6 @@ internal class DefaultFlowController @Inject internal constructor(
             activityResultCaller.registerForActivityResult(
                 GooglePayPaymentMethodLauncherContract(),
                 ::onGooglePayResult
-            )
-        linkActivityResultLauncher =
-            activityResultCaller.registerForActivityResult(
-                LinkActivityContract(),
-                ::onLinkActivityResult
             )
     }
 
@@ -467,12 +464,11 @@ internal class DefaultFlowController @Inject internal constructor(
                 // If a returning user is paying with a new card inline, launch Link
                 linkLauncher.present(
                     configuration = linkConfig,
-                    activityResultLauncher = linkActivityResultLauncher,
                     prefilledNewCardParams = linkInline.linkPaymentDetails.originalParams,
                 )
             } else if (paymentSelection is PaymentSelection.Link) {
                 // User selected Link as the payment method, not inline
-                linkLauncher.present(linkConfig, linkActivityResultLauncher)
+                linkLauncher.present(linkConfig)
             } else {
                 // New user paying inline, complete without launching Link
                 confirmPaymentSelection(paymentSelection, state)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -354,8 +354,7 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
         _transition.postValue(Event(target))
     }
 
-    @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
-    fun setStripeIntent(stripeIntent: StripeIntent?) {
+    protected fun setStripeIntent(stripeIntent: StripeIntent?) {
         savedStateHandle[SAVE_STRIPE_INTENT] = stripeIntent
 
         /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -27,7 +27,6 @@ import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.BaseAddPaymentMethodFragment
-import com.stripe.android.paymentsheet.BasePaymentMethodsListFragment
 import com.stripe.android.paymentsheet.PaymentOptionsActivity
 import com.stripe.android.paymentsheet.PaymentOptionsState
 import com.stripe.android.paymentsheet.PaymentOptionsViewModel
@@ -135,12 +134,9 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
      */
     internal val paymentMethods: LiveData<List<PaymentMethod>> = _paymentMethods
 
-    @VisibleForTesting
-    internal val _amount = savedStateHandle.getLiveData<Amount>(SAVE_AMOUNT)
-    internal val amount: LiveData<Amount> = _amount
+    internal val amount: LiveData<Amount> = savedStateHandle.getLiveData<Amount>(SAVE_AMOUNT)
 
     internal val headerText = MutableLiveData<String>()
-    internal val googlePayDividerVisibilility: MutableLiveData<Boolean> = MutableLiveData(false)
 
     /**
      * Request to retrieve the value from the repository happens when initialize any fragment
@@ -155,28 +151,17 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
     private val _transition = MutableLiveData<Event<TransitionTargetType?>>(Event(null))
     internal val transition: LiveData<Event<TransitionTargetType?>> = _transition
 
-    @VisibleForTesting
-    internal val _liveMode
-        get() = savedStateHandle.getLiveData<Boolean>(SAVE_STATE_LIVE_MODE)
+    private val _liveMode = savedStateHandle.getLiveData<Boolean>(SAVE_STATE_LIVE_MODE)
     internal val liveMode: LiveData<Boolean> = _liveMode
 
-    /**
-     * On [ComposeFormDataCollectionFragment] this is set every time the details in the add
-     * card fragment is determined to be valid (not necessarily selected)
-     * On [BasePaymentMethodsListFragment] this is set when a user selects one of the options
-     */
     private val _selection = savedStateHandle.getLiveData<PaymentSelection>(SAVE_SELECTION)
-
     internal val selection: LiveData<PaymentSelection?> = _selection
 
     private val editing = MutableLiveData(false)
 
-    @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
-    internal val _processing = savedStateHandle.getLiveData<Boolean>(SAVE_PROCESSING)
-    val processing: LiveData<Boolean> = _processing
+    val processing: LiveData<Boolean> = savedStateHandle.getLiveData<Boolean>(SAVE_PROCESSING)
 
-    @VisibleForTesting
-    internal val _contentVisible = MutableLiveData(true)
+    private val _contentVisible = MutableLiveData(true)
     internal val contentVisible: LiveData<Boolean> = _contentVisible.distinctUntilChanged()
 
     /**
@@ -192,10 +177,10 @@ internal abstract class BaseSheetViewModel<TransitionTargetType>(
     private val _notesText = MutableLiveData<String?>()
     internal val notesText: LiveData<String?> = _notesText
 
-    protected val _showLinkVerificationDialog = MutableLiveData(false)
+    private val _showLinkVerificationDialog = MutableLiveData(false)
     val showLinkVerificationDialog: LiveData<Boolean> = _showLinkVerificationDialog
 
-    protected val linkVerificationChannel = Channel<Boolean>(capacity = 1)
+    private val linkVerificationChannel = Channel<Boolean>(capacity = 1)
 
     /**
      * This should be initialized from the starter args, and then from that point forward it will be

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAddPaymentMethodFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAddPaymentMethodFragmentTest.kt
@@ -96,7 +96,6 @@ internal class PaymentOptionsAddPaymentMethodFragmentTest : PaymentOptionsViewMo
             injectorKey = args.injectorKey,
             args = args
         )
-        viewModel.setStripeIntent(args.state.stripeIntent)
         TestUtils.idleLooper()
 
         if (registerInjector) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -465,9 +465,7 @@ internal class PaymentSheetActivityTest {
         scenario.launch(intent).onActivity { activity ->
             // wait for bottom sheet to animate in
             idleLooper()
-
-            viewModel._processing.value = true
-
+            viewModel.checkout(CheckoutIdentifier.SheetBottomBuy)
             idleLooper()
 
             assertThat(activity.toolbar.isEnabled).isFalse()
@@ -573,10 +571,10 @@ internal class PaymentSheetActivityTest {
 
             activity.viewBinding.googlePayButton.performClick()
 
-            assertThat(viewModel._contentVisible.value).isEqualTo(false)
+            assertThat(viewModel.contentVisible.value).isEqualTo(false)
 
             viewModel.onGooglePayResult(GooglePayPaymentMethodLauncher.Result.Canceled)
-            assertThat(viewModel._contentVisible.value).isEqualTo(true)
+            assertThat(viewModel.contentVisible.value).isEqualTo(true)
         }
     }
 
@@ -878,24 +876,24 @@ internal class PaymentSheetActivityTest {
 
     @Test
     fun `when intent is in live mode show no indicator`() {
+        val viewModel = createViewModel(paymentIntent = PAYMENT_INTENT.copy(isLiveMode = true))
         val scenario = activityScenario(viewModel)
+
         scenario.launch(intent).onActivity { activity ->
             // wait for bottom sheet to animate in
             idleLooper()
-
-            viewModel._liveMode.value = true
             assertThat(activity.viewBinding.testmode.isVisible).isFalse()
         }
     }
 
     @Test
     fun `when intent is not in live mode show indicator`() {
+        val viewModel = createViewModel(paymentIntent = PAYMENT_INTENT.copy(isLiveMode = false))
         val scenario = activityScenario(viewModel)
+
         scenario.launch(intent).onActivity { activity ->
             // wait for bottom sheet to animate in
             idleLooper()
-
-            viewModel._liveMode.value = false
             assertThat(activity.viewBinding.testmode.isVisible).isTrue()
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -588,7 +588,7 @@ internal class PaymentSheetActivityTest {
             // wait for bottom sheet to animate in
             idleLooper()
 
-            viewModel._paymentSheetResult.value = PaymentSheetResult.Completed
+            viewModel.onFinish()
 
             idleLooper()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddPaymentMethodFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddPaymentMethodFragmentTest.kt
@@ -246,7 +246,6 @@ internal class PaymentSheetAddPaymentMethodFragmentTest : PaymentSheetViewModelT
             initialState = Lifecycle.State.INITIALIZED
         ).moveToState(Lifecycle.State.CREATED).onFragment {
             if (registerInjector) {
-                viewModel.setStripeIntent(stripeIntent)
                 idleLooper()
                 registerViewModel(args.injectorKey, viewModel, lpmRepository, addressRepository)
             } else {
@@ -254,7 +253,6 @@ internal class PaymentSheetAddPaymentMethodFragmentTest : PaymentSheetViewModelT
                     stripeIntent.paymentMethodTypes,
                     null
                 )
-                it.sheetViewModel.setStripeIntent(stripeIntent)
                 idleLooper()
             }
         }.moveToState(Lifecycle.State.STARTED).onFragment { fragment ->

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
@@ -15,7 +15,6 @@ import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.injection.InjectorKey
 import com.stripe.android.core.injection.WeakMapInjectorRegistry
-import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.SetupIntentFixtures
@@ -233,11 +232,6 @@ internal class PaymentSheetListFragmentTest : PaymentSheetViewModelTestInjection
     fun `total amount label correctly displays amount`() {
         createScenario().onFragment { fragment ->
             shadowOf(getMainLooper()).idle()
-            fragment.sheetViewModel.setStripeIntent(
-                PaymentIntentFixtures.PI_OFF_SESSION.copy(
-                    amount = 399
-                )
-            )
 
             assertThat(fragment.sheetViewModel.isProcessingPaymentIntent).isTrue()
         }
@@ -304,7 +298,6 @@ internal class PaymentSheetListFragmentTest : PaymentSheetViewModelTestInjection
                 injectorKey = starterArgs.injectorKey,
                 args = starterArgs
             ).apply {
-                setStripeIntent(fragmentConfig.stripeIntent)
                 idleLooper()
                 registerViewModel(starterArgs.injectorKey, this, lpmRepository, addressRepository)
             }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -678,59 +678,6 @@ internal class PaymentSheetViewModelTest {
         assertThat(viewModel.supportedPaymentMethods).containsExactly(expectedPaymentMethod)
     }
 
-//    @Test
-//    fun `Verify PI off_session excludes LPMs requiring mandate`() {
-//        val viewModel = createViewModel(
-//            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-//                setupFutureUsage = StripeIntent.Usage.OffSession,
-//                paymentMethodTypes = listOf("sepa_debit")
-//            ),
-//        )
-//
-//        assertThat(viewModel.supportedPaymentMethods.size).isEqualTo(0)
-//    }
-//
-//    @Test
-//    fun `Verify PI not off_session does not exclude LPMs requiring mandate`() {
-//        val viewModel = createViewModel(
-//            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-//                setupFutureUsage = StripeIntent.Usage.OnSession,
-//                paymentMethodTypes = listOf("sepa_debit")
-//            ),
-//        )
-//
-//        assertThat(viewModel.supportedPaymentMethods.size).isEqualTo(1)
-//        assertThat(viewModel.supportedPaymentMethods.first()).isEqualTo(
-//            lpmRepository.fromCode("sepa_debit")!!
-//        )
-//    }
-//
-//    @Test
-//    fun `Verify SetupIntent excludes LPMs requiring mandate`() {
-//        val viewModel = createViewModel(
-//            stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD.copy(
-//                paymentMethodTypes = listOf("sepa_debit")
-//            ),
-//        )
-//
-//        assertThat(viewModel.supportedPaymentMethods.size).isEqualTo(0)
-//    }
-//
-//    @Test
-//    fun `Verify SetupIntent not off_session excludes LPMs requiring mandate 2`() {
-//        val viewModel = createViewModel(
-//            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
-//                setupFutureUsage = StripeIntent.Usage.OnSession,
-//                paymentMethodTypes = listOf(PaymentMethod.Type.SepaDebit.code),
-//            ),
-//        )
-//
-//        assertThat(viewModel.supportedPaymentMethods.size).isEqualTo(1)
-//        assertThat(viewModel.supportedPaymentMethods.first()).isEqualTo(
-//            lpmRepository.fromCode(PaymentMethod.Type.SepaDebit.code)!!
-//        )
-//    }
-
     @Test
     fun `isGooglePayReady without google pay config should emit false`() {
         val viewModel = createViewModel(PaymentSheetFixtures.ARGS_CUSTOMER_WITHOUT_GOOGLEPAY)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -62,6 +62,7 @@ import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
@@ -298,9 +299,11 @@ internal class PaymentSheetViewModelTest {
 
     @Test
     fun `Launches Link when user is logged in to their Link account`() = runTest {
+        val configuration: LinkPaymentLauncher.Configuration = mock()
+
         val viewModel = createViewModel(
             linkState = LinkState(
-                configuration = mock(),
+                configuration = configuration,
                 loginState = LinkState.LoginState.LoggedIn,
             ),
         )
@@ -308,7 +311,11 @@ internal class PaymentSheetViewModelTest {
         assertThat(viewModel.showLinkVerificationDialog.value).isFalse()
         assertThat(viewModel.activeLinkSession.value).isTrue()
         assertThat(viewModel.isLinkEnabled.value).isTrue()
-        assertThat(viewModel.launchedLinkDirectly).isTrue()
+
+        verify(linkLauncher).present(
+            configuration = eq(configuration),
+            prefilledNewCardParams = isNull(),
+        )
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -671,7 +671,7 @@ internal class DefaultFlowControllerTest {
 
         flowController.confirm()
 
-        verify(linkPaymentLauncher).present(any(), any(), eq(null))
+        verify(linkPaymentLauncher).present(any(), isNull())
     }
 
     @Test
@@ -704,7 +704,7 @@ internal class DefaultFlowControllerTest {
 
         flowController.confirm()
 
-        verify(linkPaymentLauncher).present(any(), any(), eq(PaymentMethodCreateParamsFixtures.DEFAULT_CARD))
+        verify(linkPaymentLauncher).present(any(), eq(PaymentMethodCreateParamsFixtures.DEFAULT_CARD))
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request reduces the usage of `@VisibleForTesting` in our view models, allowing us to make some methods `private` or `protected`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Some methods and properties (such as `setStripeIntent()`) were annotated with `@VisibleForTesting` so that they could more easily be tested, even when they didn’t belong to the public API of the class. Now, we’re testing their functionality in the proper way and don’t need to access them directly anymore.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
N/A

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A
