### PR TITLE
Use `isCompletelyDisplayed` in Espresso tests

### DIFF
--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/EspressoIdButton.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/EspressoIdButton.kt
@@ -10,10 +10,13 @@ import java.security.InvalidParameterException
 
 open class EspressoIdButton(@IntegerRes val id: Int) {
 
-    fun click() {
-        val interaction = Espresso.onView(ViewMatchers.withId(id))
+    private val interaction: ViewInteraction
+        get() = Espresso.onView(ViewMatchers.withId(id))
 
-        if (interaction.isNotVisible) {
+    fun click() {
+        val isNotVisible = runCatching { isDisplayed() }.isFailure
+
+        if (isNotVisible) {
             interaction.perform(ViewActions.scrollTo())
         }
 
@@ -21,13 +24,12 @@ open class EspressoIdButton(@IntegerRes val id: Int) {
     }
 
     fun isEnabled() {
-        Espresso.onView(ViewMatchers.withId(id))
-            .check(ViewAssertions.matches(ViewMatchers.isEnabled()))
+        interaction.check(ViewAssertions.matches(ViewMatchers.isEnabled()))
     }
 
     fun checkEnabled(): Boolean {
         return try {
-            Espresso.onView(ViewMatchers.withId(id))
+            interaction
                 .withFailureHandler { _, _ ->
                     throw InvalidParameterException("No payment selector found")
                 }
@@ -39,10 +41,6 @@ open class EspressoIdButton(@IntegerRes val id: Int) {
     }
 
     fun isDisplayed() {
-        Espresso.onView(ViewMatchers.withId(id))
-            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+        interaction.check(ViewAssertions.matches(ViewMatchers.isCompletelyDisplayed()))
     }
 }
-
-private val ViewInteraction.isNotVisible: Boolean
-    get() = runCatching { check(ViewAssertions.matches(ViewMatchers.isDisplayed())) }.isFailure

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/EspressoLabelIdButton.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/EspressoLabelIdButton.kt
@@ -1,16 +1,23 @@
 package com.stripe.android.test.core.ui
 
 import androidx.annotation.StringRes
-import androidx.test.espresso.Espresso
+import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
-import androidx.test.espresso.assertion.ViewAssertions
-import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.action.ViewActions.scrollTo
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isCompletelyDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withText
 
 open class EspressoLabelIdButton(@StringRes val label: Int) {
+
     fun click() {
-        Espresso.onView(ViewMatchers.withText(label))
-            .perform(ViewActions.scrollTo())
-            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
-            .perform(ViewActions.click())
+        val interaction = onView(withText(label))
+        val isNotVisible = runCatching { interaction.check(matches(isCompletelyDisplayed())) }.isFailure
+
+        if (isNotVisible) {
+            interaction.perform(scrollTo())
+        }
+
+        interaction.perform(ViewActions.click())
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

In our UI tests, we used `isDisplayed()` before to check that we can click a view. We would call `scrollTo()` if the view wasn’t displayed.

Apparently, `isDisplayed()` succeeds for partially visible views. This isn’t enough when we call `click()`, which expects a view to be visible at least 90 percent.

Now, we use `isCompletelyDisplayed()` to make sure that Espresso can eventually perform the click action.

```
Caused by: java.lang.RuntimeException: Action will not be performed because the target view does not match one or more of the following constraints:
(view has effective visibility <VISIBLE> and view.getGlobalVisibleRect() covers at least <90> percent of the view's area)
```

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

RUN_MOBILESDK-1828

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
N/A

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A
