### PR TITLE
Add autocomplete affordance to the address element.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### PaymentSheet
 * [FIXED][5910](https://github.com/stripe/stripe-android/pull/5910) PaymentSheet now fails gracefully when launched with invalid arguments.
+* [Changed][5927](https://github.com/stripe/stripe-android/pull/5927) Customers can now re-enter the autocomplete flow of the Address Element by tapping an icon in the line 1 text field.
 
 ## 20.16.2 - 2022-12-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 2023-XX-XX
 
+### PaymentSheet
+* [CHANGED][5927](https://github.com/stripe/stripe-android/pull/5927) Customers can now re-enter the autocomplete flow of the Address Element by tapping an icon in the line 1 text field.
+
 ## 20.18.0 - 2023-01-17
 ### Payments
 * [ADDED][6012](https://github.com/stripe/stripe-android/pull/6012) Support for the predictive back gesture.
@@ -27,7 +30,6 @@
 
 ### PaymentSheet
 * [FIXED][5910](https://github.com/stripe/stripe-android/pull/5910) PaymentSheet now fails gracefully when launched with invalid arguments.
-* [Changed][5927](https://github.com/stripe/stripe-android/pull/5927) Customers can now re-enter the autocomplete flow of the Address Element by tapping an icon in the line 1 text field.
 
 ## 20.16.2 - 2022-12-05
 

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -81,6 +81,10 @@ public final class com/stripe/android/ui/core/elements/AddressSpec$Companion {
 public final class com/stripe/android/ui/core/elements/AddressTextFieldUIKt {
 }
 
+public final class com/stripe/android/ui/core/elements/AddressType$AutocompleteCapable$DefaultImpls {
+	public static fun supportsAutoComplete (Lcom/stripe/android/ui/core/elements/AddressType$AutocompleteCapable;Ljava/lang/String;)Z
+}
+
 public final class com/stripe/android/ui/core/elements/AddressType$Normal : com/stripe/android/ui/core/elements/AddressType {
 	public static final field $stable I
 	public fun <init> ()V
@@ -95,7 +99,7 @@ public final class com/stripe/android/ui/core/elements/AddressType$Normal : com/
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/stripe/android/ui/core/elements/AddressType$ShippingCondensed : com/stripe/android/ui/core/elements/AddressType {
+public final class com/stripe/android/ui/core/elements/AddressType$ShippingCondensed : com/stripe/android/ui/core/elements/AddressType, com/stripe/android/ui/core/elements/AddressType$AutocompleteCapable {
 	public static final field $stable I
 	public fun <init> (Ljava/lang/String;Ljava/util/Set;Lcom/stripe/android/ui/core/elements/PhoneNumberState;Lkotlin/jvm/functions/Function0;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -105,23 +109,31 @@ public final class com/stripe/android/ui/core/elements/AddressType$ShippingConde
 	public final fun copy (Ljava/lang/String;Ljava/util/Set;Lcom/stripe/android/ui/core/elements/PhoneNumberState;Lkotlin/jvm/functions/Function0;)Lcom/stripe/android/ui/core/elements/AddressType$ShippingCondensed;
 	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/AddressType$ShippingCondensed;Ljava/lang/String;Ljava/util/Set;Lcom/stripe/android/ui/core/elements/PhoneNumberState;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/AddressType$ShippingCondensed;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAutocompleteCountries ()Ljava/util/Set;
-	public final fun getGoogleApiKey ()Ljava/lang/String;
-	public final fun getOnNavigation ()Lkotlin/jvm/functions/Function0;
+	public fun getAutocompleteCountries ()Ljava/util/Set;
+	public fun getGoogleApiKey ()Ljava/lang/String;
+	public fun getOnNavigation ()Lkotlin/jvm/functions/Function0;
 	public fun getPhoneNumberState ()Lcom/stripe/android/ui/core/elements/PhoneNumberState;
 	public fun hashCode ()I
+	public fun supportsAutoComplete (Ljava/lang/String;)Z
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/stripe/android/ui/core/elements/AddressType$ShippingExpanded : com/stripe/android/ui/core/elements/AddressType {
+public final class com/stripe/android/ui/core/elements/AddressType$ShippingExpanded : com/stripe/android/ui/core/elements/AddressType, com/stripe/android/ui/core/elements/AddressType$AutocompleteCapable {
 	public static final field $stable I
-	public fun <init> (Lcom/stripe/android/ui/core/elements/PhoneNumberState;)V
-	public final fun component1 ()Lcom/stripe/android/ui/core/elements/PhoneNumberState;
-	public final fun copy (Lcom/stripe/android/ui/core/elements/PhoneNumberState;)Lcom/stripe/android/ui/core/elements/AddressType$ShippingExpanded;
-	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/AddressType$ShippingExpanded;Lcom/stripe/android/ui/core/elements/PhoneNumberState;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/AddressType$ShippingExpanded;
+	public fun <init> (Ljava/lang/String;Ljava/util/Set;Lcom/stripe/android/ui/core/elements/PhoneNumberState;Lkotlin/jvm/functions/Function0;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Set;
+	public final fun component3 ()Lcom/stripe/android/ui/core/elements/PhoneNumberState;
+	public final fun component4 ()Lkotlin/jvm/functions/Function0;
+	public final fun copy (Ljava/lang/String;Ljava/util/Set;Lcom/stripe/android/ui/core/elements/PhoneNumberState;Lkotlin/jvm/functions/Function0;)Lcom/stripe/android/ui/core/elements/AddressType$ShippingExpanded;
+	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/AddressType$ShippingExpanded;Ljava/lang/String;Ljava/util/Set;Lcom/stripe/android/ui/core/elements/PhoneNumberState;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/AddressType$ShippingExpanded;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getAutocompleteCountries ()Ljava/util/Set;
+	public fun getGoogleApiKey ()Ljava/lang/String;
+	public fun getOnNavigation ()Lkotlin/jvm/functions/Function0;
 	public fun getPhoneNumberState ()Lcom/stripe/android/ui/core/elements/PhoneNumberState;
 	public fun hashCode ()I
+	public fun supportsAutoComplete (Ljava/lang/String;)Z
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -81,10 +81,6 @@ public final class com/stripe/android/ui/core/elements/AddressSpec$Companion {
 public final class com/stripe/android/ui/core/elements/AddressTextFieldUIKt {
 }
 
-public final class com/stripe/android/ui/core/elements/AddressType$AutocompleteCapable$DefaultImpls {
-	public static fun supportsAutoComplete (Lcom/stripe/android/ui/core/elements/AddressType$AutocompleteCapable;Ljava/lang/String;)Z
-}
-
 public abstract class com/stripe/android/ui/core/elements/AdministrativeAreaConfig$Country {
 	public static final field $stable I
 	public synthetic fun <init> (ILjava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -85,58 +85,6 @@ public final class com/stripe/android/ui/core/elements/AddressType$AutocompleteC
 	public static fun supportsAutoComplete (Lcom/stripe/android/ui/core/elements/AddressType$AutocompleteCapable;Ljava/lang/String;)Z
 }
 
-public final class com/stripe/android/ui/core/elements/AddressType$Normal : com/stripe/android/ui/core/elements/AddressType {
-	public static final field $stable I
-	public fun <init> ()V
-	public fun <init> (Lcom/stripe/android/ui/core/elements/PhoneNumberState;)V
-	public synthetic fun <init> (Lcom/stripe/android/ui/core/elements/PhoneNumberState;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/ui/core/elements/PhoneNumberState;
-	public final fun copy (Lcom/stripe/android/ui/core/elements/PhoneNumberState;)Lcom/stripe/android/ui/core/elements/AddressType$Normal;
-	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/AddressType$Normal;Lcom/stripe/android/ui/core/elements/PhoneNumberState;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/AddressType$Normal;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun getPhoneNumberState ()Lcom/stripe/android/ui/core/elements/PhoneNumberState;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/stripe/android/ui/core/elements/AddressType$ShippingCondensed : com/stripe/android/ui/core/elements/AddressType, com/stripe/android/ui/core/elements/AddressType$AutocompleteCapable {
-	public static final field $stable I
-	public fun <init> (Ljava/lang/String;Ljava/util/Set;Lcom/stripe/android/ui/core/elements/PhoneNumberState;Lkotlin/jvm/functions/Function0;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/util/Set;
-	public final fun component3 ()Lcom/stripe/android/ui/core/elements/PhoneNumberState;
-	public final fun component4 ()Lkotlin/jvm/functions/Function0;
-	public final fun copy (Ljava/lang/String;Ljava/util/Set;Lcom/stripe/android/ui/core/elements/PhoneNumberState;Lkotlin/jvm/functions/Function0;)Lcom/stripe/android/ui/core/elements/AddressType$ShippingCondensed;
-	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/AddressType$ShippingCondensed;Ljava/lang/String;Ljava/util/Set;Lcom/stripe/android/ui/core/elements/PhoneNumberState;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/AddressType$ShippingCondensed;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun getAutocompleteCountries ()Ljava/util/Set;
-	public fun getGoogleApiKey ()Ljava/lang/String;
-	public fun getOnNavigation ()Lkotlin/jvm/functions/Function0;
-	public fun getPhoneNumberState ()Lcom/stripe/android/ui/core/elements/PhoneNumberState;
-	public fun hashCode ()I
-	public fun supportsAutoComplete (Ljava/lang/String;)Z
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/stripe/android/ui/core/elements/AddressType$ShippingExpanded : com/stripe/android/ui/core/elements/AddressType, com/stripe/android/ui/core/elements/AddressType$AutocompleteCapable {
-	public static final field $stable I
-	public fun <init> (Ljava/lang/String;Ljava/util/Set;Lcom/stripe/android/ui/core/elements/PhoneNumberState;Lkotlin/jvm/functions/Function0;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/util/Set;
-	public final fun component3 ()Lcom/stripe/android/ui/core/elements/PhoneNumberState;
-	public final fun component4 ()Lkotlin/jvm/functions/Function0;
-	public final fun copy (Ljava/lang/String;Ljava/util/Set;Lcom/stripe/android/ui/core/elements/PhoneNumberState;Lkotlin/jvm/functions/Function0;)Lcom/stripe/android/ui/core/elements/AddressType$ShippingExpanded;
-	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/elements/AddressType$ShippingExpanded;Ljava/lang/String;Ljava/util/Set;Lcom/stripe/android/ui/core/elements/PhoneNumberState;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lcom/stripe/android/ui/core/elements/AddressType$ShippingExpanded;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun getAutocompleteCountries ()Ljava/util/Set;
-	public fun getGoogleApiKey ()Ljava/lang/String;
-	public fun getOnNavigation ()Lkotlin/jvm/functions/Function0;
-	public fun getPhoneNumberState ()Lcom/stripe/android/ui/core/elements/PhoneNumberState;
-	public fun hashCode ()I
-	public fun supportsAutoComplete (Ljava/lang/String;)Z
-	public fun toString ()Ljava/lang/String;
-}
-
 public abstract class com/stripe/android/ui/core/elements/AdministrativeAreaConfig$Country {
 	public static final field $stable I
 	public synthetic fun <init> (ILjava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/payments-ui-core/res/drawable/stripe_ic_search.xml
+++ b/payments-ui-core/res/drawable/stripe_ic_search.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:width="24dp">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z" />
+</vector>

--- a/payments-ui-core/res/values-b+es+419/strings.xml
+++ b/payments-ui-core/res/values-b+es+419/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Suburbio</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Villa o localidad</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Buscar</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Paga en <num_installments/> cuotas sin interés de <installment_price/> con <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">El IBAN debe empezar con un código de país de dos letras.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">Banco iDEAL</string>
+  <string name="invalid_email_address">Dirección de correo electrónico no válida: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Compra ahora y paga después con Klarna.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-ca-rES/strings.xml
+++ b/payments-ui-core/res/values-ca-rES/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Suburbi</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Poble o municipi</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Cerca</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Feu <num_installments/> pagaments sense interessos de <installment_price/> amb <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">El teu IBAN ha de començar amb un codi de país de dues lletres.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">Bank iDeal</string>
+  <string name="invalid_email_address">Adreça electrònica no vàlida: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Compra ara o paga més endavant amb Klarna.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-cs-rCZ/strings.xml
+++ b/payments-ui-core/res/values-cs-rCZ/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Předměstí</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Vesnice nebo předměstí</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Hledat</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Platbu proveďte v <num_installments/> bezúročných splátkách, každou ve výši <installment_price/>, splácených přes <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">Číslo IBAN by mělo začínat dvěma písmeny kódu země.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">Banka iDEAL</string>
+  <string name="invalid_email_address">Neplatná e-mailová adresa: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Kupte nyní nebo zaplaťte později pomocí Klarna</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-da/strings.xml
+++ b/payments-ui-core/res/values-da/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Forstad</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Landsby eller byområde</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Søg</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Betal i <num_installments/> rentefri afdrag på <installment_price/> hver med <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">Dit IBAN-nummer skal starte med en landekode på to bogstaver.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">iDEAL Bank</string>
+  <string name="invalid_email_address">Ugyldig e-mailadresse: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Køb nu, eller betal senere med Klarna.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-de/strings.xml
+++ b/payments-ui-core/res/values-de/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Vorort</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Dorf oder Gemeinde</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Suchen</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Zahlen Sie mit <img/> in <num_installments/> zinslosen Raten zu je <installment_price/>.]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">Ihre IBAN sollte mit einem zweistelligen Ländercode beginnen.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">iDEAL-Bank</string>
+  <string name="invalid_email_address">Ungültige E-Mail-Adresse: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Jetzt kaufen oder später mit Klarna bezahlen.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-el-rGR/strings.xml
+++ b/payments-ui-core/res/values-el-rGR/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Προάστιο</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Χωριό ή κοινότητα</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Αναζήτηση</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Πληρώστε σε <num_installments/> άτοκες δόσεις των <installment_price/> με <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">Ο κωδικός IBAN σας πρέπει να αρχίζει με έναν διψήφιο κωδικό χώρας.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">iDEAL Bank</string>
+  <string name="invalid_email_address">Μη έγκυρη διεύθυνση email: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Αγορά τώρα ή πληρωμή αργότερα με Klarna.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-en-rGB/strings.xml
+++ b/payments-ui-core/res/values-en-rGB/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Suburb</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Village or Township</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Search</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Pay in <num_installments/> interest-free payments of <installment_price/> with <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">Your IBAN should start with a two-letter country code.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">iDEAL Bank</string>
+  <string name="invalid_email_address">Invalid email address: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Buy now or pay later with Klarna.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-es/strings.xml
+++ b/payments-ui-core/res/values-es/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Zona residencial</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Villa o comuna</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Buscar</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Pagar en <num_installments/> cuotas sin intereses de <installment_price/> con <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">El IBAN debe empezar con un código de país de dos letras.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">Banco iDEAL</string>
+  <string name="invalid_email_address">Dirección de correo electrónico no válida: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Compra ahora y paga después con Klarna.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-et-rEE/strings.xml
+++ b/payments-ui-core/res/values-et-rEE/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Eeslinn</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Küla või alev</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Otsi</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Makske <num_installments/> <installment_price/> suuruse intressivaba osamaksega <img/> abil]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">Teie IBAN peab algama kahetähelise riigikoodiga.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">iDEALi pank</string>
+  <string name="invalid_email_address">Kehtetu e-posti address: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Ostke nüüd või makske hiljem Klarnaga.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-fi/strings.xml
+++ b/payments-ui-core/res/values-fi/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Esikaupunki</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Kylä tai kaupunkikunta</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Etsi</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Maksu <num_installments/> korottomassa <installment_price/> osassa maksutavalla <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">IBAN-tilinumero alkaa kaksikirjaimisella maakoodilla.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">iDEAL-pankki</string>
+  <string name="invalid_email_address">Virheellinen sähköpostiosoite: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Osta nyt tai maksa myöhemmin Klarnalla.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-fil/strings.xml
+++ b/payments-ui-core/res/values-fil/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Suburb</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Bayan o Township</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Maghanap</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Magbayad ng <num_installments/> na walang interes na pagbabayad ng <installment_price/> gamit ang <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">Ang iyong IBAN ay dapat magsimula sa dalawang letra na code ng bansa.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">iDEAL Bank</string>
+  <string name="invalid_email_address">Hindi valid na email address: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Bumili ngayon o magbayad sa ibang pagkakataon gamit ang Klarna.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-fr-rCA/strings.xml
+++ b/payments-ui-core/res/values-fr-rCA/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Banlieue</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Village ou canton</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Rechercher</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Payer en <num_installments/> versements sans intérêts de <installment_price/> avec <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">Votre IBAN doit commencer par un code pays à deux lettres.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">Banque iDEAL</string>
+  <string name="invalid_email_address">Adresse de courriel non valide : %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Payez maintenant ou plus tard avec Klarna.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-fr/strings.xml
+++ b/payments-ui-core/res/values-fr/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Banlieue</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Village ou commune</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Rechercher</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Payer en <num_installments/> versements sans intérêts de <installment_price/> avec <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">Votre IBAN doit commencer par un code pays à deux lettres.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">Banque iDEAL</string>
+  <string name="invalid_email_address">Adresse e-mail non valide : %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Paiement différé avec Klarna.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-hr/strings.xml
+++ b/payments-ui-core/res/values-hr/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Predgrađe</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Selo ili grad</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Pretraži</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Platite u <num_installments/> beskamatnih obroka po <installment_price/> koristeći <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">Vaš bi IBAN trebao započeti s kodom države od dva slova.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">iDEAL Bank</string>
+  <string name="invalid_email_address">Nevažeća adresa e-pošte: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Kupite sada ili platite kasnije pomoću Klarne</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-hu/strings.xml
+++ b/payments-ui-core/res/values-hu/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Külváros</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Falu vagy község</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Keresés</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Fizetés <num_installments/>, egyenként <installment_price/> összegű kamatmentes részletben <img/> használatával]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">Az IBAN-számának egy kétbetűs országkóddal kell kezdődnie.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">iDEAL bank</string>
+  <string name="invalid_email_address">Érvénytelen e-mail-cím: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Megvásárlás most, vagy fizetés később Klarnával.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-in/strings.xml
+++ b/payments-ui-core/res/values-in/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Suburb</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Kelurahan atau Kecamatan</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Cari</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Bayar dalam <num_installments/> angsuran bebas bunga sebesar <installment_price/> dengan <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">IBAN Anda harus diawali dengan kode negara dua-huruf.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">iDEAL Bank</string>
+  <string name="invalid_email_address">Alamat email tidak valid: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Beli sekarang atau bayar nanti dengan Klarna.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-it/strings.xml
+++ b/payments-ui-core/res/values-it/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Località</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Città o località</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Cerca</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Paga in <num_installments/> rate senza interessi di <installment_price/> con <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">L\'IBAN deve iniziare con un codice di paese di due lettere.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">Banca iDEAL</string>
+  <string name="invalid_email_address">Indirizzo email non valido: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Acquista ora o paga dopo con Klarna.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-ja/strings.xml
+++ b/payments-ui-core/res/values-ja/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">近郊</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">村またはタウンシップ</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">検索</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[<img/> で毎回 <installment_price/> ずつ、無利息の <num_installments/> 回の分割払いで支払う]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">IBANコードの先頭には 2 文字の国コードを入力してください。</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">iDEAL銀行</string>
+  <string name="invalid_email_address">メールアドレスが無効です: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Klarna で後払いします。</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-ko/strings.xml
+++ b/payments-ui-core/res/values-ko/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">교외</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">마을 또는 면/리</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">검색</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[<img/>로 <installment_price/>의 <num_installments/>회 무이자 결제로 대금을 지급하십시오.]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">IBAN은 두 글자의 국가 코드로 시작해야 합니다.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">iDEAL 은행</string>
+  <string name="invalid_email_address">잘못된 이메일 주소: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">지금 구매하거나 Klarna로 나중에 결제</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-lt-rLT/strings.xml
+++ b/payments-ui-core/res/values-lt-rLT/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Priemiestis</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Kaimas arba miestelis</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Paieška</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Mokėti <num_installments/> be palūkanų <installment_price/> mokėjimus naudojant <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">Jūsų IBAN turėtų prasidėti šalies kodu iš dviejų raidžių.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">iDEAL bankas</string>
+  <string name="invalid_email_address">Netinkamas el. pašto adresas: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Pirkite dabar arba mokėkite vėliau naudodami \"Klarna\".</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-lv-rLV/strings.xml
+++ b/payments-ui-core/res/values-lv-rLV/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Priekšpilsēta</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Ciems vai apdzīvota vieta</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Meklēšana</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Maksāt ar <num_installments/> bezprocentu maksājumiem <installment_price/> ar <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">IBAN sākumā jābūt divu burtu valsts kodam.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">iDEAL banka</string>
+  <string name="invalid_email_address">Nederīga e-pasta adrese: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Pērciet tagad vai maksājiet vēlāk ar Klarna.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-ms-rMY/strings.xml
+++ b/payments-ui-core/res/values-ms-rMY/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Pinggir Bandar</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Kampung atau Perbandaran</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Cari</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Bayar dalam <num_installments/> kali pembayaran tanpa faedah sebanyak <installment_price/> dengan <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">IBAN anda harus bermula dengan kod negara dua huruf.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">Bank iDEAL</string>
+  <string name="invalid_email_address">Alamat e-mel tidak sah: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Beli sekarang atau bayar kemudian dengan Klarna.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-mt/strings.xml
+++ b/payments-ui-core/res/values-mt/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Subborg</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Raħal jew Belt</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Fittex</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Ħallas f\'dan-numru ta\' pagamenti: <num_installments/> ta\' <installment_price/> mingħajr imgħax grazzi għal <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">L-IBAN tiegħek għandu jibda b\'kodiċi tal-pajjiż magħmul minn żewġ ittri.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">Il-Bank iDEAL</string>
+  <string name="invalid_email_address">Indirizz tal-email ħażin: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Ixtri issa jew ħallas iktar tard bil-Klarna.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-nb/strings.xml
+++ b/payments-ui-core/res/values-nb/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Forstad</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Landsby eller tettsted</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Søk</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Betal med <num_installments/> rentefri avdrag på <installment_price/> med <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">IBAN-nummeret skal starte med en tosifret landskode.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">iDEAL Bank</string>
+  <string name="invalid_email_address">Ugyldig e-postadresse: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Kjøp nå eller betal senere med Klarna.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-nl/strings.xml
+++ b/payments-ui-core/res/values-nl/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Voorstad</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Dorp of kleine stad</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Zoeken</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Betaal in <num_installments/> rentevrije termijnen van <installment_price/> met <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">Het IBAN-nummer moet beginnen met een landcode van twee letters.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">iDEAL-bank</string>
+  <string name="invalid_email_address">Ongeldig e-mailadres: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Koop nu of betaal later met Klarna.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-nn-rNO/strings.xml
+++ b/payments-ui-core/res/values-nn-rNO/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Forstad</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Landsby eller township</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Søk</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Betal i <num_installments/> rentefrie betalingar på <installment_price/> med <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">IBAN-nummeret bør starte med ei landskode med to bokstavar.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">iDEAL Bank</string>
+  <string name="invalid_email_address">Ugyldig e-postadresse: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Kjøp no eller betal seinare med Klarna.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-pl-rPL/strings.xml
+++ b/payments-ui-core/res/values-pl-rPL/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Przedmieścia</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Wieś lub miasto</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Wyszukiwanie</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Zapłacić w <num_installments/> nieoprocentowanych ratach <installment_price/> z <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">IBAN powinien się zaczynać od dwuliterowego kodu kraju.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">iDEAL Bank</string>
+  <string name="invalid_email_address">Nieprawidłowy adres e-mail: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Kup teraz lub zapłać za pomocą Klarna później.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-pt-rBR/strings.xml
+++ b/payments-ui-core/res/values-pt-rBR/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Subúrbio</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Vilarejo ou município</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Pesquisar</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Pague em <num_installments/> vezes sem juros de <installment_price/> com <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">Seu IBAN deve começar com um código de país de duas letras.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">Banco iDEAL</string>
+  <string name="invalid_email_address">Endereço de e-mail inválido: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Compre agora ou pague depois com Klarna.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-pt-rPT/strings.xml
+++ b/payments-ui-core/res/values-pt-rPT/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Subúrbio</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Município ou localidade</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Pesquisar</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Pagar em <num_installments/> pagamentos sem juros de <installment_price/> com <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">O seu IBAN deve começar por um código de duas letras correspondente ao país.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">Banco iDEAL</string>
+  <string name="invalid_email_address">Endereço de email inválido: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Comprar agora ou pagar mais tarde com Klarna.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-ro-rRO/strings.xml
+++ b/payments-ui-core/res/values-ro-rRO/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Suburbie</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Sat sau comună</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Căutare</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Plătiți în <num_installments/> plăți fără dobândă a câte <installment_price/> cu <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">Codul dvs. IBAN trebuie să înceapă cu un cod de țară format din două litere.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">iDEAL Bank</string>
+  <string name="invalid_email_address">Adresă de e-mail nevalidă: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Cumpărați acum sau plătiți mai târziu folosind Klarna.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-ru/strings.xml
+++ b/payments-ui-core/res/values-ru/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Пригород</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Деревня или поселок</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Поиск</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Оплатить в беспроцентную рассрочку <num_installments/> выплатами по <installment_price/> через <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">Код IBAN должен начинаться с двухбуквенного кода страны.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">Банк в системе iDEAL</string>
+  <string name="invalid_email_address">Недопустимый эл. адрес: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Купить немедленно или оплатить позже через систему Klarna.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-sk-rSK/strings.xml
+++ b/payments-ui-core/res/values-sk-rSK/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Predmestie</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Obec alebo obvod</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Vyhľadať</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Zaplaťte v <num_installments/>bezúročných splátkach čiastku <installment_price/> pomocou <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">Váš IBAN by mal začínať dvojpísmenovým kódom krajiny.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">iDEAL banka</string>
+  <string name="invalid_email_address">Neplatná e-mailová adresa: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Kúpte teraz alebo zaplaťte neskôr pomocou služby Klarna.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-sl-rSI/strings.xml
+++ b/payments-ui-core/res/values-sl-rSI/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Predmestje</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Vas ali občina</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Iskanje</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Plačajte v <num_installments/> obrokih po <installment_price/> brez obresti s storitvijo <img/>.]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">Vaša koda IBAN se mora začeti z dvomestno kodo države.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">Banka iDEAL</string>
+  <string name="invalid_email_address">Neveljaven e-poštni naslov: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Kupite zdaj ali pa plačajte pozneje s storitvijo Klarna.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-sv/strings.xml
+++ b/payments-ui-core/res/values-sv/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Förort</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">By eller kommun</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Sök</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Betala av genom <num_installments/> räntefria delbetalningar på <installment_price/> med <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">Ditt IBAN ska börja med en landskod (två bokstäver).</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">iDEAL Bank</string>
+  <string name="invalid_email_address">Ogiltig e-postadress: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Köp nu eller betala senare med Klarna.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-th/strings.xml
+++ b/payments-ui-core/res/values-th/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">ชานเมือง</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">หมู่บ้านหรือเขตการปกครองท้องถิ่น</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">ค้นหา</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[ผ่อนชำระ <num_installments/> งวดแบบปลอดดอกเบี้ย งวดละ <installment_price/> ด้วย <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">IBAN ควรเริ่มต้นด้วยรหัสประเทศ 2 ตัวอักษร</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">ธนาคารที่รองรับ iDEAL</string>
+  <string name="invalid_email_address">ที่อยู่อีเมลไม่ถูกต้อง: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">ซื้อตอนนี้หรือจ่ายทีหลังด้วย Klarna</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-tr/strings.xml
+++ b/payments-ui-core/res/values-tr/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Banliyö</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Köy veya İlçe</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Ara</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[<img/> ile <installment_price/> tutarında faizsiz <num_installments/> taksitle ödeyin]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">IBAN numaranız iki harfli bir ülke koduyla başlamalıdır.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">iDEAL Bank</string>
+  <string name="invalid_email_address">Geçersiz e-posta adresi: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Şimdi satın alın veya daha sonra Klarna ile ödeyin.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-vi/strings.xml
+++ b/payments-ui-core/res/values-vi/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Ngoại ô</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Làng hoặc thị trấn</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Tìm kiếm</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Trả bằng <num_installments/> khoản thanh toán không lãi suất là <installment_price/> bằng <img/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">IBAN của quý vị phải bắt đầu bằng mã quốc gia gồm hai chữ cái.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">Ngân hàng iDEAL</string>
+  <string name="invalid_email_address">Địa chỉ email không hợp lệ: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Mua ngay hoặc thanh toán sau bằng Klarna.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-zh-rHK/strings.xml
+++ b/payments-ui-core/res/values-zh-rHK/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">郊區</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">村或鎮</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">搜尋</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[用 <img/> 分 <num_installments/> 支付，無利息，每期 <installment_price/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">您的 IBAN 應以一個兩字母的國家代碼開頭。</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">iDEAL 銀行</string>
+  <string name="invalid_email_address">電郵地址無效：%s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">用 Klarna 先買後付。</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-zh-rTW/strings.xml
+++ b/payments-ui-core/res/values-zh-rTW/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">郊區</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">村莊或城鎮</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">搜尋</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[用 <img/> 分 <num_installments/> 支付，無利息，每期 <installment_price/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">您的 IBAN 應以一個兩字母國家代碼開頭。</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">iDEAL 銀行</string>
+  <string name="invalid_email_address">電郵地址無效：%s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">用 Klarna 先買後付。</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values-zh/strings.xml
+++ b/payments-ui-core/res/values-zh/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">市郊</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">村庄或城镇</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">搜索</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[用 <img/> 分 <num_installments/> 支付，无利息，每期 <installment_price/>]]></string>
   <!-- Text for back button -->
@@ -64,6 +66,7 @@
   <string name="iban_invalid_start">您的 IBAN 应以一个两字母国家代码开头。</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">iDEAL 银行</string>
+  <string name="invalid_email_address">邮箱地址无效：%s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">用 Klarna 先买后付。</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values/strings.xml
+++ b/payments-ui-core/res/values/strings.xml
@@ -92,4 +92,6 @@
   <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Set up</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="stripe_address_search_content_description">Search</string>
 </resources>

--- a/payments-ui-core/res/values/strings.xml
+++ b/payments-ui-core/res/values/strings.xml
@@ -66,6 +66,7 @@
   <string name="iban_invalid_start">Your IBAN should start with a two-letter country code.</string>
   <!-- iDEAL bank section title for iDEAL form entry. -->
   <string name="ideal_bank">iDEAL Bank</string>
+  <string name="invalid_email_address">Invalid email address: %s</string>
   <!-- Klarna buy now or pay later copy -->
   <string name="klarna_buy_now_pay_later">Buy now or pay later with Klarna.</string>
   <!-- Klarna pay later copy -->

--- a/payments-ui-core/res/values/strings.xml
+++ b/payments-ui-core/res/values/strings.xml
@@ -38,6 +38,8 @@
   <string name="address_label_suburb">Suburb</string>
   <!-- Used to describe an address field. -->
   <string name="address_label_village_township">Village or Township</string>
+  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
+  <string name="address_search_content_description">Search</string>
   <!-- This shows the message on Buy Now Pay Later LPM, afterpay.  After the word "with" an Afterpay logo is displayed.  can be moved to move the logo in the string. -->
   <string name="afterpay_clearpay_message"><![CDATA[Pay in <num_installments/> interest-free payments of <installment_price/> with <img/>]]></string>
   <!-- Text for back button -->
@@ -92,6 +94,4 @@
   <string name="stripe_paymentsheet_payment_method_sepa_debit">SEPA Debit</string>
   <!-- Label of a button displayed below a payment method form. Tapping the button sets the payment method up for future use -->
   <string name="stripe_setup_button_label">Set up</string>
-  <!-- Title of a button with a 🔍 (magnifying glass) icon that starts a search when tapped -->
-  <string name="stripe_address_search_content_description">Search</string>
 </resources>

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressElement.kt
@@ -242,7 +242,7 @@ open class AddressElement constructor(
             TextFieldIcon.Trailing(
                 idRes = R.drawable.stripe_ic_search,
                 isTintable = true,
-                contentDescription = R.string.stripe_address_search_content_description,
+                contentDescription = R.string.address_search_content_description,
                 onClick = {
                     addressType.onNavigation()
                 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressElement.kt
@@ -236,7 +236,7 @@ open class AddressElement constructor(
         countryCode: String?
     ) {
         val addressType = addressType
-        val supportsAutocomplete = (addressType as? AddressType.AutocompleteCapable)
+        val supportsAutocomplete = (addressType as? AutocompleteCapableAddressType)
             ?.supportsAutoComplete(countryCode)
         val icon: TextFieldIcon.Trailing? = if (supportsAutocomplete == true) {
             TextFieldIcon.Trailing(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressElement.kt
@@ -32,10 +32,9 @@ open class AddressElement constructor(
         rawValuesMap[IdentifierSpec.Country]
     ),
     sameAsShippingElement: SameAsShippingElement?,
-    shippingValuesMap: Map<IdentifierSpec, String?>?
+    shippingValuesMap: Map<IdentifierSpec, String?>?,
+    private val isPlacesAvailable: IsPlacesAvailable = DefaultIsPlacesAvailable(),
 ) : SectionMultiFieldElement(_identifier) {
-    @VisibleForTesting
-    internal var isPlacesAvailable: IsPlacesAvailable = DefaultIsPlacesAvailable()
 
     @VisibleForTesting
     val countryElement = CountryElement(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressElement.kt
@@ -241,7 +241,7 @@ open class AddressElement constructor(
         val icon: TextFieldIcon.Trailing? = if (supportsAutocomplete == true) {
             TextFieldIcon.Trailing(
                 idRes = R.drawable.stripe_ic_search,
-                isTintable = false,
+                isTintable = true,
                 contentDescription = R.string.stripe_address_search_content_description,
                 onClick = {
                     addressType.onNavigation()

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressElement.kt
@@ -242,6 +242,7 @@ open class AddressElement constructor(
             TextFieldIcon.Trailing(
                 idRes = R.drawable.stripe_ic_search,
                 isTintable = false,
+                contentDescription = R.string.stripe_address_search_content_description,
                 onClick = {
                     addressType.onNavigation()
                 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
@@ -40,6 +40,7 @@ sealed class AddressType {
 
     abstract val phoneNumberState: PhoneNumberState
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
     data class ShippingCondensed(
         override val googleApiKey: String?,
         override val autocompleteCountries: Set<String>?,
@@ -47,6 +48,7 @@ sealed class AddressType {
         override val onNavigation: () -> Unit
     ) : AddressType(), AutocompleteCapable
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
     data class ShippingExpanded constructor(
         override val googleApiKey: String?,
         override val autocompleteCountries: Set<String>?,
@@ -54,6 +56,7 @@ sealed class AddressType {
         override val onNavigation: () -> Unit,
     ) : AddressType(), AutocompleteCapable
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
     data class Normal(
         override val phoneNumberState: PhoneNumberState =
             PhoneNumberState.HIDDEN

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.text.toLowerCase
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.address.AddressRepository
-import com.stripe.android.ui.core.elements.autocomplete.DefaultIsPlacesAvailable
 import com.stripe.android.ui.core.elements.autocomplete.IsPlacesAvailable
 import com.stripe.android.uicore.elements.CountryConfig
 import com.stripe.android.uicore.elements.DropdownFieldController
@@ -27,7 +26,7 @@ internal interface AutocompleteCapableAddressType {
 
     fun supportsAutoComplete(
         country: String?,
-        isPlacesAvailable: IsPlacesAvailable = DefaultIsPlacesAvailable(),
+        isPlacesAvailable: IsPlacesAvailable,
     ): Boolean {
         val supportedCountries = autocompleteCountries
         val autocompleteSupportsCountry = supportedCountries

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
@@ -21,6 +21,7 @@ enum class DisplayField {
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 sealed class AddressType {
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
     interface AutocompleteCapable {
         val googleApiKey: String?
         val autocompleteCountries: Set<String>?

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.text.toLowerCase
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.address.AddressRepository
 import com.stripe.android.ui.core.elements.autocomplete.DefaultIsPlacesAvailable
+import com.stripe.android.ui.core.elements.autocomplete.IsPlacesAvailable
 import com.stripe.android.uicore.elements.CountryConfig
 import com.stripe.android.uicore.elements.DropdownFieldController
 import com.stripe.android.uicore.elements.supportedBillingCountries
@@ -24,12 +25,15 @@ internal interface AutocompleteCapableAddressType {
     val autocompleteCountries: Set<String>?
     val onNavigation: () -> Unit
 
-    fun supportsAutoComplete(country: String?): Boolean {
+    fun supportsAutoComplete(
+        country: String?,
+        isPlacesAvailable: IsPlacesAvailable = DefaultIsPlacesAvailable(),
+    ): Boolean {
         val supportedCountries = autocompleteCountries
         val autocompleteSupportsCountry = supportedCountries
             ?.map { it.toLowerCase(Locale.current) }
             ?.contains(country?.toLowerCase(Locale.current)) == true
-        val autocompleteAvailable = DefaultIsPlacesAvailable().invoke() &&
+        val autocompleteAvailable = isPlacesAvailable() &&
             !googleApiKey.isNullOrBlank()
         return autocompleteSupportsCountry && autocompleteAvailable
     }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
@@ -19,25 +19,24 @@ enum class DisplayField {
     Country
 }
 
+internal interface AutocompleteCapableAddressType {
+    val googleApiKey: String?
+    val autocompleteCountries: Set<String>?
+    val onNavigation: () -> Unit
+
+    fun supportsAutoComplete(country: String?): Boolean {
+        val supportedCountries = autocompleteCountries
+        val autocompleteSupportsCountry = supportedCountries
+            ?.map { it.toLowerCase(Locale.current) }
+            ?.contains(country?.toLowerCase(Locale.current)) == true
+        val autocompleteAvailable = DefaultIsPlacesAvailable().invoke() &&
+            !googleApiKey.isNullOrBlank()
+        return autocompleteSupportsCountry && autocompleteAvailable
+    }
+}
+
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 sealed class AddressType {
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
-    interface AutocompleteCapable {
-        val googleApiKey: String?
-        val autocompleteCountries: Set<String>?
-        val onNavigation: () -> Unit
-
-        fun supportsAutoComplete(country: String?): Boolean {
-            val supportedCountries = autocompleteCountries
-            val autocompleteSupportsCountry = supportedCountries
-                ?.map { it.toLowerCase(Locale.current) }
-                ?.contains(country?.toLowerCase(Locale.current)) == true
-            val autocompleteAvailable = DefaultIsPlacesAvailable().invoke() &&
-                !googleApiKey.isNullOrBlank()
-            return autocompleteSupportsCountry && autocompleteAvailable
-        }
-    }
-
     abstract val phoneNumberState: PhoneNumberState
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
@@ -46,7 +45,7 @@ sealed class AddressType {
         override val autocompleteCountries: Set<String>?,
         override val phoneNumberState: PhoneNumberState,
         override val onNavigation: () -> Unit
-    ) : AddressType(), AutocompleteCapable
+    ) : AddressType(), AutocompleteCapableAddressType
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
     data class ShippingExpanded constructor(
@@ -54,7 +53,7 @@ sealed class AddressType {
         override val autocompleteCountries: Set<String>?,
         override val phoneNumberState: PhoneNumberState,
         override val onNavigation: () -> Unit,
-    ) : AddressType(), AutocompleteCapable
+    ) : AddressType(), AutocompleteCapableAddressType
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
     data class Normal(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/TextFieldController.kt
@@ -70,7 +70,7 @@ sealed class TextFieldIcon {
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 class SimpleTextFieldController constructor(
-    private val textFieldConfig: TextFieldConfig,
+    val textFieldConfig: TextFieldConfig,
     override val showOptionalLabel: Boolean = false,
     initialValue: String? = null
 ) : TextFieldController, SectionFieldErrorController {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy.kt
@@ -169,7 +169,7 @@ internal class UnsupportedPlacesClientProxy : PlacesClientProxy {
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-interface IsPlacesAvailable {
+fun interface IsPlacesAvailable {
     operator fun invoke(): Boolean
 }
 

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressElementTest.kt
@@ -5,7 +5,6 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.address.AddressRepository
-import com.stripe.android.ui.core.elements.autocomplete.IsPlacesAvailable
 import com.stripe.android.uicore.elements.CountryConfig
 import com.stripe.android.uicore.elements.DropdownFieldController
 import com.stripe.android.uicore.forms.FormFieldEntry
@@ -366,9 +365,9 @@ class AddressElementTest {
                 PhoneNumberState.OPTIONAL
             ) { throw AssertionError("Not Expected") },
             sameAsShippingElement = null,
-            shippingValuesMap = null
+            shippingValuesMap = null,
+            isPlacesAvailable = { false },
         )
-        addressElement.isPlacesAvailable = IsPlacesAvailable { false }
         val identifierSpecs = addressElement.fields.first().map {
             it.identifier
         }
@@ -390,9 +389,9 @@ class AddressElementTest {
                 PhoneNumberState.OPTIONAL
             ) { throw AssertionError("Not Expected") },
             sameAsShippingElement = null,
-            shippingValuesMap = null
+            shippingValuesMap = null,
+            isPlacesAvailable = { false },
         )
-        addressElement.isPlacesAvailable = IsPlacesAvailable { false }
         countryDropdownFieldController.onValueChange(1)
 
         val trailingIcon = addressElement.trailingIconFor(IdentifierSpec.Line1)
@@ -415,9 +414,9 @@ class AddressElementTest {
                 PhoneNumberState.OPTIONAL
             ) { onNavigationCounter.getAndIncrement() },
             sameAsShippingElement = null,
-            shippingValuesMap = null
+            shippingValuesMap = null,
+            isPlacesAvailable = { true },
         )
-        addressElement.isPlacesAvailable = IsPlacesAvailable { true }
         countryDropdownFieldController.onValueChange(1)
 
         val line1TrailingIcon = addressElement.trailingIconFor(IdentifierSpec.Line1)

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressElementTest.kt
@@ -227,8 +227,10 @@ class AddressElementTest {
             addressRepository,
             countryDropdownFieldController = countryDropdownFieldController,
             addressType = AddressType.ShippingExpanded(
-                PhoneNumberState.REQUIRED
-            ),
+                googleApiKey = null,
+                autocompleteCountries = null,
+                phoneNumberState = PhoneNumberState.REQUIRED,
+            ) { },
             sameAsShippingElement = null,
             shippingValuesMap = null
         )
@@ -247,8 +249,10 @@ class AddressElementTest {
             addressRepository,
             countryDropdownFieldController = countryDropdownFieldController,
             addressType = AddressType.ShippingExpanded(
-                PhoneNumberState.HIDDEN
-            ),
+                googleApiKey = null,
+                autocompleteCountries = null,
+                phoneNumberState = PhoneNumberState.HIDDEN,
+            ) { },
             sameAsShippingElement = null,
             shippingValuesMap = null
         )
@@ -266,8 +270,10 @@ class AddressElementTest {
             addressRepository,
             countryDropdownFieldController = countryDropdownFieldController,
             addressType = AddressType.ShippingExpanded(
-                PhoneNumberState.OPTIONAL
-            ),
+                googleApiKey = null,
+                autocompleteCountries = null,
+                phoneNumberState = PhoneNumberState.OPTIONAL,
+            ) { },
             sameAsShippingElement = null,
             shippingValuesMap = null
         )
@@ -362,8 +368,10 @@ class AddressElementTest {
             addressRepository,
             countryDropdownFieldController = countryDropdownFieldController,
             addressType = AddressType.ShippingExpanded(
-                PhoneNumberState.OPTIONAL
-            ),
+                googleApiKey = null,
+                autocompleteCountries = null,
+                phoneNumberState = PhoneNumberState.OPTIONAL,
+            ) { },
             sameAsShippingElement = null,
             shippingValuesMap = null
         )

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AutocompleteCapableAddressTypeTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AutocompleteCapableAddressTypeTest.kt
@@ -7,62 +7,76 @@ internal class AutocompleteCapableAddressTypeTest {
     @Test
     fun `supportsAutoComplete returns true when available and supported`() {
         val subject = createSubject(googleApiKey = "example", autocompleteCountries = setOf("US"))
-        assertThat(subject.supportsAutoComplete("US") {
-            true
-        }).isTrue()
+        assertThat(
+            subject.supportsAutoComplete("US") {
+                true
+            }
+        ).isTrue()
     }
 
     @Test
     fun `supportsAutoComplete returns false when not available but supported`() {
         val subject = createSubject(googleApiKey = "example", autocompleteCountries = setOf("CAN"))
-        assertThat(subject.supportsAutoComplete("US") {
-            true
-        }).isFalse()
+        assertThat(
+            subject.supportsAutoComplete("US") {
+                true
+            }
+        ).isFalse()
     }
 
     @Test
     fun `supportsAutoComplete returns false when available but not supported`() {
         val subject = createSubject(googleApiKey = "example", autocompleteCountries = setOf("US"))
-        assertThat(subject.supportsAutoComplete("US") {
-            false
-        }).isFalse()
+        assertThat(
+            subject.supportsAutoComplete("US") {
+                false
+            }
+        ).isFalse()
     }
 
     @Test
     fun `supportsAutoComplete returns false when available and supported but missing api key`() {
         val subject = createSubject(googleApiKey = null, autocompleteCountries = setOf("US"))
-        assertThat(subject.supportsAutoComplete("US") {
-            true
-        }).isFalse()
+        assertThat(
+            subject.supportsAutoComplete("US") {
+                true
+            }
+        ).isFalse()
     }
 
     @Test
     fun `supportsAutoComplete returns true with lowercase autocomplete country`() {
         val subject = createSubject(googleApiKey = "example", autocompleteCountries = setOf("us"))
-        assertThat(subject.supportsAutoComplete("US") {
-            true
-        }).isTrue()
+        assertThat(
+            subject.supportsAutoComplete("US") {
+                true
+            }
+        ).isTrue()
     }
 
     @Test
     fun `supportsAutoComplete returns true when available and supported with lowercase country`() {
         val subject = createSubject(googleApiKey = "example", autocompleteCountries = setOf("US"))
-        assertThat(subject.supportsAutoComplete("us") {
-            true
-        }).isTrue()
+        assertThat(
+            subject.supportsAutoComplete("us") {
+                true
+            }
+        ).isTrue()
     }
 
     @Test
     fun `supportsAutoComplete returns true with lowercase countries`() {
         val subject = createSubject(googleApiKey = "example", autocompleteCountries = setOf("us"))
-        assertThat(subject.supportsAutoComplete("us") {
-            true
-        }).isTrue()
+        assertThat(
+            subject.supportsAutoComplete("us") {
+                true
+            }
+        ).isTrue()
     }
 
     private fun createSubject(
         googleApiKey: String?,
-        autocompleteCountries: Set<String>?
+        autocompleteCountries: Set<String>?,
     ): AutocompleteCapableAddressType {
         return AddressType.ShippingExpanded(
             googleApiKey = googleApiKey,

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AutocompleteCapableAddressTypeTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AutocompleteCapableAddressTypeTest.kt
@@ -1,0 +1,73 @@
+package com.stripe.android.ui.core.elements
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+internal class AutocompleteCapableAddressTypeTest {
+    @Test
+    fun `supportsAutoComplete returns true when available and supported`() {
+        val subject = createSubject(googleApiKey = "example", autocompleteCountries = setOf("US"))
+        assertThat(subject.supportsAutoComplete("US") {
+            true
+        }).isTrue()
+    }
+
+    @Test
+    fun `supportsAutoComplete returns false when not available but supported`() {
+        val subject = createSubject(googleApiKey = "example", autocompleteCountries = setOf("CAN"))
+        assertThat(subject.supportsAutoComplete("US") {
+            true
+        }).isFalse()
+    }
+
+    @Test
+    fun `supportsAutoComplete returns false when available but not supported`() {
+        val subject = createSubject(googleApiKey = "example", autocompleteCountries = setOf("US"))
+        assertThat(subject.supportsAutoComplete("US") {
+            false
+        }).isFalse()
+    }
+
+    @Test
+    fun `supportsAutoComplete returns false when available and supported but missing api key`() {
+        val subject = createSubject(googleApiKey = null, autocompleteCountries = setOf("US"))
+        assertThat(subject.supportsAutoComplete("US") {
+            true
+        }).isFalse()
+    }
+
+    @Test
+    fun `supportsAutoComplete returns true with lowercase autocomplete country`() {
+        val subject = createSubject(googleApiKey = "example", autocompleteCountries = setOf("us"))
+        assertThat(subject.supportsAutoComplete("US") {
+            true
+        }).isTrue()
+    }
+
+    @Test
+    fun `supportsAutoComplete returns true when available and supported with lowercase country`() {
+        val subject = createSubject(googleApiKey = "example", autocompleteCountries = setOf("US"))
+        assertThat(subject.supportsAutoComplete("us") {
+            true
+        }).isTrue()
+    }
+
+    @Test
+    fun `supportsAutoComplete returns true with lowercase countries`() {
+        val subject = createSubject(googleApiKey = "example", autocompleteCountries = setOf("us"))
+        assertThat(subject.supportsAutoComplete("us") {
+            true
+        }).isTrue()
+    }
+
+    private fun createSubject(
+        googleApiKey: String?,
+        autocompleteCountries: Set<String>?
+    ): AutocompleteCapableAddressType {
+        return AddressType.ShippingExpanded(
+            googleApiKey = googleApiKey,
+            autocompleteCountries = autocompleteCountries,
+            phoneNumberState = PhoneNumberState.REQUIRED
+        ) {}
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressSpecFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressSpecFactory.kt
@@ -1,0 +1,57 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import com.stripe.android.ui.core.elements.AddressSpec
+import com.stripe.android.ui.core.elements.AddressType
+import com.stripe.android.ui.core.elements.PhoneNumberState
+
+internal object AddressSpecFactory {
+    fun create(
+        condensedForm: Boolean,
+        config: AddressLauncher.Configuration?,
+        onNavigation: () -> Unit
+    ): AddressSpec {
+        val phoneNumberState = parsePhoneNumberConfig(config?.additionalFields?.phone)
+        val addressSpec = if (condensedForm) {
+            AddressSpec(
+                showLabel = false,
+                type = AddressType.ShippingCondensed(
+                    googleApiKey = config?.googlePlacesApiKey,
+                    autocompleteCountries = config?.autocompleteCountries,
+                    phoneNumberState = phoneNumberState,
+                    onNavigation = onNavigation,
+                )
+            )
+        } else {
+            AddressSpec(
+                showLabel = false,
+                type = AddressType.ShippingExpanded(
+                    googleApiKey = config?.googlePlacesApiKey,
+                    autocompleteCountries = config?.autocompleteCountries,
+                    phoneNumberState = phoneNumberState,
+                    onNavigation = onNavigation,
+                )
+            )
+        }
+
+        val addressSpecWithAllowedCountries = config?.allowedCountries?.run {
+            addressSpec.copy(allowedCountryCodes = this)
+        }
+
+        return addressSpecWithAllowedCountries ?: addressSpec
+    }
+
+    // This mapping is required to prevent merchants from depending on ui-core.
+    fun parsePhoneNumberConfig(
+        configuration: AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration?
+    ): PhoneNumberState {
+        return when (configuration) {
+            AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.HIDDEN ->
+                PhoneNumberState.HIDDEN
+            AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.OPTIONAL ->
+                PhoneNumberState.OPTIONAL
+            AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.REQUIRED ->
+                PhoneNumberState.REQUIRED
+            null -> PhoneNumberState.OPTIONAL
+        }
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressSpecFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressSpecFactoryTest.kt
@@ -1,0 +1,122 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ui.core.elements.AddressType
+import com.stripe.android.ui.core.elements.PhoneNumberState
+import org.junit.Test
+
+class AddressSpecFactoryTest {
+    private val required = AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.REQUIRED
+
+    @Test
+    fun `null config creates condensed addressSpec`() {
+        val addressSpec = AddressSpecFactory.create(
+            condensedForm = true,
+            config = null,
+            onNavigation = {}
+        )
+        assertThat(addressSpec.showLabel).isFalse()
+        assertThat(addressSpec.allowedCountryCodes).isNotEmpty()
+        val type = addressSpec.type as AddressType.ShippingCondensed
+        assertThat(type.googleApiKey).isNull()
+        assertThat(type.autocompleteCountries).isNull()
+        assertThat(type.phoneNumberState).isEqualTo(PhoneNumberState.OPTIONAL)
+    }
+
+    @Test
+    fun `config creates condensed addressSpec`() {
+        val addressSpec = AddressSpecFactory.create(
+            condensedForm = true,
+            config = AddressLauncher.Configuration(
+                googlePlacesApiKey = "apiKey",
+                autocompleteCountries = setOf("US", "CA"),
+                additionalFields = AddressLauncher.AdditionalFieldsConfiguration(phone = required)
+            ),
+            onNavigation = {}
+        )
+        assertThat(addressSpec.showLabel).isFalse()
+        assertThat(addressSpec.allowedCountryCodes).isEmpty()
+        val type = addressSpec.type as AddressType.ShippingCondensed
+        assertThat(type.googleApiKey).isEqualTo("apiKey")
+        assertThat(type.autocompleteCountries).isEqualTo(setOf("US", "CA"))
+        assertThat(type.phoneNumberState).isEqualTo(PhoneNumberState.REQUIRED)
+    }
+
+    @Test
+    fun `null config creates expanded addressSpec`() {
+        val addressSpec = AddressSpecFactory.create(
+            condensedForm = false,
+            config = null,
+            onNavigation = {}
+        )
+        assertThat(addressSpec.showLabel).isFalse()
+        assertThat(addressSpec.allowedCountryCodes).isNotEmpty()
+        val type = addressSpec.type as AddressType.ShippingExpanded
+        assertThat(type.googleApiKey).isNull()
+        assertThat(type.autocompleteCountries).isNull()
+        assertThat(type.phoneNumberState).isEqualTo(PhoneNumberState.OPTIONAL)
+    }
+
+    @Test
+    fun `config creates expanded addressSpec`() {
+        val addressSpec = AddressSpecFactory.create(
+            condensedForm = false,
+            config = AddressLauncher.Configuration(
+                googlePlacesApiKey = "apiKey",
+                autocompleteCountries = setOf("US", "CA"),
+                additionalFields = AddressLauncher.AdditionalFieldsConfiguration(phone = required)
+            ),
+            onNavigation = {}
+        )
+        assertThat(addressSpec.showLabel).isFalse()
+        assertThat(addressSpec.allowedCountryCodes).isEmpty()
+        val type = addressSpec.type as AddressType.ShippingExpanded
+        assertThat(type.googleApiKey).isEqualTo("apiKey")
+        assertThat(type.autocompleteCountries).isEqualTo(setOf("US", "CA"))
+        assertThat(type.phoneNumberState).isEqualTo(PhoneNumberState.REQUIRED)
+    }
+
+    @Test
+    fun `onNavigation is used in address spec`() {
+        var navigationCounter = 0
+        val onNavigation: () -> Unit = {
+            navigationCounter++
+        }
+        val addressSpec = AddressSpecFactory.create(
+            condensedForm = false,
+            config = null,
+            onNavigation = onNavigation
+        )
+        val type = addressSpec.type as AddressType.ShippingExpanded
+        assertThat(navigationCounter).isEqualTo(0)
+        type.onNavigation()
+        assertThat(navigationCounter).isEqualTo(1)
+    }
+
+    @Test
+    fun `parsePhoneNumberConfig HIDDEN`() {
+        val config = AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.HIDDEN
+        assertThat(AddressSpecFactory.parsePhoneNumberConfig(config))
+            .isEqualTo(PhoneNumberState.HIDDEN)
+    }
+
+    @Test
+    fun `parsePhoneNumberConfig OPTIONAL`() {
+        val config = AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.OPTIONAL
+        assertThat(AddressSpecFactory.parsePhoneNumberConfig(config))
+            .isEqualTo(PhoneNumberState.OPTIONAL)
+    }
+
+    @Test
+    fun `parsePhoneNumberConfig REQUIRED`() {
+        val config = AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.REQUIRED
+        assertThat(AddressSpecFactory.parsePhoneNumberConfig(config))
+            .isEqualTo(PhoneNumberState.REQUIRED)
+    }
+
+    @Test
+    fun `parsePhoneNumberConfig null`() {
+        assertThat(AddressSpecFactory.parsePhoneNumberConfig(null))
+            .isEqualTo(PhoneNumberState.OPTIONAL)
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -98,7 +98,10 @@ class InputAddressViewModelTest {
         val viewModel = createViewModel()
         assertThat(viewModel.collectedAddress.value).isEqualTo(usAddress)
 
-        val expectedAddress = AddressDetails(name = "skyler", address = PaymentSheet.Address(country = "CAN", line1 = "foobar"))
+        val expectedAddress = AddressDetails(
+            name = "skyler",
+            address = PaymentSheet.Address(country = "CAN", line1 = "foobar")
+        )
         flow.tryEmit(expectedAddress)
         assertThat(viewModel.collectedAddress.value).isEqualTo(expectedAddress)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -90,6 +90,20 @@ class InputAddressViewModelTest {
     }
 
     @Test
+    fun `takes only fields in new address`() = runTest(UnconfinedTestDispatcher()) {
+        val usAddress = AddressDetails(name = "skyler", address = PaymentSheet.Address(country = "US"))
+        val flow = MutableStateFlow<AddressDetails?>(usAddress)
+        whenever(navigator.getResultFlow<AddressDetails?>(any())).thenReturn(flow)
+
+        val viewModel = createViewModel()
+        assertThat(viewModel.collectedAddress.value).isEqualTo(usAddress)
+
+        val expectedAddress = AddressDetails(name = "skyler", address = PaymentSheet.Address(country = "CAN", line1 = "foobar"))
+        flow.tryEmit(expectedAddress)
+        assertThat(viewModel.collectedAddress.value).isEqualTo(expectedAddress)
+    }
+
+    @Test
     fun `default address from merchant is parsed`() = runTest(UnconfinedTestDispatcher()) {
         val expectedAddress = AddressDetails(name = "skyler", address = PaymentSheet.Address(country = "US"))
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

[AutocompleteAffordanceDemo.webm](https://user-images.githubusercontent.com/116920913/206322037-006140f2-b9ef-4b7c-98db-19b1bfeb9807.webm)
<img width="307" alt="Screenshot 2022-12-07 at 5 56 28 PM" src="https://user-images.githubusercontent.com/116920913/206322834-7702709a-8e10-4928-822f-3ff285d4b2fa.png">
<img width="303" alt="Screenshot 2022-12-07 at 5 56 16 PM" src="https://user-images.githubusercontent.com/116920913/206322851-9ca0889e-c7cc-4820-8b7d-9e9295677540.png">


# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
* [Changed][5927](https://github.com/stripe/stripe-android/pull/5927) Customers can now re-enter the autocomplete flow of the Address Element by tapping an icon in the line 1 text field.
