### PR TITLE
Add `expand` argument to various methods on `Stripe`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## XX.XX.XX - 2022-XX-XX
 
 ### Payments
-* [ADDED][5938](https://github.com/stripe/stripe-android/pull/5938) Methods on `Stripe` for retrieving and confirming intents now accept an optional `expand` argument to expand fields in the response.
+* [CHANGED][5938](https://github.com/stripe/stripe-android/pull/5938) Methods on `Stripe` for retrieving and confirming intents now accept an optional `expand` argument to expand fields in the response.
 
 ### PaymentSheet
 * [FIXED][5910](https://github.com/stripe/stripe-android/pull/5910) PaymentSheet now fails gracefully when launched with invalid arguments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 2022-XX-XX
 
+### Payments
+* [ADDED][5938](https://github.com/stripe/stripe-android/pull/5938) Methods on `Stripe` for retrieving and confirming intents now accept an optional `expand` argument to expand fields in the response.
+
 ### PaymentSheet
 * [FIXED][5910](https://github.com/stripe/stripe-android/pull/5910) PaymentSheet now fails gracefully when launched with invalid arguments.
 

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -950,16 +950,20 @@ public final class com/stripe/android/Stripe {
 	public final fun onSetupResult (ILandroid/content/Intent;Lcom/stripe/android/ApiResultCallback;)Z
 	public final fun retrievePaymentIntent (Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
 	public final fun retrievePaymentIntent (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
-	public static synthetic fun retrievePaymentIntent$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;ILjava/lang/Object;)V
+	public final fun retrievePaymentIntent (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/stripe/android/ApiResultCallback;)V
+	public static synthetic fun retrievePaymentIntent$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/stripe/android/ApiResultCallback;ILjava/lang/Object;)V
 	public final fun retrievePaymentIntentSynchronous (Ljava/lang/String;)Lcom/stripe/android/model/PaymentIntent;
 	public final fun retrievePaymentIntentSynchronous (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PaymentIntent;
-	public static synthetic fun retrievePaymentIntentSynchronous$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentIntent;
+	public final fun retrievePaymentIntentSynchronous (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lcom/stripe/android/model/PaymentIntent;
+	public static synthetic fun retrievePaymentIntentSynchronous$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentIntent;
 	public final fun retrieveSetupIntent (Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
 	public final fun retrieveSetupIntent (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
-	public static synthetic fun retrieveSetupIntent$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;ILjava/lang/Object;)V
+	public final fun retrieveSetupIntent (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/stripe/android/ApiResultCallback;)V
+	public static synthetic fun retrieveSetupIntent$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/stripe/android/ApiResultCallback;ILjava/lang/Object;)V
 	public final fun retrieveSetupIntentSynchronous (Ljava/lang/String;)Lcom/stripe/android/model/SetupIntent;
 	public final fun retrieveSetupIntentSynchronous (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/SetupIntent;
-	public static synthetic fun retrieveSetupIntentSynchronous$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/SetupIntent;
+	public final fun retrieveSetupIntentSynchronous (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lcom/stripe/android/model/SetupIntent;
+	public static synthetic fun retrieveSetupIntentSynchronous$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lcom/stripe/android/model/SetupIntent;
 	public final fun retrieveSource (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
 	public final fun retrieveSource (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
 	public static synthetic fun retrieveSource$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;ILjava/lang/Object;)V
@@ -1017,8 +1021,8 @@ public final class com/stripe/android/StripeKtxKt {
 	public static synthetic fun confirmAlipayPayment$default (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/ConfirmPaymentIntentParams;Lcom/stripe/android/AlipayAuthenticator;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun confirmPaymentIntent (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/ConfirmPaymentIntentParams;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun confirmPaymentIntent$default (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/ConfirmPaymentIntentParams;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static final fun confirmSetupIntent (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/ConfirmSetupIntentParams;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun confirmSetupIntent$default (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/ConfirmSetupIntentParams;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun confirmSetupIntent (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/ConfirmSetupIntentParams;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun confirmSetupIntent$default (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/ConfirmSetupIntentParams;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun confirmWeChatPayPayment (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/ConfirmPaymentIntentParams;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun confirmWeChatPayPayment$default (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/ConfirmPaymentIntentParams;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun createAccountToken (Lcom/stripe/android/Stripe;Lcom/stripe/android/model/AccountParams;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -1043,10 +1047,10 @@ public final class com/stripe/android/StripeKtxKt {
 	public static final fun getAuthenticateSourceResult (Lcom/stripe/android/Stripe;ILandroid/content/Intent;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun getPaymentIntentResult (Lcom/stripe/android/Stripe;ILandroid/content/Intent;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun getSetupIntentResult (Lcom/stripe/android/Stripe;ILandroid/content/Intent;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun retrievePaymentIntent (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun retrievePaymentIntent$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static final fun retrieveSetupIntent (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun retrieveSetupIntent$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun retrievePaymentIntent (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun retrievePaymentIntent$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun retrieveSetupIntent (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun retrieveSetupIntent$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun retrieveSource (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun retrieveSource$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun verifyPaymentIntentWithMicrodeposits (Lcom/stripe/android/Stripe;Ljava/lang/String;IILkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/payments-core/src/main/java/com/stripe/android/Stripe.kt
+++ b/payments-core/src/main/java/com/stripe/android/Stripe.kt
@@ -401,6 +401,7 @@ class Stripe internal constructor(
      * @param clientSecret the client_secret with which to retrieve the [PaymentIntent]
      * @param stripeAccountId Optional, the Connect account to associate with this request.
      * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
+     * @param expand Optional, a list of keys to expand on the returned `PaymentIntent` object.
      * @param callback a [ApiResultCallback] to receive the result or error
      */
     @UiThread
@@ -408,6 +409,7 @@ class Stripe internal constructor(
     fun retrievePaymentIntent(
         clientSecret: String,
         stripeAccountId: String? = this.stripeAccountId,
+        expand: List<String> = emptyList(),
         callback: ApiResultCallback<PaymentIntent>
     ) {
         executeAsync(callback) {
@@ -416,7 +418,8 @@ class Stripe internal constructor(
                 ApiRequest.Options(
                     apiKey = publishableKey,
                     stripeAccount = stripeAccountId
-                )
+                ),
+                expand,
             )
         }
     }
@@ -431,6 +434,7 @@ class Stripe internal constructor(
      * @param clientSecret the client_secret with which to retrieve the [PaymentIntent]
      * @param stripeAccountId Optional, the Connect account to associate with this request.
      * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
+     * @param expand Optional, a list of keys to expand on the returned `PaymentIntent` object.
      * @return a [PaymentIntent] or `null` if a problem occurred
      */
     @Throws(
@@ -443,7 +447,8 @@ class Stripe internal constructor(
     @JvmOverloads
     fun retrievePaymentIntentSynchronous(
         clientSecret: String,
-        stripeAccountId: String? = this.stripeAccountId
+        stripeAccountId: String? = this.stripeAccountId,
+        expand: List<String> = emptyList(),
     ): PaymentIntent? {
         return runBlocking {
             stripeRepository.retrievePaymentIntent(
@@ -451,7 +456,8 @@ class Stripe internal constructor(
                 ApiRequest.Options(
                     apiKey = publishableKey,
                     stripeAccount = stripeAccountId
-                )
+                ),
+                expand,
             )
         }
     }
@@ -517,6 +523,7 @@ class Stripe internal constructor(
      * | Custom return_url | WebView                | WebView           | WebView  |
      *
      * @param activity the `Activity` that is launching the payment authentication flow
+     * @param confirmSetupIntentParams a set of params with which to confirm the Setup Intent
      * @param stripeAccountId Optional, the Connect account to associate with this request.
      * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      */
@@ -558,6 +565,7 @@ class Stripe internal constructor(
      * | Custom return_url | WebView                | WebView           | WebView  |
      *
      * @param fragment the `Fragment` that is launching the payment authentication flow
+     * @param confirmSetupIntentParams a set of params with which to confirm the Setup Intent
      * @param stripeAccountId Optional, the Connect account to associate with this request.
      * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
      */
@@ -683,6 +691,7 @@ class Stripe internal constructor(
      * @param clientSecret the client_secret with which to retrieve the [SetupIntent]
      * @param stripeAccountId Optional, the Connect account to associate with this request.
      * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
+     * @param expand Optional, a list of keys to expand on the returned `SetupIntent` object.
      * @param callback a [ApiResultCallback] to receive the result or error
      */
     @Throws(
@@ -696,6 +705,7 @@ class Stripe internal constructor(
     fun retrieveSetupIntent(
         clientSecret: String,
         stripeAccountId: String? = this.stripeAccountId,
+        expand: List<String> = emptyList(),
         callback: ApiResultCallback<SetupIntent>
     ) {
         executeAsync(callback) {
@@ -704,7 +714,8 @@ class Stripe internal constructor(
                 ApiRequest.Options(
                     apiKey = publishableKey,
                     stripeAccount = stripeAccountId
-                )
+                ),
+                expand,
             )
         }
     }
@@ -719,6 +730,7 @@ class Stripe internal constructor(
      * @param clientSecret client_secret of the [SetupIntent] to retrieve
      * @param stripeAccountId Optional, the Connect account to associate with this request.
      * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
+     * @param expand Optional, a list of keys to expand on the returned `SetupIntent` object.
      * @return a [SetupIntent] or `null` if a problem occurred
      */
     @Throws(
@@ -731,7 +743,8 @@ class Stripe internal constructor(
     @JvmOverloads
     fun retrieveSetupIntentSynchronous(
         clientSecret: String,
-        stripeAccountId: String? = this.stripeAccountId
+        stripeAccountId: String? = this.stripeAccountId,
+        expand: List<String> = emptyList(),
     ): SetupIntent? {
         return runBlocking {
             stripeRepository.retrieveSetupIntent(
@@ -739,7 +752,8 @@ class Stripe internal constructor(
                 ApiRequest.Options(
                     apiKey = publishableKey,
                     stripeAccount = stripeAccountId
-                )
+                ),
+                expand,
             )
         }
     }

--- a/payments-core/src/main/java/com/stripe/android/StripeKtx.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripeKtx.kt
@@ -461,6 +461,7 @@ suspend fun Stripe.createRadarSession(): RadarSession {
  * @param clientSecret the client_secret with which to retrieve the [PaymentIntent]
  * @param stripeAccountId Optional, the Connect account to associate with this request.
  * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
+ * @param expand Optional, a list of keys to expand on the returned `PaymentIntent` object.
  *
  * @return a [PaymentIntent] object
  *
@@ -477,14 +478,16 @@ suspend fun Stripe.createRadarSession(): RadarSession {
 )
 suspend fun Stripe.retrievePaymentIntent(
     clientSecret: String,
-    stripeAccountId: String? = this.stripeAccountId
+    stripeAccountId: String? = this.stripeAccountId,
+    expand: List<String> = emptyList(),
 ): PaymentIntent = runApiRequest {
     stripeRepository.retrievePaymentIntent(
         clientSecret,
         ApiRequest.Options(
             apiKey = publishableKey,
             stripeAccount = stripeAccountId
-        )
+        ),
+        expand,
     )
 }
 
@@ -497,6 +500,7 @@ suspend fun Stripe.retrievePaymentIntent(
  * @param clientSecret the client_secret with which to retrieve the [SetupIntent]
  * @param stripeAccountId Optional, the Connect account to associate with this request.
  * By default, will use the Connect account that was used to instantiate the `Stripe` object, if specified.
+ * @param expand Optional, a list of keys to expand on the returned `SetupIntent` object.
  *
  * @return a [SetupIntent] object
  *
@@ -513,14 +517,16 @@ suspend fun Stripe.retrievePaymentIntent(
 )
 suspend fun Stripe.retrieveSetupIntent(
     clientSecret: String,
-    stripeAccountId: String? = this.stripeAccountId
+    stripeAccountId: String? = this.stripeAccountId,
+    expand: List<String> = emptyList(),
 ): SetupIntent = runApiRequest {
     stripeRepository.retrieveSetupIntent(
         clientSecret,
         ApiRequest.Options(
             apiKey = publishableKey,
             stripeAccount = stripeAccountId
-        )
+        ),
+        expand,
     )
 }
 
@@ -571,6 +577,7 @@ suspend fun Stripe.retrieveSource(
  *
  * @param confirmSetupIntentParams a set of params with which to confirm the Setup Intent
  * @param idempotencyKey optional, see [Idempotent Requests](https://stripe.com/docs/api/idempotent_requests)
+ * @param expand Optional, a list of keys to expand on the returned `SetupIntent` object.
  *
  * @return a [SetupIntent] object
  *
@@ -587,7 +594,8 @@ suspend fun Stripe.retrieveSource(
 )
 suspend fun Stripe.confirmSetupIntent(
     confirmSetupIntentParams: ConfirmSetupIntentParams,
-    idempotencyKey: String? = null
+    idempotencyKey: String? = null,
+    expand: List<String> = emptyList(),
 ): SetupIntent = runApiRequest {
     stripeRepository.confirmSetupIntent(
         confirmSetupIntentParams,
@@ -595,7 +603,8 @@ suspend fun Stripe.confirmSetupIntent(
             apiKey = publishableKey,
             stripeAccount = stripeAccountId,
             idempotencyKey = idempotencyKey
-        )
+        ),
+        expand,
     )
 }
 

--- a/payments-core/src/test/java/com/stripe/android/StripeKtxTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripeKtxTest.kt
@@ -14,13 +14,17 @@ import com.stripe.android.model.StripeParamsModel
 import com.stripe.android.model.WeChatPayNextAction
 import com.stripe.android.networking.StripeApiRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isA
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import kotlin.test.assertFailsWith
 import kotlin.test.assertSame
@@ -34,7 +38,7 @@ internal class StripeKtxTest {
     private val mockApiRepository: StripeApiRepository = mock()
     private val mockPaymentController: PaymentController = mock()
 
-    private val testDispatcher = StandardTestDispatcher()
+    private val testDispatcher = UnconfinedTestDispatcher()
 
     private val stripe: Stripe =
         Stripe(
@@ -559,6 +563,125 @@ internal class StripeKtxTest {
                 )
             }
         }
+
+    @Test
+    fun `Verify retrievePaymentIntent passes expand fields on to repository`(): Unit = runTest {
+        whenever(mockApiRepository.retrievePaymentIntent(isA(), isA(), isA())).doReturn(mock())
+
+        val expandFields = listOf("payment_method")
+
+        stripe.retrievePaymentIntent(
+            clientSecret = "clientSecret",
+            expand = expandFields,
+        )
+
+        verify(mockApiRepository).retrievePaymentIntent(
+            clientSecret = eq("clientSecret"),
+            options = isA(),
+            expandFields = eq(expandFields),
+        )
+    }
+
+    @Test
+    fun `Verify retrieveSetupIntent passes expand fields on to repository`(): Unit = runTest {
+        whenever(mockApiRepository.retrieveSetupIntent(isA(), isA(), isA())).doReturn(mock())
+        val expandFields = listOf("payment_method")
+
+        stripe.retrieveSetupIntent(
+            clientSecret = "clientSecret",
+            expand = expandFields,
+        )
+
+        verify(mockApiRepository).retrieveSetupIntent(
+            clientSecret = isA(),
+            options = isA(),
+            expandFields = eq(expandFields),
+        )
+    }
+
+    @Test
+    fun `Verify confirmSetupIntent passes expand fields on to repository`(): Unit = runTest {
+        whenever(mockApiRepository.confirmSetupIntent(isA(), isA(), isA())).doReturn(mock())
+
+        val expandFields = listOf("payment_method")
+
+        stripe.confirmSetupIntent(
+            confirmSetupIntentParams = mock(),
+            expand = expandFields,
+        )
+
+        verify(mockApiRepository).confirmSetupIntent(
+            confirmSetupIntentParams = isA(),
+            options = isA(),
+            expandFields = eq(expandFields),
+        )
+    }
+
+    @Test
+    fun `Verify retrievePaymentIntent with callback passes expand fields on to repository`() = runTest {
+        val expandFields = listOf("payment_method")
+
+        stripe.retrievePaymentIntent(
+            clientSecret = "pi_123_secret_123",
+            expand = expandFields,
+            callback = mock(),
+        )
+
+        verify(mockApiRepository).retrievePaymentIntent(
+            clientSecret = eq("pi_123_secret_123"),
+            options = isA(),
+            expandFields = eq(expandFields),
+        )
+    }
+
+    @Test
+    fun `Verify retrievePaymentIntentSynchronous passes expand fields on to repository`() = runTest {
+        val expandFields = listOf("payment_method")
+
+        stripe.retrievePaymentIntentSynchronous(
+            clientSecret = "pi_123_secret_123",
+            expand = expandFields,
+        )
+
+        verify(mockApiRepository).retrievePaymentIntent(
+            clientSecret = eq("pi_123_secret_123"),
+            options = isA(),
+            expandFields = eq(expandFields),
+        )
+    }
+
+    @Test
+    fun `Verify retrieveSetupIntent with callback passes expand fields on to repository`() = runTest {
+        val expandFields = listOf("payment_method")
+
+        stripe.retrieveSetupIntent(
+            clientSecret = "seti_123_secret_123",
+            expand = expandFields,
+            callback = mock(),
+        )
+
+        verify(mockApiRepository).retrieveSetupIntent(
+            clientSecret = eq("seti_123_secret_123"),
+            options = isA(),
+            expandFields = eq(expandFields),
+        )
+    }
+
+    @Test
+    fun `Verify retrieveSetupIntentSynchronous passes expand fields on to repository`() = runTest {
+        val expandFields = listOf("payment_method")
+
+        stripe.retrieveSetupIntentSynchronous(
+            clientSecret = "seti_123_secret_123",
+            expand = expandFields,
+        )
+
+        verify(mockApiRepository).retrieveSetupIntent(
+            clientSecret = eq("seti_123_secret_123"),
+            options = isA(),
+            expandFields = eq(expandFields),
+        )
+    }
 
     private inline fun <reified ApiObject : StripeModel, reified CreateAPIParam : StripeParamsModel, reified RepositoryParam : StripeParamsModel>
     `Given repository returns non-empty value when calling createAPI then returns correct result`(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds an `expand` argument to various methods on `Stripe`, defaulting to an empty list.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

RUN_MOBILESDK-1115

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
N/A

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
~[ADDED]~ [CHANGED] Methods on `Stripe` for retrieving and confirming intents now accept an optional `expand` argument to expand fields in the response.
