### PR TITLE
Point to a standard license URL in POM

### DIFF
--- a/deploy/deploy.gradle
+++ b/deploy/deploy.gradle
@@ -66,9 +66,8 @@ afterEvaluate { project ->
 
                     licenses {
                         license {
-                            name = "The MIT License"
-                            url = "https://raw.githubusercontent.com/stripe/stripe-android/master/LICENSE"
-                            distribution = "repo"
+                            name = "MIT License"
+                            url = "https://opensource.org/licenses/MIT"
                         }
                     }
 


### PR DESCRIPTION
# Summary

- Replicating https://github.com/stripe/stripe-android/pull/5852 (CC @eric-labelle)