### PR TITLE
Fix build issue in `PaymentMethodsUITest`

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentMethodsUITest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentMethodsUITest.kt
@@ -18,6 +18,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ui.core.forms.resources.LpmRepository
+import com.stripe.android.uicore.image.StripeImageLoader
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Ignore
 import org.junit.Rule
@@ -54,7 +55,8 @@ internal class PaymentMethodsUITest {
                 ),
                 selectedIndex = 0,
                 isEnabled = true,
-                onItemSelectedListener = {}
+                imageLoader = StripeImageLoader(composeTestRule.activity.applicationContext),
+                onItemSelectedListener = {},
             )
         }
 
@@ -79,7 +81,8 @@ internal class PaymentMethodsUITest {
                 ),
                 selectedIndex = 4,
                 isEnabled = true,
-                onItemSelectedListener = {}
+                imageLoader = StripeImageLoader(composeTestRule.activity.applicationContext),
+                onItemSelectedListener = {},
             )
         }
 
@@ -107,7 +110,8 @@ internal class PaymentMethodsUITest {
                 ),
                 selectedIndex = 0,
                 isEnabled = enabled,
-                onItemSelectedListener = {}
+                imageLoader = StripeImageLoader(composeTestRule.activity.applicationContext),
+                onItemSelectedListener = {},
             )
         }
 
@@ -132,7 +136,8 @@ internal class PaymentMethodsUITest {
                 ),
                 selectedIndex = 0,
                 isEnabled = enabled,
-                onItemSelectedListener = {}
+                imageLoader = StripeImageLoader(composeTestRule.activity.applicationContext),
+                onItemSelectedListener = {},
             )
         }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes the build issue in `PaymentMethodsUITest`, which was missing a `StripeImageLoader` in its method calls.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
N/A

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A
