### PR TITLE
[Maestro] Retries end-to-end in Financial Connections before reporting

### DIFF
--- a/.github/workflows/financialconnections_nightly.yaml
+++ b/.github/workflows/financialconnections_nightly.yaml
@@ -90,6 +90,22 @@ jobs:
         env:
           STRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL: ${{ secrets.STRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL }}
 
+      - name: Run Tests (try 3)
+        id: run-tests-3
+        if: steps.run-tests-2.outcome == 'failure'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          arch: ${{ matrix.arch }}
+          profile: ${{ matrix.profile }}
+          target: ${{ matrix.target }}
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: bash scripts/execute_maestro_tests.sh
+        env:
+          STRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL: ${{ secrets.STRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL }}
+
       - name: Publish Test Report
         id: publish_test_report
         uses: mikepenz/action-junit-report@v3

--- a/.github/workflows/financialconnections_nightly.yaml
+++ b/.github/workflows/financialconnections_nightly.yaml
@@ -2,6 +2,8 @@ name: financial-connections-nightly
 on:
   # Can be executed manually.
   workflow_dispatch:
+  # DELETE
+  pull_request:
   # Execute hourly.
   schedule:
     - cron: '0 * * * *'
@@ -56,8 +58,25 @@ jobs:
       - name: Add Maestro to path
         run: echo "${HOME}/.maestro/bin" >> $GITHUB_PATH
 
-      - name: Run Tests
-        id: run-tests
+      - name: Run Tests (try 1)
+        id: run-tests-1
+        continue-on-error: true
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ matrix.api-level }}
+          arch: ${{ matrix.arch }}
+          profile: ${{ matrix.profile }}
+          target: ${{ matrix.target }}
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: bash scripts/execute_maestro_tests.sh
+        env:
+          STRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL: ${{ secrets.STRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL }}
+
+      - name: Run Tests (try 2)
+        id: run-tests-2
+        if: steps.run-tests-1.outcome == 'failure'
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
@@ -78,14 +97,6 @@ jobs:
         with:
           detailed_summary: true
           report_paths: 'report.xml'
-
-      - name: Archive maestro screenshots
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: maestro-screenshots
-          path: |
-            *.png    
 
       - name: Upload Reports
         if: always()

--- a/.github/workflows/financialconnections_nightly.yaml
+++ b/.github/workflows/financialconnections_nightly.yaml
@@ -2,8 +2,6 @@ name: financial-connections-nightly
 on:
   # Can be executed manually.
   workflow_dispatch:
-  # DELETE
-  pull_request:
   # Execute hourly.
   schedule:
     - cron: '0 * * * *'

--- a/scripts/execute_maestro_tests.sh
+++ b/scripts/execute_maestro_tests.sh
@@ -2,6 +2,8 @@
 
 reports_path="financial-connections-example/build/reports"
 logs_file_path="$reports_path/emulator.log"
+now=$(date +%F_%H-%M-%S)
+echo $now
 
 # Uninstall existing app on cached AVD.
 adb uninstall com.stripe.android.financialconnections.example || true
@@ -18,7 +20,7 @@ chmod 777 $logs_file_path
 ./gradlew -PSTRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL=$STRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL :financial-connections-example:installDebug
 
 # Start screen record (adb screenrecord has a 3 min limit, for now take consequent recordings.
-adb shell "screenrecord /sdcard/rec-1.mp4; screenrecord /sdcard/rec-2.mp4; screenrecord /sdcard/rec-3.mp4; screenrecord /sdcard/rec-4.mp4" &
+adb shell "screenrecord /sdcard/$now-1.mp4; screenrecord /sdcard/$now-2.mp4; screenrecord /sdcard/$now-3.mp4; screenrecord /sdcard/$now-4.mp4" &
 childpid=$!
 
 # Clear and start collecting logs
@@ -31,9 +33,9 @@ result=$?
 kill "$childpid"
 wait "$childpid"
 cd $reports_path/
-adb pull /sdcard/rec-1.mp4 || true
-adb pull /sdcard/rec-2.mp4 || true
-adb pull /sdcard/rec-3.mp4 || true
-adb pull /sdcard/rec-4.mp4 || true
+adb pull "/sdcard/$now-1.mp4" || true
+adb pull "/sdcard/$now-2.mp4" || true
+adb pull "/sdcard/$now-3.mp4" || true
+adb pull "/sdcard/$now-4.mp4" || true
 
 exit "$result"


### PR DESCRIPTION
# Summary
- Issue: emulators are not extremely reliable, causing sporadic false negatives on end-to-end test runs.
- See some examples of instability: https://github.com/stripe/stripe-android/actions/workflows/financialconnections_nightly.yaml
- Solution: Retries running the tests 2 times before actually notifying team about failures.

<img width="220" alt="image" src="https://user-images.githubusercontent.com/99293320/208213225-96764669-3d31-47d3-aac2-ae3bcf5bb9cb.png">
