### PR TITLE
Fix an issue where updating payment methods wasn't updating the submit action behavior.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
@@ -212,6 +212,7 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
                 PaymentMethodForm(
                     args = formArguments,
                     enabled = enabled,
+                    selectedItem = selectedItem,
                     onFormFieldValuesChanged = onFormFieldValuesChanged,
                     showCheckboxFlow = showCheckboxFlow,
                     injector = sheetViewModel.injector,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
@@ -212,7 +212,6 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
                 PaymentMethodForm(
                     args = formArguments,
                     enabled = enabled,
-                    selectedItem = selectedItem,
                     onFormFieldValuesChanged = onFormFieldValuesChanged,
                     showCheckboxFlow = showCheckboxFlow,
                     injector = sheetViewModel.injector,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodForm.kt
@@ -11,6 +11,7 @@ import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
 import com.stripe.android.ui.core.FormUI
+import com.stripe.android.ui.core.forms.resources.LpmRepository
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 
@@ -18,11 +19,12 @@ import kotlinx.coroutines.flow.Flow
 @Composable
 internal fun PaymentMethodForm(
     args: FormFragmentArguments,
+    selectedItem: LpmRepository.SupportedPaymentMethod,
     enabled: Boolean,
     onFormFieldValuesChanged: (FormFieldValues?) -> Unit,
     showCheckboxFlow: Flow<Boolean>,
     injector: NonFallbackInjector,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val formViewModel: FormViewModel = viewModel(
         key = args.paymentMethodCode,
@@ -35,7 +37,7 @@ internal fun PaymentMethodForm(
 
     val formValues by formViewModel.completeFormValues.collectAsState(null)
 
-    LaunchedEffect(formValues) {
+    LaunchedEffect(selectedItem, formValues) {
         onFormFieldValuesChanged(formValues)
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodForm.kt
@@ -11,7 +11,6 @@ import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
 import com.stripe.android.ui.core.FormUI
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 
@@ -19,7 +18,6 @@ import kotlinx.coroutines.flow.Flow
 @Composable
 internal fun PaymentMethodForm(
     args: FormFragmentArguments,
-    selectedItem: LpmRepository.SupportedPaymentMethod,
     enabled: Boolean,
     onFormFieldValuesChanged: (FormFieldValues?) -> Unit,
     showCheckboxFlow: Flow<Boolean>,
@@ -37,7 +35,7 @@ internal fun PaymentMethodForm(
 
     val formValues by formViewModel.completeFormValues.collectAsState(null)
 
-    LaunchedEffect(selectedItem, formValues) {
+    LaunchedEffect(args.paymentMethodCode, formValues) {
         onFormFieldValuesChanged(formValues)
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodForm.kt
@@ -22,7 +22,7 @@ internal fun PaymentMethodForm(
     onFormFieldValuesChanged: (FormFieldValues?) -> Unit,
     showCheckboxFlow: Flow<Boolean>,
     injector: NonFallbackInjector,
-    modifier: Modifier = Modifier,
+    modifier: Modifier = Modifier
 ) {
     val formViewModel: FormViewModel = viewModel(
         key = args.paymentMethodCode,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Till found a bug where switching PMs between paypal and revolutpay wouldn't update the submit action (it would take you to paypal instead of revolut pay, even when revolut pay was selected)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
