### PR TITLE
Update failure notification script to accept dynamic JIRA projects


### DIFF
--- a/.github/workflows/end_to_end_tests.yml
+++ b/.github/workflows/end_to_end_tests.yml
@@ -36,4 +36,9 @@ jobs:
       - name: Notify failure endpoint
         id: notifyFailureEndpoint
         if: failure()
-        run: ./scripts/notify_failure_enpiont.rb ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT }} ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT_HMAC_KEY }} ${{ github.run_id }}
+        run: |
+          ./scripts/notify_failure_endpoint.rb \
+          ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT }} \
+          ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT_HMAC_KEY }} \
+          ${{ github.run_id }} \
+          RUN_MOBILESDK

--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -35,7 +35,12 @@ jobs:
       - name: Notify failure endpoint
         id: notifyFailureEndpoint
         if: failure()
-        run: ./scripts/notify_failure_enpiont.rb ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT }} ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT_HMAC_KEY }} ${{ github.run_id }}
+        run: |
+          ./scripts/notify_failure_endpoint.rb \
+          ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT }} \
+          ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT_HMAC_KEY }} \
+          ${{ github.run_id }} \
+          RUN_MOBILESDK
 
   # This should be updated to use the browserstack github actions when supported
   browserstack-instrumentation-tests:
@@ -73,7 +78,7 @@ jobs:
       - name: Notify failure endpoint
         id: notifyFailureEndpoint
         if: failure()
-        run: ./scripts/notify_failure_enpiont.rb ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT }} ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT_HMAC_KEY }} ${{ github.run_id }}
+        run: ./scripts/notify_failure_endpoint.rb ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT }} ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT_HMAC_KEY }} ${{ github.run_id }}
 
   screenshot-regression-tests:
     runs-on: macos-latest
@@ -121,4 +126,4 @@ jobs:
 #       - name: Notify failure endpoint
 #         id: notifyFailureEndpoint
 #         if: failure()
-#         run: ./scripts/notify_failure_enpiont.rb ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT }} ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT_HMAC_KEY }} ${{ github.run_id }}
+#         run: ./scripts/notify_failure_endpoint.rb ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT }} ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT_HMAC_KEY }} ${{ github.run_id }}

--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -78,7 +78,12 @@ jobs:
       - name: Notify failure endpoint
         id: notifyFailureEndpoint
         if: failure()
-        run: ./scripts/notify_failure_endpoint.rb ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT }} ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT_HMAC_KEY }} ${{ github.run_id }}
+        run: |
+          ./scripts/notify_failure_endpoint.rb \
+          ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT }} \
+          ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT_HMAC_KEY }} \
+          ${{ github.run_id }} \
+          RUN_MOBILESDK
 
   screenshot-regression-tests:
     runs-on: macos-latest
@@ -126,4 +131,9 @@ jobs:
 #       - name: Notify failure endpoint
 #         id: notifyFailureEndpoint
 #         if: failure()
-#         run: ./scripts/notify_failure_endpoint.rb ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT }} ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT_HMAC_KEY }} ${{ github.run_id }}
+#         run: |
+#           ./scripts/notify_failure_endpoint.rb \
+#           ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT }} \
+#           ${{ secrets.SDK_FAILURE_NOTIFICATION_ENDPOINT_HMAC_KEY }} \
+#           ${{ github.run_id }} \
+#           RUN_MOBILESDK

--- a/scripts/notify_failure_endpoint.rb
+++ b/scripts/notify_failure_endpoint.rb
@@ -8,14 +8,21 @@ require 'base64'
 env_sdk_failure_notif_endpoint = ARGV[0]
 env_sdk_failure_notif_endpoint_hmac_key = ARGV[1]
 github_run_id = ARGV[2]
+jira_project = ARGV[3]
+
 
 if !env_sdk_failure_notif_endpoint || !env_sdk_failure_notif_endpoint_hmac_key
-  puts "Three environment variables required: `SDK_FAILURE_NOTIFICATION_ENDPOINT` and `SDK_FAILURE_NOTIFICATION_ENDPOINT_HMAC_KEY`"
+  puts "SDK_FAILURE_NOTIFICATION_ENDPOINT` or `SDK_FAILURE_NOTIFICATION_ENDPOINT_HMAC_KEY` not found"
   exit 102
 end
 
 if !github_run_id
   puts "github_run_id not found"
+  exit 102
+end
+
+if !jira_project
+  puts "jira_project not found"
   exit 102
 end
 
@@ -28,7 +35,7 @@ end
 req = Net::HTTP::Post.new(uri, 'Content-Type' => 'application/json')
 
 params = {
-  project: "RUN_MOBILESDK",
+  project: jira_project,
 }
 
 params[:summary] = "stripe-android E2E test failed"


### PR DESCRIPTION
# Summary
- Exposes project as a command parameter so that we can notify different JIRA projects depending on the SDK failing. 

# Motivation
:notebook_with_decorative_cover: &nbsp;**Update failure notification script to accept dynamic JIRA projects**
:globe_with_meridians: &nbsp;[BANKCON-5914](https://jira.corp.stripe.com/browse/BANKCON-5914)
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->