### PR TITLE
[Financial Connections] Adds continue-on-error on retry runs

### DIFF
--- a/.github/workflows/financialconnections_nightly.yaml
+++ b/.github/workflows/financialconnections_nightly.yaml
@@ -74,6 +74,7 @@ jobs:
 
       - name: Run Tests (try 2)
         id: run-tests-2
+        continue-on-error: true
         if: steps.run-tests-1.outcome == 'failure'
         uses: reactivecircus/android-emulator-runner@v2
         with:


### PR DESCRIPTION
# Summary
- Adds continue-on-error on retry runs to avoid failures cancelling the rest of the execution
- Example failure: https://github.com/stripe/stripe-android/actions/runs/3742144614
