### PR TITLE
[Maestro] Use default emulator target and clean-up flows.

### DIFF
--- a/.github/workflows/financialconnections_nightly.yaml
+++ b/.github/workflows/financialconnections_nightly.yaml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         api-level: [ 28 ]
         arch: [ x86_64 ]
-        target: [ playstore ]
+        target: [ default ]
         profile: [ Nexus 6 ]
     steps:
       - name: Checkout

--- a/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
+++ b/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
@@ -1,11 +1,8 @@
 appId: com.stripe.android.financialconnections.example
 ---
 - launchApp
-# Android specific: Navigate to example (1)
+# Android specific: Navigate to example
 - tapOn: "Playground"
-
-# Android specific: Navigate to example (2)
-- takeScreenshot: TestOAuth_ExampleAppLauncher
 - tapOn:
     id: "Native_checkbox"
 - tapOn:
@@ -13,28 +10,20 @@ appId: com.stripe.android.financialconnections.example
 - tapOn:
     id: "Data_checkbox"
 - tapOn: "Connect Accounts!"
-
 # Common: web AuthFlow - connect OAuth institution
 - extendedWaitUntil:
     visible: "Agree"
     timeout: 30000
-- takeScreenshot: TestOAuth_Consent
 - tapOn: "Agree"
 - assertVisible: "Test OAuth Institution"
-- takeScreenshot: TestOAuth_BankPicker
 # ERRORS
 - tapOn: ".*unknown error.*"
 - assertVisible: "Something went wrong"
-- takeScreenshot: TestOAuth_ErrorDownBankUnknown
 - back
 - tapOn: ".*unscheduled.*"
-- assertVisible: "Select another bank"
-- takeScreenshot: TestOAuth_ErrorDownBankUnscheduled
 - tapOn: "Select another bank"
 # SELECT OAUTH INSTITUTION
 - tapOn: "Test OAuth Institution"
-- assertVisible: "Continue"
-- takeScreenshot: TestOAuth_Prepane
 - tapOn: "Continue"
 ####### Bypass Chrome on-boarding screen #######
 - runFlow:
@@ -46,13 +35,10 @@ appId: com.stripe.android.financialconnections.example
 - extendedWaitUntil:
     visible: "Select all accounts"
     timeout: 60000
-- takeScreenshot: TestOAuth_AccountPicker
 - tapOn: "Select all accounts" # select all accounts
-- takeScreenshot: TestOAuth_AccountPicker_AllAccounts
 - tapOn: "Link accounts"
 # CONFIRM AND COMPLETE
 - assertVisible: "Link another account"
-- takeScreenshot: TestOAuth_Success
 - tapOn: "Done"
 - assertVisible: ".*Completed!.*"
 - assertVisible: ".*StripeBank.*"

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
@@ -1,22 +1,20 @@
 appId: com.stripe.android.financialconnections.example
 ---
 - launchApp
-# Android specific: Navigate to example (1)
+# Android specific: Navigate to example
 - tapOn: "Playground"
-# Android specific: Navigate to example (2)
 - tapOn:
     id: "Native_checkbox"
 - tapOn:
     id: "Test_checkbox"
 - tapOn:
-    id: "Data_checkbox"
+    id: "PaymentIntent_checkbox"
 - tapOn: "Connect Accounts!"
 # Common: web AuthFlow - connect OAuth institution
 - extendedWaitUntil:
     visible: "Agree"
     timeout: 30000
 - tapOn: "Agree"
-- assertVisible: "Test OAuth Institution"
 # SELECT LEGACY INSTITUTION
 - tapOn: "Test Institution"
 ####### Bypass Chrome on-boarding screen #######
@@ -27,12 +25,10 @@ appId: com.stripe.android.financialconnections.example
 ###############################################
 # SELECT ALL ACCOUNTS
 - extendedWaitUntil:
-    visible: "Select all accounts"
+    visible: "Success"
     timeout: 60000
-- tapOn: "Select all accounts" # select all accounts
-- tapOn: "Link accounts"
+- tapOn: "Success" # select all accounts
+- tapOn: "Confirm"
 # CONFIRM AND COMPLETE
-- assertVisible: "Link another account"
 - tapOn: "Done"
-- assertVisible: ".*Completed!.*"
-- assertVisible: ".*StripeBank.*"
+- assertVisible: ".*Intent Confirmed!.*"

--- a/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
+++ b/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
@@ -1,11 +1,8 @@
 appId: com.stripe.android.financialconnections.example
 ---
 - launchApp
-# Android specific: Navigate to example (1)
+# Android specific: Navigate to example
 - tapOn: "Playground"
-
-# Android specific: Navigate to example (2)
-- takeScreenshot: TestOAuth_ExampleAppLauncher
 - tapOn:
       id: "Native_checkbox"
 - tapOn:
@@ -13,35 +10,26 @@ appId: com.stripe.android.financialconnections.example
 - tapOn:
       id: "Token_checkbox"
 - tapOn: "Connect Accounts!"
-
-
 # Common: web AuthFlow - connect OAuth institution
 - extendedWaitUntil:
     visible: "Agree"
     timeout: 30000
-- assertVisible: "Enter account details manually instead"
-- takeScreenshot: ManualEntry_Consent
 - tapOn: "Enter account details manually instead"
 - assertVisible: "Enter bank account details"
-- takeScreenshot: ManualEntry_Input
 - tapOn:
     id: "RoutingInput"
 - inputText: "110000000"
-- takeScreenshot: ManualEntry_RoutingNumber
 - scroll
 - hideKeyboard
 - tapOn:
     id: "AccountInput"
 - inputText: "000123456789"
-- takeScreenshot: ManualEntry_AccountNumber
 - scroll
 - hideKeyboard
 - tapOn:
     id: "ConfirmAccountInput"
 - inputText: "000123456789"
 - hideKeyboard
-- takeScreenshot: ManualEntry_ConfirmAccountNumber
 - tapOn: "Continue"
-- takeScreenshot: ManualEntry_Success
 - tapOn: "Done"
 - assertVisible: ".*Completed!.*"

--- a/maestro/financial-connections/testmode-legacy-institution.yaml
+++ b/maestro/financial-connections/testmode-legacy-institution.yaml
@@ -28,7 +28,7 @@ appId: com.stripe.android.financialconnections.example
 # SELECT ALL ACCOUNTS
 - extendedWaitUntil:
     visible: "Select all accounts"
-    timeout: 30000
+    timeout: 60000
 - tapOn: "Select all accounts" # select all accounts
 - tapOn: "Link accounts"
 # CONFIRM AND COMPLETE

--- a/maestro/financial-connections/testmode-legacy-institution.yaml
+++ b/maestro/financial-connections/testmode-legacy-institution.yaml
@@ -26,7 +26,9 @@ appId: com.stripe.android.financialconnections.example
       APP_ID: com.stripe.android.financialconnections.example
 ###############################################
 # SELECT ALL ACCOUNTS
-- assertVisible: "Select all accounts"
+- extendedWaitUntil:
+    visible: "Select all accounts"
+    timeout: 30000
 - tapOn: "Select all accounts" # select all accounts
 - tapOn: "Link accounts"
 # CONFIRM AND COMPLETE

--- a/maestro/financial-connections/testmode-oauth.yaml
+++ b/maestro/financial-connections/testmode-oauth.yaml
@@ -45,7 +45,7 @@ appId: com.stripe.android.financialconnections.example
 # SELECT ALL ACCOUNTS
 - extendedWaitUntil:
     visible: "Select all accounts"
-    timeout: 30000
+    timeout: 60000
 - takeScreenshot: TestOAuth_AccountPicker
 - tapOn: "Select all accounts" # select all accounts
 - takeScreenshot: TestOAuth_AccountPicker_AllAccounts

--- a/maestro/financial-connections/testmode-oauth.yaml
+++ b/maestro/financial-connections/testmode-oauth.yaml
@@ -43,7 +43,9 @@ appId: com.stripe.android.financialconnections.example
       APP_ID: com.stripe.android.financialconnections.example
 ###############################################
 # SELECT ALL ACCOUNTS
-- assertVisible: "Select all accounts"
+- extendedWaitUntil:
+    visible: "Select all accounts"
+    timeout: 30000
 - takeScreenshot: TestOAuth_AccountPicker
 - tapOn: "Select all accounts" # select all accounts
 - takeScreenshot: TestOAuth_AccountPicker_AllAccounts


### PR DESCRIPTION
# Summary
- playstore targeted emulator takes longer to initialize, freezes frequently and times out maestro drivers.
- changed to default (without Google APIs).
- Also removed screenshots (since we're already taking video)
- Renamed flow files to be more descriptive.