### PR TITLE
Move clearing of errors to view models

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -82,15 +82,14 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
             closeSheet(it)
         }
 
-        viewModel.error.observe(this) {
+        viewModel.error.observe(this) { error ->
             updateErrorMessage(
                 messageView,
-                BaseSheetViewModel.UserErrorMessage(it)
+                error?.let { BaseSheetViewModel.UserErrorMessage(it) }
             )
         }
 
         viewModel.transition.observeEvents(this) { transitionTarget ->
-            clearErrorMessages()
             onTransitionTarget(transitionTarget)
         }
 
@@ -99,7 +98,7 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
         }
 
         viewModel.selection.observe(this) {
-            clearErrorMessages()
+            viewModel.clearErrorMessages()
             resetPrimaryButtonState()
         }
 
@@ -133,7 +132,6 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
         viewBinding.continueButton.setLabel(label)
 
         viewBinding.continueButton.setOnClickListener {
-            clearErrorMessages()
             viewModel.onUserSelection()
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -76,9 +76,8 @@ internal class PaymentOptionsViewModel @Inject constructor(
     internal val _paymentOptionResult = MutableLiveData<PaymentOptionResult>()
     internal val paymentOptionResult: LiveData<PaymentOptionResult> = _paymentOptionResult
 
-    private val _error = MutableLiveData<String>()
-    internal val error: LiveData<String>
-        get() = _error
+    private val _error = MutableLiveData<String?>()
+    internal val error: LiveData<String?> = _error
 
     // Only used to determine if we should skip the list and go to the add card view.
     // and how to populate that view.
@@ -159,6 +158,8 @@ internal class PaymentOptionsViewModel @Inject constructor(
     }
 
     fun onUserSelection() {
+        clearErrorMessages()
+
         selection.value?.let { paymentSelection ->
             // TODO(michelleb-stripe): Should the payment selection in the event be the saved or new item?
             eventReporter.onSelectPaymentOption(paymentSelection)
@@ -248,6 +249,10 @@ internal class PaymentOptionsViewModel @Inject constructor(
                 )
             }
         }
+    }
+
+    override fun clearErrorMessages() {
+        _error.value = null
     }
 
     private fun processExistingPaymentMethod(paymentSelection: PaymentSelection) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -125,7 +125,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
         }
 
         viewModel.transition.observeEvents(this) { transitionTarget ->
-            clearErrorMessages()
             onTransitionTarget(transitionTarget)
         }
 
@@ -153,7 +152,7 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
         }
 
         viewModel.selection.observe(this) {
-            clearErrorMessages()
+            viewModel.clearErrorMessages()
             resetPrimaryButtonState()
         }
 
@@ -251,7 +250,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
         viewBinding.buyButton.setLabel(label)
 
         viewBinding.buyButton.setOnClickListener {
-            clearErrorMessages()
             viewModel.checkout(CheckoutIdentifier.SheetBottomBuy)
         }
     }
@@ -314,11 +312,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
                 updateErrorMessage(topMessage, viewState?.errorMessage)
                 googlePayButton.updateState(viewState?.convert())
             }
-    }
-
-    override fun clearErrorMessages() {
-        super.clearErrorMessages()
-        updateErrorMessage(topMessage)
     }
 
     override fun setActivityResult(result: PaymentSheetResult) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -249,7 +249,7 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
         viewBinding.buyButton.setLabel(label)
 
         viewBinding.buyButton.setOnClickListener {
-            viewModel.checkout(CheckoutIdentifier.SheetBottomBuy)
+            viewModel.checkout()
         }
     }
 
@@ -289,18 +289,8 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
 
     private fun setupGooglePayButton() {
         googlePayButton.setOnClickListener {
-            // TODO Don't go via PS
-//            viewModel.lastSelectedPaymentMethod = viewModel.selection.value
-//            viewModel.updateSelection(PaymentSelection.GooglePay)
-
             viewModel.checkoutWithGooglePay()
         }
-
-//        viewModel.selection.observe(this) { paymentSelection ->
-//            if (paymentSelection == PaymentSelection.GooglePay) {
-//                viewModel.checkout(CheckoutIdentifier.SheetTopGooglePay)
-//            }
-//        }
 
         viewModel.getButtonStateObservable(CheckoutIdentifier.SheetTopGooglePay)
             .observe(this) { viewState ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -294,11 +294,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
 
         viewModel.getButtonStateObservable(CheckoutIdentifier.SheetTopGooglePay)
             .observe(this) { viewState ->
-//                if (viewState is PaymentSheetViewState.Reset) {
-//                    // If Google Pay was cancelled or failed, re-select the form payment method
-//                    viewModel.updateSelection(viewModel.lastSelectedPaymentMethod)
-//                }
-
                 updateErrorMessage(topMessage, viewState?.errorMessage)
                 googlePayButton.updateState(viewState?.convert())
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -24,7 +24,6 @@ import com.google.android.material.appbar.MaterialToolbar
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContract
 import com.stripe.android.paymentsheet.PaymentSheetViewModel.CheckoutIdentifier
 import com.stripe.android.paymentsheet.databinding.ActivityPaymentSheetBinding
-import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
 import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.GooglePayDividerUi
@@ -290,24 +289,25 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
 
     private fun setupGooglePayButton() {
         googlePayButton.setOnClickListener {
-            // The scroll will be made visible onResume of the activity
-            viewModel.setContentVisible(false)
-            viewModel.lastSelectedPaymentMethod = viewModel.selection.value
-            viewModel.updateSelection(PaymentSelection.GooglePay)
+            // TODO Don't go via PS
+//            viewModel.lastSelectedPaymentMethod = viewModel.selection.value
+//            viewModel.updateSelection(PaymentSelection.GooglePay)
+
+            viewModel.checkoutWithGooglePay()
         }
 
-        viewModel.selection.observe(this) { paymentSelection ->
-            if (paymentSelection == PaymentSelection.GooglePay) {
-                viewModel.checkout(CheckoutIdentifier.SheetTopGooglePay)
-            }
-        }
+//        viewModel.selection.observe(this) { paymentSelection ->
+//            if (paymentSelection == PaymentSelection.GooglePay) {
+//                viewModel.checkout(CheckoutIdentifier.SheetTopGooglePay)
+//            }
+//        }
 
         viewModel.getButtonStateObservable(CheckoutIdentifier.SheetTopGooglePay)
             .observe(this) { viewState ->
-                if (viewState is PaymentSheetViewState.Reset) {
-                    // If Google Pay was cancelled or failed, re-select the form payment method
-                    viewModel.updateSelection(viewModel.lastSelectedPaymentMethod)
-                }
+//                if (viewState is PaymentSheetViewState.Reset) {
+//                    // If Google Pay was cancelled or failed, re-select the form payment method
+//                    viewModel.updateSelection(viewModel.lastSelectedPaymentMethod)
+//                }
 
                 updateErrorMessage(topMessage, viewState?.errorMessage)
                 googlePayButton.updateState(viewState?.convert())

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -140,10 +140,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         return outputLiveData
     }
 
-    // Holds a reference to the last selected payment method while checking out with Google Pay.
-    // If Google Pay is cancelled or fails, it will be set again as the selected payment method.
-//    internal var lastSelectedPaymentMethod: PaymentSelection? = null
-
     internal val isProcessingPaymentIntent
         get() = args.clientSecret is PaymentIntentClientSecret
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -283,7 +283,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         paymentSelection: PaymentSelection?,
         identifier: CheckoutIdentifier,
     ) {
-        clearErrorMessages()
         startProcessing(identifier)
 
         if (paymentSelection is PaymentSelection.GooglePay) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -274,6 +274,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     }
 
     fun checkout(checkoutIdentifier: CheckoutIdentifier) {
+        clearErrorMessages()
         startProcessing(checkoutIdentifier)
 
         val paymentSelection = selection.value
@@ -324,6 +325,12 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             else -> {
                 // no-op
             }
+        }
+    }
+
+    override fun clearErrorMessages() {
+        if (_viewState.value is PaymentSheetViewState.Reset) {
+            _viewState.value = PaymentSheetViewState.Reset(message = null)
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -195,7 +195,6 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
         if (viewModel.processing.value == false) {
             if (supportFragmentManager.backStackEntryCount > 0) {
                 viewModel.onUserBack()
-                clearErrorMessages()
                 super.onBackPressed()
             } else {
                 viewModel.onUserCancel()
@@ -209,10 +208,6 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
         // TODO(mlb): Consider if this needs to be an abstract function
         setActivityResult(result)
         bottomSheetController.hide()
-    }
-
-    open fun clearErrorMessages() {
-        updateErrorMessage(messageView)
     }
 
     protected fun updateErrorMessage(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -50,7 +50,6 @@ import com.stripe.android.ui.core.forms.resources.ResourceRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.filter
@@ -61,7 +60,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.jetbrains.annotations.TestOnly
 import kotlin.coroutines.CoroutineContext
-import kotlin.time.Duration.Companion.seconds
 
 /**
  * Base `ViewModel` for activities that use `BottomSheet`.
@@ -250,10 +248,10 @@ internal abstract class BaseSheetViewModel(
         )
 
     init {
-        viewModelScope.launch {
-            delay(5.seconds)
-            onError("fake error")
-        }
+//        viewModelScope.launch {
+//            delay(5.seconds)
+//            onError("fake error")
+//        }
 
         if (_savedSelection.value == null) {
             viewModelScope.launch {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -248,11 +248,6 @@ internal abstract class BaseSheetViewModel(
         )
 
     init {
-//        viewModelScope.launch {
-//            delay(5.seconds)
-//            onError("fake error")
-//        }
-
         if (_savedSelection.value == null) {
             viewModelScope.launch {
                 val savedSelection = withContext(workContext) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -50,6 +50,7 @@ import com.stripe.android.ui.core.forms.resources.ResourceRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.filter
@@ -60,6 +61,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.jetbrains.annotations.TestOnly
 import kotlin.coroutines.CoroutineContext
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Base `ViewModel` for activities that use `BottomSheet`.
@@ -248,6 +250,11 @@ internal abstract class BaseSheetViewModel(
         )
 
     init {
+        viewModelScope.launch {
+            delay(5.seconds)
+            onError("fake error")
+        }
+
         if (_savedSelection.value == null) {
             viewModelScope.launch {
                 val savedSelection = withContext(workContext) {
@@ -329,6 +336,7 @@ internal abstract class BaseSheetViewModel(
     abstract fun transitionToFirstScreen()
 
     protected fun transitionTo(target: TransitionTarget) {
+        clearErrorMessages()
         _transition.postValue(Event(target))
     }
 
@@ -387,6 +395,8 @@ internal abstract class BaseSheetViewModel(
             warnUnactivatedIfNeeded(stripeIntent.unactivatedPaymentMethods)
         }
     }
+
+    abstract fun clearErrorMessages()
 
     private fun warnUnactivatedIfNeeded(unactivatedPaymentMethodTypes: List<String>) {
         if (unactivatedPaymentMethodTypes.isEmpty()) {
@@ -589,6 +599,8 @@ internal abstract class BaseSheetViewModel(
     abstract fun onUserCancel()
 
     fun onUserBack() {
+        clearErrorMessages()
+
         // Reset the selection to the one from before opening the add payment method screen
         val paymentOptionsState = paymentOptionsState.value
         updateSelection(paymentOptionsState.selectedItem?.toPaymentSelection())

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -548,6 +548,21 @@ internal class PaymentOptionsActivityTest {
         assertThat(scenario.state).isEqualTo(Lifecycle.State.DESTROYED)
     }
 
+    @Test
+    fun `Clears error on user selection`() {
+        val scenario = activityScenario()
+        scenario.launch(createIntent()).onActivity { activity ->
+            idleLooper()
+
+            viewModel.onError("some error")
+            assertThat(activity.viewBinding.message.isVisible).isTrue()
+            assertThat(activity.viewBinding.message.text.toString()).isEqualTo("some error")
+
+            viewModel.onUserSelection()
+            assertThat(activity.viewBinding.message.isVisible).isFalse()
+        }
+    }
+
     private fun createIntent(
         args: PaymentOptionContract.Args = PAYMENT_OPTIONS_CONTRACT_ARGS
     ): Intent {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -48,6 +48,7 @@ import com.stripe.android.paymentsheet.model.PaymentSheetViewState
 import com.stripe.android.paymentsheet.model.StripeIntentValidator
 import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
 import com.stripe.android.paymentsheet.repositories.StripeIntentRepository
+import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.ui.PrimaryButtonAnimator
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
@@ -198,6 +199,128 @@ internal class PaymentSheetActivityTest {
 
             assertThat(activity.viewBinding.buyButton.isEnabled)
                 .isFalse()
+        }
+    }
+
+    @Test
+    fun `Errors are cleared when checking out with a generic payment method`() {
+        val scenario = activityScenario()
+
+        scenario.launch(intent).onActivity { activity ->
+            // wait for bottom sheet to animate in
+            idleLooper()
+            assertThat(activity.viewBinding.message.isVisible).isFalse()
+
+            viewModel.onError("some error")
+            assertThat(activity.viewBinding.message.isVisible).isTrue()
+            assertThat(activity.viewBinding.message.text.toString()).isEqualTo("some error")
+
+            activity.viewBinding.buyButton.callOnClick()
+            assertThat(activity.viewBinding.message.isVisible).isFalse()
+        }
+    }
+
+    @Test
+    fun `Errors are cleared when checking out with Google Pay`() {
+        val scenario = activityScenario()
+
+        scenario.launch(intent).onActivity { activity ->
+            // wait for bottom sheet to animate in
+            idleLooper()
+            assertThat(activity.viewBinding.message.isVisible).isFalse()
+
+            viewModel.onError("some error")
+            assertThat(activity.viewBinding.message.isVisible).isTrue()
+            assertThat(activity.viewBinding.message.text.toString()).isEqualTo("some error")
+
+            activity.viewBinding.googlePayButton.callOnClick()
+            assertThat(activity.viewBinding.message.isVisible).isFalse()
+        }
+    }
+
+    @Test
+    fun `Errors are cleared when checking out with Link`() {
+        val scenario = activityScenario()
+
+        scenario.launch(intent).onActivity { activity ->
+            // wait for bottom sheet to animate in
+            idleLooper()
+            assertThat(activity.viewBinding.message.isVisible).isFalse()
+
+            viewModel.onError("some error")
+            assertThat(activity.viewBinding.message.isVisible).isTrue()
+            assertThat(activity.viewBinding.message.text.toString()).isEqualTo("some error")
+
+            val linkConfig = viewModel.linkConfiguration.getOrAwaitValue()
+            activity.viewBinding.linkButton.onClick(linkConfig)
+            assertThat(activity.viewBinding.message.isVisible).isFalse()
+        }
+    }
+
+    @Test
+    fun `Errors are cleared when updating the payment selection`() {
+        val paymentMethods = PAYMENT_METHODS
+        val viewModel = createViewModel(paymentMethods = paymentMethods)
+        val scenario = activityScenario(viewModel)
+
+        scenario.launch(intent).onActivity { activity ->
+            // wait for bottom sheet to animate in
+            idleLooper()
+            assertThat(activity.viewBinding.message.isVisible).isFalse()
+
+            viewModel.onError("some error")
+            assertThat(activity.viewBinding.message.isVisible).isTrue()
+            assertThat(activity.viewBinding.message.text.toString()).isEqualTo("some error")
+
+            val newSelection = PaymentSelection.Saved(paymentMethod = paymentMethods.last())
+            viewModel.updateSelection(newSelection)
+
+            assertThat(activity.viewBinding.message.isVisible).isFalse()
+        }
+    }
+
+    @Test
+    fun `Errors are cleared when navigating back from payment form to saved payment methods`() {
+        val paymentMethods = PAYMENT_METHODS
+        val viewModel = createViewModel(paymentMethods = paymentMethods)
+        val scenario = activityScenario(viewModel)
+
+        scenario.launch(intent).onActivity { activity ->
+            // wait for bottom sheet to animate in
+            idleLooper()
+            assertThat(activity.viewBinding.message.isVisible).isFalse()
+
+            viewModel.transitionToAddPaymentScreen()
+            idleLooper()
+
+            viewModel.onError("some error")
+            assertThat(activity.viewBinding.message.isVisible).isTrue()
+            assertThat(activity.viewBinding.message.text.toString()).isEqualTo("some error")
+
+            activity.onBackPressed()
+
+            assertThat(activity.viewBinding.message.isVisible).isFalse()
+        }
+    }
+
+    @Test
+    fun `Errors are cleared when transitioning to new screen`() {
+        val paymentMethods = PAYMENT_METHODS
+        val viewModel = createViewModel(paymentMethods = paymentMethods)
+        val scenario = activityScenario(viewModel)
+
+        scenario.launch(intent).onActivity { activity ->
+            // wait for bottom sheet to animate in
+            idleLooper()
+            assertThat(activity.viewBinding.message.isVisible).isFalse()
+
+            viewModel.onError("some error")
+            assertThat(activity.viewBinding.message.isVisible).isTrue()
+            assertThat(activity.viewBinding.message.text.toString()).isEqualTo("some error")
+
+            viewModel.transitionToAddPaymentScreen()
+            idleLooper()
+            assertThat(activity.viewBinding.message.isVisible).isFalse()
         }
     }
 
@@ -1149,6 +1272,18 @@ internal class PaymentSheetActivityTest {
             FakePaymentSheetLoader(
                 stripeIntent = paymentIntent,
                 customerPaymentMethods = paymentMethods,
+                linkState = LinkState(
+                    configuration = LinkPaymentLauncher.Configuration(
+                        stripeIntent = paymentIntent,
+                        merchantName = "Merchant",
+                        customerEmail = null,
+                        customerName = null,
+                        customerPhone = null,
+                        customerBillingCountryCode = null,
+                        shippingValues = null,
+                    ),
+                    loginState = LinkState.LoginState.LoggedOut,
+                ).takeIf { paymentIntent.paymentMethodTypes.contains("link") },
             ),
             FakeCustomerRepository(paymentMethods),
             FakePrefsRepository(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -214,7 +214,7 @@ internal class PaymentSheetActivityTest {
             assertThat(activity.viewBinding.buyButton.isEnabled).isFalse()
 
             // Update to Google Pay
-            viewModel.updateSelection(PaymentSelection.GooglePay)
+            viewModel.checkoutWithGooglePay()
             assertThat(activity.viewBinding.buyButton.isVisible).isTrue()
             assertThat(activity.viewBinding.buyButton.isEnabled).isFalse()
             viewModel.onGooglePayResult(GooglePayPaymentMethodLauncher.Result.Canceled)
@@ -264,13 +264,9 @@ internal class PaymentSheetActivityTest {
             assertThat(viewModel.selection.getOrAwaitValue()).isEqualTo(initialSelection)
 
             activity.viewBinding.googlePayButton.callOnClick()
-
-            // Updates PaymentSelection to Google Pay
-            assertThat(viewModel.selection.getOrAwaitValue()).isEqualTo(PaymentSelection.GooglePay)
-
             viewModel.onGooglePayResult(GooglePayPaymentMethodLauncher.Result.Canceled)
 
-            // Back to Ready state, should return to initial PaymentSelection
+            // Still using the initial PaymentSelection
             assertThat(viewModel.selection.getOrAwaitValue()).isEqualTo(initialSelection)
         }
     }
@@ -454,7 +450,7 @@ internal class PaymentSheetActivityTest {
         scenario.launch(intent).onActivity { activity ->
             // wait for bottom sheet to animate in
             idleLooper()
-            viewModel.checkout(CheckoutIdentifier.SheetBottomBuy)
+            viewModel.checkout()
             idleLooper()
 
             assertThat(activity.toolbar.isEnabled).isFalse()
@@ -829,7 +825,7 @@ internal class PaymentSheetActivityTest {
             assertThat(activity.viewBinding.topMessage.isVisible).isFalse()
             assertThat(activity.viewBinding.topMessage.text.isNullOrEmpty()).isTrue()
 
-            viewModel.checkout(CheckoutIdentifier.SheetBottomBuy)
+            viewModel.checkout()
 
             assertThat(activity.viewBinding.message.isVisible).isFalse()
             assertThat(activity.viewBinding.message.text.isNullOrEmpty()).isTrue()
@@ -845,7 +841,7 @@ internal class PaymentSheetActivityTest {
             assertThat(activity.viewBinding.topMessage.isVisible).isTrue()
             assertThat(activity.viewBinding.topMessage.text.toString()).isEqualTo(errorMessage)
 
-            viewModel.checkout(CheckoutIdentifier.SheetBottomBuy)
+            viewModel.checkout()
 
             assertThat(activity.viewBinding.message.isVisible).isFalse()
             assertThat(activity.viewBinding.message.text.isNullOrEmpty()).isTrue()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -156,7 +156,7 @@ internal class PaymentSheetViewModelTest {
 
         val paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
         viewModel.updateSelection(paymentSelection)
-        viewModel.checkout(CheckoutIdentifier.None)
+        viewModel.checkout()
 
         assertThat(confirmParams).hasSize(1)
         assertThat(confirmParams[0].peekContent())
@@ -181,7 +181,7 @@ internal class PaymentSheetViewModelTest {
 
         val paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.US_BANK_ACCOUNT)
         viewModel.updateSelection(paymentSelection)
-        viewModel.checkout(CheckoutIdentifier.None)
+        viewModel.checkout()
 
         assertThat(confirmParams).hasSize(1)
         assertThat(confirmParams[0].peekContent())
@@ -213,7 +213,7 @@ internal class PaymentSheetViewModelTest {
         val paymentSelection =
             PaymentSelection.Saved(PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD)
         viewModel.updateSelection(paymentSelection)
-        viewModel.checkout(CheckoutIdentifier.None)
+        viewModel.checkout()
 
         assertThat(events).hasSize(1)
         val confirmParams = events[0].peekContent() as ConfirmSetupIntentParams
@@ -235,7 +235,7 @@ internal class PaymentSheetViewModelTest {
             customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse
         )
         viewModel.updateSelection(paymentSelection)
-        viewModel.checkout(CheckoutIdentifier.None)
+        viewModel.checkout()
 
         assertThat(confirmParams).hasSize(1)
         assertThat(confirmParams[0].peekContent())
@@ -277,7 +277,7 @@ internal class PaymentSheetViewModelTest {
             customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse
         )
         viewModel.updateSelection(paymentSelection)
-        viewModel.checkout(CheckoutIdentifier.None)
+        viewModel.checkout()
 
         assertThat(confirmParams).hasSize(1)
         assertThat(confirmParams[0].peekContent())
@@ -360,8 +360,7 @@ internal class PaymentSheetViewModelTest {
     fun `Google Pay checkout cancelled returns to Ready state`() {
         val viewModel = createViewModel()
 
-        viewModel.updateSelection(PaymentSelection.GooglePay)
-        viewModel.checkout(CheckoutIdentifier.SheetTopGooglePay)
+        viewModel.checkoutWithGooglePay()
 
         val viewState: MutableList<PaymentSheetViewState?> = mutableListOf()
         viewModel.getButtonStateObservable(CheckoutIdentifier.SheetTopGooglePay)
@@ -410,7 +409,7 @@ internal class PaymentSheetViewModelTest {
             viewState.add(it)
         }
 
-        viewModel.checkout(CheckoutIdentifier.SheetBottomBuy)
+        viewModel.checkout()
 
         assertThat(googleViewState[0]).isEqualTo(PaymentSheetViewState.Reset(null))
         assertThat(buyViewState[0]).isEqualTo(PaymentSheetViewState.StartProcessing)
@@ -420,8 +419,7 @@ internal class PaymentSheetViewModelTest {
     fun `Google Pay checkout failed returns to Ready state and shows error`() {
         val viewModel = createViewModel()
 
-        viewModel.updateSelection(PaymentSelection.GooglePay)
-        viewModel.checkout(CheckoutIdentifier.SheetTopGooglePay)
+        viewModel.checkoutWithGooglePay()
 
         val viewState: MutableList<PaymentSheetViewState?> = mutableListOf()
         viewModel.getButtonStateObservable(CheckoutIdentifier.SheetTopGooglePay)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request removes `clearErrorMessages()` on `BaseSheetActivity` and moves it to the view models.

It also changes the logic when the user selects Google Pay in the complete payment flow: We no longer update `selection` to `PaymentSelection.GooglePay`, as this resulted in Google Pay errors being swallowed when returning back from a non-successful Google Pay transaction. Instead, we’re treating Google Pay like Link and simply launch directly into the flow, while the value of `selection` stays untouched.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

This change removes logic from the view layer and will help us when we’re updating our backstack handling and when we’re moving UI to Compose.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots

N/A

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

N/A
