### PR TITLE
Fix a crash when switching back to adding a card.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
@@ -333,8 +333,7 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
         isShowingLinkInlineSignup = showLinkInlineSignup
     )
 
-    @VisibleForTesting
-    internal fun transformToPaymentSelection(
+    private fun transformToPaymentSelection(
         formFieldValues: FormFieldValues?,
         selectedPaymentMethodResources: LpmRepository.SupportedPaymentMethod
     ) = formFieldValues?.let {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -41,11 +41,11 @@ internal sealed class PaymentSelection : Parcelable {
             override val customerRequestedSave: CustomerRequestedSave
         ) : New() {
             @IgnoredOnParcel
-            val last4: String = (
-                (paymentMethodCreateParams.toParamMap()["card"] as? Map<*, *>)!!
-                ["number"] as String
-                )
-                .takeLast(4)
+            val last4: String
+                get() {
+                    val cardMap = paymentMethodCreateParams.toParamMap()["card"] as? Map<*, *>
+                    return (cardMap?.get("number") as? String?)?.takeLast(4) ?: ""
+                }
         }
 
         @Parcelize

--- a/paymentsheet/src/test/java/com/stripe/android/model/PaymentSelectionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/model/PaymentSelectionTest.kt
@@ -1,0 +1,31 @@
+package com.stripe.android.model
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import org.junit.Test
+
+internal class PaymentSelectionTest {
+    @Test
+    fun testNewCardLast4_returnsLast4_whenCardInfoExists() {
+        val createParams = PaymentMethodCreateParams.create(
+            PaymentMethodCreateParams.Card("4242424242424242", 1, 2040),
+        )
+        val card = PaymentSelection.New.Card(
+            paymentMethodCreateParams = createParams,
+            brand = CardBrand.Visa,
+            customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
+        )
+        assertThat(card.last4).isEqualTo("4242")
+    }
+
+    @Test
+    fun testNewCardLast4_returnsEmpty_whenNoCardInfoExists() {
+        val createParams = PaymentMethodCreateParams.createAffirm()
+        val card = PaymentSelection.New.Card(
+            paymentMethodCreateParams = createParams,
+            brand = CardBrand.Visa,
+            customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
+        )
+        assertThat(card.last4).isEqualTo("")
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
A crash would occur when switching to another payment method, then back to card when adding a payment method.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix a crash. Found when testing paypal changes [jaynewstrom/paypal](https://github.com/stripe/stripe-android/tree/jaynewstrom/paypal)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
