### PR TITLE
Fix crash on card reselect

### DIFF
--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -70,6 +70,13 @@ dependencies {
     testImplementation "androidx.test.ext:junit-ktx:$androidTestJunitVersion"
     testImplementation "androidx.arch.core:core-testing:$androidxArchCoreVersion"
     testImplementation "androidx.fragment:fragment-testing:$androidxFragmentVersion"
+    testImplementation "androidx.compose.ui:ui-test-junit4:$androidxComposeVersion"
+
+    // Needed for createComposeRule, but not createAndroidComposeRule:
+    debugImplementation("androidx.compose.ui:ui-test-manifest:$androidxComposeVersion")
+
+    // temporary fix for running compose test in RobolectricTestRunner, see https://github.com/robolectric/robolectric/issues/6593
+    testImplementation "androidx.test.espresso:espresso-core:3.5.0"
 
     androidTestImplementation "com.google.android.libraries.places:places:$placesVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidTestJunitVersion"

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlinCoroutinesVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinSerializationVersion"
 
+    testImplementation "org.hamcrest:hamcrest:2.2"
     testImplementation project(':link')
     testImplementation project(':financial-connections')
     testImplementation "junit:junit:$junitVersion"
@@ -71,9 +72,6 @@ dependencies {
     testImplementation "androidx.arch.core:core-testing:$androidxArchCoreVersion"
     testImplementation "androidx.fragment:fragment-testing:$androidxFragmentVersion"
     testImplementation "androidx.compose.ui:ui-test-junit4:$androidxComposeVersion"
-
-    // Needed for createComposeRule, but not createAndroidComposeRule:
-    debugImplementation("androidx.compose.ui:ui-test-manifest:$androidxComposeVersion")
 
     // temporary fix for running compose test in RobolectricTestRunner, see https://github.com/robolectric/robolectric/issues/6593
     testImplementation "androidx.test.espresso:espresso-core:3.5.0"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
@@ -62,7 +62,8 @@ internal class FormViewModel @Inject internal constructor(
             return subComponentBuilderProvider.get()
                 .formFragmentArguments(config)
                 .showCheckboxFlow(showCheckboxFlow)
-                .build().viewModel as T
+                .build()
+                .viewModel as T
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
@@ -62,8 +62,7 @@ internal class FormViewModel @Inject internal constructor(
             return subComponentBuilderProvider.get()
                 .formFragmentArguments(config)
                 .showCheckboxFlow(showCheckboxFlow)
-                .build()
-                .viewModel as T
+                .build().viewModel as T
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodForm.kt
@@ -7,10 +7,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.stripe.android.core.injection.NonFallbackInjector
+import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
 import com.stripe.android.ui.core.FormUI
+import com.stripe.android.ui.core.elements.FormElement
+import com.stripe.android.ui.core.elements.IdentifierSpec
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 
@@ -22,26 +25,51 @@ internal fun PaymentMethodForm(
     onFormFieldValuesChanged: (FormFieldValues?) -> Unit,
     showCheckboxFlow: Flow<Boolean>,
     injector: NonFallbackInjector,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val formViewModel: FormViewModel = viewModel(
         key = args.paymentMethodCode,
         factory = FormViewModel.Factory(
             config = args,
             showCheckboxFlow = showCheckboxFlow,
-            injector = injector
+            injector = injector,
         )
     )
-
-    val formValues by formViewModel.completeFormValues.collectAsState(null)
-
-    LaunchedEffect(args.paymentMethodCode, formValues) {
-        onFormFieldValuesChanged(formValues)
-    }
 
     val hiddenIdentifiers by formViewModel.hiddenIdentifiers.collectAsState(emptySet())
     val elements by formViewModel.elementsFlow.collectAsState(null)
     val lastTextFieldIdentifier by formViewModel.lastTextFieldIdentifier.collectAsState(null)
+
+    PaymentMethodForm(
+        paymentMethodCode = args.paymentMethodCode,
+        enabled = enabled,
+        onFormFieldValuesChanged = onFormFieldValuesChanged,
+        completeFormValues = formViewModel.completeFormValues,
+        hiddenIdentifiers = hiddenIdentifiers,
+        elements = elements,
+        lastTextFieldIdentifier = lastTextFieldIdentifier,
+        modifier = modifier,
+    )
+}
+
+
+@FlowPreview
+@Composable
+internal fun PaymentMethodForm(
+    paymentMethodCode: PaymentMethodCode,
+    enabled: Boolean,
+    onFormFieldValuesChanged: (FormFieldValues?) -> Unit,
+    completeFormValues: Flow<FormFieldValues?>,
+    hiddenIdentifiers: Set<IdentifierSpec>,
+    elements: List<FormElement>?,
+    lastTextFieldIdentifier: IdentifierSpec?,
+    modifier: Modifier = Modifier,
+) {
+    LaunchedEffect(paymentMethodCode) {
+        completeFormValues.collect {
+            onFormFieldValuesChanged(it)
+        }
+    }
 
     FormUI(
         hiddenIdentifiers = hiddenIdentifiers,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodForm.kt
@@ -52,7 +52,6 @@ internal fun PaymentMethodForm(
     )
 }
 
-
 @FlowPreview
 @Composable
 internal fun PaymentMethodForm(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentMethodFormTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentMethodFormTest.kt
@@ -7,12 +7,14 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+@OptIn(FlowPreview::class)
 @RunWith(RobolectricTestRunner::class)
 class PaymentMethodFormTest {
 
@@ -20,7 +22,7 @@ class PaymentMethodFormTest {
     val composeTestRule = createComposeRule()
 
     @Test
-    fun foo() {
+    fun changingPaymentMethodCodes_emitsOnFormFieldValuesChangedCorrectly() {
         val paymentMethodCodeFlow = MutableStateFlow(PaymentMethod.Type.Card.code)
         val completeFormValuesFlow = MutableStateFlow<FormFieldValues?>(null)
 
@@ -44,21 +46,21 @@ class PaymentMethodFormTest {
 
         assertThat(emissions).containsExactly(null)
 
-        // TODO Comment
+        // Changing the payment method from card to PayPal.
         paymentMethodCodeFlow.value = PaymentMethod.Type.PayPal.code
 
-        // TODO Comment
-        val paypalValues = FormFieldValues(
+        // PayPalValues should only be associated with the PayPal payment method code, not card.
+        val payPalValues = FormFieldValues(
             showsMandate = false,
             userRequestedReuse = PaymentSelection.CustomerRequestedSave.NoRequest,
         )
-        completeFormValuesFlow.value = paypalValues
+        completeFormValuesFlow.value = payPalValues
 
-        assertThat(emissions).containsExactly(null, paypalValues)
+        assertThat(emissions).containsExactly(null, payPalValues)
 
         paymentMethodCodeFlow.value = PaymentMethod.Type.Card.code
         completeFormValuesFlow.value = null
 
-        assertThat(emissions).containsExactly(null, paypalValues, null)
+        assertThat(emissions).containsExactly(null, payPalValues, null)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentMethodFormTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentMethodFormTest.kt
@@ -22,7 +22,7 @@ class PaymentMethodFormTest {
     val composeTestRule = createComposeRule()
 
     @Test
-    fun changingPaymentMethodCodes_emitsOnFormFieldValuesChangedCorrectly() {
+    fun `Changing payment method emits only form values of newly selected payment method`() {
         val paymentMethodCodeFlow = MutableStateFlow(PaymentMethod.Type.Card.code)
         val completeFormValuesFlow = MutableStateFlow<FormFieldValues?>(null)
 
@@ -62,5 +62,39 @@ class PaymentMethodFormTest {
         completeFormValuesFlow.value = null
 
         assertThat(emissions).containsExactly(null, payPalValues, null)
+    }
+
+    @Test
+    fun `Changing completeFormValues emits new FormFieldValues`() {
+        val paymentMethodCodeFlow = MutableStateFlow(PaymentMethod.Type.Card.code)
+        val completeFormValuesFlow = MutableStateFlow<FormFieldValues?>(null)
+
+        val emissions = mutableListOf<FormFieldValues?>()
+
+        composeTestRule.setContent {
+            val code by paymentMethodCodeFlow.collectAsState()
+
+            PaymentMethodForm(
+                paymentMethodCode = code,
+                enabled = true,
+                completeFormValues = completeFormValuesFlow,
+                onFormFieldValuesChanged = {
+                    emissions.add(it)
+                },
+                hiddenIdentifiers = emptySet(),
+                elements = emptyList(),
+                lastTextFieldIdentifier = null,
+            )
+        }
+
+        assertThat(emissions).containsExactly(null)
+
+        val completeValues = FormFieldValues(
+            showsMandate = false,
+            userRequestedReuse = PaymentSelection.CustomerRequestedSave.NoRequest,
+        )
+        completeFormValuesFlow.value = completeValues
+
+        assertThat(emissions).containsExactly(null, completeValues)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentMethodFormTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentMethodFormTest.kt
@@ -1,0 +1,64 @@
+package com.stripe.android.paymentsheet.ui
+
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.forms.FormFieldValues
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PaymentMethodFormTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun foo() {
+        val paymentMethodCodeFlow = MutableStateFlow(PaymentMethod.Type.Card.code)
+        val completeFormValuesFlow = MutableStateFlow<FormFieldValues?>(null)
+
+        val emissions = mutableListOf<FormFieldValues?>()
+
+        composeTestRule.setContent {
+            val code by paymentMethodCodeFlow.collectAsState()
+
+            PaymentMethodForm(
+                paymentMethodCode = code,
+                enabled = true,
+                completeFormValues = completeFormValuesFlow,
+                onFormFieldValuesChanged = {
+                    emissions.add(it)
+                },
+                hiddenIdentifiers = emptySet(),
+                elements = emptyList(),
+                lastTextFieldIdentifier = null,
+            )
+        }
+
+        assertThat(emissions).containsExactly(null)
+
+        // TODO Comment
+        paymentMethodCodeFlow.value = PaymentMethod.Type.PayPal.code
+
+        // TODO Comment
+        val paypalValues = FormFieldValues(
+            showsMandate = false,
+            userRequestedReuse = PaymentSelection.CustomerRequestedSave.NoRequest,
+        )
+        completeFormValuesFlow.value = paypalValues
+
+        assertThat(emissions).containsExactly(null, paypalValues)
+
+        paymentMethodCodeFlow.value = PaymentMethod.Type.Card.code
+        completeFormValuesFlow.value = null
+
+        assertThat(emissions).containsExactly(null, paypalValues, null)
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
A crash would occur when switching to another payment method, then back to card when adding a payment method.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
