### PR TITLE
Keep track of current navigation backstack in ViewModel

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.compose.BackHandler
 import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -82,6 +83,11 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
     ) {
         val isRepositoryReady by sheetViewModel.isResourceRepositoryReady.observeAsState()
         val processing by sheetViewModel.processing.observeAsState(false)
+
+        // TODO: Comment
+        BackHandler(enabled = !processing) {
+            sheetViewModel.handleBackPressed()
+        }
 
         val linkConfig by sheetViewModel.linkConfiguration.observeAsState()
         val linkAccountStatus by linkConfig?.let {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
@@ -84,7 +84,7 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
         val isRepositoryReady by sheetViewModel.isResourceRepositoryReady.observeAsState()
         val processing by sheetViewModel.processing.observeAsState(false)
 
-        // TODO: Comment
+        // We need to provide this BackHandler to override the FragmentManager one
         BackHandler(enabled = !processing) {
             sheetViewModel.handleBackPressed()
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -27,6 +27,7 @@ import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.utils.AnimationConstants
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
 
 /**
@@ -93,7 +94,9 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
         }
 
         lifecycleScope.launch {
-            viewModel.backStack.collect(this@PaymentOptionsActivity::handleBackStackChanged)
+            viewModel.currentScreen
+                .filterNotNull()
+                .collect(this@PaymentOptionsActivity::handleCurrentScreenChanged)
         }
 
         if (savedInstanceState == null) {
@@ -139,16 +142,16 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
         }
     }
 
-    private fun handleBackStackChanged(backStack: List<BaseSheetViewModel.TransitionTarget>) {
-        val target = backStack.lastOrNull() ?: return
-        val effect = target.toNavigationEffect(this) ?: return
-
-        when (effect) {
+    private fun handleCurrentScreenChanged(currentScreen: BaseSheetViewModel.TransitionTarget) {
+        when (currentScreen.toNavigationEffect(this)) {
             is NavigationEffect.Navigate -> {
-                onTransitionTarget(target)
+                onTransitionTarget(currentScreen)
             }
             is NavigationEffect.GoBack -> {
                 supportFragmentManager.popBackStack()
+            }
+            null -> {
+                // Nothing to do here
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -188,18 +188,19 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
     private fun handleBackStackChanged(backStack: List<BaseSheetViewModel.TransitionTarget>) {
         val target = backStack.lastOrNull() ?: return
 
-        buttonContainer.isVisible = true
-
-        val effect = target.toNavigationEffect(this) ?: return
-
-        when (effect) {
+        when (target.toNavigationEffect(this)) {
             is NavigationEffect.Navigate -> {
                 onTransitionTarget(target)
             }
             is NavigationEffect.GoBack -> {
                 supportFragmentManager.popBackStack()
             }
+            null -> {
+                // Nothing to do here
+            }
         }
+
+        buttonContainer.isVisible = true
     }
 
     private fun onTransitionTarget(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -26,6 +26,7 @@ import com.stripe.android.paymentsheet.PaymentSheetViewModel.CheckoutIdentifier
 import com.stripe.android.paymentsheet.databinding.ActivityPaymentSheetBinding
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
 import com.stripe.android.paymentsheet.navigation.NavigationEffect
+import com.stripe.android.paymentsheet.navigation.constructBackStack
 import com.stripe.android.paymentsheet.navigation.toNavigationEffect
 import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.GooglePayDividerUi
@@ -130,6 +131,9 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
 
         if (savedInstanceState == null) {
             viewModel.transitionToFirstScreenWhenReady()
+        } else {
+            val backStack = supportFragmentManager.constructBackStack()
+            viewModel.syncBackStackIfNeeded(backStack = backStack)
         }
 
         viewModel.startConfirm.observe(this) { event ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -251,8 +251,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
                 }
             }
         }
-
-//        buttonContainer.isVisible = true
     }
 
     override fun resetPrimaryButtonState() {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -187,6 +187,9 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
 
     private fun handleBackStackChanged(backStack: List<BaseSheetViewModel.TransitionTarget>) {
         val target = backStack.lastOrNull() ?: return
+
+        buttonContainer.isVisible = true
+
         val effect = target.toNavigationEffect(this) ?: return
 
         when (effect) {
@@ -249,7 +252,7 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
             }
         }
 
-        buttonContainer.isVisible = true
+//        buttonContainer.isVisible = true
     }
 
     override fun resetPrimaryButtonState() {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/BackStackHandling.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/BackStackHandling.kt
@@ -57,19 +57,21 @@ internal fun canIgnoreTransition(
 }
 
 internal fun FragmentManager.constructBackStack(): List<TransitionTarget> {
-    return when (findFragmentById(R.id.fragment_container)) {
-        is BaseAddPaymentMethodFragment -> {
-            if (backStackEntryCount > 0) {
-                listOf(SelectSavedPaymentMethods, AddAnotherPaymentMethod)
-            } else {
-                listOf(AddFirstPaymentMethod)
+    return fragments.mapIndexedNotNull { index, fragment ->
+        when (fragment) {
+            is BaseAddPaymentMethodFragment -> {
+                if (index > 0) {
+                    AddAnotherPaymentMethod
+                } else {
+                    AddFirstPaymentMethod
+                }
             }
-        }
-        is BasePaymentMethodsListFragment -> {
-            listOf(SelectSavedPaymentMethods)
-        }
-        else -> {
-            emptyList()
+            is BasePaymentMethodsListFragment -> {
+                SelectSavedPaymentMethods
+            }
+            else -> {
+                null
+            }
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/BackStackHandling.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/BackStackHandling.kt
@@ -20,17 +20,15 @@ internal sealed interface NavigationEffect {
 
 internal fun TransitionTarget.toNavigationEffect(host: AppCompatActivity): NavigationEffect? {
     val currentFragment = host.supportFragmentManager.findFragmentById(R.id.fragment_container)
-    val canIgnoreTransition = canIgnoreTransition(currentFragment, target = this)
+    val canIgnoreTransition = currentFragment?.canIgnoreTransition(this) ?: true
 
     if (canIgnoreTransition) {
         return null
     }
 
-    val hasBackStack = host.supportFragmentManager.backStackEntryCount > 0
-
     return when (this) {
         SelectSavedPaymentMethods -> {
-            if (hasBackStack) {
+            if (currentFragment is BaseAddPaymentMethodFragment) {
                 NavigationEffect.GoBack
             } else {
                 NavigationEffect.Navigate(this)
@@ -43,17 +41,16 @@ internal fun TransitionTarget.toNavigationEffect(host: AppCompatActivity): Navig
     }
 }
 
-internal fun canIgnoreTransition(
-    currentFragment: Fragment?,
+internal fun Fragment.canIgnoreTransition(
     target: TransitionTarget,
 ): Boolean {
     return when (target) {
         SelectSavedPaymentMethods -> {
-            currentFragment is BasePaymentMethodsListFragment
+            this is BasePaymentMethodsListFragment
         }
         AddFirstPaymentMethod,
         AddAnotherPaymentMethod -> {
-            currentFragment is BaseAddPaymentMethodFragment
+            this is BaseAddPaymentMethodFragment
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/BackStackHandling.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/BackStackHandling.kt
@@ -1,0 +1,53 @@
+package com.stripe.android.paymentsheet.navigation
+
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import com.stripe.android.paymentsheet.BaseAddPaymentMethodFragment
+import com.stripe.android.paymentsheet.BasePaymentMethodsListFragment
+import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.TransitionTarget
+
+internal sealed interface NavigationEffect {
+    data class Navigate(val target: TransitionTarget) : NavigationEffect
+    object GoBack : NavigationEffect
+}
+
+internal fun TransitionTarget.toNavigationEffect(host: AppCompatActivity): NavigationEffect? {
+    val currentFragment = host.supportFragmentManager.findFragmentById(R.id.fragment_container)
+    val canIgnoreTransition = canIgnoreTransition(currentFragment, target = this)
+
+    if (canIgnoreTransition) {
+        return null
+    }
+
+    val hasBackStack = host.supportFragmentManager.backStackEntryCount > 0
+
+    return when (this) {
+        TransitionTarget.SelectSavedPaymentMethods -> {
+            if (hasBackStack) {
+                NavigationEffect.GoBack
+            } else {
+                NavigationEffect.Navigate(this)
+            }
+        }
+        TransitionTarget.AddFirstPaymentMethod,
+        TransitionTarget.AddAnotherPaymentMethod -> {
+            NavigationEffect.Navigate(this)
+        }
+    }
+}
+
+internal fun canIgnoreTransition(
+    currentFragment: Fragment?,
+    target: TransitionTarget,
+): Boolean {
+    return when (target) {
+        TransitionTarget.SelectSavedPaymentMethods -> {
+            currentFragment is BasePaymentMethodsListFragment
+        }
+        TransitionTarget.AddFirstPaymentMethod,
+        TransitionTarget.AddAnotherPaymentMethod -> {
+            currentFragment is BaseAddPaymentMethodFragment
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/BackStackHandling.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/BackStackHandling.kt
@@ -1,3 +1,5 @@
+@file:Suppress("MatchingDeclarationName")
+
 package com.stripe.android.paymentsheet.navigation
 
 import androidx.appcompat.app.AppCompatActivity

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -13,6 +13,7 @@ import android.view.WindowInsets
 import android.view.WindowMetrics
 import android.widget.ScrollView
 import android.widget.TextView
+import androidx.activity.addCallback
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
@@ -126,9 +127,14 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
             }
         }
 
+        val onBackPressedCallback = onBackPressedDispatcher.addCallback {
+            viewModel.handleBackPressed()
+        }
+
         viewModel.processing.observe(this) { isProcessing ->
             updateRootViewClickHandling(isProcessing)
             toolbar.isEnabled = !isProcessing
+            onBackPressedCallback.isEnabled = !isProcessing
         }
 
         // Set Toolbar to act as the ActionBar so it displays the menu items.
@@ -189,18 +195,6 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
     override fun finish() {
         super.finish()
         overridePendingTransition(AnimationConstants.FADE_IN, AnimationConstants.FADE_OUT)
-    }
-
-    @Deprecated("Deprecated in Java")
-    override fun onBackPressed() {
-        if (viewModel.processing.value == false) {
-            if (supportFragmentManager.backStackEntryCount > 0) {
-                viewModel.onUserBack()
-                super.onBackPressed()
-            } else {
-                viewModel.onUserCancel()
-            }
-        }
     }
 
     protected fun closeSheet(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.AndroidViewModel
-import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
@@ -668,15 +667,5 @@ internal abstract class BaseSheetViewModel(
         internal const val SAVE_RESOURCE_REPOSITORY_READY = "resource_repository_ready"
         internal const val SAVE_STATE_LIVE_MODE = "save_state_live_mode"
         internal const val LINK_CONFIGURATION = "link_configuration"
-    }
-}
-
-internal fun <T> LiveData<BaseSheetViewModel.Event<T>?>.observeEvents(
-    lifecycleOwner: LifecycleOwner,
-    observer: (T) -> Unit
-) {
-    observe(lifecycleOwner) { event ->
-        val content = event?.getContentIfNotHandled() ?: return@observe
-        observer(content)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -339,6 +339,12 @@ internal abstract class BaseSheetViewModel(
         transitionTo(TransitionTarget.AddAnotherPaymentMethod)
     }
 
+    fun syncBackStackIfNeeded(backStack: List<TransitionTarget>) {
+        if (_backStack.value.isEmpty()) {
+            _backStack.value = backStack
+        }
+    }
+
     internal sealed class TransitionTarget {
         object SelectSavedPaymentMethods : TransitionTarget()
         object AddAnotherPaymentMethod : TransitionTarget()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -263,16 +263,13 @@ internal class PaymentOptionsActivityTest {
         val args = PAYMENT_OPTIONS_CONTRACT_ARGS.updateState(isGooglePayReady = true)
         val viewModel = createViewModel(args)
 
-        val transitionTargets = mutableListOf<TransitionTarget>()
-        viewModel.transition.observeEventsForever { transitionTargets.add(it) }
-
         activityScenario(viewModel).launch(createIntent(args)).use {
             it.onActivity {
                 idleLooper()
             }
         }
 
-        assertThat(transitionTargets).containsExactly(TransitionTarget.SelectSavedPaymentMethods)
+        assertThat(viewModel.backStack.value).containsExactly(TransitionTarget.SelectSavedPaymentMethods)
     }
 
     @Test
@@ -285,16 +282,13 @@ internal class PaymentOptionsActivityTest {
 
         val viewModel = createViewModel(args)
 
-        val transitionTargets = mutableListOf<TransitionTarget>()
-        viewModel.transition.observeEventsForever { transitionTargets.add(it) }
-
         activityScenario(viewModel).launch(createIntent(args)).use {
             it.onActivity {
                 idleLooper()
             }
         }
 
-        assertThat(transitionTargets).containsExactly(TransitionTarget.SelectSavedPaymentMethods)
+        assertThat(viewModel.backStack.value).containsExactly(TransitionTarget.SelectSavedPaymentMethods)
     }
 
     @Test
@@ -306,14 +300,11 @@ internal class PaymentOptionsActivityTest {
 
         val viewModel = createViewModel(args)
 
-        val transitionTargets = mutableListOf<TransitionTarget>()
-        viewModel.transition.observeEventsForever { transitionTargets.add(it) }
-
         activityScenario(viewModel).launch(createIntent(args)).use {
             idleLooper()
         }
 
-        assertThat(transitionTargets).containsExactly(TransitionTarget.SelectSavedPaymentMethods)
+        assertThat(viewModel.backStack.value).containsExactly(TransitionTarget.SelectSavedPaymentMethods)
     }
 
     @Test
@@ -325,14 +316,11 @@ internal class PaymentOptionsActivityTest {
 
         val viewModel = createViewModel(args)
 
-        val transitionTargets = mutableListOf<TransitionTarget>()
-        viewModel.transition.observeEventsForever { transitionTargets.add(it) }
-
         activityScenario(viewModel).launch(createIntent(args)).use {
             idleLooper()
         }
 
-        assertThat(transitionTargets).containsExactly(TransitionTarget.AddFirstPaymentMethod)
+        assertThat(viewModel.backStack.value).containsExactly(TransitionTarget.AddFirstPaymentMethod)
     }
 
     @Test
@@ -342,9 +330,6 @@ internal class PaymentOptionsActivityTest {
         )
 
         val viewModel = createViewModel(args)
-
-        val transitionTargets = mutableListOf<TransitionTarget>()
-        viewModel.transition.observeEventsForever { transitionTargets.add(it) }
 
         activityScenario(viewModel).launch(createIntent(args)).use { scenario ->
             scenario.onActivity {
@@ -358,7 +343,7 @@ internal class PaymentOptionsActivityTest {
             }
         }
 
-        assertThat(transitionTargets).containsExactly(TransitionTarget.SelectSavedPaymentMethods)
+        assertThat(viewModel.backStack.value).containsExactly(TransitionTarget.SelectSavedPaymentMethods)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -268,7 +268,7 @@ internal class PaymentOptionsActivityTest {
             }
         }
 
-        assertThat(viewModel.backStack.value).containsExactly(TransitionTarget.SelectSavedPaymentMethods)
+        assertThat(viewModel.currentScreen.value).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
     }
 
     @Test
@@ -287,7 +287,7 @@ internal class PaymentOptionsActivityTest {
             }
         }
 
-        assertThat(viewModel.backStack.value).containsExactly(TransitionTarget.SelectSavedPaymentMethods)
+        assertThat(viewModel.currentScreen.value).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
     }
 
     @Test
@@ -303,7 +303,7 @@ internal class PaymentOptionsActivityTest {
             idleLooper()
         }
 
-        assertThat(viewModel.backStack.value).containsExactly(TransitionTarget.SelectSavedPaymentMethods)
+        assertThat(viewModel.currentScreen.value).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
     }
 
     @Test
@@ -319,7 +319,7 @@ internal class PaymentOptionsActivityTest {
             idleLooper()
         }
 
-        assertThat(viewModel.backStack.value).containsExactly(TransitionTarget.AddFirstPaymentMethod)
+        assertThat(viewModel.currentScreen.value).isEqualTo(TransitionTarget.AddFirstPaymentMethod)
     }
 
     @Test
@@ -342,7 +342,7 @@ internal class PaymentOptionsActivityTest {
             }
         }
 
-        assertThat(viewModel.backStack.value).containsExactly(TransitionTarget.SelectSavedPaymentMethods)
+        assertThat(viewModel.currentScreen.value).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -50,7 +50,6 @@ import com.stripe.android.ui.core.forms.resources.StaticLpmResourceRepository
 import com.stripe.android.utils.FakeCustomerRepository
 import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.TestUtils.idleLooper
-import com.stripe.android.utils.TestUtils.observeEventsForever
 import com.stripe.android.utils.TestUtils.viewModelFactoryFor
 import com.stripe.android.utils.injectableActivityScenario
 import com.stripe.android.view.ActivityStarter

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -26,7 +26,6 @@ import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.TransitionT
 import com.stripe.android.ui.core.forms.resources.StaticLpmResourceRepository
 import com.stripe.android.utils.FakeCustomerRepository
 import com.stripe.android.utils.TestUtils.idleLooper
-import com.stripe.android.utils.TestUtils.observeEventsForever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -123,15 +122,10 @@ internal class PaymentOptionsViewModelTest {
             args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(newPaymentSelection = null)
         )
 
-        var transitionTarget: TransitionTarget? = null
-        viewModel.transition.observeEventsForever {
-            transitionTarget = it
-        }
-
         // no customer, no new card, no paymentMethods
         viewModel.resolveTransitionTarget()
 
-        assertThat(transitionTarget).isNull()
+        assertThat(viewModel.backStack.value).isEmpty()
     }
 
     @Test
@@ -145,12 +139,9 @@ internal class PaymentOptionsViewModelTest {
             )
         )
 
-        val transitionTarget = mutableListOf<TransitionTarget>()
-        viewModel.transition.observeEventsForever { transitionTarget.add(it) }
-
         viewModel.resolveTransitionTarget()
 
-        assertThat(transitionTarget).containsExactly(TransitionTarget.AddAnotherPaymentMethod)
+        assertThat(viewModel.backStack.value).containsExactly(TransitionTarget.AddAnotherPaymentMethod)
     }
 
     @Test
@@ -164,17 +155,11 @@ internal class PaymentOptionsViewModelTest {
             )
         )
 
-        val transitionTarget = mutableListOf<TransitionTarget>()
-        viewModel.transition.observeEventsForever { transitionTarget.add(it) }
+        viewModel.resolveTransitionTarget()
+        assertThat(viewModel.backStack.value).containsExactly(TransitionTarget.AddAnotherPaymentMethod)
 
         viewModel.resolveTransitionTarget()
-        assertThat(transitionTarget).containsExactly(TransitionTarget.AddAnotherPaymentMethod)
-
-        // Reset the list of observed values
-        transitionTarget.clear()
-
-        viewModel.resolveTransitionTarget()
-        assertThat(transitionTarget).isEmpty()
+        assertThat(viewModel.backStack.value).containsExactly(TransitionTarget.AddAnotherPaymentMethod)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -125,11 +125,11 @@ internal class PaymentOptionsViewModelTest {
         // no customer, no new card, no paymentMethods
         viewModel.resolveTransitionTarget()
 
-        assertThat(viewModel.backStack.value).isEmpty()
+        assertThat(viewModel.currentScreen.value).isNull()
     }
 
     @Test
-    fun `resolveTransitionTarget new card saved`() {
+    fun `resolveTransitionTarget new card saved`() = runTest {
         val viewModel = createViewModel(
             args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(
                 stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
@@ -139,13 +139,15 @@ internal class PaymentOptionsViewModelTest {
             )
         )
 
-        viewModel.resolveTransitionTarget()
-
-        assertThat(viewModel.backStack.value).containsExactly(TransitionTarget.AddAnotherPaymentMethod)
+        viewModel.currentScreen.test {
+            skipItems(1)
+            viewModel.resolveTransitionTarget()
+            assertThat(awaitItem()).isEqualTo(TransitionTarget.AddAnotherPaymentMethod)
+        }
     }
 
     @Test
-    fun `resolveTransitionTarget new card NOT saved`() {
+    fun `resolveTransitionTarget new card NOT saved`() = runTest {
         val viewModel = createViewModel(
             args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(
                 stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
@@ -155,11 +157,15 @@ internal class PaymentOptionsViewModelTest {
             )
         )
 
-        viewModel.resolveTransitionTarget()
-        assertThat(viewModel.backStack.value).containsExactly(TransitionTarget.AddAnotherPaymentMethod)
+        viewModel.currentScreen.test {
+            skipItems(1)
 
-        viewModel.resolveTransitionTarget()
-        assertThat(viewModel.backStack.value).containsExactly(TransitionTarget.AddAnotherPaymentMethod)
+            viewModel.resolveTransitionTarget()
+            assertThat(awaitItem()).isEqualTo(TransitionTarget.AddAnotherPaymentMethod)
+
+            viewModel.resolveTransitionTarget()
+            expectNoEvents()
+        }
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -7,6 +7,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.SavedStateHandle
+import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -1194,7 +1195,7 @@ internal class PaymentSheetActivityTest {
             }
         }
 
-        assertThat(viewModel.backStack.value).containsExactly(TransitionTarget.SelectSavedPaymentMethods)
+        assertThat(viewModel.currentScreen.value).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
     }
 
     @Test
@@ -1207,7 +1208,7 @@ internal class PaymentSheetActivityTest {
             }
         }
 
-        assertThat(viewModel.backStack.value).containsExactly(TransitionTarget.AddFirstPaymentMethod)
+        assertThat(viewModel.currentScreen.value).isEqualTo(TransitionTarget.AddFirstPaymentMethod)
     }
 
     @Test
@@ -1226,7 +1227,22 @@ internal class PaymentSheetActivityTest {
             }
         }
 
-        assertThat(viewModel.backStack.value).containsExactly(TransitionTarget.AddFirstPaymentMethod)
+        assertThat(viewModel.currentScreen.value).isEqualTo(TransitionTarget.AddFirstPaymentMethod)
+    }
+
+    @Test
+    fun `Transitions to AddPaymentMethod when add button is pressed`() {
+        activityScenario().launch(intent).onActivity {
+            idleLooper()
+
+            val recyclerView = it.findViewById<RecyclerView>(R.id.recycler)
+            val adapter = recyclerView.adapter as PaymentOptionsAdapter
+            adapter.addCardClickListener()
+            idleLooper()
+
+            val currentFragment = it.supportFragmentManager.findFragmentById(R.id.fragment_container)
+            assertThat(currentFragment).isInstanceOf(PaymentSheetAddPaymentMethodFragment::class.java)
+        }
     }
 
     private fun currentFragment(activity: PaymentSheetActivity) =

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -66,7 +66,6 @@ import com.stripe.android.utils.FakePaymentSheetLoader
 import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.TestUtils.getOrAwaitValue
 import com.stripe.android.utils.TestUtils.idleLooper
-import com.stripe.android.utils.TestUtils.observeEventsForever
 import com.stripe.android.utils.TestUtils.viewModelFactoryFor
 import com.stripe.android.utils.injectableActivityScenario
 import com.stripe.android.view.ActivityScenarioFactory

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -1189,40 +1189,31 @@ internal class PaymentSheetActivityTest {
     fun `Verify if customer has payment methods, display the saved payment methods screen`() {
         val viewModel = createViewModel(paymentMethods = PAYMENT_METHODS)
 
-        val transitionTargets = mutableListOf<TransitionTarget>()
-        viewModel.transition.observeEventsForever { transitionTargets.add(it) }
-
         activityScenario(viewModel).launch(intent).use {
             it.onActivity {
                 idleLooper()
             }
         }
 
-        assertThat(transitionTargets).containsExactly(TransitionTarget.SelectSavedPaymentMethods)
+        assertThat(viewModel.backStack.value).containsExactly(TransitionTarget.SelectSavedPaymentMethods)
     }
 
     @Test
     fun `Verify if there are no payment methods, display the add payment method screen`() {
         val viewModel = createViewModel(paymentMethods = emptyList())
 
-        val transitionTargets = mutableListOf<TransitionTarget>()
-        viewModel.transition.observeEventsForever { transitionTargets.add(it) }
-
         activityScenario(viewModel).launch(intent).use {
             it.onActivity {
                 idleLooper()
             }
         }
 
-        assertThat(transitionTargets).containsExactly(TransitionTarget.AddFirstPaymentMethod)
+        assertThat(viewModel.backStack.value).containsExactly(TransitionTarget.AddFirstPaymentMethod)
     }
 
     @Test
     fun `Verify doesn't transition to first screen again on activity recreation`() {
         val viewModel = createViewModel(paymentMethods = emptyList())
-
-        val transitionTargets = mutableListOf<TransitionTarget>()
-        viewModel.transition.observeEventsForever { transitionTargets.add(it) }
 
         activityScenario(viewModel).launch(intent).use {
             it.onActivity {
@@ -1236,7 +1227,7 @@ internal class PaymentSheetActivityTest {
             }
         }
 
-        assertThat(transitionTargets).containsExactly(TransitionTarget.AddFirstPaymentMethod)
+        assertThat(viewModel.backStack.value).containsExactly(TransitionTarget.AddFirstPaymentMethod)
     }
 
     private fun currentFragment(activity: PaymentSheetActivity) =

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
@@ -21,7 +21,6 @@ import com.stripe.android.paymentsheet.PaymentSheetAddPaymentMethodFragmentTest.
 import com.stripe.android.paymentsheet.PaymentSheetAddPaymentMethodFragmentTest.Companion.lpmRepository
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
-import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.TransitionTarget
 import com.stripe.android.utils.TestUtils.idleLooper
 import org.junit.After
 import org.junit.Before
@@ -172,30 +171,6 @@ internal class PaymentSheetListFragmentTest : PaymentSheetViewModelTestInjection
 
             assertThat(activityViewModel.selection.value)
                 .isEqualTo(PaymentSelection.Saved(savedPaymentMethod))
-        }
-    }
-
-    @Test
-    fun `posts transition when add card clicked`() {
-        createScenario().onFragment {
-            val activityViewModel = activityViewModel(it)
-            it.initializePaymentOptions()
-            activityViewModel.transitionToFirstScreenWhenReady()
-
-            assertThat(activityViewModel.backStack.value).containsExactly(
-                TransitionTarget.SelectSavedPaymentMethods,
-            )
-
-            idleLooper()
-
-            val adapter = recyclerView(it).adapter as PaymentOptionsAdapter
-            adapter.addCardClickListener()
-            idleLooper()
-
-            assertThat(activityViewModel.backStack.value).containsExactly(
-                TransitionTarget.SelectSavedPaymentMethods,
-                TransitionTarget.AddAnotherPaymentMethod,
-            )
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
@@ -21,7 +21,7 @@ import com.stripe.android.paymentsheet.PaymentSheetAddPaymentMethodFragmentTest.
 import com.stripe.android.paymentsheet.PaymentSheetAddPaymentMethodFragmentTest.Companion.lpmRepository
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
-import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
+import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.TransitionTarget
 import com.stripe.android.utils.TestUtils.idleLooper
 import org.junit.After
 import org.junit.Before
@@ -179,7 +179,12 @@ internal class PaymentSheetListFragmentTest : PaymentSheetViewModelTestInjection
     fun `posts transition when add card clicked`() {
         createScenario().onFragment {
             val activityViewModel = activityViewModel(it)
-            assertThat(activityViewModel.transition.value?.peekContent()).isNull()
+            it.initializePaymentOptions()
+            activityViewModel.transitionToFirstScreenWhenReady()
+
+            assertThat(activityViewModel.backStack.value).containsExactly(
+                TransitionTarget.SelectSavedPaymentMethods,
+            )
 
             idleLooper()
 
@@ -187,8 +192,10 @@ internal class PaymentSheetListFragmentTest : PaymentSheetViewModelTestInjection
             adapter.addCardClickListener()
             idleLooper()
 
-            assertThat(activityViewModel.transition.value?.peekContent())
-                .isEqualTo(BaseSheetViewModel.TransitionTarget.AddAnotherPaymentMethod)
+            assertThat(activityViewModel.backStack.value).containsExactly(
+                TransitionTarget.SelectSavedPaymentMethods,
+                TransitionTarget.AddAnotherPaymentMethod,
+            )
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -50,7 +50,6 @@ import com.stripe.android.ui.core.forms.resources.StaticLpmResourceRepository
 import com.stripe.android.utils.FakeCustomerRepository
 import com.stripe.android.utils.FakePaymentSheetLoader
 import com.stripe.android.utils.TestUtils.idleLooper
-import com.stripe.android.utils.TestUtils.observeEventsForever
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
@@ -717,14 +716,12 @@ internal class PaymentSheetViewModelTest {
     @Test
     fun `Transition only happens when view model is ready`() = runTest(testDispatcher) {
         val viewModel = createViewModel()
-        val observedTransitions = mutableListOf<TransitionTarget>()
-        viewModel.transition.observeEventsForever { observedTransitions.add(it) }
 
         viewModel.transitionToFirstScreenWhenReady()
-        assertThat(observedTransitions).isEmpty()
+        assertThat(viewModel.backStack.value).isEmpty()
 
         viewModel._isGooglePayReady.value = true
-        assertThat(observedTransitions).containsExactly(TransitionTarget.AddFirstPaymentMethod)
+        assertThat(viewModel.backStack.value).containsExactly(TransitionTarget.AddFirstPaymentMethod)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -717,11 +717,15 @@ internal class PaymentSheetViewModelTest {
     fun `Transition only happens when view model is ready`() = runTest(testDispatcher) {
         val viewModel = createViewModel()
 
-        viewModel.transitionToFirstScreenWhenReady()
-        assertThat(viewModel.backStack.value).isEmpty()
+        viewModel.currentScreen.test {
+            skipItems(1)
 
-        viewModel._isGooglePayReady.value = true
-        assertThat(viewModel.backStack.value).containsExactly(TransitionTarget.AddFirstPaymentMethod)
+            viewModel.transitionToFirstScreenWhenReady()
+            expectNoEvents()
+
+            viewModel._isGooglePayReady.value = true
+            assertThat(awaitItem()).isEqualTo(TransitionTarget.AddFirstPaymentMethod)
+        }
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/utils/TestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/TestUtils.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import org.robolectric.shadows.ShadowLooper.idleMainLooper
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -48,14 +47,5 @@ internal object TestUtils {
 
         @Suppress("UNCHECKED_CAST")
         return data as T
-    }
-
-    fun <T> LiveData<BaseSheetViewModel.Event<T>?>.observeEventsForever(
-        observer: (T) -> Unit,
-    ) {
-        observeForever { event ->
-            val content = event?.getContentIfNotHandled() ?: return@observeForever
-            observer(content)
-        }
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request replaces `transition`, which kept track of `Event<TransitionTarget>`, with `backStack`, which stores the back stack of the payment sheet.

We’re doing this for multiple reasons:
1. This helps us encapsulate the logic for handling back presses in `BaseSheetViewModel`.
2. It’ll enable us to simplify how we’re setting the bottom sheet’s title based on the current fragment. This logic is currently spread across multiple places.
3. When we’re switching from fragments to Compose, we’ll be able to easily map the `backStack` state to the UI.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
N/A

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A
