### PR TITLE
Make `_fatal` a plain property

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -128,7 +128,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
     }
 
     override fun onFatal(throwable: Throwable) {
-        _fatal.value = throwable
+        mostRecentError = throwable
         _paymentOptionResult.value =
             PaymentOptionResult.Failed(
                 error = throwable,
@@ -139,7 +139,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
     override fun onUserCancel() {
         _paymentOptionResult.value =
             PaymentOptionResult.Canceled(
-                mostRecentError = _fatal.value,
+                mostRecentError = mostRecentError,
                 paymentMethods = _paymentMethods.value
             )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -567,7 +567,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
     override fun onFatal(throwable: Throwable) {
         logger.error("Payment Sheet error", throwable)
-        _fatal.value = throwable
+        mostRecentError = throwable
         _paymentSheetResult.value = PaymentSheetResult.Failed(throwable)
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -91,8 +91,7 @@ internal abstract class BaseSheetViewModel(
     internal val merchantName = config?.merchantDisplayName
         ?: application.applicationInfo.loadLabel(application.packageManager).toString()
 
-    // a fatal error
-    protected val _fatal = MutableLiveData<Throwable>()
+    protected var mostRecentError: Throwable? = null
 
     @VisibleForTesting
     internal val _isGooglePayReady = savedStateHandle.getLiveData<Boolean>(SAVE_GOOGLE_PAY_READY)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request removes the usage of `LiveData` for `_fatal` and renames it to `mostRecentError` in the process.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
