### PR TITLE
Remove `liveMode` from ViewModel

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.MaterialToolbar
@@ -169,8 +170,9 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
         // `rootView`'s click listener
         bottomSheet.isClickable = true
 
-        viewModel.liveMode.observe(this) { isLiveMode ->
-            testModeIndicator.visibility = if (isLiveMode) View.GONE else View.VISIBLE
+        viewModel.stripeIntent.launchAndCollectIn(this) { stripeIntent ->
+            val isLiveMode = stripeIntent?.isLiveMode ?: true
+            testModeIndicator.isGone = isLiveMode
         }
 
         val isDark = baseContext.isSystemDarkTheme()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -56,6 +56,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -152,9 +153,6 @@ internal abstract class BaseSheetViewModel(
 
     private val _transition = MutableLiveData<Event<TransitionTarget>?>(null)
     internal val transition: LiveData<Event<TransitionTarget>?> = _transition
-
-    private val _liveMode = savedStateHandle.getLiveData<Boolean>(SAVE_STATE_LIVE_MODE)
-    internal val liveMode: LiveData<Boolean> = _liveMode
 
     private val _selection = savedStateHandle.getLiveData<PaymentSelection>(SAVE_SELECTION)
     internal val selection: LiveData<PaymentSelection?> = _selection
@@ -385,7 +383,6 @@ internal abstract class BaseSheetViewModel(
         }
 
         if (stripeIntent != null) {
-            _liveMode.postValue(stripeIntent.isLiveMode)
             warnUnactivatedIfNeeded(stripeIntent.unactivatedPaymentMethods)
         }
     }
@@ -650,7 +647,6 @@ internal abstract class BaseSheetViewModel(
         internal const val SAVE_PROCESSING = "processing"
         internal const val SAVE_GOOGLE_PAY_READY = "google_pay_ready"
         internal const val SAVE_RESOURCE_REPOSITORY_READY = "resource_repository_ready"
-        internal const val SAVE_STATE_LIVE_MODE = "save_state_live_mode"
         internal const val LINK_CONFIGURATION = "link_configuration"
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request gets rid of `liveMode` and its accompanying SavedStateHandle key. We now using `stripeIntent.isLiveMode` directly.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Removing LiveData and unnecessary properties.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
N/A

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A
