### PR TITLE
Keep `backStack` in ViewModel and wrap content fragments in `ComposeView`

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -949,9 +949,9 @@ public final class com/stripe/android/paymentsheet/databinding/ActivityPaymentOp
 	public final field appbar Lcom/google/android/material/appbar/AppBarLayout;
 	public final field bottomSheet Landroid/widget/LinearLayout;
 	public final field bottomSpacer Landroid/view/View;
+	public final field contentContainer Landroidx/compose/ui/platform/ComposeView;
 	public final field continueButton Lcom/stripe/android/paymentsheet/ui/PrimaryButton;
 	public final field coordinator Landroidx/coordinatorlayout/widget/CoordinatorLayout;
-	public final field fragmentContainer Landroidx/fragment/app/FragmentContainerView;
 	public final field fragmentContainerParent Landroid/widget/LinearLayout;
 	public final field header Landroidx/compose/ui/platform/ComposeView;
 	public final field linkAuth Landroidx/compose/ui/platform/ComposeView;
@@ -973,8 +973,8 @@ public final class com/stripe/android/paymentsheet/databinding/ActivityPaymentSh
 	public final field bottomSpacer Landroid/view/View;
 	public final field buttonContainer Landroid/widget/FrameLayout;
 	public final field buyButton Lcom/stripe/android/paymentsheet/ui/PrimaryButton;
+	public final field contentContainer Landroidx/compose/ui/platform/ComposeView;
 	public final field coordinator Landroidx/coordinatorlayout/widget/CoordinatorLayout;
-	public final field fragmentContainer Landroidx/fragment/app/FragmentContainerView;
 	public final field fragmentContainerParent Landroid/widget/LinearLayout;
 	public final field googlePayButton Lcom/stripe/android/paymentsheet/ui/GooglePayButton;
 	public final field googlePayDivider Landroidx/compose/ui/platform/ComposeView;
@@ -1002,6 +1002,42 @@ public final class com/stripe/android/paymentsheet/databinding/FragmentAchBindin
 	public fun getRoot ()Landroidx/fragment/app/FragmentContainerView;
 	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/paymentsheet/databinding/FragmentAchBinding;
 	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/paymentsheet/databinding/FragmentAchBinding;
+}
+
+public final class com/stripe/android/paymentsheet/databinding/FragmentPaymentOptionsAddPmBinding : androidx/viewbinding/ViewBinding {
+	public final field fragmentContainerViewPaymentOptionsAddPm Landroidx/fragment/app/FragmentContainerView;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/paymentsheet/databinding/FragmentPaymentOptionsAddPmBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroidx/fragment/app/FragmentContainerView;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/paymentsheet/databinding/FragmentPaymentOptionsAddPmBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/paymentsheet/databinding/FragmentPaymentOptionsAddPmBinding;
+}
+
+public final class com/stripe/android/paymentsheet/databinding/FragmentPaymentOptionsListBinding : androidx/viewbinding/ViewBinding {
+	public final field fragmentContainerViewPaymentOptionsList Landroidx/fragment/app/FragmentContainerView;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/paymentsheet/databinding/FragmentPaymentOptionsListBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroidx/fragment/app/FragmentContainerView;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/paymentsheet/databinding/FragmentPaymentOptionsListBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/paymentsheet/databinding/FragmentPaymentOptionsListBinding;
+}
+
+public final class com/stripe/android/paymentsheet/databinding/FragmentPaymentSheetAddPmBinding : androidx/viewbinding/ViewBinding {
+	public final field fragmentContainerViewPaymentSheetAddPm Landroidx/fragment/app/FragmentContainerView;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/paymentsheet/databinding/FragmentPaymentSheetAddPmBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroidx/fragment/app/FragmentContainerView;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/paymentsheet/databinding/FragmentPaymentSheetAddPmBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/paymentsheet/databinding/FragmentPaymentSheetAddPmBinding;
+}
+
+public final class com/stripe/android/paymentsheet/databinding/FragmentPaymentSheetListBinding : androidx/viewbinding/ViewBinding {
+	public final field fragmentContainerViewPaymentOptionsList Landroidx/fragment/app/FragmentContainerView;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/paymentsheet/databinding/FragmentPaymentSheetListBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroidx/fragment/app/FragmentContainerView;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/paymentsheet/databinding/FragmentPaymentSheetListBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/paymentsheet/databinding/FragmentPaymentSheetListBinding;
 }
 
 public final class com/stripe/android/paymentsheet/databinding/FragmentPaymentsheetLoadingBinding : androidx/viewbinding/ViewBinding {

--- a/paymentsheet/res/layout/activity_payment_options.xml
+++ b/paymentsheet/res/layout/activity_payment_options.xml
@@ -75,9 +75,8 @@
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="@dimen/stripe_paymentsheet_outer_spacing_horizontal"/>
 
-                <androidx.fragment.app.FragmentContainerView
-                    android:id="@+id/fragment_container"
-                    android:name="com.stripe.android.paymentsheet.PaymentSheetLoadingFragment"
+                <androidx.compose.ui.platform.ComposeView
+                    android:id="@+id/content_container"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content" />
 

--- a/paymentsheet/res/layout/activity_payment_sheet.xml
+++ b/paymentsheet/res/layout/activity_payment_sheet.xml
@@ -113,9 +113,8 @@
                         android:layout_height="wrap_content" />
                 </LinearLayout>
 
-                <androidx.fragment.app.FragmentContainerView
-                    android:id="@+id/fragment_container"
-                    android:name="com.stripe.android.paymentsheet.PaymentSheetLoadingFragment"
+                <androidx.compose.ui.platform.ComposeView
+                    android:id="@+id/content_container"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content" />
 

--- a/paymentsheet/res/layout/fragment_payment_options_add_pm.xml
+++ b/paymentsheet/res/layout/fragment_payment_options_add_pm.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.fragment.app.FragmentContainerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/fragment_container_view_payment_options_add_pm"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent"
+    android:name="com.stripe.android.paymentsheet.PaymentOptionsAddPaymentMethodFragment" />

--- a/paymentsheet/res/layout/fragment_payment_options_list.xml
+++ b/paymentsheet/res/layout/fragment_payment_options_list.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.fragment.app.FragmentContainerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/fragment_container_view_payment_options_list"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent"
+    android:name="com.stripe.android.paymentsheet.PaymentOptionsListFragment" />

--- a/paymentsheet/res/layout/fragment_payment_sheet_add_pm.xml
+++ b/paymentsheet/res/layout/fragment_payment_sheet_add_pm.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.fragment.app.FragmentContainerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/fragment_container_view_payment_sheet_add_pm"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent"
+    android:name="com.stripe.android.paymentsheet.PaymentSheetAddPaymentMethodFragment" />

--- a/paymentsheet/res/layout/fragment_payment_sheet_list.xml
+++ b/paymentsheet/res/layout/fragment_payment_sheet_list.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.fragment.app.FragmentContainerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/fragment_container_view_payment_options_list"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent"
+    android:name="com.stripe.android.paymentsheet.PaymentSheetListFragment" />

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -7,25 +7,22 @@ import android.view.ViewGroup
 import android.widget.ScrollView
 import android.widget.TextView
 import androidx.activity.viewModels
-import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
-import androidx.core.os.bundleOf
 import androidx.core.view.doOnNextLayout
 import androidx.core.view.isVisible
-import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentManager
-import androidx.fragment.app.commit
 import androidx.lifecycle.ViewModelProvider
 import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.MaterialToolbar
 import com.stripe.android.paymentsheet.databinding.ActivityPaymentOptionsBinding
+import com.stripe.android.paymentsheet.navigation.PaymentOptionsContent
 import com.stripe.android.paymentsheet.navigation.TransitionTarget
 import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.PrimaryButton
+import com.stripe.android.paymentsheet.utils.launchAndCollectIn
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
-import com.stripe.android.paymentsheet.viewmodels.observeEvents
-import com.stripe.android.utils.AnimationConstants
 
 /**
  * An `Activity` for selecting a payment option.
@@ -46,10 +43,6 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
     private val starterArgs: PaymentOptionContract.Args? by lazy {
         PaymentOptionContract.Args.fromIntent(intent)
     }
-
-    private val fragmentContainerId: Int
-        @IdRes
-        get() = viewBinding.fragmentContainer.id
 
     override val rootView: ViewGroup by lazy { viewBinding.root }
     override val bottomSheet: ViewGroup by lazy { viewBinding.bottomSheet }
@@ -90,8 +83,9 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
             )
         }
 
-        viewModel.transition.observeEvents(this) { transitionTarget ->
-            onTransitionTarget(transitionTarget)
+        viewBinding.contentContainer.setContent {
+            val currentScreen by viewModel.currentScreen.collectAsState()
+            currentScreen.PaymentOptionsContent()
         }
 
         if (savedInstanceState == null) {
@@ -103,18 +97,23 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
             resetPrimaryButtonState()
         }
 
-        supportFragmentManager.registerFragmentLifecycleCallbacks(
-            object : FragmentManager.FragmentLifecycleCallbacks() {
-                override fun onFragmentStarted(fm: FragmentManager, fragment: Fragment) {
-                    val visible =
-                        fragment is PaymentOptionsAddPaymentMethodFragment ||
-                            viewModel.primaryButtonUIState.value?.visible == true
-                    viewBinding.continueButton.isVisible = visible
-                    viewBinding.bottomSpacer.isVisible = visible
+        viewModel.currentScreen.launchAndCollectIn(this) { currentScreen ->
+            val visible = currentScreen is TransitionTarget.AddFirstPaymentMethod ||
+                currentScreen is TransitionTarget.AddAnotherPaymentMethod ||
+                viewModel.primaryButtonUIState.value?.visible == true
+
+            viewBinding.continueButton.isVisible = visible
+            viewBinding.bottomSpacer.isVisible = visible
+
+            if (currentScreen != null) {
+                rootView.doOnNextLayout {
+                    // Expand sheet only after the first fragment is attached so that it
+                    // animates in. Further calls to expand() are no-op if the sheet is already
+                    // expanded.
+                    bottomSheetController.expand()
                 }
-            },
-            false
-        )
+            }
+        }
     }
 
     private fun initializeStarterArgs(): PaymentOptionContract.Args? {
@@ -134,60 +133,6 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
 
         viewBinding.continueButton.setOnClickListener {
             viewModel.onUserSelection()
-        }
-    }
-
-    private fun onTransitionTarget(
-        transitionTarget: TransitionTarget,
-    ) {
-        val fragmentArgs = bundleOf(PaymentSheetActivity.EXTRA_STARTER_ARGS to starterArgs)
-
-        supportFragmentManager.commit {
-            when (transitionTarget) {
-                is TransitionTarget.AddAnotherPaymentMethod -> {
-                    // Once the add fragment has been opened there is never a scenario that
-                    // we should back to the add fragment from the select list view.
-                    viewModel.hasTransitionToUnsavedLpm = true
-                    setCustomAnimations(
-                        AnimationConstants.FADE_IN,
-                        AnimationConstants.FADE_OUT,
-                        AnimationConstants.FADE_IN,
-                        AnimationConstants.FADE_OUT
-                    )
-                    addToBackStack(null)
-
-                    replace(
-                        fragmentContainerId,
-                        PaymentOptionsAddPaymentMethodFragment::class.java,
-                        fragmentArgs,
-                    )
-                }
-                is TransitionTarget.SelectSavedPaymentMethods -> {
-                    replace(
-                        fragmentContainerId,
-                        PaymentOptionsListFragment::class.java,
-                        fragmentArgs,
-                    )
-                }
-                is TransitionTarget.AddFirstPaymentMethod -> {
-                    // Once the add fragment has been opened there is never a scenario that
-                    // we should back to the add fragment from the select list view.
-                    viewModel.hasTransitionToUnsavedLpm = true
-                    replace(
-                        fragmentContainerId,
-                        PaymentOptionsAddPaymentMethodFragment::class.java,
-                        fragmentArgs,
-                    )
-                }
-            }
-        }
-
-        // Ensure the bottom sheet is expanded only after the fragment transaction is completed
-        supportFragmentManager.executePendingTransactions()
-        rootView.doOnNextLayout {
-            // Expand sheet only after the first fragment is attached so that it animates in.
-            // Further calls to expand() are no-op if the sheet is already expanded.
-            bottomSheetController.expand()
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsListFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsListFragment.kt
@@ -1,7 +1,5 @@
 package com.stripe.android.paymentsheet
 
-import android.os.Bundle
-import android.view.View
 import androidx.fragment.app.activityViewModels
 
 internal class PaymentOptionsListFragment : BasePaymentMethodsListFragment(
@@ -16,14 +14,6 @@ internal class PaymentOptionsListFragment : BasePaymentMethodsListFragment(
     }
 
     override val sheetViewModel: PaymentOptionsViewModel by lazy { activityViewModel }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
-        // We need to make sure the list fragment is attached before jumping, so the
-        // list is properly added to the backstack.
-        sheetViewModel.resolveTransitionTarget()
-    }
 
     override fun onResume() {
         super.onResume()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -293,13 +293,19 @@ internal class PaymentOptionsViewModel @Inject constructor(
         } else {
             AddFirstPaymentMethod
         }
-        transitionTo(target)
 
-        if (target is SelectSavedPaymentMethods && newPaymentSelection != null) {
-            // The user has previously selected a new payment method. Instead of sending them to the
-            // payment methods screen, we directly launch them into the payment method form again.
-            transitionTo(TransitionTarget.AddAnotherPaymentMethod)
+        val initialBackStack = buildList {
+            add(target)
+
+            if (target is SelectSavedPaymentMethods && newPaymentSelection != null) {
+                // The user has previously selected a new payment method. Instead of sending them
+                // to the payment methods screen, we directly launch them into the payment method
+                // form again.
+                add(TransitionTarget.AddAnotherPaymentMethod)
+            }
         }
+
+        backStack.value = initialBackStack
     }
 
     internal class Factory(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -9,14 +9,14 @@ import android.view.WindowManager
 import android.widget.ScrollView
 import android.widget.TextView
 import androidx.activity.viewModels
-import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.core.os.bundleOf
 import androidx.core.view.doOnNextLayout
 import androidx.core.view.isVisible
-import androidx.fragment.app.commit
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.appbar.AppBarLayout
@@ -25,15 +25,13 @@ import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContra
 import com.stripe.android.paymentsheet.PaymentSheetViewModel.CheckoutIdentifier
 import com.stripe.android.paymentsheet.databinding.ActivityPaymentSheetBinding
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
-import com.stripe.android.paymentsheet.navigation.TransitionTarget
+import com.stripe.android.paymentsheet.navigation.PaymentSheetContent
 import com.stripe.android.paymentsheet.state.GooglePayState
 import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.GooglePayDividerUi
 import com.stripe.android.paymentsheet.ui.PrimaryButton
-import com.stripe.android.paymentsheet.viewmodels.observeEvents
 import com.stripe.android.ui.core.PaymentsTheme
 import com.stripe.android.ui.core.forms.resources.LpmRepository
-import com.stripe.android.utils.AnimationConstants
 import kotlinx.coroutines.launch
 import java.security.InvalidParameterException
 
@@ -53,10 +51,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
     private val starterArgs: PaymentSheetContract.Args? by lazy {
         PaymentSheetContract.Args.fromIntent(intent)
     }
-
-    private val fragmentContainerId: Int
-        @IdRes
-        get() = viewBinding.fragmentContainer.id
 
     override val rootView: ViewGroup by lazy { viewBinding.root }
     override val bottomSheet: ViewGroup by lazy { viewBinding.bottomSheet }
@@ -124,8 +118,14 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
             linkPaymentLauncher = viewModel.linkLauncher
         }
 
-        viewModel.transition.observeEvents(this) { transitionTarget ->
-            onTransitionTarget(transitionTarget)
+        viewBinding.contentContainer.setContent {
+            val currentScreen by viewModel.currentScreen.collectAsState()
+
+            LaunchedEffect(currentScreen) {
+                buttonContainer.isVisible = currentScreen != null
+            }
+
+            currentScreen.PaymentSheetContent()
         }
 
         if (savedInstanceState == null) {
@@ -179,59 +179,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
 
         earlyExitDueToIllegalState = result.isFailure
         return result
-    }
-
-    private fun onTransitionTarget(
-        transitionTarget: TransitionTarget,
-    ) {
-        val fragmentArgs = bundleOf(EXTRA_STARTER_ARGS to starterArgs)
-
-        supportFragmentManager.commit {
-            when (transitionTarget) {
-                is TransitionTarget.AddAnotherPaymentMethod -> {
-                    setCustomAnimations(
-                        AnimationConstants.FADE_IN,
-                        AnimationConstants.FADE_OUT,
-                        AnimationConstants.FADE_IN,
-                        AnimationConstants.FADE_OUT
-                    )
-                    addToBackStack(null)
-                    replace(
-                        fragmentContainerId,
-                        PaymentSheetAddPaymentMethodFragment::class.java,
-                        fragmentArgs
-                    )
-                }
-                is TransitionTarget.SelectSavedPaymentMethods -> {
-                    setCustomAnimations(
-                        AnimationConstants.FADE_IN,
-                        AnimationConstants.FADE_OUT,
-                        AnimationConstants.FADE_IN,
-                        AnimationConstants.FADE_OUT
-                    )
-                    replace(
-                        fragmentContainerId,
-                        PaymentSheetListFragment::class.java,
-                        fragmentArgs
-                    )
-                }
-                is TransitionTarget.AddFirstPaymentMethod -> {
-                    setCustomAnimations(
-                        AnimationConstants.FADE_IN,
-                        AnimationConstants.FADE_OUT,
-                        AnimationConstants.FADE_IN,
-                        AnimationConstants.FADE_OUT
-                    )
-                    replace(
-                        fragmentContainerId,
-                        PaymentSheetAddPaymentMethodFragment::class.java,
-                        fragmentArgs
-                    )
-                }
-            }
-        }
-
-        buttonContainer.isVisible = true
     }
 
     override fun resetPrimaryButtonState() {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/TransitionTarget.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/TransitionTarget.kt
@@ -13,10 +13,10 @@ import com.stripe.android.paymentsheet.databinding.FragmentPaymentsheetLoadingBi
 internal sealed interface TransitionTarget {
 
     @Composable
-    abstract fun PaymentSheetContent()
+    fun PaymentSheetContent()
 
     @Composable
-    abstract fun PaymentOptionsContent()
+    fun PaymentOptionsContent()
 
     object SelectSavedPaymentMethods : TransitionTarget {
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/TransitionTarget.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/TransitionTarget.kt
@@ -94,5 +94,5 @@ internal fun TransitionTarget?.PaymentOptionsContent() {
     }
 }
 
-internal val TransitionTarget.testTag: String
+private val TransitionTarget.testTag: String
     get() = this::class.java.simpleName

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/TransitionTarget.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/TransitionTarget.kt
@@ -1,10 +1,98 @@
 package com.stripe.android.paymentsheet.navigation
 
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.viewinterop.AndroidViewBinding
+import com.stripe.android.paymentsheet.databinding.FragmentPaymentOptionsAddPmBinding
+import com.stripe.android.paymentsheet.databinding.FragmentPaymentOptionsListBinding
+import com.stripe.android.paymentsheet.databinding.FragmentPaymentSheetAddPmBinding
+import com.stripe.android.paymentsheet.databinding.FragmentPaymentSheetListBinding
+import com.stripe.android.paymentsheet.databinding.FragmentPaymentsheetLoadingBinding
+
 internal sealed interface TransitionTarget {
 
-    object SelectSavedPaymentMethods : TransitionTarget
+    @Composable
+    abstract fun PaymentSheetContent()
 
-    object AddAnotherPaymentMethod : TransitionTarget
+    @Composable
+    abstract fun PaymentOptionsContent()
 
-    object AddFirstPaymentMethod : TransitionTarget
+    object SelectSavedPaymentMethods : TransitionTarget {
+
+        @Composable
+        override fun PaymentSheetContent() {
+            AndroidViewBinding(
+                factory = FragmentPaymentSheetListBinding::inflate,
+                modifier = Modifier.testTag(testTag),
+            )
+        }
+
+        @Composable
+        override fun PaymentOptionsContent() {
+            AndroidViewBinding(
+                factory = FragmentPaymentOptionsListBinding::inflate,
+                modifier = Modifier.testTag(testTag),
+            )
+        }
+    }
+
+    object AddAnotherPaymentMethod : TransitionTarget {
+
+        @Composable
+        override fun PaymentSheetContent() {
+            AndroidViewBinding(
+                factory = FragmentPaymentSheetAddPmBinding::inflate,
+                modifier = Modifier.testTag(testTag),
+            )
+        }
+
+        @Composable
+        override fun PaymentOptionsContent() {
+            AndroidViewBinding(
+                factory = FragmentPaymentOptionsAddPmBinding::inflate,
+                modifier = Modifier.testTag(testTag),
+            )
+        }
+    }
+
+    object AddFirstPaymentMethod : TransitionTarget {
+
+        @Composable
+        override fun PaymentSheetContent() {
+            AndroidViewBinding(
+                factory = FragmentPaymentSheetAddPmBinding::inflate,
+                modifier = Modifier.testTag(testTag),
+            )
+        }
+
+        @Composable
+        override fun PaymentOptionsContent() {
+            AndroidViewBinding(
+                factory = FragmentPaymentOptionsAddPmBinding::inflate,
+                modifier = Modifier.testTag(testTag),
+            )
+        }
+    }
 }
+
+@Composable
+internal fun TransitionTarget?.PaymentSheetContent() {
+    if (this == null) {
+        AndroidViewBinding(FragmentPaymentsheetLoadingBinding::inflate)
+    } else {
+        PaymentSheetContent()
+    }
+}
+
+@Composable
+internal fun TransitionTarget?.PaymentOptionsContent() {
+    if (this == null) {
+        AndroidViewBinding(FragmentPaymentsheetLoadingBinding::inflate)
+    } else {
+        PaymentOptionsContent()
+    }
+}
+
+internal val TransitionTarget.testTag: String
+    get() = this::class.java.simpleName

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.AndroidViewModel
-import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -150,7 +150,7 @@ internal abstract class BaseSheetViewModel(
         savedStateHandle.getLiveData<SavedSelection>(SAVE_SAVED_SELECTION)
     private val savedSelection: LiveData<SavedSelection> = _savedSelection
 
-    private val backStack = MutableStateFlow<List<TransitionTarget>>(emptyList())
+    protected val backStack = MutableStateFlow<List<TransitionTarget>>(emptyList())
 
     val currentScreen: StateFlow<TransitionTarget?> = backStack
         .map { it.lastOrNull() }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -10,6 +10,7 @@ import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.asLiveData
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -50,7 +51,6 @@ import com.stripe.android.ui.core.forms.resources.StaticLpmResourceRepository
 import com.stripe.android.utils.FakeCustomerRepository
 import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.TestUtils.idleLooper
-import com.stripe.android.utils.TestUtils.observeEventsForever
 import com.stripe.android.utils.TestUtils.viewModelFactoryFor
 import com.stripe.android.utils.injectableActivityScenario
 import com.stripe.android.view.ActivityStarter
@@ -263,8 +263,8 @@ internal class PaymentOptionsActivityTest {
         val args = PAYMENT_OPTIONS_CONTRACT_ARGS.updateState(isGooglePayReady = true)
         val viewModel = createViewModel(args)
 
-        val transitionTargets = mutableListOf<TransitionTarget>()
-        viewModel.transition.observeEventsForever { transitionTargets.add(it) }
+        val transitionTargets = mutableListOf<TransitionTarget?>()
+        viewModel.currentScreen.asLiveData().observeForever { transitionTargets.add(it) }
 
         activityScenario(viewModel).launch(createIntent(args)).use {
             it.onActivity {
@@ -272,7 +272,7 @@ internal class PaymentOptionsActivityTest {
             }
         }
 
-        assertThat(transitionTargets).containsExactly(TransitionTarget.SelectSavedPaymentMethods)
+        assertThat(transitionTargets).containsExactly(null, TransitionTarget.SelectSavedPaymentMethods)
     }
 
     @Test
@@ -285,8 +285,8 @@ internal class PaymentOptionsActivityTest {
 
         val viewModel = createViewModel(args)
 
-        val transitionTargets = mutableListOf<TransitionTarget>()
-        viewModel.transition.observeEventsForever { transitionTargets.add(it) }
+        val transitionTargets = mutableListOf<TransitionTarget?>()
+        viewModel.currentScreen.asLiveData().observeForever { transitionTargets.add(it) }
 
         activityScenario(viewModel).launch(createIntent(args)).use {
             it.onActivity {
@@ -294,7 +294,7 @@ internal class PaymentOptionsActivityTest {
             }
         }
 
-        assertThat(transitionTargets).containsExactly(TransitionTarget.SelectSavedPaymentMethods)
+        assertThat(transitionTargets).containsExactly(null, TransitionTarget.SelectSavedPaymentMethods)
     }
 
     @Test
@@ -306,14 +306,14 @@ internal class PaymentOptionsActivityTest {
 
         val viewModel = createViewModel(args)
 
-        val transitionTargets = mutableListOf<TransitionTarget>()
-        viewModel.transition.observeEventsForever { transitionTargets.add(it) }
+        val transitionTargets = mutableListOf<TransitionTarget?>()
+        viewModel.currentScreen.asLiveData().observeForever { transitionTargets.add(it) }
 
         activityScenario(viewModel).launch(createIntent(args)).use {
             idleLooper()
         }
 
-        assertThat(transitionTargets).containsExactly(TransitionTarget.SelectSavedPaymentMethods)
+        assertThat(transitionTargets).containsExactly(null, TransitionTarget.SelectSavedPaymentMethods)
     }
 
     @Test
@@ -325,14 +325,14 @@ internal class PaymentOptionsActivityTest {
 
         val viewModel = createViewModel(args)
 
-        val transitionTargets = mutableListOf<TransitionTarget>()
-        viewModel.transition.observeEventsForever { transitionTargets.add(it) }
+        val transitionTargets = mutableListOf<TransitionTarget?>()
+        viewModel.currentScreen.asLiveData().observeForever { transitionTargets.add(it) }
 
         activityScenario(viewModel).launch(createIntent(args)).use {
             idleLooper()
         }
 
-        assertThat(transitionTargets).containsExactly(TransitionTarget.AddFirstPaymentMethod)
+        assertThat(transitionTargets).containsExactly(null, TransitionTarget.AddFirstPaymentMethod)
     }
 
     @Test
@@ -343,8 +343,8 @@ internal class PaymentOptionsActivityTest {
 
         val viewModel = createViewModel(args)
 
-        val transitionTargets = mutableListOf<TransitionTarget>()
-        viewModel.transition.observeEventsForever { transitionTargets.add(it) }
+        val transitionTargets = mutableListOf<TransitionTarget?>()
+        viewModel.currentScreen.asLiveData().observeForever { transitionTargets.add(it) }
 
         activityScenario(viewModel).launch(createIntent(args)).use { scenario ->
             scenario.onActivity {
@@ -358,7 +358,7 @@ internal class PaymentOptionsActivityTest {
             }
         }
 
-        assertThat(transitionTargets).containsExactly(TransitionTarget.SelectSavedPaymentMethods)
+        assertThat(transitionTargets).containsExactly(null, TransitionTarget.SelectSavedPaymentMethods)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -266,7 +266,7 @@ internal class PaymentOptionsActivityTest {
 
         viewModel.currentScreen.test {
             assertThat(awaitItem()).isNull()
-            activityScenario(viewModel).launch(createIntent(args)).onActivity { idleLooper() }
+            activityScenario(viewModel).launch(createIntent(args))
             assertThat(awaitItem()).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
         }
     }
@@ -283,7 +283,7 @@ internal class PaymentOptionsActivityTest {
 
         viewModel.currentScreen.test {
             assertThat(awaitItem()).isNull()
-            activityScenario(viewModel).launch(createIntent(args)).onActivity { idleLooper() }
+            activityScenario(viewModel).launch(createIntent(args))
             assertThat(awaitItem()).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
         }
     }
@@ -299,7 +299,7 @@ internal class PaymentOptionsActivityTest {
 
         viewModel.currentScreen.test {
             assertThat(awaitItem()).isNull()
-            activityScenario(viewModel).launch(createIntent(args)).onActivity { idleLooper() }
+            activityScenario(viewModel).launch(createIntent(args))
             assertThat(awaitItem()).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
         }
     }
@@ -315,7 +315,7 @@ internal class PaymentOptionsActivityTest {
 
         viewModel.currentScreen.test {
             assertThat(awaitItem()).isNull()
-            activityScenario(viewModel).launch(createIntent(args)).onActivity { idleLooper() }
+            activityScenario(viewModel).launch(createIntent(args))
             assertThat(awaitItem()).isEqualTo(TransitionTarget.AddFirstPaymentMethod)
         }
     }
@@ -333,11 +333,10 @@ internal class PaymentOptionsActivityTest {
             assertThat(awaitItem()).isNull()
 
             scenario.launch(createIntent(args))
-                .onActivity { idleLooper() }
-                .recreate()
-                .onActivity { idleLooper() }
-
             assertThat(awaitItem()).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
+
+            scenario.recreate()
+            expectNoEvents()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -123,7 +123,7 @@ internal class PaymentOptionsViewModelTest {
         )
 
         viewModel.currentScreen.test {
-            skipItems(1)
+            assertThat(awaitItem()).isNull()
             viewModel.transitionToFirstScreen()
             assertThat(awaitItem()).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
         }
@@ -141,7 +141,7 @@ internal class PaymentOptionsViewModelTest {
         )
 
         viewModel.currentScreen.test {
-            skipItems(1)
+            assertThat(awaitItem()).isNull()
             viewModel.transitionToFirstScreen()
             assertThat(awaitItem()).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
             assertThat(awaitItem()).isEqualTo(TransitionTarget.AddAnotherPaymentMethod)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -301,12 +301,11 @@ internal class PaymentOptionsViewModelTest {
             )
         )
 
-        val observedTransitions = mutableListOf<TransitionTarget>()
-        viewModel.transition.observeEventsForever { observedTransitions.add(it) }
-
-        viewModel.transitionToFirstScreen()
-
-        assertThat(observedTransitions).containsExactly(TransitionTarget.AddFirstPaymentMethod)
+        viewModel.currentScreen.test {
+            assertThat(awaitItem()).isNull()
+            viewModel.transitionToFirstScreen()
+            assertThat(awaitItem()).isEqualTo(TransitionTarget.AddFirstPaymentMethod)
+        }
     }
 
     @Test
@@ -319,12 +318,11 @@ internal class PaymentOptionsViewModelTest {
             )
         )
 
-        val observedTransitions = mutableListOf<TransitionTarget>()
-        viewModel.transition.observeEventsForever { observedTransitions.add(it) }
-
-        viewModel.transitionToFirstScreen()
-
-        assertThat(observedTransitions).containsExactly(TransitionTarget.SelectSavedPaymentMethods)
+        viewModel.currentScreen.test {
+            assertThat(awaitItem()).isNull()
+            viewModel.transitionToFirstScreen()
+            assertThat(awaitItem()).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
+        }
     }
 
     private fun createViewModel(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -130,7 +130,7 @@ internal class PaymentOptionsViewModelTest {
     }
 
     @Test
-    fun `Opens previously selected new payment method`() = runTest {
+    fun `Restores backstack when user previously selected a new payment method`() = runTest {
         val viewModel = createViewModel(
             args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(
                 stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
@@ -143,8 +143,10 @@ internal class PaymentOptionsViewModelTest {
         viewModel.currentScreen.test {
             assertThat(awaitItem()).isNull()
             viewModel.transitionToFirstScreen()
-            assertThat(awaitItem()).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
             assertThat(awaitItem()).isEqualTo(TransitionTarget.AddAnotherPaymentMethod)
+
+            viewModel.handleBackPressed()
+            assertThat(awaitItem()).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -117,21 +117,20 @@ internal class PaymentOptionsViewModelTest {
         }
 
     @Test
-    fun `resolveTransitionTarget no new card`() = runTest {
+    fun `Opens saved payment methods if no new payment method was previously selected`() = runTest {
         val viewModel = createViewModel(
             args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(newPaymentSelection = null)
         )
 
         viewModel.currentScreen.test {
-            assertThat(awaitItem()).isNull()
-            // no customer, no new card, no paymentMethods
-            viewModel.resolveTransitionTarget()
-            expectNoEvents()
+            skipItems(1)
+            viewModel.transitionToFirstScreen()
+            assertThat(awaitItem()).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
         }
     }
 
     @Test
-    fun `resolveTransitionTarget new card saved`() = runTest {
+    fun `Opens previously selected new payment method`() = runTest {
         val viewModel = createViewModel(
             args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(
                 stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
@@ -142,31 +141,10 @@ internal class PaymentOptionsViewModelTest {
         )
 
         viewModel.currentScreen.test {
-            assertThat(awaitItem()).isNull()
-            viewModel.resolveTransitionTarget()
+            skipItems(1)
+            viewModel.transitionToFirstScreen()
+            assertThat(awaitItem()).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
             assertThat(awaitItem()).isEqualTo(TransitionTarget.AddAnotherPaymentMethod)
-        }
-    }
-
-    @Test
-    fun `resolveTransitionTarget new card NOT saved`() = runTest {
-        val viewModel = createViewModel(
-            args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(
-                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
-                newPaymentSelection = NEW_CARD_PAYMENT_SELECTION.copy(
-                    customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse
-                )
-            )
-        )
-
-        viewModel.currentScreen.test {
-            assertThat(awaitItem()).isNull()
-
-            viewModel.resolveTransitionTarget()
-            assertThat(awaitItem()).isEqualTo(TransitionTarget.AddAnotherPaymentMethod)
-
-            viewModel.resolveTransitionTarget()
-            expectNoEvents()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -431,7 +431,7 @@ internal class PaymentSheetActivityTest {
     }
 
     @Test
-    fun `handles fragment transitions`() {
+    fun `handles screen transitions correctly`() {
         val viewModel = createViewModel()
         val scenario = activityScenario(viewModel)
 
@@ -751,7 +751,7 @@ internal class PaymentSheetActivityTest {
     }
 
     @Test
-    fun `shows add card fragment when no saved payment methods available`() {
+    fun `shows add card screen when no saved payment methods available`() {
         val viewModel = createViewModel(paymentMethods = emptyList())
         val scenario = activityScenario(viewModel)
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -438,14 +438,14 @@ internal class PaymentSheetActivityTest {
         viewModel.currentScreen.test {
             assertThat(awaitItem()).isNull()
 
-            scenario.launch(intent).onActivity { idleLooper() }
+            scenario.launch(intent)
             assertThat(awaitItem()).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
 
             viewModel.transitionToAddPaymentScreen()
             assertThat(awaitItem()).isEqualTo(TransitionTarget.AddAnotherPaymentMethod)
 
             pressBack()
-            scenario.launch(intent).onActivity { idleLooper() }
+            scenario.launch(intent)
 
             assertThat(awaitItem()).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
         }
@@ -752,7 +752,7 @@ internal class PaymentSheetActivityTest {
 
         viewModel.currentScreen.test {
             assertThat(awaitItem()).isNull()
-            scenario.launchForResult(intent).onActivity { idleLooper() }
+            scenario.launchForResult(intent)
             assertThat(awaitItem()).isEqualTo(TransitionTarget.AddFirstPaymentMethod)
         }
     }
@@ -1156,7 +1156,7 @@ internal class PaymentSheetActivityTest {
 
         viewModel.currentScreen.test {
             assertThat(awaitItem()).isNull()
-            activityScenario(viewModel).launch(intent).onActivity { idleLooper() }
+            activityScenario(viewModel).launch(intent)
             assertThat(awaitItem()).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
         }
     }
@@ -1167,7 +1167,7 @@ internal class PaymentSheetActivityTest {
 
         viewModel.currentScreen.test {
             assertThat(awaitItem()).isNull()
-            activityScenario(viewModel).launch(intent).onActivity { idleLooper() }
+            activityScenario(viewModel).launch(intent)
             assertThat(awaitItem()).isEqualTo(TransitionTarget.AddFirstPaymentMethod)
         }
     }
@@ -1180,11 +1180,11 @@ internal class PaymentSheetActivityTest {
         viewModel.currentScreen.test {
             assertThat(awaitItem()).isNull()
 
-            scenario.launch(intent).onActivity { idleLooper() }
-            scenario.recreate()
-            scenario.onActivity { idleLooper() }
-
+            scenario.launch(intent)
             assertThat(awaitItem()).isEqualTo(TransitionTarget.AddFirstPaymentMethod)
+
+            scenario.recreate()
+            expectNoEvents()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
@@ -6,6 +6,7 @@ import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.testing.FragmentScenario
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.asLiveData
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
@@ -183,7 +184,9 @@ internal class PaymentSheetListFragmentTest : PaymentSheetViewModelTestInjection
     fun `posts transition when add card clicked`() {
         createScenario().onFragment {
             val activityViewModel = activityViewModel(it)
-            assertThat(activityViewModel.transition.value?.peekContent()).isNull()
+
+            val transitionTargets = mutableListOf<TransitionTarget?>()
+            activityViewModel.currentScreen.asLiveData().observeForever { transitionTargets.add(it) }
 
             idleLooper()
 
@@ -191,8 +194,7 @@ internal class PaymentSheetListFragmentTest : PaymentSheetViewModelTestInjection
             adapter.addCardClickListener()
             idleLooper()
 
-            assertThat(activityViewModel.transition.value?.peekContent())
-                .isEqualTo(TransitionTarget.AddAnotherPaymentMethod)
+            assertThat(transitionTargets).containsExactly(null, TransitionTarget.AddAnotherPaymentMethod)
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
@@ -5,10 +5,11 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.testing.FragmentScenario
 import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.fragment.app.testing.withFragment
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.asLiveData
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
@@ -28,6 +29,8 @@ import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.Companion.S
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.Companion.SAVE_PAYMENT_METHODS
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.Companion.SAVE_SAVED_SELECTION
 import com.stripe.android.utils.TestUtils.idleLooper
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -180,21 +183,21 @@ internal class PaymentSheetListFragmentTest : PaymentSheetViewModelTestInjection
         }
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun `posts transition when add card clicked`() {
-        createScenario().onFragment {
-            val activityViewModel = activityViewModel(it)
+    fun `posts transition when add card clicked`() = runTest {
+        val scenario = createScenario()
 
-            val transitionTargets = mutableListOf<TransitionTarget?>()
-            activityViewModel.currentScreen.asLiveData().observeForever { transitionTargets.add(it) }
+        val viewModel = scenario.withFragment { activityViewModel(this) }
+        val recyclerView = scenario.withFragment { recyclerView(this) }
 
-            idleLooper()
+        viewModel.currentScreen.test {
+            assertThat(awaitItem()).isNull()
 
-            val adapter = recyclerView(it).adapter as PaymentOptionsAdapter
+            val adapter = recyclerView.adapter as PaymentOptionsAdapter
             adapter.addCardClickListener()
-            idleLooper()
 
-            assertThat(transitionTargets).containsExactly(null, TransitionTarget.AddAnotherPaymentMethod)
+            assertThat(awaitItem()).isEqualTo(TransitionTarget.AddAnotherPaymentMethod)
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -918,6 +918,50 @@ internal class PaymentSheetViewModelTest {
         }
     }
 
+    @Test
+    fun `paymentMethods is not empty if customer has payment methods`() = runTest {
+        val viewModel = createViewModel(
+            customerPaymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        )
+
+        viewModel.paymentMethods.test {
+            assertThat(awaitItem()).isNotEmpty()
+        }
+    }
+
+    @Test
+    fun `paymentMethods is empty if customer has no payment methods`() = runTest {
+        val viewModel = createViewModel(customerPaymentMethods = emptyList())
+
+        viewModel.paymentMethods.test {
+            assertThat(awaitItem()).isEmpty()
+        }
+    }
+
+    @Test
+    fun `current screen is AddFirstPaymentMethod if payment methods is empty`() = runTest {
+        val viewModel = createViewModel(customerPaymentMethods = emptyList())
+
+        viewModel.currentScreen.test {
+            assertThat(awaitItem()).isNull()
+            viewModel.transitionToFirstScreen()
+            assertThat(awaitItem()).isEqualTo(TransitionTarget.AddFirstPaymentMethod)
+        }
+    }
+
+    @Test
+    fun `current screen is SelectSavedPaymentMethods if payment methods is not empty`() = runTest {
+        val viewModel = createViewModel(
+            customerPaymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        )
+
+        viewModel.currentScreen.test {
+            assertThat(awaitItem()).isNull()
+            viewModel.transitionToFirstScreen()
+            assertThat(awaitItem()).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
+        }
+    }
+
     private fun createViewModel(
         args: PaymentSheetContract.Args = ARGS_CUSTOMER_WITH_GOOGLEPAY,
         stripeIntent: StripeIntent = PAYMENT_INTENT,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -918,56 +918,6 @@ internal class PaymentSheetViewModelTest {
         }
     }
 
-    @Test
-    fun `paymentMethods is not empty if customer has payment methods`() = runTest {
-        val viewModel = createViewModel(
-            customerPaymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
-        )
-
-        viewModel.paymentMethods.test {
-            assertThat(awaitItem()).isNotEmpty()
-        }
-    }
-
-    @Test
-    fun `paymentMethods is empty if customer has no payment methods`() = runTest {
-        val viewModel = createViewModel(
-            customerPaymentMethods = listOf()
-        )
-
-        viewModel.paymentMethods.test {
-            assertThat(awaitItem()).isEmpty()
-        }
-    }
-
-    @Test
-    fun `transition target is AddFirstPaymentMethod if payment methods is empty`() = runTest {
-        val viewModel = createViewModel(
-            customerPaymentMethods = listOf()
-        )
-
-        val observedTransitions = mutableListOf<TransitionTarget>()
-        viewModel.transition.observeEventsForever { observedTransitions.add(it) }
-
-        viewModel.transitionToFirstScreen()
-
-        assertThat(observedTransitions).containsExactly(TransitionTarget.AddFirstPaymentMethod)
-    }
-
-    @Test
-    fun `transition target is SelectSavedPaymentMethods if payment methods is not empty`() = runTest {
-        val viewModel = createViewModel(
-            customerPaymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
-        )
-
-        val observedTransitions = mutableListOf<TransitionTarget>()
-        viewModel.transition.observeEventsForever { observedTransitions.add(it) }
-
-        viewModel.transitionToFirstScreen()
-
-        assertThat(observedTransitions).containsExactly(TransitionTarget.SelectSavedPaymentMethods)
-    }
-
     private fun createViewModel(
         args: PaymentSheetContract.Args = ARGS_CUSTOMER_WITH_GOOGLEPAY,
         stripeIntent: StripeIntent = PAYMENT_INTENT,

--- a/paymentsheet/src/test/java/com/stripe/android/utils/TestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/TestUtils.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import org.robolectric.shadows.ShadowLooper.idleMainLooper
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -48,14 +47,5 @@ internal object TestUtils {
 
         @Suppress("UNCHECKED_CAST")
         return data as T
-    }
-
-    fun <T> LiveData<BaseSheetViewModel.Event<T>?>.observeEventsForever(
-        observer: (T) -> Unit,
-    ) {
-        observeForever { event ->
-            val content = event?.getContentIfNotHandled() ?: return@observeForever
-            observer(content)
-        }
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request moves our back stack management to the view model and makes some accompanying changes.

We’re replacing the event-based `LiveData<Event<TransitionTarget>>` with a state-based `StateFlow<List<TransitionTarget>>`. To avoid having to map from the state-based world to the event-based world of fragment transactions, we’re also replacing the `FragmentContainerView` with a `ComposeView`. In there, we can collect `viewModel.currentScreen` and emit new UI as required.

We currently achieve this with `AndroidViewBinding`, which itself inflates a `FragmentContainerView` that contains the correct fragment. Eventually, we’ll get rid of these fragments and have an implementation purely in Compose.

The main changes of this pull request occur in the first commit and the last commit:
- The first commit contains the intended changes.
- The last commit contains fixes for an auto-forwarding behavior in the custom flow.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [X] Manually verified

# Screenshots
N/A

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A
