### PR TITLE
Remove manual email step from release script

### DIFF
--- a/scripts/propose_release.rb
+++ b/scripts/propose_release.rb
@@ -111,13 +111,4 @@ prompt_user "Or press enter to open pre-filled ticket.\nClick 'Request Review' w
 open_url jira_url
 wait_for_enter
 
-puts "Send an email to mobile-sdk-updates@stripe.com with the following information:"
-puts "Subject: [Android SDK] #{version}"
-puts "Body:"
-puts "#{changelog}"
-puts ""
-prompt_user "Press enter to open pre-filled email in your default client...\n(To make Gmail your default email client, visit https://support.google.com/a/users/answer/9308783)"
-open_url "mailto:mobile-sdk-updates@stripe.com?subject=%5BAndroid%20SDK%5D%20#{ERB::Util.url_encode(version)}&body=#{ERB::Util.url_encode(changelog)}"
-wait_for_enter
-
 puts "Release proposed. Please contact your deployer.".green


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request removes the step to send the release announcement email during the release process, following @davidme-stripe’s integration of Blogtrottr.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Fewer manual steps.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
N/A

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A
