### PR TITLE
Give `LpmRepository.convertToSupportedPaymentMethod` access to `StripeIntent`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   check:
     name: Check
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2
@@ -36,7 +36,7 @@ jobs:
 
   unit-tests:
     name: Unit tests
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@v2

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
@@ -17,7 +17,9 @@ import java.util.regex.Pattern
  * - [PaymentIntents API Reference](https://stripe.com/docs/api/payment_intents)
  */
 @Parcelize
-data class PaymentIntent internal constructor(
+data class PaymentIntent
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+constructor(
     /**
      * Unique identifier for the object.
      */

--- a/payments-ui-core/detekt-baseline.xml
+++ b/payments-ui-core/detekt-baseline.xml
@@ -10,7 +10,7 @@
     <ID>CyclomaticComplexMethod:FormItemSpec.kt$FormItemSpecSerializer$override fun selectDeserializer(element: JsonElement): DeserializationStrategy&lt;out FormItemSpec></ID>
     <ID>CyclomaticComplexMethod:FormUI.kt$@Composable @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun FormUI( hiddenIdentifiers: Set&lt;IdentifierSpec>, enabled: Boolean, elements: List&lt;FormElement>?, lastTextFieldIdentifier: IdentifierSpec?, loadingComposable: @Composable ColumnScope.() -> Unit, modifier: Modifier = Modifier )</ID>
     <ID>CyclomaticComplexMethod:IdentifierSpec.kt$IdentifierSpec.Companion$@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) fun get(value: String)</ID>
-    <ID>CyclomaticComplexMethod:LpmRepository.kt$LpmRepository$private fun convertToSupportedPaymentMethod(sharedDataSpec: SharedDataSpec)</ID>
+    <ID>CyclomaticComplexMethod:LpmRepository.kt$LpmRepository$private fun convertToSupportedPaymentMethod( @Suppress("UNUSED_PARAMETER") stripeIntent: StripeIntent, sharedDataSpec: SharedDataSpec, )</ID>
     <ID>CyclomaticComplexMethod:TextFieldUI.kt$@Composable fun TextField( textFieldController: TextFieldController, enabled: Boolean, imeAction: ImeAction, modifier: Modifier = Modifier, onTextStateChanged: (TextFieldState?) -> Unit = {}, nextFocusDirection: FocusDirection = FocusDirection.Next, previousFocusDirection: FocusDirection = FocusDirection.Previous )</ID>
     <ID>CyclomaticComplexMethod:TransformGoogleToStripeAddress.kt$@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun Place.transformGoogleToStripeAddress( context: Context ): com.stripe.android.model.Address</ID>
     <ID>CyclomaticComplexMethod:TransformSpecToElements.kt$TransformSpecToElements$fun transform(list: List&lt;FormItemSpec>): List&lt;FormElement></ID>
@@ -18,7 +18,7 @@
     <ID>ForbiddenComment:Menu.kt$// TODO: Make sure this gets the rounded corner values</ID>
     <ID>FunctionParameterNaming:IdentifierSpec.kt$IdentifierSpec.Companion$_value: String</ID>
     <ID>LongMethod:DropdownFieldUI.kt$@Composable internal fun DropDown( controller: DropdownFieldController, enabled: Boolean, modifier: Modifier = Modifier )</ID>
-    <ID>LongMethod:LpmRepository.kt$LpmRepository$private fun convertToSupportedPaymentMethod(sharedDataSpec: SharedDataSpec)</ID>
+    <ID>LongMethod:LpmRepository.kt$LpmRepository$private fun convertToSupportedPaymentMethod( @Suppress("UNUSED_PARAMETER") stripeIntent: StripeIntent, sharedDataSpec: SharedDataSpec, )</ID>
     <ID>LongMethod:Menu.kt$@Suppress("ModifierParameter") @Composable internal fun DropdownMenuContent( expandedStates: MutableTransitionState&lt;Boolean>, transformOriginState: MutableState&lt;TransformOrigin>, initialFirstVisibleItemIndex: Int, modifier: Modifier = Modifier, content: LazyListScope.() -> Unit )</ID>
     <ID>LongMethod:OTPElementUI.kt$@OptIn(ExperimentalMaterialApi::class) @Composable @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun OTPElementUI( enabled: Boolean, element: OTPElement, modifier: Modifier = Modifier, colors: OTPElementColors = OTPElementColors( selectedBorder = MaterialTheme.colors.primary, placeholder = MaterialTheme.paymentsColors.placeholderText ), focusRequester: FocusRequester = remember { FocusRequester() } )</ID>
     <ID>LongMethod:PhoneNumberElementUI.kt$@Composable internal fun PhoneNumberElementUI( enabled: Boolean, controller: PhoneNumberController, requestFocusWhenShown: Boolean = false, imeAction: ImeAction = ImeAction.Done )</ID>

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
@@ -211,188 +211,188 @@ class LpmRepository constructor(
         sharedDataSpec: SharedDataSpec,
     ) = when (sharedDataSpec.type) {
         PaymentMethod.Type.Card.code -> SupportedPaymentMethod(
-            "card",
-            false,
-            R.string.stripe_paymentsheet_payment_method_card,
-            R.drawable.stripe_ic_paymentsheet_pm_card,
-            sharedDataSpec.selectorIcon?.lightThemePng,
-            sharedDataSpec.selectorIcon?.darkThemePng,
-            true,
-            CardRequirement,
-            if (sharedDataSpec.fields.isEmpty() || sharedDataSpec.fields == listOf(EmptyFormSpec)) {
+            code = "card",
+            requiresMandate = false,
+            displayNameResource = R.string.stripe_paymentsheet_payment_method_card,
+            iconResource = R.drawable.stripe_ic_paymentsheet_pm_card,
+            lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
+            darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
+            tintIconOnSelection = true,
+            requirement = CardRequirement,
+            formSpec = if (sharedDataSpec.fields.isEmpty() || sharedDataSpec.fields == listOf(EmptyFormSpec)) {
                 HardcodedCard.formSpec
             } else {
                 LayoutSpec(sharedDataSpec.fields)
             }
         )
         PaymentMethod.Type.Bancontact.code -> SupportedPaymentMethod(
-            "bancontact",
-            true,
-            R.string.stripe_paymentsheet_payment_method_bancontact,
-            R.drawable.stripe_ic_paymentsheet_pm_bancontact,
-            sharedDataSpec.selectorIcon?.lightThemePng,
-            sharedDataSpec.selectorIcon?.darkThemePng,
-            false,
-            BancontactRequirement,
-            LayoutSpec(sharedDataSpec.fields)
+            code = "bancontact",
+            requiresMandate = true,
+            displayNameResource = R.string.stripe_paymentsheet_payment_method_bancontact,
+            iconResource = R.drawable.stripe_ic_paymentsheet_pm_bancontact,
+            lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
+            darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
+            tintIconOnSelection = false,
+            requirement = BancontactRequirement,
+            formSpec = LayoutSpec(sharedDataSpec.fields)
         )
         PaymentMethod.Type.Sofort.code -> SupportedPaymentMethod(
-            "sofort",
-            true,
-            R.string.stripe_paymentsheet_payment_method_sofort,
-            R.drawable.stripe_ic_paymentsheet_pm_klarna,
-            sharedDataSpec.selectorIcon?.lightThemePng,
-            sharedDataSpec.selectorIcon?.darkThemePng,
-            false,
-            SofortRequirement,
-            LayoutSpec(sharedDataSpec.fields)
+            code = "sofort",
+            requiresMandate = true,
+            displayNameResource = R.string.stripe_paymentsheet_payment_method_sofort,
+            iconResource = R.drawable.stripe_ic_paymentsheet_pm_klarna,
+            lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
+            darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
+            tintIconOnSelection = false,
+            requirement = SofortRequirement,
+            formSpec = LayoutSpec(sharedDataSpec.fields)
         )
         PaymentMethod.Type.Ideal.code -> SupportedPaymentMethod(
-            "ideal",
-            true,
-            R.string.stripe_paymentsheet_payment_method_ideal,
-            R.drawable.stripe_ic_paymentsheet_pm_ideal,
-            sharedDataSpec.selectorIcon?.lightThemePng,
-            sharedDataSpec.selectorIcon?.darkThemePng,
-            false,
-            IdealRequirement,
-            LayoutSpec(sharedDataSpec.fields)
+            code = "ideal",
+            requiresMandate = true,
+            displayNameResource = R.string.stripe_paymentsheet_payment_method_ideal,
+            iconResource = R.drawable.stripe_ic_paymentsheet_pm_ideal,
+            lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
+            darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
+            tintIconOnSelection = false,
+            requirement = IdealRequirement,
+            formSpec = LayoutSpec(sharedDataSpec.fields)
         )
         PaymentMethod.Type.SepaDebit.code -> SupportedPaymentMethod(
-            "sepa_debit",
-            true,
-            R.string.stripe_paymentsheet_payment_method_sepa_debit,
-            R.drawable.stripe_ic_paymentsheet_pm_sepa_debit,
-            sharedDataSpec.selectorIcon?.lightThemePng,
-            sharedDataSpec.selectorIcon?.darkThemePng,
-            false,
-            SepaDebitRequirement,
-            LayoutSpec(sharedDataSpec.fields)
+            code = "sepa_debit",
+            requiresMandate = true,
+            displayNameResource = R.string.stripe_paymentsheet_payment_method_sepa_debit,
+            iconResource = R.drawable.stripe_ic_paymentsheet_pm_sepa_debit,
+            lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
+            darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
+            tintIconOnSelection = false,
+            requirement = SepaDebitRequirement,
+            formSpec = LayoutSpec(sharedDataSpec.fields)
         )
         PaymentMethod.Type.Eps.code -> SupportedPaymentMethod(
-            "eps",
-            true,
-            R.string.stripe_paymentsheet_payment_method_eps,
-            R.drawable.stripe_ic_paymentsheet_pm_eps,
-            sharedDataSpec.selectorIcon?.lightThemePng,
-            sharedDataSpec.selectorIcon?.darkThemePng,
-            false,
-            EpsRequirement,
-            LayoutSpec(sharedDataSpec.fields)
+            code = "eps",
+            requiresMandate = true,
+            displayNameResource = R.string.stripe_paymentsheet_payment_method_eps,
+            iconResource = R.drawable.stripe_ic_paymentsheet_pm_eps,
+            lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
+            darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
+            tintIconOnSelection = false,
+            requirement = EpsRequirement,
+            formSpec = LayoutSpec(sharedDataSpec.fields)
         )
         PaymentMethod.Type.P24.code -> SupportedPaymentMethod(
-            "p24",
-            false,
-            R.string.stripe_paymentsheet_payment_method_p24,
-            R.drawable.stripe_ic_paymentsheet_pm_p24,
-            sharedDataSpec.selectorIcon?.lightThemePng,
-            sharedDataSpec.selectorIcon?.darkThemePng,
-            false,
-            P24Requirement,
-            LayoutSpec(sharedDataSpec.fields)
+            code = "p24",
+            requiresMandate = false,
+            displayNameResource = R.string.stripe_paymentsheet_payment_method_p24,
+            iconResource = R.drawable.stripe_ic_paymentsheet_pm_p24,
+            lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
+            darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
+            tintIconOnSelection = false,
+            requirement = P24Requirement,
+            formSpec = LayoutSpec(sharedDataSpec.fields)
         )
         PaymentMethod.Type.Giropay.code -> SupportedPaymentMethod(
-            "giropay",
-            false,
-            R.string.stripe_paymentsheet_payment_method_giropay,
-            R.drawable.stripe_ic_paymentsheet_pm_giropay,
-            sharedDataSpec.selectorIcon?.lightThemePng,
-            sharedDataSpec.selectorIcon?.darkThemePng,
-            false,
-            GiropayRequirement,
-            LayoutSpec(sharedDataSpec.fields)
+            code = "giropay",
+            requiresMandate = false,
+            displayNameResource = R.string.stripe_paymentsheet_payment_method_giropay,
+            iconResource = R.drawable.stripe_ic_paymentsheet_pm_giropay,
+            lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
+            darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
+            tintIconOnSelection = false,
+            requirement = GiropayRequirement,
+            formSpec = LayoutSpec(sharedDataSpec.fields)
         )
         PaymentMethod.Type.AfterpayClearpay.code -> SupportedPaymentMethod(
-            "afterpay_clearpay",
-            false,
-            if (isClearpay()) {
+            code = "afterpay_clearpay",
+            requiresMandate = false,
+            displayNameResource = if (isClearpay()) {
                 R.string.stripe_paymentsheet_payment_method_clearpay
             } else {
                 R.string.stripe_paymentsheet_payment_method_afterpay
             },
-            R.drawable.stripe_ic_paymentsheet_pm_afterpay_clearpay,
-            sharedDataSpec.selectorIcon?.lightThemePng,
-            sharedDataSpec.selectorIcon?.darkThemePng,
-            false,
-            AfterpayClearpayRequirement,
-            LayoutSpec(sharedDataSpec.fields)
+            iconResource = R.drawable.stripe_ic_paymentsheet_pm_afterpay_clearpay,
+            lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
+            darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
+            tintIconOnSelection = false,
+            requirement = AfterpayClearpayRequirement,
+            formSpec = LayoutSpec(sharedDataSpec.fields)
         )
         PaymentMethod.Type.Klarna.code -> SupportedPaymentMethod(
-            "klarna",
-            false,
-            R.string.stripe_paymentsheet_payment_method_klarna,
-            R.drawable.stripe_ic_paymentsheet_pm_klarna,
-            sharedDataSpec.selectorIcon?.lightThemePng,
-            sharedDataSpec.selectorIcon?.darkThemePng,
-            false,
-            KlarnaRequirement,
-            LayoutSpec(sharedDataSpec.fields)
+            code = "klarna",
+            requiresMandate = false,
+            displayNameResource = R.string.stripe_paymentsheet_payment_method_klarna,
+            iconResource = R.drawable.stripe_ic_paymentsheet_pm_klarna,
+            lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
+            darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
+            tintIconOnSelection = false,
+            requirement = KlarnaRequirement,
+            formSpec = LayoutSpec(sharedDataSpec.fields)
         )
         PaymentMethod.Type.PayPal.code -> SupportedPaymentMethod(
-            "paypal",
-            false,
-            R.string.stripe_paymentsheet_payment_method_paypal,
-            R.drawable.stripe_ic_paymentsheet_pm_paypal,
-            sharedDataSpec.selectorIcon?.lightThemePng,
-            sharedDataSpec.selectorIcon?.darkThemePng,
-            false,
-            PaypalRequirement,
-            LayoutSpec(sharedDataSpec.fields)
+            code = "paypal",
+            requiresMandate = false,
+            displayNameResource = R.string.stripe_paymentsheet_payment_method_paypal,
+            iconResource = R.drawable.stripe_ic_paymentsheet_pm_paypal,
+            lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
+            darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
+            tintIconOnSelection = false,
+            requirement = PaypalRequirement,
+            formSpec = LayoutSpec(sharedDataSpec.fields)
         )
         PaymentMethod.Type.Affirm.code -> SupportedPaymentMethod(
-            "affirm",
-            false,
-            R.string.stripe_paymentsheet_payment_method_affirm,
-            R.drawable.stripe_ic_paymentsheet_pm_affirm,
-            sharedDataSpec.selectorIcon?.lightThemePng,
-            sharedDataSpec.selectorIcon?.darkThemePng,
-            false,
-            AffirmRequirement,
-            LayoutSpec(sharedDataSpec.fields)
+            code = "affirm",
+            requiresMandate = false,
+            displayNameResource = R.string.stripe_paymentsheet_payment_method_affirm,
+            iconResource = R.drawable.stripe_ic_paymentsheet_pm_affirm,
+            lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
+            darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
+            tintIconOnSelection = false,
+            requirement = AffirmRequirement,
+            formSpec = LayoutSpec(sharedDataSpec.fields)
         )
         PaymentMethod.Type.RevolutPay.code -> SupportedPaymentMethod(
-            "revolut_pay",
-            false,
-            R.string.stripe_paymentsheet_payment_method_revolut_pay,
-            R.drawable.stripe_ic_paymentsheet_pm_revolut_pay,
-            sharedDataSpec.selectorIcon?.lightThemePng,
-            sharedDataSpec.selectorIcon?.darkThemePng,
-            false,
-            RevolutPayRequirement,
-            LayoutSpec(sharedDataSpec.fields)
+            code = "revolut_pay",
+            requiresMandate = false,
+            displayNameResource = R.string.stripe_paymentsheet_payment_method_revolut_pay,
+            iconResource = R.drawable.stripe_ic_paymentsheet_pm_revolut_pay,
+            lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
+            darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
+            tintIconOnSelection = false,
+            requirement = RevolutPayRequirement,
+            formSpec = LayoutSpec(sharedDataSpec.fields)
         )
         PaymentMethod.Type.MobilePay.code -> SupportedPaymentMethod(
-            "mobilepay",
-            false,
-            R.string.stripe_paymentsheet_payment_method_mobile_pay,
-            R.drawable.stripe_ic_paymentsheet_pm_mobile_pay,
-            sharedDataSpec.selectorIcon?.lightThemePng,
-            sharedDataSpec.selectorIcon?.darkThemePng,
-            false,
-            MobilePayRequirement,
-            LayoutSpec(sharedDataSpec.fields)
+            code = "mobilepay",
+            requiresMandate = false,
+            displayNameResource = R.string.stripe_paymentsheet_payment_method_mobile_pay,
+            iconResource = R.drawable.stripe_ic_paymentsheet_pm_mobile_pay,
+            lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
+            darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
+            tintIconOnSelection = false,
+            requirement = MobilePayRequirement,
+            formSpec = LayoutSpec(sharedDataSpec.fields)
         )
         PaymentMethod.Type.AuBecsDebit.code -> SupportedPaymentMethod(
-            "au_becs_debit",
-            true,
-            R.string.stripe_paymentsheet_payment_method_au_becs_debit,
-            R.drawable.stripe_ic_paymentsheet_pm_bank,
-            sharedDataSpec.selectorIcon?.lightThemePng,
-            sharedDataSpec.selectorIcon?.darkThemePng,
-            true,
-            AuBecsDebitRequirement,
-            LayoutSpec(sharedDataSpec.fields)
+            code = "au_becs_debit",
+            requiresMandate = true,
+            displayNameResource = R.string.stripe_paymentsheet_payment_method_au_becs_debit,
+            iconResource = R.drawable.stripe_ic_paymentsheet_pm_bank,
+            lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
+            darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
+            tintIconOnSelection = true,
+            requirement = AuBecsDebitRequirement,
+            formSpec = LayoutSpec(sharedDataSpec.fields)
         )
         PaymentMethod.Type.USBankAccount.code -> SupportedPaymentMethod(
-            "us_bank_account",
-            true,
-            R.string.stripe_paymentsheet_payment_method_us_bank_account,
-            R.drawable.stripe_ic_paymentsheet_pm_bank,
-            sharedDataSpec.selectorIcon?.lightThemePng,
-            sharedDataSpec.selectorIcon?.darkThemePng,
-            true,
-            USBankAccountRequirement,
-            LayoutSpec(sharedDataSpec.fields)
+            code = "us_bank_account",
+            requiresMandate = true,
+            displayNameResource = R.string.stripe_paymentsheet_payment_method_us_bank_account,
+            iconResource = R.drawable.stripe_ic_paymentsheet_pm_bank,
+            lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
+            darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
+            tintIconOnSelection = true,
+            requirement = USBankAccountRequirement,
+            formSpec = LayoutSpec(sharedDataSpec.fields)
         )
         PaymentMethod.Type.Upi.code -> SupportedPaymentMethod(
             code = "upi",

--- a/payments-ui-core/src/test/java/com/stripe/android/utils/PaymentIntentFactory.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/utils/PaymentIntentFactory.kt
@@ -1,0 +1,37 @@
+package com.stripe.android.utils
+
+import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.StripeIntent
+
+internal object PaymentIntentFactory {
+    fun create(
+        paymentMethod: PaymentMethod? = createCardPaymentMethod(),
+        paymentMethodTypes: List<String> = listOf("card"),
+    ): PaymentIntent = PaymentIntent(
+        created = 500L,
+        amount = 1000L,
+        clientSecret = "secret",
+        paymentMethod = paymentMethod,
+        isLiveMode = false,
+        id = "pi_12345",
+        currency = "usd",
+        countryCode = null,
+        paymentMethodTypes = paymentMethodTypes,
+        status = StripeIntent.Status.RequiresConfirmation,
+        unactivatedPaymentMethods = emptyList(),
+    )
+
+    private fun createCardPaymentMethod(): PaymentMethod = PaymentMethod(
+        id = "12",
+        created = 123456789L,
+        liveMode = false,
+        type = PaymentMethod.Type.Card,
+        card = PaymentMethod.Card(
+            brand = CardBrand.Visa,
+            last4 = "4242"
+        ),
+        code = "card"
+    )
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -228,7 +228,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         val lpmRepository = lpmResourceRepository.getRepository()
 
         lpmRepository.update(
-            expectedLpms = paymentMethodPreference.intent.paymentMethodTypes,
+            stripeIntent = paymentMethodPreference.intent,
             serverLpmSpecs = paymentMethodPreference.formUI,
         )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -287,11 +287,9 @@ internal abstract class BaseSheetViewModel(
                 CoroutineScope(workContext).launch {
                     // If we have been killed and are being restored then we need to re-populate
                     // the lpm repository
-                    stripeIntent.value?.paymentMethodTypes?.let { intentPaymentMethodTypes ->
+                    stripeIntent.value?.let { intent ->
                         lpmResourceRepository.getRepository().apply {
-                            if (!isLoaded()) {
-                                update(intentPaymentMethodTypes, lpmServerSpec)
-                            }
+                            update(intent, lpmServerSpec)
                         }
                     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAddPaymentMethodFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsAddPaymentMethodFragmentTest.kt
@@ -11,12 +11,12 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.injection.DUMMY_INJECTOR_KEY
 import com.stripe.android.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.model.PaymentIntentFixtures
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.utils.FakeAndroidKeyStore
+import com.stripe.android.utils.PaymentIntentFactory
 import com.stripe.android.utils.TestUtils
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -31,9 +31,10 @@ import org.robolectric.RobolectricTestRunner
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 internal class PaymentOptionsAddPaymentMethodFragmentTest : PaymentOptionsViewModelTestInjection() {
+    private val paymentIntent = PaymentIntentFactory.create()
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val lpmRepository = LpmRepository(LpmRepository.LpmRepositoryArguments(context.resources)).apply {
-        this.forceUpdate(listOf(PaymentMethod.Type.Card.code), null)
+        this.update(paymentIntent, null)
     }
 
     @Before
@@ -102,7 +103,8 @@ internal class PaymentOptionsAddPaymentMethodFragmentTest : PaymentOptionsViewMo
             bundleOf(PaymentOptionsActivity.EXTRA_STARTER_ARGS to args),
             R.style.StripePaymentSheetDefaultTheme
         ).onFragment { fragment ->
-            fragment.sheetViewModel.lpmResourceRepository.getRepository().updateFromDisk()
+            fragment.sheetViewModel.lpmResourceRepository.getRepository()
+                .updateFromDisk(paymentIntent)
             onReady(
                 fragment,
                 viewModel

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTestInjection.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTestInjection.kt
@@ -26,6 +26,7 @@ import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.ui.core.forms.resources.StaticAddressResourceRepository
 import com.stripe.android.ui.core.forms.resources.StaticLpmResourceRepository
 import com.stripe.android.utils.FakeCustomerRepository
+import com.stripe.android.utils.PaymentIntentFactory
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.flowOf
@@ -66,10 +67,12 @@ internal open class PaymentOptionsViewModelTestInjection {
     ): PaymentOptionsViewModel = runBlocking {
         val lpmRepository =
             LpmRepository(LpmRepository.LpmRepositoryArguments(ApplicationProvider.getApplicationContext<Application>().resources))
-        lpmRepository.forceUpdate(
-            listOf(
-                PaymentMethod.Type.Card.code,
-                PaymentMethod.Type.USBankAccount.code
+        lpmRepository.update(
+            PaymentIntentFactory.create(
+                paymentMethodTypes = listOf(
+                    PaymentMethod.Type.Card.code,
+                    PaymentMethod.Type.USBankAccount.code
+                )
             ),
             null
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddPaymentMethodFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetAddPaymentMethodFragmentTest.kt
@@ -17,6 +17,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.ui.core.address.AddressRepository
 import com.stripe.android.ui.core.forms.resources.LpmRepository
+import com.stripe.android.utils.PaymentIntentFactory
 import com.stripe.android.utils.TestUtils.idleLooper
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -98,8 +99,8 @@ internal class PaymentSheetAddPaymentMethodFragmentTest : PaymentSheetViewModelT
                 idleLooper()
                 registerViewModel(args.injectorKey, viewModel, lpmRepository, addressRepository)
             } else {
-                it.sheetViewModel.lpmResourceRepository.getRepository().forceUpdate(
-                    stripeIntent.paymentMethodTypes,
+                it.sheetViewModel.lpmResourceRepository.getRepository().update(
+                    stripeIntent,
                     null
                 )
                 idleLooper()
@@ -117,12 +118,14 @@ internal class PaymentSheetAddPaymentMethodFragmentTest : PaymentSheetViewModelT
             AddressRepository(ApplicationProvider.getApplicationContext<Context>().resources)
         val lpmRepository =
             LpmRepository(LpmRepository.LpmRepositoryArguments(ApplicationProvider.getApplicationContext<Application>().resources)).apply {
-                this.forceUpdate(
-                    listOf(
-                        PaymentMethod.Type.Card.code,
-                        PaymentMethod.Type.USBankAccount.code,
-                        PaymentMethod.Type.SepaDebit.code,
-                        PaymentMethod.Type.Bancontact.code
+                this.update(
+                    PaymentIntentFactory.create(
+                        paymentMethodTypes = listOf(
+                            PaymentMethod.Type.Card.code,
+                            PaymentMethod.Type.USBankAccount.code,
+                            PaymentMethod.Type.SepaDebit.code,
+                            PaymentMethod.Type.Bancontact.code
+                        )
                     ),
                     null
                 )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -52,6 +52,7 @@ import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.ui.core.forms.resources.StaticLpmResourceRepository
 import com.stripe.android.utils.FakeCustomerRepository
 import com.stripe.android.utils.FakePaymentSheetLoader
+import com.stripe.android.utils.PaymentIntentFactory
 import com.stripe.android.utils.TestUtils.idleLooper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -90,15 +91,17 @@ internal class PaymentSheetViewModelTest {
     private val lpmRepository = LpmRepository(
         arguments = LpmRepository.LpmRepositoryArguments(application.resources),
     ).apply {
-        this.forceUpdate(
-            listOf(
-                PaymentMethod.Type.Card.code,
-                PaymentMethod.Type.USBankAccount.code,
-                PaymentMethod.Type.Ideal.code,
-                PaymentMethod.Type.SepaDebit.code,
-                PaymentMethod.Type.Sofort.code,
-                PaymentMethod.Type.Affirm.code,
-                PaymentMethod.Type.AfterpayClearpay.code,
+        this.update(
+            PaymentIntentFactory.create(
+                paymentMethodTypes = listOf(
+                    PaymentMethod.Type.Card.code,
+                    PaymentMethod.Type.USBankAccount.code,
+                    PaymentMethod.Type.Ideal.code,
+                    PaymentMethod.Type.SepaDebit.code,
+                    PaymentMethod.Type.Sofort.code,
+                    PaymentMethod.Type.Affirm.code,
+                    PaymentMethod.Type.AfterpayClearpay.code,
+                )
             ),
             null
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTestInjection.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTestInjection.kt
@@ -34,6 +34,7 @@ import com.stripe.android.ui.core.forms.resources.StaticAddressResourceRepositor
 import com.stripe.android.ui.core.forms.resources.StaticLpmResourceRepository
 import com.stripe.android.utils.FakeCustomerRepository
 import com.stripe.android.utils.FakePaymentSheetLoader
+import com.stripe.android.utils.PaymentIntentFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
@@ -107,10 +108,12 @@ internal open class PaymentSheetViewModelTestInjection {
                         ApplicationProvider.getApplicationContext<Application>().resources
                     )
                 ).apply {
-                    this.forceUpdate(
-                        listOf(
-                            PaymentMethod.Type.Card.code,
-                            PaymentMethod.Type.USBankAccount.code
+                    this.update(
+                        PaymentIntentFactory.create(
+                            paymentMethodTypes = listOf(
+                                PaymentMethod.Type.Card.code,
+                                PaymentMethod.Type.USBankAccount.code
+                            )
                         ),
                         null
                     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactoryTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.forms.resources.LpmRepository
+import com.stripe.android.utils.PaymentIntentFactory
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
@@ -27,12 +28,15 @@ class FormArgumentsFactoryTest {
     private val lpmRepository = LpmRepository(
         LpmRepository.LpmRepositoryArguments(resources)
     ).apply {
-        this.forceUpdate(
-            listOf(
-                PaymentMethod.Type.Card.code,
-                PaymentMethod.Type.USBankAccount.code,
-                PaymentMethod.Type.SepaDebit.code,
-                PaymentMethod.Type.Bancontact.code
+        this.update(
+            PaymentIntentFactory.create(
+                paymentMethodTypes =
+                listOf(
+                    PaymentMethod.Type.Card.code,
+                    PaymentMethod.Type.USBankAccount.code,
+                    PaymentMethod.Type.SepaDebit.code,
+                    PaymentMethod.Type.Bancontact.code
+                )
             ),
             null
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethodTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.CONFIG_CUSTOMER
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.ui.core.forms.resources.LpmRepository.SupportedPaymentMethod
+import com.stripe.android.utils.PaymentIntentFactory
 import kotlinx.serialization.Serializable
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -27,7 +28,10 @@ class SupportedPaymentMethodTest {
             resources = ApplicationProvider.getApplicationContext<Application>().resources,
         )
     ).apply {
-        this.forceUpdate(this.supportedPaymentMethods, null)
+        this.update(
+            PaymentIntentFactory.create(paymentMethodTypes = this.supportedPaymentMethods),
+            null
+        )
     }
     private val card = LpmRepository.HardcodedCard
     private val eps = lpmRepository.fromCode("eps")!!

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -27,6 +27,7 @@ import com.stripe.android.paymentsheet.repositories.StripeIntentRepository
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.ui.core.forms.resources.StaticLpmResourceRepository
 import com.stripe.android.utils.FakeCustomerRepository
+import com.stripe.android.utils.PaymentIntentFactory
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -56,7 +57,15 @@ internal class DefaultPaymentSheetLoaderTest {
         LpmRepository(
             LpmRepository.LpmRepositoryArguments(ApplicationProvider.getApplicationContext<Application>().resources)
         ).apply {
-            this.forceUpdate(listOf(PaymentMethod.Type.Card.code, PaymentMethod.Type.USBankAccount.code), null)
+            this.update(
+                PaymentIntentFactory.create(
+                    paymentMethodTypes = listOf(
+                        PaymentMethod.Type.Card.code,
+                        PaymentMethod.Type.USBankAccount.code
+                    )
+                ),
+                null
+            )
         }
     )
 

--- a/paymentsheet/src/test/java/com/stripe/android/utils/PaymentIntentFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/PaymentIntentFactory.kt
@@ -1,0 +1,37 @@
+package com.stripe.android.utils
+
+import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.StripeIntent
+
+internal object PaymentIntentFactory {
+    fun create(
+        paymentMethod: PaymentMethod? = createCardPaymentMethod(),
+        paymentMethodTypes: List<String> = listOf("card"),
+    ): PaymentIntent = PaymentIntent(
+        created = 500L,
+        amount = 1000L,
+        clientSecret = "secret",
+        paymentMethod = paymentMethod,
+        isLiveMode = false,
+        id = "pi_12345",
+        currency = "usd",
+        countryCode = null,
+        paymentMethodTypes = paymentMethodTypes,
+        status = StripeIntent.Status.RequiresConfirmation,
+        unactivatedPaymentMethods = emptyList(),
+    )
+
+    private fun createCardPaymentMethod(): PaymentMethod = PaymentMethod(
+        id = "12",
+        created = 123456789L,
+        liveMode = false,
+        type = PaymentMethod.Type.Card,
+        card = PaymentMethod.Card(
+            brand = CardBrand.Visa,
+            last4 = "4242"
+        ),
+        code = "card"
+    )
+}


### PR DESCRIPTION
Some LPMs change requirements based on information only available in the `StripeIntent`. A follow up to this will introduce those behavior changes.

# Summary
<!-- Simple summary of what was changed. -->

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
PayPal and CashApp require changing the behavior of UI/requiresMandate based on information only available in the `StripeIntent`

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
