### PR TITLE
Remove usage of onBackPressed()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,19 @@
 
 ## XX.XX.XX - 2023-XX-XX
 
+### Payments
+* [ADDED][6012](https://github.com/stripe/stripe-android/pull/6012) Support for the predictive back gesture.
+
 ### PaymentSheet
 * [DEPRECATED][5928](https://github.com/stripe/stripe-android/pull/5928) Deprecated `PaymentOption` public constructor, and `drawableResourceId` property.
 * [ADDED][5928](https://github.com/stripe/stripe-android/pull/5928) Added `PaymentOption.icon()`, which returns a `Drawable`, and replaces `PaymentOption.drawableResourceId`.
+* [ADDED][6012](https://github.com/stripe/stripe-android/pull/6012) Support for the predictive back gesture.
+
+### Financial Connections
+* [ADDED][6012](https://github.com/stripe/stripe-android/pull/6012) Support for the predictive back gesture.
+
+### CardScan
+* [ADDED][6012](https://github.com/stripe/stripe-android/pull/6012) Support for the predictive back gesture.
 
 ## 20.17.0 - 2022-12-12
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetActivity.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetActivity.kt
@@ -3,6 +3,7 @@ package com.stripe.android.financialconnections
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import androidx.activity.addCallback
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.appcompat.app.AppCompatActivity
 import com.airbnb.mvrx.Mavericks
@@ -42,16 +43,15 @@ internal class FinancialConnectionsSheetActivity :
             viewModel.onEach { postInvalidate() }
             if (savedInstanceState != null) viewModel.onActivityRecreated()
         }
+
+        onBackPressedDispatcher.addCallback {
+            finishWithResult(FinancialConnectionsSheetActivityResult.Canceled)
+        }
     }
 
     override fun onResume() {
         super.onResume()
         viewModel.onResume()
-    }
-
-    override fun onBackPressed() {
-        super.onBackPressed()
-        finishWithResult(FinancialConnectionsSheetActivityResult.Canceled)
     }
 
     /**

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -7214,7 +7214,6 @@ public final class com/stripe/android/view/ExpiryDateEditText : com/stripe/andro
 public final class com/stripe/android/view/PaymentAuthWebViewActivity : androidx/appcompat/app/AppCompatActivity {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun onBackPressed ()V
 	public fun onCreateOptionsMenu (Landroid/view/Menu;)Z
 	public fun onOptionsItemSelected (Landroid/view/MenuItem;)Z
 }
@@ -7223,7 +7222,6 @@ public final class com/stripe/android/view/PaymentFlowActivity : com/stripe/andr
 	public static final field $stable I
 	public fun <init> ()V
 	public fun onActionSave ()V
-	public fun onBackPressed ()V
 }
 
 public final class com/stripe/android/view/PaymentFlowActivityStarter : com/stripe/android/view/ActivityStarter {
@@ -7287,7 +7285,6 @@ public final class com/stripe/android/view/PaymentFlowViewPager : androidx/viewp
 public final class com/stripe/android/view/PaymentMethodsActivity : androidx/appcompat/app/AppCompatActivity {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun onBackPressed ()V
 	public fun onSupportNavigateUp ()Z
 }
 

--- a/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
@@ -6,6 +6,7 @@ import android.graphics.Color
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
+import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.annotation.ColorInt
 import androidx.annotation.VisibleForTesting
@@ -58,6 +59,14 @@ class PaymentAuthWebViewActivity : AppCompatActivity() {
 
         setSupportActionBar(viewBinding.toolbar)
         customizeToolbar()
+
+        onBackPressedDispatcher.addCallback {
+            if (viewBinding.webView.canGoBack()) {
+                viewBinding.webView.goBack()
+            } else {
+                cancelIntentSource()
+            }
+        }
 
         val clientSecret = args.clientSecret
         setResult(Activity.RESULT_OK, createResultIntent(viewModel.paymentResult))
@@ -146,14 +155,6 @@ class PaymentAuthWebViewActivity : AppCompatActivity() {
             return true
         }
         return super.onOptionsItemSelected(item)
-    }
-
-    override fun onBackPressed() {
-        if (viewBinding.webView.canGoBack()) {
-            viewBinding.webView.goBack()
-        } else {
-            cancelIntentSource()
-        }
     }
 
     private fun cancelIntentSource() {

--- a/payments-core/src/main/java/com/stripe/android/view/PaymentFlowActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentFlowActivity.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.view.ViewGroup
+import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.viewpager.widget.ViewPager
 import com.stripe.android.CustomerSession
@@ -78,6 +79,11 @@ class PaymentFlowActivity : StripeActivity() {
         paymentFlowPagerAdapter.shippingInformation = shippingInformation
         paymentFlowPagerAdapter.selectedShippingMethod = viewModel.selectedShippingMethod
 
+        val onBackPressedCallback = onBackPressedDispatcher.addCallback {
+            viewModel.currentPage -= 1
+            viewPager.currentItem = viewModel.currentPage
+        }
+
         viewPager.adapter = paymentFlowPagerAdapter
         viewPager.addOnPageChangeListener(
             object : ViewPager.OnPageChangeListener {
@@ -89,6 +95,8 @@ class PaymentFlowActivity : StripeActivity() {
                         viewModel.isShippingInfoSubmitted = false
                         paymentFlowPagerAdapter.isShippingInfoSubmitted = false
                     }
+
+                    onBackPressedCallback.isEnabled = hasPreviousPage()
                 }
 
                 override fun onPageScrollStateChanged(i: Int) {
@@ -244,15 +252,6 @@ class PaymentFlowActivity : StripeActivity() {
             Intent().putExtra(EXTRA_PAYMENT_SESSION_DATA, paymentSessionData)
         )
         finish()
-    }
-
-    override fun onBackPressed() {
-        if (hasPreviousPage()) {
-            viewModel.currentPage -= 1
-            viewPager.currentItem = viewModel.currentPage
-        } else {
-            super.onBackPressed()
-        }
     }
 
     internal companion object {

--- a/payments-core/src/main/java/com/stripe/android/view/PaymentFlowActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentFlowActivity.kt
@@ -105,6 +105,8 @@ class PaymentFlowActivity : StripeActivity() {
         )
 
         viewPager.currentItem = viewModel.currentPage
+        onBackPressedCallback.isEnabled = hasPreviousPage()
+
         title = paymentFlowPagerAdapter.getPageTitle(viewPager.currentItem)
     }
 

--- a/payments-core/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentMethodsActivity.kt
@@ -9,6 +9,7 @@ import android.text.util.Linkify
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.activity.addCallback
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
@@ -98,6 +99,10 @@ class PaymentMethodsActivity : AppCompatActivity() {
 
         args.windowFlags?.let {
             window.addFlags(it)
+        }
+
+        onBackPressedDispatcher.addCallback {
+            finishWithResult(adapter.selectedPaymentMethod, Activity.RESULT_CANCELED)
         }
 
         viewModel.snackbarData.observe(this) { snackbarText ->
@@ -211,10 +216,6 @@ class PaymentMethodsActivity : AppCompatActivity() {
             // Payment Method.
             finishWithResult(paymentMethod)
         }
-    }
-
-    override fun onBackPressed() {
-        finishWithResult(adapter.selectedPaymentMethod, Activity.RESULT_CANCELED)
     }
 
     private fun fetchCustomerPaymentMethods() {

--- a/payments-core/src/main/java/com/stripe/android/view/StripeActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/StripeActivity.kt
@@ -66,7 +66,7 @@ abstract class StripeActivity : AppCompatActivity() {
         } else {
             val handled = super.onOptionsItemSelected(item)
             if (!handled) {
-                onBackPressed()
+                onBackPressedDispatcher.onBackPressed()
             }
             handled
         }

--- a/payments-core/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/PaymentMethodsActivityTest.kt
@@ -239,7 +239,7 @@ class PaymentMethodsActivityTest {
                 paymentMethodsAdapter.selectedPaymentMethodId =
                     PaymentMethodFixtures.CARD_PAYMENT_METHODS[0].id
 
-                activity.onBackPressed()
+                activity.onBackPressedDispatcher.onBackPressed()
 
                 // Now it should be gone.
                 assertEquals(View.GONE, progressBar.visibility)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -13,6 +13,7 @@ import android.view.WindowInsets
 import android.view.WindowMetrics
 import android.widget.ScrollView
 import android.widget.TextView
+import androidx.activity.addCallback
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
@@ -128,9 +129,14 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
             }
         }
 
+        val onBackPressedCallback = onBackPressedDispatcher.addCallback {
+            viewModel.handleBackPressed()
+        }
+
         viewModel.processing.launchAndCollectIn(this) { isProcessing ->
             updateRootViewClickHandling(isProcessing)
             toolbar.isEnabled = !isProcessing
+            onBackPressedCallback.isEnabled = !isProcessing
         }
 
         // Set Toolbar to act as the ActionBar so it displays the menu items.
@@ -188,13 +194,6 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
     override fun finish() {
         super.finish()
         overridePendingTransition(AnimationConstants.FADE_IN, AnimationConstants.FADE_OUT)
-    }
-
-    @Deprecated("Deprecated in Java")
-    override fun onBackPressed() {
-        if (!viewModel.processing.value) {
-            viewModel.handleBackPressed()
-        }
     }
 
     protected fun closeSheet(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso.pressBack
 import app.cash.turbine.test
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.common.truth.Truth.assertThat
@@ -228,7 +229,7 @@ internal class PaymentOptionsActivityTest {
                     .isTrue()
 
                 // Navigate back to payment options list
-                activity.onBackPressed()
+                pressBack()
                 idleLooper()
 
                 assertThat(activity.viewBinding.continueButton.isVisible)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -300,7 +300,7 @@ internal class PaymentSheetActivityTest {
             assertThat(activity.viewBinding.message.isVisible).isTrue()
             assertThat(activity.viewBinding.message.text.toString()).isEqualTo("some error")
 
-            activity.onBackPressed()
+            pressBack()
 
             assertThat(activity.viewBinding.message.isVisible).isFalse()
         }
@@ -467,13 +467,13 @@ internal class PaymentSheetActivityTest {
             assertThat(activity.toolbar.navigationContentDescription)
                 .isEqualTo(context.getString(R.string.back))
 
-            activity.onBackPressed()
+            pressBack()
             idleLooper()
 
             assertThat(activity.toolbar.navigationContentDescription)
                 .isEqualTo(context.getString(R.string.stripe_paymentsheet_close))
 
-            activity.onBackPressed()
+            pressBack()
             idleLooper()
             // animating out
             assertThat(activity.bottomSheetBehavior.state)

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanActivity.kt
@@ -9,6 +9,7 @@ import android.util.Size
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
+import androidx.activity.addCallback
 import androidx.annotation.RestrictTo
 import com.stripe.android.camera.CameraPreviewImage
 import com.stripe.android.camera.framework.Stats
@@ -194,6 +195,12 @@ internal class CardScanActivity : ScanActivity(), SimpleScanStateful<CardScanSta
             return
         }
 
+        onBackPressedDispatcher.addCallback {
+            runBlocking { scanStat.trackResult("user_canceled") }
+            resultListener.userCanceled(CancellationReason.Back)
+            closeScanner()
+        }
+
         viewBinding.closeButton.setOnClickListener {
             userClosedScanner()
         }
@@ -224,15 +231,6 @@ internal class CardScanActivity : ScanActivity(), SimpleScanStateful<CardScanSta
     override fun onDestroy() {
         scanFlow.cancelFlow()
         super.onDestroy()
-    }
-
-    /**
-     * Cancel the scan when the user presses back.
-     */
-    override fun onBackPressed() {
-        runBlocking { scanStat.trackResult("user_canceled") }
-        resultListener.userCanceled(CancellationReason.Back)
-        closeScanner()
     }
 
     override fun onFlashSupported(supported: Boolean) {

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/scanui/ScanActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/scanui/ScanActivity.kt
@@ -10,6 +10,7 @@ import android.util.Size
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
+import androidx.activity.addCallback
 import androidx.appcompat.app.AlertDialog
 import com.stripe.android.camera.CameraAdapter
 import com.stripe.android.camera.CameraPermissionCheckingActivity
@@ -79,6 +80,12 @@ internal abstract class ScanActivity : CameraPermissionCheckingActivity(), Corou
         super.onCreate(savedInstanceState)
 
         Stats.startScan()
+
+        onBackPressedDispatcher.addCallback {
+            runBlocking { scanStat.trackResult("user_canceled") }
+            resultListener.userCanceled(CancellationReason.Back)
+            closeScanner()
+        }
 
         if (!CameraAdapter.isCameraSupported(this)) {
             showCameraNotSupportedDialog()
@@ -184,15 +191,6 @@ internal abstract class ScanActivity : CameraPermissionCheckingActivity(), Corou
         Log.e(LOG_TAG, "Canceling scan due to error", cause)
         runBlocking { scanStat.trackResult("scan_failure") }
         resultListener.failed(cause)
-        closeScanner()
-    }
-
-    /**
-     * Cancel the scan when the user presses back.
-     */
-    override fun onBackPressed() {
-        runBlocking { scanStat.trackResult("user_canceled") }
-        resultListener.userCanceled(CancellationReason.Back)
         closeScanner()
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request removes usage of `onBackPressed()` and replaces it with `onBackPressedDispatcher.addCallback()`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Resolves https://github.com/stripe/stripe-android/issues/5951

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

[ADDED] Support for the predictive back gesture.
