### PR TITLE
Update paymentMethods to be nullable

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
@@ -44,7 +44,7 @@ internal abstract class BasePaymentMethodsListFragment(
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        setHasOptionsMenu(sheetViewModel.paymentMethods.value.isNotEmpty())
+        setHasOptionsMenu(!sheetViewModel.paymentMethods.value.isNullOrEmpty())
         sheetViewModel.eventReporter.onShowExistingPaymentOptions(
             linkEnabled = sheetViewModel.isLinkEnabled.value ?: false,
             activeLinkSession = sheetViewModel.activeLinkSession.value ?: false
@@ -137,7 +137,7 @@ internal abstract class BasePaymentMethodsListFragment(
         }
 
         sheetViewModel.paymentMethods.launchAndCollectIn(viewLifecycleOwner) { paymentMethods ->
-            if (isEditing && paymentMethods.isEmpty()) {
+            if (isEditing && paymentMethods.isNullOrEmpty()) {
                 isEditing = false
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -610,7 +610,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     }
 
     override fun transitionToFirstScreen() {
-        val target = if (paymentMethods.value.isEmpty()) {
+        val target = if (paymentMethods.value.isNullOrEmpty()) {
             updateSelection(null)
             TransitionTarget.AddFirstPaymentMethod
         } else {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -132,8 +132,8 @@ internal abstract class BaseSheetViewModel(
      * The list of saved payment methods for the current customer.
      * Value is null until it's loaded, and non-null (could be empty) after that.
      */
-    internal val paymentMethods: StateFlow<List<PaymentMethod>> = savedStateHandle
-        .getStateFlow(SAVE_PAYMENT_METHODS, listOf())
+    internal val paymentMethods: StateFlow<List<PaymentMethod>?> = savedStateHandle
+        .getStateFlow(SAVE_PAYMENT_METHODS, null)
 
     internal val amount: StateFlow<Amount?> = savedStateHandle
         .getStateFlow(SAVE_AMOUNT, null)
@@ -452,7 +452,7 @@ internal abstract class BaseSheetViewModel(
                 _selection.value = null
             }
 
-            savedStateHandle[SAVE_PAYMENT_METHODS] = paymentMethods.value.filter {
+            savedStateHandle[SAVE_PAYMENT_METHODS] = paymentMethods.value?.filter {
                 it.id != paymentMethodId
             }
 
@@ -463,7 +463,7 @@ internal abstract class BaseSheetViewModel(
                 )
             }
 
-            val hasNoBankAccounts = paymentMethods.value.all { it.type != USBankAccount }
+            val hasNoBankAccounts = paymentMethods.value.orEmpty().all { it.type != USBankAccount }
             if (hasNoBankAccounts) {
                 updatePrimaryButtonUIState(
                     primaryButtonUIState.value?.copy(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsStateMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsStateMapper.kt
@@ -11,7 +11,7 @@ import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.state.GooglePayState
 
 internal class PaymentOptionsStateMapper(
-    private val paymentMethods: LiveData<List<PaymentMethod>>,
+    private val paymentMethods: LiveData<List<PaymentMethod>?>,
     private val googlePayState: LiveData<GooglePayState>,
     private val isLinkEnabled: LiveData<Boolean>,
     private val initialSelection: LiveData<SavedSelection>,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -73,6 +73,7 @@ import org.robolectric.RobolectricTestRunner
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.time.Duration
 
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
@@ -939,6 +940,15 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
+    fun `paymentMethods is null if payment sheet state is not loaded`() = runTest {
+        val viewModel = createViewModel(delay = Duration.INFINITE)
+
+        viewModel.paymentMethods.test {
+            assertThat(awaitItem()).isNull()
+        }
+    }
+
+    @Test
     fun `current screen is AddFirstPaymentMethod if payment methods is empty`() = runTest {
         val viewModel = createViewModel(customerPaymentMethods = emptyList())
 
@@ -979,7 +989,8 @@ internal class PaymentSheetViewModelTest {
         customerRepository: CustomerRepository = FakeCustomerRepository(PAYMENT_METHODS),
         shouldFailLoad: Boolean = false,
         linkState: LinkState? = null,
-        customerPaymentMethods: List<PaymentMethod> = listOf()
+        customerPaymentMethods: List<PaymentMethod> = listOf(),
+        delay: Duration = Duration.ZERO
     ): PaymentSheetViewModel {
         val paymentConfiguration = PaymentConfiguration(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
         return PaymentSheetViewModel(
@@ -993,7 +1004,8 @@ internal class PaymentSheetViewModelTest {
                 stripeIntent = stripeIntent,
                 shouldFail = shouldFailLoad,
                 linkState = linkState,
-                customerPaymentMethods = customerPaymentMethods
+                customerPaymentMethods = customerPaymentMethods,
+                delay = delay
             ),
             customerRepository,
             prefsRepository,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsStateMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsStateMapperTest.kt
@@ -20,7 +20,7 @@ class PaymentOptionsStateMapperTest {
     @get:Rule
     val instantTaskExecutorRule = InstantTaskExecutorRule()
 
-    private lateinit var paymentMethodsFlow: MutableLiveData<List<PaymentMethod>>
+    private lateinit var paymentMethodsFlow: MutableLiveData<List<PaymentMethod>?>
     private lateinit var initialSelectionFlow: MutableLiveData<SavedSelection>
     private lateinit var currentSelectionFlow: MutableLiveData<PaymentSelection?>
     private lateinit var googlePayStateFlow: MutableLiveData<GooglePayState>


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

In a previous refactor to update paymentMethods from LiveData to StateFlow, the underlying type was made non-null. This should be nullable, since the list of payment methods will come from the server, but can also be an empty list. So to differentiate between empty and not loaded, it makes sense to make this a nullable list.

See this comment: https://github.com/stripe/stripe-android/pull/6014/files#diff-bbc3f2e9350bfc93939031fff087aa439e01391d7fc521f13b9fd605d05da615R132-R136
