### PR TITLE
Add `HeaderTextFactory` to streamline header text selection

### DIFF
--- a/paymentsheet/res/values-b+es+419/strings.xml
+++ b/paymentsheet/res/values-b+es+419/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Agregar un nuevo método de pago</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Elimina la cuenta bancaria que termina en %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">O usar otro método de pago</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Al continuar, aceptas autorizar pagos conforme a <terms>estas condiciones</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">Agregar otro</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Agrega la información de pago</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Elegir un método de pago</string>
   <string name="stripe_paymentsheet_close">Cerrar</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe depositará $0.01 en tu cuenta dentro de 1 o 2 días hábiles. Luego, recibirás un correo electrónico con instrucciones para completar el pago de %s.</string>

--- a/paymentsheet/res/values-b+es+419/strings.xml
+++ b/paymentsheet/res/values-b+es+419/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">Agregar otro</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Agrega la información de pago</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Elegir un método de pago</string>
   <string name="stripe_paymentsheet_close">Cerrar</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-b+es+419/strings.xml
+++ b/paymentsheet/res/values-b+es+419/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Agregar un nuevo método de pago</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Elimina la cuenta bancaria que termina en %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">O usar otro método de pago</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Al continuar, aceptas autorizar pagos conforme a <terms>estas condiciones</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-ca-rES/strings.xml
+++ b/paymentsheet/res/values-ca-rES/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Afegir un mètode de pagament nou</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Elimina el compte bancari que acaba en %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">O pagueu d\'una altra manera</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[En continuar, accepteu autoritzar aquests pagaments segons <terms>aquests termes</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Afegir</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Afegir la teva informació de pagament</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Escull un mètode de pagament</string>
   <string name="stripe_paymentsheet_close">Tanca</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe farà un dipòsit de 0,01 USD al vostre compte d\'aquí 1 o 2 dies feiners. Després, rebreu un correu electrònic amb instruccions per completar el pagament a %s.</string>

--- a/paymentsheet/res/values-ca-rES/strings.xml
+++ b/paymentsheet/res/values-ca-rES/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Afegir un mètode de pagament nou</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Elimina el compte bancari que acaba en %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">O pagueu d\'una altra manera</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[En continuar, accepteu autoritzar aquests pagaments segons <terms>aquests termes</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-ca-rES/strings.xml
+++ b/paymentsheet/res/values-ca-rES/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Afegir</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Afegir la teva informació de pagament</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Escull un mètode de pagament</string>
   <string name="stripe_paymentsheet_close">Tanca</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-cs-rCZ/strings.xml
+++ b/paymentsheet/res/values-cs-rCZ/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Přidat novou platební metodu</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Odebrat bankovní účet končící na %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Nebo zaplatit jiným způsobem</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Pokračovaním souhlasíte s autorizací plateb podle <terms>těchto podmínek</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-cs-rCZ/strings.xml
+++ b/paymentsheet/res/values-cs-rCZ/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Přidat novou platební metodu</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Odebrat bankovní účet končící na %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Nebo zaplatit jiným způsobem</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Pokračovaním souhlasíte s autorizací plateb podle <terms>těchto podmínek</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Přidat</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Přidejte své platební údaje</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Zvolte platební metodu</string>
   <string name="stripe_paymentsheet_close">Zavřít</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">V průběhu 1 až 2 pracovních dnů vloží Stripe na váš účet vklad ve výšce 0,01 USD. Potom dostanete e-mail s instrukcemi k dokončení platby společnosti %s.</string>

--- a/paymentsheet/res/values-cs-rCZ/strings.xml
+++ b/paymentsheet/res/values-cs-rCZ/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Přidat</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Přidejte své platební údaje</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Zvolte platební metodu</string>
   <string name="stripe_paymentsheet_close">Zavřít</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-da/strings.xml
+++ b/paymentsheet/res/values-da/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Tilføj en ny betalingsmetode</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Fjern bankkonto, der ender på %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Eller betal på anden vis</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Ved at fortsætte accepterer du at godkende betalinger i henhold til <terms>disse vilkår</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-da/strings.xml
+++ b/paymentsheet/res/values-da/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Tilføj</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Tilføj dine betalingsoplysninger</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Vælg en betalingsmetode</string>
   <string name="stripe_paymentsheet_close">Luk</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-da/strings.xml
+++ b/paymentsheet/res/values-da/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Tilføj en ny betalingsmetode</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Fjern bankkonto, der ender på %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Eller betal på anden vis</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Ved at fortsætte accepterer du at godkende betalinger i henhold til <terms>disse vilkår</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Tilføj</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Tilføj dine betalingsoplysninger</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Vælg en betalingsmetode</string>
   <string name="stripe_paymentsheet_close">Luk</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe vil sætte 0,01 USD ind på din konto i løbet af 1-2 hverdage. Derefter modtager du en e-mail med instruktioner til at fuldføre betalingen til %s.</string>

--- a/paymentsheet/res/values-de/strings.xml
+++ b/paymentsheet/res/values-de/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Hinzufügen</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Zahlungsinformationen hinzufügen</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Zahlungsmethode auswählen </string>
   <string name="stripe_paymentsheet_close">Schließen</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-de/strings.xml
+++ b/paymentsheet/res/values-de/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Neue Zahlungsmethode hinzufügen</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Bankkonto mit den Endziffern %s entfernen</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Andere Zahlungsmethode wählen</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Indem Sie fortfahren, akzeptieren Sie die Autorisierung von Zahlungen gemäß <terms>diesen Bedingungen</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-de/strings.xml
+++ b/paymentsheet/res/values-de/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Neue Zahlungsmethode hinzufügen</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Bankkonto mit den Endziffern %s entfernen</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Andere Zahlungsmethode wählen</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Indem Sie fortfahren, akzeptieren Sie die Autorisierung von Zahlungen gemäß <terms>diesen Bedingungen</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Hinzufügen</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Zahlungsinformationen hinzufügen</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Zahlungsmethode auswählen </string>
   <string name="stripe_paymentsheet_close">Schließen</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">In ein bis zwei Werktagen wird Stripe Ihrem Konto einen Betrag von 0,01 USD gutschreiben. Danach erhalten Sie eine E-Mail mit weiteren Anweisungen zur Durchführung der Zahlung an %s.</string>

--- a/paymentsheet/res/values-el-rGR/strings.xml
+++ b/paymentsheet/res/values-el-rGR/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Προσθήκη</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Προσθέστε τα στοιχεία πληρωμής σας</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Επιλέξτε μέθοδο πληρωμής</string>
   <string name="stripe_paymentsheet_close">Κλείσιμο</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-el-rGR/strings.xml
+++ b/paymentsheet/res/values-el-rGR/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Προσθέστε νέα μέθοδο πληρωμής</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Αφαίρεση του τραπεζικού λογαριασμού που λήγει σε %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Ή πληρωμή με άλλον τρόπο</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Εάν συνεχίσετε, συμφωνείτε να εξουσιοδοτείτε πληρωμές με βάση <terms>αυτούς τους όρους</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-el-rGR/strings.xml
+++ b/paymentsheet/res/values-el-rGR/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Προσθέστε νέα μέθοδο πληρωμής</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Αφαίρεση του τραπεζικού λογαριασμού που λήγει σε %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Ή πληρωμή με άλλον τρόπο</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Εάν συνεχίσετε, συμφωνείτε να εξουσιοδοτείτε πληρωμές με βάση <terms>αυτούς τους όρους</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Προσθήκη</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Προσθέστε τα στοιχεία πληρωμής σας</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Επιλέξτε μέθοδο πληρωμής</string>
   <string name="stripe_paymentsheet_close">Κλείσιμο</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Η Stripe θα καταθέσει 0,01 $ στον λογαριασμό σας σε 1-2 εργάσιμες ημέρες. Στη συνέχεια, θα λάβετε email με οδηγίες για να ολοκληρώσετε την πληρωμή στην %s.</string>

--- a/paymentsheet/res/values-en-rGB/strings.xml
+++ b/paymentsheet/res/values-en-rGB/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Add a new payment method</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Remove bank account ending in %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Or pay another way</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[By continuing, you agree to authorize payments pursuant to <terms>these terms</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-en-rGB/strings.xml
+++ b/paymentsheet/res/values-en-rGB/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Add a new payment method</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Remove bank account ending in %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Or pay another way</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[By continuing, you agree to authorize payments pursuant to <terms>these terms</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Add</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Add your payment information</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Choose a payment method</string>
   <string name="stripe_paymentsheet_close">Close</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe will deposit $0.01 to your account in 1-2 business days. Then you’ll get an email with instructions to complete payment to %s.</string>

--- a/paymentsheet/res/values-en-rGB/strings.xml
+++ b/paymentsheet/res/values-en-rGB/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Add</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Add your payment information</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Choose a payment method</string>
   <string name="stripe_paymentsheet_close">Close</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-es/strings.xml
+++ b/paymentsheet/res/values-es/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Añadir un nuevo método de pago</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Elimina la cuenta bancaria que termina en %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">O usar otro método de pago</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Al continuar, aceptas autorizar pagos de conformidad con <terms>estas condiciones</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Añadir más datos</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Añadir información de pago</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Elige un método de pago</string>
   <string name="stripe_paymentsheet_close">Cerrar</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe depositará 0,01 $ en tu cuenta dentro de 1 o 2 días hábiles. Luego, recibirás un correo electrónico con instrucciones para completar el pago para %s.</string>

--- a/paymentsheet/res/values-es/strings.xml
+++ b/paymentsheet/res/values-es/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Añadir más datos</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Añadir información de pago</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Elige un método de pago</string>
   <string name="stripe_paymentsheet_close">Cerrar</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-es/strings.xml
+++ b/paymentsheet/res/values-es/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Añadir un nuevo método de pago</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Elimina la cuenta bancaria que termina en %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">O usar otro método de pago</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Al continuar, aceptas autorizar pagos de conformidad con <terms>estas condiciones</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-et-rEE/strings.xml
+++ b/paymentsheet/res/values-et-rEE/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ lisa</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Lisage makseteave</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Valige makseviis</string>
   <string name="stripe_paymentsheet_close">Sule</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-et-rEE/strings.xml
+++ b/paymentsheet/res/values-et-rEE/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Lisage uus makseviis</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Eemaldage pangakonto, mille lõpus on %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Või maksa muul viisil</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Jätkates nõustute maksete autoriseerimisega vastavalt nendele <terms>tingimustele</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-et-rEE/strings.xml
+++ b/paymentsheet/res/values-et-rEE/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Lisage uus makseviis</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Eemaldage pangakonto, mille lõpus on %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Või maksa muul viisil</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Jätkates nõustute maksete autoriseerimisega vastavalt nendele <terms>tingimustele</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ lisa</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Lisage makseteave</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Valige makseviis</string>
   <string name="stripe_paymentsheet_close">Sule</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe deponeerib teie pangakontole 0,01 dollarit 1–2 tööpäeva jooksul. Seejärel saate meili juhistega makse sooritamiseks ettevõttele %s.</string>

--- a/paymentsheet/res/values-fi/strings.xml
+++ b/paymentsheet/res/values-fi/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Lisää uusi maksutapa</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Poista pankkitili, joka päättyy %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Tai maksa toisella tavalla</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Jatkamalla hyväksyt maksujen valtuutuksen <terms>näiden ehtojen mukaisesti</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-fi/strings.xml
+++ b/paymentsheet/res/values-fi/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Lisää uusi maksutapa</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Poista pankkitili, joka päättyy %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Tai maksa toisella tavalla</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Jatkamalla hyväksyt maksujen valtuutuksen <terms>näiden ehtojen mukaisesti</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Lisää</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Lisää maksutiedot</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Valitse maksutapa</string>
   <string name="stripe_paymentsheet_close">Sulje</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe tallettaa 0,01 dollaria tilillesi 1–2 arkipäivän kuluessa. Saat myös sähköpostiisi ohjeet maksun suorittamiseksi loppuun yritykselle %s.</string>

--- a/paymentsheet/res/values-fi/strings.xml
+++ b/paymentsheet/res/values-fi/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Lisää</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Lisää maksutiedot</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Valitse maksutapa</string>
   <string name="stripe_paymentsheet_close">Sulje</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-fil/strings.xml
+++ b/paymentsheet/res/values-fil/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Magdagadag ng bagong pamamaraan ng pagbabayad</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Alisin ang account na nagtatapos sa %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">O magbayad sa ibang paraan</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Sa pagpapatuloy, sumasang-ayon ka na pahintulutan ang mga pagbabayad alinsunod sa <terms>mga tuntuning ito</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-fil/strings.xml
+++ b/paymentsheet/res/values-fil/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Magdagadag ng bagong pamamaraan ng pagbabayad</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Alisin ang account na nagtatapos sa %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">O magbayad sa ibang paraan</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Sa pagpapatuloy, sumasang-ayon ka na pahintulutan ang mga pagbabayad alinsunod sa <terms>mga tuntuning ito</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+Magdagdag</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Magdagdag ng iyong impormasyon sa pagbabayad</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Pumili ng pamamaraan ng pagbabayad</string>
   <string name="stripe_paymentsheet_close">Isara</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Idedeposito ng Stripe ang $0.01 sa iyong account sa loob ng 1-2 araw ng trabaho. Pagkatapos ay makakatanggap ka ng email na may mga tagubilin para kumpletuhin ang pagbabayad sa %s.</string>

--- a/paymentsheet/res/values-fil/strings.xml
+++ b/paymentsheet/res/values-fil/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+Magdagdag</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Magdagdag ng iyong impormasyon sa pagbabayad</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Pumili ng pamamaraan ng pagbabayad</string>
   <string name="stripe_paymentsheet_close">Isara</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-fr-rCA/strings.xml
+++ b/paymentsheet/res/values-fr-rCA/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Ajouter</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Ajoutez vos informations de paiement</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Choisir un moyen de paiement</string>
   <string name="stripe_paymentsheet_close">Fermer</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-fr-rCA/strings.xml
+++ b/paymentsheet/res/values-fr-rCA/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Ajouter un moyen de paiement</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Supprimer le compte bancaire se terminant par %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Ou utilisez un autre moyen de paiement</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[En continuant, vous autorisez les paiements conformément à <terms>ces conditions</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Ajouter</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Ajoutez vos informations de paiement</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Choisir un moyen de paiement</string>
   <string name="stripe_paymentsheet_close">Fermer</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe va effectuer un versement de 0,01 $ sur votre compte sous 1 ou 2 jours ouvrables. Vous recevrez ensuite un courriel contenant des instructions pour finaliser le paiement à %s.</string>

--- a/paymentsheet/res/values-fr-rCA/strings.xml
+++ b/paymentsheet/res/values-fr-rCA/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Ajouter un moyen de paiement</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Supprimer le compte bancaire se terminant par %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Ou utilisez un autre moyen de paiement</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[En continuant, vous autorisez les paiements conformément à <terms>ces conditions</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-fr/strings.xml
+++ b/paymentsheet/res/values-fr/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Ajouter</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Ajoutez vos informations de paiement</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Choisir un moyen de paiement</string>
   <string name="stripe_paymentsheet_close">Fermer</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-fr/strings.xml
+++ b/paymentsheet/res/values-fr/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Ajouter un moyen de paiement</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Supprimer le compte bancaire se terminant par %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Ou utilisez un autre moyen de paiement</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[En continuant, vous autorisez les paiements conformément à <terms>ces conditions</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Ajouter</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Ajoutez vos informations de paiement</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Choisir un moyen de paiement</string>
   <string name="stripe_paymentsheet_close">Fermer</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe va effectuer un versement de 0,01 $ sur votre compte sous 1 ou 2 jours ouvrables. Vous recevrez ensuite un e-mail contenant des instructions pour finaliser le paiement en faveur de %s.</string>

--- a/paymentsheet/res/values-fr/strings.xml
+++ b/paymentsheet/res/values-fr/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Ajouter un moyen de paiement</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Supprimer le compte bancaire se terminant par %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Ou utilisez un autre moyen de paiement</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[En continuant, vous autorisez les paiements conformément à <terms>ces conditions</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-hr/strings.xml
+++ b/paymentsheet/res/values-hr/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Dodaj novi način plaćanja</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Ukloni bankovni račun koji završava na %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Ili platite na drugi način</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Ako nastavite, pristajete na autorizaciju plaćanja u skladu s <terms>ovim uvjetima</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-hr/strings.xml
+++ b/paymentsheet/res/values-hr/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Dodaj</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Dodavanje informacija o plaćanju</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Odaberite način plaćanja</string>
   <string name="stripe_paymentsheet_close">Zatvori</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-hr/strings.xml
+++ b/paymentsheet/res/values-hr/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Dodaj novi način plaćanja</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Ukloni bankovni račun koji završava na %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Ili platite na drugi način</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Ako nastavite, pristajete na autorizaciju plaćanja u skladu s <terms>ovim uvjetima</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Dodaj</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Dodavanje informacija o plaćanju</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Odaberite način plaćanja</string>
   <string name="stripe_paymentsheet_close">Zatvori</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe će uplatiti polog u iznosu od 0,01 USD na vaš račun u roku od 1-2 radna dana. Zatim ćete zaprimiti poruku e-pošte s uputama za dovršetak plaćanja za %s.</string>

--- a/paymentsheet/res/values-hu/strings.xml
+++ b/paymentsheet/res/values-hu/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Új fizetési mód hozzáadása</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">%s számra végződő bankszámla eltávolítása</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Vagy fizetés más módon</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[A folytatással elfogadja, hogy engedélyezi a kifizetéseket ezen <terms>feltételek</terms> szerint.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Hozzáadás</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Fizetési adatok megadása</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Fizetési mód választása</string>
   <string name="stripe_paymentsheet_close">Bezárás</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">A Stripe néhány munkanapon belül egy 0,01 $ összegű utalást fog küldeni a bankszámlájára. Ezután e-mailben megkapja az útmutatást a fizetés befejezéséhez a(z) %s felé.</string>

--- a/paymentsheet/res/values-hu/strings.xml
+++ b/paymentsheet/res/values-hu/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Új fizetési mód hozzáadása</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">%s számra végződő bankszámla eltávolítása</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Vagy fizetés más módon</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[A folytatással elfogadja, hogy engedélyezi a kifizetéseket ezen <terms>feltételek</terms> szerint.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-hu/strings.xml
+++ b/paymentsheet/res/values-hu/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Hozzáadás</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Fizetési adatok megadása</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Fizetési mód választása</string>
   <string name="stripe_paymentsheet_close">Bezárás</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-in/strings.xml
+++ b/paymentsheet/res/values-in/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Tambahkan</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Tambahkan informasi pembayaran Anda</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Pilih metode pembayaran</string>
   <string name="stripe_paymentsheet_close">Tutup</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-in/strings.xml
+++ b/paymentsheet/res/values-in/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Tambahkan metode pembayaran baru</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Hapus rekening bank yang berakhiran dengan %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Atau bayar dengan cara lain</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Dengan melanjutkan, Anda berarti setuju untuk mengotorisasi pembayaran sesuai dengan <terms>ketentuan-ketentuan berikut</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Tambahkan</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Tambahkan informasi pembayaran Anda</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Pilih metode pembayaran</string>
   <string name="stripe_paymentsheet_close">Tutup</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe akan menyetorkan $0,01 ke rekening Anda dalam waktu 1–2 hari kerja. Kemudian Anda akan mendapatkan email yang berisi petunjuk untuk menyelesaikan pembayaran kepada %s.</string>

--- a/paymentsheet/res/values-in/strings.xml
+++ b/paymentsheet/res/values-in/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Tambahkan metode pembayaran baru</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Hapus rekening bank yang berakhiran dengan %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Atau bayar dengan cara lain</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Dengan melanjutkan, Anda berarti setuju untuk mengotorisasi pembayaran sesuai dengan <terms>ketentuan-ketentuan berikut</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-it/strings.xml
+++ b/paymentsheet/res/values-it/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Aggiungi</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Aggiungi dati di pagamento</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Scegli una modalità di pagamento</string>
   <string name="stripe_paymentsheet_close">Chiudi</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-it/strings.xml
+++ b/paymentsheet/res/values-it/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Aggiungi nuova modalità di pagamento</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Rimuovi conto bancario che termina con %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">O paga in altro modo</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Se continui, accetti di autorizzare i pagamenti conformemente ai <terms>questi termini</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-it/strings.xml
+++ b/paymentsheet/res/values-it/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Aggiungi nuova modalità di pagamento</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Rimuovi conto bancario che termina con %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">O paga in altro modo</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Se continui, accetti di autorizzare i pagamenti conformemente ai <terms>questi termini</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Aggiungi</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Aggiungi dati di pagamento</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Scegli una modalità di pagamento</string>
   <string name="stripe_paymentsheet_close">Chiudi</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe verserà 0,01 USD sul tuo account in 1-2 giorni lavorativi. Poi riceverai un\'email con le istruzioni per completare il pagamento a favore di %s.</string>

--- a/paymentsheet/res/values-ja/strings.xml
+++ b/paymentsheet/res/values-ja/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">新たな支払い方法を追加する</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">末尾が %s の銀行口座を削除する</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">または別の方法で支払う</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[続行すると、<terms>これらの規約</terms>に従って支払いをオーソリすることに同意したものとみなされます。]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-ja/strings.xml
+++ b/paymentsheet/res/values-ja/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">新たな支払い方法を追加する</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">末尾が %s の銀行口座を削除する</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">または別の方法で支払う</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[続行すると、<terms>これらの規約</terms>に従って支払いをオーソリすることに同意したものとみなされます。]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ 追加</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">支払い情報を追加</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">支払い方法を選択</string>
   <string name="stripe_paymentsheet_close">閉じる</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">1 ～ 2 営業日以内に Stripe は口座に $0.01 を入金します。その後、%s への支払いを完了するための手順が記載されたメールが送信されます。</string>

--- a/paymentsheet/res/values-ja/strings.xml
+++ b/paymentsheet/res/values-ja/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ 追加</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">支払い情報を追加</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">支払い方法を選択</string>
   <string name="stripe_paymentsheet_close">閉じる</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-ko/strings.xml
+++ b/paymentsheet/res/values-ko/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ 추가</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">결제 정보를 추가하세요.</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">결제 방식 선택</string>
   <string name="stripe_paymentsheet_close">닫기</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-ko/strings.xml
+++ b/paymentsheet/res/values-ko/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">새 결제 방식 추가</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">%s(으)로 끝나는 은행 계좌 제거</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">또는 다른 방법으로 결제</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[계속하면 <terms>해당 약관</terms>에 따라 결제를 승인하는 데 동의하는 것입니다.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-ko/strings.xml
+++ b/paymentsheet/res/values-ko/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">새 결제 방식 추가</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">%s(으)로 끝나는 은행 계좌 제거</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">또는 다른 방법으로 결제</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[계속하면 <terms>해당 약관</terms>에 따라 결제를 승인하는 데 동의하는 것입니다.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ 추가</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">결제 정보를 추가하세요.</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">결제 방식 선택</string>
   <string name="stripe_paymentsheet_close">닫기</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe에서 영업일 기준 1~2일 후에 계좌로 0.01$를 입금할 예정입니다. 그런 다음 %s에 대한 결제를 완료하기 위한 지침이 포함된 이메일을 전송할 것입니다.</string>

--- a/paymentsheet/res/values-lt-rLT/strings.xml
+++ b/paymentsheet/res/values-lt-rLT/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Pridėti</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Pridėkite mokėjimo informaciją</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Pasirinkite mokėjimo būdą</string>
   <string name="stripe_paymentsheet_close">Užverti</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-lt-rLT/strings.xml
+++ b/paymentsheet/res/values-lt-rLT/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Pridėti naują mokėjimo būdą</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Pašalinti banko sąskaitą, kurios paskutiniai skaičiai %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Arba mokėti kitu būdu</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Tęsdami sutinkate autorizuoti mokėjimus pagal šias <terms>sąlygas</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Pridėti</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Pridėkite mokėjimo informaciją</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Pasirinkite mokėjimo būdą</string>
   <string name="stripe_paymentsheet_close">Užverti</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Po 1–2 darbo dienas „Stripe“ į jūsų sąskaitą įneš 0,01 USD. Tada gausite el. laišką su nurodymais, kaip užbaigti mokėjimą %s.</string>

--- a/paymentsheet/res/values-lt-rLT/strings.xml
+++ b/paymentsheet/res/values-lt-rLT/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Pridėti naują mokėjimo būdą</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Pašalinti banko sąskaitą, kurios paskutiniai skaičiai %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Arba mokėti kitu būdu</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Tęsdami sutinkate autorizuoti mokėjimus pagal šias <terms>sąlygas</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-lv-rLV/strings.xml
+++ b/paymentsheet/res/values-lv-rLV/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Pievienot</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Pievienot maksājuma informāciju</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Izvēlēties maksājuma veidu</string>
   <string name="stripe_paymentsheet_close">Aizvērt</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-lv-rLV/strings.xml
+++ b/paymentsheet/res/values-lv-rLV/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Pievienot jaunu maksājuma veidu</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Noņemt bankas kontu, kas beidzas ar %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Vai maksāt citā veidā</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Turpinot, jūs piekrītat autorizēt maksājumus saskaņā ar <terms>šiem noteikumiem</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Pievienot</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Pievienot maksājuma informāciju</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Izvēlēties maksājuma veidu</string>
   <string name="stripe_paymentsheet_close">Aizvērt</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe uz jūsu kontu 1-2 darbadienu laikā nosūtīs 0,01 $. Pēc tam saņemsiet e-pastu ar norādījumiem, kā pabeigt maksājumu ar %s.</string>

--- a/paymentsheet/res/values-lv-rLV/strings.xml
+++ b/paymentsheet/res/values-lv-rLV/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Pievienot jaunu maksājuma veidu</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Noņemt bankas kontu, kas beidzas ar %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Vai maksāt citā veidā</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Turpinot, jūs piekrītat autorizēt maksājumus saskaņā ar <terms>šiem noteikumiem</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-ms-rMY/strings.xml
+++ b/paymentsheet/res/values-ms-rMY/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Tambah</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Tambah maklumat pembayaran anda</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Pilih kaedah pembayaran</string>
   <string name="stripe_paymentsheet_close">Tutup</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-ms-rMY/strings.xml
+++ b/paymentsheet/res/values-ms-rMY/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Tambah kaedah pembayaran baharu</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Alih keluar akaun bank yang berakhir dengan %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Atau bayar dengan cara lain</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Dengan meneruskan langkah, anda bersetuju untuk mengizinkan pembayaran menurut <terms>terma ini</terms>]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-ms-rMY/strings.xml
+++ b/paymentsheet/res/values-ms-rMY/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Tambah kaedah pembayaran baharu</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Alih keluar akaun bank yang berakhir dengan %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Atau bayar dengan cara lain</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Dengan meneruskan langkah, anda bersetuju untuk mengizinkan pembayaran menurut <terms>terma ini</terms>]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Tambah</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Tambah maklumat pembayaran anda</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Pilih kaedah pembayaran</string>
   <string name="stripe_paymentsheet_close">Tutup</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe akan mendepositkan sebanyak $0.01 ke dalam akaun anda dalam masa 1–2 hari bekerja. Kemudian anda akan mendapat e-mel dengan arahan untuk menyelesaikan pembayaran kepada %s.</string>

--- a/paymentsheet/res/values-mt/strings.xml
+++ b/paymentsheet/res/values-mt/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Żid metodu tal-pagament ġdid</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Neħħi l-kont tal-bank li jispiċċa b\'%s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Jew ħallas mod ieħor</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Meta tkompli tkun qed taqbel li tawtorizza l-pagamenti skont <terms>dar-regoli</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-mt/strings.xml
+++ b/paymentsheet/res/values-mt/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Żid</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Żid l-informazzjoni dwar il-pagament tiegħek</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Agħżel metodu tal-ħlas</string>
   <string name="stripe_paymentsheet_close">Agħlaq</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-mt/strings.xml
+++ b/paymentsheet/res/values-mt/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Żid metodu tal-pagament ġdid</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Neħħi l-kont tal-bank li jispiċċa b\'%s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Jew ħallas mod ieħor</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Meta tkompli tkun qed taqbel li tawtorizza l-pagamenti skont <terms>dar-regoli</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Żid</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Żid l-informazzjoni dwar il-pagament tiegħek</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Agħżel metodu tal-ħlas</string>
   <string name="stripe_paymentsheet_close">Agħlaq</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe se tiddepożita $0.01 fil-kont tiegħek fi żmien jum/jumejn tax-xogħol. Imbagħad se tirċievi email bl-istruzzjonijiet biex tagħmel il-pagament lil %s.</string>

--- a/paymentsheet/res/values-nb/strings.xml
+++ b/paymentsheet/res/values-nb/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Legg til</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Legg til betalingsinformasjon</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Velg en betalingsmetode</string>
   <string name="stripe_paymentsheet_close">Lukk</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-nb/strings.xml
+++ b/paymentsheet/res/values-nb/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Legg til en ny betalingsmetode</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Fjern bankkontoen som slutter på %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Eller betal på en annen måte</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Ved å fortsette godtar du å autorisere betalinger i samsvar med <terms>disse vilkårene</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-nb/strings.xml
+++ b/paymentsheet/res/values-nb/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Legg til en ny betalingsmetode</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Fjern bankkontoen som slutter på %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Eller betal på en annen måte</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Ved å fortsette godtar du å autorisere betalinger i samsvar med <terms>disse vilkårene</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Legg til</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Legg til betalingsinformasjon</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Velg en betalingsmetode</string>
   <string name="stripe_paymentsheet_close">Lukk</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe vil sette inn et innskudd på USD 0,01 på kontoen din innen 1–2 virkedager. Deretter vil du få en e-post med instruksjoner for å fullføre betalingen til %s.</string>

--- a/paymentsheet/res/values-nl/strings.xml
+++ b/paymentsheet/res/values-nl/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Een nieuwe betaalmethode toevoegen</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Bankrekening verwijderen die eindigt op %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Of betaal op een andere manier</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Als je doorgaat, ga je ermee akkoord betalingen in overeenstemming met <terms>deze voorwaarden</terms> te autoriseren.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Toevoegen</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Je betaalgegevens toevoegen</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Een betaalmethode kiezen</string>
   <string name="stripe_paymentsheet_close">Sluiten</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Binnen 1-2 werkdagen stort Stripe $ 0,01 op je rekening. Daarna krijg je een e-mail met instructies over hoe je de betaling aan %s kunt voltooien.</string>

--- a/paymentsheet/res/values-nl/strings.xml
+++ b/paymentsheet/res/values-nl/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Een nieuwe betaalmethode toevoegen</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Bankrekening verwijderen die eindigt op %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Of betaal op een andere manier</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Als je doorgaat, ga je ermee akkoord betalingen in overeenstemming met <terms>deze voorwaarden</terms> te autoriseren.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-nl/strings.xml
+++ b/paymentsheet/res/values-nl/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Toevoegen</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Je betaalgegevens toevoegen</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Een betaalmethode kiezen</string>
   <string name="stripe_paymentsheet_close">Sluiten</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-nn-rNO/strings.xml
+++ b/paymentsheet/res/values-nn-rNO/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Legg til</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Legg til betalingsinformasjonen din</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Vel ein betalingsmåte</string>
   <string name="stripe_paymentsheet_close">Lukk</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-nn-rNO/strings.xml
+++ b/paymentsheet/res/values-nn-rNO/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Legg til ny betalingsmåte</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Fjern bankkonto som sluttar på %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Eller betal på en annen måte</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Ved å halde fram godtek du å autorisere betalingar i samsvar med desse <terms>vilkåra</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-nn-rNO/strings.xml
+++ b/paymentsheet/res/values-nn-rNO/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Legg til ny betalingsmåte</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Fjern bankkonto som sluttar på %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Eller betal på en annen måte</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Ved å halde fram godtek du å autorisere betalingar i samsvar med desse <terms>vilkåra</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Legg til</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Legg til betalingsinformasjonen din</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Vel ein betalingsmåte</string>
   <string name="stripe_paymentsheet_close">Lukk</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe sett inn 0,01 USD på kontoen din om 1–2 verkedagar. Så får du ei e-postmelding med instruksjonar om å fullføre betaling til %s.</string>

--- a/paymentsheet/res/values-pl-rPL/strings.xml
+++ b/paymentsheet/res/values-pl-rPL/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Dodaj nową metodę płatności</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Usuń konto bankowe kończące się na %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Lub zapłać w inny sposób</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Kontynuując, wyrażasz zgodę na autoryzowanie płatności zgodnie z <terms>tymi warunkami</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Dodaj</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Dodaj informacje o płatności</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Wybierz metodę płatności</string>
   <string name="stripe_paymentsheet_close">Zamknij</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe wpłaci 0,01 USD na Twoje konto w ciągu 1-2 dni roboczych. Następnie otrzymasz wiadomość e-mail z instrukcjami dotyczącymi zakończenia płatności na rzecz %s.</string>

--- a/paymentsheet/res/values-pl-rPL/strings.xml
+++ b/paymentsheet/res/values-pl-rPL/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Dodaj nową metodę płatności</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Usuń konto bankowe kończące się na %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Lub zapłać w inny sposób</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Kontynuując, wyrażasz zgodę na autoryzowanie płatności zgodnie z <terms>tymi warunkami</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-pl-rPL/strings.xml
+++ b/paymentsheet/res/values-pl-rPL/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Dodaj</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Dodaj informacje o płatności</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Wybierz metodę płatności</string>
   <string name="stripe_paymentsheet_close">Zamknij</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-pt-rBR/strings.xml
+++ b/paymentsheet/res/values-pt-rBR/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Adicionar</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Adicione seus dados de pagamento</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Escolha uma forma de pagamento</string>
   <string name="stripe_paymentsheet_close">Fechar</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-pt-rBR/strings.xml
+++ b/paymentsheet/res/values-pt-rBR/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Adicionar nova forma de pagamento</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Remover conta bancária com final %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Ou pague de outra forma</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Ao continuar, você aceita autorizar pagamentos de acordo com <terms>estes termos</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-pt-rBR/strings.xml
+++ b/paymentsheet/res/values-pt-rBR/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Adicionar nova forma de pagamento</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Remover conta bancária com final %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Ou pague de outra forma</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Ao continuar, você aceita autorizar pagamentos de acordo com <terms>estes termos</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Adicionar</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Adicione seus dados de pagamento</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Escolha uma forma de pagamento</string>
   <string name="stripe_paymentsheet_close">Fechar</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">A Stripe depositará $ 0,01 na sua conta em 1 a 2 dias úteis. Depois disso, você receberá um e-mail com instruções de como concluir o pagamento para %s.</string>

--- a/paymentsheet/res/values-pt-rPT/strings.xml
+++ b/paymentsheet/res/values-pt-rPT/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Adicionar</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Adicione as suas informações de pagamento</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Selecione um método de pagamento</string>
   <string name="stripe_paymentsheet_close">Fechar</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-pt-rPT/strings.xml
+++ b/paymentsheet/res/values-pt-rPT/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Adicionar um novo método de pagamento</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Remover conta bancária que termina em %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Ou use outro método de pagamento</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Ao continuar, concorda em autorizar pagamentos de acordo com <terms>estas condições</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-pt-rPT/strings.xml
+++ b/paymentsheet/res/values-pt-rPT/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Adicionar um novo método de pagamento</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Remover conta bancária que termina em %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Ou use outro método de pagamento</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Ao continuar, concorda em autorizar pagamentos de acordo com <terms>estas condições</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Adicionar</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Adicione as suas informações de pagamento</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Selecione um método de pagamento</string>
   <string name="stripe_paymentsheet_close">Fechar</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">A Stripe efetuará um depósito de 0,01 USD na sua conta dentro de 1 a 2 dias úteis. Receberá posteriormente um email com instruções para concluir o pagamento a %s.</string>

--- a/paymentsheet/res/values-ro-rRO/strings.xml
+++ b/paymentsheet/res/values-ro-rRO/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Adăugați o nouă metodă de plată</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Eliminați contul bancar care se termină cu %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Sau folosiți altă metodă de plată</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Continuând, sunteți de acord să autorizați plățile în conformitate cu <terms>acești termeni</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-ro-rRO/strings.xml
+++ b/paymentsheet/res/values-ro-rRO/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Adăugați o nouă metodă de plată</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Eliminați contul bancar care se termină cu %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Sau folosiți altă metodă de plată</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Continuând, sunteți de acord să autorizați plățile în conformitate cu <terms>acești termeni</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Adăugare</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Adăugați informațiile dvs. privind plata</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Alegeți o metodă de plată</string>
   <string name="stripe_paymentsheet_close">Închidere</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe va depune 0,01 USD în contul dvs. în decurs de 1-2 zile lucrătoare. Apoi veți primi un e-mail cu instrucțiuni pentru a finaliza plata către %s.</string>

--- a/paymentsheet/res/values-ro-rRO/strings.xml
+++ b/paymentsheet/res/values-ro-rRO/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Adăugare</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Adăugați informațiile dvs. privind plata</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Alegeți o metodă de plată</string>
   <string name="stripe_paymentsheet_close">Închidere</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-ru/strings.xml
+++ b/paymentsheet/res/values-ru/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Добавление нового метода оплаты</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Удалить банковский счет, оканчивающийся на %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Или оплатите другим способом</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Продолжая, вы соглашаетесь авторизовать платежи в соответствии с <terms>этими условиями</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-ru/strings.xml
+++ b/paymentsheet/res/values-ru/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Добавить</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Укажите платежные данные</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Выберите метод оплаты</string>
   <string name="stripe_paymentsheet_close">Закрыть</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-ru/strings.xml
+++ b/paymentsheet/res/values-ru/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Добавление нового метода оплаты</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Удалить банковский счет, оканчивающийся на %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Или оплатите другим способом</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Продолжая, вы соглашаетесь авторизовать платежи в соответствии с <terms>этими условиями</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Добавить</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Укажите платежные данные</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Выберите метод оплаты</string>
   <string name="stripe_paymentsheet_close">Закрыть</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Через 1-2 рабочих дня Stripe положит вам на счет сумму $0,01. После этого вы получите электронное письмо с инструкциями по завершению платежа в адрес %s.</string>

--- a/paymentsheet/res/values-sk-rSK/strings.xml
+++ b/paymentsheet/res/values-sk-rSK/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Pridajte nový spôsob platby</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Odstrániť bankový účet končiaci na %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Alebo zaplaťte iným spôsobom</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Pokračovaním súhlasíte s autorizáciou platieb podľa <terms>týchto podmienok</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-sk-rSK/strings.xml
+++ b/paymentsheet/res/values-sk-rSK/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Pridajte nový spôsob platby</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Odstrániť bankový účet končiaci na %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Alebo zaplaťte iným spôsobom</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Pokračovaním súhlasíte s autorizáciou platieb podľa <terms>týchto podmienok</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Pridať</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Pridajte svoje informácie o platbe</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Vyberte spôsob platby</string>
   <string name="stripe_paymentsheet_close">Zatvoriť</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">V priebehu 1 až 2 pracovných dní vloží Stripe na váš účet vklad vo výške 0,01 USD. Potom dostanete e-mail s pokynmi na dokončenie platby spoločnosti %s.</string>

--- a/paymentsheet/res/values-sk-rSK/strings.xml
+++ b/paymentsheet/res/values-sk-rSK/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Pridať</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Pridajte svoje informácie o platbe</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Vyberte spôsob platby</string>
   <string name="stripe_paymentsheet_close">Zatvoriť</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-sl-rSI/strings.xml
+++ b/paymentsheet/res/values-sl-rSI/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Dodaj nov način plačila</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Odstranite bančni račun, ki se konča s števkami %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Ali pa plačajte na drugačen način</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Če nadaljujete postopek, se strinjate z odobritvijo plačil v skladu s <terms>temi pogoji</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Dodaj</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Dodajte podatke o plačilu</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Izberite način plačila</string>
   <string name="stripe_paymentsheet_close">Zapri</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe bo v 1–2 delovnih dneh na vaš račun nakazal znesek v višini 0,01 USD. Nato boste prejeli e-poštno sporočilo z navodili za dokončanje plačila podjetju %s.</string>

--- a/paymentsheet/res/values-sl-rSI/strings.xml
+++ b/paymentsheet/res/values-sl-rSI/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Dodaj</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Dodajte podatke o plačilu</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Izberite način plačila</string>
   <string name="stripe_paymentsheet_close">Zapri</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-sl-rSI/strings.xml
+++ b/paymentsheet/res/values-sl-rSI/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Dodaj nov način plačila</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Odstranite bančni račun, ki se konča s števkami %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Ali pa plačajte na drugačen način</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Če nadaljujete postopek, se strinjate z odobritvijo plačil v skladu s <terms>temi pogoji</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-sv/strings.xml
+++ b/paymentsheet/res/values-sv/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Lägg till en ny betalningsmetod</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Ta bort bankkonto som slutar på %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Eller använd en annan betalningsmetod</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Genom att fortsätta samtycker du till att godkänna betalningar i enlighet med dessa <terms>villkor</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Lägg till</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Lägg till betalningsinformation</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Välj en betalmetod</string>
   <string name="stripe_paymentsheet_close">Stäng</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe sätter in 0,01 USD på ditt konto inom 1–2 arbetsdagar. Sedan får du ett e-postmeddelande med instruktioner för att slutföra betalningen till %s.</string>

--- a/paymentsheet/res/values-sv/strings.xml
+++ b/paymentsheet/res/values-sv/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Lägg till en ny betalningsmetod</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Ta bort bankkonto som slutar på %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Eller använd en annan betalningsmetod</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Genom att fortsätta samtycker du till att godkänna betalningar i enlighet med dessa <terms>villkor</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-sv/strings.xml
+++ b/paymentsheet/res/values-sv/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Lägg till</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Lägg till betalningsinformation</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Välj en betalmetod</string>
   <string name="stripe_paymentsheet_close">Stäng</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-th/strings.xml
+++ b/paymentsheet/res/values-th/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">เพิ่มวิธีการชำระเงินใหม่</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">ลบบัญชีธนาคารที่ลงท้ายด้วย %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">หรือชำระเงินด้วยวิธีอื่น</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[การดำเนินการต่อหมายความว่าคุณตกลงที่จะอนุมัติการชำระเงินซึ่งดำเนินการตาม<terms>ข้อกำหนดเหล่านี้</terms>]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ เพิ่ม</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">เพิ่มข้อมูลการชำระเงิน</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">เลือกวิธีการชำระเงิน</string>
   <string name="stripe_paymentsheet_close">ปิด</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe จะฝากเงินจำนวน $0.01 ในบัญชีของคุณภายใน 1-2 วันทำการ จากนั้นคุณก็จะได้รับอีเมลแจ้งวิธีชำระเงินแก่ %s ให้เสร็จสิ้น</string>

--- a/paymentsheet/res/values-th/strings.xml
+++ b/paymentsheet/res/values-th/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">เพิ่มวิธีการชำระเงินใหม่</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">ลบบัญชีธนาคารที่ลงท้ายด้วย %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">หรือชำระเงินด้วยวิธีอื่น</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[การดำเนินการต่อหมายความว่าคุณตกลงที่จะอนุมัติการชำระเงินซึ่งดำเนินการตาม<terms>ข้อกำหนดเหล่านี้</terms>]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-th/strings.xml
+++ b/paymentsheet/res/values-th/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ เพิ่ม</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">เพิ่มข้อมูลการชำระเงิน</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">เลือกวิธีการชำระเงิน</string>
   <string name="stripe_paymentsheet_close">ปิด</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-tr/strings.xml
+++ b/paymentsheet/res/values-tr/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Yeni ödeme yöntemi ekle</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">%s ile biten banka hesabını kaldır</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Ya da başka bir yöntemle ödeyin</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Devam ettiğinizde ödemeleri <terms>bu koşullara</terms> göre yetkilendirmeyi kabul etmiş olursunuz.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-tr/strings.xml
+++ b/paymentsheet/res/values-tr/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Ekle</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Ödeme bilgilerinizi ekleyin</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Yeni bir ödeme yöntemi seçin</string>
   <string name="stripe_paymentsheet_close">Kapat</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-tr/strings.xml
+++ b/paymentsheet/res/values-tr/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Yeni ödeme yöntemi ekle</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">%s ile biten banka hesabını kaldır</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Ya da başka bir yöntemle ödeyin</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Devam ettiğinizde ödemeleri <terms>bu koşullara</terms> göre yetkilendirmeyi kabul etmiş olursunuz.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Ekle</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Ödeme bilgilerinizi ekleyin</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Yeni bir ödeme yöntemi seçin</string>
   <string name="stripe_paymentsheet_close">Kapat</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe, 1-2 iş günü içinde hesabınıza 0,01 ABD doları yatıracaktır. Ardından, %s ödemesini tamamlama talimatlarını içeren bir e-posta alacaksınız.</string>

--- a/paymentsheet/res/values-vi/strings.xml
+++ b/paymentsheet/res/values-vi/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Thêm</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Thêm thông tin thanh toán của bạn</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Chọn phương thức thanh toán</string>
   <string name="stripe_paymentsheet_close">Đóng</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-vi/strings.xml
+++ b/paymentsheet/res/values-vi/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Thêm phương thức thanh toán mới</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Gỡ bỏ tài khoản ngân hàng có đuôi là %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Hoặc thanh toán theo cách khác</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Bằng việc tiếp tục, bạn đồng ý cho phép thanh toán tuân theo <terms>các điều khoản này</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Thêm</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Thêm thông tin thanh toán của bạn</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Chọn phương thức thanh toán</string>
   <string name="stripe_paymentsheet_close">Đóng</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe sẽ gửi $0.01 vào tài khoản của bạn trong 1-2 ngày làm việc. Khi đó bạn sẽ nhận được một email chứa hướng dẫn để hoàn tất thanh toán cho %s.</string>

--- a/paymentsheet/res/values-vi/strings.xml
+++ b/paymentsheet/res/values-vi/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Thêm phương thức thanh toán mới</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Gỡ bỏ tài khoản ngân hàng có đuôi là %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Hoặc thanh toán theo cách khác</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[Bằng việc tiếp tục, bạn đồng ý cho phép thanh toán tuân theo <terms>các điều khoản này</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-zh-rHK/strings.xml
+++ b/paymentsheet/res/values-zh-rHK/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">添加新支付方式</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">移除尾號為 %s 的銀行帳戶</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">或用另一方式支付</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[繼續操作即表示您同意按照<terms>這些條款</terms>授權付款。]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-zh-rHK/strings.xml
+++ b/paymentsheet/res/values-zh-rHK/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">添加新支付方式</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">移除尾號為 %s 的銀行帳戶</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">或用另一方式支付</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[繼續操作即表示您同意按照<terms>這些條款</terms>授權付款。]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ 添加</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">添加您的支付資訊</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">選擇一個支付方式</string>
   <string name="stripe_paymentsheet_close">關閉</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe 會在 1-2 個工作日向您的帳戶存入 0.01 美元。然後您會收到一封郵件，指導您完成向 %s 的付款。</string>

--- a/paymentsheet/res/values-zh-rHK/strings.xml
+++ b/paymentsheet/res/values-zh-rHK/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ 添加</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">添加您的支付資訊</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">選擇一個支付方式</string>
   <string name="stripe_paymentsheet_close">關閉</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-zh-rTW/strings.xml
+++ b/paymentsheet/res/values-zh-rTW/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">添加新支付方式</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">移除尾號為 %s 的銀行帳戶</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">或用另一方式支付</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[繼續操作即表示您同意按照<terms>這些條款</terms>授權付款。]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-zh-rTW/strings.xml
+++ b/paymentsheet/res/values-zh-rTW/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">添加新支付方式</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">移除尾號為 %s 的銀行帳戶</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">或用另一方式支付</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[繼續操作即表示您同意按照<terms>這些條款</terms>授權付款。]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ 添加</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">添加您的支付資訊</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">選擇一個支付方式</string>
   <string name="stripe_paymentsheet_close">關閉</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe 會在 1-2 個工作日向您的帳戶存入 0.01 美元。然後您會收到一封郵件，指導您完成向 %s 的付款。</string>

--- a/paymentsheet/res/values-zh-rTW/strings.xml
+++ b/paymentsheet/res/values-zh-rTW/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ 添加</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">添加您的支付資訊</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">選擇一個支付方式</string>
   <string name="stripe_paymentsheet_close">關閉</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-zh/strings.xml
+++ b/paymentsheet/res/values-zh/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ 添加</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">添加您的支付信息</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">选择一个支付方式</string>
   <string name="stripe_paymentsheet_close">关闭</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/res/values-zh/strings.xml
+++ b/paymentsheet/res/values-zh/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">添加新支付方式</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">移除尾号为 %s 的银行账户</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">或用另一方式支付</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[继续操作即表示您同意按照<terms>这些条款</terms>授权付款。]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values-zh/strings.xml
+++ b/paymentsheet/res/values-zh/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">添加新支付方式</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">移除尾号为 %s 的银行账户</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">或用另一方式支付</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[继续操作即表示您同意按照<terms>这些条款</terms>授权付款。]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ 添加</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">添加您的支付信息</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">选择一个支付方式</string>
   <string name="stripe_paymentsheet_close">关闭</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe 会在 1-2 个工作日向您的账户存入 0.01 美元。然后您会收到一封邮件，指导您完成向 %s 的付款。</string>

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -4,8 +4,6 @@
   <string name="add_new_payment_method">Add a new payment method</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Remove bank account ending in %s</string>
-  <!-- Label shown before showing other payment method alternatives. -->
-  <string name="or_pay_another_way">Or pay another way</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[By continuing, you agree to authorize payments pursuant to <terms>these terms</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -4,6 +4,8 @@
   <string name="add_new_payment_method">Add a new payment method</string>
   <!-- Description of a saved bank account. E.g. 'Bank account ending in 4242' -->
   <string name="bank_account_ending_in">Remove bank account ending in %s</string>
+  <!-- Label shown before showing other payment method alternatives. -->
+  <string name="or_pay_another_way">Or pay another way</string>
   <!-- Text providing link to terms for ACH payments -->
   <string name="stripe_paymentsheet_ach_continue_mandate"><![CDATA[By continuing, you agree to authorize payments pursuant to <terms>these terms</terms>.]]></string>
   <!-- Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). -->
@@ -12,6 +14,8 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Add</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Add your payment information</string>
+  <!-- TODO -->
+  <string name="stripe_paymentsheet_choose_payment_method">Choose a payment method</string>
   <string name="stripe_paymentsheet_close">Close</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->
   <string name="stripe_paymentsheet_microdeposit">Stripe will deposit $0.01 to your account in 1-2 business days. Then you’ll get an email with instructions to complete payment to %s.</string>

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -12,7 +12,7 @@
   <string name="stripe_paymentsheet_add_payment_method_button_label">+ Add</string>
   <!-- Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. -->
   <string name="stripe_paymentsheet_add_payment_method_title">Add your payment information</string>
-  <!-- TODO -->
+  <!-- Title shown above a carousel containing available payment methods -->
   <string name="stripe_paymentsheet_choose_payment_method">Choose a payment method</string>
   <string name="stripe_paymentsheet_close">Close</string>
   <!-- Prompt for microdeposit verification before completing purchase with merchant. %@ will be replaced by merchant business name -->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
@@ -243,9 +243,6 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        sheetViewModel.updateHeaderText(
-            getString(R.string.stripe_paymentsheet_add_payment_method_title)
-        )
 
         sheetViewModel.eventReporter.onShowNewPaymentOptionForm(
             linkEnabled = sheetViewModel.isLinkEnabled.value ?: false,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsListFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsListFragment.kt
@@ -15,14 +15,6 @@ internal class PaymentOptionsListFragment : BasePaymentMethodsListFragment(
 
     override val sheetViewModel: PaymentOptionsViewModel by lazy { activityViewModel }
 
-    override fun onResume() {
-        super.onResume()
-
-        sheetViewModel.updateHeaderText(
-            getString(R.string.stripe_paymentsheet_select_payment_method)
-        )
-    }
-
     override fun onPaymentOptionsItemSelected(item: PaymentOptionsItem) {
         super.onPaymentOptionsItemSelected(item)
         sheetViewModel.onUserSelection()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -34,6 +34,7 @@ import com.stripe.android.paymentsheet.paymentdatacollection.ach.ACHText
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.state.GooglePayState
 import com.stripe.android.paymentsheet.state.LinkState
+import com.stripe.android.paymentsheet.ui.HeaderTextFactory
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.ui.core.address.AddressRepository
@@ -74,7 +75,8 @@ internal class PaymentOptionsViewModel @Inject constructor(
     lpmResourceRepository = lpmResourceRepository,
     addressResourceRepository = addressResourceRepository,
     savedStateHandle = savedStateHandle,
-    linkLauncher = linkLauncher
+    linkLauncher = linkLauncher,
+    headerTextFactory = HeaderTextFactory(isCompleteFlow = false),
 ) {
     @VisibleForTesting
     internal val _paymentOptionResult = MutableLiveData<PaymentOptionResult>()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetAddPaymentMethodFragment.kt
@@ -1,30 +1,14 @@
 package com.stripe.android.paymentsheet
 
-import android.os.Bundle
-import android.view.View
 import androidx.fragment.app.activityViewModels
 import kotlinx.coroutines.FlowPreview
 
 @OptIn(FlowPreview::class)
-internal class PaymentSheetAddPaymentMethodFragment() : BaseAddPaymentMethodFragment() {
+internal class PaymentSheetAddPaymentMethodFragment : BaseAddPaymentMethodFragment() {
 
     override val sheetViewModel by activityViewModels<PaymentSheetViewModel> {
         PaymentSheetViewModel.Factory {
             requireNotNull(requireArguments().getParcelable(PaymentSheetActivity.EXTRA_STARTER_ARGS))
-        }
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
-        sheetViewModel.showTopContainer.observe(viewLifecycleOwner) { visible ->
-            sheetViewModel.updateHeaderText(
-                if (visible) {
-                    null
-                } else {
-                    getString(R.string.stripe_paymentsheet_add_payment_method_title)
-                }
-            )
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetListFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetListFragment.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet
 
 import androidx.fragment.app.activityViewModels
-import com.stripe.android.paymentsheet.state.GooglePayState
 
 internal class PaymentSheetListFragment : BasePaymentMethodsListFragment(
     canClickSelectedItem = false
@@ -15,21 +14,4 @@ internal class PaymentSheetListFragment : BasePaymentMethodsListFragment(
     }
 
     override val sheetViewModel: PaymentSheetViewModel by lazy { activityViewModel }
-
-    override fun onResume() {
-        super.onResume()
-
-        sheetViewModel.updateHeaderText(
-            getString(
-                if (
-                    sheetViewModel.isLinkEnabled.value == true ||
-                    sheetViewModel.googlePayState.value == GooglePayState.Available
-                ) {
-                    R.string.stripe_paymentsheet_pay_using
-                } else {
-                    R.string.stripe_paymentsheet_select_payment_method
-                }
-            )
-        )
-    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -65,6 +65,7 @@ import com.stripe.android.paymentsheet.state.GooglePayState
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentSheetLoader
 import com.stripe.android.paymentsheet.state.PaymentSheetState
+import com.stripe.android.paymentsheet.ui.HeaderTextFactory
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.ui.core.address.AddressRepository
 import com.stripe.android.ui.core.forms.resources.LpmRepository
@@ -113,7 +114,8 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     lpmResourceRepository = lpmResourceRepository,
     addressResourceRepository = addressResourceRepository,
     savedStateHandle = savedStateHandle,
-    linkLauncher = linkLauncher
+    linkLauncher = linkLauncher,
+    headerTextFactory = HeaderTextFactory(isCompleteFlow = true),
 ) {
     private val confirmParamsFactory = ConfirmStripeIntentParamsFactory.createFactory(
         args.clientSecret,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.core.view.isGone
@@ -235,7 +236,7 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
                 text.value?.let {
                     PaymentsTheme {
                         H4Text(
-                            text = it,
+                            text = stringResource(it),
                             modifier = Modifier.padding(bottom = 2.dp)
                         )
                     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/HeaderTextFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/HeaderTextFactory.kt
@@ -5,10 +5,11 @@ import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 
-internal object HeaderTextFactory {
+internal class HeaderTextFactory(
+    private val isCompleteFlow: Boolean,
+) {
 
     fun create(
-        isCompleteFlow: Boolean,
         screen: PaymentSheetScreen,
         isWalletEnabled: Boolean,
         isPaymentIntent: Boolean,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/HeaderTextFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/HeaderTextFactory.kt
@@ -1,0 +1,51 @@
+package com.stripe.android.paymentsheet.ui
+
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
+
+internal object HeaderTextFactory {
+
+    fun create(
+        isCompleteFlow: Boolean,
+        screen: PaymentSheetScreen,
+        isWalletEnabled: Boolean,
+        isPaymentIntent: Boolean,
+        types: List<PaymentMethodCode>,
+    ): Int? {
+        return if (isCompleteFlow) {
+            when (screen) {
+                PaymentSheetScreen.SelectSavedPaymentMethods -> {
+                    if (isWalletEnabled && isPaymentIntent) {
+                        R.string.stripe_paymentsheet_pay_using
+                    } else {
+                        R.string.stripe_paymentsheet_select_payment_method
+                    }
+                }
+                PaymentSheetScreen.AddFirstPaymentMethod -> {
+                    R.string.stripe_paymentsheet_add_payment_method_title.takeUnless {
+                        isWalletEnabled
+                    }
+                }
+                PaymentSheetScreen.AddAnotherPaymentMethod -> {
+                    null
+                }
+            }
+        } else {
+            when (screen) {
+                PaymentSheetScreen.SelectSavedPaymentMethods -> {
+                    R.string.stripe_paymentsheet_select_payment_method
+                }
+                PaymentSheetScreen.AddFirstPaymentMethod,
+                PaymentSheetScreen.AddAnotherPaymentMethod -> {
+                    if (types.singleOrNull() == PaymentMethod.Type.Card.code) {
+                        R.string.title_add_a_card
+                    } else {
+                        R.string.stripe_paymentsheet_choose_payment_method
+                    }
+                }
+            }
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -33,7 +33,6 @@ import com.stripe.android.paymentsheet.PaymentOptionsState
 import com.stripe.android.paymentsheet.PaymentOptionsViewModel
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetActivity
-import com.stripe.android.paymentsheet.PaymentSheetViewModel
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.addresselement.toIdentifierMap
@@ -88,7 +87,8 @@ internal abstract class BaseSheetViewModel(
     val lpmResourceRepository: ResourceRepository<LpmRepository>,
     val addressResourceRepository: ResourceRepository<AddressRepository>,
     val savedStateHandle: SavedStateHandle,
-    val linkLauncher: LinkPaymentLauncher
+    val linkLauncher: LinkPaymentLauncher,
+    private val headerTextFactory: HeaderTextFactory,
 ) : AndroidViewModel(application) {
     /**
      * This ViewModel exists during the whole user flow, and needs to share the Dagger dependencies
@@ -494,8 +494,7 @@ internal abstract class BaseSheetViewModel(
         stripeIntent: StripeIntent,
     ): Int? {
         return if (screen != null) {
-            HeaderTextFactory.create(
-                isCompleteFlow = this is PaymentSheetViewModel,
+            headerTextFactory.create(
                 screen = screen,
                 isWalletEnabled = isLinkAvailable || googlePayState is GooglePayState.Available,
                 isPaymentIntent = stripeIntent is PaymentIntent,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -974,17 +974,6 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
-    fun `updateHeaderText updates headerText`() = runTest {
-        val viewModel = createViewModel()
-
-        viewModel.headerText.test {
-            assertThat(awaitItem()).isNull()
-            viewModel.updateHeaderText("something")
-            assertThat(awaitItem()).isEqualTo("something")
-        }
-    }
-
-    @Test
     fun `Produces the correct form arguments when payment intent is off-session`() {
         val viewModel = createViewModel(
             stripeIntent = PaymentIntentFixtures.PI_OFF_SESSION,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/HeaderTextFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/HeaderTextFactoryTest.kt
@@ -1,0 +1,113 @@
+package com.stripe.android.paymentsheet.ui
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
+import org.junit.Test
+
+class HeaderTextFactoryTest {
+
+    @Test
+    fun `Shows the correct header in complete flow if in payment mode and showing wallets`() {
+        val resource = HeaderTextFactory.create(
+            isCompleteFlow = true,
+            screen = PaymentSheetScreen.SelectSavedPaymentMethods,
+            isWalletEnabled = true,
+            isPaymentIntent = true,
+            types = emptyList(),
+        )
+
+        assertThat(resource).isEqualTo(R.string.stripe_paymentsheet_pay_using)
+    }
+
+    @Test
+    fun `Shows the correct header in complete flow if not in payment mode`() {
+        val resource = HeaderTextFactory.create(
+            isCompleteFlow = true,
+            screen = PaymentSheetScreen.SelectSavedPaymentMethods,
+            isWalletEnabled = true,
+            isPaymentIntent = false,
+            types = emptyList(),
+        )
+
+        assertThat(resource).isEqualTo(R.string.stripe_paymentsheet_select_payment_method)
+    }
+
+    @Test
+    fun `Does not show a header on AddAnotherPaymentMethod screen`() {
+        val resource = HeaderTextFactory.create(
+            isCompleteFlow = true,
+            screen = PaymentSheetScreen.AddAnotherPaymentMethod,
+            isWalletEnabled = true,
+            isPaymentIntent = false,
+            types = emptyList(),
+        )
+
+        assertThat(resource).isNull()
+    }
+
+    @Test
+    fun `Shows the correct header if adding the first payment method in complete flow`() {
+        val resource = HeaderTextFactory.create(
+            isCompleteFlow = true,
+            screen = PaymentSheetScreen.AddFirstPaymentMethod,
+            isWalletEnabled = false,
+            isPaymentIntent = false,
+            types = emptyList(),
+        )
+
+        assertThat(resource).isEqualTo(R.string.stripe_paymentsheet_add_payment_method_title)
+    }
+
+    @Test
+    fun `Does not show a header if adding the first payment method and wallets are available`() {
+        val resource = HeaderTextFactory.create(
+            isCompleteFlow = true,
+            screen = PaymentSheetScreen.AddFirstPaymentMethod,
+            isWalletEnabled = true,
+            isPaymentIntent = false,
+            types = emptyList(),
+        )
+
+        assertThat(resource).isNull()
+    }
+
+    @Test
+    fun `Shows the correct header when displaying saved payment methods in custom flow`() {
+        val resource = HeaderTextFactory.create(
+            isCompleteFlow = false,
+            screen = PaymentSheetScreen.SelectSavedPaymentMethods,
+            isWalletEnabled = true,
+            isPaymentIntent = false,
+            types = emptyList(),
+        )
+
+        assertThat(resource).isEqualTo(R.string.stripe_paymentsheet_select_payment_method)
+    }
+
+    @Test
+    fun `Shows the correct header when only credit card form is shown in custom flow`() {
+        val resource = HeaderTextFactory.create(
+            isCompleteFlow = false,
+            screen = PaymentSheetScreen.AddFirstPaymentMethod,
+            isWalletEnabled = false,
+            isPaymentIntent = false,
+            types = listOf("card"),
+        )
+
+        assertThat(resource).isEqualTo(R.string.title_add_a_card)
+    }
+
+    @Test
+    fun `Shows the correct header when multiple LPMs are shown in custom flow`() {
+        val resource = HeaderTextFactory.create(
+            isCompleteFlow = false,
+            screen = PaymentSheetScreen.AddFirstPaymentMethod,
+            isWalletEnabled = false,
+            isPaymentIntent = false,
+            types = listOf("card", "not_card"),
+        )
+
+        assertThat(resource).isEqualTo(R.string.stripe_paymentsheet_choose_payment_method)
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/HeaderTextFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/HeaderTextFactoryTest.kt
@@ -9,8 +9,7 @@ class HeaderTextFactoryTest {
 
     @Test
     fun `Shows the correct header in complete flow if in payment mode and showing wallets`() {
-        val resource = HeaderTextFactory.create(
-            isCompleteFlow = true,
+        val resource = HeaderTextFactory(isCompleteFlow = true).create(
             screen = PaymentSheetScreen.SelectSavedPaymentMethods,
             isWalletEnabled = true,
             isPaymentIntent = true,
@@ -22,8 +21,7 @@ class HeaderTextFactoryTest {
 
     @Test
     fun `Shows the correct header in complete flow if not in payment mode`() {
-        val resource = HeaderTextFactory.create(
-            isCompleteFlow = true,
+        val resource = HeaderTextFactory(isCompleteFlow = true).create(
             screen = PaymentSheetScreen.SelectSavedPaymentMethods,
             isWalletEnabled = true,
             isPaymentIntent = false,
@@ -35,8 +33,7 @@ class HeaderTextFactoryTest {
 
     @Test
     fun `Does not show a header on AddAnotherPaymentMethod screen`() {
-        val resource = HeaderTextFactory.create(
-            isCompleteFlow = true,
+        val resource = HeaderTextFactory(isCompleteFlow = true).create(
             screen = PaymentSheetScreen.AddAnotherPaymentMethod,
             isWalletEnabled = true,
             isPaymentIntent = false,
@@ -48,8 +45,7 @@ class HeaderTextFactoryTest {
 
     @Test
     fun `Shows the correct header if adding the first payment method in complete flow`() {
-        val resource = HeaderTextFactory.create(
-            isCompleteFlow = true,
+        val resource = HeaderTextFactory(isCompleteFlow = true).create(
             screen = PaymentSheetScreen.AddFirstPaymentMethod,
             isWalletEnabled = false,
             isPaymentIntent = false,
@@ -61,8 +57,7 @@ class HeaderTextFactoryTest {
 
     @Test
     fun `Does not show a header if adding the first payment method and wallets are available`() {
-        val resource = HeaderTextFactory.create(
-            isCompleteFlow = true,
+        val resource = HeaderTextFactory(isCompleteFlow = true).create(
             screen = PaymentSheetScreen.AddFirstPaymentMethod,
             isWalletEnabled = true,
             isPaymentIntent = false,
@@ -74,8 +69,7 @@ class HeaderTextFactoryTest {
 
     @Test
     fun `Shows the correct header when displaying saved payment methods in custom flow`() {
-        val resource = HeaderTextFactory.create(
-            isCompleteFlow = false,
+        val resource = HeaderTextFactory(isCompleteFlow = false).create(
             screen = PaymentSheetScreen.SelectSavedPaymentMethods,
             isWalletEnabled = true,
             isPaymentIntent = false,
@@ -87,8 +81,7 @@ class HeaderTextFactoryTest {
 
     @Test
     fun `Shows the correct header when only credit card form is shown in custom flow`() {
-        val resource = HeaderTextFactory.create(
-            isCompleteFlow = false,
+        val resource = HeaderTextFactory(isCompleteFlow = false).create(
             screen = PaymentSheetScreen.AddFirstPaymentMethod,
             isWalletEnabled = false,
             isPaymentIntent = false,
@@ -100,8 +93,7 @@ class HeaderTextFactoryTest {
 
     @Test
     fun `Shows the correct header when multiple LPMs are shown in custom flow`() {
-        val resource = HeaderTextFactory.create(
-            isCompleteFlow = false,
+        val resource = HeaderTextFactory(isCompleteFlow = false).create(
             screen = PaymentSheetScreen.AddFirstPaymentMethod,
             isWalletEnabled = false,
             isPaymentIntent = false,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request streamlines our header text selection, which was previously split across many different places. Instead of updating `viewModel.headerText` from various `onViewCreated()` and `onResume()` methods, we now automatically emit the correct header whenever `viewModel.currentScreen` changes.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Simpler code and easier migration to Compose.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
N/A

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A
