### PR TITLE
Rename `TransitionTarget` to `PaymentSheetScreen`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -18,7 +18,7 @@ import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.MaterialToolbar
 import com.stripe.android.paymentsheet.databinding.ActivityPaymentOptionsBinding
 import com.stripe.android.paymentsheet.navigation.PaymentOptionsContent
-import com.stripe.android.paymentsheet.navigation.TransitionTarget
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.utils.launchAndCollectIn
@@ -98,8 +98,8 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
         }
 
         viewModel.currentScreen.launchAndCollectIn(this) { currentScreen ->
-            val visible = currentScreen is TransitionTarget.AddFirstPaymentMethod ||
-                currentScreen is TransitionTarget.AddAnotherPaymentMethod ||
+            val visible = currentScreen is PaymentSheetScreen.AddFirstPaymentMethod ||
+                currentScreen is PaymentSheetScreen.AddAnotherPaymentMethod ||
                 viewModel.primaryButtonUIState.value?.visible == true
 
             viewBinding.continueButton.isVisible = visible

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -27,9 +27,9 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.injection.DaggerPaymentOptionsViewModelFactoryComponent
 import com.stripe.android.paymentsheet.injection.PaymentOptionsViewModelSubcomponent
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.navigation.TransitionTarget
-import com.stripe.android.paymentsheet.navigation.TransitionTarget.AddFirstPaymentMethod
-import com.stripe.android.paymentsheet.navigation.TransitionTarget.SelectSavedPaymentMethods
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddFirstPaymentMethod
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.SelectSavedPaymentMethods
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.ACHText
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.state.GooglePayState
@@ -301,7 +301,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
                 // The user has previously selected a new payment method. Instead of sending them
                 // to the payment methods screen, we directly launch them into the payment method
                 // form again.
-                add(TransitionTarget.AddAnotherPaymentMethod)
+                add(PaymentSheetScreen.AddAnotherPaymentMethod)
             }
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -57,7 +57,7 @@ import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
 import com.stripe.android.paymentsheet.model.StripeIntentValidator
-import com.stripe.android.paymentsheet.navigation.TransitionTarget
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.ACHText
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.StripeIntentRepository
@@ -612,9 +612,9 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     override fun transitionToFirstScreen() {
         val target = if (paymentMethods.value.isNullOrEmpty()) {
             updateSelection(null)
-            TransitionTarget.AddFirstPaymentMethod
+            PaymentSheetScreen.AddFirstPaymentMethod
         } else {
-            TransitionTarget.SelectSavedPaymentMethods
+            PaymentSheetScreen.SelectSavedPaymentMethods
         }
         transitionTo(target)
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
@@ -10,7 +10,7 @@ import com.stripe.android.paymentsheet.databinding.FragmentPaymentSheetAddPmBind
 import com.stripe.android.paymentsheet.databinding.FragmentPaymentSheetListBinding
 import com.stripe.android.paymentsheet.databinding.FragmentPaymentsheetLoadingBinding
 
-internal sealed interface TransitionTarget {
+internal sealed interface PaymentSheetScreen {
 
     @Composable
     fun PaymentSheetContent()
@@ -18,7 +18,7 @@ internal sealed interface TransitionTarget {
     @Composable
     fun PaymentOptionsContent()
 
-    object SelectSavedPaymentMethods : TransitionTarget {
+    object SelectSavedPaymentMethods : PaymentSheetScreen {
 
         @Composable
         override fun PaymentSheetContent() {
@@ -37,7 +37,7 @@ internal sealed interface TransitionTarget {
         }
     }
 
-    object AddAnotherPaymentMethod : TransitionTarget {
+    object AddAnotherPaymentMethod : PaymentSheetScreen {
 
         @Composable
         override fun PaymentSheetContent() {
@@ -56,7 +56,7 @@ internal sealed interface TransitionTarget {
         }
     }
 
-    object AddFirstPaymentMethod : TransitionTarget {
+    object AddFirstPaymentMethod : PaymentSheetScreen {
 
         @Composable
         override fun PaymentSheetContent() {
@@ -77,7 +77,7 @@ internal sealed interface TransitionTarget {
 }
 
 @Composable
-internal fun TransitionTarget?.PaymentSheetContent() {
+internal fun PaymentSheetScreen?.PaymentSheetContent() {
     if (this == null) {
         AndroidViewBinding(FragmentPaymentsheetLoadingBinding::inflate)
     } else {
@@ -86,7 +86,7 @@ internal fun TransitionTarget?.PaymentSheetContent() {
 }
 
 @Composable
-internal fun TransitionTarget?.PaymentOptionsContent() {
+internal fun PaymentSheetScreen?.PaymentOptionsContent() {
     if (this == null) {
         AndroidViewBinding(FragmentPaymentsheetLoadingBinding::inflate)
     } else {
@@ -94,5 +94,5 @@ internal fun TransitionTarget?.PaymentOptionsContent() {
     }
 }
 
-private val TransitionTarget.testTag: String
+private val PaymentSheetScreen.testTag: String
     get() = this::class.java.simpleName

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -36,7 +36,7 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.stripe.android.link.ui.verification.LinkVerificationDialog
 import com.stripe.android.paymentsheet.BottomSheetController
 import com.stripe.android.paymentsheet.R
-import com.stripe.android.paymentsheet.navigation.TransitionTarget
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
 import com.stripe.android.paymentsheet.utils.launchAndCollectIn
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
@@ -301,8 +301,8 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
         }
     }
 
-    private fun updateToolbarButton(currentScreen: TransitionTarget?) {
-        val showClose = currentScreen != TransitionTarget.AddAnotherPaymentMethod
+    private fun updateToolbarButton(currentScreen: PaymentSheetScreen?) {
+        val showClose = currentScreen != PaymentSheetScreen.AddAnotherPaymentMethod
 
         val toolbarResources = if (showClose) {
             ToolbarResources(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -40,7 +40,7 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.getPMsToAdd
-import com.stripe.android.paymentsheet.navigation.TransitionTarget
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.state.GooglePayState
 import com.stripe.android.paymentsheet.toPaymentSelection
@@ -151,9 +151,9 @@ internal abstract class BaseSheetViewModel(
         savedStateHandle.getLiveData<SavedSelection>(SAVE_SAVED_SELECTION)
     private val savedSelection: LiveData<SavedSelection> = _savedSelection
 
-    protected val backStack = MutableStateFlow<List<TransitionTarget>>(emptyList())
+    protected val backStack = MutableStateFlow<List<PaymentSheetScreen>>(emptyList())
 
-    val currentScreen: StateFlow<TransitionTarget?> = backStack
+    val currentScreen: StateFlow<PaymentSheetScreen?> = backStack
         .map { it.lastOrNull() }
         .stateIn(
             scope = viewModelScope,
@@ -334,13 +334,13 @@ internal abstract class BaseSheetViewModel(
 
     abstract fun transitionToFirstScreen()
 
-    protected fun transitionTo(target: TransitionTarget) {
+    protected fun transitionTo(target: PaymentSheetScreen) {
         clearErrorMessages()
         backStack.update { it + target }
     }
 
     fun transitionToAddPaymentScreen() {
-        transitionTo(TransitionTarget.AddAnotherPaymentMethod)
+        transitionTo(PaymentSheetScreen.AddAnotherPaymentMethod)
     }
 
     protected fun setStripeIntent(stripeIntent: StripeIntent?) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -35,7 +35,7 @@ import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.forms.PaymentMethodRequirements
 import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.navigation.TransitionTarget
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.LinkState.LoginState.LoggedIn
@@ -267,7 +267,7 @@ internal class PaymentOptionsActivityTest {
         viewModel.currentScreen.test {
             assertThat(awaitItem()).isNull()
             activityScenario(viewModel).launch(createIntent(args))
-            assertThat(awaitItem()).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.SelectSavedPaymentMethods)
         }
     }
 
@@ -284,7 +284,7 @@ internal class PaymentOptionsActivityTest {
         viewModel.currentScreen.test {
             assertThat(awaitItem()).isNull()
             activityScenario(viewModel).launch(createIntent(args))
-            assertThat(awaitItem()).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.SelectSavedPaymentMethods)
         }
     }
 
@@ -300,7 +300,7 @@ internal class PaymentOptionsActivityTest {
         viewModel.currentScreen.test {
             assertThat(awaitItem()).isNull()
             activityScenario(viewModel).launch(createIntent(args))
-            assertThat(awaitItem()).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.SelectSavedPaymentMethods)
         }
     }
 
@@ -316,7 +316,7 @@ internal class PaymentOptionsActivityTest {
         viewModel.currentScreen.test {
             assertThat(awaitItem()).isNull()
             activityScenario(viewModel).launch(createIntent(args))
-            assertThat(awaitItem()).isEqualTo(TransitionTarget.AddFirstPaymentMethod)
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.AddFirstPaymentMethod)
         }
     }
 
@@ -333,7 +333,7 @@ internal class PaymentOptionsActivityTest {
             assertThat(awaitItem()).isNull()
 
             scenario.launch(createIntent(args))
-            assertThat(awaitItem()).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.SelectSavedPaymentMethods)
 
             scenario.recreate()
             expectNoEvents()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -19,7 +19,7 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
-import com.stripe.android.paymentsheet.navigation.TransitionTarget
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.paymentsheet.ui.PrimaryButton
@@ -125,7 +125,7 @@ internal class PaymentOptionsViewModelTest {
         viewModel.currentScreen.test {
             assertThat(awaitItem()).isNull()
             viewModel.transitionToFirstScreen()
-            assertThat(awaitItem()).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.SelectSavedPaymentMethods)
         }
     }
 
@@ -143,10 +143,10 @@ internal class PaymentOptionsViewModelTest {
         viewModel.currentScreen.test {
             assertThat(awaitItem()).isNull()
             viewModel.transitionToFirstScreen()
-            assertThat(awaitItem()).isEqualTo(TransitionTarget.AddAnotherPaymentMethod)
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.AddAnotherPaymentMethod)
 
             viewModel.handleBackPressed()
-            assertThat(awaitItem()).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.SelectSavedPaymentMethods)
         }
     }
 
@@ -304,7 +304,7 @@ internal class PaymentOptionsViewModelTest {
         viewModel.currentScreen.test {
             assertThat(awaitItem()).isNull()
             viewModel.transitionToFirstScreen()
-            assertThat(awaitItem()).isEqualTo(TransitionTarget.AddFirstPaymentMethod)
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.AddFirstPaymentMethod)
         }
     }
 
@@ -321,7 +321,7 @@ internal class PaymentOptionsViewModelTest {
         viewModel.currentScreen.test {
             assertThat(awaitItem()).isNull()
             viewModel.transitionToFirstScreen()
-            assertThat(awaitItem()).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.SelectSavedPaymentMethods)
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -49,7 +49,7 @@ import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
 import com.stripe.android.paymentsheet.model.StripeIntentValidator
-import com.stripe.android.paymentsheet.navigation.TransitionTarget
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
 import com.stripe.android.paymentsheet.repositories.StripeIntentRepository
 import com.stripe.android.paymentsheet.state.LinkState
@@ -439,15 +439,15 @@ internal class PaymentSheetActivityTest {
             assertThat(awaitItem()).isNull()
 
             scenario.launch(intent)
-            assertThat(awaitItem()).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.SelectSavedPaymentMethods)
 
             viewModel.transitionToAddPaymentScreen()
-            assertThat(awaitItem()).isEqualTo(TransitionTarget.AddAnotherPaymentMethod)
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.AddAnotherPaymentMethod)
 
             pressBack()
             scenario.launch(intent)
 
-            assertThat(awaitItem()).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.SelectSavedPaymentMethods)
         }
     }
 
@@ -753,7 +753,7 @@ internal class PaymentSheetActivityTest {
         viewModel.currentScreen.test {
             assertThat(awaitItem()).isNull()
             scenario.launchForResult(intent)
-            assertThat(awaitItem()).isEqualTo(TransitionTarget.AddFirstPaymentMethod)
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.AddFirstPaymentMethod)
         }
     }
 
@@ -1157,7 +1157,7 @@ internal class PaymentSheetActivityTest {
         viewModel.currentScreen.test {
             assertThat(awaitItem()).isNull()
             activityScenario(viewModel).launch(intent)
-            assertThat(awaitItem()).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.SelectSavedPaymentMethods)
         }
     }
 
@@ -1168,7 +1168,7 @@ internal class PaymentSheetActivityTest {
         viewModel.currentScreen.test {
             assertThat(awaitItem()).isNull()
             activityScenario(viewModel).launch(intent)
-            assertThat(awaitItem()).isEqualTo(TransitionTarget.AddFirstPaymentMethod)
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.AddFirstPaymentMethod)
         }
     }
 
@@ -1181,7 +1181,7 @@ internal class PaymentSheetActivityTest {
             assertThat(awaitItem()).isNull()
 
             scenario.launch(intent)
-            assertThat(awaitItem()).isEqualTo(TransitionTarget.AddFirstPaymentMethod)
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.AddFirstPaymentMethod)
 
             scenario.recreate()
             expectNoEvents()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
@@ -23,7 +23,7 @@ import com.stripe.android.paymentsheet.PaymentSheetAddPaymentMethodFragmentTest.
 import com.stripe.android.paymentsheet.PaymentSheetAddPaymentMethodFragmentTest.Companion.lpmRepository
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
-import com.stripe.android.paymentsheet.navigation.TransitionTarget
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.state.GooglePayState
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.Companion.SAVE_GOOGLE_PAY_STATE
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.Companion.SAVE_PAYMENT_METHODS
@@ -197,7 +197,7 @@ internal class PaymentSheetListFragmentTest : PaymentSheetViewModelTestInjection
             val adapter = recyclerView.adapter as PaymentOptionsAdapter
             adapter.addCardClickListener()
 
-            assertThat(awaitItem()).isEqualTo(TransitionTarget.AddAnotherPaymentMethod)
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.AddAnotherPaymentMethod)
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -36,7 +36,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.StripeIntentValidator
-import com.stripe.android.paymentsheet.navigation.TransitionTarget
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.ACHText
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.StripeIntentRepository
@@ -727,7 +727,7 @@ internal class PaymentSheetViewModelTest {
             assertThat(awaitItem()).isNull()
 
             viewModel.savedStateHandle[SAVE_GOOGLE_PAY_STATE] = GooglePayState.Available
-            assertThat(awaitItem()).isEqualTo(TransitionTarget.AddFirstPaymentMethod)
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.AddFirstPaymentMethod)
         }
     }
 
@@ -955,7 +955,7 @@ internal class PaymentSheetViewModelTest {
         viewModel.currentScreen.test {
             assertThat(awaitItem()).isNull()
             viewModel.transitionToFirstScreen()
-            assertThat(awaitItem()).isEqualTo(TransitionTarget.AddFirstPaymentMethod)
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.AddFirstPaymentMethod)
         }
     }
 
@@ -968,7 +968,7 @@ internal class PaymentSheetViewModelTest {
         viewModel.currentScreen.test {
             assertThat(awaitItem()).isNull()
             viewModel.transitionToFirstScreen()
-            assertThat(awaitItem()).isEqualTo(TransitionTarget.SelectSavedPaymentMethods)
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.SelectSavedPaymentMethods)
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request renames `TransitionTarget` to `PaymentSheetScreen`, following the refactor from an event-based approach to a state-based approach. As a result, “transition target” doesn’t make a whole lot of sense anymore.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
