### PR TITLE
Rename `FormFragmentArguments` to `FormArguments`

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
@@ -28,7 +28,7 @@ internal class CardDetailsElement(
         controller
 
     override fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>) {
-        // Nothing from formFragmentArguments to populate
+        // Nothing from FormArguments to populate
     }
 
     override fun getTextFieldIdentifiers(): Flow<List<IdentifierSpec>> =

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberElement.kt
@@ -5,6 +5,6 @@ internal data class CardNumberElement(
     override val controller: CardNumberController
 ) : SectionSingleFieldElement(_identifier) {
     override fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>) {
-        // Nothing from formFragmentArguments to populate
+        // Nothing from FormArguments to populate
     }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcElement.kt
@@ -8,6 +8,6 @@ data class CvcElement(
     override val controller: CvcController
 ) : SectionSingleFieldElement(_identifier) {
     override fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>) {
-        // Nothing from formFragmentArguments to populate
+        // Nothing from FormArguments to populate
     }
 }

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -1248,11 +1248,11 @@ public final class com/stripe/android/paymentsheet/model/SetupIntentClientSecret
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/paymentsheet/paymentdatacollection/FormFragmentArguments$Creator : android/os/Parcelable$Creator {
+public final class com/stripe/android/paymentsheet/paymentdatacollection/FormArguments$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/paymentdatacollection/FormFragmentArguments;
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/paymentdatacollection/FormArguments;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/paymentdatacollection/FormFragmentArguments;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/paymentdatacollection/FormArguments;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseAddPaymentMethodFragment.kt
@@ -33,7 +33,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.databinding.FragmentAchBinding
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
+import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.Loading
 import com.stripe.android.paymentsheet.ui.PaymentMethodForm
@@ -181,7 +181,7 @@ internal abstract class BaseAddPaymentMethodFragment : Fragment() {
         showCheckboxFlow: Flow<Boolean>,
         onItemSelectedListener: (LpmRepository.SupportedPaymentMethod) -> Unit,
         onLinkSignupStateChanged: (LinkPaymentLauncher.Configuration, InlineSignupViewState) -> Unit,
-        formArguments: FormFragmentArguments,
+        formArguments: FormArguments,
         onFormFieldValuesChanged: (FormFieldValues?) -> Unit,
     ) {
         val horizontalPadding = dimensionResource(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
@@ -4,7 +4,7 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.getPMAddForm
-import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
+import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 
@@ -18,7 +18,7 @@ internal object FormArgumentsFactory {
         amount: Amount? = null,
         newLpm: PaymentSelection.New?,
         isShowingLinkInlineSignup: Boolean = false,
-    ): FormFragmentArguments {
+    ): FormArguments {
         val layoutFormDescriptor = paymentMethod.getPMAddForm(stripeIntent, config)
 
         val initialParams = if (newLpm is PaymentSelection.New.LinkInline) {
@@ -43,7 +43,7 @@ internal object FormArgumentsFactory {
             layoutFormDescriptor.showCheckboxControlledFields
         }
 
-        return FormFragmentArguments(
+        return FormArguments(
             paymentMethodCode = paymentMethod.code,
             showCheckbox = layoutFormDescriptor.showCheckbox && !isShowingLinkInlineSignup,
             showCheckboxControlledFields = showCheckboxControlledFields,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
@@ -9,7 +9,7 @@ import com.stripe.android.core.injection.NonFallbackInjector
 import com.stripe.android.paymentsheet.addresselement.toIdentifierMap
 import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
+import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.paymentdatacollection.getInitialValuesMap
 import com.stripe.android.ui.core.address.AddressRepository
 import com.stripe.android.ui.core.elements.CardBillingAddressElement
@@ -43,13 +43,13 @@ import javax.inject.Provider
 @FlowPreview
 internal class FormViewModel @Inject internal constructor(
     context: Context,
-    formFragmentArguments: FormFragmentArguments,
+    formArguments: FormArguments,
     lpmResourceRepository: ResourceRepository<LpmRepository>,
     addressResourceRepository: ResourceRepository<AddressRepository>,
     val showCheckboxFlow: Flow<Boolean>
 ) : ViewModel() {
     internal class Factory(
-        val config: FormFragmentArguments,
+        val config: FormArguments,
         val showCheckboxFlow: Flow<Boolean>,
         private val injector: NonFallbackInjector
     ) : ViewModelProvider.Factory, NonFallbackInjectable {
@@ -60,7 +60,7 @@ internal class FormViewModel @Inject internal constructor(
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             injector.inject(this)
             return subComponentBuilderProvider.get()
-                .formFragmentArguments(config)
+                .formArguments(config)
                 .showCheckboxFlow(showCheckboxFlow)
                 .build().viewModel as T
         }
@@ -69,17 +69,17 @@ internal class FormViewModel @Inject internal constructor(
     val elementsFlow = flowOf(
         TransformSpecToElements(
             addressResourceRepository = addressResourceRepository,
-            initialValues = formFragmentArguments.getInitialValuesMap(),
-            amount = formFragmentArguments.amount,
-            saveForFutureUseInitialValue = formFragmentArguments.showCheckboxControlledFields,
-            merchantName = formFragmentArguments.merchantName,
+            initialValues = formArguments.getInitialValuesMap(),
+            amount = formArguments.amount,
+            saveForFutureUseInitialValue = formArguments.showCheckboxControlledFields,
+            merchantName = formArguments.merchantName,
             context = context,
-            shippingValues = formFragmentArguments.shippingDetails
-                ?.toIdentifierMap(formFragmentArguments.billingDetails)
+            shippingValues = formArguments.shippingDetails
+                ?.toIdentifierMap(formArguments.billingDetails)
         ).transform(
             requireNotNull(
                 lpmResourceRepository.getRepository()
-                    .fromCode(formFragmentArguments.paymentMethodCode)
+                    .fromCode(formArguments.paymentMethodCode)
             ).formSpec.items
         )
     )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/TransformSpecToElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/TransformSpecToElement.kt
@@ -2,7 +2,7 @@ package com.stripe.android.paymentsheet.forms
 
 import android.content.Context
 import com.stripe.android.paymentsheet.addresselement.toIdentifierMap
-import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
+import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.paymentdatacollection.getInitialValuesMap
 import com.stripe.android.ui.core.address.AddressRepository
 import com.stripe.android.ui.core.elements.FormItemSpec
@@ -11,23 +11,23 @@ import com.stripe.android.ui.core.forms.resources.ResourceRepository
 import javax.inject.Inject
 
 /**
- * Wrapper around [TransformSpecToElements] that uses the parameters from [FormFragmentArguments].
+ * Wrapper around [TransformSpecToElements] that uses the parameters from [FormArguments].
  */
 internal class TransformSpecToElement @Inject constructor(
     addressResourceRepository: ResourceRepository<AddressRepository>,
-    formFragmentArguments: FormFragmentArguments,
+    formArguments: FormArguments,
     context: Context
 ) {
     private val transformSpecToElements =
         TransformSpecToElements(
             addressResourceRepository = addressResourceRepository,
-            initialValues = formFragmentArguments.getInitialValuesMap(),
-            amount = formFragmentArguments.amount,
-            saveForFutureUseInitialValue = formFragmentArguments.showCheckboxControlledFields,
-            merchantName = formFragmentArguments.merchantName,
+            initialValues = formArguments.getInitialValuesMap(),
+            amount = formArguments.amount,
+            saveForFutureUseInitialValue = formArguments.showCheckboxControlledFields,
+            merchantName = formArguments.merchantName,
             context = context,
-            shippingValues = formFragmentArguments.shippingDetails
-                ?.toIdentifierMap(formFragmentArguments.billingDetails)
+            shippingValues = formArguments.shippingDetails
+                ?.toIdentifierMap(formArguments.billingDetails)
         )
 
     internal fun transform(list: List<FormItemSpec>) = transformSpecToElements.transform(list)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/FormViewModelSubcomponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/FormViewModelSubcomponent.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.paymentsheet.injection
 
 import com.stripe.android.paymentsheet.forms.FormViewModel
-import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
+import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import dagger.BindsInstance
 import dagger.Subcomponent
 import kotlinx.coroutines.flow.Flow
@@ -12,10 +12,9 @@ internal interface FormViewModelSubcomponent {
 
     @Subcomponent.Builder
     interface Builder {
+
         @BindsInstance
-        fun formFragmentArguments(
-            config: FormFragmentArguments
-        ): Builder
+        fun formArguments(args: FormArguments): Builder
 
         @BindsInstance
         fun showCheckboxFlow(saveForFutureUseVisibleFlow: Flow<Boolean>): Builder

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormArguments.kt
@@ -11,7 +11,7 @@ import com.stripe.android.ui.core.forms.convertToFormValuesMap
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-internal data class FormFragmentArguments(
+internal data class FormArguments(
     val paymentMethodCode: PaymentMethodCode,
     val showCheckbox: Boolean,
     val showCheckboxControlledFields: Boolean,
@@ -22,7 +22,7 @@ internal data class FormFragmentArguments(
     val initialPaymentMethodCreateParams: PaymentMethodCreateParams? = null
 ) : Parcelable
 
-internal fun FormFragmentArguments.getInitialValuesMap(): Map<IdentifierSpec, String?> {
+internal fun FormArguments.getInitialValuesMap(): Map<IdentifierSpec, String?> {
     val initialValues = initialPaymentMethodCreateParams?.let {
         convertToFormValuesMap(it.toParamMap())
     } ?: emptyMap()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -34,7 +34,7 @@ import com.stripe.android.paymentsheet.model.ConfirmStripeIntentParamsFactory
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SetupIntentClientSecret
-import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
+import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.di.DaggerUSBankAccountFormComponent
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.di.USBankAccountFormViewModelSubcomponent
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
@@ -489,7 +489,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
      * @param clientSecret The client secret for the Stripe Intent being processed
      */
     data class Args(
-        val formArgs: FormFragmentArguments,
+        val formArgs: FormArguments,
         val isCompleteFlow: Boolean,
         val clientSecret: ClientSecret?,
         val savedPaymentMethod: PaymentSelection.New.USBankAccount?,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -37,7 +37,7 @@ import com.stripe.android.link.ui.verification.LinkVerificationDialog
 import com.stripe.android.paymentsheet.BottomSheetController
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
-import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
+import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.utils.launchAndCollectIn
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.ui.core.PaymentsTheme
@@ -68,7 +68,7 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
      * These arguments can't be passed through the Fragment's arguments because the Fragment is
      * added with an [AndroidViewBinding] from Compose, which doesn't allow that.
      */
-    var formArgs: FormFragmentArguments? = null
+    var formArgs: FormArguments? = null
 
     abstract val rootView: ViewGroup
     abstract val bottomSheet: ViewGroup

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodForm.kt
@@ -10,7 +10,7 @@ import com.stripe.android.core.injection.NonFallbackInjector
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.forms.FormViewModel
-import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
+import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.ui.core.FormUI
 import com.stripe.android.ui.core.elements.FormElement
 import com.stripe.android.ui.core.elements.IdentifierSpec
@@ -20,7 +20,7 @@ import kotlinx.coroutines.flow.Flow
 @FlowPreview
 @Composable
 internal fun PaymentMethodForm(
-    args: FormFragmentArguments,
+    args: FormArguments,
     enabled: Boolean,
     onFormFieldValuesChanged: (FormFieldValues?) -> Unit,
     showCheckboxFlow: Flow<Boolean>,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -42,7 +42,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.getPMsToAdd
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
-import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
+import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.state.GooglePayState
 import com.stripe.android.paymentsheet.toPaymentSelection
@@ -597,7 +597,7 @@ internal abstract class BaseSheetViewModel(
     fun createFormArguments(
         selectedItem: LpmRepository.SupportedPaymentMethod,
         showLinkInlineSignup: Boolean
-    ): FormFragmentArguments = FormArgumentsFactory.create(
+    ): FormArguments = FormArgumentsFactory.create(
         paymentMethod = selectedItem,
         stripeIntent = requireNotNull(stripeIntent.value),
         config = config,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -36,7 +36,7 @@ import com.stripe.android.paymentsheet.forms.PaymentMethodRequirements
 import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
-import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
+import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.LinkState.LoginState.LoggedIn
 import com.stripe.android.paymentsheet.ui.PrimaryButton
@@ -591,7 +591,7 @@ internal class PaymentOptionsActivityTest {
     fun registerFormViewModelInjector() {
         val formViewModel = FormViewModel(
             context = context,
-            formFragmentArguments = FormFragmentArguments(
+            formArguments = FormArguments(
                 PaymentMethod.Type.Card.code,
                 showCheckbox = true,
                 showCheckboxControlledFields = true,
@@ -609,7 +609,7 @@ internal class PaymentOptionsActivityTest {
         val mockFormSubComponentBuilderProvider =
             mock<Provider<FormViewModelSubcomponent.Builder>>()
         whenever(mockFormBuilder.build()).thenReturn(mockFormSubcomponent)
-        whenever(mockFormBuilder.formFragmentArguments(any())).thenReturn(mockFormBuilder)
+        whenever(mockFormBuilder.formArguments(any())).thenReturn(mockFormBuilder)
         whenever(mockFormBuilder.showCheckboxFlow(any())).thenReturn(mockFormBuilder)
         whenever(mockFormSubcomponent.viewModel).thenReturn(formViewModel)
         whenever(mockFormSubComponentBuilderProvider.get()).thenReturn(mockFormBuilder)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTestInjection.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTestInjection.kt
@@ -18,7 +18,7 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
 import com.stripe.android.paymentsheet.injection.PaymentOptionsViewModelSubcomponent
-import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
+import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.address.AddressRepository
@@ -102,7 +102,7 @@ internal open class PaymentOptionsViewModelTestInjection {
         lpmRepository: LpmRepository = mock(),
         formViewModel: FormViewModel = FormViewModel(
             context = context,
-            formFragmentArguments = FormFragmentArguments(
+            formArguments = FormArguments(
                 PaymentMethod.Type.Card.code,
                 showCheckbox = true,
                 showCheckboxControlledFields = true,
@@ -131,7 +131,7 @@ internal open class PaymentOptionsViewModelTestInjection {
         val mockFormSubComponentBuilderProvider =
             mock<Provider<FormViewModelSubcomponent.Builder>>()
         whenever(mockFormBuilder.build()).thenReturn(mockFormSubcomponent)
-        whenever(mockFormBuilder.formFragmentArguments(any())).thenReturn(mockFormBuilder)
+        whenever(mockFormBuilder.formArguments(any())).thenReturn(mockFormBuilder)
         whenever(mockFormSubcomponent.viewModel).thenReturn(formViewModel)
         whenever(mockFormSubComponentBuilderProvider.get()).thenReturn(mockFormBuilder)
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -50,7 +50,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
 import com.stripe.android.paymentsheet.model.StripeIntentValidator
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
-import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
+import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.repositories.StripeIntentRepository
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.ui.PrimaryButton
@@ -1323,7 +1323,7 @@ internal class PaymentSheetActivityTest {
 
         val formViewModel = FormViewModel(
             context = context,
-            formFragmentArguments = FormFragmentArguments(
+            formArguments = FormArguments(
                 PaymentMethod.Type.Card.code,
                 showCheckbox = true,
                 showCheckboxControlledFields = true,
@@ -1341,7 +1341,7 @@ internal class PaymentSheetActivityTest {
         val mockFormSubComponentBuilderProvider =
             mock<Provider<FormViewModelSubcomponent.Builder>>()
         whenever(mockFormBuilder.build()).thenReturn(mockFormSubcomponent)
-        whenever(mockFormBuilder.formFragmentArguments(any())).thenReturn(mockFormBuilder)
+        whenever(mockFormBuilder.formArguments(any())).thenReturn(mockFormBuilder)
         whenever(mockFormBuilder.showCheckboxFlow(any())).thenReturn(mockFormBuilder)
         whenever(mockFormSubcomponent.viewModel).thenReturn(formViewModel)
         whenever(mockFormSubComponentBuilderProvider.get()).thenReturn(mockFormBuilder)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -12,7 +12,7 @@ import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.SetupIntentClientSecret
-import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
+import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import org.mockito.kotlin.mock
@@ -161,7 +161,7 @@ internal object PaymentSheetFixtures {
         )
 
     internal val COMPOSE_FRAGMENT_ARGS
-        get() = FormFragmentArguments(
+        get() = FormArguments(
             PaymentMethod.Type.Bancontact.code,
             showCheckbox = true,
             showCheckboxControlledFields = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTestInjection.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTestInjection.kt
@@ -24,7 +24,7 @@ import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
 import com.stripe.android.paymentsheet.injection.PaymentSheetViewModelSubcomponent
 import com.stripe.android.paymentsheet.model.StripeIntentValidator
-import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
+import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.repositories.StripeIntentRepository
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.ui.core.Amount
@@ -137,7 +137,7 @@ internal open class PaymentSheetViewModelTestInjection {
         addressRepository: AddressRepository,
         formViewModel: FormViewModel = FormViewModel(
             context = context,
-            formFragmentArguments = FormFragmentArguments(
+            formArguments = FormArguments(
                 PaymentMethod.Type.Card.code,
                 showCheckbox = true,
                 showCheckboxControlledFields = true,
@@ -172,7 +172,7 @@ internal open class PaymentSheetViewModelTestInjection {
                         mock<Provider<FormViewModelSubcomponent.Builder>>()
 
                     whenever(mockBuilder.build()).thenReturn(mockSubcomponent)
-                    whenever(mockBuilder.formFragmentArguments(any())).thenReturn(mockBuilder)
+                    whenever(mockBuilder.formArguments(any())).thenReturn(mockBuilder)
                     whenever(mockSubcomponent.viewModel).thenReturn(formViewModel)
                     whenever(mockSubComponentBuilderProvider.get()).thenReturn(mockBuilder)
                     injectable.subComponentBuilderProvider = mockSubComponentBuilderProvider

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactoryTest.kt
@@ -10,7 +10,7 @@ import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
+import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 import org.junit.Test
@@ -95,7 +95,7 @@ class FormArgumentsFactoryTest {
 
     private fun testCardFormArguments(
         customerReuse: PaymentSelection.CustomerRequestedSave,
-    ): FormFragmentArguments {
+    ): FormArguments {
         val paymentIntent = mock<PaymentIntent>().also {
             whenever(it.paymentMethodTypes).thenReturn(listOf("card", "bancontact"))
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -9,7 +9,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.COMPOSE_FRAGMENT_ARGS
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
+import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.address.AddressRepository
 import com.stripe.android.ui.core.elements.AddressElement
@@ -600,11 +600,11 @@ internal class FormViewModelTest {
     }
 
     fun createViewModel(
-        arguments: FormFragmentArguments,
+        arguments: FormArguments,
         lpmResourceRepository: ResourceRepository<LpmRepository>
     ) = FormViewModel(
         context = context,
-        formFragmentArguments = arguments,
+        formArguments = arguments,
         lpmResourceRepository = lpmResourceRepository,
         addressResourceRepository = addressResourceRepository,
         showCheckboxFlow = showCheckboxFlow

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/FormArgumentsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/FormArgumentsTest.kt
@@ -8,7 +8,7 @@ import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.elements.IdentifierSpec
 import org.junit.Test
 
-class FormFragmentArgumentsTest {
+class FormArgumentsTest {
     private val billingDetails = PaymentSheet.BillingDetails(
         PaymentSheet.Address(
             line1 = "123 Main Street",
@@ -54,7 +54,7 @@ class FormFragmentArgumentsTest {
 
     @Test
     fun `Verify payment method parameters overrides any billing address values`() {
-        val formFragmentArguments = FormFragmentArguments(
+        val formArguments = FormArguments(
             PaymentMethod.Type.Card.code,
             showCheckbox = true,
             showCheckboxControlledFields = true,
@@ -64,7 +64,7 @@ class FormFragmentArgumentsTest {
             initialPaymentMethodCreateParams = paymentMethodCreateParams
         )
 
-        assertThat(formFragmentArguments.getInitialValuesMap()).isEqualTo(
+        assertThat(formArguments.getInitialValuesMap()).isEqualTo(
             mapOf(
                 IdentifierSpec.Name to "Jenny Rosen",
                 IdentifierSpec.Email to "jenny.rosen@example.com",
@@ -86,7 +86,7 @@ class FormFragmentArgumentsTest {
 
     @Test
     fun `Verify if only default billing address they appear in the initial values`() {
-        val formFragmentArguments = FormFragmentArguments(
+        val formArguments = FormArguments(
             PaymentMethod.Type.Card.code,
             showCheckbox = true,
             showCheckboxControlledFields = true,
@@ -96,7 +96,7 @@ class FormFragmentArgumentsTest {
             initialPaymentMethodCreateParams = null
         )
 
-        assertThat(formFragmentArguments.getInitialValuesMap()).isEqualTo(
+        assertThat(formArguments.getInitialValuesMap()).isEqualTo(
             mapOf(
                 IdentifierSpec.Name to "Jenny Smith",
                 IdentifierSpec.Email to "email.email.com",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -19,7 +19,7 @@ import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResu
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.paymentdatacollection.FormFragmentArguments
+import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.ui.core.Amount
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -47,7 +47,7 @@ class USBankAccountFormViewModelTest {
     private val onUpdateSelectionAndFinish: (PaymentSelection) -> Unit = mock()
 
     private val defaultArgs = USBankAccountFormViewModel.Args(
-        formArgs = FormFragmentArguments(
+        formArgs = FormArguments(
             paymentMethodCode = PaymentMethod.Type.USBankAccount.code,
             showCheckbox = false,
             showCheckboxControlledFields = false,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request renames `FormFragmentArguments` to `FormArguments`, for the simple reason that we don’t use a fragment for the form anymore.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
