### PR TITLE
[PaymentSheet] Fix Paparazzi tests 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"
         classpath "org.jetbrains.kotlinx:binary-compatibility-validator:0.12.1"
         classpath 'com.karumi:shot:5.14.1'
-        classpath 'dev.chrisbanes.paparazzi:paparazzi-gradle-plugin:1.1.0-sdk33-alpha02'
+        classpath 'dev.chrisbanes.paparazzi:paparazzi-gradle-plugin:1.1.0-sdk33-alpha04'
         classpath 'app.cash.paparazzi:paparazzi-gradle-plugin:1.1.0'
         classpath 'com.google.gms:google-services:4.3.14'
         classpath 'com.google.firebase:firebase-appdistribution-gradle:3.1.1'

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'kotlin-kapt'
 apply plugin: "org.jetbrains.kotlin.plugin.parcelize"
 apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'shot'
-apply plugin: 'app.cash.paparazzi'
+apply plugin: 'dev.chrisbanes.paparazzi'
 
 dependencies {
     implementation project(":link")


### PR DESCRIPTION
# Summary
- Use API 33 support paparazzi dependency from Chris Banes - https://github.com/cashapp/paparazzi/pull/605. 
- Connections is already using this fork, moved paymentsheet to use it as well.

# Motivation
Fix PaymentSheet Paparazzi tests.