### PR TITLE
Remove reflection in `PaparazziRule`

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/utils/screenshots/PaparazziRule.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/screenshots/PaparazziRule.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.utils.screenshots
 
-import android.os.Build
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
@@ -19,8 +18,6 @@ import com.stripe.android.ui.core.PaymentsTheme
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
-import java.lang.reflect.Field
-import java.lang.reflect.Modifier as ReflectionModifier
 
 class PaparazziRule(
     vararg configOptions: Array<out PaparazziConfigOption>,
@@ -105,29 +102,6 @@ class PaparazziRule(
                 compileSdkVersion = 32,
             ),
         )
-    }
-
-    companion object {
-        init {
-            makePaparazziWorkForApi33()
-        }
-    }
-}
-
-private fun makePaparazziWorkForApi33() {
-    // Temporary workaround to fix an issue with Paparazzi on API 33
-    // See: https://github.com/cashapp/paparazzi/issues/631#issuecomment-1326051546
-    val field = Build.VERSION::class.java.getField("CODENAME")
-    val newValue = "REL"
-
-    Field::class.java.getDeclaredField("modifiers").apply {
-        isAccessible = true
-        setInt(field, field.modifiers and ReflectionModifier.FINAL.inv())
-    }
-
-    field.apply {
-        isAccessible = true
-        set(null, newValue)
     }
 }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request removes the reflection in `PaparazziRule`, which is no longer necessary since #6021.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
