### PR TITLE
[Identity] Clean up camera when screen is navigated away from

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/navigation/IdentityNavGraph.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/IdentityNavGraph.kt
@@ -85,37 +85,61 @@ internal fun IdentityNavGraph(
                 )
             }
             screen(IDScanDestination.ROUTE) {
+                val identityScanViewModel: IdentityScanViewModel =
+                    viewModel(factory = identityScanViewModelFactory)
+                ScanDestinationEffect(
+                    lifecycleOwner = it,
+                    identityScanViewModel = identityScanViewModel
+                )
                 DocumentScanScreenContent(
                     navController = navController,
                     identityViewModel = identityViewModel,
-                    identityScanViewModel = viewModel(factory = identityScanViewModelFactory),
+                    identityScanViewModel = identityScanViewModel,
                     backStackEntry = it,
                     route = IDScanDestination.ROUTE.route
                 )
             }
             screen(DriverLicenseScanDestination.ROUTE) {
+                val identityScanViewModel: IdentityScanViewModel =
+                    viewModel(factory = identityScanViewModelFactory)
+                ScanDestinationEffect(
+                    lifecycleOwner = it,
+                    identityScanViewModel = identityScanViewModel
+                )
                 DocumentScanScreenContent(
                     navController = navController,
                     identityViewModel = identityViewModel,
-                    identityScanViewModel = viewModel(factory = identityScanViewModelFactory),
+                    identityScanViewModel = identityScanViewModel,
                     backStackEntry = it,
                     route = DriverLicenseScanDestination.ROUTE.route
                 )
             }
             screen(PassportScanDestination.ROUTE) {
+                val identityScanViewModel: IdentityScanViewModel =
+                    viewModel(factory = identityScanViewModelFactory)
+                ScanDestinationEffect(
+                    lifecycleOwner = it,
+                    identityScanViewModel = identityScanViewModel
+                )
                 DocumentScanScreenContent(
                     navController = navController,
                     identityViewModel = identityViewModel,
-                    identityScanViewModel = viewModel(factory = identityScanViewModelFactory),
+                    identityScanViewModel = identityScanViewModel,
                     backStackEntry = it,
                     route = PassportScanDestination.ROUTE.route
                 )
             }
             screen(SelfieDestination.ROUTE) {
+                val identityScanViewModel: IdentityScanViewModel =
+                    viewModel(factory = identityScanViewModelFactory)
+                ScanDestinationEffect(
+                    lifecycleOwner = it,
+                    identityScanViewModel = identityScanViewModel
+                )
                 SelfieScanScreen(
                     navController = navController,
                     identityViewModel = identityViewModel,
-                    identityScanViewModel = viewModel(factory = identityScanViewModelFactory)
+                    identityScanViewModel = identityScanViewModel
                 )
             }
             screen(IDUploadDestination.ROUTE) {

--- a/identity/src/main/java/com/stripe/android/identity/navigation/ScanDestinations.kt
+++ b/identity/src/main/java/com/stripe/android/identity/navigation/ScanDestinations.kt
@@ -1,12 +1,16 @@
 package com.stripe.android.identity.navigation
 
 import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.lifecycle.LifecycleOwner
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
 import com.stripe.android.identity.R
 import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.states.IdentityScanState
+import com.stripe.android.identity.viewmodel.IdentityScanViewModel
 
 internal abstract class DocumentScanDestination(
     shouldStartFromBack: Boolean = false,
@@ -154,6 +158,19 @@ internal class DriverLicenseScanDestination(
     companion object {
         private const val DRIVE_LICENSE_SCAN = "DriverLicenseScan"
         val ROUTE = DocumentScanDestinationRoute(routeBase = DRIVE_LICENSE_SCAN)
+    }
+}
+
+@Composable
+internal fun ScanDestinationEffect(
+    lifecycleOwner: LifecycleOwner,
+    identityScanViewModel: IdentityScanViewModel
+) {
+    DisposableEffect(Unit) {
+        onDispose {
+            identityScanViewModel.clearDisplayStateChangedFlow()
+            identityScanViewModel.stopScan(lifecycleOwner)
+        }
     }
 }
 

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/CameraViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/CameraViewModel.kt
@@ -19,6 +19,7 @@ import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.states.IdentityScanState
 import com.stripe.android.identity.utils.SingleLiveEvent
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.io.File
@@ -41,8 +42,11 @@ internal open class CameraViewModel(
     internal val finalResult = SingleLiveEvent<IdentityAggregator.FinalResult>()
     private val reset = MutableLiveData<Unit>()
 
-    internal val displayStateChangedFlow =
+
+    private val _displayStateChangedFlow =
         MutableStateFlow<Pair<IdentityScanState, IdentityScanState?>?>(null)
+    internal val displayStateChangedFlow:
+        StateFlow<Pair<IdentityScanState, IdentityScanState?>?> = _displayStateChangedFlow
 
     internal var identityScanFlow: IdentityScanFlow? = null
 
@@ -61,6 +65,10 @@ internal open class CameraViewModel(
         )
     }
 
+    internal fun clearDisplayStateChangedFlow() {
+        _displayStateChangedFlow.update { null }
+    }
+
     override var scanState: IdentityScanState? = null
 
     override var scanStatePrevious: IdentityScanState? = null
@@ -68,7 +76,7 @@ internal open class CameraViewModel(
     override val scanErrorListener = ScanErrorListener()
 
     override fun displayState(newState: IdentityScanState, previousState: IdentityScanState?) {
-        displayStateChangedFlow.update {
+        _displayStateChangedFlow.update {
             (newState to previousState)
         }
     }

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/CameraViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/CameraViewModel.kt
@@ -42,7 +42,6 @@ internal open class CameraViewModel(
     internal val finalResult = SingleLiveEvent<IdentityAggregator.FinalResult>()
     private val reset = MutableLiveData<Unit>()
 
-
     private val _displayStateChangedFlow =
         MutableStateFlow<Pair<IdentityScanState, IdentityScanState?>?>(null)
     internal val displayStateChangedFlow:


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
We need to tear down camera when screen is navigated away from. Otherwise the camera won't start in the previous screen

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before(click back->got stuck)  | After(click back->started automatically) |
| ------------- | ------------- |
| ![scanBefore](https://user-images.githubusercontent.com/79880926/212457223-0099e5f3-9606-4225-b901-176c14ea9d47.gif)  | ![scanAfter](https://user-images.githubusercontent.com/79880926/212457221-c7eacbb5-0234-4da4-8962-5b2018399c98.gif) |






# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
