### PR TITLE
Prepare for `PaymentOptionsAdapter` removal

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
@@ -106,7 +106,7 @@ internal abstract class BasePaymentMethodsListFragment : Fragment() {
                 val paymentMethod = sheetViewModel.lpmResourceRepository.getRepository().fromCode(it)
                 resources.getString(paymentMethod?.displayNameResource!!)
             },
-            paymentOptionSelected = { sheetViewModel.handleSelected(it.toPaymentSelection()) },
+            paymentOptionSelected = { sheetViewModel.handlePaymentMethodSelected(it.toPaymentSelection()) },
             paymentMethodDeleteListener = { sheetViewModel.removePaymentMethod(it.paymentMethod) },
             addCardClickListener = sheetViewModel::transitionToAddPaymentScreen,
         ).also {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
@@ -1,17 +1,17 @@
 package com.stripe.android.paymentsheet
 
+import android.content.Context
 import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import android.view.ViewGroup
 import androidx.annotation.VisibleForTesting
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.lifecycleScope
-import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.stripe.android.paymentsheet.databinding.FragmentPaymentsheetPaymentMethodsListBinding
 import com.stripe.android.paymentsheet.utils.launchAndCollectIn
@@ -19,37 +19,58 @@ import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.uicore.StripeThemeDefaults
 import com.stripe.android.uicore.createTextSpanFromTextStyle
 import com.stripe.android.uicore.isSystemDarkTheme
-import kotlinx.coroutines.launch
 
-internal abstract class BasePaymentMethodsListFragment(
-    private val canClickSelectedItem: Boolean
-) : Fragment(
-    R.layout.fragment_paymentsheet_payment_methods_list
-) {
+internal abstract class BasePaymentMethodsListFragment : Fragment() {
+
     abstract val sheetViewModel: BaseSheetViewModel
 
-    @VisibleForTesting
-    lateinit var adapter: PaymentOptionsAdapter
-    private var editMenuItem: MenuItem? = null
+    private var layoutManager: PaymentMethodsLayoutManager? = null
+    private var adapter: PaymentOptionsAdapter? = null
 
     @VisibleForTesting
-    internal var isEditing = false
-        set(value) {
-            field = value
-            adapter.setEditing(value)
-            setEditMenuText()
-            sheetViewModel.setEditing(value)
-        }
+    var editMenuItem: MenuItem? = null
+
+    private var viewBinding: FragmentPaymentsheetPaymentMethodsListBinding? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(!sheetViewModel.paymentMethods.value.isNullOrEmpty())
+
+        sheetViewModel.paymentOptionsState.launchAndCollectIn(this) { state ->
+            adapter?.update(
+                items = state.items,
+                selectedIndex = state.selectedIndex,
+            )
+        }
+
+        sheetViewModel.paymentMethods.launchAndCollectIn(this) { paymentMethods ->
+            val hasPaymentMethods = paymentMethods.orEmpty().isNotEmpty()
+            editMenuItem?.isVisible = hasPaymentMethods
+        }
+
+        sheetViewModel.editing.launchAndCollectIn(this) { isEditing ->
+            adapter?.setEditing(isEditing)
+            setEditMenuText(isEditing)
+        }
+
+        sheetViewModel.processing.launchAndCollectIn(this) { isProcessing ->
+            adapter?.isEnabled = !isProcessing
+            layoutManager?.canScroll = !isProcessing
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        viewBinding = FragmentPaymentsheetPaymentMethodsListBinding
+            .inflate(inflater, container, false)
+        return viewBinding?.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        setupRecyclerView(FragmentPaymentsheetPaymentMethodsListBinding.bind(view))
-        isEditing = savedInstanceState?.getBoolean(IS_EDITING) ?: false
+        setupRecyclerView(viewBinding!!)
     }
 
     @Deprecated("Deprecated in Java")
@@ -57,11 +78,11 @@ internal abstract class BasePaymentMethodsListFragment(
         inflater.inflate(R.menu.paymentsheet_payment_methods_list, menu)
         // Menu is created after view state is restored, so we need to update the title here
         editMenuItem = menu.findItem(R.id.edit)
-        setEditMenuText()
+        setEditMenuText(isEditing = false)
         super.onCreateOptionsMenu(menu, inflater)
     }
 
-    private fun setEditMenuText() {
+    private fun setEditMenuText(isEditing: Boolean) {
         val context = context ?: return
         val appearance = sheetViewModel.config?.appearance ?: return
         editMenuItem?.apply {
@@ -75,7 +96,24 @@ internal abstract class BasePaymentMethodsListFragment(
                 color = Color(appearance.getColors(context.isSystemDarkTheme()).appBarIcon),
                 fontFamily = appearance.typography.fontResId
             )
-            isVisible = adapter.hasSavedItems()
+        }
+    }
+
+    private fun setupRecyclerView(viewBinding: FragmentPaymentsheetPaymentMethodsListBinding) {
+        layoutManager = PaymentMethodsLayoutManager(requireContext()).also {
+            viewBinding.recycler.layoutManager = it
+        }
+
+        adapter = PaymentOptionsAdapter(
+            nameProvider = {
+                val paymentMethod = sheetViewModel.lpmResourceRepository.getRepository().fromCode(it)
+                resources.getString(paymentMethod?.displayNameResource!!)
+            },
+            paymentOptionSelected = { sheetViewModel.handleSelected(it.toPaymentSelection()) },
+            paymentMethodDeleteListener = { sheetViewModel.removePaymentMethod(it.paymentMethod) },
+            addCardClickListener = sheetViewModel::transitionToAddPaymentScreen,
+        ).also {
+            viewBinding.recycler.adapter = it
         }
     }
 
@@ -83,81 +121,29 @@ internal abstract class BasePaymentMethodsListFragment(
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             R.id.edit -> {
-                isEditing = !isEditing
+                sheetViewModel.toggleEditing()
                 true
             }
             else -> super.onOptionsItemSelected(item)
         }
     }
 
-    override fun onSaveInstanceState(outState: Bundle) {
-        outState.putBoolean(IS_EDITING, isEditing)
-        super.onSaveInstanceState(outState)
+    override fun onDestroyView() {
+        viewBinding = null
+        super.onDestroyView()
     }
 
-    private fun setupRecyclerView(viewBinding: FragmentPaymentsheetPaymentMethodsListBinding) {
-        val layoutManager = object : LinearLayoutManager(
-            activity,
-            HORIZONTAL,
-            false
-        ) {
-            var canScroll = true
+    private class PaymentMethodsLayoutManager(
+        context: Context,
+    ) : LinearLayoutManager(
+        context,
+        HORIZONTAL,
+        false
+    ) {
+        var canScroll = true
 
-            override fun canScrollHorizontally(): Boolean {
-                return canScroll && super.canScrollHorizontally()
-            }
-        }.also {
-            viewBinding.recycler.layoutManager = it
+        override fun canScrollHorizontally(): Boolean {
+            return canScroll && super.canScrollHorizontally()
         }
-
-        adapter = PaymentOptionsAdapter(
-            lpmRepository = sheetViewModel.lpmResourceRepository.getRepository(),
-            canClickSelectedItem = canClickSelectedItem,
-            paymentOptionSelected = ::onPaymentOptionsItemSelected,
-            paymentMethodDeleteListener = ::deletePaymentMethod,
-            addCardClickListener = ::transitionToAddPaymentMethod
-        ).also {
-            viewBinding.recycler.adapter = it
-        }
-
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.RESUMED) {
-                sheetViewModel.paymentOptionsState.collect { paymentOptionsState ->
-                    adapter.update(
-                        items = paymentOptionsState.items,
-                        selectedIndex = paymentOptionsState.selectedIndex,
-                    )
-                }
-            }
-        }
-
-        sheetViewModel.paymentMethods.launchAndCollectIn(viewLifecycleOwner) { paymentMethods ->
-            if (isEditing && paymentMethods.isNullOrEmpty()) {
-                isEditing = false
-            }
-        }
-
-        sheetViewModel.processing.launchAndCollectIn(viewLifecycleOwner) { isProcessing ->
-            adapter.isEnabled = !isProcessing
-            layoutManager.canScroll = !isProcessing
-        }
-    }
-
-    private fun transitionToAddPaymentMethod() {
-        sheetViewModel.transitionToAddPaymentScreen()
-    }
-
-    open fun onPaymentOptionsItemSelected(item: PaymentOptionsItem) {
-        val paymentSelection = item.toPaymentSelection()
-        sheetViewModel.updateSelection(paymentSelection)
-    }
-
-    @VisibleForTesting
-    fun deletePaymentMethod(item: PaymentOptionsItem.SavedPaymentMethod) {
-        sheetViewModel.removePaymentMethod(item.paymentMethod)
-    }
-
-    private companion object {
-        private const val IS_EDITING = "is_editing"
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
@@ -8,7 +8,6 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import androidx.annotation.VisibleForTesting
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.Fragment
@@ -27,9 +26,7 @@ internal abstract class BasePaymentMethodsListFragment : Fragment() {
     private var layoutManager: PaymentMethodsLayoutManager? = null
     private var adapter: PaymentOptionsAdapter? = null
 
-    @VisibleForTesting
-    var editMenuItem: MenuItem? = null
-
+    private var editMenuItem: MenuItem? = null
     private var viewBinding: FragmentPaymentsheetPaymentMethodsListBinding? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BasePaymentMethodsListFragment.kt
@@ -102,10 +102,6 @@ internal abstract class BasePaymentMethodsListFragment : Fragment() {
         }
 
         adapter = PaymentOptionsAdapter(
-            nameProvider = {
-                val paymentMethod = sheetViewModel.lpmResourceRepository.getRepository().fromCode(it)
-                resources.getString(paymentMethod?.displayNameResource!!)
-            },
             paymentOptionSelected = { sheetViewModel.handlePaymentMethodSelected(it.toPaymentSelection()) },
             paymentMethodDeleteListener = { sheetViewModel.removePaymentMethod(it.paymentMethod) },
             addCardClickListener = sheetViewModel::transitionToAddPaymentScreen,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
@@ -98,10 +98,8 @@ internal class PaymentOptionsAdapter(
 
     @VisibleForTesting
     internal fun onItemSelected(position: Int) {
-        if (position != NO_POSITION && !isEditing) {
-            val item = items[position]
-            paymentOptionSelected(item)
-        }
+        val item = items.getOrNull(position) ?: return
+        paymentOptionSelected(item)
     }
 
     override fun getItemId(position: Int): Long = items[position].hashCode().toLong()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsAdapter.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.NO_POSITION
-import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.PaymentOptionsAdapter.Companion.PM_OPTIONS_DEFAULT_PADDING
 import com.stripe.android.paymentsheet.PaymentOptionsItem.ViewType
 import com.stripe.android.paymentsheet.ui.LpmSelectorText
@@ -59,7 +58,6 @@ import kotlin.properties.Delegates
 
 @SuppressLint("NotifyDataSetChanged")
 internal class PaymentOptionsAdapter(
-    private val nameProvider: (PaymentMethodCode?) -> String,
     val paymentOptionSelected: (PaymentOptionsItem) -> Unit,
     val paymentMethodDeleteListener: (PaymentOptionsItem.SavedPaymentMethod) -> Unit,
     val addCardClickListener: () -> Unit,
@@ -125,7 +123,6 @@ internal class PaymentOptionsAdapter(
                 SavedPaymentMethodViewHolder(
                     parent,
                     width,
-                    nameProvider,
                     onItemSelectedListener = ::onItemSelected,
                     onRemoveListener = { position ->
                         val removedItem = items[position] as PaymentOptionsItem.SavedPaymentMethod
@@ -165,7 +162,6 @@ internal class PaymentOptionsAdapter(
     internal class SavedPaymentMethodViewHolder(
         private val composeView: ComposeView,
         private val width: Dp,
-        private val nameProvider: (PaymentMethodCode?) -> String,
         private val onRemoveListener: (Int) -> Unit,
         private val onItemSelectedListener: (Int) -> Unit
     ) : PaymentOptionViewHolder(
@@ -174,13 +170,11 @@ internal class PaymentOptionsAdapter(
         constructor(
             parent: ViewGroup,
             width: Dp,
-            nameProvider: (PaymentMethodCode?) -> String,
             onItemSelectedListener: (Int) -> Unit,
             onRemoveListener: (Int) -> Unit
         ) : this(
             composeView = ComposeView(parent.context),
             width = width,
-            nameProvider = nameProvider,
             onRemoveListener = onRemoveListener,
             onItemSelectedListener = onItemSelectedListener
         )
@@ -197,7 +191,7 @@ internal class PaymentOptionsAdapter(
             val labelText = savedPaymentMethod.paymentMethod.getLabel(itemView.resources) ?: return
             val removeTitle = itemView.resources.getString(
                 R.string.stripe_paymentsheet_remove_pm,
-                nameProvider(item.paymentMethod.type?.code),
+                item.displayName,
             )
 
             composeView.setContent {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsItem.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsItem.kt
@@ -21,8 +21,9 @@ internal sealed class PaymentOptionsItem {
     /**
      * Represents a [PaymentMethod] that is already saved and attached to the current customer.
      */
-    data class SavedPaymentMethod(
-        val paymentMethod: PaymentMethod
+    data class SavedPaymentMethod constructor(
+        val displayName: String,
+        val paymentMethod: PaymentMethod,
     ) : PaymentOptionsItem() {
         override val viewType: ViewType = ViewType.SavedPaymentMethod
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsListFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsListFragment.kt
@@ -2,9 +2,7 @@ package com.stripe.android.paymentsheet
 
 import androidx.fragment.app.activityViewModels
 
-internal class PaymentOptionsListFragment : BasePaymentMethodsListFragment(
-    canClickSelectedItem = true
-) {
+internal class PaymentOptionsListFragment : BasePaymentMethodsListFragment() {
     private val activityViewModel by activityViewModels<PaymentOptionsViewModel> {
         PaymentOptionsViewModel.Factory {
             requireNotNull(
@@ -14,9 +12,4 @@ internal class PaymentOptionsListFragment : BasePaymentMethodsListFragment(
     }
 
     override val sheetViewModel: PaymentOptionsViewModel by lazy { activityViewModel }
-
-    override fun onPaymentOptionsItemSelected(item: PaymentOptionsItem) {
-        super.onPaymentOptionsItemSelected(item)
-        sheetViewModel.onUserSelection()
-    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet
 
 import androidx.recyclerview.widget.RecyclerView
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 
@@ -21,13 +22,17 @@ internal object PaymentOptionsStateFactory {
         showLink: Boolean,
         initialSelection: SavedSelection,
         currentSelection: PaymentSelection? = null,
+        nameProvider: (PaymentMethodCode?) -> String,
     ): PaymentOptionsState {
         val items = listOfNotNull(
             PaymentOptionsItem.AddCard,
             PaymentOptionsItem.GooglePay.takeIf { showGooglePay },
             PaymentOptionsItem.Link.takeIf { showLink }
         ) + sortedPaymentMethods(paymentMethods, initialSelection).map {
-            PaymentOptionsItem.SavedPaymentMethod(it)
+            PaymentOptionsItem.SavedPaymentMethod(
+                displayName = nameProvider(it.type?.code),
+                paymentMethod = it,
+            )
         }
 
         val currentSelectionIndex = currentSelection?.let {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -218,9 +218,11 @@ internal class PaymentOptionsViewModel @Inject constructor(
         savedStateHandle[SAVE_PROCESSING] = false
     }
 
-    override fun handleSelected(selection: PaymentSelection?) {
-        updateSelection(selection)
-        onUserSelection()
+    override fun handlePaymentMethodSelected(selection: PaymentSelection?) {
+        if (!editing.value) {
+            updateSelection(selection)
+            onUserSelection()
+        }
     }
 
     override fun updateSelection(selection: PaymentSelection?) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -218,6 +218,11 @@ internal class PaymentOptionsViewModel @Inject constructor(
         savedStateHandle[SAVE_PROCESSING] = false
     }
 
+    override fun handleSelected(selection: PaymentSelection?) {
+        updateSelection(selection)
+        onUserSelection()
+    }
+
     override fun updateSelection(selection: PaymentSelection?) {
         super.updateSelection(selection)
         when {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetListFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetListFragment.kt
@@ -2,9 +2,7 @@ package com.stripe.android.paymentsheet
 
 import androidx.fragment.app.activityViewModels
 
-internal class PaymentSheetListFragment : BasePaymentMethodsListFragment(
-    canClickSelectedItem = false
-) {
+internal class PaymentSheetListFragment : BasePaymentMethodsListFragment() {
     private val activityViewModel by activityViewModels<PaymentSheetViewModel> {
         PaymentSheetViewModel.Factory {
             requireNotNull(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -365,8 +365,8 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         )
     }
 
-    override fun handleSelected(selection: PaymentSelection?) {
-        if (selection != this.selection.value) {
+    override fun handlePaymentMethodSelected(selection: PaymentSelection?) {
+        if (!editing.value && selection != this.selection.value) {
             updateSelection(selection)
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -365,6 +365,12 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         )
     }
 
+    override fun handleSelected(selection: PaymentSelection?) {
+        if (selection != this.selection.value) {
+            updateSelection(selection)
+        }
+    }
+
     override fun updateSelection(selection: PaymentSelection?) {
         super.updateSelection(selection)
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -436,7 +436,7 @@ internal abstract class BaseSheetViewModel(
         _notesText.value = text
     }
 
-    abstract fun handleSelected(selection: PaymentSelection?)
+    abstract fun handlePaymentMethodSelected(selection: PaymentSelection?)
 
     open fun updateSelection(selection: PaymentSelection?) {
         if (selection is PaymentSelection.New) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -234,6 +234,12 @@ internal abstract class BaseSheetViewModel(
             isLinkEnabled = linkHandler.isLinkEnabled,
             initialSelection = savedSelection,
             isNotPaymentFlow = this is PaymentOptionsViewModel,
+            nameProvider = { code ->
+                val paymentMethod = lpmResourceRepository.getRepository().fromCode(code)
+                paymentMethod?.displayNameResource?.let {
+                    application.getString(it)
+                }.orEmpty()
+            }
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -163,7 +163,8 @@ internal abstract class BaseSheetViewModel(
     internal val selection: StateFlow<PaymentSelection?> = savedStateHandle
         .getStateFlow<PaymentSelection?>(SAVE_SELECTION, null)
 
-    internal val editing = MutableStateFlow(false)
+    private val _editing = MutableStateFlow(false)
+    internal val editing: StateFlow<Boolean> = _editing
 
     val processing: StateFlow<Boolean> = savedStateHandle
         .getStateFlow(SAVE_PROCESSING, false)
@@ -255,7 +256,7 @@ internal abstract class BaseSheetViewModel(
         viewModelScope.launch {
             paymentMethods.onEach { paymentMethods ->
                 if (paymentMethods.isNullOrEmpty() && editing.value) {
-                    setEditing(false)
+                    toggleEditing()
                 }
             }.collect()
         }
@@ -454,12 +455,8 @@ internal abstract class BaseSheetViewModel(
         updateBelowButtonText(null)
     }
 
-    fun setEditing(isEditing: Boolean) {
-        editing.value = isEditing
-    }
-
     fun toggleEditing() {
-        editing.value = !editing.value
+        _editing.value = !editing.value
     }
 
     fun setContentVisible(visible: Boolean) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsStateMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsStateMapper.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.viewmodels
 
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.PaymentOptionsState
 import com.stripe.android.paymentsheet.PaymentOptionsStateFactory
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -16,6 +17,7 @@ internal class PaymentOptionsStateMapper(
     private val isLinkEnabled: StateFlow<Boolean?>,
     private val initialSelection: StateFlow<SavedSelection?>,
     private val currentSelection: StateFlow<PaymentSelection?>,
+    private val nameProvider: (PaymentMethodCode?) -> String,
     private val isNotPaymentFlow: Boolean,
 ) {
 
@@ -52,6 +54,7 @@ internal class PaymentOptionsStateMapper(
             showLink = isLinkEnabled && isNotPaymentFlow,
             initialSelection = initialSelection,
             currentSelection = currentSelection,
+            nameProvider = nameProvider,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
@@ -17,6 +17,7 @@ class PaymentOptionsStateFactoryTest {
             showLink = true,
             initialSelection = SavedSelection.None,
             currentSelection = null,
+            nameProvider = { it!! },
         )
         assertThat(state.selectedItem).isEqualTo(PaymentOptionsItem.GooglePay)
     }
@@ -30,6 +31,7 @@ class PaymentOptionsStateFactoryTest {
             showLink = true,
             initialSelection = SavedSelection.None,
             currentSelection = null,
+            nameProvider = { it!! },
         )
         assertThat(state.selectedItem).isEqualTo(PaymentOptionsItem.Link)
     }
@@ -43,9 +45,13 @@ class PaymentOptionsStateFactoryTest {
             showLink = false,
             initialSelection = SavedSelection.None,
             currentSelection = null,
+            nameProvider = { it!! },
         )
 
-        val expectedItem = PaymentOptionsItem.SavedPaymentMethod(paymentMethods.first())
+        val expectedItem = PaymentOptionsItem.SavedPaymentMethod(
+            displayName = "card",
+            paymentMethod = paymentMethods.first(),
+        )
         assertThat(state.selectedItem).isEqualTo(expectedItem)
     }
 
@@ -60,9 +66,13 @@ class PaymentOptionsStateFactoryTest {
             showLink = false,
             initialSelection = savedPaymentMethod,
             currentSelection = null,
+            nameProvider = { it!! },
         )
 
-        val expectedItem = PaymentOptionsItem.SavedPaymentMethod(paymentMethods[1])
+        val expectedItem = PaymentOptionsItem.SavedPaymentMethod(
+            displayName = "card",
+            paymentMethod = paymentMethods[1],
+        )
         assertThat(state.selectedItem).isEqualTo(expectedItem)
     }
 
@@ -76,6 +86,7 @@ class PaymentOptionsStateFactoryTest {
             showLink = true,
             initialSelection = SavedSelection.GooglePay,
             currentSelection = PaymentSelection.Link,
+            nameProvider = { it!! },
         )
 
         assertThat(state.selectedItem).isEqualTo(PaymentOptionsItem.Link)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -385,12 +385,12 @@ internal class PaymentOptionsViewModelTest {
             updateSelection(PaymentSelection.Link)
         }
 
-        viewModel.setEditing(true)
+        viewModel.toggleEditing()
         viewModel.handlePaymentMethodSelected(PaymentSelection.GooglePay)
 
         assertThat(viewModel.selection.value).isEqualTo(PaymentSelection.Link)
 
-        viewModel.setEditing(false)
+        viewModel.toggleEditing()
         viewModel.handlePaymentMethodSelected(PaymentSelection.GooglePay)
         assertThat(viewModel.selection.value).isEqualTo(PaymentSelection.GooglePay)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -379,6 +379,22 @@ internal class PaymentOptionsViewModelTest {
         }
     }
 
+    @Test
+    fun `Ignores payment selection while in edit mode`() = runTest {
+        val viewModel = createViewModel().apply {
+            updateSelection(PaymentSelection.Link)
+        }
+
+        viewModel.setEditing(true)
+        viewModel.handlePaymentMethodSelected(PaymentSelection.GooglePay)
+
+        assertThat(viewModel.selection.value).isEqualTo(PaymentSelection.Link)
+
+        viewModel.setEditing(false)
+        viewModel.handlePaymentMethodSelected(PaymentSelection.GooglePay)
+        assertThat(viewModel.selection.value).isEqualTo(PaymentSelection.GooglePay)
+    }
+
     private fun createViewModel(
         args: PaymentOptionContract.Args = PAYMENT_OPTION_CONTRACT_ARGS,
         linkState: LinkState? = args.state.linkState,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -192,7 +192,7 @@ internal class PaymentSheetActivityTest {
             assertThat(activity.viewBinding.buyButton.isEnabled)
                 .isTrue()
 
-            viewModel.setEditing(true)
+            viewModel.toggleEditing()
 
             assertThat(activity.viewBinding.buyButton.isEnabled)
                 .isFalse()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
@@ -137,7 +137,10 @@ internal class PaymentSheetListFragmentTest : BasePaymentSheetViewModelInjection
     @Test
     fun `updates selection on click`() {
         val savedPaymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
-        val selectedItem = PaymentOptionsItem.SavedPaymentMethod(savedPaymentMethod)
+        val selectedItem = PaymentOptionsItem.SavedPaymentMethod(
+            displayName = "Card",
+            paymentMethod = savedPaymentMethod,
+        )
 
         createScenario().onFragment {
             val activityViewModel = activityViewModel(it)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
@@ -79,34 +79,6 @@ internal class PaymentSheetListFragmentTest : BasePaymentSheetViewModelInjection
     }
 
     @Test
-    fun `recovers edit state when shown`() {
-        val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
-
-        createScenario(
-            initialState = Lifecycle.State.INITIALIZED
-        ).moveToState(Lifecycle.State.CREATED).onFragment { fragment ->
-            fragment.initializePaymentOptions(paymentMethods = listOf(paymentMethod))
-        }.moveToState(Lifecycle.State.STARTED).onFragment { fragment ->
-            assertThat(fragment.isEditing).isFalse()
-            fragment.isEditing = true
-        }.recreate().onFragment {
-            assertThat(it.isEditing).isTrue()
-        }
-    }
-
-    @Test
-    fun `When last item is deleted then edit menu item is hidden`() {
-        val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
-
-        createScenario().onFragment { fragment ->
-            fragment.isEditing = true
-            fragment.adapter.items = fragment.adapter.items.dropLast(1)
-            fragment.deletePaymentMethod(PaymentOptionsItem.SavedPaymentMethod(paymentMethod))
-            assertThat(fragment.isEditing).isFalse()
-        }
-    }
-
-    @Test
     fun `sets up adapter`() {
         createScenario(
             initialState = Lifecycle.State.INITIALIZED

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -691,8 +691,6 @@ internal class PaymentSheetViewModelTest {
 
         viewModel.savedStateHandle[SAVE_PROCESSING] = false
         viewModel.updateSelection(PaymentSelection.GooglePay)
-        viewModel.setEditing(false)
-
         assertThat(isEnabled).isTrue()
 
         viewModel.updateSelection(null)
@@ -713,10 +711,10 @@ internal class PaymentSheetViewModelTest {
         viewModel.savedStateHandle[SAVE_PROCESSING] = false
         assertThat(isEnabled).isTrue()
 
-        viewModel.setEditing(true)
+        viewModel.toggleEditing()
         assertThat(isEnabled).isFalse()
 
-        viewModel.setEditing(false)
+        viewModel.toggleEditing()
         assertThat(isEnabled).isTrue()
     }
 
@@ -1102,7 +1100,7 @@ internal class PaymentSheetViewModelTest {
         viewModel.editing.test {
             assertThat(awaitItem()).isFalse()
 
-            viewModel.setEditing(true)
+            viewModel.toggleEditing()
             assertThat(awaitItem()).isTrue()
 
             viewModel.removePaymentMethod(customerPaymentMethods.single())
@@ -1116,12 +1114,12 @@ internal class PaymentSheetViewModelTest {
             updateSelection(PaymentSelection.Link)
         }
 
-        viewModel.setEditing(true)
+        viewModel.toggleEditing()
         viewModel.handlePaymentMethodSelected(PaymentSelection.GooglePay)
 
         assertThat(viewModel.selection.value).isEqualTo(PaymentSelection.Link)
 
-        viewModel.setEditing(false)
+        viewModel.toggleEditing()
         viewModel.handlePaymentMethodSelected(PaymentSelection.GooglePay)
         assertThat(viewModel.selection.value).isEqualTo(PaymentSelection.GooglePay)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1110,6 +1110,22 @@ internal class PaymentSheetViewModelTest {
         }
     }
 
+    @Test
+    fun `Ignores payment selection while in edit mode`() = runTest {
+        val viewModel = createViewModel().apply {
+            updateSelection(PaymentSelection.Link)
+        }
+
+        viewModel.setEditing(true)
+        viewModel.handlePaymentMethodSelected(PaymentSelection.GooglePay)
+
+        assertThat(viewModel.selection.value).isEqualTo(PaymentSelection.Link)
+
+        viewModel.setEditing(false)
+        viewModel.handlePaymentMethodSelected(PaymentSelection.GooglePay)
+        assertThat(viewModel.selection.value).isEqualTo(PaymentSelection.GooglePay)
+    }
+
     private class NonLoadingLpmRepository(
         val lpmRepository: LpmRepository
     ) : ResourceRepository<LpmRepository> {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1093,6 +1093,23 @@ internal class PaymentSheetViewModelTest {
         }
     }
 
+    @Test
+    fun `Sets editing to false when removing the last payment method while editing`() = runTest {
+        val customerPaymentMethods = PaymentMethodFixtures.createCards(1)
+        val viewModel = createViewModel(customerPaymentMethods = customerPaymentMethods)
+        viewModel.savedStateHandle[SAVE_GOOGLE_PAY_STATE] = GooglePayState.Available
+
+        viewModel.editing.test {
+            assertThat(awaitItem()).isFalse()
+
+            viewModel.setEditing(true)
+            assertThat(awaitItem()).isTrue()
+
+            viewModel.removePaymentMethod(customerPaymentMethods.single())
+            assertThat(awaitItem()).isFalse()
+        }
+    }
+
     private class NonLoadingLpmRepository(
         val lpmRepository: LpmRepository
     ) : ResourceRepository<LpmRepository> {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsStateMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsStateMapperTest.kt
@@ -34,6 +34,7 @@ class PaymentOptionsStateMapperTest {
             googlePayState = googlePayStateFlow,
             isLinkEnabled = isLinkEnabledFlow,
             isNotPaymentFlow = true,
+            nameProvider = { it!! },
         )
 
         mapper().test {
@@ -62,6 +63,7 @@ class PaymentOptionsStateMapperTest {
             googlePayState = googlePayStateFlow,
             isLinkEnabled = isLinkEnabledFlow,
             isNotPaymentFlow = false,
+            nameProvider = { it!! },
         )
 
         mapper().test {
@@ -87,6 +89,7 @@ class PaymentOptionsStateMapperTest {
             googlePayState = googlePayStateFlow,
             isLinkEnabled = isLinkEnabledFlow,
             isNotPaymentFlow = true,
+            nameProvider = { it!! },
         )
 
         mapper().test {
@@ -99,7 +102,10 @@ class PaymentOptionsStateMapperTest {
             isLinkEnabledFlow.value = true
 
             assertThat(expectMostRecentItem()?.selectedItem).isEqualTo(
-                PaymentOptionsItem.SavedPaymentMethod(selectedPaymentMethod.paymentMethod)
+                PaymentOptionsItem.SavedPaymentMethod(
+                    displayName = "card",
+                    paymentMethod = selectedPaymentMethod.paymentMethod,
+                )
             )
 
             // Remove the currently selected payment option
@@ -119,6 +125,7 @@ class PaymentOptionsStateMapperTest {
             googlePayState = googlePayStateFlow,
             isLinkEnabled = isLinkEnabledFlow,
             isNotPaymentFlow = true,
+            nameProvider = { it!! },
         )
 
         mapper().test {
@@ -131,7 +138,10 @@ class PaymentOptionsStateMapperTest {
             isLinkEnabledFlow.value = true
 
             assertThat(expectMostRecentItem()?.selectedItem).isEqualTo(
-                PaymentOptionsItem.SavedPaymentMethod(selectedPaymentMethod.paymentMethod)
+                PaymentOptionsItem.SavedPaymentMethod(
+                    displayName = "card",
+                    paymentMethod = selectedPaymentMethod.paymentMethod,
+                )
             )
 
             // Remove the currently selected payment option


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request prepares `PaymentOptionsAdapter` for its removal. Concretely, it does the following:
1. Add payment method click handling entirely to the view models and add tests.
2. Only use observable flows to determine the edit menu’s state. (There’s still a single one-off call to `setHasOptionsMenu()`, but that will be removed during the remaining migration.)
3. Avoid passing the entire `LpmRepository` and only pass a closure for providing the payment method name instead.
4. Make other things (such as the layout manager) more easily rip-out-able.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Compose migration.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
N/A

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A
