### PR TITLE
Fix issue where SFU checkbox would incorrectly show during Link inline payment

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -145,9 +145,10 @@ private fun BaseSheetViewModel.showLinkInlineSignupView(
     linkAccountStatus: AccountStatus?
 ): Boolean {
     val validStatusStates = setOf(
+        AccountStatus.Verified,
         AccountStatus.NeedsVerification,
         AccountStatus.VerificationStarted,
-        AccountStatus.SignedOut
+        AccountStatus.SignedOut,
     )
     val linkInlineSelectionValid = linkHandler.linkInlineSelection.value != null
     return linkHandler.isLinkEnabled.value && stripeIntent.value


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes a UI glitch when paying inline with Link.

While the payment was processing, we would briefly display the normal `Save for future usage` checkbox. Now, we keep the Link sign-up card on screen.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

A polished UI 💅

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

### After

https://user-images.githubusercontent.com/110940675/212950866-d351795a-79fd-4e4d-8493-e0b527f881dc.mp4

### After

https://user-images.githubusercontent.com/110940675/212950885-b29a4714-3fa4-4d6d-8fe7-d0be11540387.mp4

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
