### PR TITLE
Navigate to `Add Payment Method` if last customer payment method is removed

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -468,6 +468,13 @@ internal abstract class BaseSheetViewModel(
                 )
             }
 
+            val shouldResetToAddPaymentMethodForm = paymentMethods.value.isNullOrEmpty() &&
+                currentScreen.value is PaymentSheetScreen.SelectSavedPaymentMethods
+
+            if (shouldResetToAddPaymentMethodForm) {
+                backStack.value = listOf(AddFirstPaymentMethod)
+            }
+
             val hasNoBankAccounts = paymentMethods.value.orEmpty().all { it.type != USBankAccount }
             if (hasNoBankAccounts) {
                 updatePrimaryButtonUIState(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1136,6 +1136,22 @@ internal class PaymentSheetViewModelTest {
         }
     }
 
+    @Test
+    fun `Resets the backstack if the last customer payment method is removed`() = runTest {
+        val paymentMethods = PaymentMethodFixtures.createCards(1)
+        val viewModel = createViewModel(customerPaymentMethods = paymentMethods)
+
+        viewModel.currentScreen.test {
+            assertThat(awaitItem()).isEqualTo(Loading)
+
+            viewModel.transitionToFirstScreen()
+            assertThat(awaitItem()).isEqualTo(SelectSavedPaymentMethods)
+
+            viewModel.removePaymentMethod(paymentMethods.single())
+            assertThat(awaitItem()).isEqualTo(AddFirstPaymentMethod)
+        }
+    }
+
     private fun createViewModel(
         args: PaymentSheetContract.Args = ARGS_CUSTOMER_WITH_GOOGLEPAY,
         stripeIntent: StripeIntent = PAYMENT_INTENT,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes a UX issue where removing the last payment method would leave the user in an empty payment methods screen. Now, we instead replace the back stack and send the user to the add payment method form.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
N/A

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A
