### PR TITLE
Remove need for `isReadyEvents`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -90,10 +90,6 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
             }
         }
 
-        if (savedInstanceState == null) {
-            viewModel.transitionToFirstScreenWhenReady()
-        }
-
         viewModel.selection.launchAndCollectIn(this) {
             viewModel.clearErrorMessages()
             resetPrimaryButtonState()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -5,7 +5,6 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.asFlow
 import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
@@ -39,8 +38,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Provider
@@ -110,6 +107,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
             setStripeIntent(args.state.stripeIntent)
         }
         savedStateHandle[SAVE_PAYMENT_METHODS] = args.state.customerPaymentMethods
+        savedStateHandle[SAVE_SAVED_SELECTION] = args.state.savedSelection
         savedStateHandle[SAVE_PROCESSING] = false
 
         // If we are not recovering from don't keep activities than the resources
@@ -119,6 +117,8 @@ internal class PaymentOptionsViewModel @Inject constructor(
             lpmServerSpec =
                 lpmResourceRepository.getRepository().serverSpecLoadingState.serverLpmSpecs
         }
+
+        transitionToFirstScreenWhenReady()
     }
 
     override val shouldCompleteLinkFlowInline: Boolean = false
@@ -295,22 +295,6 @@ internal class PaymentOptionsViewModel @Inject constructor(
                 paymentMethods = paymentMethods.value
             )
         )
-    }
-
-    fun transitionToFirstScreenWhenReady() {
-        viewModelScope.launch {
-            awaitReady()
-            awaitRepositoriesReady()
-            transitionToFirstScreen()
-        }
-    }
-
-    private suspend fun awaitReady() {
-        isReadyEvents.asFlow().filter { it.peekContent() }.first()
-    }
-
-    private suspend fun awaitRepositoriesReady() {
-        isResourceRepositoryReady.filter { it }.first()
     }
 
     override fun transitionToFirstScreen() {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -123,10 +123,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
             }
         }
 
-        if (savedInstanceState == null) {
-            viewModel.transitionToFirstScreenWhenReady()
-        }
-
         viewModel.processing.filter { it }.launchAndCollectIn(this) {
             window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN)
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -12,7 +12,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.pressBack
-import app.cash.turbine.test
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
@@ -35,12 +34,7 @@ import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.forms.PaymentMethodRequirements
 import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddFirstPaymentMethod
-import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.Loading
-import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.SelectSavedPaymentMethods
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
-import com.stripe.android.paymentsheet.state.LinkState
-import com.stripe.android.paymentsheet.state.LinkState.LoginState.LoggedIn
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.address.AddressRepository
@@ -60,7 +54,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.Rule
 import org.junit.Test
@@ -254,87 +247,6 @@ internal class PaymentOptionsActivityTest {
 
                 activity.finish()
             }
-        }
-    }
-
-    @Test
-    fun `Verify if Google Pay is ready, display the saved payment methods screen`() = runTest {
-        val args = PAYMENT_OPTIONS_CONTRACT_ARGS.updateState(isGooglePayReady = true)
-        val viewModel = createViewModel(args)
-
-        viewModel.currentScreen.test {
-            assertThat(awaitItem()).isEqualTo(Loading)
-            activityScenario(viewModel).launch(createIntent(args))
-            assertThat(awaitItem()).isEqualTo(SelectSavedPaymentMethods)
-        }
-    }
-
-    @Test
-    fun `Verify if Link is available, display the saved payment methods screen`() = runTest {
-        val args = PAYMENT_OPTIONS_CONTRACT_ARGS.updateState(
-            linkState = LinkState(configuration = mock(), loginState = LoggedIn),
-            isGooglePayReady = false,
-            paymentMethods = emptyList(),
-        )
-
-        val viewModel = createViewModel(args)
-
-        viewModel.currentScreen.test {
-            assertThat(awaitItem()).isEqualTo(Loading)
-            activityScenario(viewModel).launch(createIntent(args))
-            assertThat(awaitItem()).isEqualTo(SelectSavedPaymentMethods)
-        }
-    }
-
-    @Test
-    fun `Verify if customer has payment methods, display the saved payment methods screen`() = runTest {
-        val args = PAYMENT_OPTIONS_CONTRACT_ARGS.updateState(
-            isGooglePayReady = false,
-            paymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
-        )
-
-        val viewModel = createViewModel(args)
-
-        viewModel.currentScreen.test {
-            assertThat(awaitItem()).isEqualTo(Loading)
-            activityScenario(viewModel).launch(createIntent(args))
-            assertThat(awaitItem()).isEqualTo(SelectSavedPaymentMethods)
-        }
-    }
-
-    @Test
-    fun `Verify if there are no payment methods, display the add payment method screen`() = runTest {
-        val args = PAYMENT_OPTIONS_CONTRACT_ARGS.updateState(
-            isGooglePayReady = false,
-            paymentMethods = emptyList(),
-        )
-
-        val viewModel = createViewModel(args)
-
-        viewModel.currentScreen.test {
-            assertThat(awaitItem()).isEqualTo(Loading)
-            activityScenario(viewModel).launch(createIntent(args))
-            assertThat(awaitItem()).isEqualTo(AddFirstPaymentMethod)
-        }
-    }
-
-    @Test
-    fun `Verify doesn't transition to first screen again on activity recreation`() = runTest {
-        val args = PAYMENT_OPTIONS_CONTRACT_ARGS.updateState(
-            paymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
-        )
-
-        val viewModel = createViewModel(args)
-        val scenario = activityScenario(viewModel)
-
-        viewModel.currentScreen.test {
-            assertThat(awaitItem()).isEqualTo(Loading)
-
-            scenario.launch(createIntent(args))
-            assertThat(awaitItem()).isEqualTo(SelectSavedPaymentMethods)
-
-            scenario.recreate()
-            expectNoEvents()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -47,8 +47,6 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
 import com.stripe.android.paymentsheet.model.StripeIntentValidator
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddAnotherPaymentMethod
-import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddFirstPaymentMethod
-import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.Loading
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.SelectSavedPaymentMethods
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.repositories.StripeIntentRepository
@@ -428,8 +426,6 @@ internal class PaymentSheetActivityTest {
         val scenario = activityScenario(viewModel)
 
         viewModel.currentScreen.test {
-            assertThat(awaitItem()).isEqualTo(Loading)
-
             scenario.launch(intent)
             assertThat(awaitItem()).isEqualTo(SelectSavedPaymentMethods)
 
@@ -667,18 +663,6 @@ internal class PaymentSheetActivityTest {
 
             assertThat(activity.bottomSheetBehavior.state)
                 .isEqualTo(BottomSheetBehavior.STATE_HIDDEN)
-        }
-    }
-
-    @Test
-    fun `shows add card screen when no saved payment methods available`() = runTest {
-        val viewModel = createViewModel(paymentMethods = emptyList())
-        val scenario = activityScenario(viewModel)
-
-        viewModel.currentScreen.test {
-            assertThat(awaitItem()).isEqualTo(Loading)
-            scenario.launchForResult(intent)
-            assertThat(awaitItem()).isEqualTo(AddFirstPaymentMethod)
         }
     }
 
@@ -1033,44 +1017,6 @@ internal class PaymentSheetActivityTest {
 
         assertThat(scenario.state).isEqualTo(Lifecycle.State.DESTROYED)
         assertThat(result).isInstanceOf(PaymentSheetResult.Failed::class.java)
-    }
-
-    @Test
-    fun `Verify if customer has payment methods, display the saved payment methods screen`() = runTest {
-        val viewModel = createViewModel(paymentMethods = PAYMENT_METHODS)
-
-        viewModel.currentScreen.test {
-            assertThat(awaitItem()).isEqualTo(Loading)
-            activityScenario(viewModel).launch(intent)
-            assertThat(awaitItem()).isEqualTo(SelectSavedPaymentMethods)
-        }
-    }
-
-    @Test
-    fun `Verify if there are no payment methods, display the add payment method screen`() = runTest {
-        val viewModel = createViewModel(paymentMethods = emptyList())
-
-        viewModel.currentScreen.test {
-            assertThat(awaitItem()).isEqualTo(Loading)
-            activityScenario(viewModel).launch(intent)
-            assertThat(awaitItem()).isEqualTo(AddFirstPaymentMethod)
-        }
-    }
-
-    @Test
-    fun `Verify doesn't transition to first screen again on activity recreation`() = runTest {
-        val viewModel = createViewModel(paymentMethods = emptyList())
-        val scenario = activityScenario(viewModel)
-
-        viewModel.currentScreen.test {
-            assertThat(awaitItem()).isEqualTo(Loading)
-
-            scenario.launch(intent)
-            assertThat(awaitItem()).isEqualTo(AddFirstPaymentMethod)
-
-            scenario.recreate()
-            expectNoEvents()
-        }
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetListFragmentTest.kt
@@ -24,7 +24,7 @@ import com.stripe.android.paymentsheet.PaymentSheetViewModelInjectionTest.Compan
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddAnotherPaymentMethod
-import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.Loading
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.SelectSavedPaymentMethods
 import com.stripe.android.paymentsheet.state.GooglePayState
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.Companion.SAVE_GOOGLE_PAY_STATE
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.Companion.SAVE_PAYMENT_METHODS
@@ -163,7 +163,7 @@ internal class PaymentSheetListFragmentTest : BasePaymentSheetViewModelInjection
         val recyclerView = scenario.withFragment { recyclerView(this) }
 
         viewModel.currentScreen.test {
-            assertThat(awaitItem()).isEqualTo(Loading)
+            assertThat(awaitItem()).isEqualTo(SelectSavedPaymentMethods)
 
             val adapter = recyclerView.adapter as PaymentOptionsAdapter
             adapter.addCardClickListener()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request removes the `isReadyEvents` property in the view model. It wasn’t needed in the `PaymentOptionsViewModel`, and with the introduction of `PaymentSheetLoader`, we can also get rid of it in `PaymentSheetViewModel`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
N/A

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A
