### PR TITLE
Replace `showTopContainer` with `WalletsContainerState` and use `StateFlow`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -193,14 +193,14 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
     private fun setupTopContainer() {
         setupGooglePayButton()
 
-        viewModel.topContainerState.launchAndCollectIn(this) { config ->
+        viewModel.walletsContainerState.launchAndCollectIn(this) { config ->
             linkButton.isVisible = config.showLink
             googlePayButton.isVisible = config.showGooglePay
             topContainer.isVisible = config.shouldShow
         }
 
         googlePayDivider.setContent {
-            val topContainerState by viewModel.topContainerState.collectAsState()
+            val topContainerState by viewModel.walletsContainerState.collectAsState()
 
             StripeTheme {
                 if (topContainerState.shouldShow) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -14,7 +14,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.stringResource
 import androidx.core.view.doOnNextLayout
 import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModelProvider
@@ -24,12 +24,10 @@ import com.google.android.material.appbar.MaterialToolbar
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContract
 import com.stripe.android.paymentsheet.databinding.ActivityPaymentSheetBinding
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
-import com.stripe.android.paymentsheet.state.GooglePayState
 import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.GooglePayDividerUi
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.utils.launchAndCollectIn
-import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.uicore.StripeTheme
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
@@ -194,34 +192,20 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
 
     private fun setupTopContainer() {
         setupGooglePayButton()
-        val dividerText = resources.getString(
-            if (viewModel.supportedPaymentMethods.size == 1 &&
-                viewModel.supportedPaymentMethods.map { it.code }.contains(
-                        LpmRepository.HardcodedCard.code
-                    )
-            ) {
-                R.string.stripe_paymentsheet_or_pay_with_card
-            } else {
-                R.string.stripe_paymentsheet_or_pay_using
-            }
-        )
-        viewModel.showTopContainer.observe(this) { visible ->
-            linkButton.isVisible = linkHandler.isLinkEnabled.value == true
-            googlePayButton.isVisible =
-                viewModel.googlePayState.value == GooglePayState.Available
-            topContainer.isVisible = visible
-            // We have to set the UI after we know it's visible. Setting UI on a GONE or INVISIBLE
-            // view will cause tests to hang indefinitely.
-            if (visible) {
-                googlePayDivider.apply {
-                    setViewCompositionStrategy(
-                        ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
-                    )
-                    setContent {
-                        StripeTheme {
-                            GooglePayDividerUi(dividerText)
-                        }
-                    }
+
+        viewModel.topContainerState.launchAndCollectIn(this) { config ->
+            linkButton.isVisible = config.showLink
+            googlePayButton.isVisible = config.showGooglePay
+            topContainer.isVisible = config.shouldShow
+        }
+
+        googlePayDivider.setContent {
+            val topContainerState by viewModel.topContainerState.collectAsState()
+
+            StripeTheme {
+                if (topContainerState.shouldShow) {
+                    val text = stringResource(topContainerState.dividerTextResource)
+                    GooglePayDividerUi(text)
                 }
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -24,6 +24,7 @@ import com.google.android.material.appbar.MaterialToolbar
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContract
 import com.stripe.android.paymentsheet.databinding.ActivityPaymentSheetBinding
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
+import com.stripe.android.paymentsheet.state.WalletsContainerState
 import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.GooglePayDividerUi
 import com.stripe.android.paymentsheet.ui.PrimaryButton
@@ -200,11 +201,13 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
         }
 
         googlePayDivider.setContent {
-            val topContainerState by viewModel.walletsContainerState.collectAsState()
+            val containerState by viewModel.walletsContainerState.collectAsState(
+                initial = WalletsContainerState(),
+            )
 
             StripeTheme {
-                if (topContainerState.shouldShow) {
-                    val text = stringResource(topContainerState.dividerTextResource)
+                if (containerState.shouldShow) {
+                    val text = stringResource(containerState.dividerTextResource)
                     GooglePayDividerUi(text)
                 }
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -55,7 +55,7 @@ import com.stripe.android.paymentsheet.repositories.StripeIntentRepository
 import com.stripe.android.paymentsheet.state.GooglePayState
 import com.stripe.android.paymentsheet.state.PaymentSheetLoader
 import com.stripe.android.paymentsheet.state.PaymentSheetState
-import com.stripe.android.paymentsheet.state.TopContainerState
+import com.stripe.android.paymentsheet.state.WalletsContainerState
 import com.stripe.android.paymentsheet.ui.HeaderTextFactory
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
@@ -168,13 +168,13 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             }
         }
 
-    internal val topContainerState: StateFlow<TopContainerState> = combine(
+    internal val walletsContainerState: StateFlow<WalletsContainerState> = combine(
         linkHandler.isLinkEnabled,
         googlePayState,
         isReadyEvents.asFlow(),
         supportedPaymentMethodsFlow,
     ) { isLinkAvailable, googlePayState, isReady, paymentMethodTypes ->
-        TopContainerState(
+        WalletsContainerState(
             showLink = isLinkAvailable == true && isReady.peekContent() == true,
             showGooglePay = googlePayState.isReadyForUse && isReady.peekContent() == true,
             dividerTextResource = if (paymentMethodTypes.singleOrNull() == Card.code) {
@@ -186,7 +186,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(),
-        initialValue = TopContainerState(),
+        initialValue = WalletsContainerState(),
     )
 
     private var paymentLauncher: StripePaymentLauncher? = null

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -5,12 +5,10 @@ import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.IntegerRes
 import androidx.annotation.VisibleForTesting
-import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.asFlow
-import androidx.lifecycle.asLiveData
 import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
@@ -32,6 +30,7 @@ import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethod.Type.Card
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
 import com.stripe.android.payments.paymentlauncher.PaymentResult
@@ -56,6 +55,7 @@ import com.stripe.android.paymentsheet.repositories.StripeIntentRepository
 import com.stripe.android.paymentsheet.state.GooglePayState
 import com.stripe.android.paymentsheet.state.PaymentSheetLoader
 import com.stripe.android.paymentsheet.state.PaymentSheetState
+import com.stripe.android.paymentsheet.state.TopContainerState
 import com.stripe.android.paymentsheet.ui.HeaderTextFactory
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
@@ -69,8 +69,12 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -164,21 +168,26 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             }
         }
 
-    // Whether the top container, containing Google Pay and Link buttons, should be visible
-    internal val showTopContainer = MediatorLiveData<Boolean>().apply {
-        listOf(
-            linkHandler.isLinkEnabled.asLiveData(),
-            googlePayState.asLiveData(),
-            isReadyEvents
-        ).forEach {
-            addSource(it) {
-                value = (
-                    linkHandler.isLinkEnabled.value == true ||
-                        googlePayState.value == GooglePayState.Available
-                    ) && isReadyEvents.value?.peekContent() == true
-            }
-        }
-    }
+    internal val topContainerState: StateFlow<TopContainerState> = combine(
+        linkHandler.isLinkEnabled,
+        googlePayState,
+        isReadyEvents.asFlow(),
+        supportedPaymentMethodsFlow,
+    ) { isLinkAvailable, googlePayState, isReady, paymentMethodTypes ->
+        TopContainerState(
+            showLink = isLinkAvailable == true && isReady.peekContent() == true,
+            showGooglePay = googlePayState.isReadyForUse && isReady.peekContent() == true,
+            dividerTextResource = if (paymentMethodTypes.singleOrNull() == Card.code) {
+                R.string.stripe_paymentsheet_or_pay_with_card
+            } else {
+                R.string.stripe_paymentsheet_or_pay_using
+            },
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(),
+        initialValue = TopContainerState(),
+    )
 
     private var paymentLauncher: StripePaymentLauncher? = null
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -69,12 +69,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
@@ -168,7 +165,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             }
         }
 
-    internal val walletsContainerState: StateFlow<WalletsContainerState> = combine(
+    internal val walletsContainerState: Flow<WalletsContainerState> = combine(
         linkHandler.isLinkEnabled,
         googlePayState,
         isReadyEvents.asFlow(),
@@ -183,11 +180,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                 R.string.stripe_paymentsheet_or_pay_using
             },
         )
-    }.stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(),
-        initialValue = WalletsContainerState(),
-    )
+    }
 
     private var paymentLauncher: StripePaymentLauncher? = null
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/TopContainerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/TopContainerState.kt
@@ -1,0 +1,13 @@
+package com.stripe.android.paymentsheet.state
+
+import androidx.annotation.StringRes
+import com.stripe.android.paymentsheet.R
+
+internal data class TopContainerState(
+    val showLink: Boolean = false,
+    val showGooglePay: Boolean = false,
+    @StringRes val dividerTextResource: Int = R.string.stripe_paymentsheet_or_pay_using,
+) {
+    val shouldShow: Boolean
+        get() = showLink || showGooglePay
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/WalletsContainerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/WalletsContainerState.kt
@@ -3,7 +3,7 @@ package com.stripe.android.paymentsheet.state
 import androidx.annotation.StringRes
 import com.stripe.android.paymentsheet.R
 
-internal data class TopContainerState(
+internal data class WalletsContainerState(
     val showLink: Boolean = false,
     val showGooglePay: Boolean = false,
     @StringRes val dividerTextResource: Int = R.string.stripe_paymentsheet_or_pay_using,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -117,6 +117,9 @@ internal abstract class BaseSheetViewModel(
         } ?: emptyList()
         set(value) = savedStateHandle.set(SAVE_SUPPORTED_PAYMENT_METHOD, value.map { it.code })
 
+    protected val supportedPaymentMethodsFlow: StateFlow<List<PaymentMethodCode>> = savedStateHandle
+        .getStateFlow(SAVE_SUPPORTED_PAYMENT_METHOD, initialValue = emptyList())
+
     /**
      * The list of saved payment methods for the current customer.
      * Value is null until it's loaded, and non-null (could be empty) after that.

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1186,7 +1186,7 @@ internal class PaymentSheetViewModelTest {
             savedStateHandle[SAVE_GOOGLE_PAY_STATE] = GooglePayState.Available
         }
 
-        viewModel.topContainerState.test {
+        viewModel.walletsContainerState.test {
             assertThat(awaitItem().showGooglePay).isTrue()
         }
     }
@@ -1197,7 +1197,7 @@ internal class PaymentSheetViewModelTest {
             savedStateHandle[SAVE_GOOGLE_PAY_STATE] = GooglePayState.NotAvailable
         }
 
-        viewModel.topContainerState.test {
+        viewModel.walletsContainerState.test {
             assertThat(awaitItem().showGooglePay).isFalse()
         }
     }
@@ -1214,7 +1214,7 @@ internal class PaymentSheetViewModelTest {
             savedStateHandle[SAVE_GOOGLE_PAY_STATE] = GooglePayState.NotAvailable
         }
 
-        viewModel.topContainerState.test {
+        viewModel.walletsContainerState.test {
             assertThat(awaitItem().showLink).isTrue()
             expectNoEvents()
         }
@@ -1225,7 +1225,7 @@ internal class PaymentSheetViewModelTest {
         val intent = PAYMENT_INTENT.copy(paymentMethodTypes = listOf("card"))
         val viewModel = createViewModel(stripeIntent = intent)
 
-        viewModel.topContainerState.test {
+        viewModel.walletsContainerState.test {
             assertThat(awaitItem().showLink).isFalse()
         }
     }
@@ -1235,7 +1235,7 @@ internal class PaymentSheetViewModelTest {
         val intent = PAYMENT_INTENT.copy(paymentMethodTypes = listOf("card"))
         val viewModel = createViewModel(stripeIntent = intent)
 
-        viewModel.topContainerState.test {
+        viewModel.walletsContainerState.test {
             val textResource = awaitItem().dividerTextResource
             assertThat(textResource).isEqualTo(R.string.stripe_paymentsheet_or_pay_with_card)
         }
@@ -1253,7 +1253,7 @@ internal class PaymentSheetViewModelTest {
             stripeIntent = intent,
         )
 
-        viewModel.topContainerState.test {
+        viewModel.walletsContainerState.test {
             val textResource = awaitItem().dividerTextResource
             assertThat(textResource).isEqualTo(R.string.stripe_paymentsheet_or_pay_using)
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1180,6 +1180,85 @@ internal class PaymentSheetViewModelTest {
         }
     }
 
+    @Test
+    fun `Shows Google Pay wallet button if Link is available`() = runTest {
+        val viewModel = createViewModel().apply {
+            savedStateHandle[SAVE_GOOGLE_PAY_STATE] = GooglePayState.Available
+        }
+
+        viewModel.topContainerState.test {
+            assertThat(awaitItem().showGooglePay).isTrue()
+        }
+    }
+
+    @Test
+    fun `Hides Google Pay wallet button if Link is not available`() = runTest {
+        val viewModel = createViewModel().apply {
+            savedStateHandle[SAVE_GOOGLE_PAY_STATE] = GooglePayState.NotAvailable
+        }
+
+        viewModel.topContainerState.test {
+            assertThat(awaitItem().showGooglePay).isFalse()
+        }
+    }
+
+    @Test
+    fun `Shows Link wallet button if Link is available`() = runTest {
+        val viewModel = createViewModel(
+            linkState = LinkState(
+                configuration = mock(),
+                loginState = LinkState.LoginState.LoggedOut,
+            )
+        ).apply {
+            // This is to satisfy the isReady requirement
+            savedStateHandle[SAVE_GOOGLE_PAY_STATE] = GooglePayState.NotAvailable
+        }
+
+        viewModel.topContainerState.test {
+            assertThat(awaitItem().showLink).isTrue()
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `Hides Link wallet button if Link is not available`() = runTest {
+        val intent = PAYMENT_INTENT.copy(paymentMethodTypes = listOf("card"))
+        val viewModel = createViewModel(stripeIntent = intent)
+
+        viewModel.topContainerState.test {
+            assertThat(awaitItem().showLink).isFalse()
+        }
+    }
+
+    @Test
+    fun `Shows the correct divider text if intent only supports card`() = runTest {
+        val intent = PAYMENT_INTENT.copy(paymentMethodTypes = listOf("card"))
+        val viewModel = createViewModel(stripeIntent = intent)
+
+        viewModel.topContainerState.test {
+            val textResource = awaitItem().dividerTextResource
+            assertThat(textResource).isEqualTo(R.string.stripe_paymentsheet_or_pay_with_card)
+        }
+    }
+
+    @Test
+    fun `Shows the correct divider text if intent supports multiple payment method types`() = runTest {
+        val intent = PAYMENT_INTENT.copy(paymentMethodTypes = listOf("card", "us_bank_account"))
+        val viewModel = createViewModel(
+            args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
+                config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config?.copy(
+                    allowsDelayedPaymentMethods = true,
+                ),
+            ),
+            stripeIntent = intent,
+        )
+
+        viewModel.topContainerState.test {
+            val textResource = awaitItem().dividerTextResource
+            assertThat(textResource).isEqualTo(R.string.stripe_paymentsheet_or_pay_using)
+        }
+    }
+
     private fun createViewModel(
         args: PaymentSheetContract.Args = ARGS_CUSTOMER_WITH_GOOGLEPAY,
         stripeIntent: StripeIntent = PAYMENT_INTENT,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request replaces `showTopContainer: LiveData<Boolean>` with `topContainerState: StateFlow<TopContainerState>`. The latter contains information on which wallets and which divider text to display.

While I originally only wanted to convert the `LiveData` to a `StateFlow`, I noticed that we’re accessing the view model’s current state in the `observe()` method. Therefore, it seemed logical to me that we should include this information in the object that’s being observed.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

StateFlow migration.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
N/A

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A
