### PR TITLE
Migrate `ctaEnabled` to use `Flow` and rename

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -267,10 +267,12 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
                 resetPrimaryButtonState()
             }
         }
+
         viewModel.primaryButtonState.launchAndCollectIn(this) { state ->
             primaryButton.updateState(state)
         }
-        viewModel.ctaEnabled.observe(this) { isEnabled ->
+
+        viewModel.isPrimaryButtonEnabled.launchAndCollectIn(this) { isEnabled ->
             primaryButton.isEnabled = isEnabled
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -53,6 +53,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
@@ -218,7 +219,7 @@ internal abstract class BaseSheetViewModel(
         } else {
             buttonsEnabled && selection != null
         }
-    }
+    }.distinctUntilChanged()
 
     internal var lpmServerSpec
         get() = savedStateHandle.get<String>(LPM_SERVER_SPEC_STRING)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -56,9 +56,12 @@ import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.utils.TestUtils.viewModelFactoryFor
 import com.stripe.android.utils.injectableActivityScenario
 import com.stripe.android.view.ActivityStarter
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -120,6 +123,7 @@ internal class PaymentOptionsActivityTest {
 
     @AfterTest
     fun cleanup() {
+        Dispatchers.resetMain()
         WeakMapInjectorRegistry.clear()
     }
 
@@ -420,6 +424,8 @@ internal class PaymentOptionsActivityTest {
 
     @Test
     fun `ContinueButton should go back to initial state after updating selection`() {
+        Dispatchers.setMain(testDispatcher)
+
         val scenario = activityScenario()
         scenario.launch(
             createIntent()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -306,6 +306,8 @@ internal class PaymentSheetActivityTest {
 
     @Test
     fun `updates buy button state on add payment`() {
+        Dispatchers.setMain(testDispatcher)
+
         val viewModel = createViewModel(paymentMethods = emptyList())
         val scenario = activityScenario(viewModel)
         scenario.launch(intent).onActivity { activity ->
@@ -861,6 +863,8 @@ internal class PaymentSheetActivityTest {
 
     @Test
     fun `Buy button should go back to initial state after resetPrimaryButton called`() {
+        Dispatchers.setMain(testDispatcher)
+
         val scenario = activityScenario(viewModel)
         scenario.launch(intent).onActivity { activity ->
             viewModel.viewState.value = PaymentSheetViewState.Reset(null)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -681,39 +681,38 @@ internal class PaymentSheetViewModelTest {
     @Test
     fun `buyButton is enabled when primaryButtonEnabled is true, else not processing, not editing, and a selection has been made`() = runTest(testDispatcher) {
         val viewModel = createViewModel()
-        var isEnabled = false
 
-        viewModel.ctaEnabled.observeForever {
-            isEnabled = it
+        viewModel.isPrimaryButtonEnabled.test {
+            assertThat(awaitItem()).isFalse()
+
+            viewModel.savedStateHandle[SAVE_PROCESSING] = false
+            viewModel.updateSelection(PaymentSelection.GooglePay)
+            assertThat(awaitItem()).isTrue()
+
+            viewModel.updateSelection(null)
+            assertThat(awaitItem()).isFalse()
+
+            viewModel.updateSelection(PaymentSelection.GooglePay)
+            assertThat(awaitItem()).isTrue()
+
+            viewModel.updatePrimaryButtonUIState(primaryButtonUIState.copy(enabled = false))
+            assertThat(awaitItem()).isFalse()
+
+            viewModel.updatePrimaryButtonUIState(primaryButtonUIState.copy(enabled = true))
+            assertThat(awaitItem()).isTrue()
+
+            viewModel.savedStateHandle[SAVE_PROCESSING] = true
+            assertThat(awaitItem()).isFalse()
+
+            viewModel.savedStateHandle[SAVE_PROCESSING] = false
+            assertThat(awaitItem()).isTrue()
+
+            viewModel.toggleEditing()
+            assertThat(awaitItem()).isFalse()
+
+            viewModel.toggleEditing()
+            assertThat(awaitItem()).isTrue()
         }
-
-        viewModel.savedStateHandle[SAVE_PROCESSING] = false
-        viewModel.updateSelection(PaymentSelection.GooglePay)
-        assertThat(isEnabled).isTrue()
-
-        viewModel.updateSelection(null)
-        assertThat(isEnabled).isFalse()
-
-        viewModel.updateSelection(PaymentSelection.GooglePay)
-        assertThat(isEnabled).isTrue()
-
-        viewModel.updatePrimaryButtonUIState(primaryButtonUIState.copy(enabled = false))
-        assertThat(isEnabled).isFalse()
-
-        viewModel.updatePrimaryButtonUIState(primaryButtonUIState.copy(enabled = true))
-        assertThat(isEnabled).isTrue()
-
-        viewModel.savedStateHandle[SAVE_PROCESSING] = true
-        assertThat(isEnabled).isFalse()
-
-        viewModel.savedStateHandle[SAVE_PROCESSING] = false
-        assertThat(isEnabled).isTrue()
-
-        viewModel.toggleEditing()
-        assertThat(isEnabled).isFalse()
-
-        viewModel.toggleEditing()
-        assertThat(isEnabled).isTrue()
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request renames `ctaEnabled` to `isPrimaryButtonEnabled` and migrates it from `LiveData` to `Flow`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
N/A

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A
