### PR TITLE
Fix Google Pay event reporting

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -488,14 +488,13 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         setContentVisible(true)
         when (result) {
             is GooglePayPaymentMethodLauncher.Result.Completed -> {
-                savedStateHandle[SAVE_SELECTION] = PaymentSelection.GooglePay
-
-                confirmPaymentSelection(
-                    PaymentSelection.Saved(
-                        paymentMethod = result.paymentMethod,
-                        isGooglePay = true,
-                    )
+                val newPaymentSelection = PaymentSelection.Saved(
+                    paymentMethod = result.paymentMethod,
+                    isGooglePay = true,
                 )
+
+                savedStateHandle[SAVE_SELECTION] = newPaymentSelection
+                confirmPaymentSelection(newPaymentSelection)
             }
             is GooglePayPaymentMethodLauncher.Result.Failed -> {
                 logger.error("Error processing Google Pay payment", result.error)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -488,7 +488,14 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         setContentVisible(true)
         when (result) {
             is GooglePayPaymentMethodLauncher.Result.Completed -> {
-                confirmPaymentSelection(PaymentSelection.Saved(result.paymentMethod))
+                savedStateHandle[SAVE_SELECTION] = PaymentSelection.GooglePay
+
+                confirmPaymentSelection(
+                    PaymentSelection.Saved(
+                        paymentMethod = result.paymentMethod,
+                        isGooglePay = true,
+                    )
+                )
             }
             is GooglePayPaymentMethodLauncher.Result.Failed -> {
                 logger.error("Error processing Google Pay payment", result.error)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -87,10 +87,20 @@ internal class DefaultEventReporter @Inject internal constructor(
         paymentSelection: PaymentSelection?,
         currency: String?
     ) {
+        // Google Pay is treated as a saved payment method after confirmation, so we need to
+        // "reset" to PaymentSelection.GooglePay for accurate reporting
+        val isGooglePay = (paymentSelection as? PaymentSelection.Saved)?.isGooglePay == true
+
+        val realSelection = if (isGooglePay) {
+            PaymentSelection.GooglePay
+        } else {
+            paymentSelection
+        }
+
         fireEvent(
             PaymentSheetEvent.Payment(
                 mode = mode,
-                paymentSelection = paymentSelection,
+                paymentSelection = realSelection,
                 durationMillis = durationMillisFrom(paymentSheetShownMillis),
                 result = PaymentSheetEvent.Payment.Result.Success,
                 currency = currency

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -441,26 +441,20 @@ internal class DefaultFlowController @Inject internal constructor(
     private fun logPaymentResult(paymentResult: PaymentResult?) {
         when (paymentResult) {
             is PaymentResult.Completed -> {
-                if ((viewModel.paymentSelection as? PaymentSelection.Saved)?.isGooglePay == true) {
-                    // Google Pay is treated as a saved PM after confirmation
-                    eventReporter.onPaymentSuccess(
-                        PaymentSelection.GooglePay,
-                        viewModel.state?.stripeIntent?.currency
-                    )
-                } else {
-                    eventReporter.onPaymentSuccess(
-                        viewModel.paymentSelection,
-                        viewModel.state?.stripeIntent?.currency
-                    )
-                }
+                eventReporter.onPaymentSuccess(
+                    paymentSelection = viewModel.paymentSelection,
+                    currency = viewModel.state?.stripeIntent?.currency,
+                )
             }
             is PaymentResult.Failed -> {
                 eventReporter.onPaymentFailure(
-                    viewModel.paymentSelection,
-                    viewModel.state?.stripeIntent?.currency
+                    paymentSelection = viewModel.paymentSelection,
+                    currency = viewModel.state?.stripeIntent?.currency,
                 )
             }
-            else -> {}
+            else -> {
+                // Nothing to do here
+            }
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -118,6 +118,34 @@ class DefaultEventReporterTest {
     }
 
     @Test
+    fun `onPaymentSuccess() for Google Pay payment should fire analytics request with expected event value`() {
+        // Log initial event so that duration is tracked
+        completeEventReporter.onShowExistingPaymentOptions(
+            linkEnabled = false,
+            activeLinkSession = false,
+            currency = "usd",
+        )
+
+        reset(analyticsRequestExecutor)
+        whenever(eventTimeProvider.currentTimeMillis()).thenReturn(2000L)
+
+        completeEventReporter.onPaymentSuccess(
+            paymentSelection = PaymentSelection.Saved(
+                paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+                isGooglePay = true,
+            ),
+            currency = "usd",
+        )
+
+        verify(analyticsRequestExecutor).executeAsync(
+            argWhere { req ->
+                req.params["event"] == "mc_complete_payment_googlepay_success" &&
+                    req.params["duration"] == 1f
+            }
+        )
+    }
+
+    @Test
     fun `onPaymentFailure() should fire analytics request with expected event value`() {
         // Log initial event so that duration is tracked
         completeEventReporter.onShowExistingPaymentOptions(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes event reporting for completed Google Pay payments.

After receiving `GooglePayPaymentMethodLauncher.Result.Completed` and before confirming the payment, we set the current selection to `PaymentSelection.GooglePay`. This is in line with the behavior in the flow controller.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
