### PR TITLE
Don't use `changed_modules` script for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       # Check if there has been a binary incompatible change to the API.
       # If this change is intentional, run `./gradlew apiDump` and commit the new API files.
       - name: Run gradle tasks (ktlint detekt lintRelease apiCheck)
-        run: bash scripts/execute_task_for_changed_modules.sh ktlint detekt lintRelease apiCheck
+        run: ./gradlew ktlint detekt lintRelease apiCheck
 
   unit-tests:
     name: Unit tests
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/stripe_setup
       - name: Unit tests
-        run: bash scripts/execute_task_for_changed_modules.sh testDebugUnitTest verifyPaparazziDebug
+        run: ./gradlew testDebugUnitTest verifyPaparazziDebug
       - uses: actions/upload-artifact@v3
         if: failure()
         with:


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request removes usage of the `changed_modules` script in CI due to flakiness. Instead, we’ll be looking to speed up build times by using beefier machines.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
