### PR TITLE
[stripe-core] Add CountryListSerializer

### DIFF
--- a/stripe-core/api/stripe-core.api
+++ b/stripe-core/api/stripe-core.api
@@ -142,6 +142,42 @@ public final class com/stripe/android/core/injection/NonFallbackInjectable$Defau
 	public static fun fallbackInitialize (Lcom/stripe/android/core/injection/NonFallbackInjectable;Lkotlin/Unit;)Ljava/lang/Void;
 }
 
+public final class com/stripe/android/core/model/Country$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/core/model/Country$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/core/model/Country;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/core/model/Country;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/core/model/Country$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/core/model/Country$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/core/model/Country;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/core/model/Country;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/core/model/CountryCode$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/core/model/CountryCode$$serializer;
+	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/core/model/CountryCode;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/core/model/CountryCode;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/stripe/android/core/model/CountryCode$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/core/model/CountryCode;

--- a/stripe-core/src/main/java/com/stripe/android/core/model/Country.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/model/Country.kt
@@ -1,12 +1,17 @@
 package com.stripe.android.core.model
 
+import android.os.Parcelable
 import androidx.annotation.RestrictTo
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.Serializable
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Serializable
+@Parcelize
 data class Country(
     val code: CountryCode,
     val name: String
-) {
+) : Parcelable {
     constructor(code: String, name: String) : this(CountryCode.create(code), name)
 
     /**

--- a/stripe-core/src/main/java/com/stripe/android/core/model/CountryCode.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/model/CountryCode.kt
@@ -3,6 +3,7 @@ package com.stripe.android.core.model
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.Serializable
 import java.util.Locale
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -10,6 +11,7 @@ fun Locale.getCountryCode(): CountryCode = CountryCode.create(this.country)
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Parcelize
+@Serializable
 data class CountryCode(
     val value: String
 ) : Parcelable {

--- a/stripe-core/src/main/java/com/stripe/android/core/model/serializers/CountryListSerializer.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/model/serializers/CountryListSerializer.kt
@@ -1,0 +1,52 @@
+package com.stripe.android.core.model.serializers
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.core.model.Country
+import com.stripe.android.core.model.CountryCode
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.mapSerialDescriptor
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.encoding.encodeCollection
+
+/**
+ * A customized [KSerializer] to convert between a JSON of Map<String, String> into List<Country>.
+ * E.g {"US": "United States","AU": "Australia"} will be serialized to List<Country>(US, AU).
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+object CountryListSerializer : KSerializer<List<Country>> {
+    @OptIn(ExperimentalSerializationApi::class)
+    override val descriptor = mapSerialDescriptor<String, String>()
+
+    override fun deserialize(decoder: Decoder): List<Country> {
+        val ret = mutableListOf<Country>()
+        val compositeDecoder = decoder.beginStructure(descriptor)
+        while (true) {
+            val index = compositeDecoder.decodeElementIndex(descriptor)
+            if (index == CompositeDecoder.DECODE_DONE) break
+            val code = compositeDecoder.decodeStringElement(descriptor, index)
+            val name = compositeDecoder.decodeStringElement(
+                descriptor,
+                compositeDecoder.decodeElementIndex(
+                    descriptor
+                )
+            )
+            ret.add(Country(CountryCode(code), name))
+        }
+        compositeDecoder.endStructure(descriptor)
+        return ret
+    }
+
+    override fun serialize(encoder: Encoder, value: List<Country>) {
+        encoder.encodeCollection(descriptor, value.size) {
+            val iterator = value.iterator()
+            var index = 0
+            iterator.forEach { (code, name) ->
+                encodeStringElement(descriptor, index++, code.value)
+                encodeStringElement(descriptor, index++, name)
+            }
+        }
+    }
+}

--- a/stripe-core/src/test/java/com/stripe/android/core/model/serializers/CountryListSerializerTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/model/serializers/CountryListSerializerTest.kt
@@ -1,0 +1,55 @@
+package com.stripe.android.core.model.serializers
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.model.Country
+import com.stripe.android.core.model.CountryCode
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CountryListSerializerTest {
+
+    private val json: Json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = true
+    }
+
+    @Test
+    fun testDeserialize() {
+        assertThat(
+            json.decodeFromString(
+                CountryListSerializer,
+                TEST_COUNTRIES_STRING
+            )
+        ).containsExactly(US, SG, BR)
+    }
+
+    @Test
+    fun testSerialize() {
+        assertThat(
+            json.encodeToJsonElement(CountryListSerializer, listOf(US, SG, BR)).toString()
+        ).isEqualTo(
+            TEST_COUNTRIES_STRING
+        )
+    }
+
+    private companion object {
+        private val US = Country(CountryCode("US"), "United States")
+        private val SG = Country(CountryCode("SG"), "Singapore")
+        private val BR = Country(CountryCode("BR"), "Brazil")
+
+        private val TEST_COUNTRIES_STRING = """
+            {"US":"United States","SG":"Singapore","BR":"Brazil"}
+        """.trimIndent()
+    }
+}
+
+@Serializable
+data class CountryListTest(
+    @Serializable(with = CountryListSerializer::class)
+    val countries: List<Country>
+)

--- a/stripe-core/src/test/java/com/stripe/android/core/model/serializers/CountryListSerializerTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/model/serializers/CountryListSerializerTest.kt
@@ -6,10 +6,7 @@ import com.stripe.android.core.model.CountryCode
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
 class CountryListSerializerTest {
 
     private val json: Json = Json {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add a special Serializer to serialize a `Map<String, String>` to a list of `Country`s, as that's usually how Stripe's backend send over a list of countries, see the test for details.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
