### PR TITLE
[Identity] Parse additional API fields for id and address

### DIFF
--- a/identity/api/identity.api
+++ b/identity/api/identity.api
@@ -142,6 +142,14 @@ public final class com/stripe/android/identity/networking/models/CollectedDataPa
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/identity/networking/models/DobParam$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/identity/networking/models/DobParam;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/identity/networking/models/DobParam;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/identity/networking/models/DocumentUploadParam$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/identity/networking/models/DocumentUploadParam;
@@ -155,6 +163,30 @@ public final class com/stripe/android/identity/networking/models/FaceUploadParam
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/identity/networking/models/FaceUploadParam;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/identity/networking/models/FaceUploadParam;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/identity/networking/models/IdNumberParam$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/identity/networking/models/IdNumberParam;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/identity/networking/models/IdNumberParam;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/identity/networking/models/NameParam$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/identity/networking/models/NameParam;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/identity/networking/models/NameParam;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/identity/networking/models/RequiredInternationalAddress$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/identity/networking/models/RequiredInternationalAddress;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/identity/networking/models/RequiredInternationalAddress;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
@@ -203,6 +235,14 @@ public final class com/stripe/android/identity/networking/models/VerificationPag
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/identity/networking/models/VerificationPageStaticContentDocumentSelectPage;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/identity/networking/models/VerificationPageStaticContentDocumentSelectPage;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/identity/networking/models/VerificationPageStaticContentIndividualPage$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/identity/networking/models/VerificationPageStaticContentIndividualPage;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/identity/networking/models/VerificationPageStaticContentIndividualPage;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 

--- a/identity/src/main/java/com/stripe/android/identity/networking/NetworkConstants.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/NetworkConstants.kt
@@ -3,4 +3,4 @@ package com.stripe.android.identity.networking
 internal const val BASE_URL = "https://api.stripe.com/v1"
 internal const val IDENTITY_VERIFICATION_PAGES = "identity/verification_pages"
 internal const val IDENTITY_STRIPE_API_VERSION_WITH_BETA_HEADER =
-    "2020-08-27;identity_client_api=v2"
+    "2020-08-27;identity_client_api=v3"

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/ClearDataParam.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/ClearDataParam.kt
@@ -16,7 +16,15 @@ internal data class ClearDataParam(
     @SerialName("id_document_back")
     val idDocumentBack: Boolean = false,
     @SerialName("face")
-    val face: Boolean? = null
+    val face: Boolean? = null,
+    @SerialName("id_number")
+    val idNumber: Boolean = false,
+    @SerialName("dob")
+    val dob: Boolean = false,
+    @SerialName("name")
+    val name: Boolean = false,
+    @SerialName("address")
+    val address: Boolean = false
 ) {
     internal companion object {
         private const val CLEAR_DATA_PARAM = "clear_data"

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/CollectedDataParam.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/CollectedDataParam.kt
@@ -29,7 +29,15 @@ internal data class CollectedDataParam(
     @SerialName("id_document_back")
     val idDocumentBack: DocumentUploadParam? = null,
     @SerialName("face")
-    val face: FaceUploadParam? = null
+    val face: FaceUploadParam? = null,
+    @SerialName("id_number")
+    val idNumber: IdNumberParam? = null,
+    @SerialName("dob")
+    val dob: DobParam? = null,
+    @SerialName("name")
+    val name: NameParam? = null,
+    @SerialName("address")
+    val address: RequiredInternationalAddress? = null
 ) : Parcelable {
     @Serializable
     internal enum class Type {
@@ -161,24 +169,15 @@ internal data class CollectedDataParam(
 
         fun CollectedDataParam.clearData(field: Requirement): CollectedDataParam {
             return when (field) {
-                Requirement.BIOMETRICCONSENT ->
-                    this.copy(
-                        biometricConsent = null
-                    )
-                Requirement.IDDOCUMENTBACK ->
-                    this.copy(
-                        idDocumentBack = null
-                    )
-                Requirement.IDDOCUMENTFRONT ->
-                    this.copy(
-                        idDocumentFront = null
-                    )
-                Requirement.IDDOCUMENTTYPE ->
-                    this.copy(
-                        idDocumentType = null
-                    )
-                Requirement.FACE ->
-                    this.copy(face = null)
+                Requirement.BIOMETRICCONSENT -> this.copy(biometricConsent = null)
+                Requirement.IDDOCUMENTBACK -> this.copy(idDocumentBack = null)
+                Requirement.IDDOCUMENTFRONT -> this.copy(idDocumentFront = null)
+                Requirement.IDDOCUMENTTYPE -> this.copy(idDocumentType = null)
+                Requirement.FACE -> this.copy(face = null)
+                Requirement.IDNUMBER -> this.copy(idNumber = null)
+                Requirement.DOB -> this.copy(dob = null)
+                Requirement.NAME -> this.copy(name = null)
+                Requirement.ADDRESS -> this.copy(address = null)
             }
         }
 

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/DobParam.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/DobParam.kt
@@ -1,0 +1,17 @@
+package com.stripe.android.identity.networking.models
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+@Parcelize
+internal data class DobParam(
+    @SerialName("day")
+    val day: String? = null,
+    @SerialName("month")
+    val month: String? = null,
+    @SerialName("year")
+    val year: String? = null
+) : Parcelable

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/IdNumberParam.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/IdNumberParam.kt
@@ -1,0 +1,17 @@
+package com.stripe.android.identity.networking.models
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+@Parcelize
+internal data class IdNumberParam(
+    @SerialName("country")
+    val country: String?,
+    @SerialName("partial_value")
+    val partialValue: String?,
+    @SerialName("value")
+    val value: String?
+) : Parcelable

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/NameParam.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/NameParam.kt
@@ -1,0 +1,15 @@
+package com.stripe.android.identity.networking.models
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+@Parcelize
+internal data class NameParam(
+    @SerialName("first_name")
+    val firstName: String? = null,
+    @SerialName("last_name")
+    val lastName: String? = null
+) : Parcelable

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/RequiredInternationalAddress.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/RequiredInternationalAddress.kt
@@ -1,0 +1,21 @@
+package com.stripe.android.identity.networking.models
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+@Parcelize
+internal data class RequiredInternationalAddress(
+    @SerialName("line1")
+    val line1: String,
+    @SerialName("line2")
+    val line2: String? = null,
+    @SerialName("city")
+    val city: String? = null,
+    @SerialName("postal_code")
+    val postalCode: String? = null,
+    @SerialName("country")
+    val country: String,
+) : Parcelable

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/Requirement.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/Requirement.kt
@@ -27,7 +27,19 @@ internal enum class Requirement {
     IDDOCUMENTTYPE,
 
     @SerialName("face")
-    FACE;
+    FACE,
+
+    @SerialName("id_number")
+    IDNUMBER,
+
+    @SerialName("dob")
+    DOB,
+
+    @SerialName("name")
+    NAME,
+
+    @SerialName("address")
+    ADDRESS;
 
     internal companion object {
         private val SCAN_UPLOAD_ROUTE_SET = setOf(
@@ -62,6 +74,9 @@ internal enum class Requirement {
                 }
                 FACE -> {
                     fromRoute == SelfieDestination.ROUTE.route
+                }
+                else -> {
+                    false
                 }
             }
     }

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPage.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPage.kt
@@ -17,6 +17,8 @@ internal data class VerificationPage(
     val documentCapture: VerificationPageStaticContentDocumentCapturePage,
     @SerialName("document_select")
     val documentSelect: VerificationPageStaticContentDocumentSelectPage,
+    @SerialName("individual")
+    val individual: VerificationPageStaticContentIndividualPage? = null,
     @SerialName("selfie")
     val selfieCapture: VerificationPageStaticContentSelfieCapturePage? = null,
     /* The short-lived URL that can be used in the case that the client cannot support the VerificationSession. */

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageStaticContentIndividualPage.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageStaticContentIndividualPage.kt
@@ -1,0 +1,23 @@
+package com.stripe.android.identity.networking.models
+
+import android.os.Parcelable
+import com.stripe.android.core.model.Country
+import com.stripe.android.core.model.serializers.CountryListSerializer
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+@Parcelize
+internal data class VerificationPageStaticContentIndividualPage(
+    @SerialName("address_countries")
+    @Serializable(with = CountryListSerializer::class)
+    val addressCountries: List<Country>,
+    @SerialName("button_text")
+    val buttonText: String,
+    @SerialName("title")
+    val title: String,
+    @SerialName("id_number_countries")
+    @Serializable(with = CountryListSerializer::class)
+    val idNumberCountries: List<Country>
+) : Parcelable

--- a/identity/src/test/java/com/stripe/android/identity/networking/IdentityNetworkResponseFixtures.kt
+++ b/identity/src/test/java/com/stripe/android/identity/networking/IdentityNetworkResponseFixtures.kt
@@ -257,3 +257,551 @@ internal val FILE_UPLOAD_SUCCESS_JSON_STRING = """
       "url": null
     }
 """.trimIndent()
+
+internal val VERIFICATION_PAGE_TYPE_DOCUMENT_REQUIRE_ID_NUMBER_JSON_STRING = """
+    {
+      "id": "vs_1MOrPwEGkPhabJTjzCzKF4DM",
+      "object": "identity.verification_page",
+      "biometric_consent": {
+        "accept_button_text": "Accept and continue",
+        "body": "<p><b>How Stripe will verify your identity</b></p><p><a href='https://stripe.com/about'>Stripe</a> will use biometric technology (on images of you and your IDs), as well as other data sources and our service providers, to confirm your identity and for fraud and security purposes. Stripe will store these images and the results of this check and share them with Tora's catfood. You can subsequently opt-out by contacting Stripe. <a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn more</a></p>",
+        "decline_button_text": "No, don't verify",
+        "privacy_policy": "Data will be stored and may be used according to the <a href='https://stripe.com/privacy'>Stripe Privacy Policy</a> and Tora's catfood Privacy Policy.",
+        "scroll_to_continue_button_text": "Scroll to continue",
+        "time_estimate": "Takes about 1–2 minutes.",
+        "title": "Tora's catfood uses Stripe to verify your identity"
+      },
+      "document_capture": {
+        "autocapture_timeout": 8000,
+        "file_purpose": "identity_private",
+        "high_res_image_compression_quality": 0.92,
+        "high_res_image_crop_padding": 0.08,
+        "high_res_image_max_dimension": 3000,
+        "ios_id_card_back_barcode_timeout": 3000,
+        "ios_id_card_back_country_barcode_symbologies": {
+          "CA": "pdf417",
+          "US": "pdf417"
+        },
+        "low_res_image_compression_quality": 0.82,
+        "low_res_image_max_dimension": 3000,
+        "models": {
+          "id_detector_min_iou": 0.8,
+          "id_detector_min_score": 0.5,
+          "id_detector_url": "https://b.stripecdn.com/gelato-statics-srv/assets/d137be6ecc86477800ea4ef82154174092dc4c16/assets/id_detectors/tflite/2022-08-19/model.tflite"
+        },
+        "motion_blur_min_duration": 500,
+        "motion_blur_min_iou": 0.95,
+        "require_live_capture": true
+      },
+      "document_select": {
+        "body": null,
+        "button_text": "Next",
+        "id_document_type_allowlist": {
+          "driving_license": "Driver's license",
+          "id_card": "Identity card",
+          "passport": "Passport"
+        },
+        "title": "Which form of identification do you want to use?"
+      },
+      "fallback_url": "https://verify.stripe.com/start/test_YWNjdF8xTEliaExFR2tQaGFiSlRqLF9OOTlqVW84aWdKakk3dlBuM3gwWUdiejVrTkdUSWht0100PuDMlvY6",
+      "individual": {
+        "address_countries": {
+          "AT": "Austria",
+          "AU": "Australia",
+          "BE": "Belgium",
+          "BR": "Brazil",
+          "CA": "Canada",
+          "CH": "Switzerland",
+          "CZ": "Czech Republic",
+          "DE": "Germany",
+          "DK": "Denmark",
+          "ES": "Spain",
+          "FI": "Finland",
+          "FR": "France",
+          "GB": "United Kingdom",
+          "HK": "Hong Kong",
+          "ID": "Indonesia",
+          "IE": "Ireland",
+          "IT": "Italy",
+          "LU": "Luxembourg",
+          "MT": "Malta",
+          "MX": "Mexico",
+          "MY": "Malaysia",
+          "NL": "Netherlands",
+          "NO": "Norway",
+          "PL": "Poland",
+          "PT": "Portugal",
+          "RO": "Romania",
+          "SE": "Sweden",
+          "SG": "Singapore",
+          "SK": "Slovakia",
+          "TH": "Thailand",
+          "US": "United States"
+        },
+        "button_text": "Submit",
+        "id_number_countries": {
+          "BR": "Brazil",
+          "SG": "Singapore",
+          "US": "United States"
+        },
+        "title": "Provide personal information"
+      },
+      "livemode": false,
+      "requirements": {
+        "missing": [
+          "biometric_consent",
+          "id_document_front",
+          "id_document_back",
+          "id_document_type",
+          "id_number"
+        ]
+      },
+      "selfie": null,
+      "status": "requires_input",
+      "submitted": false,
+      "success": {
+        "body": "<p>Thank you for providing your information. Tora's catfood will reach out if additional details are required.</p><p><b>Next steps</b></p><p>Tora's catfood will contact you regarding the outcome of your identification process.</p><p><b>More about Stripe Identity</b></p><p><a href='https://support.stripe.com/questions/common-questions-about-stripe-identity'>Common questions about Stripe Identity</a></p><p><a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn how Stripe uses data</a></p><p><a href='https://stripe.com/privacy'>Stripe Privacy Policy</a></p><p><a href='mailto:privacy@stripe.com'>Contact Stripe</a></p>",
+        "button_text": "Complete",
+        "title": "Verification submitted"
+      },
+      "unsupported_client": false
+    }
+
+""".trimIndent()
+
+internal val VERIFICATION_PAGE_TYPE_DOCUMENT_REQUIRE_ADDRESS_JSON_STRING = """
+    {
+      "id": "vs_1MRjwTEGkPhabJTjIEKiUmmS",
+      "object": "identity.verification_page",
+      "biometric_consent": {
+        "accept_button_text": "Accept and continue",
+        "body": "<p><b>How Stripe will verify your identity</b></p><p><a href='https://stripe.com/about'>Stripe</a> will use biometric technology (on images of you and your IDs), as well as other data sources and our service providers, to confirm your identity and for fraud and security purposes. Stripe will store these images and the results of this check and share them with Tora's catfood. You can subsequently opt-out by contacting Stripe. <a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn more</a></p>",
+        "decline_button_text": "No, don't verify",
+        "privacy_policy": "Data will be stored and may be used according to the <a href='https://stripe.com/privacy'>Stripe Privacy Policy</a> and Tora's catfood Privacy Policy.",
+        "scroll_to_continue_button_text": "Scroll to continue",
+        "time_estimate": "Takes about 1–2 minutes.",
+        "title": "Tora's catfood uses Stripe to verify your identity"
+      },
+      "document_capture": {
+        "autocapture_timeout": 8000,
+        "file_purpose": "identity_private",
+        "high_res_image_compression_quality": 0.92,
+        "high_res_image_crop_padding": 0.08,
+        "high_res_image_max_dimension": 3000,
+        "ios_id_card_back_barcode_timeout": 3000,
+        "ios_id_card_back_country_barcode_symbologies": {
+          "CA": "pdf417",
+          "US": "pdf417"
+        },
+        "low_res_image_compression_quality": 0.82,
+        "low_res_image_max_dimension": 3000,
+        "models": {
+          "id_detector_min_iou": 0.8,
+          "id_detector_min_score": 0.5,
+          "id_detector_url": "https://b.stripecdn.com/gelato-statics-srv/assets/d137be6ecc86477800ea4ef82154174092dc4c16/assets/id_detectors/tflite/2022-08-19/model.tflite"
+        },
+        "motion_blur_min_duration": 500,
+        "motion_blur_min_iou": 0.95,
+        "require_live_capture": true
+      },
+      "document_select": {
+        "body": null,
+        "button_text": "Next",
+        "id_document_type_allowlist": {
+          "driving_license": "Driver's license",
+          "id_card": "Identity card",
+          "passport": "Passport"
+        },
+        "title": "Which form of identification do you want to use?"
+      },
+      "fallback_url": "https://verify.stripe.com/start/live_YWNjdF8xTEliaExFR2tQaGFiSlRqLF9OQzhDRjQ5TXI5ZGdyM0tKWDI1RzBKMGNTQ3JyNGVU0100vUQ0sLfw",
+      "individual": {
+        "address_countries": {
+          "AT": "Austria",
+          "AU": "Australia",
+          "BE": "Belgium",
+          "BR": "Brazil",
+          "CA": "Canada",
+          "CH": "Switzerland",
+          "CZ": "Czech Republic",
+          "DE": "Germany",
+          "DK": "Denmark",
+          "ES": "Spain",
+          "FI": "Finland",
+          "FR": "France",
+          "GB": "United Kingdom",
+          "HK": "Hong Kong",
+          "ID": "Indonesia",
+          "IE": "Ireland",
+          "IT": "Italy",
+          "LU": "Luxembourg",
+          "MT": "Malta",
+          "MX": "Mexico",
+          "MY": "Malaysia",
+          "NL": "Netherlands",
+          "NO": "Norway",
+          "PL": "Poland",
+          "PT": "Portugal",
+          "RO": "Romania",
+          "SE": "Sweden",
+          "SG": "Singapore",
+          "SK": "Slovakia",
+          "TH": "Thailand",
+          "US": "United States"
+        },
+        "button_text": "Submit",
+        "id_number_countries": {
+          "BR": "Brazil",
+          "SG": "Singapore",
+          "US": "United States"
+        },
+        "title": "Provide personal information"
+      },
+      "livemode": true,
+      "requirements": {
+        "missing": [
+          "address",
+          "biometric_consent",
+          "id_document_front",
+          "id_document_back",
+          "id_document_type"
+        ]
+      },
+      "selfie": null,
+      "status": "requires_input",
+      "submitted": false,
+      "success": {
+        "body": "<p>Thank you for providing your information. Tora's catfood will reach out if additional details are required.</p><p><b>Next steps</b></p><p>Tora's catfood will contact you regarding the outcome of your identification process.</p><p><b>More about Stripe Identity</b></p><p><a href='https://support.stripe.com/questions/common-questions-about-stripe-identity'>Common questions about Stripe Identity</a></p><p><a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn how Stripe uses data</a></p><p><a href='https://stripe.com/privacy'>Stripe Privacy Policy</a></p><p><a href='mailto:privacy@stripe.com'>Contact Stripe</a></p>",
+        "button_text": "Complete",
+        "title": "Verification submitted"
+      },
+      "unsupported_client": false
+    }
+""".trimIndent()
+
+internal val VERIFICATION_PAGE_TYPE_DOCUMENT_REQUIRE_ADDRESS_AND_ID_NUMBER_JSON_STRING = """
+    {
+      "id": "vs_1MTb71EGkPhabJTjK2kJQ5xI",
+      "object": "identity.verification_page",
+      "biometric_consent": {
+        "accept_button_text": "Accept and continue",
+        "body": "<p><b>How Stripe will verify your identity</b></p><p><a href='https://stripe.com/about'>Stripe</a> will use biometric technology (on images of you and your IDs), as well as other data sources and our service providers, to confirm your identity and for fraud and security purposes. Stripe will store these images and the results of this check and share them with Tora's catfood. You can subsequently opt-out by contacting Stripe. <a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn more</a></p>",
+        "decline_button_text": "No, don't verify",
+        "privacy_policy": "Data will be stored and may be used according to the <a href='https://stripe.com/privacy'>Stripe Privacy Policy</a> and Tora's catfood Privacy Policy.",
+        "scroll_to_continue_button_text": "Scroll to continue",
+        "time_estimate": "Takes about 1–2 minutes.",
+        "title": "Tora's catfood uses Stripe to verify your identity"
+      },
+      "document_capture": {
+        "autocapture_timeout": 8000,
+        "file_purpose": "identity_private",
+        "high_res_image_compression_quality": 0.92,
+        "high_res_image_crop_padding": 0.08,
+        "high_res_image_max_dimension": 3000,
+        "ios_id_card_back_barcode_timeout": 3000,
+        "ios_id_card_back_country_barcode_symbologies": {
+          "CA": "pdf417",
+          "US": "pdf417"
+        },
+        "low_res_image_compression_quality": 0.82,
+        "low_res_image_max_dimension": 3000,
+        "models": {
+          "id_detector_min_iou": 0.8,
+          "id_detector_min_score": 0.5,
+          "id_detector_url": "https://b.stripecdn.com/gelato-statics-srv/assets/d137be6ecc86477800ea4ef82154174092dc4c16/assets/id_detectors/tflite/2022-08-19/model.tflite"
+        },
+        "motion_blur_min_duration": 500,
+        "motion_blur_min_iou": 0.95,
+        "require_live_capture": true
+      },
+      "document_select": {
+        "body": null,
+        "button_text": "Next",
+        "id_document_type_allowlist": {
+          "driving_license": "Driver's license",
+          "id_card": "Identity card",
+          "passport": "Passport"
+        },
+        "title": "Which form of identification do you want to use?"
+      },
+      "fallback_url": "https://verify.stripe.com/start/test_YWNjdF8xTEliaExFR2tQaGFiSlRqLF9ORTNESmF3b2JCVldkRUladDZTMEw3TFk3aUt5N1BE0100D2Sn0qSX",
+      "individual": {
+        "address_countries": {
+          "AT": "Austria",
+          "AU": "Australia",
+          "BE": "Belgium",
+          "BR": "Brazil",
+          "CA": "Canada",
+          "CH": "Switzerland",
+          "CZ": "Czech Republic",
+          "DE": "Germany",
+          "DK": "Denmark",
+          "ES": "Spain",
+          "FI": "Finland",
+          "FR": "France",
+          "GB": "United Kingdom",
+          "HK": "Hong Kong",
+          "ID": "Indonesia",
+          "IE": "Ireland",
+          "IT": "Italy",
+          "LU": "Luxembourg",
+          "MT": "Malta",
+          "MX": "Mexico",
+          "MY": "Malaysia",
+          "NL": "Netherlands",
+          "NO": "Norway",
+          "PL": "Poland",
+          "PT": "Portugal",
+          "RO": "Romania",
+          "SE": "Sweden",
+          "SG": "Singapore",
+          "SK": "Slovakia",
+          "TH": "Thailand",
+          "US": "United States"
+        },
+        "button_text": "Submit",
+        "id_number_countries": {
+          "BR": "Brazil",
+          "SG": "Singapore",
+          "US": "United States"
+        },
+        "title": "Provide personal information"
+      },
+      "livemode": false,
+      "requirements": {
+        "missing": [
+          "address",
+          "biometric_consent",
+          "id_document_front",
+          "id_document_back",
+          "id_document_type",
+          "id_number"
+        ]
+      },
+      "selfie": null,
+      "status": "requires_input",
+      "submitted": false,
+      "success": {
+        "body": "<p>Thank you for providing your information. Tora's catfood will reach out if additional details are required.</p><p><b>Next steps</b></p><p>Tora's catfood will contact you regarding the outcome of your identification process.</p><p><b>More about Stripe Identity</b></p><p><a href='https://support.stripe.com/questions/common-questions-about-stripe-identity'>Common questions about Stripe Identity</a></p><p><a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn how Stripe uses data</a></p><p><a href='https://stripe.com/privacy'>Stripe Privacy Policy</a></p><p><a href='mailto:privacy@stripe.com'>Contact Stripe</a></p>",
+        "button_text": "Complete",
+        "title": "Verification submitted"
+      },
+      "unsupported_client": false
+    }
+""".trimIndent()
+
+internal val VERIFICATION_PAGE_TYPE_ID_NUMBER_JSON_STRING = """
+    {
+      "id": "vs_1MOrMgEGkPhabJTjkbUNVfh6",
+      "object": "identity.verification_page",
+      "biometric_consent": {
+        "accept_button_text": "Accept and continue",
+        "body": "<p><b>How Stripe will verify your identity</b></p><p><a href='https://stripe.com/about'>Stripe</a> will use biometric technology (on images of you and your IDs), as well as other data sources and our service providers, to confirm your identity and for fraud and security purposes. Stripe will store these images and the results of this check and share them with Tora's catfood. You can subsequently opt-out by contacting Stripe. <a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn more</a></p>",
+        "decline_button_text": "No, don't verify",
+        "privacy_policy": "Data will be stored and may be used according to the <a href='https://stripe.com/privacy'>Stripe Privacy Policy</a> and Tora's catfood Privacy Policy.",
+        "scroll_to_continue_button_text": "Scroll to continue",
+        "time_estimate": "Takes about 1–2 minutes.",
+        "title": "Tora's catfood uses Stripe to verify your identity"
+      },
+      "document_capture": {
+        "autocapture_timeout": 8000,
+        "file_purpose": "identity_private",
+        "high_res_image_compression_quality": 0.92,
+        "high_res_image_crop_padding": 0.08,
+        "high_res_image_max_dimension": 3000,
+        "ios_id_card_back_barcode_timeout": 3000,
+        "ios_id_card_back_country_barcode_symbologies": {
+          "CA": "pdf417",
+          "US": "pdf417"
+        },
+        "low_res_image_compression_quality": 0.82,
+        "low_res_image_max_dimension": 3000,
+        "models": {
+          "id_detector_min_iou": 0.8,
+          "id_detector_min_score": 0.5,
+          "id_detector_url": "https://b.stripecdn.com/gelato-statics-srv/assets/d137be6ecc86477800ea4ef82154174092dc4c16/assets/id_detectors/tflite/2022-08-19/model.tflite"
+        },
+        "motion_blur_min_duration": 500,
+        "motion_blur_min_iou": 0.95,
+        "require_live_capture": false
+      },
+      "document_select": {
+        "body": null,
+        "button_text": "Next",
+        "id_document_type_allowlist": {
+          "driving_license": "Driver's license",
+          "id_card": "Identity card",
+          "passport": "Passport"
+        },
+        "title": "Which form of identification do you want to use?"
+      },
+      "fallback_url": "https://verify.stripe.com/start/test_YWNjdF8xTEliaExFR2tQaGFiSlRqLF9OOTlnUXJWaWJSMGg3U2NzTGlQODRHR1BhbzlTd1BT0100mJdJgeY7",
+      "individual": {
+        "address_countries": {
+          "AT": "Austria",
+          "AU": "Australia",
+          "BE": "Belgium",
+          "BR": "Brazil",
+          "CA": "Canada",
+          "CH": "Switzerland",
+          "CZ": "Czech Republic",
+          "DE": "Germany",
+          "DK": "Denmark",
+          "ES": "Spain",
+          "FI": "Finland",
+          "FR": "France",
+          "GB": "United Kingdom",
+          "HK": "Hong Kong",
+          "ID": "Indonesia",
+          "IE": "Ireland",
+          "IT": "Italy",
+          "LU": "Luxembourg",
+          "MT": "Malta",
+          "MX": "Mexico",
+          "MY": "Malaysia",
+          "NL": "Netherlands",
+          "NO": "Norway",
+          "PL": "Poland",
+          "PT": "Portugal",
+          "RO": "Romania",
+          "SE": "Sweden",
+          "SG": "Singapore",
+          "SK": "Slovakia",
+          "TH": "Thailand",
+          "US": "United States"
+        },
+        "button_text": "Submit",
+        "id_number_countries": {
+          "BR": "Brazil",
+          "SG": "Singapore",
+          "US": "United States"
+        },
+        "title": "Provide personal information"
+      },
+      "livemode": false,
+      "requirements": {
+        "missing": [
+          "dob",
+          "id_number",
+          "name"
+        ]
+      },
+      "selfie": null,
+      "status": "requires_input",
+      "submitted": false,
+      "success": {
+        "body": "<p>Thank you for providing your information. Tora's catfood will reach out if additional details are required.</p><p><b>Next steps</b></p><p>Tora's catfood will contact you regarding the outcome of your identification process.</p><p><b>More about Stripe Identity</b></p><p><a href='https://support.stripe.com/questions/common-questions-about-stripe-identity'>Common questions about Stripe Identity</a></p><p><a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn how Stripe uses data</a></p><p><a href='https://stripe.com/privacy'>Stripe Privacy Policy</a></p><p><a href='mailto:privacy@stripe.com'>Contact Stripe</a></p>",
+        "button_text": "Complete",
+        "title": "Verification submitted"
+      },
+      "unsupported_client": false
+    }
+""".trimIndent()
+
+internal val VERIFICATION_PAGE_TYPE_ADDRESS_JSON_STRING = """
+    {
+      "id": "vs_1MOrKBEGkPhabJTjBA2ohFAW",
+      "object": "identity.verification_page",
+      "biometric_consent": {
+        "accept_button_text": "Accept and continue",
+        "body": "<p><b>How Stripe will verify your identity</b></p><p><a href='https://stripe.com/about'>Stripe</a> will use biometric technology (on images of you and your IDs), as well as other data sources and our service providers, to confirm your identity and for fraud and security purposes. Stripe will store these images and the results of this check and share them with Tora's catfood. You can subsequently opt-out by contacting Stripe. <a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn more</a></p>",
+        "decline_button_text": "No, don't verify",
+        "privacy_policy": "Data will be stored and may be used according to the <a href='https://stripe.com/privacy'>Stripe Privacy Policy</a> and Tora's catfood Privacy Policy.",
+        "scroll_to_continue_button_text": "Scroll to continue",
+        "time_estimate": "Takes about 1–2 minutes.",
+        "title": "Tora's catfood uses Stripe to verify your identity"
+      },
+      "document_capture": {
+        "autocapture_timeout": 8000,
+        "file_purpose": "identity_private",
+        "high_res_image_compression_quality": 0.92,
+        "high_res_image_crop_padding": 0.08,
+        "high_res_image_max_dimension": 3000,
+        "ios_id_card_back_barcode_timeout": 3000,
+        "ios_id_card_back_country_barcode_symbologies": {
+          "CA": "pdf417",
+          "US": "pdf417"
+        },
+        "low_res_image_compression_quality": 0.82,
+        "low_res_image_max_dimension": 3000,
+        "models": {
+          "id_detector_min_iou": 0.8,
+          "id_detector_min_score": 0.5,
+          "id_detector_url": "https://b.stripecdn.com/gelato-statics-srv/assets/d137be6ecc86477800ea4ef82154174092dc4c16/assets/id_detectors/tflite/2022-08-19/model.tflite"
+        },
+        "motion_blur_min_duration": 500,
+        "motion_blur_min_iou": 0.95,
+        "require_live_capture": false
+      },
+      "document_select": {
+        "body": null,
+        "button_text": "Next",
+        "id_document_type_allowlist": {
+          "driving_license": "Driver's license",
+          "id_card": "Identity card",
+          "passport": "Passport"
+        },
+        "title": "Which form of identification do you want to use?"
+      },
+      "fallback_url": "https://verify.stripe.com/start/test_YWNjdF8xTEliaExFR2tQaGFiSlRqLF9OOTlkVWhpa0hIa2s2RndYTjFxMmNwSGdxYm9hbno40100QbvpMKxr",
+      "individual": {
+        "address_countries": {
+          "AT": "Austria",
+          "AU": "Australia",
+          "BE": "Belgium",
+          "BR": "Brazil",
+          "CA": "Canada",
+          "CH": "Switzerland",
+          "CZ": "Czech Republic",
+          "DE": "Germany",
+          "DK": "Denmark",
+          "ES": "Spain",
+          "FI": "Finland",
+          "FR": "France",
+          "GB": "United Kingdom",
+          "HK": "Hong Kong",
+          "ID": "Indonesia",
+          "IE": "Ireland",
+          "IT": "Italy",
+          "LU": "Luxembourg",
+          "MT": "Malta",
+          "MX": "Mexico",
+          "MY": "Malaysia",
+          "NL": "Netherlands",
+          "NO": "Norway",
+          "PL": "Poland",
+          "PT": "Portugal",
+          "RO": "Romania",
+          "SE": "Sweden",
+          "SG": "Singapore",
+          "SK": "Slovakia",
+          "TH": "Thailand",
+          "US": "United States"
+        },
+        "button_text": "Submit",
+        "id_number_countries": {
+          "BR": "Brazil",
+          "SG": "Singapore",
+          "US": "United States"
+        },
+        "title": "Provide personal information"
+      },
+      "livemode": false,
+      "requirements": {
+        "missing": [
+          "address",
+          "dob",
+          "name"
+        ]
+      },
+      "selfie": null,
+      "status": "requires_input",
+      "submitted": false,
+      "success": {
+        "body": "<p>Thank you for providing your information. Tora's catfood will reach out if additional details are required.</p><p><b>Next steps</b></p><p>Tora's catfood will contact you regarding the outcome of your identification process.</p><p><b>More about Stripe Identity</b></p><p><a href='https://support.stripe.com/questions/common-questions-about-stripe-identity'>Common questions about Stripe Identity</a></p><p><a href='https://stripe.com/privacy-center/legal#stripe-identity'>Learn how Stripe uses data</a></p><p><a href='https://stripe.com/privacy'>Stripe Privacy Policy</a></p><p><a href='mailto:privacy@stripe.com'>Contact Stripe</a></p>",
+        "button_text": "Complete",
+        "title": "Verification submitted"
+      },
+      "unsupported_client": false
+    }
+""".trimIndent()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
* parse `individual` in `VerificationPage`
* support `DOB`, `Name`, `Address`, `ID_NUMBER` in `Requirement`, `CollectedDataParams` and `ClearDataParams`

See more details in [this](https://docs.google.com/document/d/1N3GeDgdNxRsr86XdT_5lWOLEdhWST26F9t5aDgJz-3E/edit#bookmark=id.a6cmxttvrbe7) internal doc.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Support ID and Address

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
