### PR TITLE
Remove checks from github actions that are now being run in bitrise.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,36 +11,6 @@ env:
   GRADLE_OPTS: -Dkotlin.incremental=false
 
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@v1
-      - uses: ./.github/actions/stripe_setup
-      # Check if there has been a binary incompatible change to the API.
-      # If this change is intentional, run `./gradlew apiDump` and commit the new API files.
-      - name: Run gradle tasks (ktlint detekt lintRelease apiCheck)
-        run: ./gradlew ktlint detekt lintRelease apiCheck
-
-  unit-tests:
-    name: Unit tests
-    runs-on: ubuntu-latest
-    timeout-minutes: 35
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/stripe_setup
-      - name: Unit tests
-        run: ./gradlew testDebugUnitTest verifyPaparazziDebug
-      - uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: test-failures
-          path: |
-            **/build/reports/tests/
-            **/out/failures/
-
   end-to-end-tests:
     name: End-to-end tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Moved to bitrise in #6111 
Moving required checks from github actions to bitrise here: https://git.corp.stripe.com/stripe-internal/pay-server/pull/567518

