### PR TITLE
Fix LpmRepository.waitUntilLoaded.

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
@@ -62,8 +62,7 @@ class LpmRepository constructor(
 
     private val lpmSerializer = LpmSerializer()
 
-    @Volatile
-    private var serverInitializedLatch = CountDownLatch(1)
+    private val serverInitializedLatch = CountDownLatch(1)
     var serverSpecLoadingState: ServerSpecState = ServerSpecState.Uninitialized
 
     val supportedPaymentMethods: List<String> by lazy {
@@ -116,8 +115,6 @@ class LpmRepository constructor(
         stripeIntent: StripeIntent,
         serverLpmSpecs: String?,
     ) {
-        val countDownLatch = CountDownLatch(1)
-        serverInitializedLatch = countDownLatch
         val expectedLpms = stripeIntent.paymentMethodTypes
 
         serverSpecLoadingState = ServerSpecState.NoServerSpec(serverLpmSpecs)
@@ -156,7 +153,7 @@ class LpmRepository constructor(
                 }
         }
 
-        countDownLatch.countDown()
+        serverInitializedLatch.countDown()
     }
 
     @VisibleForTesting


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I didn't fully understand what was needed, or how this was working when I did a recent refactor: #6011 

This restores the loading mechanism used before, and adds a tests to ensure it stays working that way.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

