### PR TITLE
Wrap primary button in AndroidViewBinding

### DIFF
--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/BuyButton.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/BuyButton.kt
@@ -6,7 +6,7 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
 import com.stripe.android.paymentsheet.example.R
 
-class BuyButton(private val device: UiDevice) : EspressoIdButton(R.id.buy_button) {
+class BuyButton(private val device: UiDevice) : EspressoIdButton(R.id.primary_button) {
     fun waitProcessingComplete() {
         device.wait(
             Until.findObject(

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/Selectors.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/Selectors.kt
@@ -46,7 +46,7 @@ class Selectors(
     testParameters: TestParameters
 ) {
     val reset = EspressoIdButton(R.id.reset_button)
-    val continueButton = EspressoIdButton(R.id.continue_button)
+    val continueButton = EspressoIdButton(R.id.primary_button)
     val complete = EspressoLabelIdButton(R.string.checkout_complete)
     val reload = EspressoLabelIdButton(R.string.reload_paymentsheet)
     val multiStepSelect = EspressoIdButton(R.id.payment_method)

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -5,6 +5,20 @@ public final class com/stripe/android/paymentsheet/BuildConfig {
 	public fun <init> ()V
 }
 
+public final class com/stripe/android/paymentsheet/ComposableSingletons$PaymentOptionsActivityKt {
+	public static final field INSTANCE Lcom/stripe/android/paymentsheet/ComposableSingletons$PaymentOptionsActivityKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$paymentsheet_release ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class com/stripe/android/paymentsheet/ComposableSingletons$PaymentSheetActivityKt {
+	public static final field INSTANCE Lcom/stripe/android/paymentsheet/ComposableSingletons$PaymentSheetActivityKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$paymentsheet_release ()Lkotlin/jvm/functions/Function2;
+}
+
 public final class com/stripe/android/paymentsheet/PaymentMethodsUIKt {
 	public static final field TEST_TAG_LIST Ljava/lang/String;
 }
@@ -948,8 +962,8 @@ public final class com/stripe/android/paymentsheet/addresselement/ComposableSing
 public final class com/stripe/android/paymentsheet/databinding/ActivityPaymentOptionsBinding : androidx/viewbinding/ViewBinding {
 	public final field bottomSheet Landroid/widget/LinearLayout;
 	public final field bottomSpacer Landroid/view/View;
+	public final field buttonContainer Landroidx/compose/ui/platform/ComposeView;
 	public final field contentContainer Landroidx/compose/ui/platform/ComposeView;
-	public final field continueButton Lcom/stripe/android/paymentsheet/ui/PrimaryButton;
 	public final field coordinator Landroidx/coordinatorlayout/widget/CoordinatorLayout;
 	public final field fragmentContainerParent Landroid/widget/LinearLayout;
 	public final field header Landroidx/compose/ui/platform/ComposeView;
@@ -968,8 +982,7 @@ public final class com/stripe/android/paymentsheet/databinding/ActivityPaymentOp
 public final class com/stripe/android/paymentsheet/databinding/ActivityPaymentSheetBinding : androidx/viewbinding/ViewBinding {
 	public final field bottomSheet Landroid/widget/LinearLayout;
 	public final field bottomSpacer Landroid/view/View;
-	public final field buttonContainer Landroid/widget/FrameLayout;
-	public final field buyButton Lcom/stripe/android/paymentsheet/ui/PrimaryButton;
+	public final field buttonContainer Landroidx/compose/ui/platform/ComposeView;
 	public final field contentContainer Landroidx/compose/ui/platform/ComposeView;
 	public final field coordinator Landroidx/coordinatorlayout/widget/CoordinatorLayout;
 	public final field fragmentContainerParent Landroid/widget/LinearLayout;
@@ -998,6 +1011,33 @@ public final class com/stripe/android/paymentsheet/databinding/FragmentAchBindin
 	public fun getRoot ()Landroidx/fragment/app/FragmentContainerView;
 	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/paymentsheet/databinding/FragmentAchBinding;
 	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/paymentsheet/databinding/FragmentAchBinding;
+}
+
+public final class com/stripe/android/paymentsheet/databinding/FragmentPaymentOptionsPrimaryButtonBinding : androidx/viewbinding/ViewBinding {
+	public final field paymentOptionsPrimaryButtonFragmentContainerView Landroidx/fragment/app/FragmentContainerView;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/paymentsheet/databinding/FragmentPaymentOptionsPrimaryButtonBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroidx/fragment/app/FragmentContainerView;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/paymentsheet/databinding/FragmentPaymentOptionsPrimaryButtonBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/paymentsheet/databinding/FragmentPaymentOptionsPrimaryButtonBinding;
+}
+
+public final class com/stripe/android/paymentsheet/databinding/FragmentPaymentSheetPrimaryButtonBinding : androidx/viewbinding/ViewBinding {
+	public final field paymentSheetPrimaryButtonFragmentContainerView Landroidx/fragment/app/FragmentContainerView;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/paymentsheet/databinding/FragmentPaymentSheetPrimaryButtonBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Landroidx/fragment/app/FragmentContainerView;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/paymentsheet/databinding/FragmentPaymentSheetPrimaryButtonBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/paymentsheet/databinding/FragmentPaymentSheetPrimaryButtonBinding;
+}
+
+public final class com/stripe/android/paymentsheet/databinding/FragmentPrimaryButtonContainerBinding : androidx/viewbinding/ViewBinding {
+	public final field primaryButton Lcom/stripe/android/paymentsheet/ui/PrimaryButton;
+	public static fun bind (Landroid/view/View;)Lcom/stripe/android/paymentsheet/databinding/FragmentPrimaryButtonContainerBinding;
+	public synthetic fun getRoot ()Landroid/view/View;
+	public fun getRoot ()Lcom/stripe/android/paymentsheet/ui/PrimaryButton;
+	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/paymentsheet/databinding/FragmentPrimaryButtonContainerBinding;
+	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/paymentsheet/databinding/FragmentPrimaryButtonContainerBinding;
 }
 
 public final class com/stripe/android/paymentsheet/databinding/PrimaryButtonBinding : androidx/viewbinding/ViewBinding {

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -1084,7 +1084,7 @@ public final class com/stripe/android/paymentsheet/databinding/StripeCountryDrop
 public final class com/stripe/android/paymentsheet/databinding/StripeGooglePayButtonBinding : androidx/viewbinding/ViewBinding {
 	public final field googlePayButtonContent Landroid/widget/ImageView;
 	public final field googlePayButtonLayout Landroid/widget/RelativeLayout;
-	public final field primaryButton Lcom/stripe/android/paymentsheet/ui/PrimaryButton;
+	public final field googlePayPrimaryButton Lcom/stripe/android/paymentsheet/ui/PrimaryButton;
 	public static fun bind (Landroid/view/View;)Lcom/stripe/android/paymentsheet/databinding/StripeGooglePayButtonBinding;
 	public fun getRoot ()Landroid/view/View;
 	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;)Lcom/stripe/android/paymentsheet/databinding/StripeGooglePayButtonBinding;

--- a/paymentsheet/res/layout/activity_payment_options.xml
+++ b/paymentsheet/res/layout/activity_payment_options.xml
@@ -56,21 +56,10 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content" />
 
-                <!-- Needed to avoid animating layout changes when showing/hiding the button -->
-                <FrameLayout
+                <androidx.compose.ui.platform.ComposeView
+                    android:id="@+id/button_container"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
-
-                    <com.stripe.android.paymentsheet.ui.PrimaryButton
-                        android:id="@+id/continue_button"
-                        android:layout_marginTop="@dimen/stripe_paymentsheet_button_container_spacing"
-                        android:layout_marginStart="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
-                        android:layout_marginEnd="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:visibility="gone" />
-
-                </FrameLayout>
+                    android:layout_height="wrap_content" />
 
                 <androidx.compose.ui.platform.ComposeView
                     android:id="@+id/notes"

--- a/paymentsheet/res/layout/activity_payment_sheet.xml
+++ b/paymentsheet/res/layout/activity_payment_sheet.xml
@@ -91,23 +91,10 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content" />
 
-                <FrameLayout
+                <androidx.compose.ui.platform.ComposeView
                     android:id="@+id/button_container"
-                    android:animateLayoutChanges="true"
-                    android:visibility="gone"
                     android:layout_width="match_parent"
-                    android:layout_height="@dimen/stripe_paymentsheet_max_primary_button_height"
-                    android:layout_marginTop="@dimen/stripe_paymentsheet_button_container_spacing"
-                    android:layout_marginHorizontal="@dimen/stripe_paymentsheet_outer_spacing_horizontal">
-
-                    <com.stripe.android.paymentsheet.ui.PrimaryButton
-                        android:id="@+id/buy_button"
-                        android:layout_width="match_parent"
-                        android:layout_height="@dimen/stripe_paymentsheet_primary_button_height"
-                        android:text="@string/stripe_paymentsheet_pay_button_label"
-                        android:layout_marginVertical="2dp" />
-
-                </FrameLayout>
+                    android:layout_height="wrap_content" />
 
                 <androidx.compose.ui.platform.ComposeView
                     android:id="@+id/notes"

--- a/paymentsheet/res/layout/fragment_payment_options_primary_button.xml
+++ b/paymentsheet/res/layout/fragment_payment_options_primary_button.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.fragment.app.FragmentContainerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/payment_options_primary_button_fragment_container_view"
+    android:layout_height="wrap_content"
+    android:layout_width="match_parent"
+    android:name="com.stripe.android.paymentsheet.ui.PaymentOptionsPrimaryButtonContainerFragment" />

--- a/paymentsheet/res/layout/fragment_payment_sheet_primary_button.xml
+++ b/paymentsheet/res/layout/fragment_payment_sheet_primary_button.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.fragment.app.FragmentContainerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/payment_sheet_primary_button_fragment_container_view"
+    android:layout_height="wrap_content"
+    android:layout_width="match_parent"
+    android:name="com.stripe.android.paymentsheet.ui.PaymentSheetPrimaryButtonContainerFragment" />

--- a/paymentsheet/res/layout/fragment_primary_button_container.xml
+++ b/paymentsheet/res/layout/fragment_primary_button_container.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.stripe.android.paymentsheet.ui.PrimaryButton xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/primary_button"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/stripe_paymentsheet_primary_button_height"
+    android:layout_marginTop="@dimen/stripe_paymentsheet_button_container_spacing"
+    android:layout_marginStart="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
+    android:layout_marginEnd="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
+    android:text="@string/stripe_paymentsheet_pay_button_label"
+    android:visibility="gone" />

--- a/paymentsheet/res/layout/stripe_google_pay_button.xml
+++ b/paymentsheet/res/layout/stripe_google_pay_button.xml
@@ -10,7 +10,7 @@
         android:contentDescription="@string/google_pay">
 
         <com.stripe.android.paymentsheet.ui.PrimaryButton
-            android:id="@+id/primary_button"
+            android:id="@+id/google_pay_primary_button"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:visibility="invisible" />

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -83,7 +83,7 @@ internal class PaymentSheetTest {
             response.testBodyFromFile("payment-intent-get.json")
         }
 
-        onView(withId(R.id.buy_button)).perform(scrollTo(), click())
+        onView(withId(R.id.primary_button)).perform(scrollTo(), click())
 
         assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
     }
@@ -155,7 +155,7 @@ internal class PaymentSheetTest {
             response.testBodyFromFile("payment-intent-get.json")
         }
 
-        onView(withId(R.id.continue_button)).perform(scrollTo(), click())
+        onView(withId(R.id.primary_button)).perform(scrollTo(), click())
 
         assertThat(resultCountDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -13,15 +13,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidViewBinding
 import androidx.core.view.doOnNextLayout
-import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.paymentsheet.databinding.ActivityPaymentOptionsBinding
-import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
+import com.stripe.android.paymentsheet.databinding.FragmentPaymentOptionsPrimaryButtonBinding
 import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.ErrorMessage
 import com.stripe.android.paymentsheet.ui.PaymentSheetTopBar
-import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.utils.launchAndCollectIn
 import com.stripe.android.uicore.StripeTheme
 
@@ -52,7 +51,6 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
     override val header: ComposeView by lazy { viewBinding.header }
     override val fragmentContainerParent: ViewGroup by lazy { viewBinding.fragmentContainerParent }
     override val notesView: ComposeView by lazy { viewBinding.notes }
-    override val primaryButton: PrimaryButton by lazy { viewBinding.continueButton }
     override val bottomSpacer: View by lazy { viewBinding.bottomSpacer }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -111,25 +109,21 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
             }
         }
 
-        viewModel.selection.launchAndCollectIn(this) {
-            viewModel.clearErrorMessages()
-            resetPrimaryButtonState()
+        viewBinding.buttonContainer.setContent {
+            AndroidViewBinding(
+                factory = FragmentPaymentOptionsPrimaryButtonBinding::inflate,
+            )
         }
 
-        viewModel.currentScreen.launchAndCollectIn(this) { currentScreen ->
-            val visible = currentScreen is PaymentSheetScreen.AddFirstPaymentMethod ||
-                currentScreen is PaymentSheetScreen.AddAnotherPaymentMethod ||
-                viewModel.primaryButtonUIState.value?.visible == true
+        viewModel.selection.launchAndCollectIn(this) {
+            viewModel.clearErrorMessages()
+        }
 
-            viewBinding.continueButton.isVisible = visible
-            viewBinding.bottomSpacer.isVisible = visible
-
-            rootView.doOnNextLayout {
-                // Expand sheet only after the first fragment is attached so that it
-                // animates in. Further calls to expand() are no-op if the sheet is already
-                // expanded.
-                bottomSheetController.expand()
-            }
+        rootView.doOnNextLayout {
+            // Expand sheet only after the first fragment is attached so that it
+            // animates in. Further calls to expand() are no-op if the sheet is already
+            // expanded.
+            bottomSheetController.expand()
         }
     }
 
@@ -137,20 +131,6 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
         starterArgs?.state?.config?.appearance?.parseAppearance()
         earlyExitDueToIllegalState = starterArgs == null
         return starterArgs
-    }
-
-    override fun resetPrimaryButtonState() {
-        viewBinding.continueButton.lockVisible = false
-        viewBinding.continueButton.updateState(PrimaryButton.State.Ready)
-
-        val customLabel = starterArgs?.state?.config?.primaryButtonLabel
-        val label = customLabel ?: getString(R.string.stripe_continue_button_label)
-
-        viewBinding.continueButton.setLabel(label)
-
-        viewBinding.continueButton.setOnClickListener {
-            viewModel.onUserSelection()
-        }
     }
 
     override fun setActivityResult(result: PaymentOptionResult) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -176,10 +176,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
             googlePayButton.isEnabled = enabled
         }
 
-        viewModel.amount.launchAndCollectIn(this) {
-            resetPrimaryButtonState()
-        }
-
         viewModel.selection.launchAndCollectIn(this) {
             viewModel.clearErrorMessages()
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -10,26 +10,26 @@ import android.widget.ScrollView
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.layout.padding
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidViewBinding
 import androidx.core.view.doOnNextLayout
 import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContract
 import com.stripe.android.paymentsheet.databinding.ActivityPaymentSheetBinding
-import com.stripe.android.paymentsheet.model.PaymentSheetViewState
+import com.stripe.android.paymentsheet.databinding.FragmentPaymentSheetPrimaryButtonBinding
 import com.stripe.android.paymentsheet.state.WalletsContainerState
 import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.ErrorMessage
 import com.stripe.android.paymentsheet.ui.GooglePayDividerUi
 import com.stripe.android.paymentsheet.ui.PaymentSheetTopBar
-import com.stripe.android.paymentsheet.ui.PrimaryButton
+import com.stripe.android.paymentsheet.ui.convert
 import com.stripe.android.paymentsheet.utils.launchAndCollectIn
 import com.stripe.android.uicore.StripeTheme
 import kotlinx.coroutines.flow.filter
@@ -60,10 +60,8 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
     override val header: ComposeView by lazy { viewBinding.header }
     override val fragmentContainerParent: ViewGroup by lazy { viewBinding.fragmentContainerParent }
     override val notesView: ComposeView by lazy { viewBinding.notes }
-    override val primaryButton: PrimaryButton by lazy { viewBinding.buyButton }
     override val bottomSpacer: View by lazy { viewBinding.bottomSpacer }
 
-    private val buttonContainer: ViewGroup by lazy { viewBinding.buttonContainer }
     private val topContainer by lazy { viewBinding.topContainer }
     private val googlePayButton by lazy { viewBinding.googlePayButton }
     private val linkButton by lazy { viewBinding.linkButton }
@@ -142,11 +140,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
         viewBinding.contentContainer.setContent {
             StripeTheme {
                 val currentScreen by viewModel.currentScreen.collectAsState()
-
-                LaunchedEffect(currentScreen) {
-                    buttonContainer.isVisible = currentScreen.showsBuyButton
-                }
-
                 currentScreen.Content(viewModel)
             }
         }
@@ -162,6 +155,12 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
                     )
                 }
             }
+        }
+
+        viewBinding.buttonContainer.setContent {
+            AndroidViewBinding(
+                factory = FragmentPaymentSheetPrimaryButtonBinding::inflate,
+            )
         }
 
         viewModel.processing.filter { it }.launchAndCollectIn(this) {
@@ -183,11 +182,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
 
         viewModel.selection.launchAndCollectIn(this) {
             viewModel.clearErrorMessages()
-            resetPrimaryButtonState()
-        }
-
-        viewModel.buyButtonState.launchAndCollectIn(this) { viewState ->
-            viewBinding.buyButton.updateState(viewState?.convert())
         }
     }
 
@@ -209,26 +203,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
 
         earlyExitDueToIllegalState = result.isFailure
         return result
-    }
-
-    override fun resetPrimaryButtonState() {
-        viewBinding.buyButton.updateState(PrimaryButton.State.Ready)
-
-        val customLabel = starterArgs?.config?.primaryButtonLabel
-
-        val label = if (customLabel != null) {
-            starterArgs?.config?.primaryButtonLabel
-        } else if (viewModel.isProcessingPaymentIntent) {
-            viewModel.amount.value?.buildPayButtonLabel(resources)
-        } else {
-            getString(R.string.stripe_setup_button_label)
-        }
-
-        viewBinding.buyButton.setLabel(label)
-
-        viewBinding.buyButton.setOnClickListener {
-            viewModel.checkout()
-        }
     }
 
     private fun setupTopContainer() {
@@ -277,20 +251,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
             viewModel.unregisterFromActivity()
         }
         super.onDestroy()
-    }
-
-    /**
-     * Convert a [PaymentSheetViewState] to a [PrimaryButton.State]
-     */
-    private fun PaymentSheetViewState.convert(): PrimaryButton.State {
-        return when (this) {
-            is PaymentSheetViewState.Reset ->
-                PrimaryButton.State.Ready
-            is PaymentSheetViewState.StartProcessing ->
-                PrimaryButton.State.StartProcessing
-            is PaymentSheetViewState.FinishProcessing ->
-                PrimaryButton.State.FinishProcessing(this.onComplete)
-        }
     }
 
     private fun finishWithError(error: Throwable?) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -60,6 +60,12 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
         BottomSheetController(bottomSheetBehavior = bottomSheetBehavior)
     }
 
+    /**
+     * This variable is a temporary way of passing parameters to [USBankAccountFormFragment] from
+     * [AddPaymentMethod], while the former is not fully refactored to Compose.
+     * These arguments can't be passed through the Fragment's arguments because the Fragment is
+     * added with an [AndroidViewBinding] from Compose, which doesn't allow that.
+     */
     var formArgs: FormArguments? = null
 
     abstract val rootView: ViewGroup

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet.ui
 
 import android.animation.LayoutTransition
 import android.content.pm.ActivityInfo
-import android.content.res.ColorStateList
 import android.graphics.Insets
 import android.os.Build
 import android.os.Bundle
@@ -40,7 +39,6 @@ import com.stripe.android.paymentsheet.utils.launchAndCollectIn
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.ui.core.elements.H4Text
 import com.stripe.android.uicore.StripeTheme
-import com.stripe.android.uicore.getBackgroundColor
 import com.stripe.android.uicore.isSystemDarkTheme
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.text.Html
@@ -62,12 +60,6 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
         BottomSheetController(bottomSheetBehavior = bottomSheetBehavior)
     }
 
-    /**
-     * This variable is a temporary way of passing parameters to [USBankAccountFormFragment] from
-     * [BaseAddPaymentMethodFragment], while the former is not fully refactored to Compose.
-     * These arguments can't be passed through the Fragment's arguments because the Fragment is
-     * added with an [AndroidViewBinding] from Compose, which doesn't allow that.
-     */
     var formArgs: FormArguments? = null
 
     abstract val rootView: ViewGroup
@@ -77,7 +69,6 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
     abstract val header: ComposeView
     abstract val fragmentContainerParent: ViewGroup
     abstract val notesView: ComposeView
-    abstract val primaryButton: PrimaryButton
     abstract val bottomSpacer: View
 
     protected var earlyExitDueToIllegalState: Boolean = false
@@ -185,38 +176,12 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
     private fun setupPrimaryButton() {
         viewModel.primaryButtonUIState.launchAndCollectIn(this) { state ->
             state?.let {
-                primaryButton.setOnClickListener {
-                    state.onClick?.invoke()
-                }
-                primaryButton.setLabel(state.label)
-                primaryButton.isVisible = state.visible
                 bottomSpacer.isVisible = state.visible
-            } ?: run {
-                resetPrimaryButtonState()
             }
         }
 
-        viewModel.primaryButtonState.launchAndCollectIn(this) { state ->
-            primaryButton.updateState(state)
-        }
-
-        viewModel.isPrimaryButtonEnabled.launchAndCollectIn(this) { isEnabled ->
-            primaryButton.isEnabled = isEnabled
-        }
-
-        primaryButton.setAppearanceConfiguration(
-            StripeTheme.primaryButtonStyle,
-            tintList = viewModel.config?.primaryButtonColor ?: ColorStateList.valueOf(
-                StripeTheme.primaryButtonStyle.getBackgroundColor(baseContext)
-            )
-        )
         bottomSpacer.isVisible = true
     }
-
-    /**
-     * Reset the primary button to its default state.
-     */
-    abstract fun resetPrimaryButtonState()
 
     private fun setupNotes() {
         viewModel.notesText.launchAndCollectIn(this) { text ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/GooglePayButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/GooglePayButton.kt
@@ -24,28 +24,28 @@ internal class GooglePayButton @JvmOverloads constructor(
         // Call super so we don't inadvertently effect the primary button as well.
         super.setClickable(true)
         super.setEnabled(true)
-        viewBinding.primaryButton.backgroundTintList = null
-        viewBinding.primaryButton.finishedBackgroundColor = Color.TRANSPARENT
+        viewBinding.googlePayPrimaryButton.backgroundTintList = null
+        viewBinding.googlePayPrimaryButton.finishedBackgroundColor = Color.TRANSPARENT
     }
 
     private fun onReadyState() {
-        viewBinding.primaryButton.isVisible = false
+        viewBinding.googlePayPrimaryButton.isVisible = false
         viewBinding.googlePayButtonContent.isVisible = true
     }
 
     private fun onStartProcessing() {
-        viewBinding.primaryButton.isVisible = true
+        viewBinding.googlePayPrimaryButton.isVisible = true
         viewBinding.googlePayButtonContent.isVisible = false
     }
 
     private fun onFinishProcessing() {
-        viewBinding.primaryButton.isVisible = true
+        viewBinding.googlePayPrimaryButton.isVisible = true
         viewBinding.googlePayButtonContent.isVisible = false
     }
 
     override fun setEnabled(enabled: Boolean) {
         super.setEnabled(enabled)
-        viewBinding.primaryButton.isEnabled = enabled
+        viewBinding.googlePayPrimaryButton.isEnabled = enabled
         updateAlpha()
     }
 
@@ -59,7 +59,7 @@ internal class GooglePayButton @JvmOverloads constructor(
     }
 
     fun updateState(state: PrimaryButton.State?) {
-        viewBinding.primaryButton.updateState(state)
+        viewBinding.googlePayPrimaryButton.updateState(state)
         this.state = state
         updateAlpha()
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButtonContainerFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButtonContainerFragment.kt
@@ -8,9 +8,7 @@ import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import com.stripe.android.paymentsheet.PaymentOptionsActivity
 import com.stripe.android.paymentsheet.PaymentOptionsViewModel
-import com.stripe.android.paymentsheet.PaymentSheetActivity
 import com.stripe.android.paymentsheet.PaymentSheetViewModel
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.databinding.FragmentPrimaryButtonContainerBinding
@@ -82,11 +80,7 @@ internal abstract class BasePrimaryButtonContainerFragment : Fragment() {
 internal class PaymentSheetPrimaryButtonContainerFragment : BasePrimaryButtonContainerFragment() {
 
     override val viewModel: PaymentSheetViewModel by activityViewModels {
-        PaymentSheetViewModel.Factory {
-            requireNotNull(
-                requireArguments().getParcelable(PaymentSheetActivity.EXTRA_STARTER_ARGS)
-            )
-        }
+        PaymentSheetViewModel.Factory { error("PaymentSheetViewModel should already exist") }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -126,11 +120,7 @@ internal class PaymentSheetPrimaryButtonContainerFragment : BasePrimaryButtonCon
 internal class PaymentOptionsPrimaryButtonContainerFragment : BasePrimaryButtonContainerFragment() {
 
     override val viewModel: PaymentOptionsViewModel by activityViewModels {
-        PaymentOptionsViewModel.Factory {
-            requireNotNull(
-                requireArguments().getParcelable(PaymentOptionsActivity.EXTRA_STARTER_ARGS)
-            )
-        }
+        PaymentOptionsViewModel.Factory { error("PaymentOptionsViewModel should already exist") }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButtonContainerFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButtonContainerFragment.kt
@@ -1,0 +1,177 @@
+package com.stripe.android.paymentsheet.ui
+
+import android.content.res.ColorStateList
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import com.stripe.android.paymentsheet.PaymentOptionsActivity
+import com.stripe.android.paymentsheet.PaymentOptionsViewModel
+import com.stripe.android.paymentsheet.PaymentSheetActivity
+import com.stripe.android.paymentsheet.PaymentSheetViewModel
+import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.databinding.FragmentPrimaryButtonContainerBinding
+import com.stripe.android.paymentsheet.model.PaymentSheetViewState
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
+import com.stripe.android.paymentsheet.utils.launchAndCollectIn
+import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
+import com.stripe.android.uicore.StripeTheme
+import com.stripe.android.uicore.getBackgroundColor
+
+internal abstract class BasePrimaryButtonContainerFragment : Fragment() {
+
+    protected var viewBinding: FragmentPrimaryButtonContainerBinding? = null
+
+    abstract val viewModel: BaseSheetViewModel
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        viewBinding = FragmentPrimaryButtonContainerBinding.inflate(inflater, container, false)
+        return viewBinding?.root
+    }
+
+    abstract fun resetPrimaryButtonState()
+
+    protected fun setupPrimaryButton() {
+        val viewBinding = viewBinding ?: return
+
+        viewModel.primaryButtonUIState.launchAndCollectIn(viewLifecycleOwner) { state ->
+            state?.let {
+                viewBinding.primaryButton.setOnClickListener {
+                    state.onClick?.invoke()
+                }
+                viewBinding.primaryButton.setLabel(state.label)
+                viewBinding.primaryButton.isVisible = state.visible
+            } ?: run {
+                resetPrimaryButtonState()
+            }
+        }
+
+        viewModel.amount.launchAndCollectIn(viewLifecycleOwner) {
+            resetPrimaryButtonState()
+        }
+
+        viewModel.selection.launchAndCollectIn(viewLifecycleOwner) {
+            resetPrimaryButtonState()
+        }
+
+        viewModel.isPrimaryButtonEnabled.launchAndCollectIn(viewLifecycleOwner) { isEnabled ->
+            viewBinding.primaryButton.isEnabled = isEnabled
+        }
+
+        viewBinding.primaryButton.setAppearanceConfiguration(
+            StripeTheme.primaryButtonStyle,
+            tintList = viewModel.config?.primaryButtonColor ?: ColorStateList.valueOf(
+                StripeTheme.primaryButtonStyle.getBackgroundColor(requireActivity().baseContext)
+            )
+        )
+    }
+
+    override fun onDestroyView() {
+        viewBinding = null
+        super.onDestroyView()
+    }
+}
+
+internal class PaymentSheetPrimaryButtonContainerFragment : BasePrimaryButtonContainerFragment() {
+
+    override val viewModel: PaymentSheetViewModel by activityViewModels {
+        PaymentSheetViewModel.Factory {
+            requireNotNull(
+                requireArguments().getParcelable(PaymentSheetActivity.EXTRA_STARTER_ARGS)
+            )
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        setupPrimaryButton()
+
+        viewModel.currentScreen.launchAndCollectIn(viewLifecycleOwner) { currentScreen ->
+            viewBinding?.primaryButton?.isVisible = currentScreen.showsBuyButton
+        }
+
+        viewModel.buyButtonState.launchAndCollectIn(viewLifecycleOwner) { state ->
+            viewBinding?.primaryButton?.updateState(state?.convert())
+        }
+    }
+
+    override fun resetPrimaryButtonState() {
+        val viewBinding = viewBinding ?: return
+        viewBinding.primaryButton.updateState(PrimaryButton.State.Ready)
+
+        val customLabel = viewModel.config?.primaryButtonLabel
+
+        val label = if (customLabel != null) {
+            viewModel.config?.primaryButtonLabel
+        } else if (viewModel.isProcessingPaymentIntent) {
+            viewModel.amount.value?.buildPayButtonLabel(resources)
+        } else {
+            getString(R.string.stripe_setup_button_label)
+        }
+
+        viewBinding.primaryButton.setLabel(label)
+
+        viewBinding.primaryButton.setOnClickListener {
+            viewModel.checkout()
+        }
+    }
+}
+
+internal class PaymentOptionsPrimaryButtonContainerFragment : BasePrimaryButtonContainerFragment() {
+
+    override val viewModel: PaymentOptionsViewModel by activityViewModels {
+        PaymentOptionsViewModel.Factory {
+            requireNotNull(
+                requireArguments().getParcelable(PaymentOptionsActivity.EXTRA_STARTER_ARGS)
+            )
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        setupPrimaryButton()
+
+        viewModel.currentScreen.launchAndCollectIn(viewLifecycleOwner) { currentScreen ->
+            val visible = currentScreen is PaymentSheetScreen.AddFirstPaymentMethod ||
+                currentScreen is PaymentSheetScreen.AddAnotherPaymentMethod ||
+                viewModel.primaryButtonUIState.value?.visible == true
+
+            viewBinding?.primaryButton?.isVisible = visible
+        }
+    }
+
+    override fun resetPrimaryButtonState() {
+        val viewBinding = viewBinding ?: return
+
+        viewBinding.primaryButton.lockVisible = false
+        viewBinding.primaryButton.updateState(PrimaryButton.State.Ready)
+
+        val customLabel = viewModel.config?.primaryButtonLabel
+        val label = customLabel ?: getString(R.string.stripe_continue_button_label)
+
+        viewBinding.primaryButton.setLabel(label)
+
+        viewBinding.primaryButton.setOnClickListener {
+            viewModel.onUserSelection()
+        }
+    }
+}
+
+internal fun PaymentSheetViewState.convert(): PrimaryButton.State {
+    return when (this) {
+        is PaymentSheetViewState.Reset -> {
+            PrimaryButton.State.Ready
+        }
+        is PaymentSheetViewState.StartProcessing -> {
+            PrimaryButton.State.StartProcessing
+        }
+        is PaymentSheetViewState.FinishProcessing -> {
+            PrimaryButton.State.FinishProcessing(this.onComplete)
+        }
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/GooglePayButtonTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/GooglePayButtonTest.kt
@@ -27,7 +27,7 @@ class GooglePayButtonTest {
     }
 
     private val primaryButton: PrimaryButton by lazy {
-        googlePayButton.viewBinding.primaryButton
+        googlePayButton.viewBinding.googlePayPrimaryButton
     }
 
     @BeforeTest

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -31,6 +31,7 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.PAYMENT_OPTIONS_CONTRACT_ARGS
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.updateState
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.databinding.ActivityPaymentOptionsBinding
 import com.stripe.android.paymentsheet.databinding.PrimaryButtonBinding
 import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.forms.PaymentMethodRequirements
@@ -112,6 +113,9 @@ internal class PaymentOptionsActivityTest {
         enabled = true,
         visible = true
     )
+
+    private val ActivityPaymentOptionsBinding.continueButton: PrimaryButton
+        get() = root.findViewById(R.id.primary_button)
 
     @BeforeTest
     fun setup() {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -535,9 +535,9 @@ internal class PaymentSheetActivityTest {
 
             val googlePayButton =
                 StripeGooglePayButtonBinding.bind(activity.viewBinding.googlePayButton)
-            assertThat(googlePayButton.primaryButton.isVisible).isTrue()
+            assertThat(googlePayButton.googlePayPrimaryButton.isVisible).isTrue()
             assertThat(googlePayButton.googlePayButtonContent.isVisible).isFalse()
-            assertThat(googlePayButton.primaryButton.externalLabel)
+            assertThat(googlePayButton.googlePayPrimaryButton.externalLabel)
                 .isEqualTo(activity.getString(R.string.stripe_paymentsheet_primary_button_processing))
         }
     }
@@ -557,7 +557,7 @@ internal class PaymentSheetActivityTest {
 
             val googlePayButton =
                 StripeGooglePayButtonBinding.bind(activity.viewBinding.googlePayButton)
-            assertThat(googlePayButton.primaryButton.isVisible).isTrue()
+            assertThat(googlePayButton.googlePayPrimaryButton.isVisible).isTrue()
             assertThat(googlePayButton.googlePayButtonContent.isVisible).isFalse()
             assertThat(finishProcessingCalled).isTrue()
         }
@@ -633,7 +633,7 @@ internal class PaymentSheetActivityTest {
 
             val googlePayButton =
                 StripeGooglePayButtonBinding.bind(activity.viewBinding.googlePayButton)
-            assertThat(googlePayButton.primaryButton.externalLabel)
+            assertThat(googlePayButton.googlePayPrimaryButton.externalLabel)
                 .isEqualTo(activity.getString(R.string.stripe_paymentsheet_primary_button_processing))
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -39,6 +39,7 @@ import com.stripe.android.payments.paymentlauncher.StripePaymentLauncher
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
 import com.stripe.android.paymentsheet.PaymentSheetViewModel.CheckoutIdentifier
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.databinding.ActivityPaymentSheetBinding
 import com.stripe.android.paymentsheet.databinding.PrimaryButtonBinding
 import com.stripe.android.paymentsheet.databinding.StripeGooglePayButtonBinding
 import com.stripe.android.paymentsheet.forms.FormViewModel
@@ -186,6 +187,9 @@ internal class PaymentSheetActivityTest {
             PaymentSheetResult.Canceled
         )
     }
+
+    private val ActivityPaymentSheetBinding.buyButton: PrimaryButton
+        get() = root.findViewById(R.id.primary_button)
 
     @Test
     fun `disables primary button when editing`() {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request wraps `PrimaryButton` in an `AndroidViewBinding` so that we can embed it in Compose.

Since the state of `PrimaryButton` depends on many flows, we decided to begin like this and only rewrite the button in Compose at a later point.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Compose migration.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
