### PR TITLE
Add locale and currency to payment sheet events

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -21,6 +21,7 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.injection.DaggerPaymentOptionsViewModelFactoryComponent
 import com.stripe.android.paymentsheet.injection.PaymentOptionsViewModelSubcomponent
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.currency
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddFirstPaymentMethod
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.SelectSavedPaymentMethods
@@ -129,7 +130,10 @@ internal class PaymentOptionsViewModel @Inject constructor(
                 onPaymentResult(PaymentResult.Canceled)
             }
             LinkHandler.ProcessingState.Completed -> {
-                eventReporter.onPaymentSuccess(PaymentSelection.Link)
+                eventReporter.onPaymentSuccess(
+                    PaymentSelection.Link,
+                    stripeIntent.value?.currency
+                )
                 prefsRepository.savePaymentSelection(PaymentSelection.Link)
                 onPaymentResult(PaymentResult.Completed)
             }
@@ -198,7 +202,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
 
         selection.value?.let { paymentSelection ->
             // TODO(michelleb-stripe): Should the payment selection in the event be the saved or new item?
-            eventReporter.onSelectPaymentOption(paymentSelection)
+            eventReporter.onSelectPaymentOption(paymentSelection, stripeIntent.value?.currency)
 
             when (paymentSelection) {
                 is PaymentSelection.Saved ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -47,6 +47,7 @@ import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
 import com.stripe.android.paymentsheet.model.StripeIntentValidator
+import com.stripe.android.paymentsheet.model.currency
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.ACHText
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
@@ -203,7 +204,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                 _paymentSheetResult.tryEmit(PaymentSheetResult.Canceled)
             }
             LinkHandler.ProcessingState.Completed -> {
-                eventReporter.onPaymentSuccess(PaymentSelection.Link)
+                eventReporter.onPaymentSuccess(PaymentSelection.Link, stripeIntent.value?.currency)
                 prefsRepository.savePaymentSelection(PaymentSelection.Link)
                 _paymentSheetResult.tryEmit(PaymentSheetResult.Completed)
             }
@@ -444,7 +445,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     private fun processPayment(stripeIntent: StripeIntent, paymentResult: PaymentResult) {
         when (paymentResult) {
             is PaymentResult.Completed -> {
-                eventReporter.onPaymentSuccess(selection.value)
+                eventReporter.onPaymentSuccess(selection.value, stripeIntent.currency)
 
                 // SavedSelection needs to happen after new cards have been saved.
                 when (selection.value) {
@@ -463,7 +464,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             }
             else -> {
                 if (paymentResult is PaymentResult.Failed) {
-                    eventReporter.onPaymentFailure(selection.value)
+                    eventReporter.onPaymentFailure(selection.value, stripeIntent.currency)
                 }
 
                 runCatching {
@@ -491,7 +492,10 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             }
             is GooglePayPaymentMethodLauncher.Result.Failed -> {
                 logger.error("Error processing Google Pay payment", result.error)
-                eventReporter.onPaymentFailure(PaymentSelection.GooglePay)
+                eventReporter.onPaymentFailure(
+                    PaymentSelection.GooglePay,
+                    stripeIntent.value?.currency
+                )
                 onError(
                     when (result.errorCode) {
                         GooglePayPaymentMethodLauncher.NETWORK_ERROR ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -38,55 +38,77 @@ internal class DefaultEventReporter @Inject internal constructor(
         )
     }
 
-    override fun onShowExistingPaymentOptions(linkEnabled: Boolean, activeLinkSession: Boolean) {
+    override fun onShowExistingPaymentOptions(
+        linkEnabled: Boolean,
+        activeLinkSession: Boolean,
+        currency: String?
+    ) {
         paymentSheetShownMillis = eventTimeProvider.currentTimeMillis()
         fireEvent(
             PaymentSheetEvent.ShowExistingPaymentOptions(
                 mode = mode,
                 linkEnabled = linkEnabled,
-                activeLinkSession = activeLinkSession
+                activeLinkSession = activeLinkSession,
+                currency = currency
             )
         )
     }
 
-    override fun onShowNewPaymentOptionForm(linkEnabled: Boolean, activeLinkSession: Boolean) {
+    override fun onShowNewPaymentOptionForm(
+        linkEnabled: Boolean,
+        activeLinkSession: Boolean,
+        currency: String?
+    ) {
         paymentSheetShownMillis = eventTimeProvider.currentTimeMillis()
         fireEvent(
             PaymentSheetEvent.ShowNewPaymentOptionForm(
                 mode = mode,
                 linkEnabled = linkEnabled,
-                activeLinkSession = activeLinkSession
+                activeLinkSession = activeLinkSession,
+                currency = currency
             )
         )
     }
 
-    override fun onSelectPaymentOption(paymentSelection: PaymentSelection) {
+    override fun onSelectPaymentOption(
+        paymentSelection: PaymentSelection,
+        currency: String?
+    ) {
         fireEvent(
             PaymentSheetEvent.SelectPaymentOption(
                 mode = mode,
-                paymentSelection = paymentSelection
+                paymentSelection = paymentSelection,
+                currency = currency
             )
         )
     }
 
-    override fun onPaymentSuccess(paymentSelection: PaymentSelection?) {
+    override fun onPaymentSuccess(
+        paymentSelection: PaymentSelection?,
+        currency: String?
+    ) {
         fireEvent(
             PaymentSheetEvent.Payment(
                 mode = mode,
                 paymentSelection = paymentSelection,
                 durationMillis = durationMillisFrom(paymentSheetShownMillis),
-                result = PaymentSheetEvent.Payment.Result.Success
+                result = PaymentSheetEvent.Payment.Result.Success,
+                currency = currency
             )
         )
     }
 
-    override fun onPaymentFailure(paymentSelection: PaymentSelection?) {
+    override fun onPaymentFailure(
+        paymentSelection: PaymentSelection?,
+        currency: String?
+    ) {
         fireEvent(
             PaymentSheetEvent.Payment(
                 mode = mode,
                 paymentSelection = paymentSelection,
                 durationMillis = durationMillisFrom(paymentSheetShownMillis),
-                result = PaymentSheetEvent.Payment.Result.Failure
+                result = PaymentSheetEvent.Payment.Result.Failure,
+                currency = currency
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -8,15 +8,32 @@ internal interface EventReporter {
 
     fun onDismiss()
 
-    fun onShowExistingPaymentOptions(linkEnabled: Boolean, activeLinkSession: Boolean)
+    fun onShowExistingPaymentOptions(
+        linkEnabled: Boolean,
+        activeLinkSession: Boolean,
+        currency: String?
+    )
 
-    fun onShowNewPaymentOptionForm(linkEnabled: Boolean, activeLinkSession: Boolean)
+    fun onShowNewPaymentOptionForm(
+        linkEnabled: Boolean,
+        activeLinkSession: Boolean,
+        currency: String?
+    )
 
-    fun onSelectPaymentOption(paymentSelection: PaymentSelection)
+    fun onSelectPaymentOption(
+        paymentSelection: PaymentSelection,
+        currency: String?
+    )
 
-    fun onPaymentSuccess(paymentSelection: PaymentSelection?)
+    fun onPaymentSuccess(
+        paymentSelection: PaymentSelection?,
+        currency: String?
+    )
 
-    fun onPaymentFailure(paymentSelection: PaymentSelection?)
+    fun onPaymentFailure(
+        paymentSelection: PaymentSelection?,
+        currency: String?
+    )
 
     fun onLpmSpecFailure()
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/Intent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/Intent.kt
@@ -1,0 +1,10 @@
+package com.stripe.android.paymentsheet.model
+
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.StripeIntent
+
+internal val StripeIntent.currency: String?
+    get() = when (this) {
+        is PaymentIntent -> currency
+        else -> null
+    }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -27,6 +27,7 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
+import com.stripe.android.paymentsheet.model.currency
 import com.stripe.android.paymentsheet.model.getPMsToAdd
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddAnotherPaymentMethod
@@ -311,6 +312,7 @@ internal abstract class BaseSheetViewModel(
                 eventReporter.onShowExistingPaymentOptions(
                     linkEnabled = linkHandler.isLinkEnabled.value == true,
                     activeLinkSession = linkHandler.activeLinkSession.value,
+                    currency = stripeIntent.value?.currency
                 )
             }
             AddFirstPaymentMethod,
@@ -318,6 +320,7 @@ internal abstract class BaseSheetViewModel(
                 eventReporter.onShowNewPaymentOptionForm(
                     linkEnabled = linkHandler.isLinkEnabled.value == true,
                     activeLinkSession = linkHandler.activeLinkSession.value,
+                    currency = stripeIntent.value?.currency
                 )
             }
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -66,7 +66,11 @@ internal class PaymentOptionsViewModelTest {
             ensureAllEventsConsumed()
         }
 
-        verify(eventReporter).onSelectPaymentOption(SELECTION_SAVED_PAYMENT_METHOD)
+        verify(eventReporter)
+            .onSelectPaymentOption(
+                paymentSelection = SELECTION_SAVED_PAYMENT_METHOD,
+                currency = "usd"
+            )
     }
 
     @Test
@@ -86,7 +90,11 @@ internal class PaymentOptionsViewModelTest {
                 ensureAllEventsConsumed()
             }
 
-            verify(eventReporter).onSelectPaymentOption(NEW_REQUEST_DONT_SAVE_PAYMENT_SELECTION)
+            verify(eventReporter)
+                .onSelectPaymentOption(
+                    paymentSelection = NEW_REQUEST_DONT_SAVE_PAYMENT_SELECTION,
+                    currency = "usd"
+                )
             assertThat(prefsRepository.getSavedSelection(true, true))
                 .isEqualTo(SavedSelection.None)
         }
@@ -103,7 +111,11 @@ internal class PaymentOptionsViewModelTest {
                     awaitItem() as PaymentOptionResult.Succeeded
                 assertThat((paymentOptionResultSucceeded).paymentSelection)
                     .isEqualTo(NEW_REQUEST_SAVE_PAYMENT_SELECTION)
-                verify(eventReporter).onSelectPaymentOption(paymentOptionResultSucceeded.paymentSelection)
+                verify(eventReporter)
+                    .onSelectPaymentOption(
+                        paymentSelection = paymentOptionResultSucceeded.paymentSelection,
+                        currency = "usd"
+                    )
                 ensureAllEventsConsumed()
             }
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -418,7 +418,10 @@ internal class PaymentSheetViewModelTest {
                 .isEqualTo(PaymentSheetResult.Completed)
 
             verify(eventReporter)
-                .onPaymentSuccess(selection)
+                .onPaymentSuccess(
+                    paymentSelection = selection,
+                    currency = "usd"
+                )
             assertThat(prefsRepository.paymentSelectionArgs)
                 .containsExactly(selection)
             assertThat(
@@ -463,7 +466,10 @@ internal class PaymentSheetViewModelTest {
             assertThat(resultTurbine.awaitItem()).isEqualTo(PaymentSheetResult.Completed)
 
             verify(eventReporter)
-                .onPaymentSuccess(selection)
+                .onPaymentSuccess(
+                    paymentSelection = selection,
+                    currency = "usd"
+                )
 
             assertThat(prefsRepository.paymentSelectionArgs)
                 .containsExactly(
@@ -494,7 +500,11 @@ internal class PaymentSheetViewModelTest {
 
         viewModel.stripeIntent.test {
             viewModel.onPaymentResult(PaymentResult.Failed(Throwable()))
-            verify(eventReporter).onPaymentFailure(selection)
+            verify(eventReporter)
+                .onPaymentFailure(
+                    paymentSelection = selection,
+                    currency = "usd"
+                )
 
             val stripeIntent = awaitItem()
             assertThat(stripeIntent).isNull()
@@ -964,6 +974,7 @@ internal class PaymentSheetViewModelTest {
         verify(eventReporter).onShowNewPaymentOptionForm(
             linkEnabled = eq(false),
             activeLinkSession = eq(false),
+            currency = eq("usd")
         )
 
         receiver.cancelAndIgnoreRemainingEvents()
@@ -986,6 +997,7 @@ internal class PaymentSheetViewModelTest {
         verify(eventReporter).onShowNewPaymentOptionForm(
             linkEnabled = eq(true),
             activeLinkSession = eq(false),
+            currency = eq("usd")
         )
 
         receiver.cancelAndIgnoreRemainingEvents()
@@ -1008,6 +1020,7 @@ internal class PaymentSheetViewModelTest {
         verify(eventReporter).onShowNewPaymentOptionForm(
             linkEnabled = eq(true),
             activeLinkSession = eq(true),
+            currency = eq("usd")
         )
 
         receiver.cancelAndIgnoreRemainingEvents()
@@ -1025,6 +1038,7 @@ internal class PaymentSheetViewModelTest {
         verify(eventReporter).onShowExistingPaymentOptions(
             linkEnabled = eq(false),
             activeLinkSession = eq(false),
+            currency = eq("usd")
         )
 
         viewModel.transitionToAddPaymentScreen()
@@ -1032,6 +1046,7 @@ internal class PaymentSheetViewModelTest {
         verify(eventReporter).onShowNewPaymentOptionForm(
             linkEnabled = eq(false),
             activeLinkSession = eq(false),
+            currency = eq("usd")
         )
 
         receiver.cancelAndIgnoreRemainingEvents()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -48,33 +48,46 @@ class DefaultEventReporterTest {
         completeEventReporter.onInit(PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY)
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
-                req.params["event"] == "mc_complete_init_customer_googlepay"
+                req.params["event"] == "mc_complete_init_customer_googlepay" &&
+                    req.params["locale"] == "en_US"
             }
         )
     }
 
     @Test
     fun `onShowExistingPaymentOptions() should fire analytics request with expected event value`() {
-        completeEventReporter.onShowExistingPaymentOptions(true, false)
+        completeEventReporter.onShowExistingPaymentOptions(
+            linkEnabled = true,
+            activeLinkSession = false,
+            currency = "usd"
+        )
 
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
                 req.params["event"] == "mc_complete_sheet_savedpm_show" &&
                     req.params["link_enabled"] == true &&
-                    req.params["active_link_session"] == false
+                    req.params["active_link_session"] == false &&
+                    req.params["currency"] == "usd" &&
+                    req.params["locale"] == "en_US"
             }
         )
     }
 
     @Test
     fun `onShowNewPaymentOptionForm() should fire analytics request with expected event value`() {
-        completeEventReporter.onShowNewPaymentOptionForm(false, true)
+        completeEventReporter.onShowNewPaymentOptionForm(
+            linkEnabled = false,
+            activeLinkSession = true,
+            currency = "usd"
+        )
 
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
                 req.params["event"] == "mc_complete_sheet_newpm_show" &&
                     req.params["link_enabled"] == false &&
-                    req.params["active_link_session"] == true
+                    req.params["active_link_session"] == true &&
+                    req.params["currency"] == "usd" &&
+                    req.params["locale"] == "en_US"
             }
         )
     }
@@ -82,17 +95,24 @@ class DefaultEventReporterTest {
     @Test
     fun `onPaymentSuccess() should fire analytics request with expected event value`() {
         // Log initial event so that duration is tracked
-        completeEventReporter.onShowExistingPaymentOptions(false, false)
+        completeEventReporter.onShowExistingPaymentOptions(
+            linkEnabled = false,
+            activeLinkSession = false,
+            currency = "usd"
+        )
         reset(analyticsRequestExecutor)
         whenever(eventTimeProvider.currentTimeMillis()).thenReturn(2000L)
 
         completeEventReporter.onPaymentSuccess(
-            PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+            paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+            currency = "usd"
         )
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
                 req.params["event"] == "mc_complete_payment_savedpm_success" &&
-                    req.params["duration"] == 1f
+                    req.params["duration"] == 1f &&
+                    req.params["currency"] == "usd" &&
+                    req.params["locale"] == "en_US"
             }
         )
     }
@@ -100,17 +120,24 @@ class DefaultEventReporterTest {
     @Test
     fun `onPaymentFailure() should fire analytics request with expected event value`() {
         // Log initial event so that duration is tracked
-        completeEventReporter.onShowExistingPaymentOptions(false, false)
+        completeEventReporter.onShowExistingPaymentOptions(
+            linkEnabled = false,
+            activeLinkSession = false,
+            currency = "usd"
+        )
         reset(analyticsRequestExecutor)
         whenever(eventTimeProvider.currentTimeMillis()).thenReturn(2000L)
 
         completeEventReporter.onPaymentFailure(
-            PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+            paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+            currency = "usd"
         )
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
                 req.params["event"] == "mc_complete_payment_savedpm_failure" &&
-                    req.params["duration"] == 1f
+                    req.params["duration"] == 1f &&
+                    req.params["currency"] == "usd" &&
+                    req.params["locale"] == "en_US"
             }
         )
     }
@@ -118,11 +145,14 @@ class DefaultEventReporterTest {
     @Test
     fun `onSelectPaymentOption() should fire analytics request with expected event value`() {
         customEventReporter.onSelectPaymentOption(
-            PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+            paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+            currency = "usd"
         )
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
-                req.params["event"] == "mc_custom_paymentoption_savedpm_select"
+                req.params["event"] == "mc_custom_paymentoption_savedpm_select" &&
+                    req.params["currency"] == "usd" &&
+                    req.params["locale"] == "en_US"
             }
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -204,24 +204,46 @@ internal class DefaultFlowControllerTest {
     fun `successful payment should fire analytics event`() {
         val viewModel = ViewModelProvider(activity)[FlowControllerViewModel::class.java]
         val flowController = createFlowController(viewModel = viewModel)
+        flowController.configureWithPaymentIntent(
+            PaymentSheetFixtures.CLIENT_SECRET,
+        ) { _, _ -> }
 
-        viewModel.paymentSelection = PaymentSelection.New.Card(PaymentMethodCreateParamsFixtures.DEFAULT_CARD, mock(), mock())
+        viewModel.paymentSelection = PaymentSelection.New.Card(
+            PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+            mock(),
+            mock()
+        )
 
         flowController.onPaymentResult(PaymentResult.Completed)
 
-        verify(eventReporter).onPaymentSuccess(isA<PaymentSelection.New>())
+        verify(eventReporter)
+            .onPaymentSuccess(
+                paymentSelection = isA<PaymentSelection.New>(),
+                currency = eq("usd")
+            )
     }
 
     @Test
     fun `failed payment should fire analytics event`() {
         val viewModel = ViewModelProvider(activity)[FlowControllerViewModel::class.java]
         val flowController = createFlowController(viewModel = viewModel)
+        flowController.configureWithPaymentIntent(
+            PaymentSheetFixtures.CLIENT_SECRET,
+        ) { _, _ -> }
 
-        viewModel.paymentSelection = PaymentSelection.New.Card(PaymentMethodCreateParamsFixtures.DEFAULT_CARD, mock(), mock())
+        viewModel.paymentSelection = PaymentSelection.New.Card(
+            PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+            mock(),
+            mock()
+        )
 
         flowController.onPaymentResult(PaymentResult.Failed(RuntimeException()))
 
-        verify(eventReporter).onPaymentFailure(isA<PaymentSelection.New>())
+        verify(eventReporter)
+            .onPaymentFailure(
+                paymentSelection = isA<PaymentSelection.New>(),
+                currency = eq("usd")
+            )
     }
 
     @Test

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestFactory.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestFactory.kt
@@ -15,8 +15,7 @@ open class AnalyticsRequestFactory(
     private val packageManager: PackageManager?,
     private val packageInfo: PackageInfo?,
     private val packageName: String,
-    private val publishableKeyProvider: Provider<String>,
-    internal val defaultProductUsageTokens: Set<String> = emptySet()
+    private val publishableKeyProvider: Provider<String>
 ) {
     @VisibleForTesting
     val sessionId: UUID = UUID.randomUUID()
@@ -31,7 +30,7 @@ open class AnalyticsRequestFactory(
      */
     fun createRequest(
         event: AnalyticsEvent,
-        additionalParams: Map<String, Any>
+        additionalParams: Map<String, Any?>
     ): AnalyticsRequest {
         return AnalyticsRequest(
             params = createParams(event) + additionalParams,

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/QueryStringFactory.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/QueryStringFactory.kt
@@ -113,7 +113,7 @@ object QueryStringFactory {
         keyPrefix: String
     ): List<Parameter> {
         return when (value) {
-            is Map<*, *> -> flattenParamsMap(value as Map<String, Any>?, keyPrefix)
+            is Map<*, *> -> flattenParamsMap(value as Map<String, Any?>?, keyPrefix)
             is List<*> -> flattenParamsList(value, keyPrefix)
             null -> {
                 listOf(Parameter(keyPrefix, ""))
@@ -124,7 +124,7 @@ object QueryStringFactory {
         }
     }
 
-    private data class Parameter internal constructor(
+    private data class Parameter constructor(
         private val key: String,
         private val value: String
     ) {

--- a/stripe-core/src/test/java/com/stripe/android/core/networking/QueryStringFactoryTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/networking/QueryStringFactoryTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.core.networking
 import java.net.URLDecoder
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class QueryStringFactoryTest {
@@ -73,6 +74,7 @@ class QueryStringFactoryTest {
         assertTrue(outParams.containsKey("a"))
         assertTrue(outParams.containsKey("b"))
         assertTrue(outParams.containsKey("c"))
+        assertFalse(outParams.containsKey("d"))
 
         val firstNestedMap = outParams["c"] as Map<*, *>
         assertEquals(2, firstNestedMap.size)
@@ -85,7 +87,7 @@ class QueryStringFactoryTest {
         assertTrue(secondNestedMap.containsKey("2b"))
     }
 
-    private fun createParamsWithNestedMap(): Map<String, Any> {
+    private fun createParamsWithNestedMap(): Map<String, Any?> {
         return mapOf(
             "a" to "fun param",
             "b" to "not null",
@@ -96,7 +98,8 @@ class QueryStringFactoryTest {
                     "2a" to "",
                     "2b" to "hello world"
                 )
-            )
+            ),
+            "d" to null
         )
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Table of data added to events:

|          | init | show | complete |
|----------|------|------|----------|
| locale   | x    | x    | x        |
| currency |      | x    | x        |

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[iOS counterpart](https://github.com/stripe/stripe-ios/pull/2093)

https://paper.dropbox.com/doc/PaymentSheet-conversion-tracking--BtJHMy0MyLX9QEphcDLwR0CWAg-yntdTWBj58b0dcdpJjGYT

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
