### PR TITLE
Fix SDK version on ConsumersApiService

### DIFF
--- a/link/src/main/java/com/stripe/android/link/injection/LinkCommonModule.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/LinkCommonModule.kt
@@ -1,10 +1,10 @@
 package com.stripe.android.link.injection
 
 import com.stripe.android.Stripe
-import com.stripe.android.core.ApiVersion
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
+import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.link.analytics.DefaultLinkEventsReporter
 import com.stripe.android.link.analytics.LinkEventsReporter
 import com.stripe.android.link.repositories.LinkApiRepository
@@ -35,7 +35,7 @@ internal interface LinkCommonModule {
             @IOContext workContext: CoroutineContext,
         ): ConsumersApiService = ConsumersApiServiceImpl(
             appInfo = Stripe.appInfo,
-            sdkVersion = ApiVersion(betas = emptySet()).code,
+            sdkVersion = StripeSdkVersion.VERSION,
             apiVersion = Stripe.API_VERSION,
             stripeNetworkClient = DefaultStripeNetworkClient(
                 logger = logger,

--- a/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
@@ -38,6 +38,7 @@ class ConsumersApiServiceImplTest {
             method("POST"),
             path("/v1/consumers/sessions/lookup"),
             header("Authorization", "Bearer ${DEFAULT_OPTIONS.apiKey}"),
+            header("User-Agent", "Stripe/v1 ${StripeSdkVersion.VERSION}"),
             bodyPart("email_address", "email%40example.com"),
             bodyPart("cookies%5Bverification_session_client_secrets%5D%5B%5D", cookie),
             bodyPart("request_surface", "android_payment_element"),


### PR DESCRIPTION
# Summary
- We are passing ApiVersion as SDKVersion on ConsumersApiService API requests. 

# Testing
Planning on convering this request field once https://github.com/stripe/stripe-android/pull/6146 is merged.