### PR TITLE
[Identity] Additional API changes for ID/Addr

### DIFF
--- a/identity/api/identity.api
+++ b/identity/api/identity.api
@@ -214,6 +214,14 @@ public final class com/stripe/android/identity/networking/models/VerificationPag
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/identity/networking/models/VerificationPageStaticContentCountryNotListedPage$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/identity/networking/models/VerificationPageStaticContentCountryNotListedPage;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/identity/networking/models/VerificationPageStaticContentCountryNotListedPage;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/identity/networking/models/VerificationPageStaticContentDocumentCaptureModels$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/identity/networking/models/VerificationPageStaticContentDocumentCaptureModels;

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPage.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPage.kt
@@ -18,9 +18,11 @@ internal data class VerificationPage(
     @SerialName("document_select")
     val documentSelect: VerificationPageStaticContentDocumentSelectPage,
     @SerialName("individual")
-    val individual: VerificationPageStaticContentIndividualPage? = null,
+    val individual: VerificationPageStaticContentIndividualPage,
     @SerialName("selfie")
     val selfieCapture: VerificationPageStaticContentSelfieCapturePage? = null,
+    @SerialName("country_not_listed")
+    val countryNotListedPage: VerificationPageStaticContentCountryNotListedPage,
     /* The short-lived URL that can be used in the case that the client cannot support the VerificationSession. */
     @SerialName("fallback_url")
     val fallbackUrl: String,

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageStaticContentCountryNotListedPage.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageStaticContentCountryNotListedPage.kt
@@ -1,0 +1,21 @@
+package com.stripe.android.identity.networking.models
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+@Parcelize
+internal data class VerificationPageStaticContentCountryNotListedPage(
+    @SerialName("title")
+    val title: String,
+    @SerialName("body")
+    val body: String,
+    @SerialName("cancel_button_text")
+    val cancelButtonText: String,
+    @SerialName("id_from_other_country_text_button_text")
+    val idFromOtherCountryTextButtonText: String,
+    @SerialName("address_from_other_country_text_button_text")
+    val addressFromOtherCountryTextButtonText: String
+) : Parcelable

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageStaticContentIndividualPage.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageStaticContentIndividualPage.kt
@@ -19,5 +19,9 @@ internal data class VerificationPageStaticContentIndividualPage(
     val title: String,
     @SerialName("id_number_countries")
     @Serializable(with = CountryListSerializer::class)
-    val idNumberCountries: List<Country>
+    val idNumberCountries: List<Country>,
+    @SerialName("id_number_country_not_listed_text_button_text")
+    val idNumberCountryNotListedTextButtonText: String,
+    @SerialName("address_country_not_listed_text_button_text")
+    val addressCountryNotListedTextButtonText: String
 ) : Parcelable

--- a/identity/src/test/java/com/stripe/android/identity/networking/DefaultIdentityRepositoryTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/networking/DefaultIdentityRepositoryTest.kt
@@ -151,12 +151,37 @@ class DefaultIdentityRepositoryTest {
         testFetchVerificationPage(
             VERIFICATION_PAGE_TYPE_ADDRESS_JSON_STRING
         ) {
-            assertThat(it.individual).isNotNull()
-            assertThat(requireNotNull(it.individual).addressCountries).hasSize(31)
-            assertThat(requireNotNull(it.individual).idNumberCountries).containsExactly(
+            assertThat(it.individual.addressCountries).hasSize(31)
+            assertThat(it.individual.idNumberCountries).containsExactly(
                 Country(CountryCode("BR"), "Brazil"),
                 Country(CountryCode("SG"), "Singapore"),
                 Country(CountryCode("US"), "United States"),
+            )
+            assertThat(it.individual.title).isEqualTo("Provide personal information")
+            assertThat(it.individual.addressCountryNotListedTextButtonText).isEqualTo("My country is not listed")
+            assertThat(it.individual.idNumberCountryNotListedTextButtonText).isEqualTo("My country is not listed")
+        }
+    }
+
+    @Test
+    fun `retrieveVerificationPage - verify countryNotListed page`() {
+        testFetchVerificationPage(
+            VERIFICATION_PAGE_TYPE_ADDRESS_JSON_STRING
+        ) {
+            assertThat(it.countryNotListedPage.title).isEqualTo(
+                "We cannot verify your identity"
+            )
+            assertThat(it.countryNotListedPage.idFromOtherCountryTextButtonText).isEqualTo(
+                "Have an ID from another country?"
+            )
+            assertThat(it.countryNotListedPage.addressFromOtherCountryTextButtonText).isEqualTo(
+                "Have an Address from another country?"
+            )
+            assertThat(it.countryNotListedPage.body).isEqualTo(
+                "The countries not listed are not supported yet. Unfortunately, we cannot verify your identity."
+            )
+            assertThat(it.countryNotListedPage.cancelButtonText).isEqualTo(
+                "Cancel verification"
             )
         }
     }

--- a/identity/src/test/java/com/stripe/android/identity/networking/IdentityNetworkResponseFixtures.kt
+++ b/identity/src/test/java/com/stripe/android/identity/networking/IdentityNetworkResponseFixtures.kt
@@ -32,6 +32,13 @@ internal val VERIFICATION_PAGE_NOT_REQUIRE_LIVE_CAPTURE_JSON_STRING = """
         "title": "mlgb.band uses Stripe to verify your identity",
         "scroll_to_continue_button_text": "Scroll to consent"
       },
+      "country_not_listed": {
+        "address_from_other_country_text_button_text": "Have an Address from another country?",
+        "body": "The countries not listed are not supported yet. Unfortunately, we cannot verify your identity.",
+        "cancel_button_text": "Cancel verification",
+        "id_from_other_country_text_button_text": "Have an ID from another country?",
+        "title": "We cannot verify your identity"
+      },
       "document_capture": {
         "autocapture_timeout": 8000,
         "file_purpose": "identity_private",
@@ -60,6 +67,50 @@ internal val VERIFICATION_PAGE_NOT_REQUIRE_LIVE_CAPTURE_JSON_STRING = """
         "title": "Which form of identification do you want to use?"
       },
       "fallback_url": "https://verify.stripe.com/start/test_YWNjdF8xSU84aDNFQWphT2tpdUdNLF9MTjg5dFZtRWV1T1c1QXBxMkJ6MTUwZlI5c3JtTE5U0100BzkFlqqD",
+      "individual": {
+        "address_countries": {
+          "AT": "Austria",
+          "AU": "Australia",
+          "BE": "Belgium",
+          "BR": "Brazil",
+          "CA": "Canada",
+          "CH": "Switzerland",
+          "CZ": "Czech Republic",
+          "DE": "Germany",
+          "DK": "Denmark",
+          "ES": "Spain",
+          "FI": "Finland",
+          "FR": "France",
+          "GB": "United Kingdom",
+          "HK": "Hong Kong",
+          "ID": "Indonesia",
+          "IE": "Ireland",
+          "IT": "Italy",
+          "LU": "Luxembourg",
+          "MT": "Malta",
+          "MX": "Mexico",
+          "MY": "Malaysia",
+          "NL": "Netherlands",
+          "NO": "Norway",
+          "PL": "Poland",
+          "PT": "Portugal",
+          "RO": "Romania",
+          "SE": "Sweden",
+          "SG": "Singapore",
+          "SK": "Slovakia",
+          "TH": "Thailand",
+          "US": "United States"
+        },
+        "address_country_not_listed_text_button_text": "My country is not listed",
+        "button_text": "Submit",
+        "id_number_countries": {
+          "BR": "Brazil",
+          "SG": "Singapore",
+          "US": "United States"
+        },
+        "id_number_country_not_listed_text_button_text": "My country is not listed",
+        "title": "Provide personal information"
+      },
       "livemode": false,
       "requirements": {
         "missing": [
@@ -93,6 +144,13 @@ internal val VERIFICATION_PAGE_REQUIRE_LIVE_CAPTURE_JSON_STRING = """
         "title": "mlgb.band uses Stripe to verify your identity",
         "scroll_to_continue_button_text": "Scroll to consent"
       },
+      "country_not_listed": {
+        "address_from_other_country_text_button_text": "Have an Address from another country?",
+        "body": "The countries not listed are not supported yet. Unfortunately, we cannot verify your identity.",
+        "cancel_button_text": "Cancel verification",
+        "id_from_other_country_text_button_text": "Have an ID from another country?",
+        "title": "We cannot verify your identity"
+      },
       "document_capture": {
         "autocapture_timeout": 8000,
         "file_purpose": "identity_private",
@@ -121,6 +179,50 @@ internal val VERIFICATION_PAGE_REQUIRE_LIVE_CAPTURE_JSON_STRING = """
         "title": "Which form of identification do you want to use?"
       },
       "fallback_url": "https://verify.stripe.com/start/test_YWNjdF8xSU84aDNFQWphT2tpdUdNLF9MTjg5dFZtRWV1T1c1QXBxMkJ6MTUwZlI5c3JtTE5U0100BzkFlqqD",
+      "individual": {
+        "address_countries": {
+          "AT": "Austria",
+          "AU": "Australia",
+          "BE": "Belgium",
+          "BR": "Brazil",
+          "CA": "Canada",
+          "CH": "Switzerland",
+          "CZ": "Czech Republic",
+          "DE": "Germany",
+          "DK": "Denmark",
+          "ES": "Spain",
+          "FI": "Finland",
+          "FR": "France",
+          "GB": "United Kingdom",
+          "HK": "Hong Kong",
+          "ID": "Indonesia",
+          "IE": "Ireland",
+          "IT": "Italy",
+          "LU": "Luxembourg",
+          "MT": "Malta",
+          "MX": "Mexico",
+          "MY": "Malaysia",
+          "NL": "Netherlands",
+          "NO": "Norway",
+          "PL": "Poland",
+          "PT": "Portugal",
+          "RO": "Romania",
+          "SE": "Sweden",
+          "SG": "Singapore",
+          "SK": "Slovakia",
+          "TH": "Thailand",
+          "US": "United States"
+        },
+        "address_country_not_listed_text_button_text": "My country is not listed",
+        "button_text": "Submit",
+        "id_number_countries": {
+          "BR": "Brazil",
+          "SG": "Singapore",
+          "US": "United States"
+        },
+        "id_number_country_not_listed_text_button_text": "My country is not listed",
+        "title": "Provide personal information"
+      },
       "livemode": false,
       "requirements": {
         "missing": [
@@ -153,6 +255,13 @@ internal val VERIFICATION_PAGE_REQUIRE_SELFIE_LIVE_CAPTURE_JSON_STRING = """
         "scroll_to_continue_button_text": "Scroll to continue",
         "time_estimate": "Takes about 1–2 minutes.",
         "title": "Andrew's Audio uses Stripe to verify your identity"
+      },
+      "country_not_listed": {
+        "address_from_other_country_text_button_text": "Have an Address from another country?",
+        "body": "The countries not listed are not supported yet. Unfortunately, we cannot verify your identity.",
+        "cancel_button_text": "Cancel verification",
+        "id_from_other_country_text_button_text": "Have an ID from another country?",
+        "title": "We cannot verify your identity"
       },
       "document_capture": {
         "autocapture_timeout": 8000,
@@ -187,6 +296,50 @@ internal val VERIFICATION_PAGE_REQUIRE_SELFIE_LIVE_CAPTURE_JSON_STRING = """
         "title": "Which form of identification do you want to use?"
       },
       "fallback_url": "https://verify.stripe.com/start/live_YWNjdF8xSDM0ZFhHTVpZR054SmtCLF9Nc0V5NkI2TjZ6MkZPWUxsUndtMXlyZzA5YzdDdjVU0100gEzqe9Je",
+      "individual": {
+        "address_countries": {
+          "AT": "Austria",
+          "AU": "Australia",
+          "BE": "Belgium",
+          "BR": "Brazil",
+          "CA": "Canada",
+          "CH": "Switzerland",
+          "CZ": "Czech Republic",
+          "DE": "Germany",
+          "DK": "Denmark",
+          "ES": "Spain",
+          "FI": "Finland",
+          "FR": "France",
+          "GB": "United Kingdom",
+          "HK": "Hong Kong",
+          "ID": "Indonesia",
+          "IE": "Ireland",
+          "IT": "Italy",
+          "LU": "Luxembourg",
+          "MT": "Malta",
+          "MX": "Mexico",
+          "MY": "Malaysia",
+          "NL": "Netherlands",
+          "NO": "Norway",
+          "PL": "Poland",
+          "PT": "Portugal",
+          "RO": "Romania",
+          "SE": "Sweden",
+          "SG": "Singapore",
+          "SK": "Slovakia",
+          "TH": "Thailand",
+          "US": "United States"
+        },
+        "address_country_not_listed_text_button_text": "My country is not listed",
+        "button_text": "Submit",
+        "id_number_countries": {
+          "BR": "Brazil",
+          "SG": "Singapore",
+          "US": "United States"
+        },
+        "id_number_country_not_listed_text_button_text": "My country is not listed",
+        "title": "Provide personal information"
+      },
       "livemode": true,
       "requirements": {
         "missing": [
@@ -271,6 +424,13 @@ internal val VERIFICATION_PAGE_TYPE_DOCUMENT_REQUIRE_ID_NUMBER_JSON_STRING = """
         "time_estimate": "Takes about 1–2 minutes.",
         "title": "Tora's catfood uses Stripe to verify your identity"
       },
+      "country_not_listed": {
+        "address_from_other_country_text_button_text": "Have an Address from another country?",
+        "body": "The countries not listed are not supported yet. Unfortunately, we cannot verify your identity.",
+        "cancel_button_text": "Cancel verification",
+        "id_from_other_country_text_button_text": "Have an ID from another country?",
+        "title": "We cannot verify your identity"
+      },
       "document_capture": {
         "autocapture_timeout": 8000,
         "file_purpose": "identity_private",
@@ -338,12 +498,14 @@ internal val VERIFICATION_PAGE_TYPE_DOCUMENT_REQUIRE_ID_NUMBER_JSON_STRING = """
           "TH": "Thailand",
           "US": "United States"
         },
+        "address_country_not_listed_text_button_text": "My country is not listed",
         "button_text": "Submit",
         "id_number_countries": {
           "BR": "Brazil",
           "SG": "Singapore",
           "US": "United States"
         },
+        "id_number_country_not_listed_text_button_text": "My country is not listed",
         "title": "Provide personal information"
       },
       "livemode": false,
@@ -381,6 +543,13 @@ internal val VERIFICATION_PAGE_TYPE_DOCUMENT_REQUIRE_ADDRESS_JSON_STRING = """
         "scroll_to_continue_button_text": "Scroll to continue",
         "time_estimate": "Takes about 1–2 minutes.",
         "title": "Tora's catfood uses Stripe to verify your identity"
+      },
+      "country_not_listed": {
+        "address_from_other_country_text_button_text": "Have an Address from another country?",
+        "body": "The countries not listed are not supported yet. Unfortunately, we cannot verify your identity.",
+        "cancel_button_text": "Cancel verification",
+        "id_from_other_country_text_button_text": "Have an ID from another country?",
+        "title": "We cannot verify your identity"
       },
       "document_capture": {
         "autocapture_timeout": 8000,
@@ -449,12 +618,14 @@ internal val VERIFICATION_PAGE_TYPE_DOCUMENT_REQUIRE_ADDRESS_JSON_STRING = """
           "TH": "Thailand",
           "US": "United States"
         },
+        "address_country_not_listed_text_button_text": "My country is not listed",
         "button_text": "Submit",
         "id_number_countries": {
           "BR": "Brazil",
           "SG": "Singapore",
           "US": "United States"
         },
+        "id_number_country_not_listed_text_button_text": "My country is not listed",
         "title": "Provide personal information"
       },
       "livemode": true,
@@ -491,6 +662,13 @@ internal val VERIFICATION_PAGE_TYPE_DOCUMENT_REQUIRE_ADDRESS_AND_ID_NUMBER_JSON_
         "scroll_to_continue_button_text": "Scroll to continue",
         "time_estimate": "Takes about 1–2 minutes.",
         "title": "Tora's catfood uses Stripe to verify your identity"
+      },
+      "country_not_listed": {
+        "address_from_other_country_text_button_text": "Have an Address from another country?",
+        "body": "The countries not listed are not supported yet. Unfortunately, we cannot verify your identity.",
+        "cancel_button_text": "Cancel verification",
+        "id_from_other_country_text_button_text": "Have an ID from another country?",
+        "title": "We cannot verify your identity"
       },
       "document_capture": {
         "autocapture_timeout": 8000,
@@ -559,12 +737,14 @@ internal val VERIFICATION_PAGE_TYPE_DOCUMENT_REQUIRE_ADDRESS_AND_ID_NUMBER_JSON_
           "TH": "Thailand",
           "US": "United States"
         },
+        "address_country_not_listed_text_button_text": "My country is not listed",
         "button_text": "Submit",
         "id_number_countries": {
           "BR": "Brazil",
           "SG": "Singapore",
           "US": "United States"
         },
+        "id_number_country_not_listed_text_button_text": "My country is not listed",
         "title": "Provide personal information"
       },
       "livemode": false,
@@ -602,6 +782,13 @@ internal val VERIFICATION_PAGE_TYPE_ID_NUMBER_JSON_STRING = """
         "scroll_to_continue_button_text": "Scroll to continue",
         "time_estimate": "Takes about 1–2 minutes.",
         "title": "Tora's catfood uses Stripe to verify your identity"
+      },
+      "country_not_listed": {
+        "address_from_other_country_text_button_text": "Have an Address from another country?",
+        "body": "The countries not listed are not supported yet. Unfortunately, we cannot verify your identity.",
+        "cancel_button_text": "Cancel verification",
+        "id_from_other_country_text_button_text": "Have an ID from another country?",
+        "title": "We cannot verify your identity"
       },
       "document_capture": {
         "autocapture_timeout": 8000,
@@ -670,12 +857,14 @@ internal val VERIFICATION_PAGE_TYPE_ID_NUMBER_JSON_STRING = """
           "TH": "Thailand",
           "US": "United States"
         },
+        "address_country_not_listed_text_button_text": "My country is not listed",
         "button_text": "Submit",
         "id_number_countries": {
           "BR": "Brazil",
           "SG": "Singapore",
           "US": "United States"
         },
+        "id_number_country_not_listed_text_button_text": "My country is not listed",
         "title": "Provide personal information"
       },
       "livemode": false,
@@ -710,6 +899,13 @@ internal val VERIFICATION_PAGE_TYPE_ADDRESS_JSON_STRING = """
         "scroll_to_continue_button_text": "Scroll to continue",
         "time_estimate": "Takes about 1–2 minutes.",
         "title": "Tora's catfood uses Stripe to verify your identity"
+      },
+      "country_not_listed": {
+        "address_from_other_country_text_button_text": "Have an Address from another country?",
+        "body": "The countries not listed are not supported yet. Unfortunately, we cannot verify your identity.",
+        "cancel_button_text": "Cancel verification",
+        "id_from_other_country_text_button_text": "Have an ID from another country?",
+        "title": "We cannot verify your identity"
       },
       "document_capture": {
         "autocapture_timeout": 8000,
@@ -778,12 +974,14 @@ internal val VERIFICATION_PAGE_TYPE_ADDRESS_JSON_STRING = """
           "TH": "Thailand",
           "US": "United States"
         },
+        "address_country_not_listed_text_button_text": "My country is not listed",
         "button_text": "Submit",
         "id_number_countries": {
           "BR": "Brazil",
           "SG": "Singapore",
           "US": "United States"
         },
+        "id_number_country_not_listed_text_button_text": "My country is not listed",
         "title": "Provide personal information"
       },
       "livemode": false,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add additional API fields for ID/Addr:
* `VerificationPage.country_not_listed`
* `VerificationPage.individual.address_country_not_listed_text_button_text`
* `VerificationPage.individual.id_number_country_not_listed_text_button_text`

Please see [this](https://docs.google.com/document/d/1N3GeDgdNxRsr86XdT_5lWOLEdhWST26F9t5aDgJz-3E/edit#bookmark=id.a6cmxttvrbe7) internal doc for details


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
