### PR TITLE
Make `PaymentLauncher.create` methods Java-friendly

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -6625,12 +6625,18 @@ public abstract interface class com/stripe/android/payments/paymentlauncher/Paym
 	public static final field Companion Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$Companion;
 	public abstract fun confirm (Lcom/stripe/android/model/ConfirmPaymentIntentParams;)V
 	public abstract fun confirm (Lcom/stripe/android/model/ConfirmSetupIntentParams;)V
+	public static fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$PaymentResultCallback;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher;
+	public static fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$PaymentResultCallback;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher;
+	public static fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$PaymentResultCallback;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher;
+	public static fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$PaymentResultCallback;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher;
 	public abstract fun handleNextActionForPaymentIntent (Ljava/lang/String;)V
 	public abstract fun handleNextActionForSetupIntent (Ljava/lang/String;)V
 }
 
 public final class com/stripe/android/payments/paymentlauncher/PaymentLauncher$Companion {
+	public final fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$PaymentResultCallback;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher;
 	public final fun create (Landroidx/activity/ComponentActivity;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$PaymentResultCallback;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher;
+	public final fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$PaymentResultCallback;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher;
 	public final fun create (Landroidx/fragment/app/Fragment;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$PaymentResultCallback;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher;
 	public static synthetic fun create$default (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$Companion;Landroidx/activity/ComponentActivity;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$PaymentResultCallback;ILjava/lang/Object;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher;
 	public static synthetic fun create$default (Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$Companion;Landroidx/fragment/app/Fragment;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$PaymentResultCallback;ILjava/lang/Object;)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher;

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncher.kt
@@ -50,6 +50,8 @@ interface PaymentLauncher {
          * This API registers an [ActivityResultLauncher] into the [ComponentActivity],  it needs
          * to be called before the [ComponentActivity] is created.
          */
+        @JvmStatic
+        @JvmOverloads
         fun create(
             activity: ComponentActivity,
             publishableKey: String,
@@ -63,6 +65,8 @@ interface PaymentLauncher {
          * This API registers an [ActivityResultLauncher] into the [Fragment]'s hosting Activity, it
          * needs to be called before the [Fragment] is created.
          */
+        @JvmStatic
+        @JvmOverloads
         fun create(
             fragment: Fragment,
             publishableKey: String,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds `JvmOverloads` and `JvmStatic` to the `PaymentLauncher.create()` methods for better Java interop.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Trying to avoid writing `PaymentLauncher.Companion.create()` in the Cash App Pay docs.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
