### PR TITLE
[Maestro][FC] Don't close keyboard on manual entry

### DIFF
--- a/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
+++ b/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
@@ -29,7 +29,6 @@ appId: com.stripe.android.financialconnections.example
 - tapOn:
     id: "ConfirmAccountInput"
 - inputText: "000123456789"
-- back
 - tapOn: "Continue"
 - tapOn: "Done"
 - assertVisible: ".*Completed!.*"


### PR DESCRIPTION
# Summary
Don't close keyboard on manual entry (Continue button should be visible with keyboard open)