### PR TITLE
[stripe-ui-core] Move SectionElement to stripe-ui-core

### DIFF
--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -64,11 +64,11 @@ import com.stripe.android.model.CvcCheck
 import com.stripe.android.ui.core.elements.CvcController
 import com.stripe.android.ui.core.elements.CvcElement
 import com.stripe.android.ui.core.elements.DateConfig
-import com.stripe.android.ui.core.elements.SectionElement
-import com.stripe.android.ui.core.elements.SectionElementUI
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.RowController
 import com.stripe.android.uicore.elements.RowElement
+import com.stripe.android.uicore.elements.SectionElement
+import com.stripe.android.uicore.elements.SectionElementUI
 import com.stripe.android.uicore.elements.SectionSingleFieldElement
 import com.stripe.android.uicore.elements.SimpleTextElement
 import com.stripe.android.uicore.elements.SimpleTextFieldController

--- a/link/src/test/java/com/stripe/android/link/ui/forms/FormControllerTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/forms/FormControllerTest.kt
@@ -12,11 +12,11 @@ import com.stripe.android.ui.core.elements.EmailSpec
 import com.stripe.android.ui.core.elements.LayoutSpec
 import com.stripe.android.ui.core.elements.NameSpec
 import com.stripe.android.ui.core.elements.SaveForFutureUseSpec
-import com.stripe.android.ui.core.elements.SectionElement
 import com.stripe.android.ui.core.forms.TransformSpecToElements
 import com.stripe.android.ui.core.forms.resources.StaticAddressResourceRepository
 import com.stripe.android.uicore.address.AddressRepository
 import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SectionSingleFieldElement
 import com.stripe.android.uicore.elements.TextFieldController
 import kotlinx.coroutines.flow.first

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -598,9 +598,6 @@ public final class com/stripe/android/ui/core/elements/SaveForFutureUseSpec$Comp
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/stripe/android/ui/core/elements/SectionElementUIKt {
-}
-
 public final class com/stripe/android/ui/core/elements/SimpleDialogElementUIKt {
 }
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormController.kt
@@ -3,11 +3,11 @@ package com.stripe.android.ui.core
 import androidx.annotation.RestrictTo
 import com.stripe.android.ui.core.elements.CardBillingAddressElement
 import com.stripe.android.ui.core.elements.LayoutSpec
-import com.stripe.android.ui.core.elements.SectionElement
 import com.stripe.android.ui.core.forms.TransformSpecToElements
 import com.stripe.android.ui.core.forms.resources.ResourceRepository
 import com.stripe.android.uicore.address.AddressRepository
 import com.stripe.android.uicore.elements.FormElement
+import com.stripe.android.uicore.elements.SectionElement
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormUI.kt
@@ -23,14 +23,14 @@ import com.stripe.android.ui.core.elements.MandateTextElement
 import com.stripe.android.ui.core.elements.MandateTextUI
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
 import com.stripe.android.ui.core.elements.SaveForFutureUseElementUI
-import com.stripe.android.ui.core.elements.SectionElement
-import com.stripe.android.ui.core.elements.SectionElementUI
 import com.stripe.android.ui.core.elements.StaticTextElement
 import com.stripe.android.ui.core.elements.StaticTextElementUI
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.OTPElement
 import com.stripe.android.uicore.elements.OTPElementUI
+import com.stripe.android.uicore.elements.SectionElement
+import com.stripe.android.uicore.elements.SectionElementUI
 import kotlinx.coroutines.flow.Flow
 
 @Composable

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AddressSpec.kt
@@ -11,6 +11,7 @@ import com.stripe.android.uicore.elements.DropdownFieldController
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SameAsShippingController
 import com.stripe.android.uicore.elements.SameAsShippingElement
+import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.supportedBillingCountries
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingSpec.kt
@@ -6,6 +6,7 @@ import com.stripe.android.uicore.address.AddressRepository
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SameAsShippingController
 import com.stripe.android.uicore.elements.SameAsShippingElement
+import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.supportedBillingCountries
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUI.kt
@@ -16,6 +16,9 @@ import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.cardscan.CardScanActivity
 import com.stripe.android.uicore.elements.H6Text
 import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.SectionController
+import com.stripe.android.uicore.elements.SectionElement
+import com.stripe.android.uicore.elements.SectionElementUI
 
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/FormItemSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/FormItemSpec.kt
@@ -2,6 +2,7 @@ package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SectionFieldElement
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerialName

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/UpiSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/UpiSpec.kt
@@ -3,6 +3,7 @@ package com.stripe.android.ui.core.elements
 import androidx.annotation.RestrictTo
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.SectionElement
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/TransformSpecToElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/TransformSpecToElementTest.kt
@@ -17,7 +17,6 @@ import com.stripe.android.ui.core.elements.EmptyFormElement
 import com.stripe.android.ui.core.elements.KeyboardType
 import com.stripe.android.ui.core.elements.NameConfig
 import com.stripe.android.ui.core.elements.NameSpec
-import com.stripe.android.ui.core.elements.SectionElement
 import com.stripe.android.ui.core.elements.SimpleDropdownElement
 import com.stripe.android.ui.core.elements.SimpleTextSpec
 import com.stripe.android.ui.core.elements.StaticTextElement
@@ -31,6 +30,7 @@ import com.stripe.android.uicore.elements.CountryConfig
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.EmailConfig
 import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SimpleTextElement
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
@@ -14,12 +14,12 @@ import com.stripe.android.paymentsheet.paymentdatacollection.getInitialValuesMap
 import com.stripe.android.ui.core.elements.CardBillingAddressElement
 import com.stripe.android.ui.core.elements.MandateTextElement
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
-import com.stripe.android.ui.core.elements.SectionElement
 import com.stripe.android.ui.core.forms.TransformSpecToElements
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.ui.core.forms.resources.ResourceRepository
 import com.stripe.android.uicore.address.AddressRepository
 import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.SectionElement
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/CompleteFormFieldValueFilterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/CompleteFormFieldValueFilterTest.kt
@@ -3,10 +3,10 @@ package com.stripe.android.paymentsheet.forms
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.ui.core.elements.EmailElement
-import com.stripe.android.ui.core.elements.SectionController
-import com.stripe.android.ui.core.elements.SectionElement
 import com.stripe.android.uicore.elements.EmailConfig
 import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.SectionController
+import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SimpleTextFieldController
 import com.stripe.android.uicore.forms.FormFieldEntry
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -21,7 +21,6 @@ import com.stripe.android.ui.core.elements.MandateTextSpec
 import com.stripe.android.ui.core.elements.NameSpec
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
 import com.stripe.android.ui.core.elements.SaveForFutureUseSpec
-import com.stripe.android.ui.core.elements.SectionElement
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.ui.core.forms.resources.ResourceRepository
 import com.stripe.android.ui.core.forms.resources.StaticAddressResourceRepository
@@ -30,6 +29,7 @@ import com.stripe.android.uicore.address.AddressRepository
 import com.stripe.android.uicore.elements.AddressElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.RowElement
+import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SectionSingleFieldElement
 import com.stripe.android.uicore.elements.SimpleTextFieldController
 import com.stripe.android.uicore.elements.TextFieldController

--- a/stripe-ui-core/api/stripe-ui-core.api
+++ b/stripe-ui-core/api/stripe-ui-core.api
@@ -162,6 +162,9 @@ public final class com/stripe/android/uicore/elements/SameAsShippingElementUIKt 
 	public static final field SAME_AS_SHIPPING_CHECKBOX_TEST_TAG Ljava/lang/String;
 }
 
+public final class com/stripe/android/uicore/elements/SectionElementUIKt {
+}
+
 public final class com/stripe/android/uicore/elements/SectionFieldElement$DefaultImpls {
 	public static fun getShouldRenderOutsideCard (Lcom/stripe/android/uicore/elements/SectionFieldElement;)Z
 }

--- a/stripe-ui-core/api/stripe-ui-core.api
+++ b/stripe-ui-core/api/stripe-ui-core.api
@@ -162,9 +162,6 @@ public final class com/stripe/android/uicore/elements/SameAsShippingElementUIKt 
 	public static final field SAME_AS_SHIPPING_CHECKBOX_TEST_TAG Ljava/lang/String;
 }
 
-public final class com/stripe/android/uicore/elements/SectionElementUIKt {
-}
-
 public final class com/stripe/android/uicore/elements/SectionFieldElement$DefaultImpls {
 	public static fun getShouldRenderOutsideCard (Lcom/stripe/android/uicore/elements/SectionFieldElement;)Z
 }

--- a/stripe-ui-core/detekt-baseline.xml
+++ b/stripe-ui-core/detekt-baseline.xml
@@ -36,6 +36,7 @@
     <ID>ReturnCount:PostalCodeVisualTransformation.kt$PostalCodeVisualTransformation.&lt;no name provided>$override fun transformedToOriginal(offset: Int): Int</ID>
     <ID>ReturnCount:UiUtils.kt$@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun Context.getDrawableFromUri(uri: Uri): Drawable?</ID>
     <ID>SpreadOperator:PhoneNumberElementUI.kt$( it.errorMessage, *args )</ID>
+    <ID>SpreadOperator:SectionElementUI.kt$( it.errorMessage, *args )</ID>
     <ID>SpreadOperator:TextFieldUI.kt$( it.errorMessage, *args )</ID>
     <ID>ThrowingExceptionsWithoutMessageOrCause:TransformAddressToElement.kt$IllegalArgumentException()</ID>
     <ID>ThrowsCount:UiUtils.kt$@SuppressLint("DiscouragedApi") internal fun Context.getResourceId(uri: Uri): Pair&lt;Resources, Int></ID>

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionController.kt
@@ -1,10 +1,7 @@
-package com.stripe.android.ui.core.elements
+package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
 import androidx.annotation.StringRes
-import com.stripe.android.uicore.elements.Controller
-import com.stripe.android.uicore.elements.FieldError
-import com.stripe.android.uicore.elements.SectionFieldErrorController
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 
@@ -14,7 +11,7 @@ import kotlinx.coroutines.flow.combine
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class SectionController(
     @StringRes val label: Int?,
-    val sectionFieldErrorControllers: List<SectionFieldErrorController>
+    sectionFieldErrorControllers: List<SectionFieldErrorController>
 ) : Controller {
     val error: Flow<FieldError?> = combine(
         sectionFieldErrorControllers.map {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionElement.kt
@@ -1,9 +1,6 @@
-package com.stripe.android.ui.core.elements
+package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
-import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
-import com.stripe.android.uicore.elements.SectionFieldElement
 import com.stripe.android.uicore.forms.FormFieldEntry
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionElementUI.kt
@@ -1,3 +1,5 @@
+@file:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionElementUI.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.ui.core.elements
+package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
 import androidx.compose.foundation.layout.padding
@@ -10,9 +10,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import com.stripe.android.uicore.elements.IdentifierSpec
-import com.stripe.android.uicore.elements.Section
-import com.stripe.android.uicore.elements.SectionFieldElementUI
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.stripeShapes
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Move `SectionElement`, `SectionElementUI` and `SectionElementUI` to stripe-ui-core to reuse

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Share element UI

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
