### PR TITLE
[stripe-ui-core] Support label and placeholder in `TextField`

### DIFF
--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -163,15 +163,6 @@ public final class com/stripe/android/ui/core/elements/CardDetailsSectionSpec$Co
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public abstract class com/stripe/android/ui/core/elements/CardNumberController : com/stripe/android/uicore/elements/SectionFieldErrorController, com/stripe/android/uicore/elements/TextFieldController {
-	public static final field $stable I
-	public fun ComposeUI-MxjM1cc (ZLcom/stripe/android/uicore/elements/SectionFieldElement;Landroidx/compose/ui/Modifier;Ljava/util/Set;Lcom/stripe/android/uicore/elements/IdentifierSpec;IILandroidx/compose/runtime/Composer;I)V
-	public abstract fun getCardBrandFlow ()Lkotlinx/coroutines/flow/Flow;
-	public abstract fun getCardScanEnabled ()Z
-	public fun getEnabled ()Z
-	public final fun onCardScanResult (Lcom/stripe/android/stripecardscan/cardscan/CardScanSheetResult;)V
-}
-
 public abstract class com/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs {
 	public static final field $stable I
 	public static final field Companion Lcom/stripe/android/ui/core/elements/ConfirmResponseStatusSpecs$Companion;

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlin.coroutines.CoroutineContext
 
-sealed class CardNumberController : TextFieldController, SectionFieldErrorController {
+internal sealed class CardNumberController : TextFieldController, SectionFieldErrorController {
     abstract val cardBrandFlow: Flow<CardBrand>
 
     abstract val cardScanEnabled: Boolean

--- a/stripe-ui-core/api/stripe-ui-core.api
+++ b/stripe-ui-core/api/stripe-ui-core.api
@@ -172,9 +172,14 @@ public final class com/stripe/android/uicore/elements/SectionFieldElementUIKt {
 public final class com/stripe/android/uicore/elements/SectionUIKt {
 }
 
+public final class com/stripe/android/uicore/elements/TextFieldConfig$DefaultImpls {
+	public static fun getPlaceHolder (Lcom/stripe/android/uicore/elements/TextFieldConfig;)Ljava/lang/String;
+}
+
 public final class com/stripe/android/uicore/elements/TextFieldController$DefaultImpls {
 	public static fun ComposeUI-MxjM1cc (Lcom/stripe/android/uicore/elements/TextFieldController;ZLcom/stripe/android/uicore/elements/SectionFieldElement;Landroidx/compose/ui/Modifier;Ljava/util/Set;Lcom/stripe/android/uicore/elements/IdentifierSpec;IILandroidx/compose/runtime/Composer;I)V
 	public static fun getEnabled (Lcom/stripe/android/uicore/elements/TextFieldController;)Z
+	public static fun getPlaceHolder (Lcom/stripe/android/uicore/elements/TextFieldController;)Lkotlinx/coroutines/flow/Flow;
 }
 
 public abstract class com/stripe/android/uicore/elements/TextFieldStateConstants$Error : com/stripe/android/uicore/elements/TextFieldState {

--- a/stripe-ui-core/build.gradle
+++ b/stripe-ui-core/build.gradle
@@ -60,6 +60,8 @@ dependencies {
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$kotlinCoroutinesVersion"
     testImplementation "org.mockito:mockito-core:$mockitoCoreVersion"
     testImplementation "org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion"
+    testImplementation "androidx.arch.core:core-testing:$androidxArchCoreVersion"
+    testImplementation "androidx.lifecycle:lifecycle-livedata-ktx:$androidxLifecycleVersion"
 
     ktlint "com.pinterest:ktlint:$ktlintVersion"
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldController.kt
@@ -31,7 +31,7 @@ class AddressTextFieldController(
         config.visualTransformation ?: VisualTransformation.None
     override val showOptionalLabel: Boolean = false
 
-    override val label: Flow<Int> = MutableStateFlow(config.label)
+    override val label = MutableStateFlow(config.label)
     override val debugLabel = config.debugLabel
 
     /** This is all the information that can be observed on the element */

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/InputController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/InputController.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.Flow
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface InputController : SectionFieldErrorController {
-    val label: Flow<Int>
+    val label: Flow<Int?>
     val fieldValue: Flow<String>
     val rawFieldValue: Flow<String?>
     val isComplete: Flow<Boolean>

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PlaceHolder.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PlaceHolder.kt
@@ -1,0 +1,23 @@
+package com.stripe.android.uicore.elements
+
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.stripe.android.uicore.stripeColors
+
+@Composable
+internal fun Placeholder(
+    text: String,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true
+) {
+    val color = MaterialTheme.stripeColors.placeholderText
+    Text(
+        text = text,
+        modifier = modifier,
+        color = if (enabled) color else color.copy(alpha = ContentAlpha.disabled),
+        style = MaterialTheme.typography.subtitle1
+    )
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SimpleTextFieldConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SimpleTextFieldConfig.kt
@@ -8,8 +8,8 @@ import androidx.compose.ui.text.input.VisualTransformation
 import kotlinx.coroutines.flow.MutableStateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class SimpleTextFieldConfig(
-    @StringRes override val label: Int,
+open class SimpleTextFieldConfig(
+    @StringRes override val label: Int? = null,
     override val capitalization: KeyboardCapitalization = KeyboardCapitalization.Words,
     override val keyboard: KeyboardType = KeyboardType.Text,
     override val trailingIcon: MutableStateFlow<TextFieldIcon?> = MutableStateFlow(null)

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldConfig.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldConfig.kt
@@ -15,7 +15,7 @@ interface TextFieldConfig {
     val debugLabel: String
 
     /** This is the label to describe the field */
-    val label: Int
+    val label: Int?
 
     /** This is the type of keyboard to use for this field */
     val keyboard: KeyboardType
@@ -26,6 +26,9 @@ interface TextFieldConfig {
     val trailingIcon: StateFlow<TextFieldIcon?>
 
     val loading: StateFlow<Boolean>
+
+    val placeHolder: String?
+        get() = null
 
     /** This will determine the state of the field based on the text */
     fun determineState(input: String): TextFieldState

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldController.kt
@@ -15,6 +15,7 @@ import com.stripe.android.uicore.forms.FormFieldEntry
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
@@ -26,13 +27,15 @@ interface TextFieldController : InputController, SectionFieldComposable {
     val trailingIcon: Flow<TextFieldIcon?>
     val capitalization: KeyboardCapitalization
     val keyboardType: KeyboardType
-    override val label: Flow<Int>
+    override val label: Flow<Int?>
     val visualTransformation: VisualTransformation
     override val showOptionalLabel: Boolean
     val fieldState: Flow<TextFieldState>
     override val fieldValue: Flow<String>
     val visibleError: Flow<Boolean>
     val loading: Flow<Boolean>
+    val placeHolder : Flow<String?>
+        get() = flowOf(null)
 
     // Whether the TextField should be enabled or not
     val enabled: Boolean
@@ -105,8 +108,10 @@ class SimpleTextFieldController constructor(
     override val visualTransformation =
         textFieldConfig.visualTransformation ?: VisualTransformation.None
 
-    override val label: Flow<Int> = MutableStateFlow(textFieldConfig.label)
+    override val label = MutableStateFlow(textFieldConfig.label)
     override val debugLabel = textFieldConfig.debugLabel
+
+    override val placeHolder = MutableStateFlow(textFieldConfig.placeHolder)
 
     /** This is all the information that can be observed on the element */
     private val _fieldValue = MutableStateFlow("")

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldController.kt
@@ -34,7 +34,7 @@ interface TextFieldController : InputController, SectionFieldComposable {
     override val fieldValue: Flow<String>
     val visibleError: Flow<Boolean>
     val loading: Flow<Boolean>
-    val placeHolder : Flow<String?>
+    val placeHolder: Flow<String?>
         get() = flowOf(null)
 
     // Whether the TextField should be enabled or not

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldUI.kt
@@ -108,6 +108,7 @@ fun TextField(
     val shouldShowError by textFieldController.visibleError.collectAsState(false)
     val loading by textFieldController.loading.collectAsState(false)
     val contentDescription by textFieldController.contentDescription.collectAsState("")
+    val placeHolder by textFieldController.placeHolder.collectAsState(null)
 
     var hasFocus by rememberSaveable { mutableStateOf(false) }
     val colors = TextFieldColors(shouldShowError)
@@ -160,17 +161,22 @@ fun TextField(
                 this.editableText = AnnotatedString("")
             },
         enabled = enabled && textFieldController.enabled,
-        label = {
-            FormLabel(
-                text = if (textFieldController.showOptionalLabel) {
-                    stringResource(
-                        R.string.form_label_optional,
-                        label?.let { stringResource(it) } ?: ""
-                    )
-                } else {
-                    label?.let { stringResource(it) } ?: ""
-                }
-            )
+        label = label?.let {
+            {
+                FormLabel(
+                    text = if (textFieldController.showOptionalLabel) {
+                        stringResource(
+                            R.string.form_label_optional,
+                            stringResource(it)
+                        )
+                    } else {
+                        stringResource(it)
+                    }
+                )
+            }
+        },
+        placeholder = placeHolder?.let {
+            { Placeholder(text = it) }
         },
         trailingIcon = trailingIcon?.let {
             {

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/SimpleTextFieldControllerTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/SimpleTextFieldControllerTest.kt
@@ -1,15 +1,11 @@
-package com.stripe.android.ui.core.elements
+package com.stripe.android.uicore.elements
 
 import android.os.Build
 import android.os.Looper.getMainLooper
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.asLiveData
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.ui.core.R
-import com.stripe.android.uicore.elements.FieldError
-import com.stripe.android.uicore.elements.SimpleTextFieldController
-import com.stripe.android.uicore.elements.TextFieldConfig
-import com.stripe.android.uicore.elements.TextFieldState
+import com.stripe.android.uicore.R
 import com.stripe.android.uicore.elements.TextFieldStateConstants.Error.Blank
 import com.stripe.android.uicore.elements.TextFieldStateConstants.Error.Invalid
 import com.stripe.android.uicore.elements.TextFieldStateConstants.Valid.Full
@@ -26,7 +22,7 @@ import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.P])
-internal class TextFieldControllerTest {
+internal class SimpleTextFieldControllerTest {
     @get:Rule
     val rule = InstantTaskExecutorRule()
 
@@ -225,8 +221,32 @@ internal class TextFieldControllerTest {
         verify(config).filter("1a2b3c4d")
     }
 
+
+    fun `Verify null label`() {
+        val controller = createControllerWithState(nullLabel = true)
+        assertThat(controller.label.value).isNull()
+    }
+
+    fun `Verify non-null label`() {
+        val controller = createControllerWithState(nullLabel = false)
+        assertThat(controller.label.value).isNotNull()
+    }
+
+    fun `Verify null placeHolder`() {
+        val controller = createControllerWithState(nullPlaceHolder = true)
+        assertThat(controller.placeHolder.value).isNull()
+    }
+
+    fun `Verify non-null placeHolder`() {
+        val controller = createControllerWithState(nullPlaceHolder = false)
+        assertThat(controller.placeHolder.value).isNotNull()
+
+    }
+
     private fun createControllerWithState(
-        showOptionalLabel: Boolean = false
+        showOptionalLabel: Boolean = false,
+        nullLabel: Boolean = false,
+        nullPlaceHolder: Boolean = true
     ): SimpleTextFieldController {
         val config: TextFieldConfig = mock {
             on { determineState("full") } doReturn Full
@@ -248,7 +268,13 @@ internal class TextFieldControllerTest {
             on { determineState("") } doReturn Blank
             on { filter("") } doReturn ""
 
-            on { label } doReturn R.string.address_label_full_name
+            if (!nullLabel) {
+                on { label } doReturn R.string.address_label_full_name
+            }
+
+            if (!nullPlaceHolder) {
+                on { placeHolder } doReturn "PlaceHolder"
+            }
         }
 
         return SimpleTextFieldController(config, showOptionalLabel)

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/SimpleTextFieldControllerTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/SimpleTextFieldControllerTest.kt
@@ -221,7 +221,6 @@ internal class SimpleTextFieldControllerTest {
         verify(config).filter("1a2b3c4d")
     }
 
-
     fun `Verify null label`() {
         val controller = createControllerWithState(nullLabel = true)
         assertThat(controller.label.value).isNull()
@@ -240,7 +239,6 @@ internal class SimpleTextFieldControllerTest {
     fun `Verify non-null placeHolder`() {
         val controller = createControllerWithState(nullPlaceHolder = false)
         assertThat(controller.placeHolder.value).isNotNull()
-
     }
 
     private fun createControllerWithState(

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/SimpleTextFieldControllerTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/SimpleTextFieldControllerTest.kt
@@ -239,6 +239,7 @@ internal class SimpleTextFieldControllerTest {
         assertThat(controller.placeHolder.value).isNull()
     }
 
+    @Test
     fun `Verify non-null placeHolder`() {
         val controller = createControllerWithState(nullPlaceHolder = false)
         assertThat(controller.placeHolder.value).isNotNull()

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/SimpleTextFieldControllerTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/SimpleTextFieldControllerTest.kt
@@ -221,16 +221,19 @@ internal class SimpleTextFieldControllerTest {
         verify(config).filter("1a2b3c4d")
     }
 
+    @Test
     fun `Verify null label`() {
         val controller = createControllerWithState(nullLabel = true)
         assertThat(controller.label.value).isNull()
     }
 
+    @Test
     fun `Verify non-null label`() {
         val controller = createControllerWithState(nullLabel = false)
-        assertThat(controller.label.value).isNotNull()
+        assertThat(controller.label.value).isEqualTo(R.string.address_label_full_name)
     }
 
+    @Test
     fun `Verify null placeHolder`() {
         val controller = createControllerWithState(nullPlaceHolder = true)
         assertThat(controller.placeHolder.value).isNull()
@@ -266,7 +269,9 @@ internal class SimpleTextFieldControllerTest {
             on { determineState("") } doReturn Blank
             on { filter("") } doReturn ""
 
-            if (!nullLabel) {
+            if (nullLabel) {
+                on { label } doReturn null
+            } else {
                 on { label } doReturn R.string.address_label_full_name
             }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Support nullable `label` and add a `placeholder` to `TextField`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->


# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Placeholder without label  | Place holder selected | place holder and label |
| ------------- | ------------- | ------------- |
| ![PlaceHolder](https://user-images.githubusercontent.com/79880926/217696442-9e374efb-3838-4eaf-8398-a3137317b930.png)  | ![PlaceHolderSelected](https://user-images.githubusercontent.com/79880926/217696447-b2b4ff49-891f-47e0-aa76-7108eb5a5e20.png) | ![PlaceHolderAndLabel](https://user-images.githubusercontent.com/79880926/217696445-87a97a7d-e97b-4e05-8042-a0b75c909363.png) |




# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
