### PR TITLE
Remove Espresso idling resources from `paymentsheet`

### DIFF
--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -88,10 +88,9 @@ dependencies {
     }
     androidTestImplementation "androidx.test.espresso:espresso-web:$espressoVersion"
     androidTestImplementation "androidx.test.espresso.idling:idling-concurrent:$espressoVersion"
-    // The following Espresso dependency can be either "implementation"
-    // or "androidTestImplementation", depending on whether you want the
-    // dependency to appear on your APK's compile classpath or the test APK
-    // classpath.
+
+    // We need "implementation" here because we're using the idling resource in
+    // PaymentSheetPlaygroundActivity.
     implementation "androidx.test.espresso:espresso-idling-resource:$espressoVersion"
 
     androidTestImplementation 'com.jakewharton.espresso:okhttp3-idling-resource:1.0.0'

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -82,7 +82,6 @@ dependencies {
     androidTestImplementation ("androidx.test.espresso:espresso-contrib:$espressoVersion") {
         exclude group: 'org.checkerframework', module: 'checker'
     }
-    implementation "androidx.test.espresso:espresso-idling-resource:$espressoVersion"
     androidTestImplementation "androidx.test:rules:$androidTestVersion"
     androidTestImplementation "androidx.test:runner:$androidTestRunnerVersion"
     androidTestImplementation "androidx.test.ext:junit-ktx:$androidTestJunitVersion"


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request removes the `espresso-idling-resource` dependency from the `paymentsheet` module.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

https://github.com/stripe/stripe-android/issues/6195

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
