### PR TITLE
Fix BrowserStack tests

### DIFF
--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestAuthorization.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestAuthorization.kt
@@ -91,7 +91,10 @@ class TestAuthorization {
         testDriver.confirmNewOrGuestComplete(
             bancontactNewUser.copy(
                 paymentMethod = lpmRepository.fromCode("ideal")!!,
-                authorizationAction = AuthorizeAction.Fail,
+                authorizationAction = AuthorizeAction.Fail(
+                    expectedError = "We are unable to authenticate your payment method. " +
+                        "Please choose a different payment method and try again.",
+                ),
             )
         )
     }

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestHardCodedLpms.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestHardCodedLpms.kt
@@ -286,7 +286,9 @@ class TestHardCodedLpms {
                 paymentMethod = lpmRepository.fromCode("cashapp")!!,
                 currency = Currency.USD,
                 merchantCountryCode = "US",
-                authorizationAction = AuthorizeAction.Fail,
+                authorizationAction = AuthorizeAction.Fail(
+                    expectedError = "The customer declined this payment.",
+                ),
                 supportedPaymentMethods = listOf("card", "cashapp"),
             ),
         )

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestMultiStepFieldsReloaded.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestMultiStepFieldsReloaded.kt
@@ -211,39 +211,13 @@ class TestMultiStepFieldsReloaded {
     }
 
     @Test
-    fun testCashAppPay_Success() {
+    fun testCashAppPay() {
         testDriver.confirmCustom(
             newUser.copy(
                 paymentMethod = lpmRepository.fromCode("cashapp")!!,
                 currency = Currency.USD,
                 merchantCountryCode = "US",
                 authorizationAction = AuthorizeAction.Authorize,
-                supportedPaymentMethods = listOf("card", "cashapp"),
-            )
-        )
-    }
-
-    @Test
-    fun testCashAppPay_Fail() {
-        testDriver.confirmCustom(
-            newUser.copy(
-                paymentMethod = lpmRepository.fromCode("cashapp")!!,
-                currency = Currency.USD,
-                merchantCountryCode = "US",
-                authorizationAction = AuthorizeAction.Fail,
-                supportedPaymentMethods = listOf("card", "cashapp"),
-            )
-        )
-    }
-
-    @Test
-    fun testCashAppPay_Cancel() {
-        testDriver.confirmCustom(
-            newUser.copy(
-                paymentMethod = lpmRepository.fromCode("cashapp")!!,
-                currency = Currency.USD,
-                merchantCountryCode = "US",
-                authorizationAction = AuthorizeAction.Cancel,
                 supportedPaymentMethods = listOf("card", "cashapp"),
             )
         )

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.graphics.Bitmap
 import android.os.Bundle
 import android.util.Log
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
@@ -26,7 +27,6 @@ import com.stripe.android.paymentsheet.PAYMENT_OPTION_CARD_TEST_TAG
 import com.stripe.android.paymentsheet.PaymentSheetResult
 import com.stripe.android.paymentsheet.example.playground.activity.PaymentSheetPlaygroundActivity
 import com.stripe.android.test.core.ui.BrowserUI
-import com.stripe.android.test.core.ui.EspressoText
 import com.stripe.android.test.core.ui.Selectors
 import com.stripe.android.test.core.ui.UiAutomatorText
 import org.junit.Assume
@@ -373,9 +373,7 @@ class PlaygroundTestDriver(
 
     private fun doAuthorization() {
         selectors.apply {
-            if (testParameters.authorizationAction != null
-                && this.authorizeAction != null
-            ) {
+            if (testParameters.authorizationAction != null && authorizeAction != null) {
                 // If a specific browser is requested we will use it, otherwise, we will
                 // select the first browser found
                 val selectedBrowser = getBrowser(BrowserUI.convert(testParameters.useBrowser))
@@ -390,11 +388,10 @@ class PlaygroundTestDriver(
 
                 blockUntilAuthorizationPageLoaded()
 
-                if(authorizeAction.exists()){
+                if (authorizeAction.exists()) {
                     authorizeAction.click()
-                }
+                } else if (!authorizeAction.exists()) {
                 // Buttons aren't showing the same way each time in the web page.
-                else if(!authorizeAction.exists()){
                     object : UiAutomatorText(
                         label = requireNotNull(testParameters.authorizationAction).text,
                         className = "android.widget.TextView",
@@ -403,16 +400,16 @@ class PlaygroundTestDriver(
                     Log.e("Stripe", "Fail authorization was a text view not a button this time")
                 }
 
-                when (testParameters.authorizationAction) {
-                    AuthorizeAction.Authorize -> {}
-                    AuthorizeAction.Cancel -> {
+                when (val authAction = testParameters.authorizationAction) {
+                    is AuthorizeAction.Authorize -> {}
+                    is AuthorizeAction.Cancel -> {
                         buyButton.apply {
                             waitProcessingComplete()
                             isEnabled()
                             isDisplayed()
                         }
                     }
-                    AuthorizeAction.Fail -> {
+                    is AuthorizeAction.Fail -> {
                         buyButton.apply {
                             waitProcessingComplete()
                             isEnabled()
@@ -420,11 +417,9 @@ class PlaygroundTestDriver(
                         }
 
                         // The text comes after the buy button animation is complete
-                        // TODO: This string gets localized.
-                        EspressoText(
-                            "We are unable to authenticate your payment method. Please " +
-                                "choose a different payment method and try again."
-                        ).isDisplayed()
+                        composeTestRule
+                            .onNodeWithText(authAction.expectedError)
+                            .assertIsDisplayed()
                     }
                     null -> {}
                 }

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/TestParameters.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/TestParameters.kt
@@ -78,14 +78,23 @@ enum class Browser {
  * Indicate the payment method for this test expects authorization and how the authorization
  * should be handled: complete, fail, cancel
  */
-enum class AuthorizeAction(
-    val text: String,
-) {
-    // These do not get localized.
-    Authorize("AUTHORIZE TEST PAYMENT"),
-    Fail("FAIL TEST PAYMENT"),
-    Cancel("")
+sealed interface AuthorizeAction {
+
+    abstract val text: String
+
+    object Authorize : AuthorizeAction {
+        override val text: String = "AUTHORIZE TEST PAYMENT"
+    }
+
+    data class Fail(val expectedError: String) : AuthorizeAction {
+        override val text: String = "FAIL TEST PAYMENT"
+    }
+
+    object Cancel : AuthorizeAction {
+        override val text: String = ""
+    }
 }
+
 
 /**
  * Indicates how the payment intent should be set: PaymentIntent, PaymentIntent with

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/EspressoText.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/EspressoText.kt
@@ -2,14 +2,9 @@ package com.stripe.android.test.core.ui
 
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.action.ViewActions
-import androidx.test.espresso.assertion.ViewAssertions
 import androidx.test.espresso.matcher.ViewMatchers
 
 open class EspressoText(private val text: String) {
-    fun isDisplayed() {
-        Espresso.onView(ViewMatchers.withText(text))
-            .check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
-    }
 
     fun click(){
         Espresso.onView(ViewMatchers.withText(text))

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/Selectors.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/Selectors.kt
@@ -184,7 +184,7 @@ class Selectors(
         .getInstalledApplications(PackageManager.GET_META_DATA)
 
     val authorizeAction = when (testParameters.authorizationAction) {
-        AuthorizeAction.Authorize -> {
+        is AuthorizeAction.Authorize -> {
             object : UiAutomatorText(
                 label = testParameters.authorizationAction.text,
                 className = "android.widget.Button",
@@ -203,7 +203,7 @@ class Selectors(
                 }
             }
         }
-        AuthorizeAction.Cancel -> {
+        is AuthorizeAction.Cancel -> {
             object : UiAutomatorText(
                 label = testParameters.authorizationAction.text,
                 className = "android.widget.Button",
@@ -214,7 +214,7 @@ class Selectors(
                 }
             }
         }
-        AuthorizeAction.Fail -> {
+        is AuthorizeAction.Fail -> {
             object : UiAutomatorText(
                 label = testParameters.authorizationAction.text,
                 className = "android.widget.Button",


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes two failing BrowserStack tests and makes the expected error message of `AuthorizationAction.Fail` configurable.

See [this test run](https://app-automate.browserstack.com/dashboard/v2/builds/592cdbfd72d4830e7c5a92f290f5e19b42b42fa4) (yes, the Affirm test page seems to be broken; I’m trying to find the right people to fix this).

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
