### PR TITLE
Move ConfirmVerification endpoint to payments-model

### DIFF
--- a/link/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/link/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -115,11 +115,12 @@ internal class LinkApiRepository @Inject constructor(
     ): Result<ConsumerSession> = withContext(workContext) {
         runCatching {
             requireNotNull(
-                stripeRepository.confirmConsumerVerification(
-                    consumerSessionClientSecret,
-                    verificationCode,
-                    authSessionCookie,
-                    consumerPublishableKey?.let {
+                consumersApiService.confirmConsumerVerification(
+                    consumerSessionClientSecret = consumerSessionClientSecret,
+                    verificationCode = verificationCode,
+                    authSessionCookie = authSessionCookie,
+                    requestSurface = REQUEST_SURFACE,
+                    requestOptions = consumerPublishableKey?.let {
                         ApiRequest.Options(it)
                     } ?: ApiRequest.Options(
                         publishableKeyProvider(),

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1217,41 +1217,6 @@ class StripeApiRepository @JvmOverloads internal constructor(
     }
 
     /**
-     * Confirms an SMS verification for the consumer corresponding to the given client secret.
-     */
-    override suspend fun confirmConsumerVerification(
-        consumerSessionClientSecret: String,
-        verificationCode: String,
-        authSessionCookie: String?,
-        requestOptions: ApiRequest.Options
-    ): ConsumerSession? {
-        return fetchStripeModel(
-            apiRequestFactory.createPost(
-                confirmConsumerVerificationUrl,
-                requestOptions,
-                mapOf(
-                    "request_surface" to "android_payment_element",
-                    "credentials" to mapOf(
-                        "consumer_session_client_secret" to consumerSessionClientSecret
-                    ),
-                    "type" to "SMS",
-                    "code" to verificationCode
-                ).plus(
-                    authSessionCookie?.let {
-                        mapOf(
-                            "cookies" to
-                                mapOf("verification_session_client_secrets" to listOf(it))
-                        )
-                    } ?: emptyMap()
-                )
-            ),
-            ConsumerSessionJsonParser()
-        ) {
-            // no-op
-        }
-    }
-
-    /**
      * Logs out the consumer and invalidates the cookie.
      */
     override suspend fun logoutConsumer(
@@ -1962,13 +1927,6 @@ class StripeApiRepository @JvmOverloads internal constructor(
         internal val consumerSignUpUrl: String
             @JvmSynthetic
             get() = getApiUrl("consumers/accounts/sign_up")
-
-        /**
-         * @return `https://api.stripe.com/v1/consumers/sessions/confirm_verification`
-         */
-        internal val confirmConsumerVerificationUrl: String
-            @JvmSynthetic
-            get() = getApiUrl("consumers/sessions/confirm_verification")
 
         /**
          * @return `https://api.stripe.com/v1/consumers/sessions/log_out`

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -413,14 +413,6 @@ abstract class StripeRepository {
     ): ConsumerSession?
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    abstract suspend fun confirmConsumerVerification(
-        consumerSessionClientSecret: String,
-        verificationCode: String,
-        authSessionCookie: String?,
-        requestOptions: ApiRequest.Options
-    ): ConsumerSession?
-
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     abstract suspend fun logoutConsumer(
         consumerSessionClientSecret: String,
         authSessionCookie: String?,

--- a/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
@@ -298,15 +298,6 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         return null
     }
 
-    override suspend fun confirmConsumerVerification(
-        consumerSessionClientSecret: String,
-        verificationCode: String,
-        authSessionCookie: String?,
-        requestOptions: ApiRequest.Options
-    ): ConsumerSession? {
-        return null
-    }
-
     override suspend fun logoutConsumer(
         consumerSessionClientSecret: String,
         authSessionCookie: String?,

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -243,14 +243,6 @@ internal class StripeApiRepositoryTest {
     }
 
     @Test
-    fun testConfirmConsumerVerificationUrl() {
-        assertEquals(
-            "https://api.stripe.com/v1/consumers/sessions/confirm_verification",
-            StripeApiRepository.confirmConsumerVerificationUrl
-        )
-    }
-
-    @Test
     fun testLogoutConsumerUrl() {
         assertEquals(
             "https://api.stripe.com/v1/consumers/sessions/log_out",
@@ -1716,43 +1708,6 @@ internal class StripeApiRepositoryTest {
                 assertEquals(this["legal_name"], name)
                 assertEquals(this["locale"], locale.toLanguageTag())
                 assertEquals(this["consent_action"], "clicked_button_mobile")
-                withNestedParams("cookies") {
-                    assertEquals(this["verification_session_client_secrets"], listOf(cookie))
-                }
-            }
-        }
-
-    @Test
-    fun `confirmConsumerVerification() sends all parameters`() =
-        runTest {
-            val stripeResponse = StripeResponse(
-                200,
-                ConsumerFixtures.CONSUMER_VERIFIED_JSON.toString(),
-                emptyMap()
-            )
-            whenever(stripeNetworkClient.executeRequest(any<ApiRequest>()))
-                .thenReturn(stripeResponse)
-
-            val clientSecret = "secret"
-            val verificationCode = "1234"
-            val cookie = "cookie1"
-            create().confirmConsumerVerification(
-                clientSecret,
-                verificationCode,
-                cookie,
-                DEFAULT_OPTIONS
-            )
-
-            verify(stripeNetworkClient).executeRequest(apiRequestArgumentCaptor.capture())
-            val params = requireNotNull(apiRequestArgumentCaptor.firstValue.params)
-
-            with(params) {
-                assertEquals(this["request_surface"], "android_payment_element")
-                assertEquals(this["type"], "SMS")
-                assertEquals(this["code"], verificationCode)
-                withNestedParams("credentials") {
-                    assertEquals(this["consumer_session_client_secret"], clientSecret)
-                }
                 withNestedParams("cookies") {
                     assertEquals(this["verification_session_client_secrets"], listOf(cookie))
                 }

--- a/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
@@ -131,7 +131,6 @@ class ConsumersApiServiceImplTest {
     fun `confirmConsumerVerification() sends all parameters`() = runTest {
         val clientSecret = "secret"
         val verificationCode = "1234"
-        val locale = Locale.US
         val cookie = "cookie2"
 
         networkRule.enqueue(
@@ -143,7 +142,6 @@ class ConsumersApiServiceImplTest {
             bodyPart("credentials%5Bconsumer_session_client_secret%5D", clientSecret),
             bodyPart("type", "SMS"),
             bodyPart("code", verificationCode),
-            bodyPart("locale", locale.toLanguageTag()),
             bodyPart("cookies%5Bverification_session_client_secrets%5D%5B%5D", cookie),
         ) { response ->
             response.setBody(ConsumerFixtures.CONSUMER_VERIFIED_JSON.toString())

--- a/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
@@ -128,17 +128,63 @@ class ConsumersApiServiceImplTest {
     }
 
     @Test
+    fun `confirmConsumerVerification() sends all parameters`() = runTest {
+        val clientSecret = "secret"
+        val verificationCode = "1234"
+        val locale = Locale.US
+        val cookie = "cookie2"
+
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/consumers/sessions/confirm_verification"),
+            header("Authorization", "Bearer ${DEFAULT_OPTIONS.apiKey}"),
+            header("User-Agent", "Stripe/v1 ${StripeSdkVersion.VERSION}"),
+            bodyPart("request_surface", "android_payment_element"),
+            bodyPart("credentials%5Bconsumer_session_client_secret%5D", clientSecret),
+            bodyPart("type", "SMS"),
+            bodyPart("code", verificationCode),
+            bodyPart("locale", locale.toLanguageTag()),
+            bodyPart("cookies%5Bverification_session_client_secrets%5D%5B%5D", cookie),
+        ) { response ->
+            response.setBody(ConsumerFixtures.CONSUMER_VERIFIED_JSON.toString())
+        }
+
+        val consumerSession = consumersApiService.confirmConsumerVerification(
+            consumerSessionClientSecret = clientSecret,
+            verificationCode = verificationCode,
+            authSessionCookie = cookie,
+            requestSurface = "android_payment_element",
+            requestOptions = DEFAULT_OPTIONS
+        )
+
+        assertThat(consumerSession.redactedPhoneNumber).isEqualTo("+1********56")
+        assertThat(consumerSession.verificationSessions).contains(
+            ConsumerSession.VerificationSession(
+                ConsumerSession.VerificationSession.SessionType.Sms,
+                ConsumerSession.VerificationSession.SessionState.Verified
+            )
+        )
+    }
+
+    @Test
     fun testConsumerSessionLookupUrl() {
         ApiRequest.apiTestHost = null
-        assertThat("https://api.stripe.com/v1/consumers/sessions/lookup",)
+        assertThat("https://api.stripe.com/v1/consumers/sessions/lookup")
             .isEqualTo(ConsumersApiServiceImpl.consumerSessionLookupUrl)
     }
 
     @Test
     fun testStartConsumerVerificationUrl() {
         ApiRequest.apiTestHost = null
-        assertThat("https://api.stripe.com/v1/consumers/sessions/start_verification",)
+        assertThat("https://api.stripe.com/v1/consumers/sessions/start_verification")
             .isEqualTo(ConsumersApiServiceImpl.startConsumerVerificationUrl)
+    }
+
+    @Test
+    fun testConfirmConsumerVerificationUrl() {
+        ApiRequest.apiTestHost = null
+        assertThat("https://api.stripe.com/v1/consumers/sessions/confirm_verification")
+            .isEqualTo(ConsumersApiServiceImpl.confirmConsumerVerificationUrl)
     }
 
     private companion object {


### PR DESCRIPTION
# Summary
Move ConfirmVerification endpoint to payments-model

# Motivation
:notebook_with_decorative_cover: &nbsp;**Move ConfirmVerification endpoint to payments-model**
:globe_with_meridians: &nbsp;[BANKCON-6159](https://jira.corp.stripe.com/browse/BANKCON-6159)
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified