### PR TITLE
Move entire payment sheet screen to Compose

### DIFF
--- a/link/detekt-baseline.xml
+++ b/link/detekt-baseline.xml
@@ -8,6 +8,7 @@
     <ID>FunctionNaming:LinkAppBar.kt$@Preview @Composable private fun LinkAppBar_NoEmail()</ID>
     <ID>LongMethod:LinkActivity.kt$LinkActivity$override fun onCreate(savedInstanceState: Bundle?)</ID>
     <ID>LongMethod:LinkAppBar.kt$@Composable internal fun LinkAppBar( state: LinkAppBarState, onBackPressed: () -> Unit, onLogout: () -> Unit, showBottomSheetContent: (BottomSheetContent?) -> Unit )</ID>
+    <ID>LongMethod:LinkButtonView.kt$@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) @Composable fun LinkButton( email: String?, enabled: Boolean, onClick: () -> Unit, modifier: Modifier = Modifier, )</ID>
     <ID>LongMethod:LinkInlineSignup.kt$@Composable internal fun LinkInlineSignup( merchantName: String, emailController: TextFieldController, phoneNumberController: PhoneNumberController, nameController: TextFieldController, signUpState: SignUpState, enabled: Boolean, expanded: Boolean, requiresNameCollection: Boolean, errorMessage: ErrorMessage?, toggleExpanded: () -> Unit, modifier: Modifier = Modifier )</ID>
     <ID>LongMethod:PaymentDetails.kt$@Composable internal fun PaymentDetailsListItem( paymentDetails: ConsumerPaymentDetails.PaymentDetails, enabled: Boolean, isSupported: Boolean, isSelected: Boolean, isUpdating: Boolean, onClick: () -> Unit, onMenuButtonClick: () -> Unit )</ID>
     <ID>LongMethod:PaymentMethodBody.kt$@Composable internal fun PaymentMethodBody( linkAccount: LinkAccount, injector: NonFallbackInjector, loadFromArgs: Boolean )</ID>

--- a/link/src/main/java/com/stripe/android/link/ui/LinkButtonView.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/LinkButtonView.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.AbstractComposeView
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -53,11 +54,13 @@ private fun LinkButton() {
     )
 }
 
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Composable
-private fun LinkButton(
+fun LinkButton(
     email: String?,
     enabled: Boolean,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     CompositionLocalProvider(
         LocalContentAlpha provides if (enabled) ContentAlpha.high else ContentAlpha.disabled
@@ -65,7 +68,9 @@ private fun LinkButton(
         DefaultLinkTheme {
             Button(
                 onClick = onClick,
-                modifier = Modifier.clip(LinkButtonShape),
+                modifier = modifier
+                    .clip(LinkButtonShape)
+                    .testTag("link-button"),
                 enabled = enabled,
                 elevation = ButtonDefaults.elevation(0.dp, 0.dp, 0.dp, 0.dp, 0.dp),
                 shape = LinkButtonShape,

--- a/link/src/main/java/com/stripe/android/link/ui/LinkButtonView.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/LinkButtonView.kt
@@ -1,3 +1,5 @@
+@file:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+
 package com.stripe.android.link.ui
 
 import android.content.Context

--- a/link/src/main/java/com/stripe/android/link/ui/LinkButtonView.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/LinkButtonView.kt
@@ -46,6 +46,9 @@ private val LinkButtonHorizontalPadding = 10.dp
 private val LinkButtonShape = RoundedCornerShape(22.dp)
 private val LinkButtonEmailShape = RoundedCornerShape(16.dp) // Button corner radius - padding
 
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+const val LinkButtonTestTag = "LinkButtonTestTag"
+
 @Preview
 @Composable
 private fun LinkButton() {
@@ -72,7 +75,7 @@ fun LinkButton(
                 onClick = onClick,
                 modifier = modifier
                     .clip(LinkButtonShape)
-                    .testTag("link-button"),
+                    .testTag(LinkButtonTestTag),
                 enabled = enabled,
                 elevation = ButtonDefaults.elevation(0.dp, 0.dp, 0.dp, 0.dp, 0.dp),
                 shape = LinkButtonShape,

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -5,13 +5,6 @@ public final class com/stripe/android/paymentsheet/BuildConfig {
 	public fun <init> ()V
 }
 
-public final class com/stripe/android/paymentsheet/ComposableSingletons$PaymentSheetActivityKt {
-	public static final field INSTANCE Lcom/stripe/android/paymentsheet/ComposableSingletons$PaymentSheetActivityKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function2;
-	public fun <init> ()V
-	public final fun getLambda-1$paymentsheet_release ()Lkotlin/jvm/functions/Function2;
-}
-
 public final class com/stripe/android/paymentsheet/PaymentMethodsUIKt {
 	public static final field TEST_TAG_LIST Ljava/lang/String;
 }
@@ -965,22 +958,8 @@ public final class com/stripe/android/paymentsheet/databinding/ActivityPaymentOp
 
 public final class com/stripe/android/paymentsheet/databinding/ActivityPaymentSheetBinding : androidx/viewbinding/ViewBinding {
 	public final field bottomSheet Landroid/widget/LinearLayout;
-	public final field bottomSpacer Landroid/view/View;
-	public final field buttonContainer Landroidx/compose/ui/platform/ComposeView;
-	public final field contentContainer Landroidx/compose/ui/platform/ComposeView;
+	public final field content Landroidx/compose/ui/platform/ComposeView;
 	public final field coordinator Landroidx/coordinatorlayout/widget/CoordinatorLayout;
-	public final field fragmentContainerParent Landroid/widget/LinearLayout;
-	public final field googlePayButton Landroidx/compose/ui/platform/ComposeView;
-	public final field googlePayDivider Landroidx/compose/ui/platform/ComposeView;
-	public final field header Landroidx/compose/ui/platform/ComposeView;
-	public final field linkAuth Landroidx/compose/ui/platform/ComposeView;
-	public final field linkButton Lcom/stripe/android/link/ui/LinkButtonView;
-	public final field message Landroidx/compose/ui/platform/ComposeView;
-	public final field notes Landroidx/compose/ui/platform/ComposeView;
-	public final field scrollView Landroid/widget/ScrollView;
-	public final field topBar Landroidx/compose/ui/platform/ComposeView;
-	public final field topContainer Landroid/widget/LinearLayout;
-	public final field topMessage Landroidx/compose/ui/platform/ComposeView;
 	public static fun bind (Landroid/view/View;)Lcom/stripe/android/paymentsheet/databinding/ActivityPaymentSheetBinding;
 	public synthetic fun getRoot ()Landroid/view/View;
 	public fun getRoot ()Landroidx/coordinatorlayout/widget/CoordinatorLayout;

--- a/paymentsheet/res/layout/activity_payment_sheet.xml
+++ b/paymentsheet/res/layout/activity_payment_sheet.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/coordinator"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
@@ -16,98 +15,11 @@
         android:background="?colorSurface"
         app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
 
-        <!-- This empty ComposeView is used to open a LinkVerificationDialog when needed -->
         <androidx.compose.ui.platform.ComposeView
-            android:id="@+id/link_auth"
+            android:id="@+id/content"
             android:layout_width="match_parent"
-            android:layout_height="0dp" />
+            android:layout_height="wrap_content" />
 
-        <androidx.compose.ui.platform.ComposeView
-            android:id="@+id/top_bar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@android:color/white" />
-
-        <ScrollView
-            android:id="@+id/scroll_view"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-
-            <LinearLayout
-                android:id="@+id/fragment_container_parent"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:animateLayoutChanges="true">
-
-                <androidx.compose.ui.platform.ComposeView
-                    android:id="@+id/header"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginHorizontal="@dimen/stripe_paymentsheet_outer_spacing_horizontal" />
-
-                <LinearLayout
-                    android:id="@+id/top_container"
-                    android:visibility="gone"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginHorizontal="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
-                    android:orientation="vertical">
-
-                    <androidx.compose.ui.platform.ComposeView
-                        android:id="@+id/google_pay_button"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content" />
-
-                    <com.stripe.android.link.ui.LinkButtonView
-                        android:id="@+id/link_button"
-                        android:visibility="gone"
-                        android:layout_marginTop="6dp"
-                        android:padding="2dp"
-                        android:layout_width="match_parent"
-                        android:layout_height="51dp" />
-
-                    <androidx.compose.ui.platform.ComposeView
-                        android:id="@+id/top_message"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content" />
-
-                    <androidx.compose.ui.platform.ComposeView
-                        android:id="@+id/google_pay_divider"
-                        android:visibility="visible"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content" />
-                </LinearLayout>
-
-                <androidx.compose.ui.platform.ComposeView
-                    android:id="@+id/content_container"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
-
-                <androidx.compose.ui.platform.ComposeView
-                    android:id="@+id/message"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content" />
-
-                <androidx.compose.ui.platform.ComposeView
-                    android:id="@+id/button_container"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content" />
-
-                <androidx.compose.ui.platform.ComposeView
-                    android:id="@+id/notes"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:visibility="gone"
-                    android:layout_marginVertical="2dp"
-                    android:layout_marginHorizontal="@dimen/stripe_paymentsheet_outer_spacing_horizontal" />
-
-                <View
-                    android:id="@+id/bottom_spacer"
-                    android:visibility="gone"
-                    android:layout_width="wrap_content"
-                    android:layout_height="@dimen/stripe_paymentsheet_button_container_spacing_bottom" />
-            </LinearLayout>
-        </ScrollView>
     </LinearLayout>
+
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -1,46 +1,19 @@
 package com.stripe.android.paymentsheet
 
-import android.animation.LayoutTransition
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
-import android.view.View
 import android.view.ViewGroup
-import android.view.WindowManager
-import android.widget.ScrollView
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material.MaterialTheme
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidViewBinding
-import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContract
-import com.stripe.android.link.ui.verification.LinkVerificationDialog
 import com.stripe.android.paymentsheet.databinding.ActivityPaymentSheetBinding
-import com.stripe.android.paymentsheet.databinding.FragmentPaymentSheetPrimaryButtonBinding
-import com.stripe.android.paymentsheet.state.WalletsContainerState
 import com.stripe.android.paymentsheet.ui.BaseSheetActivity
-import com.stripe.android.paymentsheet.ui.ErrorMessage
-import com.stripe.android.paymentsheet.ui.GooglePayButton
-import com.stripe.android.paymentsheet.ui.GooglePayDividerUi
-import com.stripe.android.paymentsheet.ui.PaymentSheetTopBar
-import com.stripe.android.paymentsheet.ui.convert
+import com.stripe.android.paymentsheet.ui.PaymentSheetScreen
 import com.stripe.android.paymentsheet.utils.launchAndCollectIn
-import com.stripe.android.ui.core.elements.H4Text
 import com.stripe.android.uicore.StripeTheme
-import com.stripe.android.uicore.stripeColors
-import com.stripe.android.uicore.text.Html
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
 import java.security.InvalidParameterException
 
@@ -63,17 +36,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
 
     override val rootView: ViewGroup by lazy { viewBinding.root }
     override val bottomSheet: ViewGroup by lazy { viewBinding.bottomSheet }
-
-    private val linkAuthView: ComposeView by lazy { viewBinding.linkAuth }
-    private val scrollView: ScrollView by lazy { viewBinding.scrollView }
-    private val header: ComposeView by lazy { viewBinding.header }
-    private val fragmentContainerParent: ViewGroup by lazy { viewBinding.fragmentContainerParent }
-    private val notesView: ComposeView by lazy { viewBinding.notes }
-    private val bottomSpacer: View by lazy { viewBinding.bottomSpacer }
-
-    private val topContainer by lazy { viewBinding.topContainer }
-    private val linkButton by lazy { viewBinding.linkButton }
-    private val googlePayDivider by lazy { viewBinding.googlePayDivider }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val validationResult = initializeArgs()
@@ -98,113 +60,18 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
         starterArgs?.statusBarColor?.let {
             window.statusBarColor = it
         }
+
         setContentView(viewBinding.root)
 
-        fragmentContainerParent.layoutTransition.enableTransitionType(LayoutTransition.CHANGING)
-
-        val elevation = resources.getDimension(R.dimen.stripe_paymentsheet_toolbar_elevation)
-        scrollView.viewTreeObserver.addOnScrollChangedListener {
-            viewBinding.topBar.elevation = if (scrollView.scrollY > 0) {
-                elevation
-            } else {
-                0f
-            }
-        }
-
-        // This is temporary until we embed the top bar in a Scaffold
-        viewBinding.topBar.clipToPadding = false
-
-        viewBinding.topBar.setContent {
+        viewBinding.content.setContent {
             StripeTheme {
-                PaymentSheetTopBar(viewModel)
+                PaymentSheetScreen(viewModel)
             }
-        }
-
-        setupHeader()
-        setupTopContainer()
-        setupNotes()
-
-        linkButton.apply {
-            onClick = viewModel::handleLinkPressed
-            linkPaymentLauncher = linkLauncher
-        }
-
-        viewBinding.topMessage.setContent {
-            StripeTheme {
-                val buttonState by viewModel.googlePayButtonState.collectAsState(initial = null)
-
-                buttonState?.errorMessage?.let { error ->
-                    ErrorMessage(
-                        error = error.message,
-                        modifier = Modifier.padding(vertical = 3.dp, horizontal = 1.dp),
-                    )
-                }
-            }
-        }
-
-        viewBinding.contentContainer.setContent {
-            StripeTheme {
-                val currentScreen by viewModel.currentScreen.collectAsState()
-                currentScreen.Content(
-                    viewModel = viewModel,
-                    modifier = Modifier.padding(bottom = 8.dp),
-                )
-            }
-        }
-
-        viewBinding.message.setContent {
-            StripeTheme {
-                val buttonState by viewModel.buyButtonState.collectAsState(initial = null)
-
-                buttonState?.errorMessage?.let { error ->
-                    ErrorMessage(
-                        error = error.message,
-                        modifier = Modifier.padding(vertical = 2.dp, horizontal = 20.dp),
-                    )
-                }
-            }
-        }
-
-        viewBinding.buttonContainer.setContent {
-            AndroidViewBinding(
-                factory = FragmentPaymentSheetPrimaryButtonBinding::inflate,
-            )
-        }
-
-        viewModel.processing.filter { it }.launchAndCollectIn(this) {
-            window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_HIDDEN)
         }
 
         viewModel.paymentSheetResult.filterNotNull().launchAndCollectIn(this) {
             closeSheet(it)
         }
-
-        viewModel.buttonsEnabled.launchAndCollectIn(this) { enabled ->
-            linkButton.isEnabled = enabled
-        }
-
-        viewModel.linkHandler.showLinkVerificationDialog.launchAndCollectIn(this) { show ->
-            linkAuthView.setContent {
-                if (show) {
-                    LinkVerificationDialog(
-                        linkLauncher = linkLauncher,
-                        onResult = linkHandler::handleLinkVerificationResult,
-                    )
-                }
-            }
-        }
-
-        viewModel.contentVisible.launchAndCollectIn(this) {
-            scrollView.isVisible = it
-        }
-
-        viewModel.primaryButtonUIState.launchAndCollectIn(this) { state ->
-            state?.let {
-                bottomSpacer.isVisible = state.visible
-            }
-        }
-
-        bottomSpacer.isVisible = true
     }
 
     private fun initializeArgs(): Result<PaymentSheetContract.Args?> {
@@ -227,90 +94,10 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
         return result
     }
 
-    private fun setupTopContainer() {
-        setupGooglePayButton()
-
-        viewModel.walletsContainerState.launchAndCollectIn(this) { config ->
-            linkButton.isVisible = config.showLink
-            topContainer.isVisible = config.shouldShow
-        }
-
-        googlePayDivider.setContent {
-            val containerState by viewModel.walletsContainerState.collectAsState(
-                initial = WalletsContainerState(),
-            )
-
-            StripeTheme {
-                if (containerState.shouldShow) {
-                    val text = stringResource(containerState.dividerTextResource)
-                    GooglePayDividerUi(text)
-                }
-            }
-        }
-    }
-
-    private fun setupHeader() {
-        header.apply {
-            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-            setContent {
-                val text = viewModel.headerText.collectAsState(null)
-                text.value?.let {
-                    StripeTheme {
-                        H4Text(
-                            text = stringResource(it),
-                            modifier = Modifier.padding(bottom = 2.dp)
-                        )
-                    }
-                }
-            }
-        }
-    }
-
-    private fun setupNotes() {
-        viewModel.notesText.launchAndCollectIn(this) { text ->
-            val showNotes = text != null
-            text?.let {
-                notesView.setContent {
-                    StripeTheme {
-                        Html(
-                            html = text,
-                            color = MaterialTheme.stripeColors.subtitle,
-                            style = MaterialTheme.typography.body1.copy(
-                                textAlign = TextAlign.Center
-                            )
-                        )
-                    }
-                }
-            }
-            notesView.isVisible = showNotes
-        }
-    }
-
-    private fun setupGooglePayButton() {
-        viewBinding.googlePayButton.setContent {
-            val containerState by viewModel.walletsContainerState.collectAsState(
-                initial = WalletsContainerState(),
-            )
-
-            val buttonState by viewModel.googlePayButtonState.collectAsState(initial = null)
-            val isEnabled by viewModel.buttonsEnabled.collectAsState(initial = false)
-
-            if (containerState.showGooglePay) {
-                GooglePayButton(
-                    state = buttonState?.convert(),
-                    isEnabled = isEnabled,
-                    onPressed = viewModel::checkoutWithGooglePay,
-                    modifier = Modifier.padding(top = 7.dp),
-                )
-            }
-        }
-    }
-
     override fun setActivityResult(result: PaymentSheetResult) {
         setResult(
             Activity.RESULT_OK,
-            Intent()
-                .putExtras(PaymentSheetContract.Result(result).toBundle())
+            Intent().putExtras(PaymentSheetContract.Result(result).toBundle())
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
@@ -20,7 +20,7 @@ internal sealed interface PaymentSheetScreen {
 
         @Composable
         override fun Content(viewModel: BaseSheetViewModel, modifier: Modifier) {
-            PaymentSheetLoading()
+            PaymentSheetLoading(modifier)
         }
     }
 
@@ -30,10 +30,7 @@ internal sealed interface PaymentSheetScreen {
 
         @Composable
         override fun Content(viewModel: BaseSheetViewModel, modifier: Modifier) {
-            PaymentOptions(
-                viewModel = viewModel,
-                modifier = modifier,
-            )
+            PaymentOptions(viewModel, modifier)
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetLoading.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetLoading.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.ui
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.CircularProgressIndicator
@@ -21,7 +22,9 @@ internal fun PaymentSheetLoading(
 
     Box(
         contentAlignment = Alignment.Center,
-        modifier = Modifier.height(height),
+        modifier = modifier
+            .fillMaxWidth()
+            .height(height),
     ) {
         CircularProgressIndicator(
             color = MaterialTheme.colors.onSurface,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -34,19 +33,6 @@ import com.stripe.android.paymentsheet.state.WalletsContainerState
 import com.stripe.android.ui.core.elements.H4Text
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.text.Html
-
-@OptIn(ExperimentalComposeUiApi::class)
-@Composable
-private fun DismissKeyboardOnProcessing(viewModel: PaymentSheetViewModel) {
-    val keyboardController = LocalSoftwareKeyboardController.current
-
-    val processing by viewModel.processing.collectAsState()
-    if (processing) {
-        LaunchedEffect(Unit) {
-            keyboardController?.hide()
-        }
-    }
-}
 
 @Composable
 internal fun PaymentSheetScreen(
@@ -82,6 +68,19 @@ internal fun PaymentSheetScreen(
                 viewModel = viewModel,
                 modifier = modifier.verticalScroll(scrollState),
             )
+        }
+    }
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+private fun DismissKeyboardOnProcessing(viewModel: PaymentSheetViewModel) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    val processing by viewModel.processing.collectAsState()
+    if (processing) {
+        LaunchedEffect(Unit) {
+            keyboardController?.hide()
         }
     }
 }
@@ -147,7 +146,6 @@ internal fun PaymentSheetScreenContent(
                 html = text,
                 color = MaterialTheme.stripeColors.subtitle,
                 style = MaterialTheme.typography.body1.copy(textAlign = TextAlign.Center),
-                modifier = Modifier.testTag("notes"),
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -33,8 +33,9 @@ internal fun PaymentSheetScreen(
     modifier: Modifier = Modifier,
 ) {
     val contentVisible by viewModel.contentVisible.collectAsState()
+    val processing by viewModel.processing.collectAsState()
 
-    DismissKeyboardOnProcessing(viewModel)
+    DismissKeyboardOnProcessing(processing)
 
     PaymentSheetScaffold(
         topBar = { PaymentSheetTopBar(viewModel) },
@@ -52,10 +53,9 @@ internal fun PaymentSheetScreen(
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
-private fun DismissKeyboardOnProcessing(viewModel: PaymentSheetViewModel) {
+private fun DismissKeyboardOnProcessing(processing: Boolean) {
     val keyboardController = LocalSoftwareKeyboardController.current
 
-    val processing by viewModel.processing.collectAsState()
     if (processing) {
         LaunchedEffect(Unit) {
             keyboardController?.hide()
@@ -144,38 +144,36 @@ internal fun Wallet(
 
     val padding = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_horizontal)
 
-    Column(
-        modifier = modifier.padding(horizontal = padding),
-    ) {
-        if (containerState.showGooglePay) {
-            GooglePayButton(
-                state = googlePayButtonState?.convert(),
-                isEnabled = buttonsEnabled,
-                onPressed = viewModel::checkoutWithGooglePay,
-                modifier = Modifier.padding(top = 7.dp),
-            )
-        }
+    if (containerState.shouldShow) {
+        Column(modifier = modifier.padding(horizontal = padding)) {
+            if (containerState.showGooglePay) {
+                GooglePayButton(
+                    state = googlePayButtonState?.convert(),
+                    isEnabled = buttonsEnabled,
+                    onPressed = viewModel::checkoutWithGooglePay,
+                    modifier = Modifier.padding(top = 7.dp),
+                )
+            }
 
-        if (containerState.showLink) {
-            LinkButton(
-                email = email,
-                enabled = buttonsEnabled,
-                onClick = viewModel::handleLinkPressed,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 6.dp)
-                    .requiredHeight(48.dp),
-            )
-        }
+            if (containerState.showLink) {
+                LinkButton(
+                    email = email,
+                    enabled = buttonsEnabled,
+                    onClick = viewModel::handleLinkPressed,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 6.dp)
+                        .requiredHeight(48.dp),
+                )
+            }
 
-        googlePayButtonState?.errorMessage?.let { error ->
-            ErrorMessage(
-                error = error.message,
-                modifier = Modifier.padding(vertical = 3.dp, horizontal = 1.dp),
-            )
-        }
+            googlePayButtonState?.errorMessage?.let { error ->
+                ErrorMessage(
+                    error = error.message,
+                    modifier = Modifier.padding(vertical = 3.dp, horizontal = 1.dp),
+                )
+            }
 
-        if (containerState.shouldShow) {
             val text = stringResource(containerState.dividerTextResource)
             GooglePayDividerUi(text)
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -1,0 +1,207 @@
+package com.stripe.android.paymentsheet.ui
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidViewBinding
+import androidx.compose.ui.zIndex
+import com.stripe.android.link.ui.LinkButton
+import com.stripe.android.link.ui.verification.LinkVerificationDialog
+import com.stripe.android.paymentsheet.PaymentSheetViewModel
+import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.databinding.FragmentPaymentSheetPrimaryButtonBinding
+import com.stripe.android.paymentsheet.state.WalletsContainerState
+import com.stripe.android.ui.core.elements.H4Text
+import com.stripe.android.uicore.stripeColors
+import com.stripe.android.uicore.text.Html
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+private fun DismissKeyboardOnProcessing(viewModel: PaymentSheetViewModel) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    val processing by viewModel.processing.collectAsState()
+    if (processing) {
+        LaunchedEffect(Unit) {
+            keyboardController?.hide()
+        }
+    }
+}
+
+@Composable
+internal fun PaymentSheetScreen(
+    viewModel: PaymentSheetViewModel,
+    modifier: Modifier = Modifier,
+) {
+    val scrollState = rememberScrollState()
+
+    val targetElevation by remember {
+        derivedStateOf {
+            if (scrollState.value > 0) {
+                8.dp
+            } else {
+                0.dp
+            }
+        }
+    }
+
+    val elevation by animateDpAsState(targetValue = targetElevation)
+    val contentVisible by viewModel.contentVisible.collectAsState()
+
+    DismissKeyboardOnProcessing(viewModel)
+
+    Column {
+        // We need to set a z-index to make sure that the Surface's elevation shadow is rendered
+        // correctly above the screen content.
+        Surface(elevation = elevation, modifier = Modifier.zIndex(1f)) {
+            PaymentSheetTopBar(viewModel)
+        }
+
+        if (contentVisible) {
+            PaymentSheetScreenContent(
+                viewModel = viewModel,
+                modifier = modifier.verticalScroll(scrollState),
+            )
+        }
+    }
+}
+
+@Composable
+internal fun PaymentSheetScreenContent(
+    viewModel: PaymentSheetViewModel,
+    modifier: Modifier = Modifier,
+) {
+    val showLinkDialog by viewModel.linkHandler.showLinkVerificationDialog.collectAsState()
+
+    val headerText by viewModel.headerText.collectAsState(null)
+    val buyButtonState by viewModel.buyButtonState.collectAsState(initial = null)
+
+    val currentScreen by viewModel.currentScreen.collectAsState()
+    val notes by viewModel.notesText.collectAsState()
+
+    val bottomPadding = dimensionResource(
+        R.dimen.stripe_paymentsheet_button_container_spacing_bottom
+    )
+
+    val horizontalPadding = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_horizontal)
+
+    if (showLinkDialog) {
+        LinkVerificationDialog(
+            linkLauncher = viewModel.linkHandler.linkLauncher,
+            onResult = viewModel.linkHandler::handleLinkVerificationResult,
+        )
+    }
+
+    Column(
+        modifier = modifier.padding(bottom = bottomPadding),
+    ) {
+        headerText?.let { text ->
+            H4Text(
+                text = stringResource(text),
+                modifier = Modifier
+                    .padding(bottom = 2.dp)
+                    .padding(horizontal = horizontalPadding),
+            )
+        }
+
+        Wallet(viewModel)
+
+        currentScreen.Content(
+            viewModel = viewModel,
+            modifier = Modifier.padding(bottom = 8.dp),
+        )
+
+        buyButtonState?.errorMessage?.let { error ->
+            ErrorMessage(
+                error = error.message,
+                modifier = Modifier.padding(vertical = 2.dp, horizontal = 20.dp),
+            )
+        }
+
+        AndroidViewBinding(
+            factory = FragmentPaymentSheetPrimaryButtonBinding::inflate,
+        )
+
+        notes?.let { text ->
+            Html(
+                html = text,
+                color = MaterialTheme.stripeColors.subtitle,
+                style = MaterialTheme.typography.body1.copy(textAlign = TextAlign.Center),
+                modifier = Modifier.testTag("notes"),
+            )
+        }
+    }
+}
+
+@Composable
+internal fun Wallet(
+    viewModel: PaymentSheetViewModel,
+    modifier: Modifier = Modifier,
+) {
+    val containerState by viewModel.walletsContainerState.collectAsState(
+        initial = WalletsContainerState(),
+    )
+
+    val email by viewModel.linkHandler.linkLauncher.emailFlow.collectAsState(initial = null)
+    val googlePayButtonState by viewModel.googlePayButtonState.collectAsState(initial = null)
+    val buttonsEnabled by viewModel.buttonsEnabled.collectAsState(initial = false)
+
+    val padding = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_horizontal)
+
+    Column(
+        modifier = modifier.padding(horizontal = padding),
+    ) {
+        if (containerState.showGooglePay) {
+            GooglePayButton(
+                state = googlePayButtonState?.convert(),
+                isEnabled = buttonsEnabled,
+                onPressed = viewModel::checkoutWithGooglePay,
+                modifier = Modifier.padding(top = 7.dp),
+            )
+        }
+
+        if (containerState.showLink) {
+            LinkButton(
+                email = email,
+                enabled = buttonsEnabled,
+                onClick = viewModel::handleLinkPressed,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 6.dp)
+                    .requiredHeight(48.dp),
+            )
+        }
+
+        googlePayButtonState?.errorMessage?.let { error ->
+            ErrorMessage(
+                error = error.message,
+                modifier = Modifier.padding(vertical = 3.dp, horizontal = 1.dp),
+            )
+        }
+
+        if (containerState.shouldShow) {
+            val text = stringResource(containerState.dividerTextResource)
+            GooglePayDividerUi(text)
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -1,20 +1,14 @@
 package com.stripe.android.paymentsheet.ui
 
-import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -23,7 +17,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidViewBinding
-import androidx.compose.ui.zIndex
 import com.stripe.android.link.ui.LinkButton
 import com.stripe.android.link.ui.verification.LinkVerificationDialog
 import com.stripe.android.paymentsheet.PaymentSheetViewModel
@@ -39,37 +32,22 @@ internal fun PaymentSheetScreen(
     viewModel: PaymentSheetViewModel,
     modifier: Modifier = Modifier,
 ) {
-    val scrollState = rememberScrollState()
-
-    val targetElevation by remember {
-        derivedStateOf {
-            if (scrollState.value > 0) {
-                8.dp
-            } else {
-                0.dp
-            }
-        }
-    }
-
-    val elevation by animateDpAsState(targetValue = targetElevation)
     val contentVisible by viewModel.contentVisible.collectAsState()
 
     DismissKeyboardOnProcessing(viewModel)
 
-    Column {
-        // We need to set a z-index to make sure that the Surface's elevation shadow is rendered
-        // correctly above the screen content.
-        Surface(elevation = elevation, modifier = Modifier.zIndex(1f)) {
-            PaymentSheetTopBar(viewModel)
-        }
-
-        if (contentVisible) {
-            PaymentSheetScreenContent(
-                viewModel = viewModel,
-                modifier = modifier.verticalScroll(scrollState),
-            )
-        }
-    }
+    PaymentSheetScaffold(
+        topBar = { PaymentSheetTopBar(viewModel) },
+        content = { scrollModifier ->
+            if (contentVisible) {
+                PaymentSheetScreenContent(
+                    viewModel = viewModel,
+                    modifier = scrollModifier,
+                )
+            }
+        },
+        modifier = modifier,
+    )
 }
 
 @OptIn(ExperimentalComposeUiApi::class)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -713,6 +713,7 @@ internal class PaymentSheetActivityTest {
 
     @Test
     fun `GPay button error message is displayed`() {
+        val viewModel = createViewModel(isGooglePayAvailable = true)
         val scenario = activityScenario(viewModel)
         scenario.launch(intent).onActivity { activity ->
             val errorMessage = "Error message"
@@ -733,8 +734,9 @@ internal class PaymentSheetActivityTest {
 
     @Test
     fun `when checkout starts then error message is cleared`() {
+        val viewModel = createViewModel(isGooglePayAvailable = true)
         val scenario = activityScenario(viewModel)
-        scenario.launch(intent).onActivity { activity ->
+        scenario.launch(intent).onActivity {
             val errorMessage = "Error message"
 
             composeTestRule

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet
 
+import android.animation.LayoutTransition
 import android.content.Context
 import android.os.Build
 import android.view.Gravity
@@ -36,6 +37,7 @@ import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContra
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.model.AccountStatus
+import com.stripe.android.link.ui.LinkButtonTestTag
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
@@ -222,13 +224,13 @@ internal class PaymentSheetActivityTest {
 
         scenario.launch(intent).onActivity {
             composeTestRule
-                .onNodeWithTag("link-button")
+                .onNodeWithTag(LinkButtonTestTag)
                 .assertIsEnabled()
 
             viewModel.toggleEditing()
 
             composeTestRule
-                .onNodeWithTag("link-button")
+                .onNodeWithTag(LinkButtonTestTag)
                 .assertIsNotEnabled()
         }
     }
@@ -240,13 +242,13 @@ internal class PaymentSheetActivityTest {
 
         scenario.launch(intent).onActivity { activity ->
             composeTestRule
-                .onNodeWithTag("link-button")
+                .onNodeWithTag(LinkButtonTestTag)
                 .assertIsEnabled()
 
             activity.viewBinding.buyButton.callOnClick()
 
             composeTestRule
-                .onNodeWithTag("link-button")
+                .onNodeWithTag(LinkButtonTestTag)
                 .assertIsNotEnabled()
         }
     }
@@ -309,7 +311,7 @@ internal class PaymentSheetActivityTest {
         val viewModel = createViewModel(isLinkAvailable = true)
         val scenario = activityScenario(viewModel)
 
-        scenario.launch(intent).onActivity { activity ->
+        scenario.launch(intent).onActivity {
             val error = "some error"
             composeTestRule
                 .onNodeWithText(error)
@@ -322,7 +324,7 @@ internal class PaymentSheetActivityTest {
                 .assertExists()
 
             composeTestRule
-                .onNodeWithTag("link-button")
+                .onNodeWithTag(LinkButtonTestTag)
                 .performClick()
 
             composeTestRule
@@ -835,14 +837,11 @@ internal class PaymentSheetActivityTest {
     fun `notes visibility is visible`() {
         val scenario = activityScenario(viewModel)
         scenario.launch(intent).onActivity { activity ->
-            viewModel.updateBelowButtonText(
-                context.getString(
-                    R.string.stripe_paymentsheet_payment_method_us_bank_account
-                )
-            )
+            val text = context.getString(R.string.stripe_paymentsheet_payment_method_us_bank_account)
+            viewModel.updateBelowButtonText(text)
 
             composeTestRule
-                .onNodeWithTag("notes")
+                .onNodeWithText(text)
                 .assertIsDisplayed()
         }
     }
@@ -851,32 +850,33 @@ internal class PaymentSheetActivityTest {
     fun `notes visibility is gone`() {
         val scenario = activityScenario(viewModel)
         scenario.launch(intent).onActivity {
+            val text = "some text"
+
+            viewModel.updateBelowButtonText(text)
+
+            composeTestRule
+                .onNodeWithText(text)
+                .assertIsDisplayed()
+
             viewModel.updateBelowButtonText(null)
 
             composeTestRule
-                .onNodeWithTag("notes")
+                .onNodeWithText(text)
                 .assertDoesNotExist()
         }
     }
 
-//    @Test
-//    fun `verify animation is enabled for layout transition changes`() {
-//        val scenario = activityScenario()
-//        scenario.launch(intent).onActivity { activity ->
-//            assertThat(
-//                activity.viewBinding.bottomSheet.layoutTransition.isTransitionTypeEnabled(
-//                    LayoutTransition.CHANGING
-//                )
-//            ).isTrue()
-//
-//            assertThat(
-//                activity.viewBinding.fragmentContainerParent.layoutTransition
-//                    .isTransitionTypeEnabled(
-//                        LayoutTransition.CHANGING
-//                    )
-//            ).isTrue()
-//        }
-//    }
+    @Test
+    fun `verify animation is enabled for layout transition changes`() {
+        val scenario = activityScenario()
+        scenario.launch(intent).onActivity { activity ->
+            assertThat(
+                activity.viewBinding.bottomSheet.layoutTransition.isTransitionTypeEnabled(
+                    LayoutTransition.CHANGING
+                )
+            ).isTrue()
+        }
+    }
 
     @Test
     fun `Handles missing arguments correctly`() {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request moves the entire content of `PaymentSheetActivity` to Compose. It re-uses the `PaymentSheetScaffold` and simply displays all existing Composables in a column.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Compose migration.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
