### PR TITLE
Disable flaky test in `LoopTest`

### DIFF
--- a/stripecardscan/src/test/java/com/stripe/android/stripecardscan/framework/LoopTest.kt
+++ b/stripecardscan/src/test/java/com/stripe/android/stripecardscan/framework/LoopTest.kt
@@ -74,6 +74,7 @@ class LoopTest {
         assertTrue { dataCount == resultCount.get() }
     }
 
+    @Ignore("Ignored due to flakiness")
     @Test(timeout = 200)
     @SmallTest
     @ExperimentalCoroutinesApi


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request temporarily disables `LoopTest#processBoundAnalyzerLoop_analyzeDataNoDuplicates`, which has been flaky lately. I’ll follow up with @awush-stripe about fixing it next week.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
