### PR TITLE
Make Payment Sheet easier to use in Compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## XX.XX.XX - 2023-XX-XX
 
+### PaymentSheet
+[ADDED][6230](https://github.com/stripe/stripe-android/pull/6230) Added dedicated remember methods for PaymentSheet and PaymentSheet.FlowController for easier integration in Compose.
+[ADDED][6283](https://github.com/stripe/stripe-android/pull/6283) Added support for Zip payments.
+[DEPRECATED][6230](https://github.com/stripe/stripe-android/pull/6230) Deprecated PaymentSheetContract and PaymentSheetContract.Args. Use the PaymentSheet constructor or new rememberPaymentSheet method instead.
+
+### Payments
+[ADDED][6279](https://github.com/stripe/stripe-android/pull/6279) Update to Stripe 3DS2 6.1.7, removed keep-all proguard rules in favor of the minimal required ones.
+[DEPRECATED][6230](https://github.com/stripe/stripe-android/pull/6230) Deprecated static rememberLauncher methods on GooglePayLauncher, GooglePayPaymentMethodLauncher, and PaymentLauncher in favor of top-level remember***Launcher methods.
+
 ## 20.23.1 - 2023-04-17
 
 ### PaymentSheet

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,9 @@
 # Migration Guide
 
+## Migrating from versions < 20.20.0
+- Changes to `PaymentSheetContract`:
+  * `PaymentSheetContract` and `PaymentSheetContract.Args` are now deprecated and will be removed in a future release. To create and open a `PaymentSheet`, use the constructor or the new `rememberPaymentSheet()` method.
+
 ## Migrating from versions < 20.5.0
 - Changes to `PaymentSheet.Configuration`
   * `primaryButtonColor` is now deprecated. Please use the new `Appearance` parameter instead:

--- a/example/src/main/java/com/stripe/example/activity/ComposeExampleActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/ComposeExampleActivity.kt
@@ -57,7 +57,7 @@ class ComposeExampleActivity : AppCompatActivity() {
         val paymentLauncher = rememberPaymentLauncher(
             publishableKey = settings.publishableKey,
             stripeAccountId = settings.stripeAccountId,
-            callback = onPaymentResult,
+            callback = onPaymentResult
         )
 
         ComposeScreen(

--- a/example/src/main/java/com/stripe/example/activity/GooglePayLauncherComposeActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/GooglePayLauncherComposeActivity.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.Scaffold
@@ -25,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayLauncher
+import com.stripe.android.googlepaylauncher.rememberGooglePayLauncher
 import kotlinx.coroutines.launch
 
 class GooglePayLauncherComposeActivity : StripeIntentActivity() {
@@ -79,7 +81,7 @@ class GooglePayLauncherComposeActivity : StripeIntentActivity() {
             }
         }
 
-        val googlePayLauncher = GooglePayLauncher.rememberLauncher(
+        val googlePayLauncher = rememberGooglePayLauncher(
             config = googlePayConfig,
             readyCallback = { ready ->
                 if (googlePayReady == null) {
@@ -132,8 +134,8 @@ class GooglePayLauncherComposeActivity : StripeIntentActivity() {
         completed: Boolean,
         onLaunchGooglePay: (String) -> Unit
     ) {
-        Scaffold(scaffoldState = scaffoldState) {
-            Column(Modifier.fillMaxWidth()) {
+        Scaffold(scaffoldState = scaffoldState) { paddingValues ->
+            Column(Modifier.fillMaxWidth().padding(paddingValues)) {
                 if (googlePayReady == null || clientSecret.isBlank()) {
                     LinearProgressIndicator(Modifier.fillMaxWidth())
                 }

--- a/example/src/main/java/com/stripe/example/activity/GooglePayPaymentMethodLauncherComposeActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/GooglePayPaymentMethodLauncherComposeActivity.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material.Scaffold
 import androidx.compose.material.ScaffoldState
@@ -19,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
+import com.stripe.android.googlepaylauncher.rememberGooglePayPaymentMethodLauncher
 import kotlinx.coroutines.launch
 
 class GooglePayPaymentMethodLauncherComposeActivity : AppCompatActivity() {
@@ -48,7 +50,7 @@ class GooglePayPaymentMethodLauncherComposeActivity : AppCompatActivity() {
         val scope = rememberCoroutineScope()
         var enabled by remember { mutableStateOf(false) }
 
-        val googlePayLauncher = GooglePayPaymentMethodLauncher.rememberLauncher(
+        val googlePayLauncher = rememberGooglePayPaymentMethodLauncher(
             config = googlePayConfig,
             readyCallback = { ready ->
                 if (ready) {
@@ -97,13 +99,14 @@ class GooglePayPaymentMethodLauncherComposeActivity : AppCompatActivity() {
         enabled: Boolean,
         onLaunchGooglePay: () -> Unit
     ) {
-        Scaffold(scaffoldState = scaffoldState) {
+        Scaffold(scaffoldState = scaffoldState) { paddingValues ->
             AndroidView(
                 factory = { context ->
                     GooglePayButton(context)
                 },
                 modifier = Modifier
                     .wrapContentWidth()
+                    .padding(paddingValues)
                     .clickable(
                         enabled = enabled,
                         onClick = onLaunchGooglePay

--- a/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.ActivityResultRegistry
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
@@ -40,6 +41,7 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.map
 import kotlinx.parcelize.Parcelize
+import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
@@ -106,6 +108,17 @@ class LinkPaymentLauncher @Inject internal constructor(
 
     private var linkActivityResultLauncher:
         ActivityResultLauncher<LinkActivityContract.Args>? = null
+
+    fun register(
+        activityResultRegistry: ActivityResultRegistry,
+        callback: (LinkActivityResult) -> Unit,
+    ) {
+        linkActivityResultLauncher = activityResultRegistry.register(
+            "LinkHandler_${UUID.randomUUID()}",
+            LinkActivityContract(),
+            callback,
+        )
+    }
 
     fun register(
         activityResultCaller: ActivityResultCaller,

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -1309,6 +1309,10 @@ public final class com/stripe/android/googlepaylauncher/GooglePayLauncherContrac
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/googlepaylauncher/GooglePayLauncherKt {
+	public static final fun rememberGooglePayLauncher (Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$Config;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$ReadyCallback;Lcom/stripe/android/googlepaylauncher/GooglePayLauncher$ResultCallback;Landroidx/compose/runtime/Composer;I)Lcom/stripe/android/googlepaylauncher/GooglePayLauncher;
+}
+
 public final class com/stripe/android/googlepaylauncher/GooglePayLauncherResult$Canceled$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/googlepaylauncher/GooglePayLauncherResult$Canceled;
@@ -1347,7 +1351,6 @@ public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLa
 	public static final field DEVELOPER_ERROR I
 	public static final field INTERNAL_ERROR I
 	public static final field NETWORK_ERROR I
-	public synthetic fun <init> (Landroid/content/Context;Lkotlinx/coroutines/CoroutineScope;Landroidx/activity/result/ActivityResultLauncher;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Config;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$ReadyCallback;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Landroidx/activity/ComponentActivity;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Config;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$ReadyCallback;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$ResultCallback;)V
 	public fun <init> (Landroidx/fragment/app/Fragment;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Config;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$ReadyCallback;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$ResultCallback;)V
 	public final fun present (Ljava/lang/String;)V
@@ -1559,6 +1562,10 @@ public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLa
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContract$Args$InjectionParams;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherKt {
+	public static final fun rememberGooglePayPaymentMethodLauncher (Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$Config;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$ReadyCallback;Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$ResultCallback;Landroidx/compose/runtime/Composer;I)Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher;
 }
 
 public abstract interface class com/stripe/android/googlepaylauncher/GooglePayRepository {
@@ -6856,6 +6863,10 @@ public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherCo
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/payments/paymentlauncher/PaymentLauncherContract$Args$SetupIntentNextActionArgs;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/payments/paymentlauncher/PaymentLauncherKt {
+	public static final fun rememberPaymentLauncher (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher$PaymentResultCallback;Landroidx/compose/runtime/Composer;II)Lcom/stripe/android/payments/paymentlauncher/PaymentLauncher;
 }
 
 public abstract class com/stripe/android/payments/paymentlauncher/PaymentResult : android/os/Parcelable {

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -50,12 +50,17 @@ import kotlin.coroutines.CoroutineContext
  * Creates a [GooglePayPaymentMethodLauncher] that is remembered across compositions.
  *
  * This *must* be called unconditionally, as part of the initialization path.
+ *
+ * @param config Configuration to tweak what's displayed in Google Pay
+ * @param readyCallback Called after determining whether Google Pay is available and ready on the
+ * device. [GooglePayPaymentMethodLauncher.present] may only be called if Google Pay is ready.
+ * @param resultCallback Called with the [Result] of the operation
  */
 @Composable
 fun rememberGooglePayPaymentMethodLauncher(
     config: GooglePayPaymentMethodLauncher.Config,
     readyCallback: GooglePayPaymentMethodLauncher.ReadyCallback,
-    resultCallback: GooglePayPaymentMethodLauncher.ResultCallback
+    resultCallback: GooglePayPaymentMethodLauncher.ResultCallback,
 ): GooglePayPaymentMethodLauncher {
     val currentReadyCallback by rememberUpdatedState(readyCallback)
 
@@ -63,7 +68,7 @@ fun rememberGooglePayPaymentMethodLauncher(
     val lifecycleScope = LocalLifecycleOwner.current.lifecycleScope
     val activityResultLauncher = rememberLauncherForActivityResult(
         GooglePayPaymentMethodLauncherContract(),
-        resultCallback::onResult
+        resultCallback::onResult,
     )
 
     return remember(config) {
@@ -72,9 +77,7 @@ fun rememberGooglePayPaymentMethodLauncher(
             lifecycleScope = lifecycleScope,
             activityResultLauncher = activityResultLauncher,
             config = config,
-            readyCallback = {
-                currentReadyCallback.onReady(it)
-            }
+            readyCallback = currentReadyCallback::onReady,
         )
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -47,6 +47,39 @@ import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
 
 /**
+ * Creates a [GooglePayPaymentMethodLauncher] that is remembered across compositions.
+ *
+ * This *must* be called unconditionally, as part of the initialization path.
+ */
+@Composable
+fun rememberGooglePayPaymentMethodLauncher(
+    config: GooglePayPaymentMethodLauncher.Config,
+    readyCallback: GooglePayPaymentMethodLauncher.ReadyCallback,
+    resultCallback: GooglePayPaymentMethodLauncher.ResultCallback
+): GooglePayPaymentMethodLauncher {
+    val currentReadyCallback by rememberUpdatedState(readyCallback)
+
+    val context = LocalContext.current
+    val lifecycleScope = LocalLifecycleOwner.current.lifecycleScope
+    val activityResultLauncher = rememberLauncherForActivityResult(
+        GooglePayPaymentMethodLauncherContract(),
+        resultCallback::onResult
+    )
+
+    return remember(config) {
+        GooglePayPaymentMethodLauncher(
+            context = context,
+            lifecycleScope = lifecycleScope,
+            activityResultLauncher = activityResultLauncher,
+            config = config,
+            readyCallback = {
+                currentReadyCallback.onReady(it)
+            }
+        )
+    }
+}
+
+/**
  * A drop-in class that presents a Google Pay sheet to collect a customer's payment details.
  * When successful, will return a [PaymentMethod] via [Result.Completed.paymentMethod].
  *
@@ -172,7 +205,7 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
         readyCallback
     )
 
-    private constructor (
+    internal constructor (
         context: Context,
         lifecycleScope: CoroutineScope,
         activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContract.Args>,
@@ -393,32 +426,17 @@ class GooglePayPaymentMethodLauncher @AssistedInject internal constructor(
          * The GooglePayPaymentMethodLauncher created is remembered across recompositions.
          * Recomposition will always return the value produced by composition.
          */
+        @Deprecated(
+            message = "Use the top-level rememberGooglePayPaymentMethodLauncher() method instead",
+            replaceWith = ReplaceWith("rememberGooglePayPaymentMethodLauncher(config, readyCallback, resultCallback)"),
+        )
         @Composable
         fun rememberLauncher(
             config: Config,
             readyCallback: ReadyCallback,
             resultCallback: ResultCallback
         ): GooglePayPaymentMethodLauncher {
-            val currentReadyCallback by rememberUpdatedState(readyCallback)
-
-            val context = LocalContext.current
-            val lifecycleScope = LocalLifecycleOwner.current.lifecycleScope
-            val activityResultLauncher = rememberLauncherForActivityResult(
-                GooglePayPaymentMethodLauncherContract(),
-                resultCallback::onResult
-            )
-
-            return remember(config) {
-                GooglePayPaymentMethodLauncher(
-                    context = context,
-                    lifecycleScope = lifecycleScope,
-                    activityResultLauncher = activityResultLauncher,
-                    config = config,
-                    readyCallback = {
-                        currentReadyCallback.onReady(it)
-                    }
-                )
-            }
+            return rememberGooglePayPaymentMethodLauncher(config, readyCallback, resultCallback)
         }
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncher.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.fragment.app.Fragment
+import com.stripe.android.googlepaylauncher.GooglePayLauncher.Result
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.PaymentIntent
@@ -16,6 +17,10 @@ import com.stripe.android.model.SetupIntent
  * Creates a [PaymentLauncher] that is remembered across compositions.
  *
  * This *must* be called unconditionally, as part of the initialization path.
+ *
+ * @param publishableKey Your Stripe publishable key
+ * @param stripeAccountId An optional Stripe Connect account ID.
+ * @param callback Called with the [Result] of the payment operation
  */
 @Composable
 fun rememberPaymentLauncher(
@@ -26,13 +31,13 @@ fun rememberPaymentLauncher(
     val context = LocalContext.current
     val activityResultLauncher = rememberLauncherForActivityResult(
         PaymentLauncherContract(),
-        callback::onPaymentResult
+        callback::onPaymentResult,
     )
 
     return remember(publishableKey, stripeAccountId) {
         PaymentLauncherFactory(
-            context,
-            activityResultLauncher
+            context = context,
+            hostActivityLauncher = activityResultLauncher,
         ).create(publishableKey, stripeAccountId)
     }
 }
@@ -111,7 +116,7 @@ interface PaymentLauncher {
         @Deprecated(
             message = "This method creates a new PaymentLauncher object every time it is called, " +
                 "even during recompositions.",
-            replaceWith = ReplaceWith("PaymentLauncher.rememberLauncher(publishableKey, stripeAccountId, callback)"),
+            replaceWith = ReplaceWith("rememberPaymentLauncher(publishableKey, stripeAccountId, callback)"),
             level = DeprecationLevel.ERROR,
         )
         @Composable

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/complete_flow/CompleteFlowActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/complete_flow/CompleteFlowActivity.kt
@@ -14,6 +14,7 @@ import com.stripe.android.paymentsheet.example.samples.ui.shared.BuyButton
 import com.stripe.android.paymentsheet.example.samples.ui.shared.CompletedPaymentAlertDialog
 import com.stripe.android.paymentsheet.example.samples.ui.shared.PaymentSheetExampleTheme
 import com.stripe.android.paymentsheet.example.samples.ui.shared.Receipt
+import com.stripe.android.paymentsheet.rememberPaymentSheet
 
 internal class CompleteFlowActivity : AppCompatActivity() {
 
@@ -25,23 +26,20 @@ internal class CompleteFlowActivity : AppCompatActivity() {
 
     private val viewModel by viewModels<CompleteFlowViewModel>()
 
-    private lateinit var paymentSheet: PaymentSheet
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        paymentSheet = PaymentSheet(
-            activity = this,
-            callback = viewModel::handlePaymentSheetResult,
-        )
-
         setContent {
+            val paymentSheet = rememberPaymentSheet(
+                callback = viewModel::handlePaymentSheetResult,
+            )
+
             PaymentSheetExampleTheme {
                 val uiState by viewModel.state.collectAsState()
 
                 uiState.paymentInfo?.let { paymentInfo ->
                     LaunchedEffect(paymentInfo) {
-                        presentPaymentSheet(paymentInfo)
+                        presentPaymentSheet(paymentSheet, paymentInfo)
                     }
                 }
 
@@ -71,7 +69,10 @@ internal class CompleteFlowActivity : AppCompatActivity() {
         }
     }
 
-    private fun presentPaymentSheet(paymentInfo: CompleteFlowViewState.PaymentInfo) {
+    private fun presentPaymentSheet(
+        paymentSheet: PaymentSheet,
+        paymentInfo: CompleteFlowViewState.PaymentInfo,
+    ) {
         if (!paymentInfo.shouldPresent) {
             return
         }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/custom_flow/CustomFlowActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/custom_flow/CustomFlowActivity.kt
@@ -20,6 +20,7 @@ import com.stripe.android.paymentsheet.example.samples.ui.shared.ErrorScreen
 import com.stripe.android.paymentsheet.example.samples.ui.shared.PaymentMethodSelector
 import com.stripe.android.paymentsheet.example.samples.ui.shared.PaymentSheetExampleTheme
 import com.stripe.android.paymentsheet.example.samples.ui.shared.Receipt
+import com.stripe.android.paymentsheet.flowcontroller.rememberPaymentSheetFlowController
 
 internal class CustomFlowActivity : AppCompatActivity() {
 
@@ -31,25 +32,22 @@ internal class CustomFlowActivity : AppCompatActivity() {
 
     private val viewModel by viewModels<CustomFlowViewModel>()
 
-    private lateinit var flowController: PaymentSheet.FlowController
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        flowController = PaymentSheet.FlowController.create(
-            activity = this,
-            paymentOptionCallback = viewModel::handlePaymentOptionChanged,
-            paymentResultCallback = viewModel::handlePaymentSheetResult,
-        )
-
         setContent {
+            val flowController = rememberPaymentSheetFlowController(
+                paymentOptionCallback = viewModel::handlePaymentOptionChanged,
+                paymentResultCallback = viewModel::handlePaymentSheetResult,
+            )
+
             PaymentSheetExampleTheme {
                 val uiState by viewModel.state.collectAsState()
                 val paymentMethodLabel = determinePaymentMethodLabel(uiState)
 
                 uiState.paymentInfo?.let { paymentInfo ->
                     LaunchedEffect(paymentInfo) {
-                        configureFlowController(paymentInfo)
+                        configureFlowController(flowController, paymentInfo)
                     }
                 }
 
@@ -92,7 +90,10 @@ internal class CustomFlowActivity : AppCompatActivity() {
         }
     }
 
-    private fun configureFlowController(paymentInfo: CustomFlowViewState.PaymentInfo) {
+    private fun configureFlowController(
+        flowController: PaymentSheet.FlowController,
+        paymentInfo: CustomFlowViewState.PaymentInfo,
+    ) {
         flowController.configureWithPaymentIntent(
             paymentIntentClientSecret = paymentInfo.clientSecret,
             configuration = paymentInfo.paymentSheetConfig,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/complete_flow/ServerSideConfirmationCompleteFlowActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/complete_flow/ServerSideConfirmationCompleteFlowActivity.kt
@@ -18,6 +18,7 @@ import com.stripe.android.paymentsheet.example.samples.ui.shared.ErrorScreen
 import com.stripe.android.paymentsheet.example.samples.ui.shared.PaymentSheetExampleTheme
 import com.stripe.android.paymentsheet.example.samples.ui.shared.Receipt
 import com.stripe.android.paymentsheet.example.samples.ui.shared.SubscriptionToggle
+import com.stripe.android.paymentsheet.rememberPaymentSheet
 
 internal class ServerSideConfirmationCompleteFlowActivity : AppCompatActivity() {
 
@@ -35,14 +36,13 @@ internal class ServerSideConfirmationCompleteFlowActivity : AppCompatActivity() 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        paymentSheet = PaymentSheet(
-            activity = this,
-            createIntentCallbackForServerSideConfirmation = viewModel::createAndConfirmIntent,
-            paymentResultCallback = viewModel::handlePaymentSheetResult,
-        )
-
         setContent {
             PaymentSheetExampleTheme {
+                val paymentSheet = rememberPaymentSheet(
+                    createIntentCallbackForServerSideConfirmation = viewModel::createAndConfirmIntent,
+                    paymentResultCallback = viewModel::handlePaymentSheetResult,
+                )
+
                 val uiState by viewModel.state.collectAsState()
 
                 uiState.status?.let { status ->

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -776,6 +776,10 @@ public final class com/stripe/android/paymentsheet/PaymentSheetContractV2$Result
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/paymentsheet/PaymentSheetKt {
+	public static final fun rememberPaymentSheet (Lcom/stripe/android/paymentsheet/PaymentSheetResultCallback;Landroidx/compose/runtime/Composer;I)Lcom/stripe/android/paymentsheet/PaymentSheet;
+}
+
 public abstract class com/stripe/android/paymentsheet/PaymentSheetResult : android/os/Parcelable {
 	public static final field $stable I
 }
@@ -1195,6 +1199,10 @@ public final class com/stripe/android/paymentsheet/flowcontroller/DefaultFlowCon
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/flowcontroller/DefaultFlowController$Args;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerKt {
+	public static final fun rememberPaymentSheetFlowController (Lcom/stripe/android/paymentsheet/PaymentOptionCallback;Lcom/stripe/android/paymentsheet/PaymentSheetResultCallback;Landroidx/compose/runtime/Composer;I)Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController;
 }
 
 public final class com/stripe/android/paymentsheet/model/PaymentIntentClientSecret$Creator : android/os/Parcelable$Creator {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -38,6 +38,8 @@ import kotlinx.parcelize.Parcelize
  * Creates a [PaymentSheet] that is remembered across compositions.
  *
  * This *must* be called unconditionally, as part of the initialization path.
+ *
+ * @param callback Called with the result of the payment after [PaymentSheet] is dismissed.
  */
 @Composable
 fun rememberPaymentSheet(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetContract.kt
@@ -16,6 +16,11 @@ import com.stripe.android.paymentsheet.model.SetupIntentClientSecret
 import com.stripe.android.view.ActivityStarter
 import kotlinx.parcelize.Parcelize
 
+@Deprecated(
+    message = "This isn't meant for public usage and will be removed in a future " +
+        "release. If you're looking to integrate with PaymentSheet in Compose, " +
+        "use rememberPaymentSheet() instead.",
+)
 class PaymentSheetContract :
     ActivityResultContract<PaymentSheetContract.Args, PaymentSheetResult>() {
     override fun createIntent(
@@ -38,6 +43,11 @@ class PaymentSheetContract :
         )
     }
 
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future " +
+            "release. If you're looking to integrate with PaymentSheet in Compose, " +
+            "use rememberPaymentSheet() instead.",
+    )
     @Parcelize
     data class Args internal constructor(
         internal val clientSecret: ClientSecret,
@@ -70,6 +80,11 @@ class PaymentSheetContract :
                 return intent.getParcelableExtra(EXTRA_ARGS)
             }
 
+            @Deprecated(
+                message = "This isn't meant for public usage and will be removed in a future " +
+                    "release. If you're looking to integrate with PaymentSheet in Compose, " +
+                    "use rememberPaymentSheet() instead.",
+            )
             fun createPaymentIntentArgs(
                 clientSecret: String,
                 config: PaymentSheet.Configuration? = null
@@ -78,6 +93,11 @@ class PaymentSheetContract :
                 config = config,
             )
 
+            @Deprecated(
+                message = "This isn't meant for public usage and will be removed in a future " +
+                    "release. If you're looking to integrate with PaymentSheet in Compose, " +
+                    "use rememberPaymentSheet() instead.",
+            )
             fun createSetupIntentArgs(
                 clientSecret: String,
                 config: PaymentSheet.Configuration? = null

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -79,7 +79,10 @@ import javax.inject.Singleton
  * Creates a [PaymentSheet.FlowController] that is remembered across compositions.
  *
  * This *must* be called unconditionally, as part of the initialization path.
- */
+ *
+ * @param paymentOptionCallback Called when the customer's desired payment method changes.
+ * @param paymentResultCallback Called when a [PaymentSheetResult] is available.
+*/
 @Composable
 fun rememberPaymentSheetFlowController(
     paymentOptionCallback: PaymentOptionCallback,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -11,6 +11,7 @@ import androidx.activity.result.ActivityResultRegistryOwner
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
@@ -19,6 +20,8 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import com.stripe.android.CreateIntentCallback
+import com.stripe.android.CreateIntentCallbackForServerSideConfirmation
 import com.stripe.android.ExperimentalPaymentSheetDecouplingApi
 import com.stripe.android.IntentConfirmationInterceptor
 import com.stripe.android.PaymentConfiguration
@@ -85,6 +88,49 @@ import javax.inject.Singleton
 */
 @Composable
 fun rememberPaymentSheetFlowController(
+    paymentOptionCallback: PaymentOptionCallback,
+    paymentResultCallback: PaymentSheetResultCallback,
+): PaymentSheet.FlowController {
+    return rememberPaymentSheetFlowControllerInternal(
+        paymentOptionCallback = paymentOptionCallback,
+        paymentResultCallback = paymentResultCallback,
+    )
+}
+
+@ExperimentalPaymentSheetDecouplingApi
+@Composable
+fun rememberPaymentSheetFlowController(
+    createIntentCallback: CreateIntentCallback,
+    paymentOptionCallback: PaymentOptionCallback,
+    paymentResultCallback: PaymentSheetResultCallback,
+): PaymentSheet.FlowController {
+    LaunchedEffect(createIntentCallback) {
+        IntentConfirmationInterceptor.createIntentCallback = createIntentCallback
+    }
+    return rememberPaymentSheetFlowControllerInternal(
+        paymentOptionCallback = paymentOptionCallback,
+        paymentResultCallback = paymentResultCallback,
+    )
+}
+
+@ExperimentalPaymentSheetDecouplingApi
+@Composable
+fun rememberPaymentSheetFlowController(
+    createIntentCallbackForServerSideConfirmation: CreateIntentCallbackForServerSideConfirmation,
+    paymentOptionCallback: PaymentOptionCallback,
+    paymentResultCallback: PaymentSheetResultCallback,
+): PaymentSheet.FlowController {
+    LaunchedEffect(createIntentCallbackForServerSideConfirmation) {
+        IntentConfirmationInterceptor.createIntentCallback = createIntentCallbackForServerSideConfirmation
+    }
+    return rememberPaymentSheetFlowControllerInternal(
+        paymentOptionCallback = paymentOptionCallback,
+        paymentResultCallback = paymentResultCallback,
+    )
+}
+
+@Composable
+private fun rememberPaymentSheetFlowControllerInternal(
     paymentOptionCallback: PaymentOptionCallback,
     paymentResultCallback: PaymentSheetResultCallback,
 ): PaymentSheet.FlowController {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerComponent.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.paymentsheet.flowcontroller
 
-import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultRegistryOwner
 import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.core.injection.InjectorKey
 import com.stripe.android.paymentsheet.PaymentOptionCallback
@@ -20,7 +20,9 @@ internal interface FlowControllerComponent {
         fun lifeCycleOwner(lifecycleOwner: LifecycleOwner): Builder
 
         @BindsInstance
-        fun activityResultCaller(activityResultCaller: ActivityResultCaller): Builder
+        fun activityResultRegistryOwner(
+            activityResultRegistryOwner: ActivityResultRegistryOwner,
+        ): Builder
 
         @BindsInstance
         fun statusBarColor(statusBarColor: () -> Int?): Builder

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerFactory.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.paymentsheet.flowcontroller
 
 import androidx.activity.ComponentActivity
-import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultRegistryOwner
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelStoreOwner
@@ -12,7 +12,7 @@ import com.stripe.android.paymentsheet.PaymentSheetResultCallback
 internal class FlowControllerFactory(
     private val viewModelStoreOwner: ViewModelStoreOwner,
     private val lifecycleOwner: LifecycleOwner,
-    private val activityResultCaller: ActivityResultCaller,
+    private val activityResultRegistryOwner: ActivityResultRegistryOwner,
     private val statusBarColor: () -> Int?,
     private val paymentOptionCallback: PaymentOptionCallback,
     private val paymentResultCallback: PaymentSheetResultCallback
@@ -24,7 +24,7 @@ internal class FlowControllerFactory(
     ) : this(
         viewModelStoreOwner = activity,
         lifecycleOwner = activity,
-        activityResultCaller = activity,
+        activityResultRegistryOwner = activity,
         statusBarColor = { activity.window.statusBarColor },
         paymentOptionCallback = paymentOptionCallback,
         paymentResultCallback = paymentResultCallback,
@@ -37,19 +37,18 @@ internal class FlowControllerFactory(
     ) : this(
         viewModelStoreOwner = fragment,
         lifecycleOwner = fragment,
-        activityResultCaller = fragment,
+        activityResultRegistryOwner = (fragment.host as? ActivityResultRegistryOwner) ?: fragment.requireActivity(),
         statusBarColor = { fragment.activity?.window?.statusBarColor },
         paymentOptionCallback = paymentOptionCallback,
         paymentResultCallback = paymentResultCallback,
     )
 
-    fun create(): PaymentSheet.FlowController =
-        DefaultFlowController.getInstance(
-            viewModelStoreOwner = viewModelStoreOwner,
-            lifecycleOwner = lifecycleOwner,
-            activityResultCaller = activityResultCaller,
-            statusBarColor = statusBarColor,
-            paymentOptionCallback = paymentOptionCallback,
-            paymentResultCallback = paymentResultCallback
-        )
+    fun create(): PaymentSheet.FlowController = DefaultFlowController.getInstance(
+        viewModelStoreOwner = viewModelStoreOwner,
+        lifecycleOwner = lifecycleOwner,
+        activityResultRegistryOwner = activityResultRegistryOwner,
+        statusBarColor = statusBarColor,
+        paymentOptionCallback = paymentOptionCallback,
+        paymentResultCallback = paymentResultCallback
+    )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -59,7 +59,6 @@ import com.stripe.android.testing.FakeIntentConfirmationInterceptor
 import com.stripe.android.uicore.image.StripeImageLoader
 import com.stripe.android.utils.FakePaymentSheetLoader
 import com.stripe.android.utils.RelayingPaymentSheetLoader
-import com.stripe.android.view.ActivityScenarioFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flowOf


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request makes `PaymentSheet` and `PaymentSheet.FlowController` easier to use in Compose. Instead of creating these instances outside of the Compose scope, you can now use remember methods.

For consistency, we’re also deprecating existing `***Launcher.rememberLauncher()` methods in favor of `remember***Launcher()` methods.

Finally, since `PaymentSheet` can now be used more easily from Compose, we’re deprecating `PaymentSheetContract` and its `Args` class. These classes will eventually be restricted to internal visibility.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

https://jira.corp.stripe.com/browse/MOBILE_APIREVIEW-35

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

[ADDED] Added dedicated remember methods for PaymentSheet and PaymentSheet.FlowController for easier integration in Compose.
[DEPRECATED] Deprecated static `rememberLauncher` methods on `GooglePayLauncher`, `GooglePayPaymentMethodLauncher`, and `PaymentLauncher` in favor of top-level `remember***Launcher` methods.
[DEPRECATED] Deprecated `PaymentSheetContract` and `PaymentSheetContract.Args`. Use the `PaymentSheet` constructor or new `rememberPaymentSheet` method instead.