### PR TITLE
Mark various classes as deprecated for future removal from public API

### DIFF
--- a/link/api/link.api
+++ b/link/api/link.api
@@ -185,9 +185,6 @@ public final class com/stripe/android/link/LinkPaymentLauncher$Configuration$Cre
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/link/injection/NamedConstantsKt {
-}
-
 public final class com/stripe/android/link/model/AccountStatus : java/lang/Enum {
 	public static final field Error Lcom/stripe/android/link/model/AccountStatus;
 	public static final field NeedsVerification Lcom/stripe/android/link/model/AccountStatus;

--- a/link/src/main/java/com/stripe/android/link/LinkActivityContract.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivityContract.kt
@@ -34,6 +34,9 @@ class LinkActivityContract :
      * @param injectionParams Parameters needed to perform dependency injection.
      *                        If null, a new dependency graph will be created.
      */
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     @Parcelize
     data class Args internal constructor(
         internal val configuration: LinkPaymentLauncher.Configuration,
@@ -58,6 +61,9 @@ class LinkActivityContract :
         @IgnoredOnParcel
         internal val shippingValues = configuration.shippingValues
 
+        @Deprecated(
+            message = "This isn't meant for public usage and will be removed in a future release.",
+        )
         companion object {
             internal fun fromIntent(intent: Intent): Args? {
                 return intent.getParcelableExtra(EXTRA_ARGS)
@@ -74,6 +80,9 @@ class LinkActivityContract :
         ) : Parcelable
     }
 
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     @Parcelize
     data class Result(
         val linkResult: LinkActivityResult
@@ -81,6 +90,9 @@ class LinkActivityContract :
         override fun toBundle() = bundleOf(EXTRA_RESULT to this)
     }
 
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     companion object {
         const val EXTRA_ARGS =
             "com.stripe.android.link.LinkActivityContract.extra_args"

--- a/link/src/main/java/com/stripe/android/link/LinkActivityResult.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivityResult.kt
@@ -4,18 +4,28 @@ import android.app.Activity
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
+@Deprecated(
+    message = "This isn't meant for public usage and will be removed in a future release.",
+)
 sealed class LinkActivityResult(
     val resultCode: Int
 ) : Parcelable {
+
     /**
      * Indicates that the flow was completed successfully and the Stripe Intent was confirmed.
      */
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     @Parcelize
     object Completed : LinkActivityResult(Activity.RESULT_OK)
 
     /**
      * The user cancelled the Link flow without completing it.
      */
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     @Parcelize
     data class Canceled(
         val reason: Reason
@@ -30,6 +40,9 @@ sealed class LinkActivityResult(
     /**
      * Something went wrong. See [error] for more information.
      */
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     @Parcelize
     data class Failed(
         val error: Throwable

--- a/link/src/main/java/com/stripe/android/link/LinkPaymentDetails.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkPaymentDetails.kt
@@ -24,6 +24,9 @@ sealed class LinkPaymentDetails(
     /**
      * A [ConsumerPaymentDetails.PaymentDetails] that is already saved to the consumer's account.
      */
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     @Parcelize
     internal class Saved(
         override val paymentDetails: ConsumerPaymentDetails.PaymentDetails,
@@ -35,6 +38,9 @@ sealed class LinkPaymentDetails(
      * Must hold the original [PaymentMethodCreateParams] too in case we need to populate the form
      * fields with the user-entered values.
      */
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     @Parcelize
     class New(
         override val paymentDetails: ConsumerPaymentDetails.PaymentDetails,

--- a/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
@@ -238,7 +238,6 @@ class LinkPaymentLauncher @Inject internal constructor(
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
-        const val LINK_ENABLED = true
         val supportedFundingSources = SupportedPaymentMethod.allTypes
     }
 }

--- a/link/src/main/java/com/stripe/android/link/injection/NamedConstants.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/NamedConstants.kt
@@ -1,9 +1,0 @@
-package com.stripe.android.link.injection
-
-import androidx.annotation.RestrictTo
-
-/**
- * Identifies whether Link is enabled.
- */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-const val LINK_ENABLED = "linkEnabled"

--- a/link/src/main/java/com/stripe/android/link/model/Navigator.kt
+++ b/link/src/main/java/com/stripe/android/link/model/Navigator.kt
@@ -78,4 +78,7 @@ internal class Navigator @Inject constructor() {
 
 // The Loading screen is always at the bottom of the stack, so a size of 2 means the current
 // screen is at the bottom of the navigation stack.
+@Deprecated(
+    message = "This isn't meant for public usage and will be removed in a future release.",
+)
 fun NavHostController.isOnRootScreen() = backQueue.size <= 2

--- a/link/src/main/java/com/stripe/android/link/ui/inline/UserInput.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/UserInput.kt
@@ -3,10 +3,17 @@ package com.stripe.android.link.ui.inline
 /**
  * Valid user input into the inline sign up view.
  */
+@Deprecated(
+    message = "This isn't meant for public usage and will be removed in a future release.",
+)
 sealed class UserInput {
+
     /**
      * Represents an input that is valid for signing in to a link account.
      */
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     data class SignIn(
         val email: String
     ) : UserInput()
@@ -14,6 +21,9 @@ sealed class UserInput {
     /**
      * Represents an input that is valid for signing up to a link account.
      */
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     data class SignUp(
         val email: String,
         val phone: String,

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -2373,9 +2373,6 @@ public abstract interface class com/stripe/android/model/ConfirmStripeIntentPara
 	public abstract fun withShouldUseStripeSdk (Z)Lcom/stripe/android/model/ConfirmStripeIntentParams;
 }
 
-public final class com/stripe/android/model/ConfirmStripeIntentParams$Companion {
-}
-
 public final class com/stripe/android/model/ConsumerPaymentDetails$BankAccount : com/stripe/android/model/ConsumerPaymentDetails$PaymentDetails {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
@@ -4932,7 +4929,6 @@ public final class com/stripe/android/model/SetupIntent$Error$Type : java/lang/E
 public final class com/stripe/android/model/ShippingInformation : com/stripe/android/core/model/StripeModel, com/stripe/android/model/StripeParamsModel {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public static final field Companion Lcom/stripe/android/model/ShippingInformation$Companion;
 	public fun <init> ()V
 	public fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Lcom/stripe/android/model/Address;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -4950,9 +4946,6 @@ public final class com/stripe/android/model/ShippingInformation : com/stripe/and
 	public fun toParamMap ()Ljava/util/Map;
 	public fun toString ()Ljava/lang/String;
 	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
-public final class com/stripe/android/model/ShippingInformation$Companion {
 }
 
 public final class com/stripe/android/model/ShippingInformation$Creator : android/os/Parcelable$Creator {
@@ -6894,12 +6887,8 @@ public abstract interface class com/stripe/android/view/ActivityStarter$Args : a
 	public static final field Companion Lcom/stripe/android/view/ActivityStarter$Args$Companion;
 }
 
-public final class com/stripe/android/view/ActivityStarter$Args$Companion {
-}
-
 public abstract interface class com/stripe/android/view/ActivityStarter$Result : android/os/Parcelable {
 	public static final field Companion Lcom/stripe/android/view/ActivityStarter$Result$Companion;
-	public static final field EXTRA Ljava/lang/String;
 	public abstract fun toBundle ()Landroid/os/Bundle;
 }
 

--- a/payments-core/src/main/java/com/stripe/android/model/Address.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/Address.kt
@@ -88,6 +88,9 @@ data class Address @VisibleForTesting constructor(
         }
     }
 
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     companion object {
         private const val PARAM_CITY = "city"
 

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmStripeIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmStripeIntentParams.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model
 
 import android.os.Parcelable
+import androidx.annotation.RestrictTo
 
 /**
  * Interface for params for confirming a [PaymentIntent] or [SetupIntent].
@@ -17,6 +18,7 @@ sealed interface ConfirmStripeIntentParams : StripeParamsModel, Parcelable {
 
     fun withShouldUseStripeSdk(shouldUseStripeSdk: Boolean): ConfirmStripeIntentParams
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
         internal const val PARAM_CLIENT_SECRET: String = "client_secret"
         internal const val PARAM_RETURN_URL: String = "return_url"

--- a/payments-core/src/main/java/com/stripe/android/model/ConsumerPaymentDetails.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConsumerPaymentDetails.kt
@@ -19,6 +19,9 @@ data class ConsumerPaymentDetails internal constructor(
         open val type: String
     ) : Parcelable
 
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     @Parcelize
     data class Card(
         override val id: String,
@@ -40,6 +43,9 @@ data class ConsumerPaymentDetails internal constructor(
                 expiryYear = expiryYear
             )
 
+        @Deprecated(
+            message = "This isn't meant for public usage and will be removed in a future release.",
+        )
         companion object {
             const val type = "card"
 
@@ -66,6 +72,9 @@ data class ConsumerPaymentDetails internal constructor(
         }
     }
 
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     @Parcelize
     data class BankAccount(
         override val id: String,
@@ -74,11 +83,18 @@ data class ConsumerPaymentDetails internal constructor(
         val bankName: String,
         val last4: String
     ) : PaymentDetails(id, isDefault, Companion.type) {
+
+        @Deprecated(
+            message = "This isn't meant for public usage and will be removed in a future release.",
+        )
         companion object {
             const val type = "bank_account"
         }
     }
 
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     @Parcelize
     data class BillingAddress(
         val countryCode: CountryCode?,

--- a/payments-core/src/main/java/com/stripe/android/model/LuxeNextActionRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/LuxeNextActionRepository.kt
@@ -51,6 +51,9 @@ class LuxeNextActionRepository {
     private fun getActionCreator(lpmCode: PaymentMethodCode?, status: StripeIntent.Status?) =
         codeToNextActionSpec[lpmCode]?.postConfirmStatusNextStatus.takeIf { it?.status == status }
 
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     companion object {
         val Instance: LuxeNextActionRepository = LuxeNextActionRepository()
     }

--- a/payments-core/src/main/java/com/stripe/android/model/LuxePostConfirmActionCreator.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/LuxePostConfirmActionCreator.kt
@@ -4,6 +4,9 @@ import android.net.Uri
 import androidx.annotation.RestrictTo
 import org.json.JSONObject
 
+@Deprecated(
+    message = "This isn't meant for public usage and will be removed in a future release.",
+)
 sealed class LuxePostConfirmActionCreator {
     internal fun create(stripeIntentJsonString: String) =
         create(JSONObject(stripeIntentJsonString))

--- a/payments-core/src/main/java/com/stripe/android/model/LuxePostConfirmActionRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/LuxePostConfirmActionRepository.kt
@@ -55,6 +55,9 @@ class LuxePostConfirmActionRepository {
             ?.map { it.value }
             ?.firstOrNull()
 
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     companion object {
         val Instance: LuxePostConfirmActionRepository = LuxePostConfirmActionRepository()
     }

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
@@ -424,6 +424,9 @@ constructor(
         }
     }
 
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     companion object {
         @JvmStatic
         fun fromJson(jsonObject: JSONObject?): PaymentIntent? {

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -372,6 +372,9 @@ constructor(
             return code
         }
 
+        @Deprecated(
+            message = "This isn't meant for public usage and will be removed in a future release.",
+        )
         companion object {
             @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
             // For paymentsheet

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -998,6 +998,9 @@ constructor(
         ) : StripeModel
     }
 
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     companion object {
         @JvmStatic
         fun fromJson(paymentMethod: JSONObject?): PaymentMethod? {

--- a/payments-core/src/main/java/com/stripe/android/model/SetupIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/SetupIntent.kt
@@ -254,6 +254,9 @@ data class SetupIntent internal constructor(
         }
     }
 
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     companion object {
         @JvmStatic
         fun fromJson(jsonObject: JSONObject?): SetupIntent? {

--- a/payments-core/src/main/java/com/stripe/android/model/ShippingInformation.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ShippingInformation.kt
@@ -3,6 +3,10 @@ package com.stripe.android.model
 import com.stripe.android.core.model.StripeModel
 import kotlinx.parcelize.Parcelize
 
+private const val PARAM_ADDRESS = "address"
+private const val PARAM_NAME = "name"
+private const val PARAM_PHONE = "phone"
+
 /**
  * Model representing a shipping address object
  */
@@ -21,11 +25,5 @@ data class ShippingInformation constructor(
         )
             .mapNotNull { (first, second) -> second?.let { Pair(first, it) } }
             .toMap()
-    }
-
-    companion object {
-        private const val PARAM_ADDRESS = "address"
-        private const val PARAM_NAME = "name"
-        private const val PARAM_PHONE = "phone"
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/model/Source.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/Source.kt
@@ -413,6 +413,9 @@ data class Source internal constructor(
         val customPaymentMethods: Set<String>
     ) : StripeModel
 
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     companion object {
         internal const val EURO: String = "eur"
         internal const val USD: String = "usd"

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/navigation/CollectBankAccountContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/navigation/CollectBankAccountContract.kt
@@ -79,6 +79,9 @@ class CollectBankAccountContract :
             attachToIntent = attachToIntent
         )
 
+        @Deprecated(
+            message = "This isn't meant for public usage and will be removed in a future release.",
+        )
         companion object {
             fun fromIntent(intent: Intent): Args? {
                 return intent.getParcelableExtra(EXTRA_ARGS)

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherContract.kt
@@ -15,6 +15,7 @@ import kotlinx.parcelize.Parcelize
 /**
  * [ActivityResultContract] to start [PaymentLauncherConfirmationActivity] and return a [PaymentResult].
  */
+// TODO: Why is this publicly accessible?
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class PaymentLauncherContract :
     ActivityResultContract<PaymentLauncherContract.Args, PaymentResult>() {
@@ -30,6 +31,9 @@ class PaymentLauncherContract :
         return PaymentResult.fromIntent(intent)
     }
 
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     sealed class Args(
         @InjectorKey open val injectorKey: String,
         open val publishableKey: String,
@@ -40,6 +44,9 @@ class PaymentLauncherContract :
     ) : Parcelable {
         fun toBundle() = bundleOf(EXTRA_ARGS to this)
 
+        @Deprecated(
+            message = "This isn't meant for public usage and will be removed in a future release.",
+        )
         @Parcelize
         data class IntentConfirmationArgs internal constructor(
             @InjectorKey override val injectorKey: String,
@@ -58,6 +65,9 @@ class PaymentLauncherContract :
             statusBarColor
         )
 
+        @Deprecated(
+            message = "This isn't meant for public usage and will be removed in a future release.",
+        )
         @Parcelize
         data class PaymentIntentNextActionArgs internal constructor(
             @InjectorKey override val injectorKey: String,
@@ -76,6 +86,9 @@ class PaymentLauncherContract :
             statusBarColor
         )
 
+        @Deprecated(
+            message = "This isn't meant for public usage and will be removed in a future release.",
+        )
         @Parcelize
         data class SetupIntentNextActionArgs internal constructor(
             @InjectorKey override val injectorKey: String,

--- a/payments-core/src/main/java/com/stripe/android/view/ActivityStarter.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/ActivityStarter.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
-import androidx.annotation.VisibleForTesting
 import androidx.fragment.app.Fragment
 
 /**
@@ -66,9 +65,11 @@ abstract class ActivityStarter<TargetActivityType : Activity, ArgsType : Activit
     }
 
     interface Args : Parcelable {
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         companion object {
+
             @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-            @VisibleForTesting
             const val EXTRA: String = "extra_activity_args"
         }
     }
@@ -78,6 +79,8 @@ abstract class ActivityStarter<TargetActivityType : Activity, ArgsType : Activit
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) // For paymentsheet
         companion object {
+
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
             const val EXTRA: String = "extra_activity_result"
         }
     }

--- a/payments-model/src/main/java/com/stripe/android/model/Token.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/Token.kt
@@ -68,6 +68,9 @@ constructor(
         }
     }
 
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     companion object {
         @JvmStatic
         fun fromJson(jsonObject: JSONObject?): Token? {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement.kt
@@ -50,6 +50,9 @@ data class AfterpayClearpayHeaderElement(
             )
     }
 
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     companion object {
         const val url = "https://static.afterpay.com/modal/%s.html"
         const val NO_BREAK_SPACE = "\u00A0"

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
@@ -484,6 +484,9 @@ class LpmRepository constructor(
         fun supportsCustomerSavedPM() = requirement.getConfirmPMFromCustomer(code)
     }
 
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
     class LpmInitialFormData {
 
@@ -506,7 +509,11 @@ class LpmRepository constructor(
         }
     }
 
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     companion object {
+
         @Volatile
         private var INSTANCE: LpmRepository? = null
         fun getInstance(args: LpmRepositoryArguments): LpmRepository =
@@ -530,9 +537,25 @@ class LpmRepository constructor(
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     sealed class ServerSpecState(val serverLpmSpecs: String?) {
+
+        @Deprecated(
+            message = "This isn't meant for public usage and will be removed in a future release.",
+        )
         object Uninitialized : ServerSpecState(null)
+
+        @Deprecated(
+            message = "This isn't meant for public usage and will be removed in a future release.",
+        )
         class NoServerSpec(serverLpmSpecs: String?) : ServerSpecState(serverLpmSpecs)
+
+        @Deprecated(
+            message = "This isn't meant for public usage and will be removed in a future release.",
+        )
         class ServerParsed(serverLpmSpecs: String?) : ServerSpecState(serverLpmSpecs)
+
+        @Deprecated(
+            message = "This isn't meant for public usage and will be removed in a future release.",
+        )
         class ServerNotParsed(serverLpmSpecs: String?) : ServerSpecState(serverLpmSpecs)
     }
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/injection/ResourceRepositoryModule.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/injection/ResourceRepositoryModule.kt
@@ -12,6 +12,9 @@ import dagger.Module
 import dagger.Provides
 import javax.inject.Singleton
 
+@Deprecated(
+    message = "This isn't meant for public usage and will be removed in a future release.",
+)
 @Module
 abstract class ResourceRepositoryModule {
     @Binds
@@ -22,6 +25,9 @@ abstract class ResourceRepositoryModule {
     abstract fun bindsAddressRepository(address: AsyncAddressResourceRepository):
         ResourceRepository<AddressRepository>
 
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     companion object {
         @Provides
         @Singleton

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/injection/FormControllerModule.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/injection/FormControllerModule.kt
@@ -19,6 +19,9 @@ import javax.inject.Named
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 abstract class FormControllerModule {
 
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     companion object {
 
         @Provides

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/injection/FormControllerSubcomponent.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/injection/FormControllerSubcomponent.kt
@@ -22,6 +22,9 @@ import javax.inject.Named
 interface FormControllerSubcomponent {
     val formController: FormController
 
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     @Subcomponent.Builder
     interface Builder {
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentMethodsUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentMethodsUI.kt
@@ -46,6 +46,9 @@ private object Spacing {
     val iconSize = 28.dp
 }
 
+@Deprecated(
+    message = "This isn't meant for public usage and will be removed in a future release.",
+)
 @VisibleForTesting
 const val TEST_TAG_LIST = "PaymentMethodsUITestTag"
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionUi.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionUi.kt
@@ -42,6 +42,9 @@ import com.stripe.android.ui.core.elements.SimpleDialogElementUI
 import com.stripe.android.uicore.elements.SectionCard
 import com.stripe.android.uicore.shouldUseDarkDynamicColor
 
+@Deprecated(
+    message = "This isn't meant for public usage and will be removed in a future release.",
+)
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
 const val PAYMENT_OPTION_CARD_TEST_TAG = "PAYMENT_OPTION_CARD_TEST_TAG"
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -768,9 +768,19 @@ class PaymentSheet internal constructor(
          */
         fun confirm()
 
+        @Deprecated(
+            message = "This isn't meant for public usage and will be removed in a future release.",
+        )
         sealed class Result {
+
+            @Deprecated(
+                message = "This isn't meant for public usage and will be removed in a future release.",
+            )
             object Success : Result()
 
+            @Deprecated(
+                message = "This isn't meant for public usage and will be removed in a future release.",
+            )
             class Failure(
                 val error: Throwable
             ) : Result()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressDetails.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressDetails.kt
@@ -30,6 +30,10 @@ data class AddressDetails(
      */
     val isCheckboxSelected: Boolean? = null
 ) : Parcelable {
+
+    @Deprecated(
+        message = "This isn't meant for public usage and will be removed in a future release.",
+    )
     companion object {
         const val KEY = "AddressDetails"
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds a deprecation warning to various classes and fields that shouldn't have been exposed in the first place. We'll restrict them to the library group in a future breaking release.

Note: `PaymentSheetContract` and `PaymentSheetContract.Args` aren’t being deprecated in this pull request. This will happen as part of #6230.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Cleaning up our public API.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
