### PR TITLE
Add `InitializationMode` and use it throughout PS + FC

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -372,6 +372,7 @@ public abstract interface class com/stripe/android/paymentsheet/PaymentSheet$Flo
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheet$FlowController$DefaultImpls {
+	public static synthetic fun configure$default (Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController;Lcom/stripe/android/paymentsheet/PaymentSheet$InitializationMode;Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController$ConfigCallback;ILjava/lang/Object;)V
 	public static synthetic fun configureWithPaymentIntent$default (Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController$ConfigCallback;ILjava/lang/Object;)V
 	public static synthetic fun configureWithSetupIntent$default (Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController$ConfigCallback;ILjava/lang/Object;)V
 }
@@ -425,6 +426,22 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$GooglePayConfigu
 	public static final field Test Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;
 	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;
 	public static fun values ()[Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$InitializationMode$PaymentIntent$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheet$InitializationMode$PaymentIntent;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentSheet$InitializationMode$PaymentIntent;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$InitializationMode$SetupIntent$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheet$InitializationMode$SetupIntent;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentSheet$InitializationMode$SetupIntent;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheet$PrimaryButton : android/os/Parcelable {
@@ -655,6 +672,22 @@ public final class com/stripe/android/paymentsheet/PaymentSheetContract$Result$C
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheetContract$Result;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentSheetContract$Result;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheetContractV2$Args$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheetContractV2$Args;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentSheetContractV2$Args;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheetContractV2$Result$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheetContractV2$Result;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentSheetContractV2$Result;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -12,6 +12,7 @@
     <ID>FunctionOnlyReturningConstant:SupportedPaymentMethodTest.kt$SupportedPaymentMethodTest.PaymentIntentTestInput.Companion$fun toCsvHeader()</ID>
     <ID>FunctionOnlyReturningConstant:SupportedPaymentMethodTest.kt$SupportedPaymentMethodTest.TestOutput.Companion$fun toCsvHeader()</ID>
     <ID>LargeClass:DefaultFlowControllerTest.kt$DefaultFlowControllerTest</ID>
+    <ID>LargeClass:DefaultPaymentSheetLoaderTest.kt$DefaultPaymentSheetLoaderTest</ID>
     <ID>LargeClass:PaymentIntentFixtures.kt$PaymentIntentFixtures</ID>
     <ID>LargeClass:PaymentSheetActivityTest.kt$PaymentSheetActivityTest</ID>
     <ID>LargeClass:PaymentSheetViewModelTest.kt$PaymentSheetViewModelTest</ID>
@@ -51,7 +52,6 @@
     <ID>MaxLineLength:PaymentSheet.kt$PaymentSheet.GooglePayConfiguration$*</ID>
     <ID>MaxLineLength:PaymentSheetViewModelTest.kt$PaymentSheetViewModelTest$fun</ID>
     <ID>MaxLineLength:PrimaryButtonTest.kt$PrimaryButtonTest$primaryButton.setAppearanceConfiguration(StripeThemeDefaults.primaryButtonStyle, ColorStateList.valueOf(Color.BLACK))</ID>
-    <ID>MaxLineLength:StripeIntentRepositoryTest.kt$StripeIntentRepositoryTest$fun</ID>
     <ID>MaxLineLength:SupportedPaymentMethodTest.kt$SupportedPaymentMethodTest$* This will generate payment intent scenarios for all combinations of customers, lpm types in the intent, shipping, and SFU states</ID>
     <ID>MaxLineLength:SupportedPaymentMethodTest.kt$SupportedPaymentMethodTest$val formDescriptor = lpm.getSpecWithFullfilledRequirements(testInput.getIntent(lpm), testInput.getConfig())</ID>
     <ID>MaxLineLength:SupportedPaymentMethodTest.kt$SupportedPaymentMethodTest.PaymentIntentTestInput$fun toCsv()</ID>
@@ -62,6 +62,7 @@
     <ID>NestedBlockDepth:SupportedPaymentMethodTest.kt$SupportedPaymentMethodTest$private fun generatePaymentIntentScenarios(): List&lt;PaymentIntentTestInput></ID>
     <ID>ReturnCount:AddressUtils.kt$internal fun CharSequence.levenshtein(other: CharSequence): Int</ID>
     <ID>ThrowsCount:PaymentSheetConfigurationKtx.kt$internal fun PaymentSheet.Configuration.validate()</ID>
+    <ID>TooManyFunctions:DefaultFlowController.kt$DefaultFlowController : FlowControllerNonFallbackInjector</ID>
     <ID>TooManyFunctions:PaymentOption.kt$DelegateDrawable : Drawable</ID>
     <ID>TooManyFunctions:PaymentOptionsViewModel.kt$PaymentOptionsViewModel : BaseSheetViewModel</ID>
     <ID>TooManyFunctions:PaymentSheetViewModel.kt$PaymentSheetViewModel : BaseSheetViewModel</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncher.kt
@@ -19,7 +19,7 @@ import org.jetbrains.annotations.TestOnly
  * able to pass in an activity.
  */
 internal class DefaultPaymentSheetLauncher(
-    private val activityResultLauncher: ActivityResultLauncher<PaymentSheetContract.Args>,
+    private val activityResultLauncher: ActivityResultLauncher<PaymentSheetContractV2.Args>,
     application: Application
 ) : PaymentSheetLauncher, NonFallbackInjector {
     @InjectorKey
@@ -42,7 +42,7 @@ internal class DefaultPaymentSheetLauncher(
         callback: PaymentSheetResultCallback
     ) : this(
         activity.registerForActivityResult(
-            PaymentSheetContract()
+            PaymentSheetContractV2()
         ) {
             callback.onPaymentSheetResult(it)
         },
@@ -54,7 +54,7 @@ internal class DefaultPaymentSheetLauncher(
         callback: PaymentSheetResultCallback
     ) : this(
         fragment.registerForActivityResult(
-            PaymentSheetContract()
+            PaymentSheetContractV2()
         ) {
             callback.onPaymentSheetResult(it)
         },
@@ -68,7 +68,7 @@ internal class DefaultPaymentSheetLauncher(
         callback: PaymentSheetResultCallback
     ) : this(
         fragment.registerForActivityResult(
-            PaymentSheetContract(),
+            PaymentSheetContractV2(),
             registry
         ) {
             callback.onPaymentSheetResult(it)
@@ -76,29 +76,15 @@ internal class DefaultPaymentSheetLauncher(
         fragment.requireActivity().application
     )
 
-    override fun presentWithPaymentIntent(
-        paymentIntentClientSecret: String,
+    override fun present(
+        mode: PaymentSheet.InitializationMode,
         configuration: PaymentSheet.Configuration?
-    ) = present(
-        PaymentSheetContract.Args.createPaymentIntentArgsWithInjectorKey(
-            paymentIntentClientSecret,
-            configuration,
-            injectorKey
+    ) {
+        val args = PaymentSheetContractV2.Args(
+            initializationMode = mode,
+            config = configuration,
+            injectorKey = injectorKey,
         )
-    )
-
-    override fun presentWithSetupIntent(
-        setupIntentClientSecret: String,
-        configuration: PaymentSheet.Configuration?
-    ) = present(
-        PaymentSheetContract.Args.createSetupIntentArgsWithInjectorKey(
-            setupIntentClientSecret,
-            configuration,
-            injectorKey
-        )
-    )
-
-    private fun present(args: PaymentSheetContract.Args) {
         activityResultLauncher.launch(args)
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -6,15 +6,19 @@ import android.os.Parcelable
 import androidx.activity.ComponentActivity
 import androidx.annotation.ColorInt
 import androidx.annotation.FontRes
+import androidx.annotation.RestrictTo
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.fragment.app.Fragment
 import com.stripe.android.link.account.CookieStore
+import com.stripe.android.model.ElementsSessionParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.flowcontroller.FlowControllerFactory
+import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentOption
+import com.stripe.android.paymentsheet.model.SetupIntentClientSecret
 import com.stripe.android.uicore.StripeThemeDefaults
 import com.stripe.android.uicore.getRawValueFromDimenResource
 import kotlinx.parcelize.Parcelize
@@ -64,7 +68,10 @@ class PaymentSheet internal constructor(
         paymentIntentClientSecret: String,
         configuration: Configuration? = null
     ) {
-        paymentSheetLauncher.presentWithPaymentIntent(paymentIntentClientSecret, configuration)
+        paymentSheetLauncher.present(
+            mode = InitializationMode.PaymentIntent(paymentIntentClientSecret),
+            configuration = configuration,
+        )
     }
 
     /**
@@ -80,7 +87,53 @@ class PaymentSheet internal constructor(
         setupIntentClientSecret: String,
         configuration: Configuration? = null
     ) {
-        paymentSheetLauncher.presentWithSetupIntent(setupIntentClientSecret, configuration)
+        paymentSheetLauncher.present(
+            mode = InitializationMode.SetupIntent(setupIntentClientSecret),
+            configuration = configuration,
+        )
+    }
+
+    /**
+     * Present the payment sheet with an [InitializationMode].
+     *
+     * If the [InitializationMode] is [InitializationMode.PaymentIntent] or
+     * [InitializationMode.SetupIntent] and the underlying intent is already confirmed,
+     * [PaymentSheetResultCallback] will be invoked with [PaymentSheetResult.Completed].
+     *
+     * @param mode The [InitializationMode] to use.
+     * @param configuration An optional [PaymentSheet] configuration.
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @JvmOverloads
+    fun present(
+        mode: InitializationMode,
+        configuration: Configuration? = null,
+    ) {
+        paymentSheetLauncher.present(mode, configuration)
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    sealed class InitializationMode : Parcelable {
+
+        internal abstract fun validate()
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @Parcelize
+        class PaymentIntent(val clientSecret: String) : InitializationMode() {
+
+            override fun validate() {
+                PaymentIntentClientSecret(clientSecret).validate()
+            }
+        }
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @Parcelize
+        class SetupIntent(val clientSecret: String) : InitializationMode() {
+
+            override fun validate() {
+                SetupIntentClientSecret(clientSecret).validate()
+            }
+        }
     }
 
     /** Configuration for [PaymentSheet] **/
@@ -746,6 +799,20 @@ class PaymentSheet internal constructor(
          */
         fun configureWithSetupIntent(
             setupIntentClientSecret: String,
+            configuration: Configuration? = null,
+            callback: ConfigCallback
+        )
+
+        /**
+         * Configure the FlowController with an [InitializationMode].
+         *
+         * @param mode The [InitializationMode] to use.
+         * @param configuration An optional [PaymentSheet] configuration.
+         * @param callback called with the result of configuring the FlowController.
+         */
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        fun configure(
+            mode: InitializationMode,
             configuration: Configuration? = null,
             callback: ConfigCallback
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.fragment.app.Fragment
 import com.stripe.android.link.account.CookieStore
-import com.stripe.android.model.ElementsSessionParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.paymentsheet.addresselement.AddressDetails

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -30,8 +30,8 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
 
     override val viewModel: PaymentSheetViewModel by viewModels { viewModelFactory }
 
-    private val starterArgs: PaymentSheetContract.Args? by lazy {
-        PaymentSheetContract.Args.fromIntent(intent)
+    private val starterArgs: PaymentSheetContractV2.Args? by lazy {
+        PaymentSheetContractV2.Args.fromIntent(intent)
     }
 
     override val rootView: ViewGroup by lazy { viewBinding.root }
@@ -74,15 +74,15 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
         }
     }
 
-    private fun initializeArgs(): Result<PaymentSheetContract.Args?> {
+    private fun initializeArgs(): Result<PaymentSheetContractV2.Args?> {
         val starterArgs = this.starterArgs
 
         val result = if (starterArgs == null) {
             Result.failure(defaultInitializationError())
         } else {
             try {
+                starterArgs.initializationMode.validate()
                 starterArgs.config?.validate()
-                starterArgs.clientSecret.validate()
                 starterArgs.config?.appearance?.parseAppearance()
                 Result.success(starterArgs)
             } catch (e: InvalidParameterException) {
@@ -97,7 +97,7 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
     override fun setActivityResult(result: PaymentSheetResult) {
         setResult(
             Activity.RESULT_OK,
-            Intent().putExtras(PaymentSheetContract.Result(result).toBundle())
+            Intent().putExtras(PaymentSheetContractV2.Result(result).toBundle())
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetLauncher.kt
@@ -1,13 +1,9 @@
 package com.stripe.android.paymentsheet
 
 internal interface PaymentSheetLauncher {
-    fun presentWithPaymentIntent(
-        paymentIntentClientSecret: String,
-        configuration: PaymentSheet.Configuration? = null
-    )
 
-    fun presentWithSetupIntent(
-        setupIntentClientSecret: String,
+    fun present(
+        mode: PaymentSheet.InitializationMode,
         configuration: PaymentSheet.Configuration? = null
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -46,7 +46,6 @@ import com.stripe.android.paymentsheet.extensions.unregisterPollingAuthenticator
 import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.injection.DaggerFlowControllerComponent
 import com.stripe.android.paymentsheet.injection.FlowControllerComponent
-import com.stripe.android.paymentsheet.model.ClientSecret
 import com.stripe.android.paymentsheet.model.ConfirmStripeIntentParamsFactory
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentOption
@@ -188,10 +187,10 @@ internal class DefaultFlowController @Inject internal constructor(
         configuration: PaymentSheet.Configuration?,
         callback: PaymentSheet.FlowController.ConfigCallback
     ) {
-        configureInternal(
-            PaymentIntentClientSecret(paymentIntentClientSecret),
-            configuration,
-            callback
+        configure(
+            mode = PaymentSheet.InitializationMode.PaymentIntent(paymentIntentClientSecret),
+            configuration = configuration,
+            callback = callback,
         )
     }
 
@@ -200,31 +199,30 @@ internal class DefaultFlowController @Inject internal constructor(
         configuration: PaymentSheet.Configuration?,
         callback: PaymentSheet.FlowController.ConfigCallback
     ) {
-        configureInternal(
-            SetupIntentClientSecret(setupIntentClientSecret),
-            configuration,
-            callback
+        configure(
+            mode = PaymentSheet.InitializationMode.SetupIntent(setupIntentClientSecret),
+            configuration = configuration,
+            callback = callback,
         )
     }
 
-    private fun configureInternal(
-        clientSecret: ClientSecret,
+    override fun configure(
+        mode: PaymentSheet.InitializationMode,
         configuration: PaymentSheet.Configuration?,
         callback: PaymentSheet.FlowController.ConfigCallback
     ) {
         try {
+            mode.validate()
             configuration?.validate()
-            clientSecret.validate()
         } catch (e: InvalidParameterException) {
             callback.onConfigured(success = false, e)
             return
         }
 
+        viewModel.initializationMode = mode
+
         lifecycleScope.launch {
-            val result = paymentSheetLoader.load(
-                clientSecret,
-                configuration
-            )
+            val result = paymentSheetLoader.load(mode, configuration)
 
             // Wait until all required resources are loaded before completing initialization.
             resourceRepositories.forEach { it.waitUntilLoaded() }
@@ -291,11 +289,21 @@ internal class DefaultFlowController @Inject internal constructor(
         paymentSelection: PaymentSelection?,
         state: PaymentSheetState.Full,
     ) {
-        val confirmParamsFactory =
-            ConfirmStripeIntentParamsFactory.createFactory(
-                state.clientSecret,
-                state.config?.shippingDetails?.toConfirmPaymentIntentShipping()
-            )
+        val mode = viewModel.initializationMode ?: return
+
+        val clientSecret = when (mode) {
+            is PaymentSheet.InitializationMode.PaymentIntent -> {
+                PaymentIntentClientSecret(mode.clientSecret)
+            }
+            is PaymentSheet.InitializationMode.SetupIntent -> {
+                SetupIntentClientSecret(mode.clientSecret)
+            }
+        }
+
+        val confirmParamsFactory = ConfirmStripeIntentParamsFactory.createFactory(
+            clientSecret = clientSecret,
+            shipping = state.config?.shippingDetails?.toConfirmPaymentIntentShipping(),
+        )
 
         when (paymentSelection) {
             is PaymentSelection.Saved -> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
@@ -2,12 +2,16 @@ package com.stripe.android.paymentsheet.flowcontroller
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 
 internal class FlowControllerViewModel(
     private val handle: SavedStateHandle
 ) : ViewModel() {
+
+    var initializationMode: PaymentSheet.InitializationMode? = null
+
     var paymentSelection: PaymentSelection? = null
 
     var state: PaymentSheetState.Full?

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetViewModelModule.kt
@@ -3,17 +3,17 @@ package com.stripe.android.paymentsheet.injection
 import android.content.Context
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
-import com.stripe.android.paymentsheet.PaymentSheetContract
+import com.stripe.android.paymentsheet.PaymentSheetContractV2
 import com.stripe.android.paymentsheet.PrefsRepository
 import dagger.Module
 import dagger.Provides
 import kotlin.coroutines.CoroutineContext
 
 @Module
-internal class PaymentSheetViewModelModule(private val starterArgs: PaymentSheetContract.Args) {
+internal class PaymentSheetViewModelModule(private val starterArgs: PaymentSheetContractV2.Args) {
 
     @Provides
-    fun provideArgs(): PaymentSheetContract.Args {
+    fun provideArgs(): PaymentSheetContractV2.Args {
         return starterArgs
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetState.kt
@@ -4,7 +4,6 @@ import android.os.Parcelable
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.model.ClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import kotlinx.parcelize.Parcelize
@@ -17,7 +16,6 @@ internal sealed interface PaymentSheetState : Parcelable {
     @Parcelize
     data class Full(
         val config: PaymentSheet.Configuration?,
-        val clientSecret: ClientSecret,
         val stripeIntent: StripeIntent,
         val customerPaymentMethods: List<PaymentMethod>,
         val savedSelection: SavedSelection,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/BasePaymentSheetViewModelInjectionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/BasePaymentSheetViewModelInjectionTest.kt
@@ -81,7 +81,7 @@ internal open class BasePaymentSheetViewModelInjectionTest {
         stripeIntent: StripeIntent,
         customerRepositoryPMs: List<PaymentMethod> = emptyList(),
         @InjectorKey injectorKey: String,
-        args: PaymentSheetContract.Args = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY
+        args: PaymentSheetContractV2.Args = PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY
     ): PaymentSheetViewModel = runBlocking {
         TestViewModelFactory.create { linkHandler, savedStateHandle ->
             PaymentSheetViewModel(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncherTest.kt
@@ -44,7 +44,7 @@ class DefaultPaymentSheetLauncherTest {
                 }
 
                 moveToState(Lifecycle.State.RESUMED)
-                launcher.presentWithPaymentIntent("pi_fake")
+                launcher.present(mode = PaymentSheet.InitializationMode.PaymentIntent("pi_fake"))
                 assertThat(results)
                     .containsExactly(com.stripe.android.paymentsheet.PaymentSheetResult.Completed)
             }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelInjectionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelInjectionTest.kt
@@ -9,7 +9,6 @@ import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.injection.DUMMY_INJECTOR_KEY
 import com.stripe.android.model.PaymentIntentFixtures
-import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.ui.core.forms.resources.LpmRepository
@@ -82,7 +81,6 @@ internal class PaymentOptionsViewModelInjectionTest : BasePaymentOptionsViewMode
         return PaymentOptionContract.Args(
             state = PaymentSheetState.Full(
                 stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-                clientSecret = PaymentIntentClientSecret("secret"),
                 customerPaymentMethods = emptyList(),
                 savedSelection = SavedSelection.None,
                 config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -16,7 +16,6 @@ import com.stripe.android.model.PaymentMethodCreateParamsFixtures.DEFAULT_CARD
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.updateState
 import com.stripe.android.paymentsheet.analytics.EventReporter
-import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
@@ -462,7 +461,6 @@ internal class PaymentOptionsViewModelTest {
         private val PAYMENT_OPTION_CONTRACT_ARGS = PaymentOptionContract.Args(
             state = PaymentSheetState.Full(
                 stripeIntent = PAYMENT_INTENT,
-                clientSecret = PaymentIntentClientSecret("secret"),
                 customerPaymentMethods = emptyList(),
                 config = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
                 isGooglePayReady = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -55,7 +55,6 @@ import com.stripe.android.paymentsheet.databinding.PrimaryButtonBinding
 import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.forms.PaymentMethodRequirements
 import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
-import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
 import com.stripe.android.paymentsheet.model.StripeIntentValidator
@@ -141,12 +140,14 @@ internal class PaymentSheetActivityTest {
 
     private lateinit var viewModel: PaymentSheetViewModel
 
-    private val contract = PaymentSheetContract()
+    private val contract = PaymentSheetContractV2()
 
     private val intent = contract.createIntent(
         context,
-        PaymentSheetContract.Args(
-            PaymentIntentClientSecret("client_secret"),
+        PaymentSheetContractV2.Args(
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                clientSecret = "client_secret",
+            ),
             PaymentSheetFixtures.CONFIG_CUSTOMER,
             statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR
         )
@@ -677,14 +678,15 @@ internal class PaymentSheetActivityTest {
 
             val intent = contract.createIntent(
                 activity,
-                PaymentSheetContract.Args(
-                    PaymentIntentClientSecret("client_secret"),
+                PaymentSheetContractV2.Args(
+                    initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                        clientSecret = "client_secret",
+                    ),
                     PaymentSheetFixtures.CONFIG_CUSTOMER
                 )
             )
 
-            val args =
-                intent.extras?.get(PaymentSheetContract.EXTRA_ARGS) as PaymentSheetContract.Args
+            val args = intent.extras?.get(PaymentSheetContractV2.EXTRA_ARGS) as PaymentSheetContractV2.Args
             assertThat(args.statusBarColor)
                 .isEqualTo(PaymentSheetFixtures.STATUS_BAR_COLOR)
         }
@@ -900,8 +902,10 @@ internal class PaymentSheetActivityTest {
             ephemeralKeySecret = "",
         )
 
-        val args = PaymentSheetContract.Args(
-            clientSecret = PaymentIntentClientSecret("abc"),
+        val args = PaymentSheetContractV2.Args(
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                clientSecret = "abc",
+            ),
             config = PaymentSheet.Configuration(
                 merchantDisplayName = "Some name",
                 customer = invalidCustomerConfig,
@@ -923,8 +927,8 @@ internal class PaymentSheetActivityTest {
 
     @Test
     fun `Handles invalid client secret correctly`() {
-        val args = PaymentSheetContract.Args(
-            clientSecret = PaymentIntentClientSecret(""),
+        val args = PaymentSheetContractV2.Args(
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(clientSecret = ""),
             config = null,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -7,11 +7,9 @@ import com.stripe.android.core.injection.DUMMY_INJECTOR_KEY
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.paymentsheet.model.ClientSecret
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
-import com.stripe.android.paymentsheet.model.SetupIntentClientSecret
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentSheetState
@@ -89,7 +87,6 @@ internal object PaymentSheetFixtures {
     internal val PAYMENT_OPTIONS_CONTRACT_ARGS = PaymentOptionContract.Args(
         state = PaymentSheetState.Full(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-            clientSecret = PaymentIntentClientSecret("pssst… this is a secret"),
             customerPaymentMethods = emptyList(),
             config = CONFIG_GOOGLEPAY,
             isGooglePayReady = false,
@@ -109,7 +106,6 @@ internal object PaymentSheetFixtures {
         stripeIntent: StripeIntent = state.stripeIntent,
         config: PaymentSheet.Configuration? = state.config,
         newPaymentSelection: PaymentSelection.New? = state.newPaymentSelection,
-        clientSecret: ClientSecret = state.clientSecret,
         linkState: LinkState? = state.linkState,
     ): PaymentOptionContract.Args {
         return copy(
@@ -119,36 +115,41 @@ internal object PaymentSheetFixtures {
                 stripeIntent = stripeIntent,
                 config = config,
                 newPaymentSelection = newPaymentSelection,
-                clientSecret = clientSecret,
                 linkState = linkState,
             ),
         )
     }
 
     internal val ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP
-        get() = PaymentSheetContract.Args(
-            SetupIntentClientSecret(CLIENT_SECRET),
+        get() = PaymentSheetContractV2.Args(
+            initializationMode = PaymentSheet.InitializationMode.SetupIntent(CLIENT_SECRET),
             CONFIG_CUSTOMER_WITH_GOOGLEPAY,
             STATUS_BAR_COLOR
         )
 
     internal val ARGS_CUSTOMER_WITH_GOOGLEPAY
-        get() = PaymentSheetContract.Args(
-            PAYMENT_INTENT_CLIENT_SECRET,
+        get() = PaymentSheetContractV2.Args(
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                clientSecret = PAYMENT_INTENT_CLIENT_SECRET.value,
+            ),
             CONFIG_CUSTOMER_WITH_GOOGLEPAY,
             STATUS_BAR_COLOR
         )
 
     internal val ARGS_CUSTOMER_WITHOUT_GOOGLEPAY
-        get() = PaymentSheetContract.Args(
-            PAYMENT_INTENT_CLIENT_SECRET,
+        get() = PaymentSheetContractV2.Args(
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                clientSecret = PAYMENT_INTENT_CLIENT_SECRET.value,
+            ),
             CONFIG_CUSTOMER,
             STATUS_BAR_COLOR
         )
 
     internal val ARGS_WITHOUT_CONFIG
-        get() = PaymentSheetContract.Args(
-            PAYMENT_INTENT_CLIENT_SECRET,
+        get() = PaymentSheetContractV2.Args(
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                clientSecret = PAYMENT_INTENT_CLIENT_SECRET.value,
+            ),
             config = null,
             STATUS_BAR_COLOR
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelInjectionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelInjectionTest.kt
@@ -55,13 +55,13 @@ internal class PaymentSheetViewModelInjectionTest : BasePaymentSheetViewModelInj
         }
     }
 
-    private fun createArgs(): PaymentSheetContract.Args {
+    private fun createArgs(): PaymentSheetContractV2.Args {
         return PaymentSheetFixtures.ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
             injectorKey = "testInjectorKeyAddFragmentTest"
         )
     }
 
-    private fun createViewModel(args: PaymentSheetContract.Args): PaymentSheetViewModel {
+    private fun createViewModel(args: PaymentSheetContractV2.Args): PaymentSheetViewModel {
         return createViewModel(
             stripeIntent = PaymentIntentFixtures.PI_WITH_SHIPPING,
             customerRepositoryPMs = emptyList(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1266,7 +1266,7 @@ internal class PaymentSheetViewModelTest {
     }
 
     private fun createViewModel(
-        args: PaymentSheetContract.Args = ARGS_CUSTOMER_WITH_GOOGLEPAY,
+        args: PaymentSheetContractV2.Args = ARGS_CUSTOMER_WITH_GOOGLEPAY,
         stripeIntent: StripeIntent = PAYMENT_INTENT,
         customerPaymentMethods: List<PaymentMethod> = PAYMENT_METHODS,
         customerRepository: CustomerRepository = FakeCustomerRepository(customerPaymentMethods),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
@@ -8,7 +8,7 @@ import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.ElementsSessionParams
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.networking.StripeRepository
-import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
+import com.stripe.android.paymentsheet.PaymentSheet
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
@@ -42,7 +42,11 @@ internal class ElementsSessionRepositoryTest {
 
         val locale = Locale.GERMANY
         val session = withLocale(locale) {
-            createRepository().get(PaymentIntentClientSecret("client_secret"))
+            createRepository().get(
+                initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                    clientSecret = "client_secret",
+                )
+            )
         }
 
         val argumentCaptor: KArgumentCaptor<ElementsSessionParams> = argumentCaptor()
@@ -64,7 +68,11 @@ internal class ElementsSessionRepositoryTest {
                 .thenReturn(PaymentIntentFixtures.PI_WITH_SHIPPING)
 
             val session = withLocale(Locale.ITALY) {
-                createRepository().get(PaymentIntentClientSecret("client_secret"))
+                createRepository().get(
+                    initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                        clientSecret = "client_secret",
+                    )
+                )
             }
 
             verify(stripeRepository).retrieveElementsSession(any(), any())
@@ -83,7 +91,11 @@ internal class ElementsSessionRepositoryTest {
                 .thenReturn(PaymentIntentFixtures.PI_WITH_SHIPPING)
 
             val session = withLocale(Locale.ITALY) {
-                createRepository().get(PaymentIntentClientSecret("client_secret"))
+                createRepository().get(
+                    initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                        clientSecret = "client_secret",
+                    )
+                )
             }
 
             verify(stripeRepository).retrieveElementsSession(any(), any())
@@ -107,7 +119,11 @@ internal class ElementsSessionRepositoryTest {
             stripeRepository,
             { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
-        ).get(PaymentIntentClientSecret("client_secret"))
+        ).get(
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                clientSecret = "client_secret",
+            )
+        )
 
         val argumentCaptor: KArgumentCaptor<ElementsSessionParams> = argumentCaptor()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -18,7 +18,6 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.analytics.EventReporter
-import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.StripeIntentValidator
@@ -99,14 +98,15 @@ internal class DefaultPaymentSheetLoaderTest {
 
         assertThat(
             loader.load(
-                clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET,
+                initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                    clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+                ),
                 paymentSheetConfiguration = null,
             )
         ).isEqualTo(
             PaymentSheetLoader.Result.Success(
                 PaymentSheetState.Full(
                     config = null,
-                    clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET,
                     stripeIntent = stripeIntent,
                     customerPaymentMethods = emptyList(),
                     savedSelection = SavedSelection.Link,
@@ -141,14 +141,15 @@ internal class DefaultPaymentSheetLoaderTest {
 
         assertThat(
             loader.load(
-                PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET,
+                initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                    clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+                ),
                 PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
             )
         ).isEqualTo(
             PaymentSheetLoader.Result.Success(
                 PaymentSheetState.Full(
                     config = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
-                    clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET,
                     stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
                     customerPaymentMethods = PAYMENT_METHODS,
                     savedSelection = SavedSelection.PaymentMethod(id = "pm_123456789"),
@@ -169,14 +170,15 @@ internal class DefaultPaymentSheetLoaderTest {
 
         assertThat(
             loader.load(
-                PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET,
+                initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                    clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+                ),
                 PaymentSheetFixtures.CONFIG_GOOGLEPAY
             )
         ).isEqualTo(
             PaymentSheetLoader.Result.Success(
                 PaymentSheetState.Full(
                     config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
-                    clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET,
                     stripeIntent = stripeIntent,
                     customerPaymentMethods = emptyList(),
                     savedSelection = SavedSelection.Link,
@@ -221,14 +223,15 @@ internal class DefaultPaymentSheetLoaderTest {
 
         assertThat(
             loader.load(
-                PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET,
+                initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                    clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+                ),
                 PaymentSheetFixtures.CONFIG_GOOGLEPAY
             )
         ).isEqualTo(
             PaymentSheetLoader.Result.Success(
                 PaymentSheetState.Full(
                     config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
-                    clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET,
                     stripeIntent = expectedIntent,
                     customerPaymentMethods = emptyList(),
                     savedSelection = SavedSelection.Link,
@@ -251,14 +254,15 @@ internal class DefaultPaymentSheetLoaderTest {
 
             assertThat(
                 loader.load(
-                    PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET,
+                    initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                        clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+                    ),
                     PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
                 )
             ).isEqualTo(
                 PaymentSheetLoader.Result.Success(
                     PaymentSheetState.Full(
                         config = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
-                        clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET,
                         stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
                         customerPaymentMethods = PAYMENT_METHODS,
                         savedSelection = SavedSelection.PaymentMethod("pm_123456789"),
@@ -302,14 +306,15 @@ internal class DefaultPaymentSheetLoaderTest {
             )
             assertThat(
                 loader.load(
-                    PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET,
+                    initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                        clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+                    ),
                     PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
                 )
             ).isEqualTo(
                 PaymentSheetLoader.Result.Success(
                     PaymentSheetState.Full(
                         PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
-                        PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET,
                         expectedIntent,
                         newPaymentSelection = null,
                         customerPaymentMethods = emptyList(),
@@ -348,14 +353,15 @@ internal class DefaultPaymentSheetLoaderTest {
             )
             assertThat(
                 loader.load(
-                    PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET,
+                    initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                        clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+                    ),
                     PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
                 )
             ).isEqualTo(
                 PaymentSheetLoader.Result.Success(
                     PaymentSheetState.Full(
                         PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
-                        PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET,
                         expectedIntent,
                         newPaymentSelection = null,
                         customerPaymentMethods = emptyList(),
@@ -391,7 +397,9 @@ internal class DefaultPaymentSheetLoaderTest {
             )
 
             loader.load(
-                PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET,
+                initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                    clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+                ),
                 PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
             )
 
@@ -422,7 +430,9 @@ internal class DefaultPaymentSheetLoaderTest {
             )
 
             loader.load(
-                PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET,
+                initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                    clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+                ),
                 PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
             )
 
@@ -445,7 +455,9 @@ internal class DefaultPaymentSheetLoaderTest {
                     )
                 )
             ).load(
-                PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET,
+                initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                    clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+                ),
                 PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
             ) as PaymentSheetLoader.Result.Success
 
@@ -465,8 +477,10 @@ internal class DefaultPaymentSheetLoaderTest {
                 )
             )
         ).load(
-            PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET,
-            PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                clientSecret = PaymentSheetFixtures.CLIENT_SECRET,
+            ),
+            paymentSheetConfiguration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
         ) as PaymentSheetLoader.Result.Success
 
         assertThat(result.state.customerPaymentMethods)
@@ -481,7 +495,9 @@ internal class DefaultPaymentSheetLoaderTest {
                     status = StripeIntent.Status.Succeeded
                 ),
             ).load(
-                PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET,
+                initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                    clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+                ),
                 PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
             )
             assertThat(result)
@@ -496,7 +512,9 @@ internal class DefaultPaymentSheetLoaderTest {
                     confirmationMethod = PaymentIntent.ConfirmationMethod.Manual
                 ),
             ).load(
-                PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET
+                initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                    clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+                ),
             )
             assertThat(result)
                 .isInstanceOf(PaymentSheetLoader.Result::class.java)
@@ -507,7 +525,9 @@ internal class DefaultPaymentSheetLoaderTest {
         val result = createPaymentSheetLoader(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
         ).load(
-            clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET,
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+            ),
             paymentSheetConfiguration = mockConfiguration()
         ) as PaymentSheetLoader.Result.Success
 
@@ -518,7 +538,9 @@ internal class DefaultPaymentSheetLoaderTest {
     @Test
     fun `Defaults to Link for guests if available`() = runTest {
         val result = createPaymentSheetLoader().load(
-            clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET,
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+            ),
             // The mock configuration is necessary to enable Google Pay. We want to do that,
             // so that we can check that Link is preferred.
             paymentSheetConfiguration = mockConfiguration()
@@ -532,7 +554,9 @@ internal class DefaultPaymentSheetLoaderTest {
         val result = createPaymentSheetLoader(
             customerRepo = FakeCustomerRepository(paymentMethods = PAYMENT_METHODS)
         ).load(
-            clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET,
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+            ),
             paymentSheetConfiguration = mockConfiguration(
                 customer = PaymentSheet.CustomerConfiguration(
                     id = "some_id",
@@ -550,7 +574,7 @@ internal class DefaultPaymentSheetLoaderTest {
         val loader = createPaymentSheetLoader(linkAccountState = AccountStatus.Verified)
 
         val result = loader.load(
-            clientSecret = PaymentIntentClientSecret("secret"),
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent("secret"),
             paymentSheetConfiguration = mockConfiguration(),
         ) as PaymentSheetLoader.Result.Success
 
@@ -562,7 +586,7 @@ internal class DefaultPaymentSheetLoaderTest {
         val loader = createPaymentSheetLoader(linkAccountState = AccountStatus.NeedsVerification)
 
         val result = loader.load(
-            clientSecret = PaymentIntentClientSecret("secret"),
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent("secret"),
             paymentSheetConfiguration = mockConfiguration(),
         ) as PaymentSheetLoader.Result.Success
 
@@ -574,7 +598,7 @@ internal class DefaultPaymentSheetLoaderTest {
         val loader = createPaymentSheetLoader(linkAccountState = AccountStatus.VerificationStarted)
 
         val result = loader.load(
-            clientSecret = PaymentIntentClientSecret("secret"),
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent("secret"),
             paymentSheetConfiguration = mockConfiguration(),
         ) as PaymentSheetLoader.Result.Success
 
@@ -586,7 +610,7 @@ internal class DefaultPaymentSheetLoaderTest {
         val loader = createPaymentSheetLoader(linkAccountState = AccountStatus.SignedOut)
 
         val result = loader.load(
-            clientSecret = PaymentIntentClientSecret("secret"),
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent("secret"),
             paymentSheetConfiguration = mockConfiguration(),
         ) as PaymentSheetLoader.Result.Success
 
@@ -603,7 +627,7 @@ internal class DefaultPaymentSheetLoaderTest {
         )
 
         val result = loader.load(
-            clientSecret = PaymentIntentClientSecret("secret"),
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent("secret"),
             paymentSheetConfiguration = mockConfiguration(
                 defaultBillingDetails = billingDetails,
             ),
@@ -633,7 +657,7 @@ internal class DefaultPaymentSheetLoaderTest {
         )
 
         val result = loader.load(
-            clientSecret = PaymentIntentClientSecret("secret"),
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent("secret"),
             paymentSheetConfiguration = mockConfiguration(
                 shippingDetails = shippingDetails,
             ),
@@ -655,7 +679,7 @@ internal class DefaultPaymentSheetLoaderTest {
         )
 
         val result = loader.load(
-            clientSecret = PaymentIntentClientSecret("secret"),
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent("secret"),
             paymentSheetConfiguration = mockConfiguration(
                 shippingDetails = shippingDetails,
                 defaultBillingDetails = billingDetails,
@@ -677,7 +701,7 @@ internal class DefaultPaymentSheetLoaderTest {
         )
 
         val result = loader.load(
-            clientSecret = PaymentIntentClientSecret("secret"),
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent("secret"),
             paymentSheetConfiguration = mockConfiguration(
                 customer = PaymentSheet.CustomerConfiguration(id = "id", ephemeralKeySecret = "key"),
             ),

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentSheetLoader.kt
@@ -4,7 +4,6 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.model.ClientSecret
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentSheetLoader
@@ -27,7 +26,7 @@ internal class FakePaymentSheetLoader(
     }
 
     override suspend fun load(
-        clientSecret: ClientSecret,
+        initializationMode: PaymentSheet.InitializationMode,
         paymentSheetConfiguration: PaymentSheet.Configuration?
     ): PaymentSheetLoader.Result {
         delay(delay)
@@ -37,7 +36,6 @@ internal class FakePaymentSheetLoader(
             PaymentSheetLoader.Result.Success(
                 state = PaymentSheetState.Full(
                     config = paymentSheetConfiguration,
-                    clientSecret = clientSecret,
                     stripeIntent = stripeIntent,
                     customerPaymentMethods = customerPaymentMethods,
                     savedSelection = savedSelection,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request introduces `PaymentSheet.InitializationMode`, which can be `PaymentIntent` or `SetupIntent` for now. Eventually, we’ll extend it with `DeferredIntent` in https://github.com/stripe/stripe-android/pull/6244.

The `InitializationMode` mostly replaces `ClientSecret` as a way to determine which flow we’re in. While we might want to remodel this down the road, it’s not in scope for the decoupling project.

A big change here is the introduction of `PaymentSheetContractV2` — the rationale for that is added below as a comment.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Decoupling project.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
