### PR TITLE
Add deferred initialization mode

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSessionParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSessionParams.kt
@@ -45,10 +45,12 @@ sealed interface ElementsSessionParams : Parcelable {
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
     class DeferredIntentType(
-        override val clientSecret: String? = null,
         override val locale: String? = Locale.getDefault().toLanguageTag(),
-        val deferredIntentParams: DeferredIntentParams
+        val deferredIntentParams: DeferredIntentParams,
     ) : ElementsSessionParams {
+
+        override val clientSecret: String?
+            get() = null
 
         override val type: String
             get() = "deferred_intent"

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
@@ -393,17 +393,24 @@ class LpmRepository constructor(
             requirement = AuBecsDebitRequirement,
             formSpec = LayoutSpec(sharedDataSpec.fields)
         )
-        PaymentMethod.Type.USBankAccount.code -> SupportedPaymentMethod(
-            code = "us_bank_account",
-            requiresMandate = true,
-            displayNameResource = R.string.stripe_paymentsheet_payment_method_us_bank_account,
-            iconResource = R.drawable.stripe_ic_paymentsheet_pm_bank,
-            lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
-            darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
-            tintIconOnSelection = true,
-            requirement = USBankAccountRequirement,
-            formSpec = LayoutSpec(sharedDataSpec.fields)
-        )
+        PaymentMethod.Type.USBankAccount.code -> {
+            if (stripeIntent.clientSecret != null) {
+                SupportedPaymentMethod(
+                    code = "us_bank_account",
+                    requiresMandate = true,
+                    displayNameResource = R.string.stripe_paymentsheet_payment_method_us_bank_account,
+                    iconResource = R.drawable.stripe_ic_paymentsheet_pm_bank,
+                    lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
+                    darkThemeIconUrl = sharedDataSpec.selectorIcon?.darkThemePng,
+                    tintIconOnSelection = true,
+                    requirement = USBankAccountRequirement,
+                    formSpec = LayoutSpec(sharedDataSpec.fields)
+                )
+            } else {
+                // A deferred intent without a client secret doesn't support this
+                null
+            }
+        }
         PaymentMethod.Type.Upi.code -> SupportedPaymentMethod(
             code = "upi",
             requiresMandate = false,

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestAuthorization.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestAuthorization.kt
@@ -60,13 +60,13 @@ class TestAuthorization {
     }
 
     private val bancontactNewUser = TestParameters(
-        lpmRepository.fromCode("bancontact")!!,
-        Customer.New,
-        LinkState.Off,
-        GooglePayState.On,
-        Currency.EUR,
-        IntentType.Pay,
-        Billing.On,
+        paymentMethod = lpmRepository.fromCode("bancontact")!!,
+        customer = Customer.New,
+        linkState = LinkState.Off,
+        googlePayState = GooglePayState.On,
+        currency = Currency.EUR,
+        intentType = IntentType.Pay,
+        billing = Billing.On,
         shipping = Shipping.Off,
         delayed = DelayedPMs.Off,
         automatic = Automatic.Off,

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestBrowsers.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestBrowsers.kt
@@ -65,13 +65,13 @@ class TestBrowsers {
     }
 
     private val bancontactNewUser = TestParameters(
-        lpmRepository.fromCode("bancontact")!!,
-        Customer.New,
-        LinkState.Off,
-        GooglePayState.On,
-        Currency.EUR,
-        IntentType.Pay,
-        Billing.On,
+        paymentMethod = lpmRepository.fromCode("bancontact")!!,
+        customer = Customer.New,
+        linkState = LinkState.Off,
+        googlePayState = GooglePayState.On,
+        currency = Currency.EUR,
+        intentType = IntentType.Pay,
+        billing = Billing.On,
         shipping = Shipping.Off,
         delayed = DelayedPMs.Off,
         automatic = Automatic.Off,

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestCustomers.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestCustomers.kt
@@ -58,13 +58,13 @@ class TestCustomers {
     }
 
     private val bancontactNewUser = TestParameters(
-        lpmRepository.fromCode("bancontact")!!,
-        Customer.New,
-        LinkState.Off,
-        GooglePayState.On,
-        Currency.EUR,
-        IntentType.Pay,
-        Billing.On,
+        paymentMethod = lpmRepository.fromCode("bancontact")!!,
+        customer = Customer.New,
+        linkState = LinkState.Off,
+        googlePayState = GooglePayState.On,
+        currency = Currency.EUR,
+        intentType = IntentType.Pay,
+        billing = Billing.On,
         shipping = Shipping.Off,
         delayed = DelayedPMs.Off,
         automatic = Automatic.Off,

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestFieldPopulation.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestFieldPopulation.kt
@@ -100,13 +100,13 @@ class TestFieldPopulation {
     )
 
     private val bancontact = TestParameters(
-        lpmRepository.fromCode("bancontact")!!,
-        Customer.New,
-        LinkState.Off,
-        GooglePayState.Off,
-        Currency.EUR,
-        IntentType.Pay,
-        Billing.Off,
+        paymentMethod = lpmRepository.fromCode("bancontact")!!,
+        customer = Customer.New,
+        linkState = LinkState.Off,
+        googlePayState = GooglePayState.Off,
+        currency = Currency.EUR,
+        intentType = IntentType.Pay,
+        billing = Billing.Off,
         shipping = Shipping.Off,
         delayed = DelayedPMs.Off,
         automatic = Automatic.Off,

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestGooglePay.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestGooglePay.kt
@@ -63,13 +63,13 @@ class TestGooglePay {
     }
 
     private val testParameters = TestParameters(
-        lpmRepository.fromCode("bancontact")!!,
-        Customer.New,
-        LinkState.Off,
-        GooglePayState.On,
-        Currency.EUR,
-        IntentType.Pay,
-        Billing.On,
+        paymentMethod = lpmRepository.fromCode("bancontact")!!,
+        customer = Customer.New,
+        linkState = LinkState.Off,
+        googlePayState = GooglePayState.On,
+        currency = Currency.EUR,
+        intentType = IntentType.Pay,
+        billing = Billing.On,
         shipping = Shipping.Off,
         delayed = DelayedPMs.Off,
         automatic = Automatic.Off,

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestHardCodedLpms.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestHardCodedLpms.kt
@@ -65,13 +65,13 @@ class TestHardCodedLpms {
     }
 
     private val newUser = TestParameters(
-        lpmRepository.fromCode("bancontact")!!,
-        Customer.New,
-        LinkState.Off,
-        GooglePayState.On,
-        Currency.EUR,
-        IntentType.Pay,
-        Billing.On,
+        paymentMethod = lpmRepository.fromCode("bancontact")!!,
+        customer = Customer.New,
+        linkState = LinkState.Off,
+        googlePayState = GooglePayState.On,
+        currency = Currency.EUR,
+        intentType = IntentType.Pay,
+        billing = Billing.On,
         shipping = Shipping.Off,
         delayed = DelayedPMs.Off,
         automatic = Automatic.Off,

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestMultiStepFieldsReloaded.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/TestMultiStepFieldsReloaded.kt
@@ -52,12 +52,12 @@ class TestMultiStepFieldsReloaded {
 
     private val newUser = TestParameters(
         paymentMethod = lpmRepository.fromCode("bancontact")!!,
-        Customer.New,
-        LinkState.Off,
-        GooglePayState.Off,
-        Currency.EUR,
-        IntentType.Pay,
-        Billing.Off,
+        customer = Customer.New,
+        linkState = LinkState.Off,
+        googlePayState = GooglePayState.Off,
+        currency = Currency.EUR,
+        intentType = IntentType.Pay,
+        billing = Billing.Off,
         shipping = Shipping.Off,
         delayed = DelayedPMs.Off,
         automatic = Automatic.Off,

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/screenshot/TestPaymentSheetScreenshots.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/screenshot/TestPaymentSheetScreenshots.kt
@@ -50,13 +50,13 @@ class TestPaymentSheetScreenshots {
     }
 
     private val testParams = TestParameters(
-        LpmRepository.HardcodedCard,
-        Customer.New,
-        LinkState.Off,
-        GooglePayState.On,
-        Currency.EUR,
-        IntentType.Pay,
-        Billing.On,
+        paymentMethod = LpmRepository.HardcodedCard,
+        customer = Customer.New,
+        linkState = LinkState.Off,
+        googlePayState = GooglePayState.On,
+        currency = Currency.EUR,
+        intentType = IntentType.Pay,
+        billing = Billing.On,
         shipping = Shipping.Off,
         delayed = DelayedPMs.Off,
         automatic = Automatic.Off,

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -342,6 +342,8 @@ class PlaygroundTestDriver(
         selectors.customer.click()
         selectors.automatic.click()
 
+        selectors.initializationType.click()
+
         // Set the country first because it will update the default currency value
         selectors.setMerchantCountry(testParameters.merchantCountryCode)
         selectors.setCurrency(testParameters.currency)

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/TestParameters.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/TestParameters.kt
@@ -8,6 +8,7 @@ import com.stripe.android.ui.core.forms.resources.LpmRepository.SupportedPayment
  * This is the data class that represents the parameters used to run the test.
  */
 data class TestParameters(
+    val initializationType: InitializationType = InitializationType.Normal,
     val paymentMethod: SupportedPaymentMethod,
     val customer: Customer,
     val linkState: LinkState = LinkState.Off,
@@ -30,6 +31,14 @@ data class TestParameters(
     val supportedPaymentMethods: List<PaymentMethodCode> = listOf(),
     val customPrimaryButtonLabel: String? = null,
 )
+
+/**
+ * Indicates if we use the normal or deferred payment sheet initialization
+ */
+enum class InitializationType {
+    Normal,
+    Deferred,
+}
 
 /**
  * Indicates if automatic payment methods are used on the payment intent

--- a/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/Selectors.kt
+++ b/paymentsheet-example/src/androidTestDebug/java/com/stripe/android/test/core/ui/Selectors.kt
@@ -29,6 +29,7 @@ import com.stripe.android.test.core.Customer
 import com.stripe.android.test.core.DelayedPMs
 import com.stripe.android.test.core.GooglePayState
 import com.stripe.android.test.core.HOOKS_PAGE_LOAD_TIMEOUT
+import com.stripe.android.test.core.InitializationType
 import com.stripe.android.test.core.IntentType
 import com.stripe.android.test.core.LinkState
 import com.stripe.android.test.core.Shipping
@@ -93,6 +94,11 @@ class Selectors(
     val automatic = when (testParameters.automatic) {
         Automatic.Off -> EspressoIdButton(R.id.automatic_pm_off_button)
         Automatic.On -> EspressoIdButton(R.id.automatic_pm_on_button)
+    }
+
+    val initializationType = when (testParameters.initializationType) {
+        InitializationType.Normal -> EspressoIdButton(R.id.normal_initialization_button)
+        InitializationType.Deferred -> EspressoIdButton(R.id.deferred_initialization_button)
     }
 
     val paymentSelection = PaymentSelection(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
@@ -5,6 +5,11 @@ import com.google.gson.annotations.SerializedName
 import com.stripe.android.paymentsheet.PaymentSheet
 import kotlinx.serialization.Serializable
 
+enum class InitializationType(val value: String) {
+    Normal("normal"),
+    Deferred("deferred"),
+}
+
 enum class CheckoutMode(val value: String) {
     Setup("setup"),
     Payment("payment"),
@@ -27,6 +32,7 @@ data class CheckoutCurrency(val value: String) {
 }
 
 data class SavedToggles(
+    val initialization: String,
     val customer: String,
     val googlePay: Boolean,
     val currency: String,
@@ -40,6 +46,7 @@ data class SavedToggles(
 )
 
 enum class Toggle(val key: String, val default: Any) {
+    Initialization("initialization", InitializationType.Normal.value),
     Customer("customer", CheckoutCustomer.Guest.value),
     Link("link", true),
     GooglePay("googlePayConfig", true),
@@ -63,6 +70,8 @@ sealed class CheckoutCustomer(val value: String) {
 @Serializable
 @Keep
 data class CheckoutRequest(
+    @SerializedName("initialization")
+    val initialization: String,
     @SerializedName("customer")
     val customer: String,
     @SerializedName("currency")
@@ -91,7 +100,9 @@ data class CheckoutResponse(
     @SerializedName("customerId")
     val customerId: String? = null,
     @SerializedName("customerEphemeralKeySecret")
-    val customerEphemeralKeySecret: String? = null
+    val customerEphemeralKeySecret: String? = null,
+    @SerializedName("paymentMethodTypes")
+    val paymentMethodTypes: List<String>? = null,
 ) {
     fun makeCustomerConfig() =
         if (customerId != null && customerEphemeralKeySecret != null) {

--- a/paymentsheet-example/src/main/res/layout/activity_payment_sheet_playground.xml
+++ b/paymentsheet-example/src/main/res/layout/activity_payment_sheet_playground.xml
@@ -10,6 +10,42 @@
         android:layout_height="wrap_content">
 
         <TextView
+            android:id="@+id/initialization"
+            android:text="Initialization"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <RadioGroup
+            android:id="@+id/initialization_radio_group"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginStart="16dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/initialization">
+
+            <RadioButton
+                android:id="@+id/normal_initialization_button"
+                android:text="Normal"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:checked="true" />
+
+            <RadioButton
+                android:id="@+id/deferred_initialization_button"
+                android:text="Deferred"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+        </RadioGroup>
+
+        <TextView
             android:id="@+id/customer_text_view"
             android:text="@string/customer"
             android:layout_width="wrap_content"
@@ -18,7 +54,7 @@
             android:layout_marginTop="16dp"
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toBottomOf="@id/initialization_radio_group" />
 
         <RadioGroup
             android:id="@+id/customer_radio_group"

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -428,6 +428,14 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$GooglePayConfigu
 	public static fun values ()[Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration$Environment;
 }
 
+public final class com/stripe/android/paymentsheet/PaymentSheet$InitializationMode$DeferredIntent$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheet$InitializationMode$DeferredIntent;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentSheet$InitializationMode$DeferredIntent;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/paymentsheet/PaymentSheet$InitializationMode$PaymentIntent$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheet$InitializationMode$PaymentIntent;
@@ -441,6 +449,30 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$InitializationMo
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheet$InitializationMode$SetupIntent;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentSheet$InitializationMode$SetupIntent;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$Mode$Payment$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$Mode$Payment;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$Mode$Payment;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$Mode$Setup$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$Mode$Setup;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration$Mode$Setup;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -133,6 +133,61 @@ class PaymentSheet internal constructor(
                 SetupIntentClientSecret(clientSecret).validate()
             }
         }
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @Parcelize
+        class DeferredIntent(val intentConfiguration: IntentConfiguration) : InitializationMode() {
+
+            override fun validate() {
+                // Nothing to do here
+            }
+        }
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @Parcelize
+    class IntentConfiguration(
+        val mode: Mode,
+        val captureMethod: CaptureMethod? = null,
+        val customer: String? = null,
+        val paymentMethodTypes: List<String> = emptyList(),
+    ) : Parcelable {
+
+        internal val setupFutureUse: SetupFutureUse?
+            get() = mode.setupFutureUse
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        sealed class Mode : Parcelable {
+
+            internal abstract val setupFutureUse: SetupFutureUse?
+
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            @Parcelize
+            data class Payment(
+                val amount: Long,
+                val currency: String,
+                override val setupFutureUse: SetupFutureUse? = null,
+            ) : Mode()
+
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            @Parcelize
+            data class Setup(
+                val currency: String?,
+                override val setupFutureUse: SetupFutureUse = SetupFutureUse.OffSession,
+            ) : Mode()
+        }
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        enum class SetupFutureUse {
+            OnSession,
+            OffSession,
+        }
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        enum class CaptureMethod {
+            Automatic,
+            Manual,
+        }
     }
 
     /** Configuration for [PaymentSheet] **/

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -424,6 +424,9 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             is PaymentSheet.InitializationMode.SetupIntent -> {
                 SetupIntentClientSecret(mode.clientSecret)
             }
+            is PaymentSheet.InitializationMode.DeferredIntent -> {
+                TODO("Not implemented yet")
+            }
         }
 
         val confirmParamsFactory = ConfirmStripeIntentParamsFactory.createFactory(
@@ -615,4 +618,7 @@ private val PaymentSheet.InitializationMode.isProcessingPayment: Boolean
     get() = when (this) {
         is PaymentSheet.InitializationMode.PaymentIntent -> true
         is PaymentSheet.InitializationMode.SetupIntent -> false
+        is PaymentSheet.InitializationMode.DeferredIntent -> {
+            intentConfiguration.mode is PaymentSheet.IntentConfiguration.Mode.Payment
+        }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -298,6 +298,9 @@ internal class DefaultFlowController @Inject internal constructor(
             is PaymentSheet.InitializationMode.SetupIntent -> {
                 SetupIntentClientSecret(mode.clientSecret)
             }
+            is PaymentSheet.InitializationMode.DeferredIntent -> {
+                TODO("Not implemented yet")
+            }
         }
 
         val confirmParamsFactory = ConfirmStripeIntentParamsFactory.createFactory(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
@@ -3,9 +3,13 @@ package com.stripe.android.paymentsheet.repositories
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.model.DeferredIntentParams
+import com.stripe.android.model.DeferredIntentParams.CaptureMethod
+import com.stripe.android.model.DeferredIntentParams.Mode
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.ElementsSessionParams
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.model.StripeIntent.Usage
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentsheet.PaymentSheet
 import kotlinx.coroutines.withContext
@@ -115,5 +119,37 @@ private fun PaymentSheet.InitializationMode.toElementsSessionParams(): ElementsS
         is PaymentSheet.InitializationMode.SetupIntent -> {
             ElementsSessionParams.SetupIntentType(clientSecret = clientSecret)
         }
+        is PaymentSheet.InitializationMode.DeferredIntent -> {
+            ElementsSessionParams.DeferredIntentType(
+                deferredIntentParams = DeferredIntentParams(
+                    mode = intentConfiguration.mode.toElementsSessionParam(),
+                    setupFutureUsage = intentConfiguration.setupFutureUse?.toElementsSessionParam(),
+                    captureMethod = intentConfiguration.captureMethod?.toElementsSessionParam(),
+                    customer = intentConfiguration.customer,
+                    paymentMethodTypes = intentConfiguration.paymentMethodTypes.toSet(),
+                ),
+            )
+        }
+    }
+}
+
+private fun PaymentSheet.IntentConfiguration.Mode.toElementsSessionParam(): Mode {
+    return when (this) {
+        is PaymentSheet.IntentConfiguration.Mode.Payment -> Mode.Payment(amount, currency)
+        is PaymentSheet.IntentConfiguration.Mode.Setup -> Mode.Setup(currency)
+    }
+}
+
+private fun PaymentSheet.IntentConfiguration.SetupFutureUse.toElementsSessionParam(): Usage {
+    return when (this) {
+        PaymentSheet.IntentConfiguration.SetupFutureUse.OnSession -> Usage.OnSession
+        PaymentSheet.IntentConfiguration.SetupFutureUse.OffSession -> Usage.OffSession
+    }
+}
+
+private fun PaymentSheet.IntentConfiguration.CaptureMethod.toElementsSessionParam(): CaptureMethod {
+    return when (this) {
+        PaymentSheet.IntentConfiguration.CaptureMethod.Automatic -> CaptureMethod.Automatic
+        PaymentSheet.IntentConfiguration.CaptureMethod.Manual -> CaptureMethod.Manual
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds the deferred initialization mode to `PaymentSheet` and `FlowController`, and makes it possible to test this initialization in the playground.

Note that the playground gets increasingly messy. In the process of adding the deferred initialization mode, I began to rewrite it [here](https://github.com/stripe/stripe-android/pull/6257). Hoping to be able to merge this soon.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Decoupling project.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
