### PR TITLE
Add consumer client secret to attach payment endpoint


### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAttachPaymentAccount.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAttachPaymentAccount.kt
@@ -20,6 +20,8 @@ internal class PollAttachPaymentAccount @Inject constructor(
         allowManualEntry: Boolean,
         // null, when attaching via manual entry.
         activeInstitution: FinancialConnectionsInstitution?,
+        // null, if account should not be saved to Link user.
+        consumerSessionClientSecret: String?,
         params: PaymentAccountParams
     ): LinkAccountSessionPaymentAccount {
         return retryOnException(
@@ -30,7 +32,8 @@ internal class PollAttachPaymentAccount @Inject constructor(
             try {
                 repository.postLinkAccountSessionPaymentAccount(
                     clientSecret = configuration.financialConnectionsSessionClientSecret,
-                    paymentAccount = params
+                    paymentAccount = params,
+                    consumerSessionClientSecret = consumerSessionClientSecret
                 )
             } catch (
                 @Suppress("SwallowedException") e: StripeException

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/attachpayment/AttachPaymentViewModel.kt
@@ -12,6 +12,7 @@ import com.stripe.android.financialconnections.analytics.FinancialConnectionsEve
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.PaneLoaded
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.PollAttachPaymentsSucceeded
 import com.stripe.android.financialconnections.domain.GetCachedAccounts
+import com.stripe.android.financialconnections.domain.GetCachedConsumerSession
 import com.stripe.android.financialconnections.domain.GetManifest
 import com.stripe.android.financialconnections.domain.GoNext
 import com.stripe.android.financialconnections.domain.PollAttachPaymentAccount
@@ -32,6 +33,7 @@ internal class AttachPaymentViewModel @Inject constructor(
     private val getCachedAccounts: GetCachedAccounts,
     private val navigationManager: NavigationManager,
     private val getManifest: GetManifest,
+    private val getCachedConsumerSession: GetCachedConsumerSession,
     private val goNext: GoNext,
     private val logger: Logger
 ) : MavericksViewModel<AttachPaymentState>(initialState) {
@@ -47,6 +49,7 @@ internal class AttachPaymentViewModel @Inject constructor(
         }.execute { copy(payload = it) }
         suspend {
             val manifest = getManifest()
+            val consumerSession = getCachedConsumerSession()
             val authSession = requireNotNull(manifest.activeAuthSession)
             val activeInstitution = requireNotNull(manifest.activeInstitution)
             val accounts = getCachedAccounts()
@@ -56,6 +59,7 @@ internal class AttachPaymentViewModel @Inject constructor(
                 pollAttachPaymentAccount(
                     allowManualEntry = manifest.allowManualEntry,
                     activeInstitution = activeInstitution,
+                    consumerSessionClientSecret = consumerSession?.clientSecret,
                     params = PaymentAccountParams.LinkedAccount(requireNotNull(id))
                 ).also { goNext(it.nextPane ?: Pane.SUCCESS) }
             }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/manualentry/ManualEntryViewModel.kt
@@ -127,6 +127,7 @@ internal class ManualEntryViewModel @Inject constructor(
             pollAttachPaymentAccount(
                 allowManualEntry = manifest.allowManualEntry,
                 activeInstitution = null,
+                consumerSessionClientSecret = null,
                 params = PaymentAccountParams.BankAccount(
                     routingNumber = requireNotNull(state.routing),
                     accountNumber = requireNotNull(state.account)

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsAccountsRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsAccountsRepository.kt
@@ -13,6 +13,7 @@ import com.stripe.android.financialconnections.network.NetworkConstants.PARAMS_C
 import com.stripe.android.financialconnections.network.NetworkConstants.PARAMS_CONSUMER_CLIENT_SECRET
 import com.stripe.android.financialconnections.network.NetworkConstants.PARAMS_ID
 import com.stripe.android.financialconnections.network.NetworkConstants.PARAM_SELECTED_ACCOUNTS
+import com.stripe.android.financialconnections.utils.filterNotNullValues
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -44,7 +45,7 @@ internal interface FinancialConnectionsAccountsRepository {
     suspend fun postLinkAccountSessionPaymentAccount(
         clientSecret: String,
         paymentAccount: PaymentAccountParams,
-        consumerSessionClientSecret: String? = null
+        consumerSessionClientSecret: String?
     ): LinkAccountSessionPaymentAccount
 
     suspend fun postAuthorizationSessionSelectedAccounts(
@@ -165,8 +166,9 @@ private class FinancialConnectionsAccountsRepositoryImpl(
             url = attachPaymentAccountUrl,
             options = apiOptions,
             params = mapOf(
+                PARAMS_CONSUMER_CLIENT_SECRET to consumerSessionClientSecret,
                 PARAMS_CLIENT_SECRET to clientSecret
-            ) + paymentAccount.toParamMap()
+            ).filterNotNullValues() + paymentAccount.toParamMap()
         )
         return requestExecutor.execute(
             request,


### PR DESCRIPTION
# Summary
`attach_payment_account` should send the consumer session secret now, so that when an existing user ([figma](https://www.figma.com/file/A4T5gNxmyRYmY02Y8YKgA2/Connections---Networking?node-id=3014%3A99775&t=XiSeVMGckiand47E-1)) links a new account it gets saved. 

See video of a saved account being available on the next session.

https://user-images.githubusercontent.com/99293320/220799038-a98f6601-3af1-4c12-bb0e-fdc6c4f3cdb7.mp4

# Motivation
:notebook_with_decorative_cover: &nbsp;**Add consumer client secret to attach payment endpoint**
:globe_with_meridians: &nbsp;[BANKCON-6221](https://jira.corp.stripe.com/browse/BANKCON-6221)

> Implement [NetworkingLinkLogin](https://docs.google.com/document/d/1qrhciAfX9BdqMDlsq3mRTndSlw4BX2wvcE_yX82vh3Y/edit#heading=h.staizn19dm2d) pane
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

