### PR TITLE
Update timeout for loop test

### DIFF
--- a/stripecardscan/src/test/java/com/stripe/android/stripecardscan/framework/LoopTest.kt
+++ b/stripecardscan/src/test/java/com/stripe/android/stripecardscan/framework/LoopTest.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
-import org.junit.Ignore
 import org.junit.Test
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertEquals
@@ -67,6 +66,8 @@ class LoopTest {
         repeat(dataCount) {
             while (!channel.trySend(it).isSuccess) {
                 // loop until the channel accepts the data
+                println("Waiting for channel to become available to send data $it")
+                yield()
             }
         }
 
@@ -74,8 +75,7 @@ class LoopTest {
         assertTrue { dataCount == resultCount.get() }
     }
 
-    @Ignore("Ignored due to flakiness")
-    @Test(timeout = 200)
+    @Test(timeout = 1000)
     @SmallTest
     @ExperimentalCoroutinesApi
     fun processBoundAnalyzerLoop_analyzeDataNoDuplicates() = runTest {
@@ -121,6 +121,8 @@ class LoopTest {
         repeat(dataCount) {
             while (!channel.trySend(it).isSuccess) {
                 // loop until the channel accepts the data
+                println("Waiting for channel to become available to send data $it")
+                yield()
             }
         }
 
@@ -133,7 +135,7 @@ class LoopTest {
         }
     }
 
-    @Test(timeout = 200)
+    @Test(timeout = 1000)
     @SmallTest
     @ExperimentalCoroutinesApi
     fun processBoundAnalyzerLoop_noAnalyzersAvailable() = runTest {
@@ -172,7 +174,6 @@ class LoopTest {
     @Test(timeout = 1000)
     @SmallTest
     @ExperimentalCoroutinesApi
-    @Ignore("This test is flaking in CI")
     fun finiteAnalyzerLoop_analyzeData() = runTest {
         val dataCount = 3
         var dataProcessed = false
@@ -262,7 +263,7 @@ class LoopTest {
         assertTrue { terminatedEarly }
     }
 
-    @Test(timeout = 200)
+    @Test(timeout = 1000)
     @SmallTest
     @ExperimentalCoroutinesApi
     fun finiteAnalyzerLoop_analyzeDataNoData() = runTest {


### PR DESCRIPTION
# Summary
Since these tests are timing out intermittently, I suspect that the 200ms timeout on the tests was insufficient. This PR bumps it to 1s per test, which should be sufficient.

If these tests continue to flake, it may indicate a different problem, such as the queue not becoming available. In this case, they should be ignored again and re-evaluated.

# Motivation
Flaking tests should generally be made reliable where possible

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified
