### PR TITLE
Use activity instead of fragment for cardscan

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/CardScanActivity.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/CardScanActivity.kt
@@ -25,17 +25,18 @@ internal class CardScanActivity : AppCompatActivity() {
             PaymentConfiguration.getInstance(this).publishableKey,
             this::onScanFinished
         )
+        stripeCardScanProxy.present()
     }
 
-    override fun onStart() {
-        super.onStart()
-        stripeCardScanProxy.attachCardScanFragment(
-            this,
-            supportFragmentManager,
-            R.id.fragment_container,
-            this::onScanFinished
-        )
-    }
+//    override fun onStart() {
+//        super.onStart()
+//        stripeCardScanProxy.attachCardScanFragment(
+//            this,
+//            supportFragmentManager,
+//            R.id.fragment_container,
+//            this::onScanFinished
+//        )
+//    }
 
     private fun onScanFinished(result: CardScanSheetResult) {
         val intent = Intent()
@@ -47,10 +48,10 @@ internal class CardScanActivity : AppCompatActivity() {
         finish()
     }
 
-    override fun onStop() {
-        StripeCardScanProxy.removeCardScanFragment(supportFragmentManager)
-        super.onStop()
-    }
+//    override fun onStop() {
+//        StripeCardScanProxy.removeCardScanFragment(supportFragmentManager)
+//        super.onStop()
+//    }
 
     companion object {
         const val CARD_SCAN_PARCELABLE_NAME = "CardScanActivityResult"

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/CardScanActivity.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/CardScanActivity.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.stripecardscan.cardscan.CardScanSheetResult
-import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.StripeCardScanProxy
 import com.stripe.android.ui.core.databinding.ActivityCardScanBinding
 
@@ -28,16 +27,6 @@ internal class CardScanActivity : AppCompatActivity() {
         stripeCardScanProxy.present()
     }
 
-//    override fun onStart() {
-//        super.onStart()
-//        stripeCardScanProxy.attachCardScanFragment(
-//            this,
-//            supportFragmentManager,
-//            R.id.fragment_container,
-//            this::onScanFinished
-//        )
-//    }
-
     private fun onScanFinished(result: CardScanSheetResult) {
         val intent = Intent()
             .putExtra(
@@ -47,11 +36,6 @@ internal class CardScanActivity : AppCompatActivity() {
         setResult(RESULT_OK, intent)
         finish()
     }
-
-//    override fun onStop() {
-//        StripeCardScanProxy.removeCardScanFragment(supportFragmentManager)
-//        super.onStop()
-//    }
 
     companion object {
         const val CARD_SCAN_PARCELABLE_NAME = "CardScanActivityResult"


### PR DESCRIPTION
# Summary
The cardscan fragment is causing crashes on the stripe payment sheets page. Replace the fragment with the full-screen scan, which should not have the same camera error issues.

# Motivation
https://github.com/stripe/stripe-android/issues/6116

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified