### PR TITLE
Streamline primary button UI state flow

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -38,6 +38,9 @@
     <ID>MagicNumber:PaymentOptionUi.kt$14</ID>
     <ID>MagicNumber:PaymentOptionUi.kt$18</ID>
     <ID>MagicNumber:PrimaryButton.kt$PrimaryButton$0.5f</ID>
+    <ID>MagicNumber:PrimaryButtonUiStateMapper.kt$PrimaryButtonUiStateMapper$3</ID>
+    <ID>MagicNumber:PrimaryButtonUiStateMapper.kt$PrimaryButtonUiStateMapper$4</ID>
+    <ID>MagicNumber:PrimaryButtonUiStateMapper.kt$PrimaryButtonUiStateMapper$5</ID>
     <ID>MagicNumber:USBankAccountFormFragment.kt$USBankAccountFormFragment$0.5f</ID>
     <ID>MaxLineLength:BillingAddressViewTest.kt$BillingAddressViewTest$fun</ID>
     <ID>MaxLineLength:ConfirmPaymentIntentParamsFactoryTest.kt$ConfirmPaymentIntentParamsFactoryTest$fun</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/LinkHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/LinkHandler.kt
@@ -129,7 +129,6 @@ internal class LinkHandler @Inject constructor(
     }
 
     suspend fun payWithLinkInline(
-        configuration: LinkPaymentLauncher.Configuration,
         userInput: UserInput?,
         paymentSelection: PaymentSelection?,
         shouldCompleteLinkInlineFlow: Boolean,
@@ -137,6 +136,8 @@ internal class LinkHandler @Inject constructor(
         (paymentSelection as? PaymentSelection.New.Card?)?.paymentMethodCreateParams?.let { params ->
             savedStateHandle[SAVE_PROCESSING] = true
             _processingState.emit(ProcessingState.Started)
+
+            val configuration = requireNotNull(linkConfiguration.value)
 
             when (linkLauncher.getAccountStatusFlow(configuration).first()) {
                 AccountStatus.Verified -> {
@@ -170,7 +171,6 @@ internal class LinkHandler @Inject constructor(
                             onSuccess = {
                                 // If successful, the account was fetched or created, so try again
                                 payWithLinkInline(
-                                    configuration = configuration,
                                     userInput = userInput,
                                     paymentSelection = paymentSelection,
                                     shouldCompleteLinkInlineFlow = shouldCompleteLinkInlineFlow,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -15,6 +15,8 @@ import com.stripe.android.core.injection.Injector
 import com.stripe.android.core.injection.InjectorKey
 import com.stripe.android.core.injection.NonFallbackInjector
 import com.stripe.android.core.injection.injectWithFallback
+import com.stripe.android.link.ui.inline.UserInput
+import com.stripe.android.model.PaymentIntent
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.injection.DaggerPaymentOptionsViewModelFactoryComponent
@@ -29,6 +31,7 @@ import com.stripe.android.paymentsheet.state.GooglePayState
 import com.stripe.android.paymentsheet.ui.HeaderTextFactory
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
+import com.stripe.android.paymentsheet.viewmodels.PrimaryButtonUiStateMapper
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.ui.core.forms.resources.ResourceRepository
 import com.stripe.android.uicore.address.AddressRepository
@@ -36,8 +39,9 @@ import com.stripe.android.utils.requireApplication
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Provider
@@ -72,6 +76,14 @@ internal class PaymentOptionsViewModel @Inject constructor(
     linkHandler = linkHandler,
     headerTextFactory = HeaderTextFactory(isCompleteFlow = false),
 ) {
+
+    private val primaryButtonUiStateMapper = PrimaryButtonUiStateMapper(
+        context = getApplication(),
+        config = config,
+        isProcessingPayment = args.state.stripeIntent is PaymentIntent,
+        onClick = this::onUserSelection,
+    )
+
     private val _paymentOptionResult = MutableSharedFlow<PaymentOptionResult>(replay = 1)
     internal val paymentOptionResult: SharedFlow<PaymentOptionResult> = _paymentOptionResult
 
@@ -82,14 +94,16 @@ internal class PaymentOptionsViewModel @Inject constructor(
     // and how to populate that view.
     override var newPaymentSelection = args.state.newPaymentSelection
 
-    val isPrimaryButtonVisible = combine(
-        currentScreen,
-        primaryButtonUIState,
-        selection,
-    ) { screen, uiState, selection ->
-        screen.showsContinueButton || uiState?.visible == true ||
-            selection?.requiresConfirmation == true
-    }
+    override val primaryButtonUiState = primaryButtonUiStateMapper.forCustomFlow(
+        currentScreenFlow = currentScreen,
+        buttonsEnabledFlow = buttonsEnabled,
+        selectionFlow = selection,
+        customPrimaryButtonUiStateFlow = customPrimaryButtonUiState,
+    ).stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(),
+        initialValue = null,
+    )
 
     init {
         savedStateHandle[SAVE_GOOGLE_PAY_STATE] = if (args.state.isGooglePayReady) {
@@ -131,6 +145,10 @@ internal class PaymentOptionsViewModel @Inject constructor(
     }
 
     override val shouldCompleteLinkFlowInline: Boolean = false
+
+    override fun payWithLinkInline(userInput: UserInput?) {
+        // Not happening here
+    }
 
     private fun handleLinkProcessingState(processingState: LinkHandler.ProcessingState) {
         when (processingState) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -80,6 +80,11 @@ internal class PaymentOptionsViewModel @Inject constructor(
         context = getApplication(),
         config = config,
         isProcessingPayment = args.state.stripeIntent is PaymentIntent,
+        currentScreenFlow = currentScreen,
+        buttonsEnabledFlow = buttonsEnabled,
+        amountFlow = amount,
+        selectionFlow = selection,
+        customPrimaryButtonUiStateFlow = customPrimaryButtonUiState,
         onClick = this::onUserSelection,
     )
 
@@ -93,12 +98,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
     // and how to populate that view.
     override var newPaymentSelection = args.state.newPaymentSelection
 
-    override val primaryButtonUiState = primaryButtonUiStateMapper.forCustomFlow(
-        currentScreenFlow = currentScreen,
-        buttonsEnabledFlow = buttonsEnabled,
-        selectionFlow = selection,
-        customPrimaryButtonUiStateFlow = customPrimaryButtonUiState,
-    ).stateIn(
+    override val primaryButtonUiState = primaryButtonUiStateMapper.forCustomFlow().stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(),
         initialValue = null,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -15,7 +15,6 @@ import com.stripe.android.core.injection.Injector
 import com.stripe.android.core.injection.InjectorKey
 import com.stripe.android.core.injection.NonFallbackInjector
 import com.stripe.android.core.injection.injectWithFallback
-import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.analytics.EventReporter
@@ -145,10 +144,6 @@ internal class PaymentOptionsViewModel @Inject constructor(
     }
 
     override val shouldCompleteLinkFlowInline: Boolean = false
-
-    override fun payWithLinkInline(userInput: UserInput?) {
-        // Not happening here
-    }
 
     private fun handleLinkProcessingState(processingState: LinkHandler.ProcessingState) {
         when (processingState) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -121,6 +121,11 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         context = getApplication(),
         config = config,
         isProcessingPayment = isProcessingPaymentIntent,
+        currentScreenFlow = currentScreen,
+        buttonsEnabledFlow = buttonsEnabled,
+        amountFlow = amount,
+        selectionFlow = selection,
+        customPrimaryButtonUiStateFlow = customPrimaryButtonUiState,
         onClick = this::checkout,
     )
 
@@ -170,13 +175,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             }
         }
 
-    override val primaryButtonUiState = primaryButtonUiStateMapper.forCompleteFlow(
-        currentScreenFlow = currentScreen,
-        buttonsEnabledFlow = buttonsEnabled,
-        amountFlow = amount,
-        selectionFlow = selection,
-        customPrimaryButtonUiStateFlow = customPrimaryButtonUiState,
-    ).stateIn(
+    override val primaryButtonUiState = primaryButtonUiStateMapper.forCompleteFlow().stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(),
         initialValue = null,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -25,7 +25,6 @@ import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContract
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
-import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
@@ -216,17 +215,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     }
 
     override val shouldCompleteLinkFlowInline: Boolean = true
-
-    override fun payWithLinkInline(userInput: UserInput?) {
-        viewModelScope.launch {
-            startProcessing(CheckoutIdentifier.SheetBottomBuy)
-            linkHandler.payWithLinkInline(
-                userInput = userInput,
-                paymentSelection = selection.value,
-                shouldCompleteLinkInlineFlow = shouldCompleteLinkFlowInline,
-            )
-        }
-    }
 
     fun handleLinkPressed() {
         linkHandler.launchLink()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormScreenState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormScreenState.kt
@@ -7,14 +7,14 @@ import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
 internal sealed class USBankAccountFormScreenState(
     @StringRes open val error: Int? = null
 ) {
-    abstract val primaryButtonText: String?
+    abstract val primaryButtonText: String
     abstract val mandateText: String?
 
     class NameAndEmailCollection(
         @StringRes override val error: Int? = null,
         val name: String,
         val email: String?,
-        override val primaryButtonText: String?
+        override val primaryButtonText: String,
     ) : USBankAccountFormScreenState() {
 
         override val mandateText: String? = null
@@ -34,7 +34,7 @@ internal sealed class USBankAccountFormScreenState(
         val paymentAccount: FinancialConnectionsAccount,
         val financialConnectionsSessionId: String,
         val intentId: String,
-        override val primaryButtonText: String?,
+        override val primaryButtonText: String,
         override val mandateText: String?,
         val saveForFutureUsage: Boolean
     ) : USBankAccountFormScreenState() {
@@ -48,7 +48,7 @@ internal sealed class USBankAccountFormScreenState(
         val paymentAccount: BankAccount,
         val financialConnectionsSessionId: String,
         val intentId: String,
-        override val primaryButtonText: String?,
+        override val primaryButtonText: String,
         override val mandateText: String?,
         val saveForFutureUsage: Boolean
     ) : USBankAccountFormScreenState() {
@@ -63,7 +63,7 @@ internal sealed class USBankAccountFormScreenState(
         val intentId: String,
         val bankName: String,
         val last4: String?,
-        override val primaryButtonText: String?,
+        override val primaryButtonText: String,
         override val mandateText: String?,
         val saveForFutureUsage: Boolean
     ) : USBankAccountFormScreenState() {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -419,11 +419,11 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         }
     }
 
-    private fun buildPrimaryButtonText(): String? {
+    private fun buildPrimaryButtonText(): String {
         return when {
             args.isCompleteFlow -> {
                 if (args.clientSecret is PaymentIntentClientSecret) {
-                    args.formArgs.amount?.buildPayButtonLabel(application.resources)
+                    args.formArgs.amount!!.buildPayButtonLabel(application.resources)
                 } else {
                     application.getString(
                         R.string.stripe_setup_button_label

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
@@ -126,7 +126,7 @@ internal class PrimaryButton @JvmOverloads constructor(
         return text
     }
 
-    fun setLabel(text: String?) {
+    private fun setLabel(text: String?) {
         externalLabel = text
         text?.let {
             if (state !is State.StartProcessing) {
@@ -176,6 +176,21 @@ internal class PrimaryButton @JvmOverloads constructor(
         updateAlpha()
     }
 
+    fun updateUiState(uiState: UIState?) {
+        isVisible = uiState != null
+
+        if (uiState != null) {
+            if (state !is State.StartProcessing && state !is State.FinishProcessing) {
+                // If we're processing or finishing, we're not overriding the label
+                setLabel(uiState.label)
+            }
+
+            isEnabled = uiState.enabled
+            lockVisible = uiState.lockVisible
+            setOnClickListener { uiState.onClick() }
+        }
+    }
+
     fun updateState(state: State?) {
         this.state = state
         updateAlpha()
@@ -219,11 +234,11 @@ internal class PrimaryButton @JvmOverloads constructor(
     /**
      * Used to override the current UI state of the Primary Button
      */
-    internal data class UIState(
-        val label: String?,
-        val onClick: (() -> Unit)?,
+    internal data class UIState constructor(
+        val label: String,
+        val onClick: () -> Unit,
         val enabled: Boolean,
-        val visible: Boolean
+        val lockVisible: Boolean,
     )
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButton.kt
@@ -231,10 +231,7 @@ internal class PrimaryButton @JvmOverloads constructor(
         data class FinishProcessing(val onComplete: () -> Unit) : State()
     }
 
-    /**
-     * Used to override the current UI state of the Primary Button
-     */
-    internal data class UIState constructor(
+    internal data class UIState(
         val label: String,
         val onClick: () -> Unit,
         val enabled: Boolean,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButtonContainerFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButtonContainerFragment.kt
@@ -5,12 +5,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import com.stripe.android.paymentsheet.PaymentOptionsViewModel
 import com.stripe.android.paymentsheet.PaymentSheetViewModel
-import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.databinding.FragmentPrimaryButtonContainerBinding
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
 import com.stripe.android.paymentsheet.utils.launchAndCollectIn
@@ -33,34 +31,17 @@ internal abstract class BasePrimaryButtonContainerFragment : Fragment() {
         return viewBinding?.root
     }
 
-    abstract fun resetPrimaryButtonState()
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupPrimaryButton()
 
-    protected fun setupPrimaryButton() {
+        viewModel.primaryButtonUiState.launchAndCollectIn(viewLifecycleOwner) { uiState ->
+            viewBinding?.primaryButton?.updateUiState(uiState)
+        }
+    }
+
+    private fun setupPrimaryButton() {
         val viewBinding = viewBinding ?: return
-
-        viewModel.primaryButtonUIState.launchAndCollectIn(viewLifecycleOwner) { state ->
-            state?.let {
-                viewBinding.primaryButton.setOnClickListener {
-                    state.onClick?.invoke()
-                }
-                viewBinding.primaryButton.setLabel(state.label)
-                viewBinding.primaryButton.isVisible = state.visible
-            } ?: run {
-                resetPrimaryButtonState()
-            }
-        }
-
-        viewModel.amount.launchAndCollectIn(viewLifecycleOwner) {
-            resetPrimaryButtonState()
-        }
-
-        viewModel.selection.launchAndCollectIn(viewLifecycleOwner) {
-            resetPrimaryButtonState()
-        }
-
-        viewModel.isPrimaryButtonEnabled.launchAndCollectIn(viewLifecycleOwner) { isEnabled ->
-            viewBinding.primaryButton.isEnabled = isEnabled
-        }
 
         viewBinding.primaryButton.setAppearanceConfiguration(
             StripeTheme.primaryButtonStyle,
@@ -83,36 +64,10 @@ internal class PaymentSheetPrimaryButtonContainerFragment : BasePrimaryButtonCon
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        setupPrimaryButton()
-
-        viewModel.currentScreen.launchAndCollectIn(viewLifecycleOwner) { currentScreen ->
-            viewBinding?.primaryButton?.isVisible = currentScreen.showsBuyButton
-        }
+        super.onViewCreated(view, savedInstanceState)
 
         viewModel.buyButtonState.launchAndCollectIn(viewLifecycleOwner) { state ->
             viewBinding?.primaryButton?.updateState(state?.convert())
-        }
-    }
-
-    override fun resetPrimaryButtonState() {
-        val viewBinding = viewBinding ?: return
-        viewBinding.primaryButton.updateState(PrimaryButton.State.Ready)
-
-        val customLabel = viewModel.config?.primaryButtonLabel
-
-        val label = if (customLabel != null) {
-            viewModel.config?.primaryButtonLabel
-        } else if (viewModel.isProcessingPaymentIntent) {
-            viewModel.amount.value?.buildPayButtonLabel(resources)
-        } else {
-            getString(R.string.stripe_setup_button_label)
-        }
-
-        viewBinding.primaryButton.isEnabled = viewModel.selection.value != null
-        viewBinding.primaryButton.setLabel(label)
-
-        viewBinding.primaryButton.setOnClickListener {
-            viewModel.checkout()
         }
     }
 }
@@ -121,31 +76,6 @@ internal class PaymentOptionsPrimaryButtonContainerFragment : BasePrimaryButtonC
 
     override val viewModel: PaymentOptionsViewModel by activityViewModels {
         PaymentOptionsViewModel.Factory { error("PaymentOptionsViewModel should already exist") }
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        setupPrimaryButton()
-
-        viewModel.isPrimaryButtonVisible.launchAndCollectIn(viewLifecycleOwner) { isVisible ->
-            viewBinding?.primaryButton?.isVisible = isVisible
-        }
-    }
-
-    override fun resetPrimaryButtonState() {
-        val viewBinding = viewBinding ?: return
-
-        viewBinding.primaryButton.lockVisible = false
-        viewBinding.primaryButton.updateState(PrimaryButton.State.Ready)
-
-        val customLabel = viewModel.config?.primaryButtonLabel
-        val label = customLabel ?: getString(R.string.stripe_continue_button_label)
-
-        viewBinding.primaryButton.isEnabled = viewModel.selection.value != null
-        viewBinding.primaryButton.setLabel(label)
-
-        viewBinding.primaryButton.setOnClickListener {
-            viewModel.onUserSelection()
-        }
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -8,11 +8,10 @@ import androidx.lifecycle.viewModelScope
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.InjectorKey
 import com.stripe.android.core.injection.NonFallbackInjector
-import com.stripe.android.link.LinkPaymentLauncher
+import com.stripe.android.link.ui.inline.InlineSignupViewState
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.model.PaymentMethod.Type.USBankAccount
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.paymentlauncher.PaymentResult
@@ -22,6 +21,7 @@ import com.stripe.android.paymentsheet.PaymentOptionsState
 import com.stripe.android.paymentsheet.PaymentOptionsViewModel
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetActivity
+import com.stripe.android.paymentsheet.PaymentSheetViewModel
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
@@ -168,15 +168,12 @@ internal abstract class BaseSheetViewModel(
     private val _contentVisible = MutableStateFlow(true)
     internal val contentVisible: StateFlow<Boolean> = _contentVisible
 
-    /**
-     * Use this to override the current UI state of the primary button. The UI state is reset every
-     * time the payment selection is changed.
-     */
-    private val _primaryButtonUIState = MutableStateFlow<PrimaryButton.UIState?>(null)
-    val primaryButtonUIState: StateFlow<PrimaryButton.UIState?> = _primaryButtonUIState
-
     private val _primaryButtonState = MutableStateFlow<PrimaryButton.State?>(null)
     val primaryButtonState: StateFlow<PrimaryButton.State?> = _primaryButtonState
+
+    protected val customPrimaryButtonUiState = MutableStateFlow<PrimaryButton.UIState?>(null)
+
+    abstract val primaryButtonUiState: StateFlow<PrimaryButton.UIState?>
 
     private val _notesText = MutableStateFlow<String?>(null)
     internal val notesText: StateFlow<String?> = _notesText
@@ -197,18 +194,6 @@ internal abstract class BaseSheetViewModel(
         editing
     ) { isProcessing, isEditing ->
         !isProcessing && !isEditing
-    }.distinctUntilChanged()
-
-    val isPrimaryButtonEnabled = combine(
-        primaryButtonUIState,
-        buttonsEnabled,
-        selection,
-    ) { uiState, buttonsEnabled, selection ->
-        if (uiState != null) {
-            uiState.enabled && buttonsEnabled
-        } else {
-            buttonsEnabled && selection != null
-        }
     }.distinctUntilChanged()
 
     internal var lpmServerSpec: String? = null
@@ -352,8 +337,6 @@ internal abstract class BaseSheetViewModel(
                     requireNotNull(stripeIntent.amount),
                     requireNotNull(stripeIntent.currency)
                 )
-                // Reset the primary button state to display the amount
-                _primaryButtonUIState.value = null
             }.onFailure {
                 onFatal(
                     IllegalStateException("PaymentIntent must contain amount and currency.")
@@ -383,8 +366,57 @@ internal abstract class BaseSheetViewModel(
         logger.warning(message)
     }
 
-    fun updatePrimaryButtonUIState(state: PrimaryButton.UIState?) {
-        _primaryButtonUIState.value = state
+    fun updatePrimaryButtonForLinkSignup(viewState: InlineSignupViewState) {
+        val uiState = primaryButtonUiState.value ?: return
+
+        updateLinkPrimaryButtonUiState(
+            if (viewState.useLink) {
+                val userInput = viewState.userInput
+                val paymentSelection = selection.value
+
+                if (userInput != null && paymentSelection != null) {
+                    PrimaryButton.UIState(
+                        label = uiState.label,
+                        onClick = { payWithLinkInline(userInput) },
+                        enabled = true,
+                        lockVisible = this is PaymentSheetViewModel,
+                    )
+                } else {
+                    PrimaryButton.UIState(
+                        label = uiState.label,
+                        onClick = {},
+                        enabled = false,
+                        lockVisible = this is PaymentSheetViewModel,
+                    )
+                }
+            } else {
+                null
+            }
+        )
+    }
+
+    fun updatePrimaryButtonForLinkInline() {
+        val uiState = primaryButtonUiState.value ?: return
+        updateLinkPrimaryButtonUiState(
+            PrimaryButton.UIState(
+                label = uiState.label,
+                onClick = { payWithLinkInline(userInput = null) },
+                enabled = true,
+                lockVisible = this is PaymentSheetViewModel,
+            )
+        )
+    }
+
+    private fun updateLinkPrimaryButtonUiState(state: PrimaryButton.UIState?) {
+        customPrimaryButtonUiState.value = state
+    }
+
+    fun updateCustomPrimaryButtonUiState(block: (PrimaryButton.UIState?) -> PrimaryButton.UIState?) {
+        customPrimaryButtonUiState.update(block)
+    }
+
+    fun resetUSBankPrimaryButton() {
+        customPrimaryButtonUiState.value = null
     }
 
     fun updatePrimaryButtonState(state: PrimaryButton.State) {
@@ -448,16 +480,6 @@ internal abstract class BaseSheetViewModel(
             if (shouldResetToAddPaymentMethodForm) {
                 backStack.value = listOf(AddFirstPaymentMethod)
             }
-
-            val hasNoBankAccounts = paymentMethods.value.orEmpty().all { it.type != USBankAccount }
-            if (hasNoBankAccounts) {
-                updatePrimaryButtonUIState(
-                    primaryButtonUIState.value?.copy(
-                        visible = false
-                    )
-                )
-                updateBelowButtonText(null)
-            }
         }
     }
 
@@ -481,16 +503,7 @@ internal abstract class BaseSheetViewModel(
 
     abstract val shouldCompleteLinkFlowInline: Boolean
 
-    fun payWithLinkInline(linkConfig: LinkPaymentLauncher.Configuration, userInput: UserInput?) {
-        viewModelScope.launch {
-            linkHandler.payWithLinkInline(
-                configuration = linkConfig,
-                userInput = userInput,
-                paymentSelection = selection.value,
-                shouldCompleteLinkInlineFlow = shouldCompleteLinkFlowInline,
-            )
-        }
-    }
+    abstract fun payWithLinkInline(userInput: UserInput?)
 
     fun createFormArguments(
         selectedItem: LpmRepository.SupportedPaymentMethod,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -503,7 +503,15 @@ internal abstract class BaseSheetViewModel(
 
     abstract val shouldCompleteLinkFlowInline: Boolean
 
-    abstract fun payWithLinkInline(userInput: UserInput?)
+    fun payWithLinkInline(userInput: UserInput?) {
+        viewModelScope.launch {
+            linkHandler.payWithLinkInline(
+                userInput = userInput,
+                paymentSelection = selection.value,
+                shouldCompleteLinkInlineFlow = shouldCompleteLinkFlowInline,
+            )
+        }
+    }
 
     fun createFormArguments(
         selectedItem: LpmRepository.SupportedPaymentMethod,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PrimaryButtonUiStateMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PrimaryButtonUiStateMapper.kt
@@ -1,0 +1,81 @@
+package com.stripe.android.paymentsheet.viewmodels
+
+import android.content.Context
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
+import com.stripe.android.paymentsheet.ui.PrimaryButton
+import com.stripe.android.ui.core.Amount
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+
+internal class PrimaryButtonUiStateMapper(
+    private val context: Context,
+    private val config: PaymentSheet.Configuration?,
+    private val isProcessingPayment: Boolean,
+    private val onClick: () -> Unit,
+) {
+
+    fun forCompleteFlow(
+        currentScreenFlow: Flow<PaymentSheetScreen>,
+        buttonsEnabledFlow: Flow<Boolean>,
+        amountFlow: Flow<Amount?>,
+        selectionFlow: Flow<PaymentSelection?>,
+        customPrimaryButtonUiStateFlow: Flow<PrimaryButton.UIState?>,
+    ): Flow<PrimaryButton.UIState?> {
+        return combine(
+            currentScreenFlow,
+            buttonsEnabledFlow,
+            amountFlow,
+            selectionFlow,
+            customPrimaryButtonUiStateFlow,
+        ) { screen, buttonsEnabled, amount, selection, customPrimaryButton ->
+            customPrimaryButton ?: PrimaryButton.UIState(
+                label = buyButtonLabel(amount),
+                onClick = onClick,
+                enabled = buttonsEnabled && selection != null,
+                lockVisible = true,
+            ).takeIf { screen.showsBuyButton }
+        }
+    }
+
+    fun forCustomFlow(
+        currentScreenFlow: Flow<PaymentSheetScreen>,
+        buttonsEnabledFlow: Flow<Boolean>,
+        selectionFlow: Flow<PaymentSelection?>,
+        customPrimaryButtonUiStateFlow: Flow<PrimaryButton.UIState?>,
+    ): Flow<PrimaryButton.UIState?> {
+        return combine(
+            currentScreenFlow,
+            buttonsEnabledFlow,
+            selectionFlow,
+            customPrimaryButtonUiStateFlow,
+        ) { screen, buttonsEnabled, selection, customPrimaryButton ->
+            customPrimaryButton ?: PrimaryButton.UIState(
+                label = continueButtonLabel(),
+                onClick = onClick,
+                enabled = buttonsEnabled && selection != null,
+                lockVisible = false,
+            ).takeIf {
+                screen.showsContinueButton || selection?.requiresConfirmation == true
+            }
+        }
+    }
+
+    private fun buyButtonLabel(amount: Amount?): String {
+        return if (config?.primaryButtonLabel != null) {
+            config.primaryButtonLabel
+        } else if (isProcessingPayment) {
+            val fallback = context.getString(R.string.stripe_paymentsheet_pay_button_label)
+            amount?.buildPayButtonLabel(context.resources) ?: fallback
+        } else {
+            context.getString(R.string.stripe_setup_button_label)
+        }
+    }
+
+    private fun continueButtonLabel(): String {
+        val customLabel = config?.primaryButtonLabel
+        return customLabel ?: context.getString(R.string.stripe_continue_button_label)
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PrimaryButtonUiStateMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PrimaryButtonUiStateMapper.kt
@@ -14,16 +14,15 @@ internal class PrimaryButtonUiStateMapper(
     private val context: Context,
     private val config: PaymentSheet.Configuration?,
     private val isProcessingPayment: Boolean,
+    private val currentScreenFlow: Flow<PaymentSheetScreen>,
+    private val buttonsEnabledFlow: Flow<Boolean>,
+    private val amountFlow: Flow<Amount?>,
+    private val selectionFlow: Flow<PaymentSelection?>,
+    private val customPrimaryButtonUiStateFlow: Flow<PrimaryButton.UIState?>,
     private val onClick: () -> Unit,
 ) {
 
-    fun forCompleteFlow(
-        currentScreenFlow: Flow<PaymentSheetScreen>,
-        buttonsEnabledFlow: Flow<Boolean>,
-        amountFlow: Flow<Amount?>,
-        selectionFlow: Flow<PaymentSelection?>,
-        customPrimaryButtonUiStateFlow: Flow<PrimaryButton.UIState?>,
-    ): Flow<PrimaryButton.UIState?> {
+    fun forCompleteFlow(): Flow<PrimaryButton.UIState?> {
         return combine(
             currentScreenFlow,
             buttonsEnabledFlow,
@@ -40,12 +39,7 @@ internal class PrimaryButtonUiStateMapper(
         }
     }
 
-    fun forCustomFlow(
-        currentScreenFlow: Flow<PaymentSheetScreen>,
-        buttonsEnabledFlow: Flow<Boolean>,
-        selectionFlow: Flow<PaymentSelection?>,
-        customPrimaryButtonUiStateFlow: Flow<PrimaryButton.UIState?>,
-    ): Flow<PrimaryButton.UIState?> {
+    fun forCustomFlow(): Flow<PrimaryButton.UIState?> {
         return combine(
             currentScreenFlow,
             buttonsEnabledFlow,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -60,7 +60,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -109,13 +108,6 @@ internal class PaymentOptionsActivityTest {
     }
 
     private val viewModel = createViewModel()
-
-    private val primaryButtonUIState = PrimaryButton.UIState(
-        label = "Test",
-        onClick = {},
-        enabled = true,
-        visible = true
-    )
 
     private val ActivityPaymentOptionsBinding.continueButton: PrimaryButton
         get() = root.findViewById(R.id.primary_button)
@@ -293,82 +285,6 @@ internal class PaymentOptionsActivityTest {
 
                 assertThat(activity.bottomSheetBehavior.state)
                     .isEqualTo(BottomSheetBehavior.STATE_HIDDEN)
-            }
-        }
-    }
-
-    @Test
-    fun `ContinueButton should be enabled when primaryButtonEnabled is true`() {
-        val scenario = activityScenario()
-        scenario.launch(
-            createIntent()
-        ).use {
-            it.onActivity { activity ->
-                viewModel.updatePrimaryButtonUIState(
-                    primaryButtonUIState.copy(
-                        enabled = true
-                    )
-                )
-                assertThat(activity.viewBinding.continueButton.isEnabled).isTrue()
-            }
-        }
-    }
-
-    @Test
-    fun `ContinueButton should be disabled when primaryButtonEnabled is false`() {
-        val scenario = activityScenario()
-        scenario.launch(
-            createIntent()
-        ).use {
-            it.onActivity { activity ->
-                viewModel.updatePrimaryButtonUIState(
-                    primaryButtonUIState.copy(
-                        enabled = false
-                    )
-                )
-                assertThat(activity.viewBinding.continueButton.isEnabled).isFalse()
-            }
-        }
-    }
-
-    @Test
-    fun `ContinueButton text should update when primaryButtonText updates`() {
-        val scenario = activityScenario()
-        scenario.launch(
-            createIntent()
-        ).use {
-            it.onActivity { activity ->
-                viewModel.updatePrimaryButtonUIState(
-                    primaryButtonUIState.copy(
-                        label = "Some text"
-                    )
-                )
-                assertThat(activity.viewBinding.continueButton.externalLabel).isEqualTo("Some text")
-            }
-        }
-    }
-
-    @Test
-    fun `ContinueButton should go back to initial state after updating selection`() {
-        Dispatchers.setMain(testDispatcher)
-
-        val scenario = activityScenario()
-        scenario.launch(
-            createIntent()
-        ).use {
-            it.onActivity { activity ->
-                viewModel.updatePrimaryButtonUIState(
-                    primaryButtonUIState.copy(
-                        label = "Some text",
-                        enabled = false
-                    )
-                )
-                assertThat(activity.viewBinding.continueButton.externalLabel).isEqualTo("Some text")
-                assertThat(activity.viewBinding.continueButton.isEnabled).isFalse()
-
-                viewModel.updateSelection(mock<PaymentSelection.New.Card>())
-                assertThat(activity.viewBinding.continueButton.externalLabel).isEqualTo("Continue")
-                assertThat(activity.viewBinding.continueButton.isEnabled).isTrue()
             }
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -193,9 +193,8 @@ internal class PaymentOptionsViewModelTest {
 
         viewModel.removePaymentMethod(paymentMethod)
 
-        assertThat(viewModel.paymentMethods.value)
-            .isEmpty()
-        assertThat(viewModel.primaryButtonUIState.value).isNull()
+        assertThat(viewModel.paymentMethods.value).isEmpty()
+        assertThat(viewModel.primaryButtonUiState.value).isNull()
         assertThat(viewModel.notesText.value).isNull()
     }
 
@@ -416,23 +415,6 @@ internal class PaymentOptionsViewModelTest {
 
             val result = awaitItem() as? PaymentOptionResult.Succeeded
             assertThat(result?.paymentSelection).isEqualTo(PaymentSelection.Link)
-        }
-    }
-
-    @Test
-    fun `Primary button is visible if the selected payment method requires confirmation`() = runTest {
-        val selection = PaymentSelection.Saved(PaymentMethodFixtures.US_BANK_ACCOUNT)
-
-        val viewModel = createViewModel().apply { updateSelection(PaymentSelection.Link) }
-
-        viewModel.isPrimaryButtonVisible.test {
-            assertThat(awaitItem()).isFalse()
-
-            viewModel.handlePaymentMethodSelected(selection)
-            assertThat(awaitItem()).isTrue()
-
-            viewModel.handlePaymentMethodSelected(PaymentSelection.Link)
-            assertThat(awaitItem()).isFalse()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -153,13 +153,6 @@ internal class PaymentSheetActivityTest {
         )
     )
 
-    private val primaryButtonUIState = PrimaryButton.UIState(
-        label = "Test",
-        onClick = {},
-        enabled = true,
-        visible = true
-    )
-
     @BeforeTest
     fun before() {
         viewModel = createViewModel()
@@ -775,69 +768,6 @@ internal class PaymentSheetActivityTest {
     }
 
     @Test
-    fun `Buy button should be enabled when primaryButtonEnabled is true`() {
-        val scenario = activityScenario(viewModel)
-        scenario.launch(intent).onActivity { activity ->
-            viewModel.updatePrimaryButtonUIState(
-                primaryButtonUIState.copy(
-                    enabled = true
-                )
-            )
-            assertThat(activity.viewBinding.buyButton.isEnabled).isTrue()
-        }
-    }
-
-    @Test
-    fun `Buy button should be disabled when primaryButtonEnabled is false`() {
-        val scenario = activityScenario(viewModel)
-        scenario.launch(intent).onActivity { activity ->
-            viewModel.updatePrimaryButtonUIState(
-                primaryButtonUIState.copy(
-                    enabled = false
-                )
-            )
-            assertThat(activity.viewBinding.buyButton.isEnabled).isFalse()
-        }
-    }
-
-    @Test
-    fun `Buy button text should update when primaryButtonText updates`() {
-        val scenario = activityScenario(viewModel)
-        scenario.launch(intent).onActivity { activity ->
-            viewModel.updatePrimaryButtonUIState(
-                primaryButtonUIState.copy(
-                    label = "Some text"
-                )
-            )
-            assertThat(activity.viewBinding.buyButton.externalLabel).isEqualTo("Some text")
-        }
-    }
-
-    @Test
-    fun `Buy button should go back to initial state after resetPrimaryButton called`() {
-        Dispatchers.setMain(testDispatcher)
-
-        val scenario = activityScenario(viewModel)
-        scenario.launch(intent).onActivity { activity ->
-            viewModel.viewState.value = PaymentSheetViewState.Reset(null)
-
-            viewModel.updatePrimaryButtonUIState(
-                primaryButtonUIState.copy(
-                    label = "Some text",
-                    enabled = false
-                )
-            )
-            assertThat(activity.viewBinding.buyButton.externalLabel).isEqualTo("Some text")
-            assertThat(activity.viewBinding.buyButton.isEnabled).isFalse()
-
-            viewModel.updatePrimaryButtonUIState(null)
-            assertThat(activity.viewBinding.buyButton.externalLabel)
-                .isEqualTo(viewModel.amount.value?.buildPayButtonLabel(context.resources))
-            assertThat(activity.viewBinding.buyButton.isEnabled).isTrue()
-        }
-    }
-
-    @Test
     fun `notes visibility is visible`() {
         val scenario = activityScenario(viewModel)
         scenario.launch(intent).onActivity { activity ->
@@ -989,7 +919,7 @@ internal class PaymentSheetActivityTest {
 
         scenario.launch(intent).onActivity { activity ->
             testDispatcher.scheduler.advanceTimeBy(50)
-            assertThat(activity.viewBinding.buyButton.externalLabel).isNull()
+            assertThat(activity.viewBinding.buyButton.externalLabel).isEqualTo("Pay")
             testDispatcher.scheduler.advanceTimeBy(250)
             assertThat(activity.viewBinding.buyButton.externalLabel).isEqualTo("Pay CA\$99.99")
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -112,13 +112,6 @@ internal class PaymentSheetViewModelTest {
         on { getAccountStatusFlow(any()) } doReturn flowOf(AccountStatus.SignedOut)
     }
 
-    private val primaryButtonUIState = PrimaryButton.UIState(
-        label = "Test",
-        onClick = {},
-        enabled = true,
-        visible = true
-    )
-
     @BeforeTest
     fun setup() {
         MockitoAnnotations.openMocks(this)
@@ -645,64 +638,6 @@ internal class PaymentSheetViewModelTest {
         val viewModel = createViewModel(ARGS_CUSTOMER_WITH_GOOGLEPAY_SETUP)
         assertThat(viewModel.googlePayLauncherConfig)
             .isNotNull()
-    }
-
-    @Test
-    fun `buyButton is enabled when primaryButtonEnabled is true, else not processing, not editing, and a selection has been made`() = runTest(testDispatcher) {
-        val viewModel = createViewModel()
-
-        viewModel.isPrimaryButtonEnabled.test {
-            assertThat(awaitItem()).isFalse()
-
-            viewModel.savedStateHandle[SAVE_PROCESSING] = false
-            viewModel.updateSelection(PaymentSelection.GooglePay)
-            assertThat(awaitItem()).isTrue()
-
-            viewModel.updateSelection(null)
-            assertThat(awaitItem()).isFalse()
-
-            viewModel.updateSelection(PaymentSelection.GooglePay)
-            assertThat(awaitItem()).isTrue()
-
-            viewModel.updatePrimaryButtonUIState(primaryButtonUIState.copy(enabled = false))
-            assertThat(awaitItem()).isFalse()
-
-            viewModel.updatePrimaryButtonUIState(primaryButtonUIState.copy(enabled = true))
-            assertThat(awaitItem()).isTrue()
-
-            viewModel.savedStateHandle[SAVE_PROCESSING] = true
-            assertThat(awaitItem()).isFalse()
-
-            viewModel.savedStateHandle[SAVE_PROCESSING] = false
-            assertThat(awaitItem()).isTrue()
-
-            viewModel.toggleEditing()
-            assertThat(awaitItem()).isFalse()
-
-            viewModel.toggleEditing()
-            assertThat(awaitItem()).isTrue()
-        }
-    }
-
-    @Test
-    fun `buttonsEnabled should be true when not processing and not editing`() = runTest {
-        val viewModel = createViewModel()
-
-        viewModel.buttonsEnabled.test {
-            assertThat(awaitItem()).isTrue()
-
-            viewModel.toggleEditing()
-            assertThat(awaitItem()).isFalse()
-
-            viewModel.toggleEditing()
-            assertThat(awaitItem()).isTrue()
-
-            viewModel.savedStateHandle[SAVE_PROCESSING] = true
-            assertThat(awaitItem()).isFalse()
-
-            viewModel.savedStateHandle[SAVE_PROCESSING] = false
-            assertThat(awaitItem()).isTrue()
-        }
     }
 
     @Test
@@ -1262,6 +1197,22 @@ internal class PaymentSheetViewModelTest {
         viewModel.walletsContainerState.test {
             val textResource = awaitItem().dividerTextResource
             assertThat(textResource).isEqualTo(R.string.stripe_paymentsheet_or_pay_using)
+        }
+    }
+
+    @Test
+    fun `Shows processing state when paying inline with Link`() = runTest {
+        val viewModel = createViewModel(
+            linkState = LinkState(
+                configuration = mock(),
+                loginState = LinkState.LoginState.LoggedOut,
+            )
+        )
+
+        viewModel.processing.test {
+            assertThat(awaitItem()).isFalse()
+            viewModel.payWithLinkInline(userInput = null)
+            assertThat(awaitItem()).isTrue()
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1200,22 +1200,6 @@ internal class PaymentSheetViewModelTest {
         }
     }
 
-    @Test
-    fun `Shows processing state when paying inline with Link`() = runTest {
-        val viewModel = createViewModel(
-            linkState = LinkState(
-                configuration = mock(),
-                loginState = LinkState.LoginState.LoggedOut,
-            )
-        )
-
-        viewModel.processing.test {
-            assertThat(awaitItem()).isFalse()
-            viewModel.payWithLinkInline(userInput = null)
-            assertThat(awaitItem()).isTrue()
-        }
-    }
-
     private fun createViewModel(
         args: PaymentSheetContractV2.Args = ARGS_CUSTOMER_WITH_GOOGLEPAY,
         stripeIntent: StripeIntent = PAYMENT_INTENT,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PrimaryButtonTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PrimaryButtonTest.kt
@@ -75,12 +75,18 @@ class PrimaryButtonTest {
 
     @Test
     fun `onReadyState() should update label`() {
-        primaryButton.setLabel("Pay $10.99")
+        primaryButton.updateUiState(
+            PrimaryButton.UIState(
+                label = "Pay $10.99",
+                onClick = {},
+                enabled = true,
+                lockVisible = true,
+            )
+        )
+
         primaryButton.backgroundTintList = ColorStateList.valueOf(Color.BLACK)
 
-        primaryButton.updateState(
-            PrimaryButton.State.StartProcessing
-        )
+        primaryButton.updateState(PrimaryButton.State.StartProcessing)
         assertThat(
             primaryButton.externalLabel
         ).isEqualTo(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PrimaryButtonUiStateMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/viewmodels/PrimaryButtonUiStateMapperTest.kt
@@ -1,0 +1,210 @@
+package com.stripe.android.paymentsheet.viewmodels
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentMethodCreateParamsFixtures
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
+import com.stripe.android.paymentsheet.ui.PrimaryButton
+import com.stripe.android.ui.core.Amount
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PrimaryButtonUiStateMapperTest {
+
+    @Test
+    fun `Chooses custom button over default one`() = runTest {
+        val mapper = createMapper(isProcessingPayment = true)
+
+        val usBankButton = PrimaryButton.UIState(
+            label = "US Bank Account FTW",
+            onClick = {},
+            enabled = false,
+            lockVisible = true,
+        )
+
+        val result = mapper.forCompleteFlow(
+            currentScreenFlow = flowOf(PaymentSheetScreen.SelectSavedPaymentMethods),
+            buttonsEnabledFlow = flowOf(true),
+            amountFlow = flowOf(Amount(value = 1234, currencyCode = "usd")),
+            selectionFlow = flowOf(null),
+            customPrimaryButtonUiStateFlow = flowOf(usBankButton),
+        )
+
+        result.test {
+            assertThat(awaitItem()).isEqualTo(usBankButton)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `Enables button if selection is not null`() = runTest {
+        val mapper = createMapper(isProcessingPayment = true)
+
+        val result = mapper.forCompleteFlow(
+            currentScreenFlow = flowOf(PaymentSheetScreen.SelectSavedPaymentMethods),
+            buttonsEnabledFlow = flowOf(true),
+            amountFlow = flowOf(Amount(value = 1234, currencyCode = "usd")),
+            selectionFlow = flowOf(cardSelection()),
+            customPrimaryButtonUiStateFlow = flowOf(null),
+        )
+
+        result.test {
+            assertThat(awaitItem()?.enabled).isTrue()
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `Disables button if selection is null`() = runTest {
+        val mapper = createMapper(isProcessingPayment = true)
+
+        val result = mapper.forCompleteFlow(
+            currentScreenFlow = flowOf(PaymentSheetScreen.SelectSavedPaymentMethods),
+            buttonsEnabledFlow = flowOf(true),
+            amountFlow = flowOf(Amount(value = 1234, currencyCode = "usd")),
+            selectionFlow = flowOf(null),
+            customPrimaryButtonUiStateFlow = flowOf(null),
+        )
+
+        result.test {
+            assertThat(awaitItem()?.enabled).isFalse()
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `Disables button if editing or processing, even if selection is not null`() = runTest {
+        val mapper = createMapper(isProcessingPayment = true)
+
+        val result = mapper.forCompleteFlow(
+            currentScreenFlow = flowOf(PaymentSheetScreen.SelectSavedPaymentMethods),
+            buttonsEnabledFlow = flowOf(false),
+            amountFlow = flowOf(Amount(value = 1234, currencyCode = "usd")),
+            selectionFlow = flowOf(cardSelection()),
+            customPrimaryButtonUiStateFlow = flowOf(null),
+        )
+
+        result.test {
+            assertThat(awaitItem()?.enabled).isFalse()
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `Hides button in complete flow if on a screen that isn't supposed to show it`() = runTest {
+        val mapper = createMapper(isProcessingPayment = true)
+
+        val result = mapper.forCompleteFlow(
+            currentScreenFlow = flowOf(PaymentSheetScreen.Loading),
+            buttonsEnabledFlow = flowOf(false),
+            amountFlow = flowOf(Amount(value = 1234, currencyCode = "usd")),
+            selectionFlow = flowOf(cardSelection()),
+            customPrimaryButtonUiStateFlow = flowOf(null),
+        )
+
+        result.test {
+            assertThat(awaitItem()).isNull()
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `Hides button in custom flow if on a screen that isn't supposed to show it`() = runTest {
+        val mapper = createMapper(isProcessingPayment = true)
+
+        val result = mapper.forCustomFlow(
+            currentScreenFlow = flowOf(PaymentSheetScreen.SelectSavedPaymentMethods),
+            buttonsEnabledFlow = flowOf(false),
+            selectionFlow = flowOf(cardSelection()),
+            customPrimaryButtonUiStateFlow = flowOf(null),
+        )
+
+        result.test {
+            assertThat(awaitItem()).isNull()
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `Shows button in custom flow if selected payment method requires confirmation`() = runTest {
+        val mapper = createMapper(isProcessingPayment = true)
+
+        val result = mapper.forCustomFlow(
+            currentScreenFlow = flowOf(PaymentSheetScreen.SelectSavedPaymentMethods),
+            buttonsEnabledFlow = flowOf(false),
+            selectionFlow = flowOf(usBankAccountSelection()),
+            customPrimaryButtonUiStateFlow = flowOf(null),
+        )
+
+        result.test {
+            assertThat(awaitItem()).isNotNull()
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `Shows lock icon correctly based on the flow type`() = runTest {
+        val mapper = createMapper(isProcessingPayment = true)
+
+        val resultWithLock = mapper.forCompleteFlow(
+            currentScreenFlow = flowOf(PaymentSheetScreen.SelectSavedPaymentMethods),
+            buttonsEnabledFlow = flowOf(false),
+            amountFlow = flowOf(Amount(value = 1234, currencyCode = "usd")),
+            selectionFlow = flowOf(usBankAccountSelection()),
+            customPrimaryButtonUiStateFlow = flowOf(null),
+        )
+
+        val resultWithoutLock = mapper.forCustomFlow(
+            currentScreenFlow = flowOf(PaymentSheetScreen.SelectSavedPaymentMethods),
+            buttonsEnabledFlow = flowOf(false),
+            selectionFlow = flowOf(usBankAccountSelection()),
+            customPrimaryButtonUiStateFlow = flowOf(null),
+        )
+
+        resultWithLock.test {
+            assertThat(awaitItem()?.lockVisible).isTrue()
+            awaitComplete()
+        }
+
+        resultWithoutLock.test {
+            assertThat(awaitItem()?.lockVisible).isFalse()
+            awaitComplete()
+        }
+    }
+
+    private fun createMapper(
+        isProcessingPayment: Boolean,
+        config: PaymentSheet.Configuration? = null,
+    ): PrimaryButtonUiStateMapper {
+        return PrimaryButtonUiStateMapper(
+            context = ApplicationProvider.getApplicationContext(),
+            config = config,
+            isProcessingPayment = isProcessingPayment,
+            onClick = {},
+        )
+    }
+
+    private fun cardSelection(): PaymentSelection {
+        return PaymentSelection.New.Card(
+            paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+            brand = CardBrand.Visa,
+            customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse
+        )
+    }
+
+    private fun usBankAccountSelection(): PaymentSelection {
+        return PaymentSelection.Saved(
+            paymentMethod = PaymentMethodFixtures.US_BANK_ACCOUNT,
+            isGooglePay = false,
+        )
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds a new `primaryButtonUiState` flow to `BaseSheetViewModel` and removes the old one.

Previously, we explicitly updated the flow’s value. Now, we observe every other flow that influences the `UiState`’s value and use a mapper to produce the correct value. A `PrimaryButtonUiStateMapperTest` helps us verify the correctness.

For now, we use two “special cases” for Link and US Bank Account. These unfortunately have special logic that isn’t present in `BaseSheetViewModel` yet, so we allow them to provide their own `UiState` instances that are prioritized over the “general” `UiState`.

A future improvement would be to move `PrimaryButton.State` (which describes the processing state and should probably be renamed accordingly) into `PrimaryButton.UiState`, but I’d like to leave this as a follow-up task for this already pretty large change. Similarly, we’d want to remove the special handling for Link and US Bank Account, but especially the latter requires a larger refactor.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Simpler data flow.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
