### PR TITLE
Make proguard work with financial connections.

### DIFF
--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsExampleViewModel.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsExampleViewModel.kt
@@ -3,8 +3,8 @@ package com.stripe.android.financialconnections.example
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
-import com.stripe.android.financialconnections.FinancialConnectionsSheetForTokenResult
 import com.stripe.android.financialconnections.FinancialConnectionsSheet
+import com.stripe.android.financialconnections.FinancialConnectionsSheetForTokenResult
 import com.stripe.android.financialconnections.FinancialConnectionsSheetResult
 import com.stripe.android.financialconnections.example.FinancialConnectionsExampleViewEffect.OpenFinancialConnectionsSheetExample
 import com.stripe.android.financialconnections.example.data.BackendRepository

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/BackendApiService.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/BackendApiService.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.example.data
 
+import androidx.annotation.Keep
 import com.google.gson.annotations.SerializedName
 import com.stripe.android.financialconnections.example.data.model.CreateIntentResponse
 import com.stripe.android.financialconnections.example.data.model.CreateLinkAccountSessionResponse
@@ -23,10 +24,13 @@ interface BackendApiService {
     ): CreateIntentResponse
 }
 
+@Keep
 data class LinkAccountSessionBody(
+    @SerializedName("flow")
     val flow: String?
 )
 
+@Keep
 data class PaymentIntentBody(
     @SerializedName("flow")
     val flow: String?,

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/model/CreateLinkAccountSessionResponse.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/model/CreateLinkAccountSessionResponse.kt
@@ -1,14 +1,16 @@
 package com.stripe.android.financialconnections.example.data.model
 
+import androidx.annotation.Keep
 import com.google.gson.annotations.SerializedName
 
+@Keep
 data class CreateLinkAccountSessionResponse(
     @SerializedName("client_secret") val clientSecret: String,
     @SerializedName("las_id") val lasId: String,
     @SerializedName("publishable_key") val publishableKey: String
 )
 
-
+@Keep
 data class CreateIntentResponse(
     @SerializedName("secret") val intentSecret: String,
     @SerializedName("publishable_key") val publishableKey: String

--- a/financial-connections/consumer-rules.txt
+++ b/financial-connections/consumer-rules.txt
@@ -1,0 +1,4 @@
+# We don't directly reference enum fields annotated with @Serializable
+-keep @kotlinx.serialization.Serializable enum com.stripe.android.financialconnections.** {
+    *;
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This is an incomplete diff, but makes financial connections work with proguard/R8.

Using consumer-rules.txt instead of proguard-rules.txt will happen here: #6227

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Proguard/R8!

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
