### PR TITLE
[stripe-ui-core] Fix the error of SectionController

### DIFF
--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionController.kt
@@ -17,7 +17,7 @@ class SectionController(
         sectionFieldErrorControllers.map {
             it.error
         }
-    ) {
-        it.firstOrNull()
+    ) { errorArray ->
+        errorArray.firstNotNullOfOrNull { it }
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
`it. firstOrNull` will return the first element if the array is not empty. However the array here is of type `Array<FieldError?>`, so it's possible that `array[0]` is null the error returns null.
Instead we should use `firstNotNullOfOrNull` to find the actual first non-null error

See the recording for a `SectionElement` with two subelements - before the fix when an error happens in the 2nd element, the sectionError will not trigger


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![errroTextBefore](https://user-images.githubusercontent.com/79880926/221698791-6c7b0052-561d-4a47-aa18-3f10f73d53a6.gif)  | ![errorTextAfter](https://user-images.githubusercontent.com/79880926/221698779-fc7a7e78-4ad4-4657-a0cf-9c0ea460f2ca.gif) |








# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
