### PR TITLE
Tweak the API for the decoupled flow

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
@@ -468,16 +468,11 @@ class PaymentSheetPlaygroundActivity : AppCompatActivity() {
                 }
             }
 
-            val initMode = PaymentSheet.InitializationMode.DeferredIntent(
+            paymentSheet.presentWithIntentConfiguration(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = mode,
-                    customer = viewModel.customerConfig.value?.id,
                     paymentMethodTypes = viewModel.paymentMethodTypes.value,
-                )
-            )
-
-            paymentSheet.present(
-                mode = initMode,
+                ),
                 configuration = makeConfiguration(),
             )
         }
@@ -550,17 +545,19 @@ class PaymentSheetPlaygroundActivity : AppCompatActivity() {
         if (viewModel.initializationType.value == InitializationType.Normal) {
             val clientSecret = viewModel.clientSecret.value ?: return
 
-            val mode = if (viewModel.checkoutMode.value == CheckoutMode.Payment) {
-                PaymentSheet.InitializationMode.PaymentIntent(clientSecret)
+            if (viewModel.checkoutMode.value == CheckoutMode.Payment) {
+                flowController.configureWithPaymentIntent(
+                    paymentIntentClientSecret = clientSecret,
+                    configuration = makeConfiguration(),
+                    callback = ::onConfigured,
+                )
             } else {
-                PaymentSheet.InitializationMode.SetupIntent(clientSecret)
+                flowController.configureWithSetupIntent(
+                    setupIntentClientSecret = clientSecret,
+                    configuration = makeConfiguration(),
+                    callback = ::onConfigured,
+                )
             }
-
-            flowController.configure(
-                mode = mode,
-                configuration = makeConfiguration(),
-                callback = ::onConfigured,
-            )
         } else {
             val mode = when (viewModel.checkoutMode.value) {
                 CheckoutMode.Setup -> {
@@ -584,16 +581,11 @@ class PaymentSheetPlaygroundActivity : AppCompatActivity() {
                 }
             }
 
-            val initMode = PaymentSheet.InitializationMode.DeferredIntent(
+            flowController.configureWithIntentConfiguration(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = mode,
-                    customer = viewModel.customerConfig.value?.id,
                     paymentMethodTypes = viewModel.paymentMethodTypes.value,
-                )
-            )
-
-            flowController.configure(
-                mode = initMode,
+                ),
                 configuration = makeConfiguration(),
                 callback = ::onConfigured,
             )

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -372,7 +372,7 @@ public abstract interface class com/stripe/android/paymentsheet/PaymentSheet$Flo
 }
 
 public final class com/stripe/android/paymentsheet/PaymentSheet$FlowController$DefaultImpls {
-	public static synthetic fun configure$default (Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController;Lcom/stripe/android/paymentsheet/PaymentSheet$InitializationMode;Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController$ConfigCallback;ILjava/lang/Object;)V
+	public static synthetic fun configureWithIntentConfiguration$default (Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController;Lcom/stripe/android/paymentsheet/PaymentSheet$IntentConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController$ConfigCallback;ILjava/lang/Object;)V
 	public static synthetic fun configureWithPaymentIntent$default (Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController$ConfigCallback;ILjava/lang/Object;)V
 	public static synthetic fun configureWithSetupIntent$default (Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Lcom/stripe/android/paymentsheet/PaymentSheet$FlowController$ConfigCallback;ILjava/lang/Object;)V
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -451,7 +451,10 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     override fun onPaymentResult(paymentResult: PaymentResult) {
         viewModelScope.launch {
             runCatching {
-                elementsSessionRepository.get(args.initializationMode)
+                elementsSessionRepository.get(
+                    initializationMode = args.initializationMode,
+                    configuration = args.config,
+                )
             }.fold(
                 onSuccess = { session ->
                     processPayment(session.stripeIntent, paymentResult)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -189,7 +189,19 @@ internal class DefaultFlowController @Inject internal constructor(
         )
     }
 
-    override fun configure(
+    override fun configureWithIntentConfiguration(
+        intentConfiguration: PaymentSheet.IntentConfiguration,
+        configuration: PaymentSheet.Configuration?,
+        callback: PaymentSheet.FlowController.ConfigCallback
+    ) {
+        configure(
+            mode = PaymentSheet.InitializationMode.DeferredIntent(intentConfiguration),
+            configuration = configuration,
+            callback = callback,
+        )
+    }
+
+    private fun configure(
         mode: PaymentSheet.InitializationMode,
         configuration: PaymentSheet.Configuration?,
         callback: PaymentSheet.FlowController.ConfigCallback

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -73,7 +73,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         val isGooglePayReady = isGooglePayReady(paymentSheetConfiguration)
 
         runCatching {
-            retrieveElementsSession(initializationMode)
+            retrieveElementsSession(initializationMode, paymentSheetConfiguration)
         }.fold(
             onSuccess = { stripeIntent ->
                 create(
@@ -222,8 +222,12 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
 
     private suspend fun retrieveElementsSession(
         initializationMode: PaymentSheet.InitializationMode,
+        configuration: PaymentSheet.Configuration?,
     ): StripeIntent {
-        val elementsSession = elementsSessionRepository.get(initializationMode)
+        val elementsSession = elementsSessionRepository.get(
+            initializationMode = initializationMode,
+            configuration = configuration,
+        )
         val lpmRepository = lpmResourceRepository.getRepository()
 
         lpmRepository.update(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -37,7 +37,6 @@ import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssisted
 import com.stripe.android.paymentsheet.PaymentOptionCallback
 import com.stripe.android.paymentsheet.PaymentOptionContract
 import com.stripe.android.paymentsheet.PaymentOptionResult
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.PaymentSheetResult
 import com.stripe.android.paymentsheet.PaymentSheetResultCallback
@@ -501,10 +500,8 @@ internal class DefaultFlowControllerTest {
 
     @Test
     fun `confirmPaymentSelection() with new card payment method should start paymentlauncher`() = runTest {
-        flowController.configure(
-            mode = PaymentSheet.InitializationMode.PaymentIntent(
-                clientSecret = PaymentSheetFixtures.CLIENT_SECRET,
-            ),
+        flowController.configureWithPaymentIntent(
+            paymentIntentClientSecret = PaymentSheetFixtures.CLIENT_SECRET,
             callback = { _, _ -> },
         )
 
@@ -532,10 +529,8 @@ internal class DefaultFlowControllerTest {
 
     @Test
     fun `confirmPaymentSelection() with generic payment method should start paymentLauncher`() {
-        flowController.configure(
-            mode = PaymentSheet.InitializationMode.PaymentIntent(
-                clientSecret = PaymentSheetFixtures.CLIENT_SECRET,
-            ),
+        flowController.configureWithPaymentIntent(
+            paymentIntentClientSecret = PaymentSheetFixtures.CLIENT_SECRET,
             callback = { _, _ -> },
         )
 
@@ -562,10 +557,8 @@ internal class DefaultFlowControllerTest {
 
     @Test
     fun `confirmPaymentSelection() with us_bank_account payment method should start paymentLauncher`() {
-        flowController.configure(
-            mode = PaymentSheet.InitializationMode.PaymentIntent(
-                clientSecret = PaymentSheetFixtures.CLIENT_SECRET,
-            ),
+        flowController.configureWithPaymentIntent(
+            paymentIntentClientSecret = PaymentSheetFixtures.CLIENT_SECRET,
             callback = { _, _ -> },
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
@@ -45,7 +45,8 @@ internal class ElementsSessionRepositoryTest {
             createRepository().get(
                 initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
                     clientSecret = "client_secret",
-                )
+                ),
+                configuration = null,
             )
         }
 
@@ -71,7 +72,8 @@ internal class ElementsSessionRepositoryTest {
                 createRepository().get(
                     initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
                         clientSecret = "client_secret",
-                    )
+                    ),
+                    configuration = null,
                 )
             }
 
@@ -94,7 +96,8 @@ internal class ElementsSessionRepositoryTest {
                 createRepository().get(
                     initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
                         clientSecret = "client_secret",
-                    )
+                    ),
+                    configuration = null,
                 )
             }
 
@@ -122,7 +125,8 @@ internal class ElementsSessionRepositoryTest {
         ).get(
             initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
                 clientSecret = "client_secret",
-            )
+            ),
+            configuration = null,
         )
 
         val argumentCaptor: KArgumentCaptor<ElementsSessionParams> = argumentCaptor()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request tweaks the API for the decoupled flow, including:
1. Removing `InitializationMode` from the (soon-to-be) public API and instead going with the existing `presentWith***` and `configureWith***` methods.
2. Moving `captureMethod` into `IntentConfiguration.Mode.Payment`.
3. Removing `customer` from `IntentConfiguration`, as we’ll be using the customer ID provided in `PaymentSheet.Configuration.CustomerConfiguration`.

cc @yuki-stripe

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
