### PR TITLE
Simplify primary button logic

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -21,7 +21,6 @@ import com.stripe.android.paymentsheet.injection.DaggerPaymentOptionsViewModelFa
 import com.stripe.android.paymentsheet.injection.PaymentOptionsViewModelSubcomponent
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.currency
-import com.stripe.android.paymentsheet.model.requiresConfirmation
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddFirstPaymentMethod
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.SelectSavedPaymentMethods

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Provider
@@ -80,6 +81,15 @@ internal class PaymentOptionsViewModel @Inject constructor(
     // Only used to determine if we should skip the list and go to the add card view.
     // and how to populate that view.
     override var newPaymentSelection = args.state.newPaymentSelection
+
+    val isPrimaryButtonVisible = combine(
+        currentScreen,
+        primaryButtonUIState,
+        selection,
+    ) { screen, uiState, selection ->
+        screen.showsContinueButton || uiState?.visible == true ||
+            selection?.requiresConfirmation == true
+    }
 
     init {
         savedStateHandle[SAVE_GOOGLE_PAY_STATE] = if (args.state.isGooglePayReady) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -29,7 +29,6 @@ import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.PaymentIntent
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethod.Type.Card
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
@@ -51,7 +50,6 @@ import com.stripe.android.paymentsheet.model.StripeIntentValidator
 import com.stripe.android.paymentsheet.model.create
 import com.stripe.android.paymentsheet.model.currency
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
-import com.stripe.android.paymentsheet.paymentdatacollection.ach.ACHText
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.paymentsheet.state.GooglePayState
@@ -362,23 +360,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     override fun handlePaymentMethodSelected(selection: PaymentSelection?) {
         if (!editing.value && selection != this.selection.value) {
             updateSelection(selection)
-        }
-    }
-
-    override fun updateSelection(selection: PaymentSelection?) {
-        super.updateSelection(selection)
-
-        when (selection) {
-            is PaymentSelection.Saved -> {
-                if (selection.paymentMethod.type == PaymentMethod.Type.USBankAccount) {
-                    updateBelowButtonText(
-                        ACHText.getContinueMandateText(getApplication())
-                    )
-                }
-            }
-            else -> {
-                // no-op
-            }
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
@@ -10,6 +10,7 @@ import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 internal sealed interface PaymentSheetScreen {
 
     val showsBuyButton: Boolean
+    val showsContinueButton: Boolean
 
     @Composable
     fun Content(viewModel: BaseSheetViewModel, modifier: Modifier)
@@ -17,6 +18,7 @@ internal sealed interface PaymentSheetScreen {
     object Loading : PaymentSheetScreen {
 
         override val showsBuyButton: Boolean = false
+        override val showsContinueButton: Boolean = false
 
         @Composable
         override fun Content(viewModel: BaseSheetViewModel, modifier: Modifier) {
@@ -27,6 +29,7 @@ internal sealed interface PaymentSheetScreen {
     object SelectSavedPaymentMethods : PaymentSheetScreen {
 
         override val showsBuyButton: Boolean = true
+        override val showsContinueButton: Boolean = false
 
         @Composable
         override fun Content(viewModel: BaseSheetViewModel, modifier: Modifier) {
@@ -37,6 +40,7 @@ internal sealed interface PaymentSheetScreen {
     object AddAnotherPaymentMethod : PaymentSheetScreen {
 
         override val showsBuyButton: Boolean = true
+        override val showsContinueButton: Boolean = true
 
         @Composable
         override fun Content(viewModel: BaseSheetViewModel, modifier: Modifier) {
@@ -47,6 +51,7 @@ internal sealed interface PaymentSheetScreen {
     object AddFirstPaymentMethod : PaymentSheetScreen {
 
         override val showsBuyButton: Boolean = true
+        override val showsContinueButton: Boolean = true
 
         @Composable
         override fun Content(viewModel: BaseSheetViewModel, modifier: Modifier) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -129,6 +129,7 @@ internal fun PaymentSheetScreenContent(
                 html = text,
                 color = MaterialTheme.stripeColors.subtitle,
                 style = MaterialTheme.typography.body1.copy(textAlign = TextAlign.Center),
+                modifier = Modifier.padding(top = 8.dp),
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButtonContainerFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButtonContainerFragment.kt
@@ -13,7 +13,6 @@ import com.stripe.android.paymentsheet.PaymentSheetViewModel
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.databinding.FragmentPrimaryButtonContainerBinding
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
-import com.stripe.android.paymentsheet.model.requiresConfirmation
 import com.stripe.android.paymentsheet.utils.launchAndCollectIn
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.uicore.StripeTheme

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButtonContainerFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButtonContainerFragment.kt
@@ -13,7 +13,7 @@ import com.stripe.android.paymentsheet.PaymentSheetViewModel
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.databinding.FragmentPrimaryButtonContainerBinding
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
-import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
+import com.stripe.android.paymentsheet.model.requiresConfirmation
 import com.stripe.android.paymentsheet.utils.launchAndCollectIn
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.uicore.StripeTheme
@@ -109,6 +109,7 @@ internal class PaymentSheetPrimaryButtonContainerFragment : BasePrimaryButtonCon
             getString(R.string.stripe_setup_button_label)
         }
 
+        viewBinding.primaryButton.isEnabled = viewModel.selection.value != null
         viewBinding.primaryButton.setLabel(label)
 
         viewBinding.primaryButton.setOnClickListener {
@@ -127,9 +128,9 @@ internal class PaymentOptionsPrimaryButtonContainerFragment : BasePrimaryButtonC
         setupPrimaryButton()
 
         viewModel.currentScreen.launchAndCollectIn(viewLifecycleOwner) { currentScreen ->
-            val visible = currentScreen is PaymentSheetScreen.AddFirstPaymentMethod ||
-                currentScreen is PaymentSheetScreen.AddAnotherPaymentMethod ||
-                viewModel.primaryButtonUIState.value?.visible == true
+            val visible = currentScreen.showsContinueButton ||
+                viewModel.primaryButtonUIState.value?.visible == true ||
+                viewModel.selection.value?.requiresConfirmation == true
 
             viewBinding?.primaryButton?.isVisible = visible
         }
@@ -144,6 +145,7 @@ internal class PaymentOptionsPrimaryButtonContainerFragment : BasePrimaryButtonC
         val customLabel = viewModel.config?.primaryButtonLabel
         val label = customLabel ?: getString(R.string.stripe_continue_button_label)
 
+        viewBinding.primaryButton.isEnabled = viewModel.selection.value != null
         viewBinding.primaryButton.setLabel(label)
 
         viewBinding.primaryButton.setOnClickListener {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButtonContainerFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PrimaryButtonContainerFragment.kt
@@ -126,12 +126,8 @@ internal class PaymentOptionsPrimaryButtonContainerFragment : BasePrimaryButtonC
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         setupPrimaryButton()
 
-        viewModel.currentScreen.launchAndCollectIn(viewLifecycleOwner) { currentScreen ->
-            val visible = currentScreen.showsContinueButton ||
-                viewModel.primaryButtonUIState.value?.visible == true ||
-                viewModel.selection.value?.requiresConfirmation == true
-
-            viewBinding?.primaryButton?.isVisible = visible
+        viewModel.isPrimaryButtonVisible.launchAndCollectIn(viewLifecycleOwner) { isVisible ->
+            viewBinding?.primaryButton?.isVisible = isVisible
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -29,7 +29,6 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.currency
 import com.stripe.android.paymentsheet.model.getPMsToAdd
-import com.stripe.android.paymentsheet.model.mandateText
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddAnotherPaymentMethod
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddFirstPaymentMethod

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -29,6 +29,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.currency
 import com.stripe.android.paymentsheet.model.getPMsToAdd
+import com.stripe.android.paymentsheet.model.mandateText
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddAnotherPaymentMethod
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddFirstPaymentMethod
@@ -397,14 +398,16 @@ internal abstract class BaseSheetViewModel(
 
     abstract fun handlePaymentMethodSelected(selection: PaymentSelection?)
 
-    open fun updateSelection(selection: PaymentSelection?) {
+    fun updateSelection(selection: PaymentSelection?) {
         if (selection is PaymentSelection.New) {
             newPaymentSelection = selection
         }
 
         savedStateHandle[SAVE_SELECTION] = selection
 
-        updateBelowButtonText(null)
+        val mandateText = selection?.mandateText(getApplication())
+        updateBelowButtonText(mandateText)
+
         clearErrorMessages()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -402,6 +402,23 @@ internal class PaymentOptionsViewModelTest {
         assertThat(viewModel.selection.value).isEqualTo(PaymentSelection.GooglePay)
     }
 
+    @Test
+    fun `Does not close the sheet if the selected payment method requires confirmation`() = runTest {
+        val selection = PaymentSelection.Saved(PaymentMethodFixtures.US_BANK_ACCOUNT)
+
+        val viewModel = createViewModel().apply { updateSelection(PaymentSelection.Link) }
+
+        viewModel.paymentOptionResult.test {
+            viewModel.handlePaymentMethodSelected(selection)
+            expectNoEvents()
+
+            viewModel.handlePaymentMethodSelected(PaymentSelection.Link)
+
+            val result = awaitItem() as? PaymentOptionResult.Succeeded
+            assertThat(result?.paymentSelection).isEqualTo(PaymentSelection.Link)
+        }
+    }
+
     private fun createViewModel(
         args: PaymentOptionContract.Args = PAYMENT_OPTION_CONTRACT_ARGS,
         linkState: LinkState? = args.state.linkState,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -419,6 +419,23 @@ internal class PaymentOptionsViewModelTest {
         }
     }
 
+    @Test
+    fun `Primary button is visible if the selected payment method requires confirmation`() = runTest {
+        val selection = PaymentSelection.Saved(PaymentMethodFixtures.US_BANK_ACCOUNT)
+
+        val viewModel = createViewModel().apply { updateSelection(PaymentSelection.Link) }
+
+        viewModel.isPrimaryButtonVisible.test {
+            assertThat(awaitItem()).isFalse()
+
+            viewModel.handlePaymentMethodSelected(selection)
+            assertThat(awaitItem()).isTrue()
+
+            viewModel.handlePaymentMethodSelected(PaymentSelection.Link)
+            assertThat(awaitItem()).isFalse()
+        }
+    }
+
     private fun createViewModel(
         args: PaymentOptionContract.Args = PAYMENT_OPTION_CONTRACT_ARGS,
         linkState: LinkState? = args.state.linkState,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request simplifies some logic around the primary button and prepares for bigger changes in https://github.com/stripe/stripe-android/pull/6260.

- Add `requiresConfirmation` to `PaymentSelection`. This determines if the sheet will stay open when the payment option that requires confirmation is being selected.
- Add `mandateText()` to `PaymentSelection` to remove the need for overriding `BaseSheetViewModel#updateSelection`.
- Add `showsContinueButton` in `PaymentSheetScreen` to avoid `is` checks.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Simpler data flow.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
