### PR TITLE
Cache FlowController elements/sessions call.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/ElementsSessionParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ElementsSessionParams.kt
@@ -16,7 +16,7 @@ sealed interface ElementsSessionParams : Parcelable {
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
-    class PaymentIntentType(
+    data class PaymentIntentType(
         override val clientSecret: String,
         override val locale: String? = Locale.getDefault().toLanguageTag(),
     ) : ElementsSessionParams {
@@ -30,7 +30,7 @@ sealed interface ElementsSessionParams : Parcelable {
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
-    class SetupIntentType(
+    data class SetupIntentType(
         override val clientSecret: String,
         override val locale: String? = Locale.getDefault().toLanguageTag(),
     ) : ElementsSessionParams {
@@ -44,7 +44,7 @@ sealed interface ElementsSessionParams : Parcelable {
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
-    class DeferredIntentType(
+    data class DeferredIntentType(
         override val locale: String? = Locale.getDefault().toLanguageTag(),
         val deferredIntentParams: DeferredIntentParams,
     ) : ElementsSessionParams {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -14,6 +14,7 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.path
+import com.stripe.android.networktesting.RequestMatchers.query
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG
 import org.junit.Rule
@@ -338,6 +339,147 @@ internal class PaymentSheetTest {
         }
 
         assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
+    }
+
+    @Test
+    fun testCustomFlowActivityRecreationDoesNotMakeSubsequentCallsToElementsSession() {
+        networkRule.enqueue(
+            method("GET"),
+            path("/v1/elements/sessions"),
+        ) { response ->
+            response.testBodyFromFile("elements-sessions-requires_payment_method.json")
+        }
+
+        val paymentOptionCallbackCountDownLatch = CountDownLatch(1)
+        val activityScenarioRule = composeTestRule.activityRule
+        val scenario = activityScenarioRule.scenario
+        lateinit var flowController: PaymentSheet.FlowController
+
+        fun initializeActivity() {
+            scenario.moveToState(Lifecycle.State.CREATED)
+            scenario.onActivity {
+                PaymentConfiguration.init(it, "pk_test_123")
+                flowController = PaymentSheet.FlowController.create(
+                    activity = it,
+                    paymentOptionCallback = { paymentOption ->
+                        assertThat(paymentOption?.label).endsWith("4242")
+                        paymentOptionCallbackCountDownLatch.countDown()
+                    },
+                    paymentResultCallback = {
+                        throw AssertionError("Not expected")
+                    },
+                )
+            }
+            scenario.moveToState(Lifecycle.State.RESUMED)
+        }
+
+        initializeActivity()
+        scenario.onActivity {
+            flowController.configureWithPaymentIntent(
+                paymentIntentClientSecret = "pi_example_secret_example",
+                configuration = null,
+                callback = { success, error ->
+                    assertThat(success).isTrue()
+                    assertThat(error).isNull()
+                    flowController.presentPaymentOptions()
+                }
+            )
+        }
+
+        composeTestRule.waitUntil {
+            composeTestRule.onAllNodes(hasText("+ Add"))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNode(hasText("+ Add"))
+            .onParent()
+            .onParent()
+            .performClick()
+
+        fillOutCard()
+
+        composeTestRule.onNode(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG))
+            .performScrollTo()
+            .performClick()
+
+        assertThat(paymentOptionCallbackCountDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
+
+        scenario.recreate()
+        initializeActivity()
+
+        val configureCallbackCountDownLatch = CountDownLatch(1)
+        scenario.onActivity {
+            flowController.configureWithPaymentIntent(
+                paymentIntentClientSecret = "pi_example_secret_example",
+                configuration = null,
+                callback = { success, error ->
+                    assertThat(success).isTrue()
+                    assertThat(error).isNull()
+                    assertThat(flowController.getPaymentOption()?.label).endsWith("4242")
+                    configureCallbackCountDownLatch.countDown()
+                }
+            )
+        }
+
+        assertThat(configureCallbackCountDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
+    }
+
+    @Test
+    fun testCustomFlowCallsElementsSessionsForSeparateConfiguredClientSecrets() {
+        val activityScenarioRule = composeTestRule.activityRule
+        val scenario = activityScenarioRule.scenario
+        lateinit var flowController: PaymentSheet.FlowController
+
+        scenario.moveToState(Lifecycle.State.CREATED)
+        scenario.onActivity {
+            PaymentConfiguration.init(it, "pk_test_123")
+            flowController = PaymentSheet.FlowController.create(
+                activity = it,
+                paymentOptionCallback = {
+                    throw AssertionError("Not expected")
+                },
+                paymentResultCallback = {
+                    throw AssertionError("Not expected")
+                },
+            )
+        }
+        scenario.moveToState(Lifecycle.State.RESUMED)
+
+        fun configureFlowController(paymentIntentClientSecret: String) {
+            val countDownLatch = CountDownLatch(1)
+
+            scenario.onActivity {
+                flowController.configureWithPaymentIntent(
+                    paymentIntentClientSecret = paymentIntentClientSecret,
+                    configuration = null,
+                    callback = { success, error ->
+                        assertThat(success).isTrue()
+                        assertThat(error).isNull()
+                        countDownLatch.countDown()
+                    }
+                )
+            }
+
+            assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
+        }
+
+        networkRule.enqueue(
+            method("GET"),
+            path("/v1/elements/sessions"),
+            query("client_secret", "pi_example_secret_example"),
+        ) { response ->
+            response.testBodyFromFile("elements-sessions-requires_payment_method.json")
+        }
+        configureFlowController("pi_example_secret_example")
+
+        networkRule.enqueue(
+            method("GET"),
+            path("/v1/elements/sessions"),
+            query("client_secret", "pi_example2_secret_example2"),
+        ) { response ->
+            response.testBodyFromFile("elements-sessions-requires_payment_method.json")
+        }
+        configureFlowController("pi_example2_secret_example2")
     }
 
     private fun fillOutCard() {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.flowcontroller
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import com.stripe.android.model.ElementsSessionParams
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.PaymentSheetState
@@ -13,6 +14,9 @@ internal class FlowControllerViewModel(
     var initializationMode: PaymentSheet.InitializationMode? = null
 
     var paymentSelection: PaymentSelection? = null
+
+    // Used to determine if we need to reload the flow controller configuration.
+    var previousElementsSessionParams: ElementsSessionParams? = null
 
     var state: PaymentSheetState.Full?
         get() = handle[STATE_KEY]

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
@@ -114,7 +114,7 @@ internal sealed class ElementsSessionRepository {
     }
 }
 
-private fun PaymentSheet.InitializationMode.toElementsSessionParams(
+internal fun PaymentSheet.InitializationMode.toElementsSessionParams(
     configuration: PaymentSheet.Configuration?,
 ): ElementsSessionParams {
     return when (this) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -73,7 +73,10 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         val isGooglePayReady = isGooglePayReady(paymentSheetConfiguration)
 
         runCatching {
-            retrieveElementsSession(initializationMode, paymentSheetConfiguration)
+            retrieveElementsSession(
+                initializationMode = initializationMode,
+                configuration = paymentSheetConfiguration,
+            )
         }.fold(
             onSuccess = { stripeIntent ->
                 create(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -21,6 +21,7 @@ internal object PaymentSheetFixtures {
 
     internal const val MERCHANT_DISPLAY_NAME = "Merchant, Inc."
     internal const val CLIENT_SECRET = "pi_1234_secret_1234"
+    internal const val DIFFERENT_CLIENT_SECRET = "pi_4321_secret_4321"
 
     internal val PAYMENT_INTENT_CLIENT_SECRET = PaymentIntentClientSecret(
         CLIENT_SECRET

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -294,7 +294,7 @@ internal class DefaultFlowControllerTest {
         paymentSheetLoader.updatePaymentMethods(emptyList())
 
         flowController.configureWithPaymentIntent(
-            PaymentSheetFixtures.CLIENT_SECRET,
+            PaymentSheetFixtures.DIFFERENT_CLIENT_SECRET,
             PaymentSheetFixtures.CONFIG_MINIMUM
         ) { _, _ ->
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Cache elements/session call in FlowControllerConfigurationHandler/FlowControllerViewModel

This is needed because the flow controller lifecycle is tied to the application developers activity, unlike the activity we use internally for PaymentSheet.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Lifecycle Handling Project

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified


