### PR TITLE
Add kotlin 1.6 compatibility to SDKs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### PaymentSheet
 * [ADDED][6283](https://github.com/stripe/stripe-android/pull/6283) Added support for Zip payments.
 
+### All SDKs
+[FIXED][6316](https://github.com/stripe/stripe-android/pull/6316) No longer requiring Kotlin 1.8 compiler.
+
 ## 20.19.4 - 2023-02-27
 
 ### StripeCardScan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * [ADDED][6283](https://github.com/stripe/stripe-android/pull/6283) Added support for Zip payments.
 
 ### All SDKs
-[FIXED][6316](https://github.com/stripe/stripe-android/pull/6316) No longer requiring Kotlin 1.8 compiler.
+* [FIXED][6316](https://github.com/stripe/stripe-android/pull/6316) No longer requiring Kotlin 1.8 compiler.
 
 ## 20.19.4 - 2023-02-27
 

--- a/build-configuration/android-library.gradle
+++ b/build-configuration/android-library.gradle
@@ -63,6 +63,8 @@ android {
 
     kotlinOptions {
         jvmTarget = "11"
+        apiVersion = "1.6"
+        languageVersion = "1.6"
     }
 
     kotlin {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Keep compiling with kotlin 1.8, but keep compatibility at 1.6.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://github.com/stripe/stripe-android/pull/6158 caused some grief with kotlin breaking changes. 

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

[FIXED][6316](https://github.com/stripe/stripe-android/pull/6316) No longer requiring Kotlin 1.8 compiler.