### PR TITLE
Fix an issue where the primary button got extra wide on configuration changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 2023-XX-XX
 
+### PaymentSheet
+* [FIXED][63260](https://github.com/stripe/stripe-android/pull/6326) Fixed and issue where the pay button would lose it's padding on configuration changes.
+
 ## 20.19.5 - 2023-03-06
 
 ### Payments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## XX.XX.XX - 2023-XX-XX
 
 ### PaymentSheet
-* [FIXED][63260](https://github.com/stripe/stripe-android/pull/6326) Fixed and issue where the pay button would lose it's padding on configuration changes.
+* [FIXED][6326](https://github.com/stripe/stripe-android/pull/6326) Fixed an issue where the primary button would lose its padding on configuration changes.
 
 ## 20.19.5 - 2023-03-06
 

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -1072,7 +1072,7 @@ public final class com/stripe/android/paymentsheet/databinding/FragmentPrimaryBu
 	public final field primaryButton Lcom/stripe/android/paymentsheet/ui/PrimaryButton;
 	public static fun bind (Landroid/view/View;)Lcom/stripe/android/paymentsheet/databinding/FragmentPrimaryButtonContainerBinding;
 	public synthetic fun getRoot ()Landroid/view/View;
-	public fun getRoot ()Lcom/stripe/android/paymentsheet/ui/PrimaryButton;
+	public fun getRoot ()Landroid/widget/FrameLayout;
 	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/stripe/android/paymentsheet/databinding/FragmentPrimaryButtonContainerBinding;
 	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/stripe/android/paymentsheet/databinding/FragmentPrimaryButtonContainerBinding;
 }

--- a/paymentsheet/res/layout/fragment_primary_button_container.xml
+++ b/paymentsheet/res/layout/fragment_primary_button_container.xml
@@ -1,10 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.stripe.android.paymentsheet.ui.PrimaryButton xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/primary_button"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/stripe_paymentsheet_primary_button_height"
-    android:layout_marginTop="@dimen/stripe_paymentsheet_button_container_spacing"
-    android:layout_marginStart="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
-    android:layout_marginEnd="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
-    android:text="@string/stripe_paymentsheet_pay_button_label"
-    android:visibility="gone" />
+    android:layout_height="wrap_content">
+    <!-- Needs to be wrapped in a FrameLayout to prevent layout issues after configuration changes. -->
+
+    <com.stripe.android.paymentsheet.ui.PrimaryButton
+        android:id="@+id/primary_button"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/stripe_paymentsheet_primary_button_height"
+        android:layout_marginTop="@dimen/stripe_paymentsheet_button_container_spacing"
+        android:layout_marginStart="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
+        android:layout_marginEnd="@dimen/stripe_paymentsheet_outer_spacing_horizontal"
+        android:text="@string/stripe_paymentsheet_pay_button_label"
+        android:visibility="gone" />
+</FrameLayout>


### PR DESCRIPTION
# Summary
When causing a configuration change (I did it by changing from light theme to dark theme), the primary button would lose it's margin. This change wraps the primary button in a `FrameLayout` so the layout params of the PrimaryButton aren't lost.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
It was a bug! 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |
| <img src="https://user-images.githubusercontent.com/116920913/223242205-ce16fc41-1383-466e-aac4-316b2d101f71.png"  width = 360px > |  <img src="https://user-images.githubusercontent.com/116920913/223242260-0ffa2cb3-f22a-42ee-86a6-6753ebee3725.png"  width = 360px > |

