### PR TITLE
Add CreateIntentCallback

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -369,6 +369,12 @@ public abstract interface class com/stripe/android/IssuingCardPinService$Listene
 	public abstract fun onError (Lcom/stripe/android/IssuingCardPinService$CardPinActionError;Ljava/lang/String;Ljava/lang/Throwable;)V
 }
 
+public final class com/stripe/android/LegacyCreateIntentCallback$DefaultImpls {
+}
+
+public final class com/stripe/android/LegacyCreateIntentCallbackForServerSideConfirmation$DefaultImpls {
+}
+
 public final class com/stripe/android/PayWithGoogleUtils {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/PayWithGoogleUtils;
@@ -990,6 +996,9 @@ public final class com/stripe/android/StripeApiBeta : java/lang/Enum {
 	public final fun getCode ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/StripeApiBeta;
 	public static fun values ()[Lcom/stripe/android/StripeApiBeta;
+}
+
+public abstract interface annotation class com/stripe/android/StripeDeferredIntentCreationBetaApi : java/lang/annotation/Annotation {
 }
 
 public abstract class com/stripe/android/StripeIntentResult : com/stripe/android/core/model/StripeModel {

--- a/payments-core/src/main/java/com/stripe/android/CreateIntentCallback.kt
+++ b/payments-core/src/main/java/com/stripe/android/CreateIntentCallback.kt
@@ -1,0 +1,161 @@
+package com.stripe.android
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.CreateIntentCallback.Result
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+@StripeDeferredIntentCreationBetaApi
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun interface CreateIntentCallback {
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    sealed interface Result {
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        data class Success(val clientSecret: String) : Result
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        data class Failure(val error: Throwable) : Result
+    }
+
+    /**
+     * 🚧 Under construction 🚧
+     * Called when the customer confirms payment.
+     * Your implementation should create and confirm a [PaymentIntent] or [SetupIntent] on your
+     * server and call [onIntentCreated] with its client secret or an error if one occurred.
+     *
+     * Note: You must create the PaymentIntent or SetupIntent with the same values used as the
+     * `IntentConfiguration` e.g. the same amount, currency, etc.
+     *
+     * @param paymentMethodId the payment method ID to create the intent with
+     *
+     * @return a [Result] which contains the intent client secret
+     */
+    suspend fun onIntentCreated(
+        paymentMethodId: String,
+    ): Result
+}
+
+/**
+ * 🚧 Under construction 🚧
+ * The legacy version of the [CreateIntentCallback]. Callback style interface with java support.
+ */
+@StripeDeferredIntentCreationBetaApi
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun interface LegacyCreateIntentCallback : CreateIntentCallback {
+
+    /**
+     * 🚧 Under construction 🚧
+     * Called when the customer confirms payment.
+     * Your implementation should create and confirm a [PaymentIntent] or [SetupIntent] on your
+     * server and call [onIntentCreated] with its client secret or an error if one occurred.
+     *
+     * Note: You must create the PaymentIntent or SetupIntent with the same values used as the
+     * `IntentConfiguration` e.g. the same amount, currency, etc.
+     *
+     * @param paymentMethodId the payment method ID to create the intent with
+     *
+     * @return a [Result] which contains the intent client secret
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    override suspend fun onIntentCreated(paymentMethodId: String): Result {
+        return suspendCoroutine { continuation ->
+            onIntentCreated(
+                paymentMethodId = paymentMethodId,
+                resultListener = continuation::resume,
+            )
+        }
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun onIntentCreated(
+        paymentMethodId: String,
+        resultListener: ResultListener,
+    )
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun interface ResultListener {
+        fun onResult(result: Result)
+    }
+}
+
+@StripeDeferredIntentCreationBetaApi
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun interface CreateIntentCallbackForServerSideConfirmation {
+
+    /**
+     * 🚧 Under construction 🚧
+     * For advanced users who need server-side confirmation.
+     * Called when the customer confirms payment.
+     * Your implementation should create and confirm a [PaymentIntent] or [SetupIntent] on your
+     * server and call [onIntentCreated] with its client secret or an error if one occurred.
+     *
+     * Note: You must create the PaymentIntent or SetupIntent with the same values used as the
+     * `IntentConfiguration` e.g. the same amount, currency, etc.
+     *
+     * @param paymentMethodId the payment method ID to create the intent with
+     * @param customerRequestedSave whether or not the customer requested to save the payment
+     * method. This is true if the customer selected the "Save this payment method for future use"
+     * checkbox.
+     *
+     * @return a [Result] which contains the intent client secret
+     */
+    suspend fun onIntentCreated(
+        paymentMethodId: String,
+        customerRequestedSave: Boolean,
+    ): Result
+}
+
+/**
+ * 🚧 Under construction 🚧
+ * The legacy version of the [CreateIntentCallbackForServerSideConfirmation].
+ * Callback style interface with java support.
+ */
+@StripeDeferredIntentCreationBetaApi
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun interface LegacyCreateIntentCallbackForServerSideConfirmation : CreateIntentCallbackForServerSideConfirmation {
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    override suspend fun onIntentCreated(
+        paymentMethodId: String,
+        customerRequestedSave: Boolean
+    ): Result {
+        return suspendCoroutine { continuation ->
+            onIntentCreated(
+                paymentMethodId = paymentMethodId,
+                customerRequestedSave = customerRequestedSave,
+                resultListener = continuation::resume,
+            )
+        }
+    }
+
+    /**
+     * 🚧 Under construction 🚧
+     * For advanced users who need server-side confirmation.
+     * Called when the customer confirms payment.
+     * Your implementation should create and confirm a [PaymentIntent] or [SetupIntent] on your
+     * server and call [onIntentCreated] with its client secret or an error if one occurred.
+     *
+     * Note: You must create the PaymentIntent or SetupIntent with the same values used as the
+     * `IntentConfiguration` e.g. the same amount, currency, etc.
+     *
+     * @param paymentMethodId the payment method ID to create the intent with
+     * @param customerRequestedSave whether or not the customer requested to save the payment
+     * method. This is true if the customer selected the "Save this payment method for future use"
+     * checkbox.
+     *
+     * @return a [Result] which contains the intent client secret
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun onIntentCreated(
+        paymentMethodId: String,
+        customerRequestedSave: Boolean,
+        resultListener: ResultListener,
+    )
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun interface ResultListener {
+        fun onResult(result: Result)
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/StripeDeferredIntentCreationBetaApi.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripeDeferredIntentCreationBetaApi.kt
@@ -1,0 +1,5 @@
+package com.stripe.android
+
+@Retention(AnnotationRetention.BINARY)
+@RequiresOptIn("This API is experimental and may change in the future.")
+annotation class StripeDeferredIntentCreationBetaApi

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncher.kt
@@ -76,6 +76,34 @@ internal class DefaultPaymentSheetLauncher(
         fragment.requireActivity().application
     )
 
+    @Suppress("UnusedPrivateMember")
+    internal constructor(
+        activity: ComponentActivity,
+        callback: PaymentSheetResultCallback,
+        deferredIntentCallback: DeferredIntentCallback
+    ) : this(
+        activity.registerForActivityResult(
+            PaymentSheetContractV2()
+        ) {
+            callback.onPaymentSheetResult(it)
+        },
+        activity.application
+    )
+
+    @Suppress("UnusedPrivateMember")
+    internal constructor(
+        fragment: Fragment,
+        callback: PaymentSheetResultCallback,
+        deferredIntentCallback: DeferredIntentCallback
+    ) : this(
+        fragment.registerForActivityResult(
+            PaymentSheetContractV2()
+        ) {
+            callback.onPaymentSheetResult(it)
+        },
+        fragment.requireActivity().application
+    )
+
     override fun present(
         mode: PaymentSheet.InitializationMode,
         configuration: PaymentSheet.Configuration?

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DeferredIntentCallback.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DeferredIntentCallback.kt
@@ -1,0 +1,12 @@
+package com.stripe.android.paymentsheet
+
+import com.stripe.android.CreateIntentCallback
+import com.stripe.android.StripeDeferredIntentCreationBetaApi
+
+@OptIn(StripeDeferredIntentCreationBetaApi::class)
+internal fun interface DeferredIntentCallback {
+    suspend fun onIntentCreated(
+        paymentMethodId: String,
+        customerRequestedSave: Boolean,
+    ): CreateIntentCallback.Result
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -10,6 +10,9 @@ import androidx.annotation.RestrictTo
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.fragment.app.Fragment
+import com.stripe.android.CreateIntentCallback
+import com.stripe.android.CreateIntentCallbackForServerSideConfirmation
+import com.stripe.android.StripeDeferredIntentCreationBetaApi
 import com.stripe.android.link.account.CookieStore
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
@@ -52,6 +55,104 @@ class PaymentSheet internal constructor(
         callback: PaymentSheetResultCallback
     ) : this(
         DefaultPaymentSheetLauncher(fragment, callback)
+    )
+
+    /**
+     * 🚧 Under construction 🚧
+     * Constructor to be used when launching payment sheet with the deferred intent flow.
+     *
+     * @param activity  the Activity that is presenting the payment sheet.
+     * @param createIntentCallback called when the customer confirms payment.
+     * @param resultCallback  called with the result of the payment after the payment sheet is
+     * dismissed.
+     */
+    @StripeDeferredIntentCreationBetaApi
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    constructor(
+        activity: ComponentActivity,
+        createIntentCallback: CreateIntentCallback,
+        resultCallback: PaymentSheetResultCallback
+    ) : this(
+        DefaultPaymentSheetLauncher(activity, resultCallback) { paymentMethodId, _ ->
+            createIntentCallback.onIntentCreated(paymentMethodId)
+        }
+    )
+
+    /**
+     * 🚧 Under construction 🚧
+     * Constructor to be used when launching payment sheet with the deferred intent flow.
+     *
+     * @param fragment  the Fragment that is presenting the payment sheet.
+     * @param createIntentCallback called when the customer confirms payment.
+     * @param resultCallback  called with the result of the payment after the payment sheet is
+     * dismissed.
+     */
+    @StripeDeferredIntentCreationBetaApi
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    constructor(
+        fragment: Fragment,
+        createIntentCallback: CreateIntentCallback,
+        resultCallback: PaymentSheetResultCallback
+    ) : this(
+        DefaultPaymentSheetLauncher(fragment, resultCallback) { paymentMethodId, _ ->
+            createIntentCallback.onIntentCreated(paymentMethodId)
+        }
+    )
+
+    /**
+     * 🚧 Under construction 🚧
+     * For advanced users who need server-side confirmation.
+     * Constructor to be used when launching payment sheet with the deferred intent flow.
+     *
+     * @param activity  the Activity that is presenting the payment sheet.
+     * @param serverSideConfirmCreateIntentCallback called when the customer confirms payment.
+     * @param resultCallback  called with the result of the payment after the payment sheet is
+     * dismissed.
+     */
+    @StripeDeferredIntentCreationBetaApi
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    constructor(
+        activity: ComponentActivity,
+        serverSideConfirmCreateIntentCallback: CreateIntentCallbackForServerSideConfirmation,
+        resultCallback: PaymentSheetResultCallback
+    ) : this(
+        DefaultPaymentSheetLauncher(
+            activity,
+            resultCallback
+        ) { paymentMethodId, customerRequestedSave ->
+            serverSideConfirmCreateIntentCallback.onIntentCreated(
+                paymentMethodId,
+                customerRequestedSave
+            )
+        }
+    )
+
+    /**
+     * 🚧 Under construction 🚧
+     * For advanced users who need server-side confirmation.
+     * Constructor to be used when launching payment sheet with the deferred intent flow.
+     *
+     * @param fragment  the Fragment that is presenting the payment sheet.
+     * @param serverSideConfirmCreateIntentCallback called when the customer confirms payment.
+     * @param resultCallback  called with the result of the payment after the payment sheet is
+     * dismissed.
+     */
+    @StripeDeferredIntentCreationBetaApi
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    constructor(
+        fragment: Fragment,
+        serverSideConfirmCreateIntentCallback: CreateIntentCallbackForServerSideConfirmation,
+        resultCallback: PaymentSheetResultCallback
+    ) : this(
+        DefaultPaymentSheetLauncher(
+            fragment,
+            resultCallback
+        ) { paymentMethodId, customerRequestedSave ->
+            serverSideConfirmCreateIntentCallback.onIntentCreated(
+                paymentMethodId,
+                customerRequestedSave
+            )
+        }
     )
 
     /**
@@ -953,6 +1054,134 @@ class PaymentSheet internal constructor(
                     paymentOptionCallback,
                     paymentResultCallback
                 ).create()
+            }
+
+            /**
+             * 🚧 Under construction 🚧
+             * Create the FlowController when launching the payment sheet from an Activity.
+             *
+             * @param activity  the Activity that is presenting the payment sheet.
+             * @param createIntentCallback Called after you call [FlowController.confirm].
+             * @param paymentOptionCallback called when the customer's desired payment method
+             * changes. Called in response to the [FlowController.presentPaymentOptions]
+             * @param paymentResultCallback called when a [PaymentSheetResult] is available.
+             */
+            @OptIn(StripeDeferredIntentCreationBetaApi::class)
+            @JvmStatic
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            fun create(
+                activity: ComponentActivity,
+                createIntentCallback: CreateIntentCallback,
+                paymentOptionCallback: PaymentOptionCallback,
+                paymentResultCallback: PaymentSheetResultCallback
+            ): FlowController {
+                return FlowControllerFactory(
+                    activity,
+                    paymentOptionCallback,
+                    paymentResultCallback
+                ) { paymentMethodId, _ ->
+                    createIntentCallback.onIntentCreated(
+                        paymentMethodId
+                    )
+                }.create()
+            }
+
+            /**
+             * 🚧 Under construction 🚧
+             * Create the FlowController when launching the payment sheet from a Fragment.
+             *
+             * @param fragment the Fragment that is presenting the payment sheet.
+             * @param createIntentCallback Called after you call [FlowController.confirm].
+             * @param paymentOptionCallback called when the customer's desired payment method
+             * changes. Called in response to the [FlowController.presentPaymentOptions]
+             * @param paymentResultCallback called when a [PaymentSheetResult] is available.
+             */
+            @OptIn(StripeDeferredIntentCreationBetaApi::class)
+            @JvmStatic
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            fun create(
+                fragment: Fragment,
+                createIntentCallback: CreateIntentCallback,
+                paymentOptionCallback: PaymentOptionCallback,
+                paymentResultCallback: PaymentSheetResultCallback
+            ): FlowController {
+                return FlowControllerFactory(
+                    fragment,
+                    paymentOptionCallback,
+                    paymentResultCallback
+                ) { paymentMethodId, _ ->
+                    createIntentCallback.onIntentCreated(
+                        paymentMethodId
+                    )
+                }.create()
+            }
+
+            /**
+             * 🚧 Under construction 🚧
+             * For advanced users who need server-side confirmation.
+             * Create the FlowController when launching the payment sheet from an Activity.
+             *
+             * @param activity  the Activity that is presenting the payment sheet.
+             * @param serverSideConfirmCreateIntentCallback Called after you call
+             * [FlowController.confirm].
+             * @param paymentOptionCallback called when the customer's desired payment method
+             * changes. Called in response to the [FlowController.presentPaymentOptions]
+             * @param paymentResultCallback called when a [PaymentSheetResult] is available.
+             */
+            @OptIn(StripeDeferredIntentCreationBetaApi::class)
+            @JvmStatic
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            fun create(
+                activity: ComponentActivity,
+                serverSideConfirmCreateIntentCallback:
+                    CreateIntentCallbackForServerSideConfirmation,
+                paymentOptionCallback: PaymentOptionCallback,
+                paymentResultCallback: PaymentSheetResultCallback
+            ): FlowController {
+                return FlowControllerFactory(
+                    activity,
+                    paymentOptionCallback,
+                    paymentResultCallback
+                ) { paymentMethodId, customerRequestedSave ->
+                    serverSideConfirmCreateIntentCallback.onIntentCreated(
+                        paymentMethodId,
+                        customerRequestedSave
+                    )
+                }.create()
+            }
+
+            /**
+             * 🚧 Under construction 🚧
+             * For advanced users who need server-side confirmation.
+             * Create the FlowController when launching the payment sheet from a Fragment.
+             *
+             * @param fragment the Fragment that is presenting the payment sheet.
+             * @param serverSideConfirmCreateIntentCallback Called after you call
+             * [FlowController.confirm].
+             * @param paymentOptionCallback called when the customer's desired payment method
+             * changes. Called in response to the [FlowController.presentPaymentOptions]
+             * @param paymentResultCallback called when a [PaymentSheetResult] is available.
+             */
+            @OptIn(StripeDeferredIntentCreationBetaApi::class)
+            @JvmStatic
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            fun create(
+                fragment: Fragment,
+                serverSideConfirmCreateIntentCallback:
+                    CreateIntentCallbackForServerSideConfirmation,
+                paymentOptionCallback: PaymentOptionCallback,
+                paymentResultCallback: PaymentSheetResultCallback
+            ): FlowController {
+                return FlowControllerFactory(
+                    fragment,
+                    paymentOptionCallback,
+                    paymentResultCallback
+                ) { paymentMethodId, customerRequestedSave ->
+                    serverSideConfirmCreateIntentCallback.onIntentCreated(
+                        paymentMethodId,
+                        customerRequestedSave
+                    )
+                }.create()
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerFactory.kt
@@ -5,6 +5,7 @@ import androidx.activity.result.ActivityResultCaller
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelStoreOwner
+import com.stripe.android.paymentsheet.DeferredIntentCallback
 import com.stripe.android.paymentsheet.PaymentOptionCallback
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResultCallback
@@ -34,6 +35,36 @@ internal class FlowControllerFactory(
         fragment: Fragment,
         paymentOptionCallback: PaymentOptionCallback,
         paymentResultCallback: PaymentSheetResultCallback
+    ) : this(
+        viewModelStoreOwner = fragment,
+        lifecycleOwner = fragment,
+        activityResultCaller = fragment,
+        statusBarColor = { fragment.activity?.window?.statusBarColor },
+        paymentOptionCallback = paymentOptionCallback,
+        paymentResultCallback = paymentResultCallback,
+    )
+
+    @Suppress("UnusedPrivateMember")
+    internal constructor(
+        activity: ComponentActivity,
+        paymentOptionCallback: PaymentOptionCallback,
+        paymentResultCallback: PaymentSheetResultCallback,
+        deferredIntentCallback: DeferredIntentCallback
+    ) : this(
+        viewModelStoreOwner = activity,
+        lifecycleOwner = activity,
+        activityResultCaller = activity,
+        statusBarColor = { activity.window.statusBarColor },
+        paymentOptionCallback = paymentOptionCallback,
+        paymentResultCallback = paymentResultCallback,
+    )
+
+    @Suppress("UnusedPrivateMember")
+    internal constructor(
+        fragment: Fragment,
+        paymentOptionCallback: PaymentOptionCallback,
+        paymentResultCallback: PaymentSheetResultCallback,
+        deferredIntentCallback: DeferredIntentCallback
     ) : this(
         viewModelStoreOwner = fragment,
         lifecycleOwner = fragment,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

- Add `CreateIntentCallback`
- Add placeholder constructors for `DefaultPaymentSheetLauncher` and `FlowControllerFactory`. This will be updated in a future PR to handle dagger graph changes
- Add internal `DeferredIntentCallback` a shim to allow easier interfacing when injecting and using this callback internally where payment sheet calls the merchants server

# Usage

Kotlin + Suspend

```kotlin
val clientCreateIntentCallback = CreateIntentCallback {
    CreateIntent.Result.Success("client secret")
}

val serverCreateIntentCallback = CreateIntentCallbackForServerSideConfirmation { paymentMethodId, customerRequestedSave ->
    CreateIntent.Result.Success("client secret")
}
```

Java

```java
public class JavaPlaygroundActivity extends AppCompatActivity {
    @Override
    @StripeDeferredIntentCreationBetaApi
    protected void onCreate(@Nullable Bundle savedInstanceState) {
        super.onCreate(savedInstanceState);

        LegacyCreateIntentCallback clientCallback = (paymentMethodId, resultListener) -> {
            // if success
            resultListener.onResult(
                    new CreateIntentCallback.Result.Success("client secret")
            );

            // if failure
            resultListener.onResult(
                    new CreateIntentCallback.Result.Failure(new Exception("something went wrong"))
            );
        };

        LegacyCreateIntentCallbackForServerSideConfirmation serverCallback = (paymentMethodId, customerRequestedSave, resultListener) -> {
            // if success
            resultListener.onResult(
                    new CreateIntentCallback.Result.Success("client secret")
            );

            // if failure
            resultListener.onResult(
                    new CreateIntentCallback.Result.Failure(new Exception("something went wrong"))
            );
        };
    }
}
```
