### PR TITLE
Add `CreateIntentCallback` to PaymentSheet

### DIFF
--- a/payments-core/src/test/java/com/stripe/android/DefaultIntentConfirmationInterceptorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/DefaultIntentConfirmationInterceptorTest.kt
@@ -34,8 +34,6 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeAccountIdProvider = { null },
         )
 
-        IntentConfirmationInterceptor.createIntentCallback = null
-
         val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
 
         val nextStep = interceptor.intercept(
@@ -50,6 +48,7 @@ class DefaultIntentConfirmationInterceptorTest {
 
         assertThat(confirmParams?.paymentMethodId).isEqualTo(paymentMethod.id)
         assertThat(confirmParams?.paymentMethodCreateParams).isNull()
+        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNull()
     }
 
     @Test
@@ -60,8 +59,6 @@ class DefaultIntentConfirmationInterceptorTest {
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
         )
-
-        IntentConfirmationInterceptor.createIntentCallback = null
 
         val createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD
 
@@ -77,6 +74,7 @@ class DefaultIntentConfirmationInterceptorTest {
 
         assertThat(confirmParams?.paymentMethodId).isNull()
         assertThat(confirmParams?.paymentMethodCreateParams).isEqualTo(createParams)
+        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNull()
     }
 
     @Test
@@ -87,8 +85,6 @@ class DefaultIntentConfirmationInterceptorTest {
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
         )
-
-        IntentConfirmationInterceptor.createIntentCallback = null
 
         val error = assertFailsWith<IllegalStateException> {
             interceptor.intercept(
@@ -102,6 +98,7 @@ class DefaultIntentConfirmationInterceptorTest {
         assertThat(error.message).isEqualTo(
             "CreateIntentCallback must be implemented when using IntentConfiguration with PaymentSheet"
         )
+        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNull()
     }
 
     @Test
@@ -113,8 +110,6 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeAccountIdProvider = { null },
         )
 
-        IntentConfirmationInterceptor.createIntentCallback = null
-
         val nextStep = interceptor.intercept(
             clientSecret = null,
             paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
@@ -123,6 +118,7 @@ class DefaultIntentConfirmationInterceptorTest {
         )
 
         assertThat(nextStep).isInstanceOf(IntentConfirmationInterceptor.NextStep.Fail::class.java)
+        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNull()
     }
 
     @Test
@@ -145,8 +141,6 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeAccountIdProvider = { null },
         )
 
-        IntentConfirmationInterceptor.createIntentCallback = null
-
         val nextStep = interceptor.intercept(
             clientSecret = null,
             paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
@@ -155,6 +149,7 @@ class DefaultIntentConfirmationInterceptorTest {
         )
 
         assertThat(nextStep).isInstanceOf(IntentConfirmationInterceptor.NextStep.Fail::class.java)
+        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNull()
     }
 
     @Test
@@ -188,6 +183,7 @@ class DefaultIntentConfirmationInterceptorTest {
         )
 
         assertThat(nextStep).isInstanceOf(IntentConfirmationInterceptor.NextStep.Fail::class.java)
+        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNull()
     }
 
     @Test
@@ -209,6 +205,7 @@ class DefaultIntentConfirmationInterceptorTest {
         )
 
         assertThat(nextStep).isInstanceOf(IntentConfirmationInterceptor.NextStep.Fail::class.java)
+        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNull()
     }
 
     @Test
@@ -230,6 +227,7 @@ class DefaultIntentConfirmationInterceptorTest {
         )
 
         assertThat(nextStep).isInstanceOf(IntentConfirmationInterceptor.NextStep.Fail::class.java)
+        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNull()
     }
 
     @Test
@@ -254,6 +252,7 @@ class DefaultIntentConfirmationInterceptorTest {
         )
 
         assertThat(nextStep).isInstanceOf(IntentConfirmationInterceptor.NextStep.Confirm::class.java)
+        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNull()
     }
 
     @Test
@@ -286,6 +285,7 @@ class DefaultIntentConfirmationInterceptorTest {
         )
 
         assertThat(nextStep).isInstanceOf(IntentConfirmationInterceptor.NextStep.Complete::class.java)
+        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNull()
     }
 
     @Test
@@ -322,6 +322,7 @@ class DefaultIntentConfirmationInterceptorTest {
         assertThat(nextStep).isEqualTo(
             IntentConfirmationInterceptor.NextStep.HandleNextAction("pi_123_secret_456")
         )
+        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNull()
     }
 
     @Test
@@ -336,12 +337,6 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeAccountIdProvider = { null },
         )
 
-        IntentConfirmationInterceptor.createIntentCallback =
-            CreateIntentCallbackForServerSideConfirmation { paymentMethodId, shouldSavePaymentMethod ->
-                observedValues += shouldSavePaymentMethod
-                CreateIntentCallback.Result.Success("pi_123_secret_456")
-            }
-
         val inputs = listOf(
             null,
             ConfirmPaymentIntentParams.SetupFutureUsage.Blank,
@@ -350,6 +345,11 @@ class DefaultIntentConfirmationInterceptorTest {
         )
 
         for (input in inputs) {
+            IntentConfirmationInterceptor.createIntentCallback =
+                CreateIntentCallbackForServerSideConfirmation { paymentMethodId, shouldSavePaymentMethod ->
+                    observedValues += shouldSavePaymentMethod
+                    CreateIntentCallback.Result.Success("pi_123_secret_456")
+                }
             interceptor.intercept(
                 clientSecret = null,
                 paymentMethod = paymentMethod,
@@ -359,6 +359,7 @@ class DefaultIntentConfirmationInterceptorTest {
         }
 
         assertThat(observedValues).containsExactly(false, false, true, false).inOrder()
+        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNull()
     }
 
     private fun succeedingClientSideCallback(

--- a/payments-core/src/test/java/com/stripe/android/DefaultIntentConfirmationInterceptorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/DefaultIntentConfirmationInterceptorTest.kt
@@ -32,8 +32,9 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeRepository = object : AbsFakeStripeRepository() {},
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
-            createIntentCallback = null,
         )
+
+        IntentConfirmationInterceptor.createIntentCallback = null
 
         val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
 
@@ -58,8 +59,9 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeRepository = object : AbsFakeStripeRepository() {},
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
-            createIntentCallback = null,
         )
+
+        IntentConfirmationInterceptor.createIntentCallback = null
 
         val createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD
 
@@ -84,8 +86,9 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeRepository = object : AbsFakeStripeRepository() {},
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
-            createIntentCallback = null,
         )
+
+        IntentConfirmationInterceptor.createIntentCallback = null
 
         val error = assertFailsWith<IllegalStateException> {
             interceptor.intercept(
@@ -108,8 +111,9 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeRepository = object : AbsFakeStripeRepository() {},
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
-            createIntentCallback = null,
         )
+
+        IntentConfirmationInterceptor.createIntentCallback = null
 
         val nextStep = interceptor.intercept(
             clientSecret = null,
@@ -139,8 +143,9 @@ class DefaultIntentConfirmationInterceptorTest {
             },
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
-            createIntentCallback = null,
         )
+
+        IntentConfirmationInterceptor.createIntentCallback = null
 
         val nextStep = interceptor.intercept(
             clientSecret = null,
@@ -171,8 +176,9 @@ class DefaultIntentConfirmationInterceptorTest {
             },
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
-            createIntentCallback = succeedingServerSideCallback("pm_123456789"),
         )
+
+        IntentConfirmationInterceptor.createIntentCallback = succeedingServerSideCallback("pm_123456789")
 
         val nextStep = interceptor.intercept(
             clientSecret = null,
@@ -191,8 +197,9 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeRepository = mock(),
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
-            createIntentCallback = failingClientSideCallback(),
         )
+
+        IntentConfirmationInterceptor.createIntentCallback = failingClientSideCallback()
 
         val nextStep = interceptor.intercept(
             clientSecret = null,
@@ -211,8 +218,9 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeRepository = mock(),
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
-            createIntentCallback = failingServerSideCallback(),
         )
+
+        IntentConfirmationInterceptor.createIntentCallback = failingServerSideCallback()
 
         val nextStep = interceptor.intercept(
             clientSecret = null,
@@ -234,8 +242,9 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeRepository = mock(),
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
-            createIntentCallback = succeedingClientSideCallback(expectedPaymentMethodId),
         )
+
+        IntentConfirmationInterceptor.createIntentCallback = succeedingClientSideCallback(expectedPaymentMethodId)
 
         val nextStep = interceptor.intercept(
             clientSecret = null,
@@ -265,8 +274,9 @@ class DefaultIntentConfirmationInterceptorTest {
             },
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
-            createIntentCallback = succeedingServerSideCallback(expectedPaymentMethodId),
         )
+
+        IntentConfirmationInterceptor.createIntentCallback = succeedingServerSideCallback(expectedPaymentMethodId)
 
         val nextStep = interceptor.intercept(
             clientSecret = null,
@@ -298,8 +308,9 @@ class DefaultIntentConfirmationInterceptorTest {
             },
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
-            createIntentCallback = succeedingServerSideCallback(expectedPaymentMethodId),
         )
+
+        IntentConfirmationInterceptor.createIntentCallback = succeedingServerSideCallback(expectedPaymentMethodId)
 
         val nextStep = interceptor.intercept(
             clientSecret = null,
@@ -323,16 +334,13 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeRepository = mock(),
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
-            createIntentCallback = object : CreateIntentCallbackForServerSideConfirmation {
-                override suspend fun onCreateIntent(
-                    paymentMethodId: String,
-                    shouldSavePaymentMethod: Boolean
-                ): CreateIntentCallback.Result {
-                    observedValues += shouldSavePaymentMethod
-                    return CreateIntentCallback.Result.Success("pi_123_secret_456")
-                }
-            },
         )
+
+        IntentConfirmationInterceptor.createIntentCallback =
+            CreateIntentCallbackForServerSideConfirmation { paymentMethodId, shouldSavePaymentMethod ->
+                observedValues += shouldSavePaymentMethod
+                CreateIntentCallback.Result.Success("pi_123_secret_456")
+            }
 
         val inputs = listOf(
             null,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -10,6 +10,9 @@ import androidx.annotation.RestrictTo
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.fragment.app.Fragment
+import com.stripe.android.CreateIntentCallback
+import com.stripe.android.CreateIntentCallbackForServerSideConfirmation
+import com.stripe.android.IntentConfirmationInterceptor
 import com.stripe.android.link.account.CookieStore
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
@@ -41,6 +44,28 @@ class PaymentSheet internal constructor(
         DefaultPaymentSheetLauncher(activity, callback)
     )
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    constructor(
+        activity: ComponentActivity,
+        createIntentCallback: CreateIntentCallback,
+        paymentResultCallback: PaymentSheetResultCallback,
+    ) : this(
+        DefaultPaymentSheetLauncher(activity, paymentResultCallback)
+    ) {
+        IntentConfirmationInterceptor.createIntentCallback = createIntentCallback
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    constructor(
+        activity: ComponentActivity,
+        createIntentCallbackForServerSideConfirmation: CreateIntentCallbackForServerSideConfirmation,
+        paymentResultCallback: PaymentSheetResultCallback,
+    ) : this(
+        DefaultPaymentSheetLauncher(activity, paymentResultCallback)
+    ) {
+        IntentConfirmationInterceptor.createIntentCallback = createIntentCallbackForServerSideConfirmation
+    }
+
     /**
      * Constructor to be used when launching the payment sheet from a Fragment.
      *
@@ -53,6 +78,28 @@ class PaymentSheet internal constructor(
     ) : this(
         DefaultPaymentSheetLauncher(fragment, callback)
     )
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    constructor(
+        fragment: Fragment,
+        createIntentCallback: CreateIntentCallback,
+        paymentResultCallback: PaymentSheetResultCallback,
+    ) : this(
+        DefaultPaymentSheetLauncher(fragment, paymentResultCallback)
+    ) {
+        IntentConfirmationInterceptor.createIntentCallback = createIntentCallback
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    constructor(
+        fragment: Fragment,
+        createIntentCallbackForServerSideConfirmation: CreateIntentCallbackForServerSideConfirmation,
+        paymentResultCallback: PaymentSheetResultCallback,
+    ) : this(
+        DefaultPaymentSheetLauncher(fragment, paymentResultCallback)
+    ) {
+        IntentConfirmationInterceptor.createIntentCallback = createIntentCallbackForServerSideConfirmation
+    }
 
     /**
      * Present the payment sheet to process a [PaymentIntent].
@@ -935,6 +982,38 @@ class PaymentSheet internal constructor(
                 ).create()
             }
 
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            @JvmStatic
+            fun create(
+                activity: ComponentActivity,
+                paymentOptionCallback: PaymentOptionCallback,
+                createIntentCallback: CreateIntentCallback,
+                paymentResultCallback: PaymentSheetResultCallback,
+            ): FlowController {
+                IntentConfirmationInterceptor.createIntentCallback = createIntentCallback
+                return FlowControllerFactory(
+                    activity,
+                    paymentOptionCallback,
+                    paymentResultCallback
+                ).create()
+            }
+
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            @JvmStatic
+            fun create(
+                activity: ComponentActivity,
+                paymentOptionCallback: PaymentOptionCallback,
+                createIntentCallbackForServerSideConfirmation: CreateIntentCallbackForServerSideConfirmation,
+                paymentResultCallback: PaymentSheetResultCallback,
+            ): FlowController {
+                IntentConfirmationInterceptor.createIntentCallback = createIntentCallbackForServerSideConfirmation
+                return FlowControllerFactory(
+                    activity,
+                    paymentOptionCallback,
+                    paymentResultCallback
+                ).create()
+            }
+
             /**
              * Create the FlowController when launching the payment sheet from a Fragment.
              *
@@ -948,6 +1027,38 @@ class PaymentSheet internal constructor(
                 paymentOptionCallback: PaymentOptionCallback,
                 paymentResultCallback: PaymentSheetResultCallback
             ): FlowController {
+                return FlowControllerFactory(
+                    fragment,
+                    paymentOptionCallback,
+                    paymentResultCallback
+                ).create()
+            }
+
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            @JvmStatic
+            fun create(
+                fragment: Fragment,
+                paymentOptionCallback: PaymentOptionCallback,
+                createIntentCallback: CreateIntentCallback,
+                paymentResultCallback: PaymentSheetResultCallback,
+            ): FlowController {
+                IntentConfirmationInterceptor.createIntentCallback = createIntentCallback
+                return FlowControllerFactory(
+                    fragment,
+                    paymentOptionCallback,
+                    paymentResultCallback
+                ).create()
+            }
+
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            @JvmStatic
+            fun create(
+                fragment: Fragment,
+                paymentOptionCallback: PaymentOptionCallback,
+                createIntentCallbackForServerSideConfirmation: CreateIntentCallbackForServerSideConfirmation,
+                paymentResultCallback: PaymentSheetResultCallback,
+            ): FlowController {
+                IntentConfirmationInterceptor.createIntentCallback = createIntentCallbackForServerSideConfirmation
                 return FlowControllerFactory(
                     fragment,
                     paymentOptionCallback,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

- Add CreateIntentCallback to PaymentSheet constructors, 4 new constructors, 2 for the client side confirmation flow (for activity and fragments) and 2 for the server side confirmation flow (for activity and fragments)
- Add CreateIntentCallback to FlowController initializer, 4 new create methods, 2 for the client side confirmation flow (for activity and fragments) and 2 for the server side confirmation flow (for activity and fragments)
- Add static createIntentCallback in IntentConfirmationInterceptor. We will be storing the callback statically as it will handle process death, whereas process death wouldn't be handled in the dagger implementation for PaymentSheet (it would work in FlowController)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Decoupling Private Beta

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified
