### PR TITLE
Add Android Jira component for E2E test failures

### DIFF
--- a/scripts/notify_failure_endpoint.rb
+++ b/scripts/notify_failure_endpoint.rb
@@ -40,6 +40,7 @@ params = {
 
 params[:summary] = "stripe-android E2E test failed"
 params[:description] = "Please ACK this ticket and investigate the failure. See https://github.com/stripe/stripe-android/actions/runs/#{github_run_id}"
+params[:components] = %w[Android]
 
 req.body = params.to_json
 


### PR DESCRIPTION
# Summary
Adds the "Android" component to Jira tickets opened for E2E test failures

# Motivation
Right now, E2E test failures aren't tagged with a component in our Jira bucket. This makes it difficult to split out run metrics by component (iOS vs. Android, for example). While we could add the component when we resolve (I just did this for all previously created tickets as a bulk operation in Jira), having a robot do it for us is much nicer.

# Testing
I confirmed the name of the parameter and that it's a string array in go/ticketmaker, but otherwise I haven't tested this! I have no idea how to so would love any feedback
