### PR TITLE
Prepare playground for decoupled flow

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/Settings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/Settings.kt
@@ -31,13 +31,11 @@ class Settings(context: Context) {
 
     internal companion object {
         /**
-         * The base URL of the test backend, implementing a `/checkout` endpoint as defined by
-         * [CheckoutBackendApi].
+         * The base URL of the test backend, implementing a `/checkout` endpoint.
          *
          * Note: only necessary if not configured via `gradle.properties`.
          */
-        private const val BASE_URL =
-            "https://stripe-mobile-payment-sheet-test-playground-v6.glitch.me/"
+        private const val BASE_URL = "https://stp-mobile-ci-test-backend-v7.stripedemos.com/"
 
         private const val METADATA_KEY_BACKEND_URL_KEY =
             "com.stripe.android.paymentsheet.example.metadata.backend_url"

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
@@ -455,13 +455,13 @@ class PaymentSheetPlaygroundActivity : AppCompatActivity() {
                 }
                 CheckoutMode.Payment -> {
                     PaymentSheet.IntentConfiguration.Mode.Payment(
-                        amount = 12345,
+                        amount = viewModel.amount.value,
                         currency = currency.value,
                     )
                 }
                 CheckoutMode.PaymentWithSetup -> {
                     PaymentSheet.IntentConfiguration.Mode.Payment(
-                        amount = 12345,
+                        amount = viewModel.amount.value,
                         currency = currency.value,
                         setupFutureUse = PaymentSheet.IntentConfiguration.SetupFutureUse.OffSession,
                     )

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
@@ -101,6 +101,8 @@ data class CheckoutResponse(
     val customerId: String? = null,
     @SerializedName("customerEphemeralKeySecret")
     val customerEphemeralKeySecret: String? = null,
+    @SerializedName("amount")
+    val amount: Long,
     @SerializedName("paymentMethodTypes")
     val paymentMethodTypes: String? = null,
 ) {
@@ -114,3 +116,27 @@ data class CheckoutResponse(
             null
         }
 }
+
+@Serializable
+@Keep
+data class ConfirmIntentRequest(
+    @SerializedName("client_secret")
+    val clientSecret: String,
+    @SerializedName("payment_method_id")
+    val paymentMethodId: String,
+    @SerializedName("should_save_payment_method")
+    val shouldSavePaymentMethod: Boolean,
+    @SerializedName("merchant_country_code")
+    val merchantCountryCode: String,
+    @SerializedName("mode")
+    val mode: String,
+    @SerializedName("return_url")
+    val returnUrl: String,
+)
+
+@Serializable
+@Keep
+data class ConfirmIntentResponse(
+    @SerializedName("client_secret")
+    val clientSecret: String,
+)

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/viewmodel/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/viewmodel/PaymentSheetPlaygroundViewModel.kt
@@ -10,6 +10,7 @@ import com.github.kittinunf.fuel.Fuel
 import com.github.kittinunf.fuel.core.extensions.jsonBody
 import com.github.kittinunf.result.Result
 import com.google.gson.Gson
+import com.stripe.android.CreateIntentCallback
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -18,11 +19,15 @@ import com.stripe.android.paymentsheet.example.playground.model.CheckoutCustomer
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutMode
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutRequest
 import com.stripe.android.paymentsheet.example.playground.model.CheckoutResponse
+import com.stripe.android.paymentsheet.example.playground.model.ConfirmIntentRequest
+import com.stripe.android.paymentsheet.example.playground.model.ConfirmIntentResponse
 import com.stripe.android.paymentsheet.example.playground.model.InitializationType
 import com.stripe.android.paymentsheet.example.playground.model.SavedToggles
 import com.stripe.android.paymentsheet.example.playground.model.Toggle
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 
 class PaymentSheetPlaygroundViewModel(
     application: Application
@@ -34,6 +39,7 @@ class PaymentSheetPlaygroundViewModel(
     val clientSecret = MutableLiveData<String?>(null)
 
     val initializationType = MutableStateFlow(InitializationType.Normal)
+    val amount = MutableStateFlow<Long>(0)
     val paymentMethodTypes = MutableStateFlow<List<String>>(emptyList())
 
     val readyToCheckout = combine(
@@ -42,7 +48,7 @@ class PaymentSheetPlaygroundViewModel(
     ) { type, secret ->
         when (type) {
             InitializationType.Normal -> secret != null
-            InitializationType.Deferred -> true
+            InitializationType.Deferred -> paymentMethodTypes.value.isNotEmpty()
         }
     }
 
@@ -209,10 +215,74 @@ class PaymentSheetPlaygroundViewModel(
 
                         customerConfig.postValue(checkoutResponse.makeCustomerConfig())
                         clientSecret.postValue(checkoutResponse.intentClientSecret)
+
+                        amount.value = checkoutResponse.amount
                         paymentMethodTypes.value = checkoutResponse.paymentMethodTypes.orEmpty().split(",")
                     }
                 }
                 inProgress.postValue(false)
             }
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    fun createIntent(
+        paymentMethodId: String,
+        merchantCountryCode: String,
+        mode: String,
+        returnUrl: String,
+        backendUrl: String,
+    ): CreateIntentCallback.Result {
+        // Note: This is not how you'd do this in a real application. Instead, your app would
+        // call your backend and create (and optionally confirm) a payment or setup intent.
+        return CreateIntentCallback.Result.Success(clientSecret = clientSecret.value!!)
+    }
+
+    suspend fun createAndConfirmIntent(
+        paymentMethodId: String,
+        shouldSavePaymentMethod: Boolean,
+        merchantCountryCode: String,
+        mode: String,
+        returnUrl: String,
+        backendUrl: String,
+    ): CreateIntentCallback.Result {
+        // Note: This is not how you'd do this in a real application. You wouldn't have a client
+        // secret available at this point, but you'd call your backend to create (and optionally
+        // confirm) a payment or setup intent.
+        val request = ConfirmIntentRequest(
+            clientSecret = clientSecret.value!!,
+            paymentMethodId = paymentMethodId,
+            shouldSavePaymentMethod = shouldSavePaymentMethod,
+            merchantCountryCode = merchantCountryCode,
+            mode = mode,
+            returnUrl = returnUrl,
+        )
+
+        return suspendCoroutine { continuation ->
+            Fuel.post(backendUrl + "confirm_intent")
+                .jsonBody(Gson().toJson(request))
+                .responseString { _, _, result ->
+                    when (result) {
+                        is Result.Failure -> {
+                            status.postValue("Creating intent failed:\n${result.getException().message}")
+                            continuation.resume(
+                                CreateIntentCallback.Result.Failure("Couldn't finish operation")
+                            )
+                        }
+                        is Result.Success -> {
+                            val confirmIntentResponse = Gson().fromJson(
+                                result.get(),
+                                ConfirmIntentResponse::class.java,
+                            )
+
+                            continuation.resume(
+                                CreateIntentCallback.Result.Success(
+                                    clientSecret = confirmIntentResponse.clientSecret,
+                                )
+                            )
+                        }
+                    }
+                    inProgress.postValue(false)
+                }
+        }
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates the payment sheet playground to use the new sample backend and adds methods for confirming an intent server-side. This will be used once we’ve fully integrated the decoupled flow.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
