### PR TITLE
Don't create cardAccountRangeRepository until it's needed.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -112,7 +112,7 @@ import kotlin.coroutines.CoroutineContext
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 class StripeApiRepository @JvmOverloads internal constructor(
     private val context: Context,
-    publishableKeyProvider: () -> String,
+    private val publishableKeyProvider: () -> String,
     private val appInfo: AppInfo? = Stripe.appInfo,
     private val logger: Logger = Logger.noop(),
     private val workContext: CoroutineContext = Dispatchers.IO,
@@ -163,16 +163,8 @@ class StripeApiRepository @JvmOverloads internal constructor(
     private val fraudDetectionData: FraudDetectionData?
         get() = fraudDetectionDataRepository.getCached()
 
-    private val cardAccountRangeRepository: CardAccountRangeRepository
-
     init {
         fireFraudDetectionDataRequest()
-
-        cardAccountRangeRepository =
-            cardAccountRangeRepositoryFactory.createWithStripeRepository(
-                stripeRepository = this,
-                publishableKey = publishableKeyProvider()
-            )
 
         CoroutineScope(workContext).launch {
             val httpCacheDir = File(context.cacheDir, "stripe_api_repository_cache")
@@ -1609,6 +1601,11 @@ class StripeApiRepository @JvmOverloads internal constructor(
 
         val bin = unvalidatedNumber.bin ?: return null
 
+        val cardAccountRangeRepository =
+            cardAccountRangeRepositoryFactory.createWithStripeRepository(
+                stripeRepository = this,
+                publishableKey = publishableKeyProvider()
+            )
         val accountRanges = cardAccountRangeRepository.getAccountRanges(
             cardNumber = unvalidatedNumber
         ) ?: listOf()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Don't create cardAccountRangeRepository until we use it. Creating it eagerly was causing instrumentation test failures.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Test failures
