### PR TITLE
Revert "Restrict possible brands"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Payments
 * [ADDED][6306](https://github.com/stripe/stripe-android/pull/6306) Added support for Cash App Pay. See the docs [here](https://stripe.com/docs/payments/cash-app-pay).
+* [ADDED][6335](https://github.com/stripe/stripe-android/pull/6335) Added `Stripe.possibleCardBrands` which retrieves a list of possible card brands given a card number.
 
 ### PaymentSheet
 * [ADDED][6306](https://github.com/stripe/stripe-android/pull/6306) Added support for Cash App Pay.

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -956,6 +956,7 @@ public final class com/stripe/android/Stripe {
 	public final fun retrievePaymentIntentSynchronous (Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/model/PaymentIntent;
 	public final fun retrievePaymentIntentSynchronous (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lcom/stripe/android/model/PaymentIntent;
 	public static synthetic fun retrievePaymentIntentSynchronous$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentIntent;
+	public final fun retrievePossibleBrands (Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
 	public final fun retrieveSetupIntent (Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
 	public final fun retrieveSetupIntent (Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/ApiResultCallback;)V
 	public final fun retrieveSetupIntent (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/stripe/android/ApiResultCallback;)V
@@ -1049,6 +1050,7 @@ public final class com/stripe/android/StripeKtxKt {
 	public static final fun getSetupIntentResult (Lcom/stripe/android/Stripe;ILandroid/content/Intent;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun retrievePaymentIntent (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun retrievePaymentIntent$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun retrievePossibleBrands (Lcom/stripe/android/Stripe;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun retrieveSetupIntent (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun retrieveSetupIntent$default (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun retrieveSource (Lcom/stripe/android/Stripe;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -4786,6 +4788,21 @@ public final class com/stripe/android/model/PiiTokenParams$Creator : android/os/
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/model/PiiTokenParams;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/PossibleBrands : com/stripe/android/core/model/StripeModel {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/stripe/android/model/PossibleBrands;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/PossibleBrands;Ljava/util/List;ILjava/lang/Object;)Lcom/stripe/android/model/PossibleBrands;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBrands ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
 public final class com/stripe/android/model/PossibleBrands$Creator : android/os/Parcelable$Creator {

--- a/payments-core/src/main/java/com/stripe/android/Stripe.kt
+++ b/payments-core/src/main/java/com/stripe/android/Stripe.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import androidx.activity.ComponentActivity
-import androidx.annotation.RestrictTo
 import androidx.annotation.Size
 import androidx.annotation.UiThread
 import androidx.annotation.WorkerThread
@@ -1804,7 +1803,6 @@ class Stripe internal constructor(
      * @param cardNumber the card number
      * @param callback a [ApiResultCallback] to receive the result or error
      */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun retrievePossibleBrands(
         cardNumber: String,
         callback: ApiResultCallback<PossibleBrands>

--- a/payments-core/src/main/java/com/stripe/android/StripeKtx.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripeKtx.kt
@@ -1,7 +1,6 @@
 package com.stripe.android
 
 import android.content.Intent
-import androidx.annotation.RestrictTo
 import androidx.annotation.Size
 import com.stripe.android.cards.CardNumber
 import com.stripe.android.core.exception.APIConnectionException
@@ -987,7 +986,6 @@ suspend fun Stripe.verifySetupIntentWithMicrodeposits(
     APIConnectionException::class,
     APIException::class
 )
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 suspend fun Stripe.retrievePossibleBrands(
     cardNumber: String
 ): PossibleBrands = runApiRequest {

--- a/payments-core/src/main/java/com/stripe/android/model/PossibleBrands.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PossibleBrands.kt
@@ -1,11 +1,9 @@
 package com.stripe.android.model
 
-import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeModel
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class PossibleBrands(
     val brands: List<CardBrand>
 ) : StripeModel


### PR DESCRIPTION
# Summary

Release possible brands.

We are keeping the current API as is and allow integrators to use the current API with raw card numbers.

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

- [Added] Added `Stripe.possibleCardBrands` which retrieves a list of possible card brands given a card number.