### PR TITLE
Null out `createIntentCallback` in `onDestroy()`

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/IntentConfirmationInterceptor.kt
+++ b/payments-core/src/main/java/com/stripe/android/IntentConfirmationInterceptor.kt
@@ -77,7 +77,7 @@ class DefaultIntentConfirmationInterceptor @Inject constructor(
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
         setupForFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage?,
     ): IntentConfirmationInterceptor.NextStep {
-        val nextStep = if (clientSecret != null) {
+        return if (clientSecret != null) {
             createConfirmStep(
                 clientSecret = clientSecret,
                 shippingValues = shippingValues,
@@ -99,10 +99,6 @@ class DefaultIntentConfirmationInterceptor @Inject constructor(
                 }
             )
         }
-
-        IntentConfirmationInterceptor.createIntentCallback = null
-
-        return nextStep
     }
 
     override suspend fun intercept(
@@ -111,7 +107,7 @@ class DefaultIntentConfirmationInterceptor @Inject constructor(
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
         setupForFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage?,
     ): IntentConfirmationInterceptor.NextStep {
-        val nextStep = if (clientSecret != null) {
+        return if (clientSecret != null) {
             createConfirmStep(clientSecret, shippingValues, paymentMethod)
         } else {
             when (val callback = IntentConfirmationInterceptor.createIntentCallback) {
@@ -131,7 +127,6 @@ class DefaultIntentConfirmationInterceptor @Inject constructor(
                     )
                 }
                 else -> {
-                    IntentConfirmationInterceptor.createIntentCallback = null
                     error(
                         "${CreateIntentCallback::class.java.simpleName} must be implemented " +
                             "when using IntentConfiguration with PaymentSheet"
@@ -139,10 +134,6 @@ class DefaultIntentConfirmationInterceptor @Inject constructor(
                 }
             }
         }
-
-        IntentConfirmationInterceptor.createIntentCallback = null
-
-        return nextStep
     }
 
     private suspend fun createPaymentMethod(

--- a/payments-core/src/test/java/com/stripe/android/DefaultIntentConfirmationInterceptorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/DefaultIntentConfirmationInterceptorTest.kt
@@ -18,12 +18,18 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
+import kotlin.test.BeforeTest
 import kotlin.test.assertFailsWith
 
 @RunWith(RobolectricTestRunner::class)
 class DefaultIntentConfirmationInterceptorTest {
 
     private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @BeforeTest
+    fun before() {
+        IntentConfirmationInterceptor.createIntentCallback = null
+    }
 
     @Test
     fun `Returns confirm as next step if invoked with client secret for existing payment method`() = runTest {
@@ -48,7 +54,6 @@ class DefaultIntentConfirmationInterceptorTest {
 
         assertThat(confirmParams?.paymentMethodId).isEqualTo(paymentMethod.id)
         assertThat(confirmParams?.paymentMethodCreateParams).isNull()
-        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNull()
     }
 
     @Test
@@ -74,7 +79,6 @@ class DefaultIntentConfirmationInterceptorTest {
 
         assertThat(confirmParams?.paymentMethodId).isNull()
         assertThat(confirmParams?.paymentMethodCreateParams).isEqualTo(createParams)
-        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNull()
     }
 
     @Test
@@ -98,7 +102,6 @@ class DefaultIntentConfirmationInterceptorTest {
         assertThat(error.message).isEqualTo(
             "CreateIntentCallback must be implemented when using IntentConfiguration with PaymentSheet"
         )
-        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNull()
     }
 
     @Test
@@ -118,7 +121,6 @@ class DefaultIntentConfirmationInterceptorTest {
         )
 
         assertThat(nextStep).isInstanceOf(IntentConfirmationInterceptor.NextStep.Fail::class.java)
-        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNull()
     }
 
     @Test
@@ -149,7 +151,6 @@ class DefaultIntentConfirmationInterceptorTest {
         )
 
         assertThat(nextStep).isInstanceOf(IntentConfirmationInterceptor.NextStep.Fail::class.java)
-        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNull()
     }
 
     @Test
@@ -183,7 +184,6 @@ class DefaultIntentConfirmationInterceptorTest {
         )
 
         assertThat(nextStep).isInstanceOf(IntentConfirmationInterceptor.NextStep.Fail::class.java)
-        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNull()
     }
 
     @Test
@@ -205,7 +205,6 @@ class DefaultIntentConfirmationInterceptorTest {
         )
 
         assertThat(nextStep).isInstanceOf(IntentConfirmationInterceptor.NextStep.Fail::class.java)
-        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNull()
     }
 
     @Test
@@ -227,7 +226,6 @@ class DefaultIntentConfirmationInterceptorTest {
         )
 
         assertThat(nextStep).isInstanceOf(IntentConfirmationInterceptor.NextStep.Fail::class.java)
-        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNull()
     }
 
     @Test
@@ -252,7 +250,6 @@ class DefaultIntentConfirmationInterceptorTest {
         )
 
         assertThat(nextStep).isInstanceOf(IntentConfirmationInterceptor.NextStep.Confirm::class.java)
-        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNull()
     }
 
     @Test
@@ -285,7 +282,6 @@ class DefaultIntentConfirmationInterceptorTest {
         )
 
         assertThat(nextStep).isInstanceOf(IntentConfirmationInterceptor.NextStep.Complete::class.java)
-        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNull()
     }
 
     @Test
@@ -322,7 +318,6 @@ class DefaultIntentConfirmationInterceptorTest {
         assertThat(nextStep).isEqualTo(
             IntentConfirmationInterceptor.NextStep.HandleNextAction("pi_123_secret_456")
         )
-        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNull()
     }
 
     @Test
@@ -359,7 +354,6 @@ class DefaultIntentConfirmationInterceptorTest {
         }
 
         assertThat(observedValues).containsExactly(false, false, true, false).inOrder()
-        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNull()
     }
 
     private fun succeedingClientSideCallback(

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     testImplementation "androidx.arch.core:core-testing:$androidxArchCoreVersion"
     testImplementation "androidx.fragment:fragment-testing:$androidxFragmentVersion"
     testImplementation "androidx.compose.ui:ui-test-junit4:$androidxComposeUiVersion"
+    testImplementation "androidx.lifecycle:lifecycle-runtime-testing:$androidxLifecycleVersion"
     testImplementation testLibs.turbine
 
     // temporary fix for running compose test in RobolectricTestRunner, see https://github.com/robolectric/robolectric/issues/6593

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncherTest.kt
@@ -6,17 +6,22 @@ import androidx.core.app.ActivityOptionsCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.CreateIntentCallback
+import com.stripe.android.IntentConfirmationInterceptor
 import com.stripe.android.PaymentConfiguration
 import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 
 @RunWith(RobolectricTestRunner::class)
 class DefaultPaymentSheetLauncherTest {
+
     @BeforeTest
     fun setup() {
         PaymentConfiguration.init(
@@ -36,7 +41,7 @@ class DefaultPaymentSheetLauncherTest {
         ) {
             onFragment { fragment ->
                 val results = mutableListOf<PaymentSheetResult>()
-                val launcher = com.stripe.android.paymentsheet.DefaultPaymentSheetLauncher(
+                val launcher = DefaultPaymentSheetLauncher(
                     fragment,
                     testRegistry
                 ) {
@@ -45,10 +50,33 @@ class DefaultPaymentSheetLauncherTest {
 
                 moveToState(Lifecycle.State.RESUMED)
                 launcher.present(mode = PaymentSheet.InitializationMode.PaymentIntent("pi_fake"))
-                assertThat(results)
-                    .containsExactly(com.stripe.android.paymentsheet.PaymentSheetResult.Completed)
+                assertThat(results).containsExactly(PaymentSheetResult.Completed)
             }
         }
+    }
+
+    @Test
+    fun `Clears out CreateIntentCallback when lifecycle owner is destroyed`() {
+        IntentConfirmationInterceptor.createIntentCallback = CreateIntentCallback {
+            error("I’m alive")
+        }
+
+        val lifecycleOwner = TestLifecycleOwner()
+
+        DefaultPaymentSheetLauncher(
+            activityResultLauncher = mock(),
+            lifecycleOwner = lifecycleOwner,
+            application = ApplicationProvider.getApplicationContext(),
+        )
+
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNotNull()
+
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNotNull()
+
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        assertThat(IntentConfirmationInterceptor.createIntentCallback).isNull()
     }
 
     private class FakeActivityResultRegistry(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request nulls out the `createIntentCallback` in the lifecycle owner’s `onDestroy()` call. This avoids memory leaks without breaking flows where the `createIntentCallback` might be called multiple times (e.g. if it fails on the first try).

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
