### PR TITLE
Add client-side mapping for errors in auth flows

### DIFF
--- a/payments-core/detekt-baseline.xml
+++ b/payments-core/detekt-baseline.xml
@@ -11,6 +11,7 @@
     <ID>CyclomaticComplexMethod:Source.kt$Source.Companion$@SourceType @JvmStatic fun asSourceType(sourceType: String?): String</ID>
     <ID>CyclomaticComplexMethod:SourceJsonParser.kt$SourceJsonParser.Companion$@Source.SourceType private fun asSourceType(sourceType: String?): String</ID>
     <ID>CyclomaticComplexMethod:SourceJsonParser.kt$SourceJsonParser.Companion$private inline fun &lt;reified T : StripeModel> optStripeJsonModel( jsonObject: JSONObject, @Size(min = 1) key: String ): T?</ID>
+    <ID>CyclomaticComplexMethod:StripeErrorMapping.kt$internal fun Context.mapErrorCodeToLocalizedMessage(code: String?): String?</ID>
     <ID>EmptyFunctionBlock:AbsFakeStripeRepository.kt$AbsFakeStripeRepository${ }</ID>
     <ID>EmptyFunctionBlock:AbsPaymentController.kt$AbsPaymentController${ }</ID>
     <ID>EmptyFunctionBlock:CardWidgetProgressView.kt$CardWidgetProgressView.&lt;no name provided>${ }</ID>

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeErrorMapping.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeErrorMapping.kt
@@ -6,6 +6,11 @@ import com.stripe.android.core.StripeError
 
 @Suppress("ComplexMethod")
 internal fun StripeError.withLocalizedMessage(context: Context): StripeError {
+    val newMessage = context.mapErrorCodeToLocalizedMessage(code) ?: message
+    return copy(message = newMessage)
+}
+
+internal fun Context.mapErrorCodeToLocalizedMessage(code: String?): String? {
     val messageResourceId = when (code) {
         "incorrect_number" -> R.string.invalid_card_number
         "invalid_number" -> R.string.invalid_card_number
@@ -21,7 +26,5 @@ internal fun StripeError.withLocalizedMessage(context: Context): StripeError {
         "generic_decline" -> R.string.generic_decline
         else -> null
     }
-
-    val newMessage = messageResourceId?.let { context.getString(it) } ?: message
-    return copy(message = newMessage)
+    return messageResourceId?.let { getString(it) }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowFailureMessageFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowFailureMessageFactory.kt
@@ -7,6 +7,7 @@ import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
+import com.stripe.android.networking.mapErrorCodeToLocalizedMessage
 
 internal class PaymentFlowFailureMessageFactory(
     private val context: Context
@@ -51,7 +52,8 @@ internal class PaymentFlowFailureMessageFactory(
             context.resources.getString(R.string.stripe_failure_reason_authentication)
         }
         paymentIntent.lastPaymentError?.type == PaymentIntent.Error.Type.CardError -> {
-            paymentIntent.lastPaymentError.message
+            val error = paymentIntent.lastPaymentError
+            context.mapErrorCodeToLocalizedMessage(error.code) ?: error.message
         }
         else -> {
             null
@@ -65,7 +67,8 @@ internal class PaymentFlowFailureMessageFactory(
             context.resources.getString(R.string.stripe_failure_reason_authentication)
         }
         setupIntent.lastSetupError?.type == SetupIntent.Error.Type.CardError -> {
-            setupIntent.lastSetupError.message
+            val error = setupIntent.lastSetupError
+            context.mapErrorCodeToLocalizedMessage(error.code) ?: error.message
         }
         else -> {
             null


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request aligns Android with iOS and adds client-side mapping for errors encountered during auth flows, completing the work that was started with https://github.com/stripe/stripe-android/pull/5858.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

https://github.com/stripe/stripe-android/issues/5058

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
