### PR TITLE
Use IntentConfirmationInterceptor in FlowController

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/CreateIntentCallback.kt
+++ b/payments-core/src/main/java/com/stripe/android/CreateIntentCallback.kt
@@ -18,8 +18,8 @@ fun interface CreateIntentCallback : AbsCreateIntentCallback {
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         data class Failure(
-            val cause: Exception,
-            val message: String? = null
+            internal val cause: Exception,
+            internal val message: String? = null
         ) : Result
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/CreateIntentCallback.kt
+++ b/payments-core/src/main/java/com/stripe/android/CreateIntentCallback.kt
@@ -17,7 +17,7 @@ fun interface CreateIntentCallback : AbsCreateIntentCallback {
         data class Success(val clientSecret: String) : Result
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        data class Failure(val errorMessage: String) : Result
+        data class Failure(val cause: Exception) : Result
     }
 }
 

--- a/payments-core/src/main/java/com/stripe/android/CreateIntentCallback.kt
+++ b/payments-core/src/main/java/com/stripe/android/CreateIntentCallback.kt
@@ -17,7 +17,10 @@ fun interface CreateIntentCallback : AbsCreateIntentCallback {
         data class Success(val clientSecret: String) : Result
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        data class Failure(val cause: Exception) : Result
+        data class Failure(
+            val cause: Exception,
+            val message: String? = null
+        ) : Result
     }
 }
 

--- a/payments-core/src/main/java/com/stripe/android/CreateIntentCallback.kt
+++ b/payments-core/src/main/java/com/stripe/android/CreateIntentCallback.kt
@@ -19,7 +19,7 @@ fun interface CreateIntentCallback : AbsCreateIntentCallback {
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         data class Failure(
             internal val cause: Exception,
-            internal val message: String? = null
+            internal val displayMessage: String? = null
         ) : Result
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/IntentConfirmationInterceptor.kt
+++ b/payments-core/src/main/java/com/stripe/android/IntentConfirmationInterceptor.kt
@@ -168,7 +168,7 @@ class DefaultIntentConfirmationInterceptor @Inject constructor(
             is CreateIntentCallback.Result.Failure -> {
                 IntentConfirmationInterceptor.NextStep.Fail(
                     cause = result.cause,
-                    message = result.message ?: genericErrorMessage,
+                    message = result.displayMessage ?: genericErrorMessage,
                 )
             }
         }
@@ -208,7 +208,7 @@ class DefaultIntentConfirmationInterceptor @Inject constructor(
             is CreateIntentCallback.Result.Failure -> {
                 IntentConfirmationInterceptor.NextStep.Fail(
                     cause = result.cause,
-                    message = result.message ?: genericErrorMessage,
+                    message = result.displayMessage ?: genericErrorMessage,
                 )
             }
         }

--- a/payments-core/src/main/java/com/stripe/android/IntentConfirmationInterceptor.kt
+++ b/payments-core/src/main/java/com/stripe/android/IntentConfirmationInterceptor.kt
@@ -168,7 +168,7 @@ class DefaultIntentConfirmationInterceptor @Inject constructor(
             is CreateIntentCallback.Result.Failure -> {
                 IntentConfirmationInterceptor.NextStep.Fail(
                     cause = result.cause,
-                    message = result.cause.message ?: genericErrorMessage,
+                    message = result.message ?: genericErrorMessage,
                 )
             }
         }
@@ -208,7 +208,7 @@ class DefaultIntentConfirmationInterceptor @Inject constructor(
             is CreateIntentCallback.Result.Failure -> {
                 IntentConfirmationInterceptor.NextStep.Fail(
                     cause = result.cause,
-                    message = result.cause.message ?: genericErrorMessage,
+                    message = result.message ?: genericErrorMessage,
                 )
             }
         }

--- a/payments-core/src/test/java/com/stripe/android/DefaultIntentConfirmationInterceptorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/DefaultIntentConfirmationInterceptorTest.kt
@@ -482,7 +482,7 @@ class DefaultIntentConfirmationInterceptorTest {
         return CreateIntentCallback {
             CreateIntentCallback.Result.Failure(
                 cause = TestException(message),
-                message = message
+                displayMessage = message
             )
         }
     }
@@ -493,7 +493,7 @@ class DefaultIntentConfirmationInterceptorTest {
         return CreateIntentCallbackForServerSideConfirmation { _, _ ->
             CreateIntentCallback.Result.Failure(
                 cause = TestException(message),
-                message = message
+                displayMessage = message
             )
         }
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
@@ -172,6 +172,16 @@ class PaymentSheetPlaygroundActivity : AppCompatActivity() {
         flowController = PaymentSheet.FlowController.create(
             activity = this,
             paymentOptionCallback = ::onPaymentOption,
+            createIntentCallbackForServerSideConfirmation = { paymentMethodId, shouldSavePaymentMethod ->
+                viewModel.createAndConfirmIntent(
+                    paymentMethodId = paymentMethodId,
+                    shouldSavePaymentMethod = shouldSavePaymentMethod,
+                    merchantCountryCode = merchantCountryCode.value,
+                    mode = mode.value,
+                    returnUrl = returnUrl,
+                    backendUrl = settings.playgroundBackendUrl,
+                )
+            },
             paymentResultCallback = ::onPaymentSheetResult,
         )
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
@@ -37,6 +37,8 @@ import com.stripe.android.paymentsheet.example.playground.model.CheckoutMode
 import com.stripe.android.paymentsheet.example.playground.model.InitializationType
 import com.stripe.android.paymentsheet.example.playground.model.Shipping
 import com.stripe.android.paymentsheet.example.playground.model.Toggle
+import com.stripe.android.paymentsheet.example.playground.viewmodel.ConfirmIntentEndpointException
+import com.stripe.android.paymentsheet.example.playground.viewmodel.ConfirmIntentNetworkException
 import com.stripe.android.paymentsheet.example.playground.viewmodel.PaymentSheetPlaygroundViewModel
 import com.stripe.android.paymentsheet.model.PaymentOption
 import kotlinx.coroutines.launch
@@ -666,7 +668,29 @@ class PaymentSheetPlaygroundActivity : AppCompatActivity() {
             disableViews()
         }
 
-        viewModel.status.value = paymentResult.toString()
+        val status = when (paymentResult) {
+            is PaymentSheetResult.Canceled -> {
+                "Canceled"
+            }
+            is PaymentSheetResult.Completed -> {
+                "Success"
+            }
+            is PaymentSheetResult.Failed -> {
+                when (paymentResult.error) {
+                    is ConfirmIntentEndpointException -> {
+                        "Couldn't process your payment."
+                    }
+                    is ConfirmIntentNetworkException -> {
+                        "No internet. Try again later."
+                    }
+                    else -> {
+                        paymentResult.error.message
+                    }
+                }
+            }
+        }
+
+        viewModel.status.value = status
     }
 
     private fun showAppearancePicker() {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/viewmodel/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/viewmodel/PaymentSheetPlaygroundViewModel.kt
@@ -264,7 +264,8 @@ class PaymentSheetPlaygroundViewModel(
                 .responseString { _, _, result ->
                     when (result) {
                         is Result.Failure -> {
-                            status.postValue("Creating intent failed:\n${result.getException().message}")
+                            val message = "Creating intent failed:\n${result.getException().message}"
+                            status.postValue(message)
 
                             val error = if (result.error.cause is IOException) {
                                 ConfirmIntentNetworkException()
@@ -272,7 +273,12 @@ class PaymentSheetPlaygroundViewModel(
                                 ConfirmIntentEndpointException()
                             }
 
-                            continuation.resume(CreateIntentCallback.Result.Failure(cause = error))
+                            continuation.resume(
+                                CreateIntentCallback.Result.Failure(
+                                    cause = error,
+                                    message = message
+                                )
+                            )
                         }
                         is Result.Success -> {
                             val confirmIntentResponse = Gson().fromJson(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/viewmodel/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/viewmodel/PaymentSheetPlaygroundViewModel.kt
@@ -276,7 +276,7 @@ class PaymentSheetPlaygroundViewModel(
                             continuation.resume(
                                 CreateIntentCallback.Result.Failure(
                                     cause = error,
-                                    message = message
+                                    displayMessage = message
                                 )
                             )
                         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -453,7 +453,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                     confirmStripeIntent(nextStep.confirmParams)
                 }
                 is IntentConfirmationInterceptor.NextStep.Fail -> {
-                    onError(nextStep.errorMessage)
+                    onError(nextStep.message)
                 }
                 is IntentConfirmationInterceptor.NextStep.Complete -> {
                     processPayment(stripeIntent, PaymentResult.Completed)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -288,8 +288,7 @@ internal class DefaultFlowController @Inject internal constructor(
                 is IntentConfirmationInterceptor.NextStep.Fail -> {
                     onPaymentResult(
                         PaymentResult.Failed(
-                            // TODO (jameswoo): Exposing new type here
-                            ConfirmPaymentException(nextStep.errorMessage)
+                            nextStep.cause
                         )
                     )
                 }
@@ -525,10 +524,6 @@ internal class DefaultFlowController @Inject internal constructor(
     class GooglePayException(
         val throwable: Throwable
     ) : Exception(throwable)
-
-    class ConfirmPaymentException(
-        override val message: String
-    ) : Exception(message)
 
     @Parcelize
     data class Args(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -9,7 +9,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
-import com.stripe.android.ConfirmStripeIntentParamsFactory
+import com.stripe.android.IntentConfirmationInterceptor
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.Injectable
@@ -25,7 +25,10 @@ import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
+import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.SetupIntent
+import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
 import com.stripe.android.payments.paymentlauncher.PaymentResult
@@ -44,12 +47,10 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.extensions.registerPollingAuthenticator
 import com.stripe.android.paymentsheet.extensions.unregisterPollingAuthenticator
 import com.stripe.android.paymentsheet.forms.FormViewModel
-import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
+import com.stripe.android.paymentsheet.intercept
 import com.stripe.android.paymentsheet.model.PaymentOption
 import com.stripe.android.paymentsheet.model.PaymentOptionFactory
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.model.SetupIntentClientSecret
-import com.stripe.android.paymentsheet.model.create
 import com.stripe.android.paymentsheet.model.currency
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import dagger.Lazy
@@ -86,6 +87,7 @@ internal class DefaultFlowController @Inject internal constructor(
     private val googlePayPaymentMethodLauncherFactory: GooglePayPaymentMethodLauncherFactory,
     private val linkLauncher: LinkPaymentLauncher,
     private val configurationHandler: FlowControllerConfigurationHandler,
+    private val intentConfirmationInterceptor: IntentConfirmationInterceptor,
 ) : PaymentSheet.FlowController, NonFallbackInjector {
     private val paymentOptionActivityLauncher: ActivityResultLauncher<PaymentOptionContract.Args>
     private val googlePayActivityLauncher:
@@ -264,45 +266,77 @@ internal class DefaultFlowController @Inject internal constructor(
         paymentSelection: PaymentSelection?,
         state: PaymentSheetState.Full,
     ) {
-        val mode = viewModel.initializationMode ?: return
+        lifecycleScope.launch {
+            val stripeIntent = requireNotNull(state.stripeIntent)
 
-        val clientSecret = when (mode) {
-            is PaymentSheet.InitializationMode.PaymentIntent -> {
-                PaymentIntentClientSecret(mode.clientSecret)
-            }
-            is PaymentSheet.InitializationMode.SetupIntent -> {
-                SetupIntentClientSecret(mode.clientSecret)
-            }
-            is PaymentSheet.InitializationMode.DeferredIntent -> {
-                TODO("Not implemented yet")
-            }
-        }
+            val nextStep = intentConfirmationInterceptor.intercept(
+                clientSecret = stripeIntent.clientSecret,
+                paymentSelection = paymentSelection,
+                shippingValues = state.config?.shippingDetails?.toConfirmPaymentIntentShipping(),
+            )
 
-        val confirmParamsFactory = ConfirmStripeIntentParamsFactory.createFactory(
-            clientSecret = clientSecret.value,
-            shipping = state.config?.shippingDetails?.toConfirmPaymentIntentShipping(),
-        )
-
-        when (paymentSelection) {
-            is PaymentSelection.Saved -> {
-                confirmParamsFactory.create(paymentSelection)
-            }
-            is PaymentSelection.New -> {
-                confirmParamsFactory.create(paymentSelection)
-            }
-            else -> null
-        }?.let { confirmParams ->
-            lifecycleScope.launch {
-                when (confirmParams) {
-                    is ConfirmPaymentIntentParams -> {
-                        paymentLauncher?.confirm(confirmParams)
-                    }
-                    is ConfirmSetupIntentParams -> {
-                        paymentLauncher?.confirm(confirmParams)
-                    }
+            when (nextStep) {
+                is IntentConfirmationInterceptor.NextStep.HandleNextAction -> {
+                    handleNextAction(
+                        clientSecret = nextStep.clientSecret,
+                        stripeIntent = stripeIntent,
+                    )
+                }
+                is IntentConfirmationInterceptor.NextStep.Confirm -> {
+                    confirmStripeIntent(nextStep.confirmParams)
+                }
+                is IntentConfirmationInterceptor.NextStep.Fail -> {
+                    onPaymentResult(
+                        PaymentResult.Failed(
+                            // TODO (jameswoo): Exposing new type here
+                            ConfirmPaymentException(nextStep.errorMessage)
+                        )
+                    )
+                }
+                is IntentConfirmationInterceptor.NextStep.Complete -> {
+                    onPaymentResult(PaymentResult.Completed)
                 }
             }
         }
+    }
+
+    private fun confirmStripeIntent(confirmStripeIntentParams: ConfirmStripeIntentParams) {
+        runCatching {
+            requireNotNull(paymentLauncher)
+        }.fold(
+            onSuccess = {
+                when (confirmStripeIntentParams) {
+                    is ConfirmPaymentIntentParams -> {
+                        it.confirm(confirmStripeIntentParams)
+                    }
+                    is ConfirmSetupIntentParams -> {
+                        it.confirm(confirmStripeIntentParams)
+                    }
+                }
+            },
+            onFailure = ::error
+        )
+    }
+
+    private fun handleNextAction(
+        clientSecret: String,
+        stripeIntent: StripeIntent,
+    ) {
+        runCatching {
+            requireNotNull(paymentLauncher)
+        }.fold(
+            onSuccess = {
+                when (stripeIntent) {
+                    is PaymentIntent -> {
+                        it.handleNextActionForPaymentIntent(clientSecret)
+                    }
+                    is SetupIntent -> {
+                        it.handleNextActionForSetupIntent(clientSecret)
+                    }
+                }
+            },
+            onFailure = ::error
+        )
     }
 
     internal fun onGooglePayResult(
@@ -491,6 +525,10 @@ internal class DefaultFlowController @Inject internal constructor(
     class GooglePayException(
         val throwable: Throwable
     ) : Exception(throwable)
+
+    class ConfirmPaymentException(
+        override val message: String
+    ) : Exception(message)
 
     @Parcelize
     data class Args(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1286,7 +1286,10 @@ internal class PaymentSheetViewModelTest {
             viewModel.checkout()
             assertThat(awaitItem()).isEqualTo(PaymentSheetViewState.StartProcessing)
 
-            fakeIntentConfirmationInterceptor.enqueueFailureStep(error)
+            fakeIntentConfirmationInterceptor.enqueueFailureStep(
+                cause = Exception(error),
+                message = error
+            )
             assertThat(awaitItem()).isEqualTo(PaymentSheetViewState.Reset(UserErrorMessage(error)))
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -1047,7 +1047,10 @@ internal class DefaultFlowControllerTest {
             )
         )
 
-        fakeIntentConfirmationInterceptor.enqueueFailureStep("something went wrong")
+        fakeIntentConfirmationInterceptor.enqueueFailureStep(
+            cause = Exception("something went wrong"),
+            message = "something went wrong"
+        )
 
         flowController.confirm()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -20,9 +20,11 @@ import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.model.AccountStatus
+import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentDetailsFixtures
+import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -37,11 +39,11 @@ import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssisted
 import com.stripe.android.paymentsheet.PaymentOptionCallback
 import com.stripe.android.paymentsheet.PaymentOptionContract
 import com.stripe.android.paymentsheet.PaymentOptionResult
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.PaymentSheetResult
 import com.stripe.android.paymentsheet.PaymentSheetResultCallback
 import com.stripe.android.paymentsheet.R
-import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.addresselement.AddressElementActivityContract
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentOption
@@ -52,6 +54,7 @@ import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentSheetLoader
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.uicore.image.StripeImageLoader
+import com.stripe.android.utils.FakeIntentConfirmationInterceptor
 import com.stripe.android.utils.FakePaymentSheetLoader
 import com.stripe.android.view.ActivityScenarioFactory
 import kotlinx.coroutines.CoroutineScope
@@ -123,6 +126,8 @@ internal class DefaultFlowControllerTest {
     private val activityResultCaller = mock<ActivityResultCaller>()
 
     private lateinit var activity: ComponentActivity
+
+    private val fakeIntentConfirmationInterceptor = FakeIntentConfirmationInterceptor()
 
     @BeforeTest
     fun setup() {
@@ -505,6 +510,14 @@ internal class DefaultFlowControllerTest {
             callback = { _, _ -> },
         )
 
+        fakeIntentConfirmationInterceptor.enqueueConfirmStep(
+            confirmParams = ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
+                paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
+                clientSecret = PaymentSheetFixtures.CLIENT_SECRET,
+                paymentMethodOptions = PaymentMethodOptionsParams.Card()
+            )
+        )
+
         flowController.confirmPaymentSelection(
             NEW_CARD_PAYMENT_SELECTION,
             PaymentSheetState.Full(
@@ -532,6 +545,14 @@ internal class DefaultFlowControllerTest {
         flowController.configureWithPaymentIntent(
             paymentIntentClientSecret = PaymentSheetFixtures.CLIENT_SECRET,
             callback = { _, _ -> },
+        )
+
+        fakeIntentConfirmationInterceptor.enqueueConfirmStep(
+            confirmParams = ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
+                paymentMethodCreateParams = GENERIC_PAYMENT_SELECTION.paymentMethodCreateParams,
+                clientSecret = PaymentSheetFixtures.CLIENT_SECRET,
+                paymentMethodOptions = PaymentMethodOptionsParams.Card()
+            )
         )
 
         flowController.confirmPaymentSelection(
@@ -564,6 +585,14 @@ internal class DefaultFlowControllerTest {
 
         val paymentSelection = GENERIC_PAYMENT_SELECTION.copy(
             paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.US_BANK_ACCOUNT
+        )
+
+        fakeIntentConfirmationInterceptor.enqueueConfirmStep(
+            confirmParams = ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
+                paymentMethodCreateParams = paymentSelection.paymentMethodCreateParams,
+                clientSecret = PaymentSheetFixtures.CLIENT_SECRET,
+                paymentMethodOptions = PaymentMethodOptionsParams.USBankAccount()
+            )
         )
 
         flowController.confirmPaymentSelection(
@@ -657,15 +686,24 @@ internal class DefaultFlowControllerTest {
             PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
         ) { _, _ -> }
 
+        val paymentSelection = PaymentSelection.New.LinkInline(
+            LinkPaymentDetails.New(
+                PaymentDetailsFixtures.CONSUMER_SINGLE_PAYMENT_DETAILS.paymentDetails.first(),
+                mock(),
+                PaymentMethodCreateParamsFixtures.DEFAULT_CARD
+            )
+        )
+
         flowController.onPaymentOptionResult(
             PaymentOptionResult.Succeeded(
-                PaymentSelection.New.LinkInline(
-                    LinkPaymentDetails.New(
-                        PaymentDetailsFixtures.CONSUMER_SINGLE_PAYMENT_DETAILS.paymentDetails.first(),
-                        mock(),
-                        PaymentMethodCreateParamsFixtures.DEFAULT_CARD
-                    )
-                )
+                paymentSelection
+            )
+        )
+
+        fakeIntentConfirmationInterceptor.enqueueConfirmStep(
+            confirmParams = ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
+                paymentMethodCreateParams = paymentSelection.paymentMethodCreateParams,
+                clientSecret = PaymentSheetFixtures.CLIENT_SECRET
             )
         )
 
@@ -687,21 +725,28 @@ internal class DefaultFlowControllerTest {
 
         flowController.configureWithPaymentIntent(
             PaymentSheetFixtures.CLIENT_SECRET,
-            PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY.copy(
-                shippingDetails = AddressDetails(
-                    name = "Test"
-                )
-            )
+            PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
         ) { _, _ -> }
 
+        val paymentSelection = PaymentSelection.New.LinkInline(
+            LinkPaymentDetails.New(
+                PaymentDetailsFixtures.CONSUMER_SINGLE_PAYMENT_DETAILS.paymentDetails.first(),
+                mock(),
+                PaymentMethodCreateParamsFixtures.DEFAULT_CARD
+            )
+        )
+
         flowController.onPaymentOptionResult(
-            PaymentOptionResult.Succeeded(
-                PaymentSelection.New.LinkInline(
-                    LinkPaymentDetails.New(
-                        PaymentDetailsFixtures.CONSUMER_SINGLE_PAYMENT_DETAILS.paymentDetails.first(),
-                        mock(),
-                        PaymentMethodCreateParamsFixtures.DEFAULT_CARD
-                    )
+            PaymentOptionResult.Succeeded(paymentSelection)
+        )
+
+        fakeIntentConfirmationInterceptor.enqueueConfirmStep(
+            confirmParams = ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
+                paymentMethodCreateParams = paymentSelection.paymentMethodCreateParams,
+                clientSecret = PaymentSheetFixtures.CLIENT_SECRET,
+                shipping = ConfirmPaymentIntentParams.Shipping(
+                    name = "Test",
+                    address = Address()
                 )
             )
         )
@@ -736,15 +781,22 @@ internal class DefaultFlowControllerTest {
             PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
         ) { _, _ -> }
 
+        val paymentSelection = PaymentSelection.New.LinkInline(
+            LinkPaymentDetails.New(
+                PaymentDetailsFixtures.CONSUMER_SINGLE_PAYMENT_DETAILS.paymentDetails.first(),
+                mock(),
+                PaymentMethodCreateParamsFixtures.DEFAULT_CARD
+            )
+        )
+
         flowController.onPaymentOptionResult(
-            PaymentOptionResult.Succeeded(
-                PaymentSelection.New.LinkInline(
-                    LinkPaymentDetails.New(
-                        PaymentDetailsFixtures.CONSUMER_SINGLE_PAYMENT_DETAILS.paymentDetails.first(),
-                        mock(),
-                        PaymentMethodCreateParamsFixtures.DEFAULT_CARD
-                    )
-                )
+            PaymentOptionResult.Succeeded(paymentSelection)
+        )
+
+        fakeIntentConfirmationInterceptor.enqueueConfirmStep(
+            confirmParams = ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
+                paymentMethodCreateParams = paymentSelection.paymentMethodCreateParams,
+                clientSecret = PaymentSheetFixtures.CLIENT_SECRET
             )
         )
 
@@ -821,6 +873,13 @@ internal class DefaultFlowControllerTest {
                 PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
             ) { _, _ ->
             }
+
+            fakeIntentConfirmationInterceptor.enqueueConfirmStep(
+                confirmParams = ConfirmPaymentIntentParams.createWithPaymentMethodId(
+                    paymentMethodId = PaymentMethodFixtures.CARD_PAYMENT_METHOD.id!!,
+                    clientSecret = PaymentSheetFixtures.CLIENT_SECRET
+                )
+            )
 
             flowController.onGooglePayResult(
                 GooglePayPaymentMethodLauncher.Result.Completed(
@@ -914,6 +973,111 @@ internal class DefaultFlowControllerTest {
         )
     }
 
+    @Test
+    fun `Confirms intent if intent confirmation interceptor returns an unconfirmed intent`() {
+        val flowController = createAndConfigureFlowControllerForDeferredIntent()
+
+        val paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+
+        flowController.onPaymentOptionResult(
+            PaymentOptionResult.Succeeded(
+                paymentSelection
+            )
+        )
+
+        val expectedParams = ConfirmPaymentIntentParams.createWithPaymentMethodId(
+            paymentMethodId = paymentSelection.paymentMethod.id!!,
+            clientSecret = PaymentSheetFixtures.CLIENT_SECRET
+        )
+
+        fakeIntentConfirmationInterceptor.enqueueConfirmStep(expectedParams)
+
+        flowController.confirm()
+
+        verify(paymentLauncher).confirm(expectedParams)
+    }
+
+    @Test
+    fun `Handles next action if intent confirmation interceptor returns an intent with an outstanding action`() {
+        val flowController = createAndConfigureFlowControllerForDeferredIntent()
+
+        val paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+
+        flowController.onPaymentOptionResult(
+            PaymentOptionResult.Succeeded(
+                paymentSelection
+            )
+        )
+
+        fakeIntentConfirmationInterceptor.enqueueNextActionStep(PaymentSheetFixtures.CLIENT_SECRET)
+
+        flowController.confirm()
+
+        verify(paymentLauncher).handleNextActionForPaymentIntent(PaymentSheetFixtures.CLIENT_SECRET)
+    }
+
+    @Test
+    fun `Completes if intent confirmation interceptor returns a completed event`() {
+        val flowController = createAndConfigureFlowControllerForDeferredIntent()
+
+        val paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+
+        flowController.onPaymentOptionResult(
+            PaymentOptionResult.Succeeded(
+                paymentSelection
+            )
+        )
+
+        fakeIntentConfirmationInterceptor.enqueueCompleteStep(PaymentIntentFixtures.PI_SUCCEEDED)
+
+        flowController.confirm()
+
+        verify(paymentResultCallback).onPaymentSheetResult(PaymentSheetResult.Completed)
+    }
+
+    @Test
+    fun `Returns failure if intent confirmation interceptor returns a failure`() {
+        val flowController = createAndConfigureFlowControllerForDeferredIntent()
+
+        val paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+
+        flowController.onPaymentOptionResult(
+            PaymentOptionResult.Succeeded(
+                paymentSelection
+            )
+        )
+
+        fakeIntentConfirmationInterceptor.enqueueFailureStep("something went wrong")
+
+        flowController.confirm()
+
+        verify(paymentResultCallback).onPaymentSheetResult(
+            argWhere {
+                (it as PaymentSheetResult.Failed).error.message == "something went wrong"
+            }
+        )
+    }
+
+    private fun createAndConfigureFlowControllerForDeferredIntent(
+        paymentIntent: PaymentIntent = PaymentIntentFixtures.PI_SUCCEEDED,
+    ): DefaultFlowController {
+        val deferredIntent = paymentIntent.copy(id = null, clientSecret = null)
+        return createFlowController(
+            stripeIntent = deferredIntent
+        ).apply {
+            configureWithIntentConfiguration(
+                intentConfiguration = PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                        amount = 12345,
+                        currency = "usd"
+                    )
+                ),
+                configuration = null,
+                callback = { _, _ -> },
+            )
+        }
+    }
+
     private fun createFlowController(
         paymentMethods: List<PaymentMethod> = emptyList(),
         savedSelection: SavedSelection = SavedSelection.None,
@@ -961,6 +1125,7 @@ internal class DefaultFlowControllerTest {
             eventReporter = eventReporter,
             viewModel = viewModel,
         ),
+        intentConfirmationInterceptor = fakeIntentConfirmationInterceptor,
     )
 
     private fun createGooglePayPaymentMethodLauncherFactory() =

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
@@ -27,8 +27,11 @@ internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor
         channel.trySend(nextStep)
     }
 
-    fun enqueueFailureStep(errorMessage: String) {
-        val nextStep = IntentConfirmationInterceptor.NextStep.Fail(errorMessage)
+    fun enqueueFailureStep(cause: Exception, message: String) {
+        val nextStep = IntentConfirmationInterceptor.NextStep.Fail(
+            cause = cause,
+            message = message
+        )
         channel.trySend(nextStep)
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

* Use IntentConfirmationInterceptor in FlowController.
* Update CreateIntentCallback.Fail to use exception instead of string
* Make sure we are bubbling exception to end user in both PaymentSheet and FlowController

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Decoupling

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
