### PR TITLE
Inject `CreateIntentCallback` into interceptor

### DIFF
--- a/link/src/main/java/com/stripe/android/link/injection/LinkCommonModule.kt
+++ b/link/src/main/java/com/stripe/android/link/injection/LinkCommonModule.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.link.injection
 
+import com.stripe.android.DefaultIntentConfirmationInterceptor
+import com.stripe.android.IntentConfirmationInterceptor
 import com.stripe.android.Stripe
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.IOContext
@@ -26,6 +28,12 @@ internal interface LinkCommonModule {
     @Binds
     @Singleton
     fun bindLinkEventsReporter(linkEventsReporter: DefaultLinkEventsReporter): LinkEventsReporter
+
+    @Binds
+    @Singleton
+    fun bindIntentConfirmationInterceptor(
+        impl: DefaultIntentConfirmationInterceptor,
+    ): IntentConfirmationInterceptor
 
     companion object {
         @Provides

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -3,7 +3,7 @@ package com.stripe.android.link.ui.wallet
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import com.stripe.android.ConfirmStripeIntentParamsFactory
+import com.stripe.android.IntentConfirmationInterceptor
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.NonFallbackInjectable
 import com.stripe.android.core.injection.NonFallbackInjector
@@ -47,7 +47,8 @@ internal class WalletViewModel @Inject constructor(
     private val linkAccountManager: LinkAccountManager,
     private val navigator: Navigator,
     private val confirmationManager: ConfirmationManager,
-    private val logger: Logger
+    private val logger: Logger,
+    private val intentConfirmationInterceptor: IntentConfirmationInterceptor,
 ) : ViewModel() {
 
     private val stripeIntent = args.stripeIntent
@@ -149,17 +150,41 @@ internal class WalletViewModel @Inject constructor(
                 }
             )
         } else {
-            val params = createConfirmStripeIntentParams(
+            val params = createPaymentMethodCreateParams(
                 selectedPaymentDetails = selectedPaymentDetails,
-                linkAccount = linkAccount
+                linkAccount = linkAccount,
             )
 
-            confirmationManager.confirmStripeIntent(params) { result ->
-                result.fold(
-                    onSuccess = ::handleConfirmPaymentSuccess,
-                    onFailure = ::onError
-                )
+            val nextStep = intentConfirmationInterceptor.intercept(
+                clientSecret = stripeIntent.clientSecret,
+                paymentMethodCreateParams = params,
+                shippingValues = args.shippingValues?.toConfirmPaymentIntentShipping(),
+                setupForFutureUsage = null,
+            )
+
+            when (nextStep) {
+                is IntentConfirmationInterceptor.NextStep.Confirm -> {
+                    confirmStripeIntent(nextStep.confirmParams)
+                }
+                is IntentConfirmationInterceptor.NextStep.HandleNextAction -> {
+                    // This can't happen for Link
+                }
+                is IntentConfirmationInterceptor.NextStep.Fail -> {
+                    onError(ErrorMessage.Raw(nextStep.errorMessage))
+                }
+                is IntentConfirmationInterceptor.NextStep.Complete -> {
+                    handleConfirmPaymentSuccess(PaymentResult.Completed)
+                }
             }
+        }
+    }
+
+    private fun confirmStripeIntent(confirmParams: ConfirmStripeIntentParams) {
+        confirmationManager.confirmStripeIntent(confirmParams) { result ->
+            result.fold(
+                onSuccess = ::handleConfirmPaymentSuccess,
+                onFailure = ::onError
+            )
         }
     }
 
@@ -177,15 +202,10 @@ internal class WalletViewModel @Inject constructor(
         return linkAccountManager.updatePaymentDetails(updateParams)
     }
 
-    private fun createConfirmStripeIntentParams(
+    private fun createPaymentMethodCreateParams(
         selectedPaymentDetails: ConsumerPaymentDetails.PaymentDetails,
-        linkAccount: LinkAccount
-    ): ConfirmStripeIntentParams {
-        val paramsFactory = ConfirmStripeIntentParamsFactory.createFactory(
-            clientSecret = requireNotNull(stripeIntent.clientSecret),
-            shipping = args.shippingValues?.toConfirmPaymentIntentShipping()
-        )
-
+        linkAccount: LinkAccount,
+    ): PaymentMethodCreateParams {
         val cvc = uiState.value.cvcInput.takeIf { it.isComplete }?.value
         val extraParams = if (cvc != null) {
             mapOf("card" to mapOf("cvc" to cvc))
@@ -193,13 +213,11 @@ internal class WalletViewModel @Inject constructor(
             null
         }
 
-        val params = PaymentMethodCreateParams.createLink(
+        return PaymentMethodCreateParams.createLink(
             paymentDetailsId = selectedPaymentDetails.id,
             consumerSessionClientSecret = linkAccount.clientSecret,
-            extraParams = extraParams
+            extraParams = extraParams,
         )
-
-        return paramsFactory.create(params)
     }
 
     private fun handleConfirmPaymentSuccess(paymentResult: PaymentResult) {

--- a/link/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModelTest.kt
@@ -9,7 +9,6 @@ import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.Injectable
 import com.stripe.android.core.injection.NonFallbackInjector
 import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetLinkResult
-import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
 import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkActivityResult.Canceled.Reason
@@ -27,6 +26,7 @@ import com.stripe.android.link.model.StripeIntentFixtures
 import com.stripe.android.link.ui.ErrorMessage
 import com.stripe.android.link.ui.PrimaryButtonState
 import com.stripe.android.link.ui.wallet.PaymentDetailsResult
+import com.stripe.android.link.utils.FakeIntentConfirmationInterceptor
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.FinancialConnectionsSession
@@ -94,7 +94,10 @@ class PaymentMethodViewModelTest {
             whenever(shippingValues(anyOrNull())).thenReturn(this)
             whenever(build()).thenReturn(formControllerSubcomponent)
         }
+
     private val formControllerProvider = Provider { formControllerSubcomponentBuilder }
+
+    private val intentConfirmationInterceptor = FakeIntentConfirmationInterceptor()
 
     @Before
     fun before() {
@@ -484,13 +487,14 @@ class PaymentMethodViewModelTest {
 
     private fun createViewModel(loadFromArgs: Boolean = false) =
         PaymentMethodViewModel(
-            args,
-            linkAccount,
-            linkAccountManager,
-            navigator,
-            confirmationManager,
-            logger,
-            formControllerProvider
+            args = args,
+            linkAccount = linkAccount,
+            linkAccountManager = linkAccountManager,
+            navigator = navigator,
+            confirmationManager = confirmationManager,
+            logger = logger,
+            formControllerProvider = formControllerProvider,
+            intentConfirmationInterceptor = intentConfirmationInterceptor,
         ).apply { init(loadFromArgs) }
 
     private fun createLinkPaymentDetails() =
@@ -509,14 +513,6 @@ class PaymentMethodViewModelTest {
                 )
             )
         }
-
-    private fun createFinancialConnectionsAccount(id: String = "id") = FinancialConnectionsAccount(
-        created = 1,
-        id = id,
-        institutionName = "name",
-        livemode = false,
-        supportedPaymentMethodTypes = listOf()
-    )
 
     companion object {
         const val CLIENT_SECRET = "client_secret"

--- a/link/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -5,6 +5,7 @@ import androidx.savedstate.SavedStateRegistry
 import androidx.savedstate.SavedStateRegistryOwner
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.IntentConfirmationInterceptor
 import com.stripe.android.R
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.APIConnectionException
@@ -13,6 +14,7 @@ import com.stripe.android.core.injection.NonFallbackInjector
 import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkActivityResult.Canceled.Reason
+import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.LinkScreen
 import com.stripe.android.link.account.LinkAccountManager
 import com.stripe.android.link.confirmation.ConfirmationManager
@@ -24,9 +26,9 @@ import com.stripe.android.link.model.PaymentDetailsFixtures.CONSUMER_PAYMENT_DET
 import com.stripe.android.link.model.StripeIntentFixtures
 import com.stripe.android.link.ui.ErrorMessage
 import com.stripe.android.link.ui.PrimaryButtonState
+import com.stripe.android.link.utils.FakeIntentConfirmationInterceptor
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.ConfirmPaymentIntentParams
-import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.ConsumerPaymentDetails
 import com.stripe.android.model.ConsumerPaymentDetailsUpdateParams
 import com.stripe.android.model.CvcCheck
@@ -51,6 +53,7 @@ import org.mockito.kotlin.argWhere
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.clearInvocations
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.spy
@@ -63,16 +66,30 @@ import kotlin.random.Random
 
 @RunWith(RobolectricTestRunner::class)
 class WalletViewModelTest {
-    private val args = mock<LinkActivityContract.Args>()
+
     private lateinit var linkAccountManager: LinkAccountManager
     private val navigator = mock<Navigator>()
     private val confirmationManager = mock<ConfirmationManager>()
     private val logger = Logger.noop()
+    private val intentConfirmationInterceptor = FakeIntentConfirmationInterceptor()
+
+    private val args = LinkActivityContract.Args(
+        configuration = LinkPaymentLauncher.Configuration(
+            stripeIntent = StripeIntentFixtures.PI_SUCCEEDED,
+            merchantName = "Merchant, Inc.",
+            customerName = null,
+            customerPhone = null,
+            customerEmail = null,
+            customerBillingCountryCode = null,
+            shippingValues = null,
+        ),
+        prefilledCardParams = null,
+        injectionParams = null,
+    )
 
     @Before
     fun before() {
         Dispatchers.setMain(UnconfinedTestDispatcher())
-        whenever(args.stripeIntent).thenReturn(StripeIntentFixtures.PI_SUCCEEDED)
         val mockLinkAccount = mock<LinkAccount>().apply {
             whenever(clientSecret).thenReturn(CLIENT_SECRET)
             whenever(email).thenReturn("email@stripe.com")
@@ -125,11 +142,11 @@ class WalletViewModelTest {
     @Test
     fun `On initialization when prefilledCardParams is not null then navigate to AddPaymentMethod`() =
         runTest {
-            whenever(args.prefilledCardParams).thenReturn(mock())
             whenever(linkAccountManager.listPaymentDetails())
                 .thenReturn(Result.success(CONSUMER_PAYMENT_DETAILS))
 
-            createViewModel()
+            val argsWithPrefilledCardParams = args.copy(prefilledCardParams = mock())
+            createViewModel(argsWithPrefilledCardParams)
 
             verify(navigator).navigateTo(
                 argWhere {
@@ -144,52 +161,54 @@ class WalletViewModelTest {
         val paymentDetails = CONSUMER_PAYMENT_DETAILS.paymentDetails.first()
         whenever(linkAccountManager.listPaymentDetails())
             .thenReturn(Result.success(CONSUMER_PAYMENT_DETAILS))
-        whenever(args.shippingValues)
-            .thenReturn(null)
 
         val viewModel = createViewModel()
 
         viewModel.onItemSelected(paymentDetails)
         viewModel.onConfirmPayment()
 
-        val paramsCaptor = argumentCaptor<ConfirmStripeIntentParams>()
-        verify(confirmationManager).confirmStripeIntent(paramsCaptor.capture(), any())
+        val confirmParams = mock<ConfirmPaymentIntentParams>()
+        intentConfirmationInterceptor.enqueueConfirmStep(confirmParams)
 
-        assertThat(paramsCaptor.firstValue).isEqualTo(
-            ConfirmPaymentIntentParams.createWithPaymentMethodCreateParams(
-                PaymentMethodCreateParams.createLink(
-                    paymentDetails.id,
-                    CLIENT_SECRET
-                ),
-                StripeIntentFixtures.PI_SUCCEEDED.clientSecret!!
-            )
-        )
+        verify(confirmationManager).confirmStripeIntent(eq(confirmParams), any())
     }
 
     @Test
     fun `when shippingValues are passed ConfirmPaymentIntentParams has shipping`() = runTest {
         whenever(linkAccountManager.listPaymentDetails())
             .thenReturn(Result.success(CONSUMER_PAYMENT_DETAILS))
-        whenever(args.shippingValues).thenReturn(
-            mapOf(
-                IdentifierSpec.Name to "Test Name",
-                IdentifierSpec.Country to "US"
+
+        val argsWithShippingValues = args.copy(
+            configuration = args.configuration.copy(
+                shippingValues = mapOf(
+                    IdentifierSpec.Name to "Test Name",
+                    IdentifierSpec.Country to "US",
+                ),
             )
         )
 
-        val viewModel = createViewModel()
+        val mockInterceptor = mock<IntentConfirmationInterceptor>()
+
+        val viewModel = createViewModel(
+            args = argsWithShippingValues,
+            intentConfirmationInterceptor = mockInterceptor,
+        )
 
         viewModel.onConfirmPayment()
 
-        val paramsCaptor = argumentCaptor<ConfirmStripeIntentParams>()
-        verify(confirmationManager).confirmStripeIntent(paramsCaptor.capture(), any())
+        val paramsCaptor = argumentCaptor<ConfirmPaymentIntentParams.Shipping>()
 
-        assertThat(paramsCaptor.firstValue.toParamMap()["shipping"]).isEqualTo(
+        verify(mockInterceptor).intercept(
+            clientSecret = anyOrNull(),
+            paymentMethodCreateParams = any(),
+            shippingValues = paramsCaptor.capture(),
+            setupForFutureUsage = isNull(),
+        )
+
+        assertThat(paramsCaptor.firstValue.toParamMap()).isEqualTo(
             mapOf(
-                "address" to mapOf(
-                    "country" to "US"
-                ),
-                "name" to "Test Name"
+                "address" to mapOf("country" to "US"),
+                "name" to "Test Name",
             )
         )
     }
@@ -233,15 +252,17 @@ class WalletViewModelTest {
 
     @Test
     fun `when default item is not supported then first supported item is selected`() = runTest {
-        whenever(args.stripeIntent).thenReturn(
-            StripeIntentFixtures.PI_SUCCEEDED.copy(
-                linkFundingSources = listOf(ConsumerPaymentDetails.BankAccount.type)
-            )
-        )
         whenever(linkAccountManager.listPaymentDetails())
             .thenReturn(Result.success(CONSUMER_PAYMENT_DETAILS))
 
-        val viewModel = createViewModel()
+        val argsWithFundingSources = args.copy(
+            configuration = args.configuration.copy(
+                stripeIntent = StripeIntentFixtures.PI_SUCCEEDED.copy(
+                    linkFundingSources = listOf(ConsumerPaymentDetails.BankAccount.type),
+                ),
+            )
+        )
+        val viewModel = createViewModel(argsWithFundingSources)
 
         val bankAccount = CONSUMER_PAYMENT_DETAILS.paymentDetails[2]
         assertThat(viewModel.uiState.value.selectedItem).isEqualTo(bankAccount)
@@ -255,8 +276,11 @@ class WalletViewModelTest {
         viewModel.onItemSelected(CONSUMER_PAYMENT_DETAILS.paymentDetails.first())
         viewModel.onConfirmPayment()
 
+        val confirmParams = mock<ConfirmPaymentIntentParams>()
+        intentConfirmationInterceptor.enqueueConfirmStep(confirmParams)
+
         val callbackCaptor = argumentCaptor<PaymentConfirmationCallback>()
-        verify(confirmationManager).confirmStripeIntent(any(), callbackCaptor.capture())
+        verify(confirmationManager).confirmStripeIntent(eq(confirmParams), callbackCaptor.capture())
 
         callbackCaptor.firstValue(Result.success(PaymentResult.Failed(RuntimeException(errorThrown))))
 
@@ -358,10 +382,11 @@ class WalletViewModelTest {
         val viewModel = createViewModel()
         viewModel.onConfirmPayment()
 
+        val confirmParams = mock<ConfirmPaymentIntentParams>()
+        intentConfirmationInterceptor.enqueueConfirmStep(confirmParams)
         assertThat(viewModel.uiState.value.primaryButtonState).isEqualTo(PrimaryButtonState.Completed)
 
         advanceTimeBy(PrimaryButtonState.COMPLETED_DELAY_MS + 1)
-
         verify(navigator).dismiss(LinkActivityResult.Completed)
     }
 
@@ -431,19 +456,26 @@ class WalletViewModelTest {
     @Test
     fun `Sends CVC if paying with card that requires CVC recollection`() = runTest {
         val paymentDetails = mockCard(cvcCheck = CvcCheck.Fail)
-        val viewModel = createViewModel()
+        val mockInterceptor = mock<IntentConfirmationInterceptor>()
 
+        val viewModel = createViewModel(intentConfirmationInterceptor = mockInterceptor)
         val cvcInput = "123"
 
         viewModel.onItemSelected(paymentDetails)
         viewModel.cvcController.onRawValueChange(cvcInput)
         viewModel.onConfirmPayment()
 
-        val paramsCaptor = argumentCaptor<ConfirmStripeIntentParams>()
-        verify(confirmationManager).confirmStripeIntent(paramsCaptor.capture(), any())
+        val paramsCaptor = argumentCaptor<PaymentMethodCreateParams>()
+//        verify(confirmationManager).confirmStripeIntent(paramsCaptor.capture(), any())
 
-        val paymentIntentParams = paramsCaptor.firstValue as ConfirmPaymentIntentParams
-        val paramsMap = paymentIntentParams.paymentMethodCreateParams!!.toParamMap()
+        verify(mockInterceptor).intercept(
+            clientSecret = anyOrNull(),
+            paymentMethodCreateParams = paramsCaptor.capture(),
+            shippingValues = anyOrNull(),
+            setupForFutureUsage = anyOrNull(),
+        )
+
+        val paramsMap = paramsCaptor.firstValue.toParamMap()
 
         val link = paramsMap["link"] as Map<*, *>
         val card = link["card"] as Map<*, *>
@@ -458,16 +490,21 @@ class WalletViewModelTest {
             .thenReturn(Result.success(CONSUMER_PAYMENT_DETAILS))
 
         val paymentDetails = mockCard(cvcCheck = CvcCheck.Pass)
-        val viewModel = createViewModel()
+        val mockInterceptor = mock<IntentConfirmationInterceptor>()
 
+        val viewModel = createViewModel(intentConfirmationInterceptor = mockInterceptor)
         viewModel.onItemSelected(paymentDetails)
         viewModel.onConfirmPayment()
 
-        val paramsCaptor = argumentCaptor<ConfirmStripeIntentParams>()
-        verify(confirmationManager).confirmStripeIntent(paramsCaptor.capture(), any())
+        val paramsCaptor = argumentCaptor<PaymentMethodCreateParams>()
+        verify(mockInterceptor).intercept(
+            clientSecret = anyOrNull(),
+            paymentMethodCreateParams = paramsCaptor.capture(),
+            shippingValues = anyOrNull(),
+            setupForFutureUsage = anyOrNull(),
+        )
 
-        val paymentIntentParams = paramsCaptor.firstValue as ConfirmPaymentIntentParams
-        val paramsMap = paymentIntentParams.paymentMethodCreateParams!!.toParamMap()
+        val paramsMap = paramsCaptor.firstValue.toParamMap()
 
         val link = paramsMap["link"] as Map<*, *>
         assertThat(link).doesNotContainKey("card")
@@ -589,6 +626,81 @@ class WalletViewModelTest {
     }
 
     @Test
+    fun `Confirms intent if confirmation interceptor returns unconfirmed intent`() = runTest {
+        val args = args.copy(
+            configuration = args.configuration.copy(
+                stripeIntent = StripeIntentFixtures.PI_SUCCEEDED.copy(clientSecret = null),
+            ),
+        )
+
+        val viewModel = createViewModel(args)
+        val paymentDetails = CONSUMER_PAYMENT_DETAILS.paymentDetails.first()
+
+        viewModel.onItemSelected(paymentDetails)
+        viewModel.onConfirmPayment()
+
+        val confirmParams = mock<ConfirmPaymentIntentParams>()
+        intentConfirmationInterceptor.enqueueConfirmStep(confirmParams)
+
+        verify(confirmationManager).confirmStripeIntent(eq(confirmParams), any())
+    }
+
+    @Test
+    fun `Finishes with success if confirmation interceptor returns confirmed intent`() = runTest {
+        whenever(confirmationManager.confirmStripeIntent(any(), any())).thenAnswer { invocation ->
+            (invocation.getArgument(1) as? PaymentConfirmationCallback)?.let {
+                it(Result.success(PaymentResult.Completed))
+            }
+        }
+        whenever(linkAccountManager.listPaymentDetails())
+            .thenReturn(Result.success(CONSUMER_PAYMENT_DETAILS))
+
+        val stripeIntent = StripeIntentFixtures.PI_SUCCEEDED
+
+        val args = args.copy(
+            configuration = args.configuration.copy(
+                stripeIntent = stripeIntent.copy(clientSecret = null),
+            ),
+        )
+
+        val viewModel = createViewModel(args)
+        val paymentDetails = CONSUMER_PAYMENT_DETAILS.paymentDetails.first()
+
+        viewModel.onItemSelected(paymentDetails)
+        viewModel.onConfirmPayment()
+
+        val confirmParams = mock<ConfirmPaymentIntentParams>()
+        intentConfirmationInterceptor.enqueueConfirmStep(confirmParams)
+
+        advanceTimeBy(PrimaryButtonState.COMPLETED_DELAY_MS + 1)
+        verify(navigator).dismiss(eq(LinkActivityResult.Completed))
+    }
+
+    @Test
+    fun `Displays error if confirmation interceptor returns a failure`() = runTest {
+        val stripeIntent = StripeIntentFixtures.PI_SUCCEEDED
+
+        val args = args.copy(
+            configuration = args.configuration.copy(
+                stripeIntent = stripeIntent.copy(clientSecret = null),
+            ),
+        )
+
+        val viewModel = createViewModel(args)
+        val paymentDetails = CONSUMER_PAYMENT_DETAILS.paymentDetails.first()
+
+        viewModel.onItemSelected(paymentDetails)
+        viewModel.onConfirmPayment()
+
+        val error = "oops, this one failed"
+        intentConfirmationInterceptor.enqueueFailureStep(error)
+
+        viewModel.uiState.test {
+            assertThat(awaitItem().errorMessage).isEqualTo(ErrorMessage.Raw(error))
+        }
+    }
+
+    @Test
     fun `Factory gets initialized by Injector`() {
         val mockBuilder = mock<SignedInViewModelSubcomponent.Builder>()
         val mockSubComponent = mock<SignedInViewModelSubcomponent>()
@@ -622,14 +734,17 @@ class WalletViewModelTest {
         assertThat(createdViewModel).isEqualTo(vmToBeReturned)
     }
 
-    private fun createViewModel() =
-        WalletViewModel(
-            args,
-            linkAccountManager,
-            navigator,
-            confirmationManager,
-            logger
-        )
+    private fun createViewModel(
+        args: LinkActivityContract.Args = this.args,
+        intentConfirmationInterceptor: IntentConfirmationInterceptor = this.intentConfirmationInterceptor,
+    ): WalletViewModel = WalletViewModel(
+        args = args,
+        linkAccountManager = linkAccountManager,
+        navigator = navigator,
+        confirmationManager = confirmationManager,
+        logger = logger,
+        intentConfirmationInterceptor = intentConfirmationInterceptor,
+    )
 
     private fun mockCard(
         cvcCheck: CvcCheck = CvcCheck.Pass,

--- a/link/src/test/java/com/stripe/android/link/utils/FakeIntentConfirmationInterceptor.kt
+++ b/link/src/test/java/com/stripe/android/link/utils/FakeIntentConfirmationInterceptor.kt
@@ -1,0 +1,52 @@
+package com.stripe.android.link.utils
+
+import com.stripe.android.IntentConfirmationInterceptor
+import com.stripe.android.model.ConfirmPaymentIntentParams
+import com.stripe.android.model.ConfirmStripeIntentParams
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.StripeIntent
+import kotlinx.coroutines.channels.Channel
+
+internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor {
+
+    private val channel = Channel<IntentConfirmationInterceptor.NextStep>(capacity = 1)
+
+    fun enqueueConfirmStep(confirmParams: ConfirmStripeIntentParams) {
+        val nextStep = IntentConfirmationInterceptor.NextStep.Confirm(confirmParams)
+        channel.trySend(nextStep)
+    }
+
+    fun enqueueCompleteStep(stripeIntent: StripeIntent) {
+        val nextStep = IntentConfirmationInterceptor.NextStep.Complete(stripeIntent)
+        channel.trySend(nextStep)
+    }
+
+    fun enqueueNextActionStep(clientSecret: String) {
+        val nextStep = IntentConfirmationInterceptor.NextStep.HandleNextAction(clientSecret)
+        channel.trySend(nextStep)
+    }
+
+    fun enqueueFailureStep(errorMessage: String) {
+        val nextStep = IntentConfirmationInterceptor.NextStep.Fail(errorMessage)
+        channel.trySend(nextStep)
+    }
+
+    override suspend fun intercept(
+        clientSecret: String?,
+        paymentMethodCreateParams: PaymentMethodCreateParams,
+        shippingValues: ConfirmPaymentIntentParams.Shipping?,
+        setupForFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage?
+    ): IntentConfirmationInterceptor.NextStep {
+        return channel.receive()
+    }
+
+    override suspend fun intercept(
+        clientSecret: String?,
+        paymentMethod: PaymentMethod,
+        shippingValues: ConfirmPaymentIntentParams.Shipping?,
+        setupForFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage?
+    ): IntentConfirmationInterceptor.NextStep {
+        return channel.receive()
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/IntentConfirmationInterceptor.kt
+++ b/payments-core/src/main/java/com/stripe/android/IntentConfirmationInterceptor.kt
@@ -22,10 +22,10 @@ import javax.inject.Named
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Module
-abstract class IntentConfirmationInterceptorModule {
+interface IntentConfirmationInterceptorModule {
 
     @Binds
-    abstract fun bindsIntentConfirmationInterceptor(
+    fun bindsIntentConfirmationInterceptor(
         impl: DefaultIntentConfirmationInterceptor,
     ): IntentConfirmationInterceptor
 }

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -38,13 +38,11 @@
     <ID>MagicNumber:PaymentOptionUi.kt$14</ID>
     <ID>MagicNumber:PaymentOptionUi.kt$18</ID>
     <ID>MagicNumber:PrimaryButton.kt$PrimaryButton$0.5f</ID>
-    <ID>MagicNumber:PrimaryButtonUiStateMapper.kt$PrimaryButtonUiStateMapper$3</ID>
-    <ID>MagicNumber:PrimaryButtonUiStateMapper.kt$PrimaryButtonUiStateMapper$4</ID>
-    <ID>MagicNumber:PrimaryButtonUiStateMapper.kt$PrimaryButtonUiStateMapper$5</ID>
     <ID>MagicNumber:USBankAccountFormFragment.kt$USBankAccountFormFragment$0.5f</ID>
     <ID>MaxLineLength:BillingAddressViewTest.kt$BillingAddressViewTest$fun</ID>
     <ID>MaxLineLength:CustomerRepositoryTest.kt$CustomerRepositoryTest$onBlocking { detachPaymentMethod(anyString(), any(), anyString(), any()) }.doThrow(InvalidParameterException("error"))</ID>
     <ID>MaxLineLength:DefaultFlowControllerTest.kt$DefaultFlowControllerTest$fun</ID>
+    <ID>MaxLineLength:FakeIntentConfirmationInterceptor.kt$internal</ID>
     <ID>MaxLineLength:FlowControllerConfigurationHandlerTest.kt$FlowControllerConfigurationHandlerTest$.</ID>
     <ID>MaxLineLength:InjectableActivityScenario.kt$InjectableActivityScenario$delegate ?: throw IllegalStateException("Cannot move to state $newState since the activity hasn't been launched.")</ID>
     <ID>MaxLineLength:InjectableActivityScenario.kt$InjectableActivityScenario$val d = delegate ?: throw IllegalStateException("Cannot run onActivity since the activity hasn't been launched.")</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.IntentConfirmationInterceptor
+import com.stripe.android.IntentConfirmationInterceptorSubcomponent
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.DUMMY_INJECTOR_KEY
@@ -94,7 +95,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     @IOContext workContext: CoroutineContext,
     savedStateHandle: SavedStateHandle,
     linkHandler: LinkHandler,
-    private val intentConfirmationInterceptor: IntentConfirmationInterceptor,
+    private val interceptorSubcomponentBuilder: IntentConfirmationInterceptorSubcomponent.Builder,
 ) : BaseSheetViewModel(
     application = application,
     config = args.config,
@@ -435,6 +436,11 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     private fun confirmPaymentSelection(paymentSelection: PaymentSelection?) {
         viewModelScope.launch {
             val stripeIntent = requireNotNull(stripeIntent.value)
+
+            val intentConfirmationInterceptor = interceptorSubcomponentBuilder
+                .createIntentCallback(IntentConfirmationInterceptor.createIntentCallback)
+                .build()
+                .intentConfirmationInterceptor
 
             val nextStep = intentConfirmationInterceptor.intercept(
                 clientSecret = stripeIntent.clientSecret,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerComponent.kt
@@ -2,6 +2,8 @@ package com.stripe.android.paymentsheet.flowcontroller
 
 import androidx.activity.result.ActivityResultCaller
 import androidx.lifecycle.LifecycleOwner
+import com.stripe.android.AbsCreateIntentCallback
+import com.stripe.android.IntentConfirmationInterceptorModule
 import com.stripe.android.core.injection.InjectorKey
 import com.stripe.android.paymentsheet.PaymentOptionCallback
 import com.stripe.android.paymentsheet.PaymentSheetResultCallback
@@ -9,7 +11,7 @@ import dagger.BindsInstance
 import dagger.Subcomponent
 
 @FlowControllerScope
-@Subcomponent
+@Subcomponent(modules = [IntentConfirmationInterceptorModule::class])
 internal interface FlowControllerComponent {
     val flowController: DefaultFlowController
     val stateComponent: FlowControllerStateComponent
@@ -30,6 +32,9 @@ internal interface FlowControllerComponent {
 
         @BindsInstance
         fun paymentResultCallback(paymentResultCallback: PaymentSheetResultCallback): Builder
+
+        @BindsInstance
+        fun createIntentCallback(createIntentCallback: AbsCreateIntentCallback?): Builder
 
         @BindsInstance
         fun injectorKey(@InjectorKey injectorKey: String): Builder

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerModule.kt
@@ -16,7 +16,7 @@ import javax.inject.Singleton
 @Module(
     subcomponents = [
         PaymentOptionsViewModelSubcomponent::class,
-        FormViewModelSubcomponent::class
+        FormViewModelSubcomponent::class,
     ]
 )
 internal object FlowControllerModule {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
@@ -2,8 +2,6 @@ package com.stripe.android.paymentsheet.injection
 
 import android.app.Application
 import android.content.Context
-import com.stripe.android.DefaultIntentConfirmationInterceptor
-import com.stripe.android.IntentConfirmationInterceptor
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
@@ -53,11 +51,6 @@ internal abstract class PaymentSheetCommonModule {
     abstract fun bindsLinkAccountStatusProvider(
         impl: DefaultLinkAccountStatusProvider,
     ): LinkAccountStatusProvider
-
-    @Binds
-    abstract fun bindsIntentConfirmationInterceptor(
-        impl: DefaultIntentConfirmationInterceptor,
-    ): IntentConfirmationInterceptor
 
     companion object {
         /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherModule.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.injection
 
 import android.app.Application
 import android.content.Context
+import com.stripe.android.IntentConfirmationInterceptorSubcomponent
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import dagger.Binds
@@ -13,7 +14,8 @@ import javax.inject.Singleton
 @Module(
     subcomponents = [
         PaymentSheetViewModelSubcomponent::class,
-        FormViewModelSubcomponent::class
+        FormViewModelSubcomponent::class,
+        IntentConfirmationInterceptorSubcomponent::class,
     ]
 )
 internal abstract class PaymentSheetLauncherModule {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/BasePaymentSheetViewModelInjectionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/BasePaymentSheetViewModelInjectionTest.kt
@@ -32,6 +32,7 @@ import com.stripe.android.utils.FakeCustomerRepository
 import com.stripe.android.utils.FakeIntentConfirmationInterceptor
 import com.stripe.android.utils.FakePaymentSheetLoader
 import com.stripe.android.utils.PaymentIntentFactory
+import com.stripe.android.utils.wrappedInSubcomponentBuilder
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -118,7 +119,7 @@ internal open class BasePaymentSheetViewModelInjectionTest {
                 testDispatcher,
                 savedStateHandle = savedStateHandle,
                 linkHandler = linkHandler,
-                intentConfirmationInterceptor = fakeIntentConfirmationInterceptor,
+                interceptorSubcomponentBuilder = fakeIntentConfirmationInterceptor.wrappedInSubcomponentBuilder(),
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -79,6 +79,7 @@ import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.utils.TestUtils.viewModelFactoryFor
 import com.stripe.android.utils.injectableActivityScenario
+import com.stripe.android.utils.wrappedInSubcomponentBuilder
 import com.stripe.android.view.ActivityScenarioFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -999,7 +1000,7 @@ internal class PaymentSheetActivityTest {
                 testDispatcher,
                 savedStateHandle = savedStateHandle,
                 linkHandler = linkHandler,
-                intentConfirmationInterceptor = fakeIntentConfirmationInterceptor,
+                interceptorSubcomponentBuilder = fakeIntentConfirmationInterceptor.wrappedInSubcomponentBuilder(),
             ).also {
                 it.injector = injector
             }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -58,6 +58,7 @@ import com.stripe.android.utils.FakeCustomerRepository
 import com.stripe.android.utils.FakeIntentConfirmationInterceptor
 import com.stripe.android.utils.FakePaymentSheetLoader
 import com.stripe.android.utils.PaymentIntentFactory
+import com.stripe.android.utils.wrappedInSubcomponentBuilder
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -1306,6 +1307,7 @@ internal class PaymentSheetViewModelTest {
         lpmRepository: LpmRepository = this.lpmRepository,
     ): PaymentSheetViewModel {
         val paymentConfiguration = PaymentConfiguration(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
+
         return TestViewModelFactory.create(
             linkLauncher = linkLauncher,
         ) { linkHandler, savedStateHandle ->
@@ -1333,7 +1335,7 @@ internal class PaymentSheetViewModelTest {
                 testDispatcher,
                 savedStateHandle = savedStateHandle,
                 linkHandler = linkHandler,
-                intentConfirmationInterceptor = fakeIntentConfirmationInterceptor,
+                interceptorSubcomponentBuilder = fakeIntentConfirmationInterceptor.wrappedInSubcomponentBuilder(),
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
@@ -1,12 +1,16 @@
 package com.stripe.android.utils
 
 import com.stripe.android.IntentConfirmationInterceptor
+import com.stripe.android.IntentConfirmationInterceptorSubcomponent
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.StripeIntent
 import kotlinx.coroutines.channels.Channel
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 
 internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor {
 
@@ -51,5 +55,16 @@ internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor
         setupForFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage?
     ): IntentConfirmationInterceptor.NextStep {
         return channel.receive()
+    }
+}
+
+internal fun FakeIntentConfirmationInterceptor.wrappedInSubcomponentBuilder(): IntentConfirmationInterceptorSubcomponent.Builder {
+    val interceptorSubcomponent = mock<IntentConfirmationInterceptorSubcomponent> {
+        on { intentConfirmationInterceptor } doReturn this@wrappedInSubcomponentBuilder
+    }
+
+    return mock {
+        on { createIntentCallback(anyOrNull()) } doReturn mock
+        on { build() } doReturn interceptorSubcomponent
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request changes how we’re accessing `CreateIntentCallback` in `IntentConfirmationInterceptor`. Instead of using the static member, we use constructor injection.

This doesn’t change much for the custom flow involving `FlowController`, but required some changes for the complete flow of `PaymentSheet`. We’re adding `IntentConfirmationInterceptorSubcomponent`, which is constructed and provided with the `CreateIntentCallback`, and build it just in time when the user presses the primary button.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
