### PR TITLE
Fix ClassCastException in PaymentSheetContract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## XX.XX.XX - 2023-XX-XX
+
+### PaymentSheet
+* [FIXED][6366](https://github.com/stripe/stripe-android/pull/6366) Fixed an issue where the result couldn't be parsed in `PaymentSheetContract`.
+
 ## 20.20.0 - 2023-03-13
 
 ### Payments

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetContract.kt
@@ -31,7 +31,7 @@ class PaymentSheetContract :
         resultCode: Int,
         intent: Intent?
     ): PaymentSheetResult {
-        val paymentResult = intent?.getParcelableExtra<Result>(EXTRA_RESULT)?.paymentSheetResult
+        val paymentResult = intent?.getParcelableExtra<PaymentSheetContractV2.Result>(EXTRA_RESULT)?.paymentSheetResult
         return paymentResult ?: PaymentSheetResult.Failed(
             IllegalArgumentException("Failed to retrieve a PaymentSheetResult.")
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetContractTest.kt
@@ -1,7 +1,12 @@
 package com.stripe.android.paymentsheet
 
+import android.content.Context
 import android.content.Intent
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
@@ -9,9 +14,31 @@ import kotlin.test.Test
 @RunWith(RobolectricTestRunner::class)
 class PaymentSheetContractTest {
 
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @get:Rule
+    val composeTestRule = createEmptyComposeRule()
+
     @Test
     fun `parseResult() with missing data should return failed result`() {
         assertThat(PaymentSheetContract().parseResult(0, Intent()))
             .isInstanceOf(PaymentSheetResult.Failed::class.java)
+    }
+
+    @Test
+    fun `Converts PaymentSheetContractV2 result correctly back to PaymentSheetContract result`() {
+        val contract = PaymentSheetContract()
+        val args = PaymentSheetContract.Args.createPaymentIntentArgs("pi_123_secret_456")
+        val intent = contract.createIntent(context, args)
+
+        val scenario = ActivityScenario.launchActivityForResult<PaymentSheetActivity>(intent)
+
+        scenario.onActivity { activity ->
+            activity.setActivityResult(PaymentSheetResult.Canceled)
+            activity.finish()
+        }
+
+        val result = contract.parseResult(scenario.result.resultCode, scenario.result.resultData)
+        assertThat(result).isEqualTo(PaymentSheetResult.Canceled)
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes a `ClassCastException` in `PaymentSheetResult`. The issue originated when we switched to using `PaymentSheetContractV2` internally.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

https://github.com/stripe/stripe-android/issues/6365

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

[FIXED] Fixed an issue where the result couldn't be parsed in `PaymentSheetContract`.
