### PR TITLE
Add `prepare_release` script to update changelog

### DIFF
--- a/scripts/prepare_release.rb
+++ b/scripts/prepare_release.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env ruby
+
+require 'octokit'
+require 'fileutils'
+require 'erb'
+require 'colorize'
+require 'optparse'
+
+def update_changelog(version)
+  done = false
+  final_lines = []
+
+  File.foreach('CHANGELOG.md') { |line|
+    is_line = line.include? "XX.XX.XX"
+    final_lines.append(line)
+
+    date = Time.now.strftime("%Y-%m-%d")
+
+    if is_line
+        final_lines.append("\n")
+        final_lines.append("## #{version} - #{date}\n")
+    end
+  }
+
+  File.write('CHANGELOG.md', final_lines.join(""))
+end
+
+def github_login
+  token = `fetch-password -q bindings/gh-tokens/$USER`
+  if $?.exitstatus != 0
+    puts "Couldn't fetch GitHub token. Follow the Android SDK Deploy Guide (https://go/android-sdk-deploy) to set up a token. \a".red
+    exit(1)
+  end
+  client = Octokit::Client.new(access_token: token)
+  abort('Invalid GitHub token. Follow the wiki instructions for setting up a GitHub token.') unless client.login
+  client
+end
+
+def open_url(url)
+  `open '#{url}'`
+end
+
+# Script start
+
+if ARGV.length != 1
+    abort('Provide the new version number as an argument.')
+end
+
+new_version_number = ARGV[0]
+new_branch_name = "release/#{new_version_number}"
+action_title = "Update release notes for #{new_version_number}"
+
+# Pull the current state
+system("git checkout master")
+system("git pull")
+
+# Update the changelog on a new branch
+system("git checkout -b #{new_branch_name}")
+update_changelog(new_version_number)
+
+# Push the new branch
+system("git add .")
+system("git commit -m \"#{action_title}\"")
+system("git push -u origin")
+
+# Open the pull request creation page
+compare_url = "https://github.com/stripe/stripe-android/compare/master...#{new_branch_name}?expand=1"
+open_url(compare_url)

--- a/scripts/prepare_release.rb
+++ b/scripts/prepare_release.rb
@@ -5,6 +5,7 @@ require 'fileutils'
 require 'erb'
 require 'colorize'
 require 'optparse'
+require 'open3'
 
 def prompt_for_new_version
   puts "What's the new version number?"
@@ -24,6 +25,19 @@ def validate_version_number(version_number)
       part_name = part_names[index]
       abort("Invalid version number: #{part_name} number can\'t begin with 0.")
     end
+  end
+end
+
+def ensure_clean_repo()
+  repo_dir = File.basename(Dir.getwd)
+  if repo_dir != "stripe-android"
+    abort("You must run this script from 'stripe-android'.")
+  end
+
+  stdout, stderr, status = Open3.capture3("git status --porcelain")
+
+  if !stdout.empty?
+    abort("You must have a clean working directory to continue.")
   end
 end
 
@@ -52,6 +66,8 @@ end
 
 # Script start
 
+ensure_clean_repo
+
 new_version_number = prompt_for_new_version
 validate_version_number(new_version_number)
 
@@ -67,7 +83,7 @@ system("git checkout -b #{new_branch_name}")
 update_changelog(new_version_number)
 
 # Push the new branch
-system("git add .")
+system("git add CHANGELOG.md")
 system("git commit -m \"#{action_title}\"")
 system("git push -u origin")
 

--- a/scripts/prepare_release.rb
+++ b/scripts/prepare_release.rb
@@ -6,6 +6,27 @@ require 'erb'
 require 'colorize'
 require 'optparse'
 
+def prompt_for_new_version
+  puts "What's the new version number?"
+  version = gets.chomp
+end
+
+def validate_version_number(version_number)
+  part_names = ['major', 'minor', 'patch']
+  parts = version_number.split('.')
+
+  unless parts.length() == 3
+    abort("Invalid version number. It should consists of a major, minor, and patch number.")
+  end
+
+  parts.each_with_index do | part, index |
+    if part.start_with?('0') && part.length() > 1
+      part_name = part_names[index]
+      abort("Invalid version number: #{part_name} number can\'t begin with 0.")
+    end
+  end
+end
+
 def update_changelog(version)
   done = false
   final_lines = []
@@ -25,28 +46,15 @@ def update_changelog(version)
   File.write('CHANGELOG.md', final_lines.join(""))
 end
 
-def github_login
-  token = `fetch-password -q bindings/gh-tokens/$USER`
-  if $?.exitstatus != 0
-    puts "Couldn't fetch GitHub token. Follow the Android SDK Deploy Guide (https://go/android-sdk-deploy) to set up a token. \a".red
-    exit(1)
-  end
-  client = Octokit::Client.new(access_token: token)
-  abort('Invalid GitHub token. Follow the wiki instructions for setting up a GitHub token.') unless client.login
-  client
-end
-
 def open_url(url)
   `open '#{url}'`
 end
 
 # Script start
 
-if ARGV.length != 1
-    abort('Provide the new version number as an argument.')
-end
+new_version_number = prompt_for_new_version
+validate_version_number(new_version_number)
 
-new_version_number = ARGV[0]
 new_branch_name = "release/#{new_version_number}"
 action_title = "Update release notes for #{new_version_number}"
 

--- a/scripts/prepare_release.rb
+++ b/scripts/prepare_release.rb
@@ -75,20 +75,24 @@ def open_url(url)
   `open '#{url}'`
 end
 
+def execute_or_fail(command)
+    system(command) or raise "Failed to execute #{command}"
+end
+
 def pull_current_master
-  system("git checkout master")
-  system("git pull")
+  execute_or_fail("git checkout master")
+  execute_or_fail("git pull")
 end
 
 def update_changelog_on_new_branch(branch_name, version_number)
-  system("git checkout -b #{branch_name}")
+  execute_or_fail("git checkout -b #{branch_name}")
   update_changelog(version_number)
 end
 
 def push_changes(commit_title)
-  system("git add CHANGELOG.md")
-  system("git commit -m \"#{commit_title}\"")
-  system("git push -u origin")
+  execute_or_fail("git add CHANGELOG.md")
+  execute_or_fail("git commit -m \"#{commit_title}\"")
+  execute_or_fail("git push -u origin")
 end
 
 def create_pull_request_body(version_number)

--- a/scripts/prepare_release.rb
+++ b/scripts/prepare_release.rb
@@ -45,7 +45,7 @@ def update_changelog(version)
   done = false
   final_lines = []
 
-  File.foreach('CHANGELOG.md') { |line|
+  File.foreach('CHANGELOG.md') do |line|
     is_line = line.include? "XX.XX.XX"
     final_lines.append(line)
 
@@ -55,7 +55,7 @@ def update_changelog(version)
         final_lines.append("\n")
         final_lines.append("## #{version} - #{date}\n")
     end
-  }
+  end
 
   File.write('CHANGELOG.md', final_lines.join(""))
 end

--- a/scripts/prepare_release.rb
+++ b/scripts/prepare_release.rb
@@ -119,8 +119,7 @@ def open_pull_request(branch_name, title, body)
       "master",
       branch_name,
       title,
-      body,
-      options
+      body
     )
 end
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds a script to prepare the changelog for a new release. You’ll just run `ruby scripts/prepare_release.rb` and it’ll create a new pull request for you.

The script also validates the release version for the correct format, as this has caused a release to fail midway through.

I’ll update the deployment guide as soon as this pull request is merged.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
