### PR TITLE
Fix janky auto selection of payment method

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -12,7 +12,6 @@
     <ID>FunctionOnlyReturningConstant:SupportedPaymentMethodTest.kt$SupportedPaymentMethodTest.PaymentIntentTestInput.Companion$fun toCsvHeader()</ID>
     <ID>FunctionOnlyReturningConstant:SupportedPaymentMethodTest.kt$SupportedPaymentMethodTest.TestOutput.Companion$fun toCsvHeader()</ID>
     <ID>LargeClass:DefaultFlowControllerTest.kt$DefaultFlowControllerTest</ID>
-    <ID>LargeClass:DefaultPaymentSheetLoaderTest.kt$DefaultPaymentSheetLoaderTest</ID>
     <ID>LargeClass:PaymentIntentFixtures.kt$PaymentIntentFixtures</ID>
     <ID>LargeClass:PaymentSheetActivityTest.kt$PaymentSheetActivityTest</ID>
     <ID>LargeClass:PaymentSheetViewModelTest.kt$PaymentSheetViewModelTest</ID>
@@ -25,6 +24,7 @@
     <ID>LongMethod:PaymentElement.kt$@Composable internal fun PaymentElement( sheetViewModel: BaseSheetViewModel, enabled: Boolean, supportedPaymentMethods: List&lt;LpmRepository.SupportedPaymentMethod>, selectedItem: LpmRepository.SupportedPaymentMethod, showLinkInlineSignup: Boolean, linkPaymentLauncher: LinkPaymentLauncher, showCheckboxFlow: Flow&lt;Boolean>, onItemSelectedListener: (LpmRepository.SupportedPaymentMethod) -> Unit, onLinkSignupStateChanged: (LinkPaymentLauncher.Configuration, InlineSignupViewState) -> Unit, formArguments: FormArguments, onFormFieldValuesChanged: (FormFieldValues?) -> Unit, )</ID>
     <ID>LongMethod:PaymentOptionFactory.kt$PaymentOptionFactory$fun create(selection: PaymentSelection): PaymentOption</ID>
     <ID>LongMethod:PaymentSheetConfigurationKtx.kt$internal fun PaymentSheet.Appearance.parseAppearance()</ID>
+    <ID>LongMethod:PaymentSheetLoader.kt$DefaultPaymentSheetLoader$private suspend fun create( stripeIntent: StripeIntent, customerConfig: PaymentSheet.CustomerConfiguration?, config: PaymentSheet.Configuration?, isGooglePayReady: Boolean, ): PaymentSheetLoader.Result</ID>
     <ID>LongMethod:USBankAccountFormFragment.kt$USBankAccountFormFragment$@Composable private fun AccountDetailsForm( bankName: String?, last4: String?, saveForFutureUsage: Boolean )</ID>
     <ID>LongMethod:USBankAccountFormFragment.kt$USBankAccountFormFragment$override fun onCreateView( inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle? ): View</ID>
     <ID>LongMethod:USBankAccountFormViewModel.kt$USBankAccountFormViewModel$private fun attachFinancialAccountToIntent( clientSecret: ClientSecret, intentId: String, linkAccountId: String, bankName: String?, last4: String? )</ID>
@@ -38,13 +38,11 @@
     <ID>MagicNumber:PaymentOptionUi.kt$14</ID>
     <ID>MagicNumber:PaymentOptionUi.kt$18</ID>
     <ID>MagicNumber:PrimaryButton.kt$PrimaryButton$0.5f</ID>
-    <ID>MagicNumber:PrimaryButtonUiStateMapper.kt$PrimaryButtonUiStateMapper$3</ID>
-    <ID>MagicNumber:PrimaryButtonUiStateMapper.kt$PrimaryButtonUiStateMapper$4</ID>
-    <ID>MagicNumber:PrimaryButtonUiStateMapper.kt$PrimaryButtonUiStateMapper$5</ID>
     <ID>MagicNumber:USBankAccountFormFragment.kt$USBankAccountFormFragment$0.5f</ID>
     <ID>MaxLineLength:BillingAddressViewTest.kt$BillingAddressViewTest$fun</ID>
     <ID>MaxLineLength:CustomerRepositoryTest.kt$CustomerRepositoryTest$onBlocking { detachPaymentMethod(anyString(), any(), anyString(), any()) }.doThrow(InvalidParameterException("error"))</ID>
     <ID>MaxLineLength:DefaultFlowControllerTest.kt$DefaultFlowControllerTest$fun</ID>
+    <ID>MaxLineLength:DefaultPaymentSheetLoaderTest.kt$DefaultPaymentSheetLoaderTest$fun</ID>
     <ID>MaxLineLength:FlowControllerConfigurationHandlerTest.kt$FlowControllerConfigurationHandlerTest$.</ID>
     <ID>MaxLineLength:InjectableActivityScenario.kt$InjectableActivityScenario$delegate ?: throw IllegalStateException("Cannot move to state $newState since the activity hasn't been launched.")</ID>
     <ID>MaxLineLength:InjectableActivityScenario.kt$InjectableActivityScenario$val d = delegate ?: throw IllegalStateException("Cannot run onActivity since the activity hasn't been launched.")</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/LinkHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/LinkHandler.kt
@@ -12,7 +12,6 @@ import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.Companion.SAVE_PROCESSING
-import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.Companion.SAVE_SELECTION
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -110,11 +109,6 @@ internal class LinkHandler @Inject constructor(
 
     fun prepareLink(state: LinkState?) {
         setupLink(state)
-
-        if (state?.isReadyForUse == true) {
-            // If account exists, select Link by default
-            savedStateHandle[SAVE_SELECTION] = PaymentSelection.Link
-        }
     }
 
     private suspend fun requestLinkVerification(): Boolean {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactory.kt
@@ -19,15 +19,14 @@ internal object PaymentOptionsStateFactory {
         paymentMethods: List<PaymentMethod>,
         showGooglePay: Boolean,
         showLink: Boolean,
-        initialSelection: SavedSelection,
-        currentSelection: PaymentSelection? = null,
+        currentSelection: PaymentSelection?,
         nameProvider: (PaymentMethodCode?) -> String,
     ): PaymentOptionsState {
         val items = listOfNotNull(
             PaymentOptionsItem.AddCard,
             PaymentOptionsItem.GooglePay.takeIf { showGooglePay },
             PaymentOptionsItem.Link.takeIf { showLink }
-        ) + sortedPaymentMethods(paymentMethods, initialSelection).map {
+        ) + paymentMethods.map {
             PaymentOptionsItem.SavedPaymentMethod(
                 displayName = nameProvider(it.type?.code),
                 paymentMethod = it,
@@ -36,38 +35,12 @@ internal object PaymentOptionsStateFactory {
 
         val currentSelectionIndex = currentSelection?.let {
             items.findSelectedPosition(it)
-        }.takeIf { it != -1 }
-
-        val initialSelectionIndex = items.findInitialSelectedPosition(initialSelection)
+        } ?: -1
 
         return PaymentOptionsState(
             items = items,
-            selectedIndex = currentSelectionIndex ?: initialSelectionIndex,
+            selectedIndex = currentSelectionIndex,
         )
-    }
-
-    private fun sortedPaymentMethods(
-        paymentMethods: List<PaymentMethod>,
-        savedSelection: SavedSelection
-    ): List<PaymentMethod> {
-        val primaryPaymentMethodIndex = when (savedSelection) {
-            is SavedSelection.PaymentMethod -> {
-                paymentMethods.indexOfFirst {
-                    it.id == savedSelection.id
-                }
-            }
-            else -> -1
-        }
-        return if (primaryPaymentMethodIndex != -1) {
-            val mutablePaymentMethods = paymentMethods.toMutableList()
-            mutablePaymentMethods.removeAt(primaryPaymentMethodIndex)
-                .also { primaryPaymentMethod ->
-                    mutablePaymentMethods.add(0, primaryPaymentMethod)
-                }
-            mutablePaymentMethods
-        } else {
-            paymentMethods
-        }
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -123,8 +123,9 @@ internal class PaymentOptionsViewModel @Inject constructor(
             setStripeIntent(args.state.stripeIntent)
         }
         savedStateHandle[SAVE_PAYMENT_METHODS] = args.state.customerPaymentMethods
-        savedStateHandle[SAVE_SELECTION] = args.state.paymentSelection
         savedStateHandle[SAVE_PROCESSING] = false
+
+        updateSelection(args.state.paymentSelection)
 
         lpmServerSpec = lpmRepository.serverSpecLoadingState.serverLpmSpecs
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -89,7 +89,8 @@ internal class PaymentOptionsViewModel @Inject constructor(
 
     // Only used to determine if we should skip the list and go to the add card view.
     // and how to populate that view.
-    override var newPaymentSelection = args.state.newPaymentSelection
+    override var newPaymentSelection: PaymentSelection.New? =
+        args.state.paymentSelection as? PaymentSelection.New
 
     override val primaryButtonUiState = primaryButtonUiStateMapper.forCustomFlow().stateIn(
         scope = viewModelScope,
@@ -112,7 +113,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
             }
         }
 
-        linkHandler.linkInlineSelection.value = args.state.newPaymentSelection as? PaymentSelection.New.LinkInline
+        linkHandler.linkInlineSelection.value = args.state.paymentSelection as? PaymentSelection.New.LinkInline
         linkHandler.prepareLink(linkState)
 
         // After recovering from don't keep activities the stripe intent will be saved,
@@ -122,7 +123,7 @@ internal class PaymentOptionsViewModel @Inject constructor(
             setStripeIntent(args.state.stripeIntent)
         }
         savedStateHandle[SAVE_PAYMENT_METHODS] = args.state.customerPaymentMethods
-        savedStateHandle[SAVE_SAVED_SELECTION] = args.state.savedSelection
+        savedStateHandle[SAVE_SELECTION] = args.state.paymentSelection
         savedStateHandle[SAVE_PROCESSING] = false
 
         lpmServerSpec = lpmRepository.serverSpecLoadingState.serverLpmSpecs

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -272,7 +272,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         lpmServerSpec = lpmRepository.serverSpecLoadingState.serverLpmSpecs
 
         savedStateHandle[SAVE_PAYMENT_METHODS] = state.customerPaymentMethods
-        savedStateHandle[SAVE_SELECTION] = state.paymentSelection
+        updateSelection(state.paymentSelection)
 
         savedStateHandle[SAVE_GOOGLE_PAY_STATE] = if (state.isGooglePayReady) {
             GooglePayState.Available
@@ -529,7 +529,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                     isGooglePay = true,
                 )
 
-                savedStateHandle[SAVE_SELECTION] = newPaymentSelection
+                updateSelection(newPaymentSelection)
                 confirmPaymentSelection(newPaymentSelection)
             }
             is GooglePayPaymentMethodLauncher.Result.Failed -> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -272,7 +272,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
         lpmServerSpec = lpmRepository.serverSpecLoadingState.serverLpmSpecs
 
         savedStateHandle[SAVE_PAYMENT_METHODS] = state.customerPaymentMethods
-        savedStateHandle[SAVE_SAVED_SELECTION] = state.savedSelection
+        savedStateHandle[SAVE_SELECTION] = state.paymentSelection
 
         savedStateHandle[SAVE_GOOGLE_PAY_STATE] = if (state.isGooglePayReady) {
             GooglePayState.Available

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -231,9 +231,7 @@ internal class DefaultFlowController @Inject internal constructor(
 
         paymentOptionActivityLauncher.launch(
             PaymentOptionContract.Args(
-                state = state.copy(
-                    newPaymentSelection = viewModel.paymentSelection as? PaymentSelection.New,
-                ),
+                state = state.copy(paymentSelection = viewModel.paymentSelection),
                 statusBarColor = statusBarColor(),
                 injectorKey = injectorKey,
                 enableLogging = enableLogging,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
@@ -74,7 +74,7 @@ internal class FlowControllerConfigurationHandler @Inject constructor(
     ) {
         eventReporter.onInit(state.config)
 
-        viewModel.paymentSelection = state.initialPaymentSelection
+        viewModel.paymentSelection = state.paymentSelection
         viewModel.state = state
 
         callback.onConfigured(true, null)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/LinkState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/LinkState.kt
@@ -10,9 +10,6 @@ internal data class LinkState(
     val loginState: LoginState,
 ) : Parcelable {
 
-    val isReadyForUse: Boolean
-        get() = loginState in setOf(LoginState.LoggedIn, LoginState.NeedsVerification)
-
     enum class LoginState {
         LoggedIn, NeedsVerification, LoggedOut,
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -122,7 +122,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
             prefsRepository.getSavedSelection(
                 isGooglePayAvailable = isGooglePayReady,
                 isLinkAvailable = isLinkAvailable,
-            ).takeIf { it != SavedSelection.None }
+            )
         }
 
         val paymentMethods = async {
@@ -154,7 +154,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
                 is SavedSelection.PaymentMethod -> {
                     paymentMethods.await().find { it.id == selection.id }?.toPaymentSelection()
                 }
-                is SavedSelection.None, null -> {
+                is SavedSelection.None -> {
                     null
                 }
             }
@@ -288,7 +288,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
 }
 
 private fun List<PaymentMethod>.sorted(
-    savedSelection: SavedSelection?,
+    savedSelection: SavedSelection,
 ): List<PaymentMethod> {
     val defaultPaymentMethodIndex = (savedSelection as? SavedSelection.PaymentMethod)?.let {
         indexOfFirst { it.id == savedSelection.id }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -118,25 +118,48 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         val isLinkAvailable = stripeIntent.paymentMethodTypes.contains(Link.code) &&
             stripeIntent.linkFundingSources.intersect(supportedFundingSources).isNotEmpty()
 
+        val savedSelection = async {
+            prefsRepository.getSavedSelection(
+                isGooglePayAvailable = isGooglePayReady,
+                isLinkAvailable = isLinkAvailable,
+            ).takeIf { it != SavedSelection.None }
+        }
+
         val paymentMethods = async {
             if (customerConfig != null) {
                 retrieveCustomerPaymentMethods(
-                    stripeIntent,
-                    config,
-                    customerConfig
+                    stripeIntent = stripeIntent,
+                    config = config,
+                    customerConfig = customerConfig,
                 )
             } else {
                 emptyList()
             }
         }
 
-        val savedSelection = async {
-            retrieveSavedPaymentSelection(
-                prefsRepository,
-                isGooglePayReady,
-                isLinkAvailable,
-                paymentMethods.await()
+        val sortedPaymentMethods = async {
+            paymentMethods.await().sorted(
+                savedSelection = savedSelection.await(),
             )
+        }
+
+        val initialPaymentSelection = async {
+            val desiredSelection = when (val selection = savedSelection.await()) {
+                is SavedSelection.GooglePay -> {
+                    PaymentSelection.GooglePay
+                }
+                is SavedSelection.Link -> {
+                    PaymentSelection.Link
+                }
+                is SavedSelection.PaymentMethod -> {
+                    paymentMethods.await().find { it.id == selection.id }?.toPaymentSelection()
+                }
+                is SavedSelection.None, null -> {
+                    null
+                }
+            }
+
+            desiredSelection ?: sortedPaymentMethods.await().firstOrNull()?.toPaymentSelection()
         }
 
         val linkState = async {
@@ -152,10 +175,9 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
                 config = config,
                 stripeIntent = stripeIntent,
                 customerPaymentMethods = paymentMethods.await(),
-                savedSelection = savedSelection.await(),
                 isGooglePayReady = isGooglePayReady,
                 linkState = linkState.await(),
-                newPaymentSelection = null,
+                paymentSelection = initialPaymentSelection.await(),
             )
         )
     }
@@ -163,7 +185,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
     private suspend fun retrieveCustomerPaymentMethods(
         stripeIntent: StripeIntent,
         config: PaymentSheet.Configuration?,
-        customerConfig: PaymentSheet.CustomerConfiguration
+        customerConfig: PaymentSheet.CustomerConfiguration,
     ): List<PaymentMethod> {
         val paymentMethodTypes = getSupportedSavedCustomerPMs(
             stripeIntent,
@@ -176,49 +198,12 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         }
 
         return customerRepository.getPaymentMethods(
-            customerConfig,
-            paymentMethodTypes
+            customerConfig = customerConfig,
+            types = paymentMethodTypes,
         ).filter { paymentMethod ->
             paymentMethod.hasExpectedDetails() &&
                 // PayPal isn't supported yet as a saved payment method (backend limitation).
                 paymentMethod.type != PaymentMethod.Type.PayPal
-        }
-    }
-
-    private suspend fun retrieveSavedPaymentSelection(
-        prefsRepository: PrefsRepository,
-        isGooglePayReady: Boolean,
-        isLinkReady: Boolean,
-        paymentMethods: List<PaymentMethod>
-    ): SavedSelection {
-        val savedSelection = prefsRepository.getSavedSelection(isGooglePayReady, isLinkReady)
-        if (savedSelection != SavedSelection.None) {
-            return savedSelection
-        }
-
-        // No saved selection has been set yet, so we'll initialize it with a default
-        // value based on which payment methods are available.
-        val paymentSelection = determineDefaultPaymentSelection(
-            isGooglePayReady,
-            isLinkReady,
-            paymentMethods
-        )
-
-        prefsRepository.savePaymentSelection(paymentSelection)
-
-        return prefsRepository.getSavedSelection(isGooglePayReady, isLinkReady)
-    }
-
-    private fun determineDefaultPaymentSelection(
-        isGooglePayReady: Boolean,
-        isLinkReady: Boolean,
-        paymentMethods: List<PaymentMethod>
-    ): PaymentSelection? {
-        return when {
-            paymentMethods.isNotEmpty() -> PaymentSelection.Saved(paymentMethods.first())
-            isLinkReady -> PaymentSelection.Link
-            isGooglePayReady -> PaymentSelection.GooglePay
-            else -> null
         }
     }
 
@@ -300,4 +285,25 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
             shippingValues = shippingAddress
         )
     }
+}
+
+private fun List<PaymentMethod>.sorted(
+    savedSelection: SavedSelection?,
+): List<PaymentMethod> {
+    val defaultPaymentMethodIndex = (savedSelection as? SavedSelection.PaymentMethod)?.let {
+        indexOfFirst { it.id == savedSelection.id }
+    }
+
+    return if (defaultPaymentMethodIndex != null) {
+        val mutablePaymentMethods = toMutableList()
+        val primaryPaymentMethod = mutablePaymentMethods.removeAt(defaultPaymentMethodIndex)
+        mutablePaymentMethods.add(0, primaryPaymentMethod)
+        mutablePaymentMethods
+    } else {
+        this
+    }
+}
+
+private fun PaymentMethod.toPaymentSelection(): PaymentSelection.Saved {
+    return PaymentSelection.Saved(this, isGooglePay = false)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetState.kt
@@ -5,7 +5,6 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.model.SavedSelection
 import kotlinx.parcelize.Parcelize
 
 internal sealed interface PaymentSheetState : Parcelable {
@@ -18,29 +17,12 @@ internal sealed interface PaymentSheetState : Parcelable {
         val config: PaymentSheet.Configuration?,
         val stripeIntent: StripeIntent,
         val customerPaymentMethods: List<PaymentMethod>,
-        val savedSelection: SavedSelection,
         val isGooglePayReady: Boolean,
         val linkState: LinkState?,
-        val newPaymentSelection: PaymentSelection.New?,
+        val paymentSelection: PaymentSelection?,
     ) : PaymentSheetState {
 
         val hasPaymentOptions: Boolean
             get() = isGooglePayReady || linkState != null || customerPaymentMethods.isNotEmpty()
-
-        val initialPaymentSelection: PaymentSelection?
-            get() = when (savedSelection) {
-                is SavedSelection.GooglePay -> PaymentSelection.GooglePay
-                is SavedSelection.Link -> PaymentSelection.Link
-                is SavedSelection.PaymentMethod -> {
-                    val paymentMethod = customerPaymentMethods.firstOrNull {
-                        it.id == savedSelection.id
-                    }
-
-                    paymentMethod?.let {
-                        PaymentSelection.Saved(it)
-                    }
-                }
-                else -> null
-            }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -405,7 +405,7 @@ internal abstract class BaseSheetViewModel(
             if (didRemoveSelectedItem) {
                 // Remove the current selection. The new selection will be set when we're computing
                 // the next PaymentOptionsState.
-                savedStateHandle[SAVE_SELECTION] = null
+                updateSelection(null)
             }
 
             savedStateHandle[SAVE_PAYMENT_METHODS] = paymentMethods.value?.filter {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -15,17 +15,14 @@ import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.paymentsheet.LinkHandler
-import com.stripe.android.paymentsheet.PaymentOptionsActivity
 import com.stripe.android.paymentsheet.PaymentOptionsState
 import com.stripe.android.paymentsheet.PaymentOptionsViewModel
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.PaymentSheetActivity
 import com.stripe.android.paymentsheet.PaymentSheetViewModel
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.currency
 import com.stripe.android.paymentsheet.model.getPMsToAdd
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
@@ -114,15 +111,6 @@ internal abstract class BaseSheetViewModel(
     private val _amount = MutableStateFlow<Amount?>(null)
     internal val amount: StateFlow<Amount?> = _amount
 
-    /**
-     * Request to retrieve the value from the repository happens when initialize any fragment
-     * and any fragment will re-update when the result comes back.
-     * Represents what the user last selects (add or buy) on the
-     * [PaymentOptionsActivity]/[PaymentSheetActivity], and saved/restored from the preferences.
-     */
-    private val savedSelection: StateFlow<SavedSelection?> = savedStateHandle
-        .getStateFlow<SavedSelection?>(SAVE_SAVED_SELECTION, null)
-
     protected val backStack = MutableStateFlow<List<PaymentSheetScreen>>(
         value = listOf(PaymentSheetScreen.Loading),
     )
@@ -192,7 +180,6 @@ internal abstract class BaseSheetViewModel(
             currentSelection = selection,
             googlePayState = googlePayState,
             isLinkEnabled = linkHandler.isLinkEnabled,
-            initialSelection = savedSelection,
             isNotPaymentFlow = this is PaymentOptionsViewModel,
             nameProvider = { code ->
                 val paymentMethod = lpmRepository.fromCode(code)
@@ -519,7 +506,6 @@ internal abstract class BaseSheetViewModel(
     companion object {
         internal const val SAVE_PAYMENT_METHODS = "customer_payment_methods"
         internal const val SAVE_SELECTION = "selection"
-        internal const val SAVE_SAVED_SELECTION = "saved_selection"
         internal const val SAVE_PROCESSING = "processing"
         internal const val SAVE_GOOGLE_PAY_STATE = "google_pay_state"
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsStateMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/PaymentOptionsStateMapper.kt
@@ -5,7 +5,6 @@ import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.PaymentOptionsState
 import com.stripe.android.paymentsheet.PaymentOptionsStateFactory
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.state.GooglePayState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
@@ -15,7 +14,6 @@ internal class PaymentOptionsStateMapper(
     private val paymentMethods: StateFlow<List<PaymentMethod>?>,
     private val googlePayState: StateFlow<GooglePayState>,
     private val isLinkEnabled: StateFlow<Boolean?>,
-    private val initialSelection: StateFlow<SavedSelection?>,
     private val currentSelection: StateFlow<PaymentSelection?>,
     private val nameProvider: (PaymentMethodCode?) -> String,
     private val isNotPaymentFlow: Boolean,
@@ -23,22 +21,14 @@ internal class PaymentOptionsStateMapper(
 
     operator fun invoke(): Flow<PaymentOptionsState?> {
         return combine(
-            combine(
-                paymentMethods,
-                currentSelection,
-                initialSelection,
-                ::Triple
-            ),
-            combine(
-                isLinkEnabled,
-                googlePayState,
-                ::Pair
-            )
-        ) { (paymentMethods, currentSelection, initialSelection), (isLinkEnabled, googlePayState) ->
+            paymentMethods,
+            currentSelection,
+            isLinkEnabled,
+            googlePayState,
+        ) { paymentMethods, currentSelection, isLinkEnabled, googlePayState ->
             createPaymentOptionsState(
                 paymentMethods = paymentMethods,
                 currentSelection = currentSelection,
-                initialSelection = initialSelection,
                 isLinkEnabled = isLinkEnabled,
                 googlePayState = googlePayState,
             )
@@ -49,19 +39,16 @@ internal class PaymentOptionsStateMapper(
     private fun createPaymentOptionsState(
         paymentMethods: List<PaymentMethod>?,
         currentSelection: PaymentSelection?,
-        initialSelection: SavedSelection?,
         isLinkEnabled: Boolean?,
         googlePayState: GooglePayState,
     ): PaymentOptionsState? {
         if (paymentMethods == null) return null
-        if (initialSelection == null) return null
         if (isLinkEnabled == null) return null
 
         return PaymentOptionsStateFactory.create(
             paymentMethods = paymentMethods,
             showGooglePay = (googlePayState is GooglePayState.Available) && isNotPaymentFlow,
             showLink = isLinkEnabled && isNotPaymentFlow,
-            initialSelection = initialSelection,
             currentSelection = currentSelection,
             nameProvider = nameProvider,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/LinkHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/LinkHandlerTest.kt
@@ -124,8 +124,6 @@ class LinkHandlerTest {
         assertThat(handler.activeLinkSession.first()).isTrue()
         assertThat(handler.linkConfiguration.first()).isEqualTo(configuration)
         assertThat(handler.showLinkVerificationDialog.first()).isFalse()
-        assertThat(savedStateHandle.get<PaymentSelection>(SAVE_SELECTION))
-            .isEqualTo(PaymentSelection.Link)
         verifyNoInteractions(linkLauncher)
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsStateFactoryTest.kt
@@ -3,92 +3,39 @@ package com.stripe.android.paymentsheet
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.model.SavedSelection
 import org.junit.Test
 
 class PaymentOptionsStateFactoryTest {
 
     @Test
-    fun `Defaults to Google Pay if Google Pay and Link are available`() {
+    fun `Returns current selection if available`() {
         val paymentMethods = PaymentMethodFixtures.createCards(3)
-        val state = PaymentOptionsStateFactory.create(
-            paymentMethods = paymentMethods,
-            showGooglePay = true,
-            showLink = true,
-            initialSelection = SavedSelection.None,
-            currentSelection = null,
-            nameProvider = { it!! },
-        )
-        assertThat(state.selectedItem).isEqualTo(PaymentOptionsItem.GooglePay)
-    }
-
-    @Test
-    fun `Defaults to Link if Google Pay is not available`() {
-        val paymentMethods = PaymentMethodFixtures.createCards(3)
-        val state = PaymentOptionsStateFactory.create(
-            paymentMethods = paymentMethods,
-            showGooglePay = false,
-            showLink = true,
-            initialSelection = SavedSelection.None,
-            currentSelection = null,
-            nameProvider = { it!! },
-        )
-        assertThat(state.selectedItem).isEqualTo(PaymentOptionsItem.Link)
-    }
-
-    @Test
-    fun `Defaults to first saved payment method if Google Pay and Link aren't available`() {
-        val paymentMethods = PaymentMethodFixtures.createCards(3)
-        val state = PaymentOptionsStateFactory.create(
-            paymentMethods = paymentMethods,
-            showGooglePay = false,
-            showLink = false,
-            initialSelection = SavedSelection.None,
-            currentSelection = null,
-            nameProvider = { it!! },
-        )
-
-        val expectedItem = PaymentOptionsItem.SavedPaymentMethod(
-            displayName = "card",
-            paymentMethod = paymentMethods.first(),
-        )
-        assertThat(state.selectedItem).isEqualTo(expectedItem)
-    }
-
-    @Test
-    fun `Defaults to saved selection if available`() {
-        val paymentMethods = PaymentMethodFixtures.createCards(3)
-        val savedPaymentMethod = SavedSelection.PaymentMethod(id = paymentMethods[1].id!!)
-
-        val state = PaymentOptionsStateFactory.create(
-            paymentMethods = paymentMethods,
-            showGooglePay = false,
-            showLink = false,
-            initialSelection = savedPaymentMethod,
-            currentSelection = null,
-            nameProvider = { it!! },
-        )
-
-        val expectedItem = PaymentOptionsItem.SavedPaymentMethod(
-            displayName = "card",
-            paymentMethod = paymentMethods[1],
-        )
-        assertThat(state.selectedItem).isEqualTo(expectedItem)
-    }
-
-    @Test
-    fun `Uses current selection over initial selection`() {
-        val paymentMethods = PaymentMethodFixtures.createCards(3)
+        val paymentMethod = paymentMethods.random()
 
         val state = PaymentOptionsStateFactory.create(
             paymentMethods = paymentMethods,
             showGooglePay = true,
             showLink = true,
-            initialSelection = SavedSelection.GooglePay,
+            currentSelection = PaymentSelection.Saved(paymentMethod),
+            nameProvider = { it!! },
+        )
+
+        val selectedPaymentMethod = state.selectedItem as? PaymentOptionsItem.SavedPaymentMethod
+        assertThat(selectedPaymentMethod?.paymentMethod).isEqualTo(paymentMethod)
+    }
+
+    @Test
+    fun `Returns no payment selection if the current selection is no longer available`() {
+        val paymentMethods = PaymentMethodFixtures.createCards(3)
+
+        val state = PaymentOptionsStateFactory.create(
+            paymentMethods = paymentMethods,
+            showGooglePay = false,
+            showLink = false,
             currentSelection = PaymentSelection.Link,
             nameProvider = { it!! },
         )
 
-        assertThat(state.selectedItem).isEqualTo(PaymentOptionsItem.Link)
+        assertThat(state.selectedItem).isNull()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelInjectionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelInjectionTest.kt
@@ -81,7 +81,6 @@ internal class PaymentOptionsViewModelInjectionTest : BasePaymentOptionsViewMode
             state = PaymentSheetState.Full(
                 stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 customerPaymentMethods = emptyList(),
-//                savedSelection = SavedSelection.None,
                 config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
                 isGooglePayReady = false,
                 paymentSelection = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelInjectionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelInjectionTest.kt
@@ -9,7 +9,6 @@ import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.injection.DUMMY_INJECTOR_KEY
 import com.stripe.android.model.PaymentIntentFixtures
-import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.fakeCreationExtras
@@ -82,10 +81,10 @@ internal class PaymentOptionsViewModelInjectionTest : BasePaymentOptionsViewMode
             state = PaymentSheetState.Full(
                 stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 customerPaymentMethods = emptyList(),
-                savedSelection = SavedSelection.None,
+//                savedSelection = SavedSelection.None,
                 config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
                 isGooglePayReady = false,
-                newPaymentSelection = null,
+                paymentSelection = null,
                 linkState = null,
             ),
             statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -446,7 +446,6 @@ internal class PaymentOptionsViewModelTest {
                 isGooglePayReady = true,
                 paymentSelection = null,
                 linkState = null,
-//                savedSelection = SavedSelection.None,
             ),
             statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR,
             injectorKey = DUMMY_INJECTOR_KEY,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -120,7 +120,7 @@ internal class PaymentOptionsViewModelTest {
     @Test
     fun `Opens saved payment methods if no new payment method was previously selected`() = runTest {
         val viewModel = createViewModel(
-            args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(newPaymentSelection = null)
+            args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(paymentSelection = null)
         )
 
         viewModel.currentScreen.test {
@@ -134,7 +134,7 @@ internal class PaymentOptionsViewModelTest {
         val viewModel = createViewModel(
             args = PAYMENT_OPTION_CONTRACT_ARGS.updateState(
                 stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
-                newPaymentSelection = NEW_CARD_PAYMENT_SELECTION.copy(
+                paymentSelection = NEW_CARD_PAYMENT_SELECTION.copy(
                     customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse
                 ),
             )
@@ -192,34 +192,6 @@ internal class PaymentOptionsViewModelTest {
         assertThat(viewModel.paymentMethods.value).isEmpty()
         assertThat(viewModel.primaryButtonUiState.value).isNull()
         assertThat(viewModel.notesText.value).isNull()
-    }
-
-    @Test
-    fun `Selects Link when user is logged in to their Link account`() = runTest {
-        val viewModel = createViewModel(
-            linkState = LinkState(
-                configuration = mock(),
-                loginState = LinkState.LoginState.LoggedIn,
-            ),
-        )
-
-        assertThat(viewModel.selection.value).isEqualTo(PaymentSelection.Link)
-        assertThat(viewModel.linkHandler.activeLinkSession.value).isTrue()
-        assertThat(viewModel.linkHandler.isLinkEnabled.value).isTrue()
-    }
-
-    @Test
-    fun `Selects Link when user needs to verify their Link account`() = runTest {
-        val viewModel = createViewModel(
-            linkState = LinkState(
-                configuration = mock(),
-                loginState = LinkState.LoginState.NeedsVerification,
-            ),
-        )
-
-        assertThat(viewModel.selection.value).isEqualTo(PaymentSelection.Link)
-        assertThat(viewModel.linkHandler.activeLinkSession.value).isFalse()
-        assertThat(viewModel.linkHandler.isLinkEnabled.value).isTrue()
     }
 
     @Test
@@ -472,9 +444,9 @@ internal class PaymentOptionsViewModelTest {
                 customerPaymentMethods = emptyList(),
                 config = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
                 isGooglePayReady = true,
-                newPaymentSelection = null,
+                paymentSelection = null,
                 linkState = null,
-                savedSelection = SavedSelection.None,
+//                savedSelection = SavedSelection.None,
             ),
             statusBarColor = PaymentSheetFixtures.STATUS_BAR_COLOR,
             injectorKey = DUMMY_INJECTOR_KEY,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -199,15 +199,17 @@ internal class PaymentSheetActivityTest {
 
     @Test
     fun `disables primary button when editing`() {
+        val viewModel = createViewModel(
+            initialPaymentSelection = PaymentSelection.Saved(PAYMENT_METHODS.last()),
+        )
+
         val scenario = activityScenario(viewModel)
+
         scenario.launch(intent).onActivity { activity ->
-            assertThat(activity.viewBinding.buyButton.isEnabled)
-                .isTrue()
+            assertThat(activity.viewBinding.buyButton.isEnabled).isTrue()
 
             viewModel.toggleEditing()
-
-            assertThat(activity.viewBinding.buyButton.isEnabled)
-                .isFalse()
+            assertThat(activity.viewBinding.buyButton.isEnabled).isFalse()
         }
     }
 
@@ -958,6 +960,7 @@ internal class PaymentSheetActivityTest {
         loadDelay: Duration = Duration.ZERO,
         isGooglePayAvailable: Boolean = false,
         isLinkAvailable: Boolean = false,
+        initialPaymentSelection: PaymentSelection? = null,
     ): PaymentSheetViewModel = runBlocking {
         val lpmRepository = mock<LpmRepository>()
         whenever(lpmRepository.fromCode(any())).thenReturn(LpmRepository.HardcodedCard)
@@ -989,6 +992,7 @@ internal class PaymentSheetActivityTest {
                         loginState = LinkState.LoginState.LoggedOut,
                     ).takeIf { isLinkAvailable },
                     delay = loadDelay,
+                    paymentSelection = initialPaymentSelection,
                 ),
                 FakeCustomerRepository(paymentMethods),
                 FakePrefsRepository(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -9,7 +9,6 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentSheetState
@@ -91,9 +90,9 @@ internal object PaymentSheetFixtures {
             customerPaymentMethods = emptyList(),
             config = CONFIG_GOOGLEPAY,
             isGooglePayReady = false,
-            newPaymentSelection = null,
+            paymentSelection = null,
             linkState = null,
-            savedSelection = SavedSelection.None,
+//            savedSelection = SavedSelection.None,
         ),
         statusBarColor = STATUS_BAR_COLOR,
         injectorKey = DUMMY_INJECTOR_KEY,
@@ -106,7 +105,7 @@ internal object PaymentSheetFixtures {
         isGooglePayReady: Boolean = state.isGooglePayReady,
         stripeIntent: StripeIntent = state.stripeIntent,
         config: PaymentSheet.Configuration? = state.config,
-        newPaymentSelection: PaymentSelection.New? = state.newPaymentSelection,
+        paymentSelection: PaymentSelection? = state.paymentSelection,
         linkState: LinkState? = state.linkState,
     ): PaymentOptionContract.Args {
         return copy(
@@ -115,7 +114,7 @@ internal object PaymentSheetFixtures {
                 isGooglePayReady = isGooglePayReady,
                 stripeIntent = stripeIntent,
                 config = config,
-                newPaymentSelection = newPaymentSelection,
+                paymentSelection = paymentSelection,
                 linkState = linkState,
             ),
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -92,7 +92,6 @@ internal object PaymentSheetFixtures {
             isGooglePayReady = false,
             paymentSelection = null,
             linkState = null,
-//            savedSelection = SavedSelection.None,
         ),
         statusBarColor = STATUS_BAR_COLOR,
         injectorKey = DUMMY_INJECTOR_KEY,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -49,7 +49,6 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentOption
 import com.stripe.android.paymentsheet.model.PaymentOptionFactory
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentSheetLoader
 import com.stripe.android.paymentsheet.state.PaymentSheetState
@@ -248,9 +247,7 @@ internal class DefaultFlowControllerTest {
 
         val flowController = createFlowController(
             paymentMethods = paymentMethods,
-            savedSelection = SavedSelection.PaymentMethod(
-                requireNotNull(paymentMethods.first().id)
-            )
+            paymentSelection = PaymentSelection.Saved(paymentMethods.first()),
         )
         flowController.configureWithPaymentIntent(
             PaymentSheetFixtures.CLIENT_SECRET,
@@ -274,9 +271,7 @@ internal class DefaultFlowControllerTest {
         // Initially configure for a customer with saved payment methods
         val paymentSheetLoader = FakePaymentSheetLoader(
             customerPaymentMethods = paymentMethods,
-            savedSelection = SavedSelection.PaymentMethod(
-                requireNotNull(paymentMethods.first().id)
-            ),
+            paymentSelection = PaymentSelection.Saved(paymentMethods.first()),
         )
 
         val flowController = createFlowController(paymentSheetLoader)
@@ -305,8 +300,7 @@ internal class DefaultFlowControllerTest {
         }
 
         // Should return null instead of any cached value from the previous customer
-        assertThat(flowController.getPaymentOption())
-            .isNull()
+        assertThat(flowController.getPaymentOption()).isNull()
     }
 
     @Test
@@ -343,9 +337,9 @@ internal class DefaultFlowControllerTest {
                 customerPaymentMethods = emptyList(),
                 config = null,
                 isGooglePayReady = false,
-                newPaymentSelection = null,
+                paymentSelection = null,
                 linkState = null,
-                savedSelection = SavedSelection.None,
+//                savedSelection = SavedSelection.None,
             ),
             statusBarColor = ContextCompat.getColor(
                 activity,
@@ -388,7 +382,7 @@ internal class DefaultFlowControllerTest {
     @Test
     fun `onPaymentOptionResult() with failure when initial value is a card invoke callback with last saved`() {
         val flowController = createFlowController(
-            savedSelection = SavedSelection.GooglePay
+            paymentSelection = PaymentSelection.GooglePay,
         )
 
         flowController.configureWithPaymentIntent(
@@ -412,7 +406,7 @@ internal class DefaultFlowControllerTest {
     @Test
     fun `onPaymentOptionResult() with null invoke callback with null`() {
         val flowController = createFlowController(
-            savedSelection = SavedSelection.GooglePay
+            paymentSelection = PaymentSelection.GooglePay,
         )
 
         flowController.configureWithPaymentIntent(
@@ -432,9 +426,7 @@ internal class DefaultFlowControllerTest {
         val initialPaymentMethods = PaymentMethodFixtures.createCards(5)
         val flowController = createFlowController(
             paymentMethods = initialPaymentMethods,
-            savedSelection = SavedSelection.PaymentMethod(
-                requireNotNull(initialPaymentMethods.first().id)
-            )
+            paymentSelection = PaymentSelection.Saved(initialPaymentMethods.first())
         )
         flowController.configureWithPaymentIntent(
             PaymentSheetFixtures.CLIENT_SECRET,
@@ -474,7 +466,7 @@ internal class DefaultFlowControllerTest {
     @Test
     fun `onPaymentOptionResult() with cancelled invoke callback when initial value is a card`() {
         val flowController = createFlowController(
-            savedSelection = SavedSelection.GooglePay
+            paymentSelection = PaymentSelection.GooglePay,
         )
 
         flowController.configureWithPaymentIntent(
@@ -518,18 +510,22 @@ internal class DefaultFlowControllerTest {
             )
         )
 
+        val initialSelection = PaymentSelection.Saved(
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+        )
+
         flowController.confirmPaymentSelection(
             NEW_CARD_PAYMENT_SELECTION,
             PaymentSheetState.Full(
                 PaymentSheetFixtures.CONFIG_CUSTOMER,
                 PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 customerPaymentMethods = PAYMENT_METHODS,
-                savedSelection = SavedSelection.PaymentMethod(
-                    id = "pm_123456789"
-                ),
+//                savedSelection = SavedSelection.PaymentMethod(
+//                    id = "pm_123456789"
+//                ),
                 isGooglePayReady = false,
                 linkState = null,
-                newPaymentSelection = null,
+                paymentSelection = initialSelection, // PaymentSelection.Saved(pm),
             )
         )
 
@@ -555,18 +551,22 @@ internal class DefaultFlowControllerTest {
             )
         )
 
+        val initialSelection = PaymentSelection.Saved(
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+        )
+
         flowController.confirmPaymentSelection(
             GENERIC_PAYMENT_SELECTION,
             PaymentSheetState.Full(
                 PaymentSheetFixtures.CONFIG_CUSTOMER,
                 PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 customerPaymentMethods = PAYMENT_METHODS,
-                savedSelection = SavedSelection.PaymentMethod(
-                    id = "pm_123456789"
-                ),
+//                savedSelection = SavedSelection.PaymentMethod(
+//                    id = "pm_123456789"
+//                ),
                 isGooglePayReady = false,
                 linkState = null,
-                newPaymentSelection = null,
+                paymentSelection = initialSelection,
             )
         )
 
@@ -595,18 +595,22 @@ internal class DefaultFlowControllerTest {
             )
         )
 
+        val initialSelection = PaymentSelection.Saved(
+            paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+        )
+
         flowController.confirmPaymentSelection(
             paymentSelection,
             PaymentSheetState.Full(
                 PaymentSheetFixtures.CONFIG_CUSTOMER,
                 PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 customerPaymentMethods = PAYMENT_METHODS,
-                savedSelection = SavedSelection.PaymentMethod(
-                    id = "pm_123456789"
-                ),
+//                savedSelection = SavedSelection.PaymentMethod(
+//                    id = "pm_123456789"
+//                ),
                 isGooglePayReady = false,
                 linkState = null,
-                newPaymentSelection = null,
+                paymentSelection = initialSelection,
             )
         )
 
@@ -621,7 +625,7 @@ internal class DefaultFlowControllerTest {
     fun `confirmPaymentSelection() with link payment method should launch LinkPaymentLauncher`() = runTest {
         whenever(linkPaymentLauncher.getAccountStatusFlow(any())).thenReturn(flowOf(AccountStatus.Verified))
         val flowController = createFlowController(
-            savedSelection = SavedSelection.Link,
+            paymentSelection = PaymentSelection.Link,
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
                 paymentMethodTypes = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.paymentMethodTypes.plus("link")
             )
@@ -642,7 +646,7 @@ internal class DefaultFlowControllerTest {
         whenever(linkPaymentLauncher.getAccountStatusFlow(any())).thenReturn(flowOf(AccountStatus.Verified))
 
         val flowController = createFlowController(
-            savedSelection = SavedSelection.Link,
+            paymentSelection = PaymentSelection.Link,
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
                 paymentMethodTypes = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.paymentMethodTypes.plus("link")
             )
@@ -675,7 +679,7 @@ internal class DefaultFlowControllerTest {
         whenever(linkPaymentLauncher.getAccountStatusFlow(any())).thenReturn(flowOf(AccountStatus.SignedOut))
 
         val flowController = createFlowController(
-            savedSelection = SavedSelection.Link,
+            paymentSelection = PaymentSelection.Link,
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
                 paymentMethodTypes = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.paymentMethodTypes.plus("link")
             )
@@ -717,7 +721,7 @@ internal class DefaultFlowControllerTest {
         whenever(linkPaymentLauncher.getAccountStatusFlow(any())).thenReturn(flowOf(AccountStatus.SignedOut))
 
         val flowController = createFlowController(
-            savedSelection = SavedSelection.Link,
+            paymentSelection = PaymentSelection.Link,
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
                 paymentMethodTypes = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.paymentMethodTypes.plus("link")
             )
@@ -770,7 +774,7 @@ internal class DefaultFlowControllerTest {
         whenever(linkPaymentLauncher.getAccountStatusFlow(any())).thenReturn(flowOf(AccountStatus.SignedOut))
 
         val flowController = createFlowController(
-            savedSelection = SavedSelection.Link,
+            paymentSelection = PaymentSelection.Link,
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
                 paymentMethodTypes = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.paymentMethodTypes.plus("link")
             )
@@ -968,7 +972,7 @@ internal class DefaultFlowControllerTest {
 
         verify(paymentOptionActivityLauncher).launch(
             argWhere {
-                it.state.newPaymentSelection == previousPaymentSelection
+                it.state.paymentSelection == previousPaymentSelection
             }
         )
     }
@@ -1083,7 +1087,7 @@ internal class DefaultFlowControllerTest {
 
     private fun createFlowController(
         paymentMethods: List<PaymentMethod> = emptyList(),
-        savedSelection: SavedSelection = SavedSelection.None,
+        paymentSelection: PaymentSelection? = null,
         stripeIntent: StripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
         linkState: LinkState? = LinkState(
             configuration = mock(),
@@ -1095,7 +1099,7 @@ internal class DefaultFlowControllerTest {
             FakePaymentSheetLoader(
                 customerPaymentMethods = paymentMethods,
                 stripeIntent = stripeIntent,
-                savedSelection = savedSelection,
+                paymentSelection = paymentSelection,
                 linkState = linkState,
             ),
             viewModel

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -339,7 +339,6 @@ internal class DefaultFlowControllerTest {
                 isGooglePayReady = false,
                 paymentSelection = null,
                 linkState = null,
-//                savedSelection = SavedSelection.None,
             ),
             statusBarColor = ContextCompat.getColor(
                 activity,
@@ -520,12 +519,9 @@ internal class DefaultFlowControllerTest {
                 PaymentSheetFixtures.CONFIG_CUSTOMER,
                 PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 customerPaymentMethods = PAYMENT_METHODS,
-//                savedSelection = SavedSelection.PaymentMethod(
-//                    id = "pm_123456789"
-//                ),
                 isGooglePayReady = false,
                 linkState = null,
-                paymentSelection = initialSelection, // PaymentSelection.Saved(pm),
+                paymentSelection = initialSelection,
             )
         )
 
@@ -561,9 +557,6 @@ internal class DefaultFlowControllerTest {
                 PaymentSheetFixtures.CONFIG_CUSTOMER,
                 PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 customerPaymentMethods = PAYMENT_METHODS,
-//                savedSelection = SavedSelection.PaymentMethod(
-//                    id = "pm_123456789"
-//                ),
                 isGooglePayReady = false,
                 linkState = null,
                 paymentSelection = initialSelection,
@@ -605,9 +598,6 @@ internal class DefaultFlowControllerTest {
                 PaymentSheetFixtures.CONFIG_CUSTOMER,
                 PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 customerPaymentMethods = PAYMENT_METHODS,
-//                savedSelection = SavedSelection.PaymentMethod(
-//                    id = "pm_123456789"
-//                ),
                 isGooglePayReady = false,
                 linkState = null,
                 paymentSelection = initialSelection,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
@@ -13,7 +13,6 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.repositories.toElementsSessionParams
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentSheetLoader
@@ -249,7 +248,7 @@ class FlowControllerConfigurationHandlerTest {
         return FakePaymentSheetLoader(
             customerPaymentMethods = emptyList(),
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
-            savedSelection = SavedSelection.Link,
+            paymentSelection = PaymentSelection.Link,
             linkState = LinkState(
                 configuration = mock(),
                 loginState = LinkState.LoginState.LoggedIn,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -19,7 +19,6 @@ import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.StripeIntentValidator
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
@@ -88,43 +87,43 @@ internal class DefaultPaymentSheetLoaderTest {
         )
     }
 
-    @Test
-    fun `load without configuration should return expected result`() = runTest {
-        val stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
-        val loader = createPaymentSheetLoader(stripeIntent = stripeIntent)
-
-        assertThat(
-            loader.load(
-                initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
-                    clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
-                ),
-                paymentSheetConfiguration = null,
-            )
-        ).isEqualTo(
-            PaymentSheetLoader.Result.Success(
-                PaymentSheetState.Full(
-                    config = null,
-                    stripeIntent = stripeIntent,
-                    customerPaymentMethods = emptyList(),
-                    savedSelection = SavedSelection.Link,
-                    isGooglePayReady = false,
-                    newPaymentSelection = null,
-                    linkState = LinkState(
-                        configuration = LinkPaymentLauncher.Configuration(
-                            stripeIntent = stripeIntent,
-                            merchantName = "App Name",
-                            customerName = null,
-                            customerEmail = null,
-                            customerPhone = null,
-                            customerBillingCountryCode = null,
-                            shippingValues = null,
-                        ),
-                        loginState = LinkState.LoginState.LoggedIn,
-                    ),
-                )
-            )
-        )
-    }
+//    @Test
+//    fun `load without configuration should return expected result`() = runTest {
+//        val stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
+//        val loader = createPaymentSheetLoader(stripeIntent = stripeIntent)
+//
+//        assertThat(
+//            loader.load(
+//                initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+//                    clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+//                ),
+//                paymentSheetConfiguration = null,
+//            )
+//        ).isEqualTo(
+//            PaymentSheetLoader.Result.Success(
+//                PaymentSheetState.Full(
+//                    config = null,
+//                    stripeIntent = stripeIntent,
+//                    customerPaymentMethods = emptyList(),
+////                    savedSelection = SavedSelection.Link,
+//                    isGooglePayReady = false,
+//                    paymentSelection = PaymentSelection.Link,
+//                    linkState = LinkState(
+//                        configuration = LinkPaymentLauncher.Configuration(
+//                            stripeIntent = stripeIntent,
+//                            merchantName = "App Name",
+//                            customerName = null,
+//                            customerEmail = null,
+//                            customerPhone = null,
+//                            customerBillingCountryCode = null,
+//                            shippingValues = null,
+//                        ),
+//                        loginState = LinkState.LoginState.LoggedIn,
+//                    ),
+//                )
+//            )
+//        )
+//    }
 
     @Test
     fun `load with configuration should return expected result`() = runTest {
@@ -149,229 +148,159 @@ internal class DefaultPaymentSheetLoaderTest {
                     config = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
                     stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
                     customerPaymentMethods = PAYMENT_METHODS,
-                    savedSelection = SavedSelection.PaymentMethod(id = "pm_123456789"),
+//                    savedSelection = SavedSelection.PaymentMethod(id = "pm_123456789"),
                     isGooglePayReady = true,
-                    newPaymentSelection = null,
+                    paymentSelection = PaymentSelection.Saved(
+                        paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+                    ),
                     linkState = null,
                 )
             )
         )
     }
 
+//    @Test
+//    fun `load() with no customer and google pay ready should default to Link`() = runTest {
+//        prefsRepository.savePaymentSelection(null)
+//
+//        val stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
+//        val loader = createPaymentSheetLoader(stripeIntent = stripeIntent)
+//
+//        assertThat(
+//            loader.load(
+//                initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+//                    clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+//                ),
+//                PaymentSheetFixtures.CONFIG_GOOGLEPAY
+//            )
+//        ).isEqualTo(
+//            PaymentSheetLoader.Result.Success(
+//                PaymentSheetState.Full(
+//                    config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
+//                    stripeIntent = stripeIntent,
+//                    customerPaymentMethods = emptyList(),
+//                    isGooglePayReady = true,
+//                    paymentSelection = PaymentSelection.Link,
+//                    linkState = LinkState(
+//                        configuration = LinkPaymentLauncher.Configuration(
+//                            stripeIntent = stripeIntent,
+//                            merchantName = "Merchant, Inc.",
+//                            customerName = null,
+//                            customerEmail = null,
+//                            customerPhone = null,
+//                            customerBillingCountryCode = null,
+//                            shippingValues = null,
+//                        ),
+//                        loginState = LinkState.LoginState.LoggedIn,
+//                    ),
+//                )
+//            )
+//        )
+//    }
+
+//    @Test
+//    fun `load() with no customer and Google Pay not ready should default to Link`() = runTest {
+//        prefsRepository.savePaymentSelection(null)
+//
+//        val expectedIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
+//        val expectedLinkState = LinkState(
+//            configuration = LinkPaymentLauncher.Configuration(
+//                stripeIntent = expectedIntent,
+//                merchantName = "Merchant, Inc.",
+//                customerName = null,
+//                customerEmail = null,
+//                customerPhone = null,
+//                customerBillingCountryCode = null,
+//                shippingValues = null,
+//            ),
+//            loginState = LinkState.LoginState.LoggedIn,
+//        )
+//
+//        val loader = createPaymentSheetLoader(isGooglePayReady = false)
+//
+//        assertThat(
+//            loader.load(
+//                initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+//                    clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+//                ),
+//                PaymentSheetFixtures.CONFIG_GOOGLEPAY
+//            )
+//        ).isEqualTo(
+//            PaymentSheetLoader.Result.Success(
+//                PaymentSheetState.Full(
+//                    config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
+//                    stripeIntent = expectedIntent,
+//                    customerPaymentMethods = emptyList(),
+////                    savedSelection = SavedSelection.Link,
+//                    isGooglePayReady = false,
+//                    paymentSelection = PaymentSelection.Link,
+//                    linkState = expectedLinkState,
+//                )
+//            )
+//        )
+//    }
+
     @Test
-    fun `load() with no customer and google pay ready should default to Link`() = runTest {
+    fun `Should default to first payment method if customer has payment methods`() = runTest {
         prefsRepository.savePaymentSelection(null)
 
-        val stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
-        val loader = createPaymentSheetLoader(stripeIntent = stripeIntent)
-
-        assertThat(
-            loader.load(
-                initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
-                    clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
-                ),
-                PaymentSheetFixtures.CONFIG_GOOGLEPAY
-            )
-        ).isEqualTo(
-            PaymentSheetLoader.Result.Success(
-                PaymentSheetState.Full(
-                    config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
-                    stripeIntent = stripeIntent,
-                    customerPaymentMethods = emptyList(),
-                    savedSelection = SavedSelection.Link,
-                    isGooglePayReady = true,
-                    newPaymentSelection = null,
-                    linkState = LinkState(
-                        configuration = LinkPaymentLauncher.Configuration(
-                            stripeIntent = stripeIntent,
-                            merchantName = "Merchant, Inc.",
-                            customerName = null,
-                            customerEmail = null,
-                            customerPhone = null,
-                            customerBillingCountryCode = null,
-                            shippingValues = null,
-                        ),
-                        loginState = LinkState.LoginState.LoggedIn,
-                    ),
-                )
-            )
+        val loader = createPaymentSheetLoader(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
+            isGooglePayReady = true,
+            customerRepo = FakeCustomerRepository(paymentMethods = PAYMENT_METHODS),
         )
-    }
 
-    @Test
-    fun `load() with no customer and Google Pay not ready should default to Link`() = runTest {
-        prefsRepository.savePaymentSelection(null)
-
-        val expectedIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
-        val expectedLinkState = LinkState(
-            configuration = LinkPaymentLauncher.Configuration(
-                stripeIntent = expectedIntent,
-                merchantName = "Merchant, Inc.",
-                customerName = null,
-                customerEmail = null,
-                customerPhone = null,
-                customerBillingCountryCode = null,
-                shippingValues = null,
+        val result = loader.load(
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
             ),
-            loginState = LinkState.LoginState.LoggedIn,
-        )
+            paymentSheetConfiguration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
+        ) as PaymentSheetLoader.Result.Success
 
-        val loader = createPaymentSheetLoader(isGooglePayReady = false)
-
-        assertThat(
-            loader.load(
-                initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
-                    clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
-                ),
-                PaymentSheetFixtures.CONFIG_GOOGLEPAY
-            )
-        ).isEqualTo(
-            PaymentSheetLoader.Result.Success(
-                PaymentSheetState.Full(
-                    config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
-                    stripeIntent = expectedIntent,
-                    customerPaymentMethods = emptyList(),
-                    savedSelection = SavedSelection.Link,
-                    isGooglePayReady = false,
-                    newPaymentSelection = null,
-                    linkState = expectedLinkState,
-                )
-            )
+        assertThat(result.state.paymentSelection).isEqualTo(
+            PaymentSelection.Saved(paymentMethod = PAYMENT_METHODS.first())
         )
     }
 
     @Test
-    fun `load() with payment methods, and google pay ready should default to last payment method`() =
-        runTest {
-            prefsRepository.savePaymentSelection(null)
+    fun `Should default to last used payment method if available even if customer has payment methods`() = runTest {
+        prefsRepository.savePaymentSelection(PaymentSelection.GooglePay)
 
-            val loader = createPaymentSheetLoader(
-                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
-            )
+        val loader = createPaymentSheetLoader(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
+            isGooglePayReady = true,
+            customerRepo = FakeCustomerRepository(paymentMethods = PAYMENT_METHODS),
+        )
 
-            assertThat(
-                loader.load(
-                    initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
-                        clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
-                    ),
-                    PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
-                )
-            ).isEqualTo(
-                PaymentSheetLoader.Result.Success(
-                    PaymentSheetState.Full(
-                        config = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
-                        stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
-                        customerPaymentMethods = PAYMENT_METHODS,
-                        savedSelection = SavedSelection.PaymentMethod("pm_123456789"),
-                        isGooglePayReady = true,
-                        newPaymentSelection = null,
-                        linkState = null,
-                    )
-                )
-            )
+        val result = loader.load(
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+            ),
+            paymentSheetConfiguration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
+        ) as PaymentSheetLoader.Result.Success
 
-            assertThat(prefsRepository.getSavedSelection(true, true))
-                .isEqualTo(
-                    SavedSelection.PaymentMethod(
-                        id = "pm_123456789"
-                    )
-                )
-        }
+        assertThat(result.state.paymentSelection).isEqualTo(PaymentSelection.GooglePay)
+    }
 
     @Test
-    fun `load() with customer, no methods, and google pay not ready, should set first payment method as Link`() =
-        runTest {
-            val expectedIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
-            val expectedLinkState = LinkState(
-                configuration = LinkPaymentLauncher.Configuration(
-                    stripeIntent = expectedIntent,
-                    merchantName = "Merchant, Inc.",
-                    customerName = null,
-                    customerEmail = null,
-                    customerPhone = null,
-                    customerBillingCountryCode = null,
-                    shippingValues = null,
-                ),
-                loginState = LinkState.LoginState.LoggedIn,
-            )
+    fun `Should default to no payment method if customer has no payment methods and no last used payment method`() = runTest {
+        prefsRepository.savePaymentSelection(null)
 
-            prefsRepository.savePaymentSelection(null)
+        val loader = createPaymentSheetLoader(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
+            isGooglePayReady = true,
+            customerRepo = FakeCustomerRepository(paymentMethods = emptyList()),
+        )
 
-            val loader = createPaymentSheetLoader(
-                isGooglePayReady = false,
-                customerRepo = FakeCustomerRepository(emptyList())
-            )
-            assertThat(
-                loader.load(
-                    initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
-                        clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
-                    ),
-                    PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
-                )
-            ).isEqualTo(
-                PaymentSheetLoader.Result.Success(
-                    PaymentSheetState.Full(
-                        PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
-                        expectedIntent,
-                        newPaymentSelection = null,
-                        customerPaymentMethods = emptyList(),
-                        savedSelection = SavedSelection.Link,
-                        isGooglePayReady = false,
-                        linkState = expectedLinkState,
-                    )
-                )
-            )
+        val result = loader.load(
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+            ),
+            paymentSheetConfiguration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
+        ) as PaymentSheetLoader.Result.Success
 
-            assertThat(prefsRepository.getSavedSelection(true, true))
-                .isEqualTo(SavedSelection.Link)
-        }
-
-    @Test
-    fun `load() with customer, no methods, and google pay ready, should set first payment method as Link`() =
-        runTest {
-            val expectedIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
-            val expectedLinkState = LinkState(
-                configuration = LinkPaymentLauncher.Configuration(
-                    stripeIntent = expectedIntent,
-                    merchantName = "Merchant, Inc.",
-                    customerName = null,
-                    customerEmail = null,
-                    customerPhone = null,
-                    customerBillingCountryCode = null,
-                    shippingValues = null,
-                ),
-                loginState = LinkState.LoginState.LoggedIn,
-            )
-
-            prefsRepository.savePaymentSelection(null)
-
-            val loader = createPaymentSheetLoader(
-                customerRepo = FakeCustomerRepository(emptyList())
-            )
-            assertThat(
-                loader.load(
-                    initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
-                        clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
-                    ),
-                    PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
-                )
-            ).isEqualTo(
-                PaymentSheetLoader.Result.Success(
-                    PaymentSheetState.Full(
-                        PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
-                        expectedIntent,
-                        newPaymentSelection = null,
-                        customerPaymentMethods = emptyList(),
-                        savedSelection = SavedSelection.Link,
-                        isGooglePayReady = true,
-                        linkState = expectedLinkState,
-                    )
-                )
-            )
-
-            assertThat(prefsRepository.getSavedSelection(true, true))
-                .isEqualTo(SavedSelection.Link)
-        }
+        assertThat(result.state.paymentSelection).isNull()
+    }
 
     @Test
     fun `load() with customer should fetch only supported payment method types`() =
@@ -518,35 +447,6 @@ internal class DefaultPaymentSheetLoaderTest {
         }
 
     @Test
-    fun `Defaults to Google Play for guests if Link is not enabled`() = runTest {
-        val result = createPaymentSheetLoader(
-            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
-        ).load(
-            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
-                clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
-            ),
-            paymentSheetConfiguration = mockConfiguration()
-        ) as PaymentSheetLoader.Result.Success
-
-        assertThat(result.state.linkState).isNull()
-        assertThat(result.state.savedSelection).isEqualTo(SavedSelection.GooglePay)
-    }
-
-    @Test
-    fun `Defaults to Link for guests if available`() = runTest {
-        val result = createPaymentSheetLoader().load(
-            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
-                clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
-            ),
-            // The mock configuration is necessary to enable Google Pay. We want to do that,
-            // so that we can check that Link is preferred.
-            paymentSheetConfiguration = mockConfiguration()
-        ) as PaymentSheetLoader.Result.Success
-
-        assertThat(result.state.savedSelection).isEqualTo(SavedSelection.Link)
-    }
-
-    @Test
     fun `Defaults to first existing payment method for known customer`() = runTest {
         val result = createPaymentSheetLoader(
             customerRepo = FakeCustomerRepository(paymentMethods = PAYMENT_METHODS)
@@ -562,8 +462,8 @@ internal class DefaultPaymentSheetLoaderTest {
             )
         ) as PaymentSheetLoader.Result.Success
 
-        val expectedPaymentMethodId = requireNotNull(PAYMENT_METHODS.first().id)
-        assertThat(result.state.savedSelection).isEqualTo(SavedSelection.PaymentMethod(id = expectedPaymentMethodId))
+        val expectedPaymentMethod = requireNotNull(PAYMENT_METHODS.first())
+        assertThat(result.state.paymentSelection).isEqualTo(PaymentSelection.Saved(expectedPaymentMethod))
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -87,44 +87,6 @@ internal class DefaultPaymentSheetLoaderTest {
         )
     }
 
-//    @Test
-//    fun `load without configuration should return expected result`() = runTest {
-//        val stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
-//        val loader = createPaymentSheetLoader(stripeIntent = stripeIntent)
-//
-//        assertThat(
-//            loader.load(
-//                initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
-//                    clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
-//                ),
-//                paymentSheetConfiguration = null,
-//            )
-//        ).isEqualTo(
-//            PaymentSheetLoader.Result.Success(
-//                PaymentSheetState.Full(
-//                    config = null,
-//                    stripeIntent = stripeIntent,
-//                    customerPaymentMethods = emptyList(),
-////                    savedSelection = SavedSelection.Link,
-//                    isGooglePayReady = false,
-//                    paymentSelection = PaymentSelection.Link,
-//                    linkState = LinkState(
-//                        configuration = LinkPaymentLauncher.Configuration(
-//                            stripeIntent = stripeIntent,
-//                            merchantName = "App Name",
-//                            customerName = null,
-//                            customerEmail = null,
-//                            customerPhone = null,
-//                            customerBillingCountryCode = null,
-//                            shippingValues = null,
-//                        ),
-//                        loginState = LinkState.LoginState.LoggedIn,
-//                    ),
-//                )
-//            )
-//        )
-//    }
-
     @Test
     fun `load with configuration should return expected result`() = runTest {
         prefsRepository.savePaymentSelection(
@@ -148,7 +110,6 @@ internal class DefaultPaymentSheetLoaderTest {
                     config = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
                     stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
                     customerPaymentMethods = PAYMENT_METHODS,
-//                    savedSelection = SavedSelection.PaymentMethod(id = "pm_123456789"),
                     isGooglePayReady = true,
                     paymentSelection = PaymentSelection.Saved(
                         paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
@@ -158,87 +119,6 @@ internal class DefaultPaymentSheetLoaderTest {
             )
         )
     }
-
-//    @Test
-//    fun `load() with no customer and google pay ready should default to Link`() = runTest {
-//        prefsRepository.savePaymentSelection(null)
-//
-//        val stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
-//        val loader = createPaymentSheetLoader(stripeIntent = stripeIntent)
-//
-//        assertThat(
-//            loader.load(
-//                initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
-//                    clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
-//                ),
-//                PaymentSheetFixtures.CONFIG_GOOGLEPAY
-//            )
-//        ).isEqualTo(
-//            PaymentSheetLoader.Result.Success(
-//                PaymentSheetState.Full(
-//                    config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
-//                    stripeIntent = stripeIntent,
-//                    customerPaymentMethods = emptyList(),
-//                    isGooglePayReady = true,
-//                    paymentSelection = PaymentSelection.Link,
-//                    linkState = LinkState(
-//                        configuration = LinkPaymentLauncher.Configuration(
-//                            stripeIntent = stripeIntent,
-//                            merchantName = "Merchant, Inc.",
-//                            customerName = null,
-//                            customerEmail = null,
-//                            customerPhone = null,
-//                            customerBillingCountryCode = null,
-//                            shippingValues = null,
-//                        ),
-//                        loginState = LinkState.LoginState.LoggedIn,
-//                    ),
-//                )
-//            )
-//        )
-//    }
-
-//    @Test
-//    fun `load() with no customer and Google Pay not ready should default to Link`() = runTest {
-//        prefsRepository.savePaymentSelection(null)
-//
-//        val expectedIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
-//        val expectedLinkState = LinkState(
-//            configuration = LinkPaymentLauncher.Configuration(
-//                stripeIntent = expectedIntent,
-//                merchantName = "Merchant, Inc.",
-//                customerName = null,
-//                customerEmail = null,
-//                customerPhone = null,
-//                customerBillingCountryCode = null,
-//                shippingValues = null,
-//            ),
-//            loginState = LinkState.LoginState.LoggedIn,
-//        )
-//
-//        val loader = createPaymentSheetLoader(isGooglePayReady = false)
-//
-//        assertThat(
-//            loader.load(
-//                initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
-//                    clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
-//                ),
-//                PaymentSheetFixtures.CONFIG_GOOGLEPAY
-//            )
-//        ).isEqualTo(
-//            PaymentSheetLoader.Result.Success(
-//                PaymentSheetState.Full(
-//                    config = PaymentSheetFixtures.CONFIG_GOOGLEPAY,
-//                    stripeIntent = expectedIntent,
-//                    customerPaymentMethods = emptyList(),
-////                    savedSelection = SavedSelection.Link,
-//                    isGooglePayReady = false,
-//                    paymentSelection = PaymentSelection.Link,
-//                    linkState = expectedLinkState,
-//                )
-//            )
-//        )
-//    }
 
     @Test
     fun `Should default to first payment method if customer has payment methods`() = runTest {

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentSheetLoader.kt
@@ -4,7 +4,7 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.model.SavedSelection
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentSheetLoader
 import com.stripe.android.paymentsheet.state.PaymentSheetState
@@ -15,7 +15,7 @@ internal class FakePaymentSheetLoader(
     private val stripeIntent: StripeIntent = PaymentIntentFixtures.PI_SUCCEEDED,
     private val shouldFail: Boolean = false,
     private var customerPaymentMethods: List<PaymentMethod> = emptyList(),
-    private val savedSelection: SavedSelection = SavedSelection.None,
+    private var paymentSelection: PaymentSelection? = null,
     private val isGooglePayAvailable: Boolean = false,
     private val delay: Duration = Duration.ZERO,
     private val linkState: LinkState? = null,
@@ -23,6 +23,9 @@ internal class FakePaymentSheetLoader(
 
     fun updatePaymentMethods(paymentMethods: List<PaymentMethod>) {
         this.customerPaymentMethods = paymentMethods
+        this.paymentSelection = paymentSelection.takeIf {
+            (it !is PaymentSelection.Saved) || it.paymentMethod in paymentMethods
+        }
     }
 
     override suspend fun load(
@@ -38,10 +41,10 @@ internal class FakePaymentSheetLoader(
                     config = paymentSheetConfiguration,
                     stripeIntent = stripeIntent,
                     customerPaymentMethods = customerPaymentMethods,
-                    savedSelection = savedSelection,
+//                    savedSelection = savedSelection,
                     isGooglePayReady = isGooglePayAvailable,
                     linkState = linkState,
-                    newPaymentSelection = null,
+                    paymentSelection = paymentSelection,
                 )
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentSheetLoader.kt
@@ -41,7 +41,6 @@ internal class FakePaymentSheetLoader(
                     config = paymentSheetConfiguration,
                     stripeIntent = stripeIntent,
                     customerPaymentMethods = customerPaymentMethods,
-//                    savedSelection = savedSelection,
                     isGooglePayReady = isGooglePayAvailable,
                     linkState = linkState,
                     paymentSelection = paymentSelection,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates the janky auto-selection of payment methods in `FlowController`.

Here are the highlights:
- We only use `SavedSelection` in `PaymentSheetLoader` now. We retrieve it from disk and then map it to a `PaymentSelection` (or `null` if the payment method isn’t available anymore).
- We sort the customer payment methods in `PaymentSheetLoader` instead of in the `PaymentOptionsStateFactory`.
- When retrieving `SavedSelection`, we don’t write anything to disk. A payment method is now only considered “last used” if the user has actively selected it.
- We don’t auto-select Google Pay or Link anymore unless they are the last used payment method. The only payment option that we auto-select even if it’s not the last used one is the customer’s first payment method.

Note that a lot of tests are no longer required. I have removed them across `DefaultFlowControllerTest`, `DefaultPaymentSheetLoaderTest`, and `PaymentOptionsStateMapperTest`.

To review this most easily, take a look at commits 1 and 4. Commits 2 and 3 contain updates to the tests.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

More predictable and less aggressive behavior.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
