### PR TITLE
fix stripe 3ds2 ITMX not trigger

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/parsers/NextActionDataParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/NextActionDataParser.kt
@@ -96,7 +96,7 @@ internal class NextActionDataParser : ModelJsonParser<StripeIntent.NextActionDat
                 TYPE_3DS1 -> StripeIntent.NextActionData.SdkData.Use3DS1(
                     json.optString(FIELD_STRIPE_JS)
                 )
-                TYPE_3DS2 -> StripeIntent.NextActionData.SdkData.Use3DS2(
+                TYPE_3DS2, TYPE_3DS2_ITMX -> StripeIntent.NextActionData.SdkData.Use3DS2(
                     json.optString(FIELD_THREE_D_SECURE_2_SOURCE),
                     json.optString(FIELD_DIRECTORY_SERVER_NAME),
                     json.optString(FIELD_SERVER_TRANSACTION_ID),
@@ -136,6 +136,7 @@ internal class NextActionDataParser : ModelJsonParser<StripeIntent.NextActionDat
             private const val FIELD_TYPE = "type"
 
             private const val TYPE_3DS2 = "stripe_3ds2_fingerprint"
+            private const val TYPE_3DS2_ITMX = "stripe_3ds2_itmx"
             private const val TYPE_3DS1 = "three_d_secure_redirect"
 
             private const val FIELD_THREE_D_SECURE_2_SOURCE = "three_d_secure_2_source"


### PR DESCRIPTION
# Summary
Added "stripe_3ds2_itmx" next action type to support next action type from Thailand debit card.

# Motivation
https://github.com/stripe/stripe-android/issues/6393 From this issue. I tried to edit some code in the SDK to support "stripe_3ds2_itmx" and test with the card that I found the issue. The result is the SDK can trigger 3DS and can proceed until it success.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before video*  | *after screenshot* |
| https://user-images.githubusercontent.com/13759163/226253064-0cfa4ab8-2a91-479b-a941-de37836f5890.mov | <img width="895" alt="Screen Shot 2566-03-19 at 17 14 16" src="https://user-images.githubusercontent.com/13759163/226253201-078eb63f-c20a-4b07-acf0-4b34f6d7bf27.png"> |  



# Changelog
- [Fixed] fix stripe 3ds2 ITMX not trigger
