### PR TITLE
Re-enable E2E test

### DIFF
--- a/stripe-test-e2e/src/test/java/com/stripe/android/test/e2e/EndToEndTest.kt
+++ b/stripe-test-e2e/src/test/java/com/stripe/android/test/e2e/EndToEndTest.kt
@@ -21,7 +21,6 @@ import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.runner.RunWith
 import kotlin.coroutines.resume
@@ -474,7 +473,6 @@ internal class EndToEndTest {
             .isEqualTo(StripeIntent.NextActionType.CashAppRedirect)
     }
 
-    @Ignore("Ignore until we can figure out how to create a new customer on every test run")
     @Test
     fun `test cashapp setup intent flow`() = runTest {
         val stripe = Stripe(context, settings.publishableKey)
@@ -483,7 +481,6 @@ internal class EndToEndTest {
             Request.CreateSetupIntentParams(
                 createParams = Request.CreateParams(
                     paymentMethodTypes = listOf("cashapp"),
-                    customer = "cus_NPaWWxhQLIw2jW",
                 ),
             )
         )

--- a/stripe-test-e2e/src/test/java/com/stripe/android/test/e2e/Request.kt
+++ b/stripe-test-e2e/src/test/java/com/stripe/android/test/e2e/Request.kt
@@ -18,6 +18,5 @@ sealed class Request {
 
     data class CreateParams(
         @field:Json(name = "payment_method_types") val paymentMethodTypes: List<String>,
-        @field:Json(name = "customer") val customer: String? = null,
     )
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request re-enables an ignored test in `EndToEndTest`. The test was disabled because the used customer had reached the maximum payment methods threshold, but it turns out that the `customer` property has recently been made optional. Therefore, I’m re-enabling this test and removing the `customer` argument.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
