### PR TITLE
Re-enable `InputAddressScreenTest`

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreenTest.kt
@@ -1,32 +1,28 @@
 package com.stripe.android.paymentsheet.addresselement
 
-import androidx.activity.ComponentActivity
-import androidx.compose.animation.ExperimentalAnimationApi
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
 import com.stripe.android.uicore.DefaultStripeTheme
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
-@ExperimentalAnimationApi
 @RunWith(AndroidJUnit4::class)
-@Ignore("Flakes on CI, need to investigate.")
 class InputAddressScreenTest {
+
     @get:Rule
-    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+    val composeTestRule = createComposeRule()
 
     @Test
     fun clicking_primary_button_triggers_callback_when_enabled() {
         var counter = 0
         setContent(primaryButtonEnabled = true, primaryButtonCallback = { counter++ })
         composeTestRule.onNodeWithText("Save Address").performClick()
-        Truth.assertThat(counter).isEqualTo(1)
+        assertThat(counter).isEqualTo(1)
     }
 
     @Test
@@ -34,7 +30,7 @@ class InputAddressScreenTest {
         var counter = 0
         setContent(primaryButtonEnabled = false, primaryButtonCallback = { counter++ })
         composeTestRule.onNodeWithText("Save Address").performClick()
-        Truth.assertThat(counter).isEqualTo(0)
+        assertThat(counter).isEqualTo(0)
     }
 
     @Test
@@ -42,7 +38,7 @@ class InputAddressScreenTest {
         var counter = 0
         setContent(onCloseCallback = { counter++ })
         composeTestRule.onNodeWithContentDescription("Close").performClick()
-        Truth.assertThat(counter).isEqualTo(1)
+        assertThat(counter).isEqualTo(1)
     }
 
     private fun setContent(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request re-enables `InputAddressScreenTest` which has seemingly been disabled to due flakiness. It’s been pretty stable on this branch though.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
