### PR TITLE
[FC] Use light status bar and navigation bar.

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/theme/Theme.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/theme/Theme.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.ui.theme
 
+import android.app.Activity
 import androidx.compose.foundation.text.selection.LocalTextSelectionColors
 import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.material.Colors
@@ -9,11 +10,15 @@ import androidx.compose.material.ripple.RippleTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
+import androidx.core.view.WindowCompat
 
 private val LightColorPalette = FinancialConnectionsColors(
     backgroundSurface = Color.White,
@@ -146,10 +151,23 @@ private object FinancialConnectionsRippleTheme : RippleTheme {
 
 @Composable
 internal fun FinancialConnectionsTheme(content: @Composable () -> Unit) {
+
     CompositionLocalProvider(
         LocalFinancialConnectionsTypography provides Typography,
         LocalFinancialConnectionsColors provides LightColorPalette
     ) {
+        val view = LocalView.current
+        val barColor = FinancialConnectionsTheme.colors.borderDefault
+        if (!view.isInEditMode) {
+            SideEffect {
+                val window = (view.context as Activity).window
+                val insets = WindowCompat.getInsetsController(window, view)
+                window.statusBarColor = barColor.toArgb()
+                window.navigationBarColor = barColor.toArgb()
+                insets.isAppearanceLightStatusBars = true
+                insets.isAppearanceLightNavigationBars = true
+            }
+        }
         MaterialTheme(
             colors = debugColors(),
             content = {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/theme/Theme.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/theme/Theme.kt
@@ -151,7 +151,6 @@ private object FinancialConnectionsRippleTheme : RippleTheme {
 
 @Composable
 internal fun FinancialConnectionsTheme(content: @Composable () -> Unit) {
-
     CompositionLocalProvider(
         LocalFinancialConnectionsTypography provides Typography,
         LocalFinancialConnectionsColors provides LightColorPalette
@@ -160,7 +159,7 @@ internal fun FinancialConnectionsTheme(content: @Composable () -> Unit) {
         val barColor = FinancialConnectionsTheme.colors.borderDefault
         if (!view.isInEditMode) {
             SideEffect {
-                (view.context as? Activity)?.window?.let {window ->
+                (view.context as? Activity)?.window?.let { window ->
                     val insets = WindowCompat.getInsetsController(window, view)
                     window.statusBarColor = barColor.toArgb()
                     window.navigationBarColor = barColor.toArgb()
@@ -183,9 +182,10 @@ internal fun FinancialConnectionsTheme(content: @Composable () -> Unit) {
     }
 }
 
-private val LocalFinancialConnectionsTypography = staticCompositionLocalOf<FinancialConnectionsTypography> {
-    error("no FinancialConnectionsTypography provided")
-}
+private val LocalFinancialConnectionsTypography =
+    staticCompositionLocalOf<FinancialConnectionsTypography> {
+        error("no FinancialConnectionsTypography provided")
+    }
 
 private val LocalFinancialConnectionsColors = staticCompositionLocalOf<FinancialConnectionsColors> {
     error("No FinancialConnectionsColors provided")

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/theme/Theme.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/theme/Theme.kt
@@ -160,12 +160,13 @@ internal fun FinancialConnectionsTheme(content: @Composable () -> Unit) {
         val barColor = FinancialConnectionsTheme.colors.borderDefault
         if (!view.isInEditMode) {
             SideEffect {
-                val window = (view.context as Activity).window
-                val insets = WindowCompat.getInsetsController(window, view)
-                window.statusBarColor = barColor.toArgb()
-                window.navigationBarColor = barColor.toArgb()
-                insets.isAppearanceLightStatusBars = true
-                insets.isAppearanceLightNavigationBars = true
+                (view.context as? Activity)?.window?.let {window ->
+                    val insets = WindowCompat.getInsetsController(window, view)
+                    window.statusBarColor = barColor.toArgb()
+                    window.navigationBarColor = barColor.toArgb()
+                    insets.isAppearanceLightStatusBars = true
+                    insets.isAppearanceLightNavigationBars = true
+                }
             }
         }
         MaterialTheme(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/theme/Theme.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/ui/theme/Theme.kt
@@ -1,6 +1,9 @@
 package com.stripe.android.financialconnections.ui.theme
 
 import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.view.Window
 import androidx.compose.foundation.text.selection.LocalTextSelectionColors
 import androidx.compose.foundation.text.selection.TextSelectionColors
 import androidx.compose.material.Colors
@@ -18,6 +21,7 @@ import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.DialogWindowProvider
 import androidx.core.view.WindowCompat
 
 private val LightColorPalette = FinancialConnectionsColors(
@@ -156,10 +160,11 @@ internal fun FinancialConnectionsTheme(content: @Composable () -> Unit) {
         LocalFinancialConnectionsColors provides LightColorPalette
     ) {
         val view = LocalView.current
+        val window = findWindow()
         val barColor = FinancialConnectionsTheme.colors.borderDefault
         if (!view.isInEditMode) {
             SideEffect {
-                (view.context as? Activity)?.window?.let { window ->
+                window?.let { window ->
                     val insets = WindowCompat.getInsetsController(window, view)
                     window.statusBarColor = barColor.toArgb()
                     window.navigationBarColor = barColor.toArgb()
@@ -181,6 +186,18 @@ internal fun FinancialConnectionsTheme(content: @Composable () -> Unit) {
         )
     }
 }
+
+@Composable
+private fun findWindow(): Window? =
+    (LocalView.current.parent as? DialogWindowProvider)?.window
+        ?: LocalView.current.context.findWindow()
+
+private tailrec fun Context.findWindow(): Window? =
+    when (this) {
+        is Activity -> window
+        is ContextWrapper -> baseContext.findWindow()
+        else -> null
+    }
 
 private val LocalFinancialConnectionsTypography =
     staticCompositionLocalOf<FinancialConnectionsTypography> {


### PR DESCRIPTION
# Summary
Use light color instead of default purple on statusbar and toolbar.

# Motivation
:notebook_with_decorative_cover: &nbsp;**[Android] Use light statusbar**
:globe_with_meridians: &nbsp;[BANKCON-6405](https://jira.corp.stripe.com/browse/BANKCON-6405)

<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![test](https://user-images.githubusercontent.com/99293320/226486305-9be687e4-2edc-4cb5-843c-70361d1185f3.png) | ![image](https://user-images.githubusercontent.com/99293320/226486162-c469b45e-b343-463e-b693-ab72170d4225.png) |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->