### PR TITLE
Add functionality to selectively update payment selection after `configureWith` calls

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
@@ -23,6 +23,7 @@ internal class FlowControllerConfigurationHandler @Inject constructor(
     private val eventReporter: EventReporter,
     private val viewModel: FlowControllerViewModel,
 ) {
+
     suspend fun configure(
         initializationMode: PaymentSheet.InitializationMode,
         configuration: PaymentSheet.Configuration?,
@@ -74,7 +75,11 @@ internal class FlowControllerConfigurationHandler @Inject constructor(
     ) {
         eventReporter.onInit(state.config)
 
-        viewModel.paymentSelection = state.paymentSelection
+        viewModel.paymentSelection = PaymentSelectionUpdater.process(
+            currentSelection = viewModel.paymentSelection,
+            newState = state,
+        )
+
         viewModel.state = state
 
         callback.onConfigured(true, null)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdater.kt
@@ -1,0 +1,33 @@
+package com.stripe.android.paymentsheet.flowcontroller
+
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.state.PaymentSheetState
+
+internal object PaymentSelectionUpdater {
+
+    fun process(
+        currentSelection: PaymentSelection?,
+        newState: PaymentSheetState.Full,
+    ): PaymentSelection? {
+        return currentSelection?.takeIf { it.canBeUsedIn(newState) } ?: newState.paymentSelection
+    }
+}
+
+private fun PaymentSelection.canBeUsedIn(state: PaymentSheetState.Full): Boolean {
+    val allowedTypes = state.stripeIntent.paymentMethodTypes
+
+    return when (this) {
+        is PaymentSelection.New -> {
+            paymentMethodCreateParams.typeCode in allowedTypes
+        }
+        is PaymentSelection.Saved -> {
+            paymentMethod.type?.code in allowedTypes && paymentMethod in state.customerPaymentMethods
+        }
+        is PaymentSelection.GooglePay -> {
+            state.isGooglePayReady
+        }
+        is PaymentSelection.Link -> {
+            state.linkState != null
+        }
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/PaymentSelectionUpdaterTest.kt
@@ -1,0 +1,111 @@
+package com.stripe.android.paymentsheet.flowcontroller
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCreateParamsFixtures
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.state.PaymentSheetState
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+
+@RunWith(RobolectricTestRunner::class)
+class PaymentSelectionUpdaterTest {
+
+    @Test
+    fun `Uses new payment selection if there's no existing one`() {
+        val newState = mockPaymentSheetState(paymentSelection = PaymentSelection.GooglePay)
+        val result = PaymentSelectionUpdater.process(
+            currentSelection = null,
+            newState = newState,
+        )
+        assertThat(result).isEqualTo(PaymentSelection.GooglePay)
+    }
+
+    @Test
+    fun `Can use existing new payment selection if it's still supported`() {
+        val existingSelection = PaymentSelection.New.GenericPaymentMethod(
+            labelResource = "Sofort",
+            iconResource = R.drawable.stripe_ic_paymentsheet_pm_klarna,
+            lightThemeIconUrl = null,
+            darkThemeIconUrl = null,
+            paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.SOFORT,
+            customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest,
+        )
+        val newState = mockPaymentSheetState(paymentMethodTypes = listOf("card", "sofort"))
+
+        val result = PaymentSelectionUpdater.process(
+            currentSelection = existingSelection,
+            newState = newState,
+        )
+        assertThat(result).isEqualTo(existingSelection)
+    }
+
+    @Test
+    fun `Can use existing saved payment selection if it's still supported`() {
+        val paymentMethod = PaymentMethodFixtures.createCard()
+        val existingSelection = PaymentSelection.Saved(paymentMethod)
+
+        val newState = mockPaymentSheetState(
+            paymentMethodTypes = listOf("card", "cashapp"),
+            customerPaymentMethods = PaymentMethodFixtures.createCards(3) + paymentMethod,
+        )
+
+        val result = PaymentSelectionUpdater.process(
+            currentSelection = existingSelection,
+            newState = newState,
+        )
+        assertThat(result).isEqualTo(existingSelection)
+    }
+
+    @Test
+    fun `Can't use existing saved payment method if it's no longer supported`() {
+        val existing = PaymentSelection.Saved(PaymentMethodFixtures.SEPA_DEBIT_PAYMENT_METHOD)
+        val newState = mockPaymentSheetState(paymentMethodTypes = listOf("card", "cashapp"))
+
+        val result = PaymentSelectionUpdater.process(
+            currentSelection = existing,
+            newState = newState,
+        )
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `Can't use existing saved payment selection if it's no longer in customer payment methods`() {
+        val paymentMethod = PaymentMethodFixtures.createCard()
+        val existingSelection = PaymentSelection.Saved(paymentMethod)
+
+        val newState = mockPaymentSheetState(
+            paymentMethodTypes = listOf("card", "cashapp"),
+            customerPaymentMethods = PaymentMethodFixtures.createCards(3),
+        )
+
+        val result = PaymentSelectionUpdater.process(
+            currentSelection = existingSelection,
+            newState = newState,
+        )
+        assertThat(result).isNull()
+    }
+
+    private fun mockPaymentSheetState(
+        paymentMethodTypes: List<String>? = null,
+        paymentSelection: PaymentSelection? = null,
+        customerPaymentMethods: List<PaymentMethod> = emptyList(),
+    ): PaymentSheetState.Full {
+        val intent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
+
+        return PaymentSheetState.Full(
+            config = null,
+            stripeIntent = intent.copy(
+                paymentMethodTypes = paymentMethodTypes ?: intent.paymentMethodTypes,
+            ),
+            customerPaymentMethods = customerPaymentMethods,
+            isGooglePayReady = true,
+            linkState = null,
+            paymentSelection = paymentSelection,
+        )
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds the functionality in `FlowControllerConfigurationHandler` to selectively update the current `PaymentSelection`.

- For Link and Google Pay, we carry over an existing payment selection if these two are still enabled.
- For a new payment method, we carry it over if it’s still allowed (meaning: listed in `stripeIntent.paymentMethodTypes`).
- For an existing payment method, we carry it over if it’s still allowed and still available in the customer’s payment methods.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Decoupling project.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
