### PR TITLE
[stripecardscan] Use `ml-core` for CardScan

### DIFF
--- a/ml-core/base/src/main/java/com/stripe/android/mlcore/base/InterpreterWrapper.kt
+++ b/ml-core/base/src/main/java/com/stripe/android/mlcore/base/InterpreterWrapper.kt
@@ -13,4 +13,6 @@ interface InterpreterWrapper {
     )
 
     fun run(input: Any, output: Any)
+
+    fun close()
 }

--- a/ml-core/cardscan/src/main/java/com/stripe/android/mlcore/impl/InterpreterWrapperImpl.kt
+++ b/ml-core/cardscan/src/main/java/com/stripe/android/mlcore/impl/InterpreterWrapperImpl.kt
@@ -5,10 +5,19 @@ import com.stripe.android.mlcore.base.InterpreterOptionsWrapper
 import com.stripe.android.mlcore.base.InterpreterWrapper
 import org.tensorflow.lite.Interpreter
 import java.io.File
+import java.nio.ByteBuffer
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class InterpreterWrapperImpl(file: File, options: InterpreterOptionsWrapper) : InterpreterWrapper {
-    private val interpreter: Interpreter = Interpreter(file, options.toInterpreterOptions())
+class InterpreterWrapperImpl : InterpreterWrapper {
+    private val interpreter: Interpreter
+
+    constructor(byteBuffer: ByteBuffer, options: InterpreterOptionsWrapper) {
+        interpreter = Interpreter(byteBuffer, options.toInterpreterOptions())
+    }
+
+    constructor(file: File, options: InterpreterOptionsWrapper) {
+        interpreter = Interpreter(file, options.toInterpreterOptions())
+    }
 
     override fun runForMultipleInputsOutputs(inputs: Array<Any>, outputs: Map<Int, Any>) {
         interpreter.runForMultipleInputsOutputs(inputs, outputs)
@@ -16,6 +25,10 @@ class InterpreterWrapperImpl(file: File, options: InterpreterOptionsWrapper) : I
 
     override fun run(input: Any, output: Any) {
         interpreter.run(input, output)
+    }
+
+    override fun close() {
+        interpreter.close()
     }
 }
 

--- a/ml-core/default/src/main/java/com/stripe/android/mlcore/impl/InterpreterWrapperImpl.kt
+++ b/ml-core/default/src/main/java/com/stripe/android/mlcore/impl/InterpreterWrapperImpl.kt
@@ -17,6 +17,10 @@ class InterpreterWrapperImpl(file: File, options: InterpreterOptionsWrapper) : I
     override fun run(input: Any, output: Any) {
         interpreter.run(input, output)
     }
+
+    override fun close() {
+        interpreter.close()
+    }
 }
 
 private fun InterpreterOptionsWrapper.toInterpreterOptions(): Interpreter.Options {

--- a/ml-core/googleplay/src/main/java/com/stripe/android/mlcore/impl/InterpreterWrapperImpl.kt
+++ b/ml-core/googleplay/src/main/java/com/stripe/android/mlcore/impl/InterpreterWrapperImpl.kt
@@ -5,11 +5,19 @@ import com.stripe.android.mlcore.base.InterpreterOptionsWrapper
 import com.stripe.android.mlcore.base.InterpreterWrapper
 import org.tensorflow.lite.InterpreterApi
 import java.io.File
+import java.nio.ByteBuffer
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class InterpreterWrapperImpl(file: File, options: InterpreterOptionsWrapper) : InterpreterWrapper {
-    private val interpreter: InterpreterApi =
-        InterpreterApi.create(file, options.toInterpreterApiOptions())
+class InterpreterWrapperImpl : InterpreterWrapper {
+    private val interpreter: InterpreterApi
+
+    constructor(byteBuffer: ByteBuffer, options: InterpreterOptionsWrapper) {
+        interpreter = InterpreterApi.create(byteBuffer, options.toInterpreterApiOptions())
+    }
+
+    constructor(file: File, options: InterpreterOptionsWrapper) {
+        interpreter = InterpreterApi.create(file, options.toInterpreterApiOptions())
+    }
 
     override fun runForMultipleInputsOutputs(inputs: Array<Any>, outputs: Map<Int, Any>) {
         interpreter.runForMultipleInputsOutputs(inputs, outputs)
@@ -17,6 +25,10 @@ class InterpreterWrapperImpl(file: File, options: InterpreterOptionsWrapper) : I
 
     override fun run(input: Any, output: Any) {
         interpreter.run(input, output)
+    }
+
+    override fun close() {
+        interpreter.close()
     }
 }
 

--- a/stripecardscan/README.md
+++ b/stripecardscan/README.md
@@ -26,6 +26,18 @@ See the `stripecardscan-example` directory for an example application that you c
     }
     ```
 
+## Use TFLite in Google play to reduce binary size
+
+CardScan Android SDK uses a portable TFLite runtime to execute machine learning models, if your application is released through Google play, you could instead use the Google play runtime, this would reduce the SDK size by ~400kb.
+
+To do so, configure your app's dependency on stripecardscan as follows.
+```
+    implementation("com.stripe:stripecardscan:$stripeVersion") {
+      exclude group: 'com.stripe', module: 'ml-core:cardscan' // exclude the cardscan-specific portable tflite runtime
+    }
+    implementation("com.stripe:ml-core-googleplay:$stripeVersion") // include the google play tflite runtime
+```
+
 # Credit Card OCR
 
 Add `CardScanSheet` in your activity or fragment where you want to invoke the verification flow

--- a/stripecardscan/README.md
+++ b/stripecardscan/README.md
@@ -32,10 +32,10 @@ CardScan Android SDK uses a portable TFLite runtime to execute machine learning 
 
 To do so, configure your app's dependency on stripecardscan as follows.
 ```
-    implementation("com.stripe:stripecardscan:$stripeVersion") {
-      exclude group: 'com.stripe', module: 'ml-core:cardscan' // exclude the cardscan-specific portable tflite runtime
+    implementation('com.stripe:stripecardscan:$stripeVersion') {
+      exclude group: 'com.stripe', module: 'ml-core-cardscan' // exclude the cardscan-specific portable tflite runtime
     }
-    implementation("com.stripe:ml-core-googleplay:$stripeVersion") // include the google play tflite runtime
+    implementation('com.stripe:ml-core-googleplay:$stripeVersion') // include the google play tflite runtime
 ```
 
 # Credit Card OCR

--- a/stripecardscan/build.gradle
+++ b/stripecardscan/build.gradle
@@ -8,9 +8,7 @@ dependencies {
     api project(":stripe-core")
     implementation project(":camera-core")
 
-    // If a user wants to use their own TFLite implementation, they can exclude this dependency
-    // explicitly in their gradle dependency.
-    implementation project(":stripecardscan-tflite")
+    implementation project(":ml-core:cardscan")
 
     implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"
     implementation "androidx.constraintlayout:constraintlayout:$androidxConstraintlayoutVersion"

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/payment/ml/SSDOcr.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/payment/ml/SSDOcr.kt
@@ -187,6 +187,7 @@ internal class SSDOcr private constructor(interpreter: InterpreterWrapper) :
             1 to arrayOf(FloatArray(NUM_LOC))
         )
 
+        @Suppress("UNCHECKED_CAST")
         tfInterpreter.runForMultipleInputsOutputs(data as Array<Any>, mlOutput)
         return mlOutput
     }

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/payment/ml/SSDOcr.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/payment/ml/SSDOcr.kt
@@ -3,11 +3,14 @@ package com.stripe.android.stripecardscan.payment.ml
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Rect
+import android.util.Log
 import android.util.Size
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.camera.framework.image.cropCameraPreviewToViewFinder
 import com.stripe.android.camera.framework.image.hasOpenGl31
 import com.stripe.android.camera.framework.image.scale
+import com.stripe.android.mlcore.base.InterpreterOptionsWrapper
+import com.stripe.android.mlcore.base.InterpreterWrapper
 import com.stripe.android.stripecardscan.framework.FetchedData
 import com.stripe.android.stripecardscan.framework.image.MLImage
 import com.stripe.android.stripecardscan.framework.image.toMLImage
@@ -23,7 +26,6 @@ import com.stripe.android.stripecardscan.payment.ml.ssd.combinePriors
 import com.stripe.android.stripecardscan.payment.ml.ssd.determineLayoutAndFilter
 import com.stripe.android.stripecardscan.payment.ml.ssd.extractPredictions
 import com.stripe.android.stripecardscan.payment.ml.ssd.rearrangeOCRArray
-import org.tensorflow.lite.Interpreter
 import java.nio.ByteBuffer
 
 /** Training images are normalized with mean 127.5 and std 128.5. */
@@ -89,7 +91,7 @@ private val PRIORS = combinePriors(SSDOcr.Factory.TRAINED_IMAGE_SIZE)
 /**
  * This model performs SSD OCR recognition on a card.
  */
-internal class SSDOcr private constructor(interpreter: Interpreter) :
+internal class SSDOcr private constructor(interpreter: InterpreterWrapper) :
     TensorFlowLiteAnalyzer<
         SSDOcr.Input,
         Array<ByteBuffer>,
@@ -178,7 +180,7 @@ internal class SSDOcr private constructor(interpreter: Interpreter) :
     }
 
     override suspend fun executeInference(
-        tfInterpreter: Interpreter,
+        tfInterpreter: InterpreterWrapper,
         data: Array<ByteBuffer>
     ): Map<Int, Array<FloatArray>> {
         val mlOutput = mapOf(
@@ -186,7 +188,7 @@ internal class SSDOcr private constructor(interpreter: Interpreter) :
             1 to arrayOf(FloatArray(NUM_LOC))
         )
 
-        tfInterpreter.runForMultipleInputsOutputs(data, mlOutput)
+        tfInterpreter.runForMultipleInputsOutputs(data as Array<Any>, mlOutput)
         return mlOutput
     }
 
@@ -205,10 +207,10 @@ internal class SSDOcr private constructor(interpreter: Interpreter) :
             val TRAINED_IMAGE_SIZE = Size(600, 375)
         }
 
-        override val tfOptions: Interpreter.Options = Interpreter
-            .Options()
-            .setUseNNAPI(USE_GPU && hasOpenGl31(context.applicationContext))
-            .setNumThreads(threads)
+        override val tfOptions = InterpreterOptionsWrapper.Builder()
+            .useNNAPI(USE_GPU && hasOpenGl31(context.applicationContext))
+            .numThreads(threads)
+            .build()
 
         override suspend fun newInstance(): SSDOcr? = createInterpreter()?.let { SSDOcr(it) }
     }

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/payment/ml/SSDOcr.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/payment/ml/SSDOcr.kt
@@ -3,7 +3,6 @@ package com.stripe.android.stripecardscan.payment.ml
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Rect
-import android.util.Log
 import android.util.Size
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.camera.framework.image.cropCameraPreviewToViewFinder

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/scanui/ScanActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/scanui/ScanActivity.kt
@@ -12,11 +12,13 @@ import android.view.ViewGroup
 import android.view.WindowManager
 import androidx.activity.addCallback
 import androidx.appcompat.app.AlertDialog
+import androidx.lifecycle.lifecycleScope
 import com.stripe.android.camera.CameraAdapter
 import com.stripe.android.camera.CameraPermissionCheckingActivity
 import com.stripe.android.camera.CameraPreviewImage
 import com.stripe.android.camera.DefaultCameraErrorListener
 import com.stripe.android.camera.framework.Stats
+import com.stripe.android.mlcore.impl.InterpreterInitializerImpl
 import com.stripe.android.stripecardscan.R
 import com.stripe.android.stripecardscan.camera.getCameraAdapter
 import kotlinx.coroutines.CoroutineScope
@@ -249,7 +251,18 @@ internal abstract class ScanActivity : CameraPermissionCheckingActivity(), Corou
             onSupportsMultipleCameras(it)
         }
 
-        launch { onCameraStreamAvailable(cameraAdapter.getImageStream()) }
+        lifecycleScope.launch(Dispatchers.IO) {
+            InterpreterInitializerImpl.initialize(
+                context = this@ScanActivity,
+                onSuccess = {
+                    lifecycleScope.launch { onCameraStreamAvailable(cameraAdapter.getImageStream()) }
+                },
+                onFailure = {
+                    scanFailure(it)
+                }
+            )
+        }
+
     }
 
     /**

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/scanui/ScanActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/scanui/ScanActivity.kt
@@ -262,7 +262,6 @@ internal abstract class ScanActivity : CameraPermissionCheckingActivity(), Corou
                 }
             )
         }
-
     }
 
     /**


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Replace the dependency to `ml-core:cardscan` by default and document the option to swap with google play.


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Use TFLite in Google play

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified - 

* manually verified in `ScanActivity` and `ScanFragment` with `ml-core:cardscan`
* manually verified in `ScanActivity` and `ScanFragment` with `ml-core:googleplay`


# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
