### PR TITLE
Cancel in-flight configure call in `FlowController` if new call is kicked off

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
@@ -32,7 +32,7 @@ internal class FlowControllerConfigurationHandler @Inject constructor(
     ) {
         job?.cancel()
 
-        val completableJob = Job().apply {
+        job = Job().apply {
             invokeOnCompletion { error ->
                 if (error !is CancellationException) {
                     callback.onConfigured(
@@ -44,14 +44,12 @@ internal class FlowControllerConfigurationHandler @Inject constructor(
             }
         }
 
-        scope.launch(completableJob) {
+        scope.launch(job!!) {
             configureInternal(
                 initializationMode = initializationMode,
                 configuration = configuration,
             )
         }
-
-        job = completableJob
     }
 
     private suspend fun configureInternal(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -1102,7 +1102,7 @@ internal class DefaultFlowControllerTest {
         paymentSheetLoader: PaymentSheetLoader,
         viewModel: FlowControllerViewModel = ViewModelProvider(activity)[FlowControllerViewModel::class.java]
     ) = DefaultFlowController(
-        lifecycleScope = testScope,
+        viewModelScope = testScope,
         lifecycleOwner = lifeCycleOwner,
         statusBarColor = { activity.window.statusBarColor },
         paymentOptionFactory = PaymentOptionFactory(activity.resources, StripeImageLoader(activity)),
@@ -1120,7 +1120,6 @@ internal class DefaultFlowControllerTest {
         linkLauncher = linkPaymentLauncher,
         configurationHandler = FlowControllerConfigurationHandler(
             paymentSheetLoader = paymentSheetLoader,
-            uiContext = testDispatcher,
             eventReporter = eventReporter,
             viewModel = viewModel,
             paymentSelectionUpdater = { _, newState -> newState.paymentSelection },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -1120,6 +1120,7 @@ internal class DefaultFlowControllerTest {
         linkLauncher = linkPaymentLauncher,
         configurationHandler = FlowControllerConfigurationHandler(
             paymentSheetLoader = paymentSheetLoader,
+            uiContext = testDispatcher,
             eventReporter = eventReporter,
             viewModel = viewModel,
             paymentSelectionUpdater = { _, newState -> newState.paymentSelection },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
@@ -368,6 +368,7 @@ class FlowControllerConfigurationHandlerTest {
     ): FlowControllerConfigurationHandler {
         return FlowControllerConfigurationHandler(
             paymentSheetLoader = paymentSheetLoader,
+            uiContext = testDispatcher,
             eventReporter = eventReporter,
             viewModel = viewModel,
             paymentSelectionUpdater = { _, newState -> newState.paymentSelection },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
@@ -345,6 +345,31 @@ class FlowControllerConfigurationHandlerTest {
         assertThat(completedCall).isEqualTo(amounts.last())
     }
 
+    @Test
+    fun `Cancels current configure job if coroutine scope is canceled`() = runTest {
+        val configurationHandler = createConfigurationHandler(
+            FakePaymentSheetLoader(
+                customerPaymentMethods = emptyList(),
+                delay = 1.seconds,
+            )
+        )
+
+        configurationHandler.configure(
+            scope = testScope,
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                clientSecret = PaymentSheetFixtures.CLIENT_SECRET,
+                ),
+            configuration = null,
+            callback = { _, _ ->
+                throw AssertionError("Shouldn't have called ConfigCallback")
+            },
+        )
+
+        testScope.advanceTimeBy(500L)
+        testScope.cancel()
+        testScope.advanceTimeBy(1_000L)
+    }
+
     private fun defaultPaymentSheetLoader(): PaymentSheetLoader {
         return FakePaymentSheetLoader(
             customerPaymentMethods = emptyList(),

--- a/paymentsheet/src/test/java/com/stripe/android/utils/DelayingPaymentSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/DelayingPaymentSheetLoader.kt
@@ -1,0 +1,46 @@
+package com.stripe.android.utils
+
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.state.PaymentSheetLoader
+import com.stripe.android.paymentsheet.state.PaymentSheetState
+import com.stripe.android.testing.PaymentIntentFactory
+import kotlinx.coroutines.channels.Channel
+
+internal class DelayingPaymentSheetLoader : PaymentSheetLoader {
+
+    private val results = Channel<PaymentSheetLoader.Result>(capacity = 1)
+
+    fun enqueueSuccess(
+        stripeIntent: StripeIntent = PaymentIntentFactory.create(),
+    ) {
+        enqueue(
+            PaymentSheetLoader.Result.Success(
+                state = PaymentSheetState.Full(
+                    stripeIntent = stripeIntent,
+                    customerPaymentMethods = emptyList(),
+                    config = null,
+                    isGooglePayReady = false,
+                    paymentSelection = null,
+                    linkState = null,
+                ),
+            )
+        )
+    }
+
+    fun enqueueFailure() {
+        val error = RuntimeException("whoops")
+        enqueue(PaymentSheetLoader.Result.Failure(error))
+    }
+
+    private fun enqueue(result: PaymentSheetLoader.Result) {
+        results.trySend(result)
+    }
+
+    override suspend fun load(
+        initializationMode: PaymentSheet.InitializationMode,
+        paymentSheetConfiguration: PaymentSheet.Configuration?
+    ): PaymentSheetLoader.Result {
+        return results.receive()
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds automatic cancelation of in-flight configure calls when a new configure call is kicked off.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Decoupling.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
