### PR TITLE
Add sample screen for decoupled flow

### DIFF
--- a/paymentsheet-example/src/main/AndroidManifest.xml
+++ b/paymentsheet-example/src/main/AndroidManifest.xml
@@ -42,6 +42,7 @@
 
         <activity android:name=".samples.ui.complete_flow.CompleteFlowActivity" />
         <activity android:name=".samples.ui.custom_flow.CustomFlowActivity" />
+        <activity android:name=".samples.ui.server_side_confirm.ServerSideConfirmationActivity" />
         <activity android:name=".playground.activity.PaymentSheetPlaygroundActivity" />
     </application>
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/MainActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/MainActivity.kt
@@ -25,6 +25,7 @@ import com.stripe.android.paymentsheet.example.databinding.ActivityMainBinding
 import com.stripe.android.paymentsheet.example.playground.activity.PaymentSheetPlaygroundActivity
 import com.stripe.android.paymentsheet.example.samples.ui.complete_flow.CompleteFlowActivity
 import com.stripe.android.paymentsheet.example.samples.ui.custom_flow.CustomFlowActivity
+import com.stripe.android.paymentsheet.example.samples.ui.server_side_confirm.ServerSideConfirmationActivity
 
 class MainActivity : AppCompatActivity() {
 
@@ -43,6 +44,11 @@ class MainActivity : AppCompatActivity() {
                 title = "PaymentSheet with FlowController",
                 subtitle = "A more advanced integration with greater flexibility",
                 klass = CustomFlowActivity::class.java,
+            ),
+            MenuItem(
+                title = "PaymentSheet with server-side confirmation",
+                subtitle = "Create and confirm the payment or setup intent on your own backend",
+                klass = ServerSideConfirmationActivity::class.java,
             ),
             MenuItem(
                 title = "Playground",

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/MainActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/MainActivity.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.paymentsheet.example
 
+import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.appcompat.app.AppCompatActivity
@@ -12,8 +14,15 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Chip
+import androidx.compose.material.ChipDefaults
 import androidx.compose.material.Divider
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -26,6 +35,8 @@ import com.stripe.android.paymentsheet.example.playground.activity.PaymentSheetP
 import com.stripe.android.paymentsheet.example.samples.ui.complete_flow.CompleteFlowActivity
 import com.stripe.android.paymentsheet.example.samples.ui.custom_flow.CustomFlowActivity
 import com.stripe.android.paymentsheet.example.samples.ui.server_side_confirm.ServerSideConfirmationActivity
+
+private const val SurfaceOverlayOpacity = 0.12f
 
 class MainActivity : AppCompatActivity() {
 
@@ -49,6 +60,7 @@ class MainActivity : AppCompatActivity() {
                 title = "PaymentSheet with server-side confirmation",
                 subtitle = "Create and confirm the payment or setup intent on your own backend",
                 klass = ServerSideConfirmationActivity::class.java,
+                isBeta = true,
             ),
             MenuItem(
                 title = "Playground",
@@ -73,6 +85,7 @@ private data class MenuItem(
     val title: String,
     val subtitle: String,
     val klass: Class<out ComponentActivity>,
+    val isBeta: Boolean = false,
 )
 
 @Composable
@@ -98,6 +111,7 @@ private fun MainScreen(items: List<MenuItem>) {
     }
 }
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 private fun MenuItemRow(item: MenuItem) {
     val context = LocalContext.current
@@ -113,6 +127,35 @@ private fun MenuItemRow(item: MenuItem) {
             fontWeight = FontWeight.SemiBold,
             modifier = Modifier.padding(bottom = 4.dp),
         )
+
         Text(text = item.subtitle)
+
+        if (item.isBeta) {
+            Chip(
+                colors = ChipDefaults.chipColors(
+                    backgroundColor = MaterialTheme.colors.secondary.copy(
+                        alpha = SurfaceOverlayOpacity,
+                    ),
+                ),
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Default.Info,
+                        contentDescription = null,
+                    )
+                },
+                onClick = context::openDecouplingBetaLink,
+                modifier = Modifier.padding(top = 4.dp),
+            ) {
+                Text(text = "This is currently in beta.")
+            }
+        }
     }
+}
+
+private fun Context.openDecouplingBetaLink() {
+    val url = "https://stripe.com/docs/payments/finalize-payments-on-the-server?platform=mobile"
+    val intent = Intent(Intent.ACTION_VIEW).apply {
+        data = Uri.parse(url)
+    }
+    startActivity(intent)
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/MainActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/MainActivity.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.stripe.android.core.version.StripeSdkVersion
@@ -47,24 +48,27 @@ class MainActivity : AppCompatActivity() {
     private val items: List<MenuItem> by lazy {
         listOf(
             MenuItem(
-                title = "Basic PaymentSheet",
-                subtitle = "Our simplest integration",
+                titleResId = R.string.paymentsheet_title,
+                subtitleResId = R.string.paymentsheet_subtitle,
                 klass = CompleteFlowActivity::class.java,
             ),
             MenuItem(
-                title = "PaymentSheet with FlowController",
-                subtitle = "A more advanced integration with greater flexibility",
+                titleResId = R.string.paymentsheet_custom_title,
+                subtitleResId = R.string.paymentsheet_custom_subtitle,
                 klass = CustomFlowActivity::class.java,
             ),
             MenuItem(
-                title = "PaymentSheet with server-side confirmation",
-                subtitle = "Create and confirm the payment or setup intent on your own backend",
+                titleResId = R.string.paymentsheet_serverside_confirmation_title,
+                subtitleResId = R.string.paymentsheet_serverside_confirmation_subtitle,
                 klass = ServerSideConfirmationActivity::class.java,
-                isBeta = true,
+                badge = MenuItem.Badge(
+                    labelResId = R.string.beta_badge_label,
+                    onClick = this::openDecouplingBetaLink,
+                ),
             ),
             MenuItem(
-                title = "Playground",
-                subtitle = "Testing playground for Stripe engineers",
+                titleResId = R.string.playground_title,
+                subtitleResId = R.string.playground_subtitle,
                 klass = PaymentSheetPlaygroundActivity::class.java,
             ),
         )
@@ -82,11 +86,16 @@ class MainActivity : AppCompatActivity() {
 }
 
 private data class MenuItem(
-    val title: String,
-    val subtitle: String,
+    val titleResId: Int,
+    val subtitleResId: Int,
     val klass: Class<out ComponentActivity>,
-    val isBeta: Boolean = false,
-)
+    val badge: Badge? = null,
+) {
+    data class Badge(
+        val labelResId: Int,
+        val onClick: () -> Unit,
+    )
+}
 
 @Composable
 private fun MainScreen(items: List<MenuItem>) {
@@ -123,14 +132,14 @@ private fun MenuItemRow(item: MenuItem) {
             .padding(16.dp),
     ) {
         Text(
-            text = item.title,
+            text = stringResource(item.titleResId),
             fontWeight = FontWeight.SemiBold,
             modifier = Modifier.padding(bottom = 4.dp),
         )
 
-        Text(text = item.subtitle)
+        Text(text = stringResource(item.subtitleResId))
 
-        if (item.isBeta) {
+        if (item.badge != null) {
             Chip(
                 colors = ChipDefaults.chipColors(
                     backgroundColor = MaterialTheme.colors.secondary.copy(
@@ -143,10 +152,10 @@ private fun MenuItemRow(item: MenuItem) {
                         contentDescription = null,
                     )
                 },
-                onClick = context::openDecouplingBetaLink,
+                onClick = item.badge.onClick,
                 modifier = Modifier.padding(top = 4.dp),
             ) {
-                Text(text = "This is currently in beta.")
+                Text(text = stringResource(item.badge.labelResId))
             }
         }
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/model/CartState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/model/CartState.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet.example.samples.model
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.samples.networking.ExampleCheckoutResponse
 import com.stripe.android.paymentsheet.example.samples.networking.ExampleUpdateResponse
-import kotlin.math.roundToLong
 
 data class CartState(
     val products: List<CartProduct>,
@@ -11,7 +10,6 @@ data class CartState(
     val subtotal: Long? = null,
     val salesTax: Long? = null,
     val total: Long? = null,
-    val requiresCalculation: Boolean = false,
 ) {
 
     val formattedSubtotal: String
@@ -32,7 +30,6 @@ data class CartState(
                     product
                 }
             },
-            requiresCalculation = true,
         )
     }
 
@@ -60,10 +57,9 @@ internal fun CartState.updateWithResponse(
     response: ExampleUpdateResponse,
 ): CartState {
     return copy(
-        subtotal = response.subtotal.roundToLong(),
-        salesTax = response.tax.roundToLong(),
-        total = response.total.roundToLong(),
-        requiresCalculation = false,
+        subtotal = response.subtotal,
+        salesTax = response.tax,
+        total = response.total,
     )
 }
 
@@ -71,10 +67,9 @@ internal fun CartState.updateWithResponse(
     response: ExampleCheckoutResponse,
 ): CartState {
     return copy(
-        subtotal = response.subtotal.roundToLong(),
-        salesTax = response.tax.roundToLong(),
-        total = response.total.roundToLong(),
-        requiresCalculation = false,
+        subtotal = response.subtotal,
+        salesTax = response.tax,
+        total = response.total,
     )
 }
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/model/CartState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/model/CartState.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.example.samples.model
 
+import com.stripe.android.ExperimentalPaymentSheetDecouplingApi
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.samples.networking.ExampleCheckoutResponse
 import com.stripe.android.paymentsheet.example.samples.networking.ExampleUpdateResponse
@@ -73,6 +74,7 @@ internal fun CartState.updateWithResponse(
     )
 }
 
+@OptIn(ExperimentalPaymentSheetDecouplingApi::class)
 internal fun CartState.toIntentConfiguration(): PaymentSheet.IntentConfiguration {
     return PaymentSheet.IntentConfiguration(
         mode = PaymentSheet.IntentConfiguration.Mode.Payment(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/networking/Models.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/networking/Models.kt
@@ -65,3 +65,68 @@ data class ExampleCheckoutResponse(
         }
     }
 }
+
+@Serializable
+@Keep
+data class ExampleUpdateRequest(
+    @SerializedName("hot_dog_count")
+    val hotDogCount: Int,
+    @SerializedName("salad_count")
+    val saladCount: Int,
+    @SerializedName("is_subscribing")
+    val isSubscribing: Boolean,
+)
+
+fun CartState.toUpdateRequest(): ExampleUpdateRequest {
+    return ExampleUpdateRequest(
+        hotDogCount = countOf(CartProduct.Id.HotDog),
+        saladCount = countOf(CartProduct.Id.Salad),
+        isSubscribing = isSubscription,
+    )
+}
+
+@Serializable
+@Keep
+data class ExampleUpdateResponse(
+    @SerializedName("subtotal")
+    val subtotal: Float,
+    @SerializedName("tax")
+    val tax: Float,
+    @SerializedName("total")
+    val total: Float,
+)
+
+@Serializable
+@Keep
+data class ExampleCreateIntentRequest(
+    @SerializedName("payment_method_id")
+    val paymentMethodId: String,
+    @SerializedName("should_save_payment_method")
+    val shouldSavePaymentMethod: Boolean,
+    @SerializedName("hot_dog_count")
+    val hotDogCount: Int,
+    @SerializedName("salad_count")
+    val saladCount: Int,
+    @SerializedName("is_subscribing")
+    val isSubscribing: Boolean,
+)
+
+fun CartState.toCreateIntentRequest(
+    paymentMethodId: String,
+    shouldSavePaymentMethod: Boolean,
+): ExampleCreateIntentRequest {
+    return ExampleCreateIntentRequest(
+        paymentMethodId = paymentMethodId,
+        shouldSavePaymentMethod = shouldSavePaymentMethod,
+        hotDogCount = countOf(CartProduct.Id.HotDog),
+        saladCount = countOf(CartProduct.Id.Salad),
+        isSubscribing = isSubscription,
+    )
+}
+
+@Serializable
+@Keep
+data class ExampleCreateIntentResponse(
+    @SerializedName("intentClientSecret")
+    val clientSecret: String,
+)

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/networking/Models.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/networking/Models.kt
@@ -45,11 +45,11 @@ data class ExampleCheckoutResponse(
     @SerializedName("ephemeralKey")
     val ephemeralKey: String? = null,
     @SerializedName("subtotal")
-    val subtotal: Float,
+    val subtotal: Long,
     @SerializedName("tax")
-    val tax: Float,
+    val tax: Long,
     @SerializedName("total")
-    val total: Float,
+    val total: Long,
 ) {
 
     internal fun makeCustomerConfig() = if (customer != null && ephemeralKey != null) {
@@ -85,11 +85,11 @@ fun CartState.toUpdateRequest(): ExampleUpdateRequest {
 @Keep
 data class ExampleUpdateResponse(
     @SerializedName("subtotal")
-    val subtotal: Float,
+    val subtotal: Long,
     @SerializedName("tax")
-    val tax: Float,
+    val tax: Long,
     @SerializedName("total")
-    val total: Float,
+    val total: Long,
 )
 
 @Serializable

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/complete_flow/CompleteFlowViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/complete_flow/CompleteFlowViewModel.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.github.kittinunf.fuel.Fuel
-import com.github.kittinunf.fuel.core.awaitResult
 import com.github.kittinunf.fuel.core.extensions.jsonBody
 import com.github.kittinunf.fuel.core.requests.suspendable
 import com.github.kittinunf.result.Result
@@ -12,6 +11,7 @@ import com.google.gson.Gson
 import com.stripe.android.paymentsheet.PaymentSheetResult
 import com.stripe.android.paymentsheet.example.samples.model.CartState
 import com.stripe.android.paymentsheet.example.samples.networking.ExampleCheckoutResponse
+import com.stripe.android.paymentsheet.example.samples.networking.awaitModel
 import com.stripe.android.paymentsheet.example.samples.networking.toCheckoutRequest
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -42,7 +42,7 @@ internal class CompleteFlowViewModel(
                 .post("$backendUrl/checkout")
                 .jsonBody(requestBody)
                 .suspendable()
-                .awaitResult(ExampleCheckoutResponse.Deserializer)
+                .awaitModel<ExampleCheckoutResponse>()
 
             when (apiResult) {
                 is Result.Success -> {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/custom_flow/CustomFlowActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/custom_flow/CustomFlowActivity.kt
@@ -93,7 +93,7 @@ internal class CustomFlowActivity : AppCompatActivity() {
 private fun determinePaymentMethodLabel(uiState: CustomFlowViewState): String {
     val context = LocalContext.current
     return remember(uiState) {
-        if (uiState.paymentOption?.label  != null) {
+        if (uiState.paymentOption?.label != null) {
             uiState.paymentOption.label
         } else if (!uiState.isProcessing) {
             context.getString(R.string.select)

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/custom_flow/CustomFlowActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/custom_flow/CustomFlowActivity.kt
@@ -18,6 +18,7 @@ import com.stripe.android.paymentsheet.example.R
 import com.stripe.android.paymentsheet.example.samples.ui.BuyButton
 import com.stripe.android.paymentsheet.example.samples.ui.PaymentMethodSelector
 import com.stripe.android.paymentsheet.example.samples.ui.Receipt
+import com.stripe.android.paymentsheet.example.samples.ui.shared.ErrorScreen
 
 internal class CustomFlowActivity : AppCompatActivity() {
 
@@ -58,23 +59,27 @@ internal class CustomFlowActivity : AppCompatActivity() {
                     }
                 }
 
-                Receipt(
-                    isLoading = uiState.isProcessing,
-                    cartState = uiState.cartState,
-                ) {
-                    PaymentMethodSelector(
-                        isEnabled = uiState.isPaymentMethodButtonEnabled,
-                        paymentMethodLabel = paymentMethodLabel,
-                        paymentMethodIcon = uiState.paymentOption?.icon(),
-                        onClick = flowController::presentPaymentOptions,
-                    )
-                    BuyButton(
-                        buyButtonEnabled = uiState.isBuyButtonEnabled,
-                        onClick = {
-                            viewModel.handleBuyButtonPressed()
-                            flowController.confirm()
-                        }
-                    )
+                if (uiState.isError) {
+                    ErrorScreen(onRetry = viewModel::retry)
+                } else {
+                    Receipt(
+                        isLoading = uiState.isProcessing,
+                        cartState = uiState.cartState,
+                    ) {
+                        PaymentMethodSelector(
+                            isEnabled = uiState.isPaymentMethodButtonEnabled,
+                            paymentMethodLabel = paymentMethodLabel,
+                            paymentMethodIcon = uiState.paymentOption?.icon(),
+                            onClick = flowController::presentPaymentOptions,
+                        )
+                        BuyButton(
+                            buyButtonEnabled = uiState.isBuyButtonEnabled,
+                            onClick = {
+                                viewModel.handleBuyButtonPressed()
+                                flowController.confirm()
+                            }
+                        )
+                    }
                 }
             }
         }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/custom_flow/CustomFlowViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/custom_flow/CustomFlowViewModel.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.github.kittinunf.fuel.Fuel
-import com.github.kittinunf.fuel.core.awaitResult
 import com.github.kittinunf.fuel.core.extensions.jsonBody
 import com.github.kittinunf.fuel.core.requests.suspendable
 import com.google.gson.Gson
@@ -12,6 +11,7 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.paymentsheet.PaymentSheetResult
 import com.stripe.android.paymentsheet.example.samples.model.CartState
 import com.stripe.android.paymentsheet.example.samples.networking.ExampleCheckoutResponse
+import com.stripe.android.paymentsheet.example.samples.networking.awaitModel
 import com.stripe.android.paymentsheet.example.samples.networking.toCheckoutRequest
 import com.stripe.android.paymentsheet.model.PaymentOption
 import kotlinx.coroutines.Dispatchers
@@ -89,7 +89,7 @@ internal class CustomFlowViewModel(
             .post("${backendUrl}/checkout")
             .jsonBody(requestBody)
             .suspendable()
-            .awaitResult(ExampleCheckoutResponse.Deserializer)
+            .awaitModel<ExampleCheckoutResponse>()
 
         when (apiResult) {
             is ApiResult.Success -> {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/custom_flow/CustomFlowViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/custom_flow/CustomFlowViewModel.kt
@@ -43,6 +43,12 @@ internal class CustomFlowViewModel(
         }
     }
 
+    fun retry() {
+        viewModelScope.launch(Dispatchers.IO) {
+            prepareCheckout()
+        }
+    }
+
     @Suppress("UNUSED_PARAMETER")
     fun handleFlowControllerConfigured(success: Boolean, error: Throwable?) {
         _state.update {
@@ -79,7 +85,7 @@ internal class CustomFlowViewModel(
 
     private suspend fun prepareCheckout() {
         val currentState = _state.updateAndGet {
-            it.copy(isProcessing = true)
+            it.copy(isProcessing = true, isError = false)
         }
 
         val request = currentState.cartState.toCheckoutRequest()
@@ -109,9 +115,8 @@ internal class CustomFlowViewModel(
                 }
             }
             is ApiResult.Failure -> {
-                val status = "Preparing checkout failed\n${apiResult.error.message}"
                 _state.update {
-                    it.copy(isProcessing = false, status = status)
+                    it.copy(isProcessing = false, isError = false)
                 }
             }
         }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/custom_flow/CustomFlowViewState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/custom_flow/CustomFlowViewState.kt
@@ -6,6 +6,7 @@ import com.stripe.android.paymentsheet.model.PaymentOption
 
 data class CustomFlowViewState(
     val isProcessing: Boolean = false,
+    val isError: Boolean = false,
     val cartState: CartState = CartState.default,
     val paymentInfo: PaymentInfo? = null,
     val status: String? = null,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/ServerSideConfirmationActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/ServerSideConfirmationActivity.kt
@@ -100,7 +100,7 @@ internal class ServerSideConfirmationActivity : AppCompatActivity() {
 private fun determinePaymentMethodLabel(uiState: ServerSideConfirmationViewState): String {
     val context = LocalContext.current
     return remember(uiState) {
-        if (uiState.paymentOption?.label  != null) {
+        if (uiState.paymentOption?.label != null) {
             uiState.paymentOption.label
         } else if (!uiState.isProcessing) {
             context.getString(R.string.select)

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/ServerSideConfirmationActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/ServerSideConfirmationActivity.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import com.google.android.material.snackbar.Snackbar
+import com.stripe.android.ExperimentalPaymentSheetDecouplingApi
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.R
 import com.stripe.android.paymentsheet.example.samples.model.toIntentConfiguration
@@ -36,6 +37,7 @@ internal class ServerSideConfirmationActivity : AppCompatActivity() {
 
     private lateinit var flowController: PaymentSheet.FlowController
 
+    @OptIn(ExperimentalPaymentSheetDecouplingApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -94,6 +96,7 @@ internal class ServerSideConfirmationActivity : AppCompatActivity() {
         }
     }
 
+    @OptIn(ExperimentalPaymentSheetDecouplingApi::class)
     @Composable
     fun AttachFlowControllerToViewModel(
         uiState: ServerSideConfirmationViewState,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/ServerSideConfirmationActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/ServerSideConfirmationActivity.kt
@@ -1,0 +1,111 @@
+package com.stripe.android.paymentsheet.example.samples.ui.server_side_confirm
+
+import android.graphics.Color
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import com.google.android.material.snackbar.Snackbar
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.example.R
+import com.stripe.android.paymentsheet.example.samples.model.toIntentConfiguration
+import com.stripe.android.paymentsheet.example.samples.ui.BuyButton
+import com.stripe.android.paymentsheet.example.samples.ui.PaymentMethodSelector
+import com.stripe.android.paymentsheet.example.samples.ui.Receipt
+import com.stripe.android.paymentsheet.example.samples.ui.SubscriptionToggle
+
+internal class ServerSideConfirmationActivity : AppCompatActivity() {
+
+    private val snackbar by lazy {
+        Snackbar.make(findViewById(android.R.id.content), "", Snackbar.LENGTH_SHORT)
+            .setBackgroundTint(Color.BLACK)
+            .setTextColor(Color.WHITE)
+    }
+
+    private val viewModel by viewModels<ServerSideConfirmationViewModel>()
+
+    private lateinit var flowController: PaymentSheet.FlowController
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        flowController = PaymentSheet.FlowController.create(
+            activity = this,
+            paymentOptionCallback = viewModel::handlePaymentOptionChanged,
+            createIntentCallbackForServerSideConfirmation = viewModel::createAndConfirmIntent,
+            paymentResultCallback = viewModel::handlePaymentSheetResult,
+        )
+
+        setContent {
+            MaterialTheme {
+                val uiState by viewModel.state.collectAsState()
+                val paymentMethodLabel = determinePaymentMethodLabel(uiState)
+
+                uiState.status?.let {
+                    LaunchedEffect(it) {
+                        snackbar.setText(it).show()
+                        viewModel.statusDisplayed()
+                    }
+                }
+
+                LaunchedEffect(uiState.requiresFlowControllerConfigure) {
+                    if (uiState.requiresFlowControllerConfigure) {
+                        flowController.configureWithIntentConfiguration(
+                            intentConfiguration = uiState.cartState.toIntentConfiguration(),
+                            configuration = uiState.paymentSheetConfig,
+                            callback = viewModel::handleFlowControllerConfigured,
+                        )
+                    }
+                }
+
+                Receipt(
+                    isLoading = uiState.isProcessing,
+                    cartState = uiState.cartState,
+                    isEditable = true,
+                    onQuantityChanged = viewModel::updateQuantity,
+                ) {
+                    PaymentMethodSelector(
+                        isEnabled = uiState.isPaymentMethodButtonEnabled,
+                        paymentMethodLabel = paymentMethodLabel,
+                        paymentMethodIcon = uiState.paymentOption?.icon(),
+                        onClick = flowController::presentPaymentOptions,
+                    )
+
+                    SubscriptionToggle(
+                        checked = uiState.cartState.isSubscription,
+                        onCheckedChange = viewModel::updateSubscription,
+                    )
+
+                    BuyButton(
+                        buyButtonEnabled = uiState.isBuyButtonEnabled,
+                        onClick = {
+                            viewModel.handleBuyButtonPressed()
+                            flowController.confirm()
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun determinePaymentMethodLabel(uiState: ServerSideConfirmationViewState): String {
+    val context = LocalContext.current
+    return remember(uiState) {
+        if (uiState.paymentOption?.label  != null) {
+            uiState.paymentOption.label
+        } else if (!uiState.isProcessing) {
+            context.getString(R.string.select)
+        } else {
+            context.getString(R.string.loading)
+        }
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/ServerSideConfirmationViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/ServerSideConfirmationViewModel.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
@@ -201,6 +202,7 @@ internal class ServerSideConfirmationViewModel(
     private suspend fun observeCartUpdates() {
         state
             .mapNotNull { it.dirtyCartState }
+            .distinctUntilChanged()
             .debounce(300.milliseconds)
             .onEach { renderProcessing() }
             .map(::updateCart)

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/ServerSideConfirmationViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/ServerSideConfirmationViewModel.kt
@@ -1,0 +1,255 @@
+package com.stripe.android.paymentsheet.example.samples.ui.server_side_confirm
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.github.kittinunf.fuel.Fuel
+import com.github.kittinunf.fuel.core.extensions.jsonBody
+import com.google.gson.Gson
+import com.stripe.android.CreateIntentCallback
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.paymentsheet.PaymentSheetResult
+import com.stripe.android.paymentsheet.example.samples.model.CartProduct
+import com.stripe.android.paymentsheet.example.samples.model.CartState
+import com.stripe.android.paymentsheet.example.samples.model.updateWithResponse
+import com.stripe.android.paymentsheet.example.samples.networking.ExampleCheckoutResponse
+import com.stripe.android.paymentsheet.example.samples.networking.ExampleCreateIntentResponse
+import com.stripe.android.paymentsheet.example.samples.networking.ExampleUpdateResponse
+import com.stripe.android.paymentsheet.example.samples.networking.toCheckoutRequest
+import com.stripe.android.paymentsheet.example.samples.networking.toCreateIntentRequest
+import com.stripe.android.paymentsheet.example.samples.networking.toUpdateRequest
+import com.stripe.android.paymentsheet.model.PaymentOption
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.updateAndGet
+import kotlinx.coroutines.launch
+import kotlin.Result
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+import kotlin.time.Duration.Companion.milliseconds
+import com.github.kittinunf.result.Result as ApiResult
+
+internal class ServerSideConfirmationViewModel(
+    application: Application,
+) : AndroidViewModel(application) {
+
+    private val _state = MutableStateFlow(
+        value = ServerSideConfirmationViewState(confirmedCartState = CartState.default),
+    )
+    val state: StateFlow<ServerSideConfirmationViewState> = _state
+
+    init {
+        viewModelScope.launch {
+            prepareCheckout()
+        }
+
+        viewModelScope.launch {
+            observeCartUpdates()
+        }
+    }
+
+    fun statusDisplayed() {
+        _state.update {
+            it.copy(status = null)
+        }
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    fun handleFlowControllerConfigured(success: Boolean, error: Throwable?) {
+        _state.update {
+            it.copy(
+                isProcessing = false,
+                requiresFlowControllerConfigure = false,
+                status = error?.let { "Failed to configure\n$it" },
+            )
+        }
+    }
+
+    fun handlePaymentOptionChanged(paymentOption: PaymentOption?) {
+        viewModelScope.launch {
+            _state.update {
+                it.copy(paymentOption = paymentOption)
+            }
+        }
+    }
+
+    suspend fun createAndConfirmIntent(
+        paymentMethodId: String,
+        shouldSavePaymentMethod: Boolean,
+    ): CreateIntentCallback.Result {
+
+        val request = state.value.cartState.toCreateIntentRequest(
+            paymentMethodId = paymentMethodId,
+            shouldSavePaymentMethod = shouldSavePaymentMethod,
+        )
+
+        val requestBody = Gson().toJson(request)
+
+        val result = suspendCoroutine { continuation ->
+            Fuel.post("$backendUrl/create_intent")
+                .jsonBody(requestBody)
+                .responseString { _, _, result ->
+                    continuation.resume(result)
+                }
+        }
+
+        return when (result) {
+            is ApiResult.Success -> {
+                val response = Gson().fromJson(result.get(), ExampleCreateIntentResponse::class.java)
+                CreateIntentCallback.Result.Success(response.clientSecret)
+            }
+            is ApiResult.Failure -> {
+                CreateIntentCallback.Result.Failure(
+                    cause = RuntimeException("Unable to create intent"),
+                    displayMessage = "Something went wrong…",
+                )
+            }
+        }
+    }
+
+    fun handlePaymentSheetResult(paymentResult: PaymentSheetResult) {
+        val status = when (paymentResult) {
+            is PaymentSheetResult.Canceled -> null
+            is PaymentSheetResult.Completed -> "Success"
+            is PaymentSheetResult.Failed -> paymentResult.error.message
+        }
+
+        _state.update {
+            it.copy(
+                isProcessing = false,
+                status = status,
+                didComplete = paymentResult is PaymentSheetResult.Completed,
+            )
+        }
+    }
+
+    fun updateQuantity(productId: CartProduct.Id, newQuantity: Int) {
+        val dirtyCartState = state.value.cartState.updateQuantity(productId, newQuantity)
+        _state.update {
+            it.copy(dirtyCartState = dirtyCartState)
+        }
+    }
+
+    fun updateSubscription(isSubscription: Boolean) {
+        val dirtyCartState = state.value.cartState.copy(
+            isSubscription = isSubscription,
+            requiresCalculation = true,
+        )
+        _state.update {
+            it.copy(dirtyCartState = dirtyCartState)
+        }
+    }
+
+    fun handleBuyButtonPressed() {
+        _state.update {
+            it.copy(isProcessing = true)
+        }
+    }
+
+    private suspend fun prepareCheckout() {
+        val currentState = _state.updateAndGet {
+            it.copy(isProcessing = true)
+        }
+
+        val request = currentState.cartState.toCheckoutRequest()
+        val requestBody = Gson().toJson(request)
+
+        val result = suspendCoroutine { continuation ->
+            Fuel.post("$backendUrl/checkout")
+                .jsonBody(requestBody)
+                .responseString { _, _, result ->
+                    continuation.resume(result)
+                }
+        }
+
+        when (result) {
+            is ApiResult.Success -> {
+                val response = Gson().fromJson(result.get(), ExampleCheckoutResponse::class.java)
+                val newCartState = currentState.cartState.updateWithResponse(response)
+
+                PaymentConfiguration.init(
+                    context = getApplication(),
+                    publishableKey = response.publishableKey,
+                )
+
+                _state.update {
+                    it.copy(
+                        isProcessing = false,
+                        isError = false,
+                        confirmedCartState = newCartState,
+                        dirtyCartState = null,
+                        requiresFlowControllerConfigure = true,
+                    )
+                }
+            }
+            is ApiResult.Failure -> {
+                val status = "Preparing checkout failed\n${result.error.message}"
+                _state.update {
+                    it.copy(isProcessing = false, isError = true, status = status)
+                }
+            }
+        }
+    }
+
+    @OptIn(FlowPreview::class)
+    private suspend fun observeCartUpdates() {
+        state
+            .mapNotNull { it.dirtyCartState }
+            .debounce(300.milliseconds)
+            .map(::updateCart)
+            .collect(::handleCartUpdated)
+    }
+
+    private fun handleCartUpdated(result: Result<CartState>) {
+        val currentState = state.value
+
+        val newCartState = result.getOrNull() ?: currentState.confirmedCartState
+        val status = result.exceptionOrNull()?.let { "Failed to update cart\n$it" }
+
+        _state.update {
+            it.copy(
+                // Keep processing on success, because we'll re-configure FlowController
+                isProcessing = result.isSuccess,
+                confirmedCartState = newCartState,
+                dirtyCartState = null,
+                status = status,
+                requiresFlowControllerConfigure = result.isSuccess,
+            )
+        }
+    }
+
+    private suspend fun updateCart(currentState: CartState): Result<CartState> {
+        _state.update { it.copy(isProcessing = true) }
+
+        val request = currentState.toUpdateRequest()
+        val requestBody = Gson().toJson(request)
+
+        val result = suspendCoroutine { continuation ->
+            Fuel.post("$backendUrl/compute_totals")
+                .jsonBody(requestBody)
+                .responseString { _, _, result ->
+                    continuation.resume(result)
+                }
+        }
+
+        return when (result) {
+            is ApiResult.Success -> {
+                val response = Gson().fromJson(result.get(), ExampleUpdateResponse::class.java)
+                val newCartState = currentState.updateWithResponse(response)
+                Result.success(newCartState)
+            }
+            is ApiResult.Failure -> {
+                Result.failure(result.error.exception)
+            }
+        }
+    }
+
+    companion object {
+        const val backendUrl = "https://stripe-mobile-payment-sheet-custom-deferred.glitch.me"
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/ServerSideConfirmationViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/ServerSideConfirmationViewModel.kt
@@ -199,8 +199,8 @@ internal class ServerSideConfirmationViewModel(
     private suspend fun observeCartUpdates() {
         state
             .mapNotNull { it.dirtyCartState }
-            .onEach { renderProcessing() }
             .debounce(300.milliseconds)
+            .onEach { renderProcessing() }
             .map(::updateCart)
             .collect(::handleCartUpdated)
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/ServerSideConfirmationViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/ServerSideConfirmationViewModel.kt
@@ -8,6 +8,7 @@ import com.github.kittinunf.fuel.core.extensions.jsonBody
 import com.github.kittinunf.fuel.core.requests.suspendable
 import com.google.gson.Gson
 import com.stripe.android.CreateIntentCallback
+import com.stripe.android.ExperimentalPaymentSheetDecouplingApi
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.paymentsheet.PaymentSheetResult
 import com.stripe.android.paymentsheet.example.samples.model.CartProduct
@@ -82,6 +83,7 @@ internal class ServerSideConfirmationViewModel(
         }
     }
 
+    @OptIn(ExperimentalPaymentSheetDecouplingApi::class)
     suspend fun createAndConfirmIntent(
         paymentMethodId: String,
         shouldSavePaymentMethod: Boolean,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/ServerSideConfirmationViewState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/ServerSideConfirmationViewState.kt
@@ -34,5 +34,5 @@ data class ServerSideConfirmationViewState(
         get() = !isProcessing && !didComplete && !isError
 
     val isBuyButtonEnabled: Boolean
-        get() = isPaymentMethodButtonEnabled && paymentOption != null
+        get() = dirtyCartState == null && isPaymentMethodButtonEnabled && paymentOption != null
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/ServerSideConfirmationViewState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/ServerSideConfirmationViewState.kt
@@ -12,7 +12,6 @@ data class ServerSideConfirmationViewState(
     val status: String? = null,
     val paymentOption: PaymentOption? = null,
     val didComplete: Boolean = false,
-    val requiresFlowControllerConfigure: Boolean = false,
 ) {
 
     val cartState: CartState

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/ServerSideConfirmationViewState.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/ServerSideConfirmationViewState.kt
@@ -1,0 +1,39 @@
+package com.stripe.android.paymentsheet.example.samples.ui.server_side_confirm
+
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.example.samples.model.CartState
+import com.stripe.android.paymentsheet.model.PaymentOption
+
+data class ServerSideConfirmationViewState(
+    val isProcessing: Boolean = false,
+    val isError: Boolean = false,
+    val confirmedCartState: CartState = CartState.default,
+    val dirtyCartState: CartState? = null,
+    val status: String? = null,
+    val paymentOption: PaymentOption? = null,
+    val didComplete: Boolean = false,
+    val requiresFlowControllerConfigure: Boolean = false,
+) {
+
+    val cartState: CartState
+        get() = dirtyCartState ?: confirmedCartState
+
+    val paymentSheetConfig: PaymentSheet.Configuration
+        get() = PaymentSheet.Configuration(
+            merchantDisplayName = "Example, Inc.",
+            customer = null,
+            googlePay = PaymentSheet.GooglePayConfiguration(
+                environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                countryCode = "US",
+            ),
+            // Set `allowsDelayedPaymentMethods` to true if your business can handle payment
+            // methods that complete payment after a delay, like SEPA Debit and Sofort.
+            allowsDelayedPaymentMethods = true,
+        )
+
+    val isPaymentMethodButtonEnabled: Boolean
+        get() = !isProcessing && !didComplete && !isError
+
+    val isBuyButtonEnabled: Boolean
+        get() = isPaymentMethodButtonEnabled && paymentOption != null
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/shared/ErrorScreen.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/shared/ErrorScreen.kt
@@ -1,0 +1,43 @@
+package com.stripe.android.paymentsheet.example.samples.ui.shared
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ErrorScreen(
+    onRetry: () -> Unit,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+        modifier = Modifier.fillMaxSize().padding(32.dp),
+    ) {
+        Text(
+            text = "Unable to load checkout",
+            fontWeight = FontWeight.SemiBold,
+            textAlign = TextAlign.Center,
+        )
+
+        Text(
+            text = "Maybe wait a few seconds, have some tea, read a book… then try again.",
+            textAlign = TextAlign.Center,
+        )
+
+        Button(
+            onClick = onRetry,
+            modifier = Modifier.padding(top = 8.dp),
+        ) {
+            Text(text = "Try again")
+        }
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/shared/ErrorScreen.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/shared/ErrorScreen.kt
@@ -9,9 +9,11 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.stripe.android.paymentsheet.example.R
 
 @Composable
 fun ErrorScreen(
@@ -20,16 +22,18 @@ fun ErrorScreen(
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
-        modifier = Modifier.fillMaxSize().padding(32.dp),
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
     ) {
         Text(
-            text = "Unable to load checkout",
+            text = stringResource(R.string.unable_to_load_checkout_title),
             fontWeight = FontWeight.SemiBold,
             textAlign = TextAlign.Center,
         )
 
         Text(
-            text = "Maybe wait a few seconds, have some tea, read a book… then try again.",
+            text = stringResource(R.string.unable_to_load_checkout_subtitle),
             textAlign = TextAlign.Center,
         )
 
@@ -37,7 +41,7 @@ fun ErrorScreen(
             onClick = onRetry,
             modifier = Modifier.padding(top = 8.dp),
         ) {
-            Text(text = "Try again")
+            Text(text = stringResource(R.string.unable_to_load_checkout_button))
         }
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/shared/Receipt.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/shared/Receipt.kt
@@ -87,6 +87,7 @@ fun Receipt(
                 Column(Modifier.fillMaxWidth(1f)) {
                     for (product in cartState.products) {
                         ProductRow(
+                            isProcessing = isLoading,
                             productEmoji = product.icon,
                             productResId = product.nameResId,
                             priceString = product.unitPriceString,
@@ -116,6 +117,7 @@ fun Receipt(
 
 @Composable
 fun ProductRow(
+    isProcessing: Boolean,
     productEmoji: String,
     productResId: Int,
     priceString: String,
@@ -156,7 +158,7 @@ fun ProductRow(
                     val currentQuantity = quantity ?: 0
                     onQuantityChanged(currentQuantity - 1)
                 },
-                enabled = isEditable && (quantity ?: 0) > 0,
+                enabled = !isProcessing && isEditable && (quantity ?: 0) > 0,
             ) {
                 Icon(imageVector = Icons.Default.Remove, contentDescription = null)
             }
@@ -171,7 +173,7 @@ fun ProductRow(
                     val currentQuantity = quantity ?: 0
                     onQuantityChanged(currentQuantity + 1)
                 },
-                enabled = isEditable,
+                enabled = !isProcessing && isEditable,
             ) {
                 Icon(imageVector = Icons.Default.Add, contentDescription = null)
             }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/shared/SubscriptionToggle.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/shared/SubscriptionToggle.kt
@@ -1,0 +1,26 @@
+package com.stripe.android.paymentsheet.example.samples.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Switch
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun SubscriptionToggle(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier.fillMaxWidth(),
+    ) {
+        Text(text = "Subscribe for 5% discount")
+        Switch(checked = checked, onCheckedChange = onCheckedChange)
+    }
+}

--- a/paymentsheet-example/src/main/res/values/strings.xml
+++ b/paymentsheet-example/src/main/res/values/strings.xml
@@ -1,9 +1,14 @@
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <string name="app_name">PaymentSheet Example</string>
-    <string name="paymentsheet">PaymentSheet</string>
-    <string name="paymentsheet_custom">PaymentSheet Custom</string>
-    <string name="paymentsheet_serverside_confirmation">PaymentSheet with server-side confirmation</string>
-    <string name="playground">Playground</string>
+    <string name="paymentsheet_title">Basic PaymentSheet</string>
+    <string name="paymentsheet_subtitle">Our simplest integration</string>
+    <string name="paymentsheet_custom_title">PaymentSheet with FlowController</string>
+    <string name="paymentsheet_custom_subtitle">A more advanced integration with greater flexibility</string>
+    <string name="paymentsheet_serverside_confirmation_title">PaymentSheet with server-side confirmation</string>
+    <string name="paymentsheet_serverside_confirmation_subtitle">Create and confirm the payment or setup intent on your own backend</string>
+    <string name="beta_badge_label">This is currently in beta</string>
+    <string name="playground_title">Playground</string>
+    <string name="playground_subtitle">Testing playground for Stripe engineers</string>
     <string name="action_settings">Settings</string>
     <string name="product_subtitle">1 x Regular %s</string>
     <string name="subtotal">Subtotal</string>

--- a/paymentsheet-example/src/main/res/values/strings.xml
+++ b/paymentsheet-example/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
     <string name="app_name">PaymentSheet Example</string>
     <string name="paymentsheet">PaymentSheet</string>
     <string name="paymentsheet_custom">PaymentSheet Custom</string>
+    <string name="paymentsheet_serverside_confirmation">PaymentSheet with server-side confirmation</string>
     <string name="playground">Playground</string>
     <string name="action_settings">Settings</string>
     <string name="product_subtitle">1 x Regular %s</string>

--- a/paymentsheet-example/src/main/res/values/strings.xml
+++ b/paymentsheet-example/src/main/res/values/strings.xml
@@ -71,4 +71,7 @@
     <string name="auto">Auto</string>
     <string name="always">Always</string>
     <string name="full">Full</string>
+    <string name="unable_to_load_checkout_title">Unable to load checkout</string>
+    <string name="unable_to_load_checkout_subtitle">Maybe wait a few seconds, have some tea, read a book… then try again.</string>
+    <string name="unable_to_load_checkout_button">Try again</string>
 </resources>


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds a sample screen for using `PaymentSheet.FlowController` with server-side confirmation.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Showcasing the new functionality to finalize payments on the server.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
