### PR TITLE
Fix broken logic in `isLpmLevelSetupFutureUsageSet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 2023-XX-XX
 
+### PaymentSheet
+* [FIXED][6434](https://github.com/stripe/stripe-android/pull/6434) Fixed an issue where the `Save this card for future payments` checkbox wasn't displayed in some cases even though it should have been.
+
 ## 20.21.1 - 2023-03-27
 
 ### PaymentSheet

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
@@ -208,22 +208,26 @@ constructor(
         return status === StripeIntent.Status.RequiresConfirmation
     }
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun isSetupFutureUsageSet(code: PaymentMethodCode): Boolean {
+        return isTopLevelSetupFutureUsageSet() || isLpmLevelSetupFutureUsageSet(code)
+    }
+
     /**
      * SetupFutureUsage is considered to be set if it is on or off session.
      */
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    fun isTopLevelSetupFutureUsageSet() =
-        when (setupFutureUsage) {
+    private fun isTopLevelSetupFutureUsageSet(): Boolean {
+        return when (setupFutureUsage) {
             StripeIntent.Usage.OnSession -> true
             StripeIntent.Usage.OffSession -> true
             StripeIntent.Usage.OneTime -> false
             null -> false
         }
+    }
 
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    fun isLpmLevelSetupFutureUsageSet(code: PaymentMethodCode): Boolean {
-        return paymentMethodOptionsJsonString?.let {
-            val pmOptions = JSONObject(paymentMethodOptionsJsonString).optJSONObject(code)
+    private fun isLpmLevelSetupFutureUsageSet(code: PaymentMethodCode): Boolean {
+        return paymentMethodOptionsJsonString?.let { json ->
+            val pmOptions = JSONObject(json).optJSONObject(code)
             pmOptions?.has("setup_future_usage") ?: false
         } ?: false
     }

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
@@ -223,11 +223,8 @@ constructor(
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun isLpmLevelSetupFutureUsageSet(code: PaymentMethodCode): Boolean {
         return isTopLevelSetupFutureUsageSet() || paymentMethodOptionsJsonString?.let {
-            JSONObject(paymentMethodOptionsJsonString)
-                .optJSONObject(code)
-                ?.optString("setup_future_usage")?.let {
-                    true
-                } ?: false
+            val pmOptions = JSONObject(paymentMethodOptionsJsonString).optJSONObject(code)
+            pmOptions?.has("setup_future_usage") ?: false
         } ?: false
     }
 

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
@@ -212,7 +212,7 @@ constructor(
      * SetupFutureUsage is considered to be set if it is on or off session.
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    private fun isTopLevelSetupFutureUsageSet() =
+    fun isTopLevelSetupFutureUsageSet() =
         when (setupFutureUsage) {
             StripeIntent.Usage.OnSession -> true
             StripeIntent.Usage.OffSession -> true
@@ -222,7 +222,7 @@ constructor(
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     fun isLpmLevelSetupFutureUsageSet(code: PaymentMethodCode): Boolean {
-        return isTopLevelSetupFutureUsageSet() || paymentMethodOptionsJsonString?.let {
+        return paymentMethodOptionsJsonString?.let {
             val pmOptions = JSONObject(paymentMethodOptionsJsonString).optJSONObject(code)
             pmOptions?.has("setup_future_usage") ?: false
         } ?: false

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentIntentTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentIntentTest.kt
@@ -221,7 +221,30 @@ class PaymentIntentTest {
     }
 
     @Test
-    fun `Determines LPM-level SFU correctly if setup_future_usage exists`() {
+    fun `Determines SFU correctly if it's set on the intent itself`() {
+        val offSession = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+            setupFutureUsage = StripeIntent.Usage.OffSession,
+        )
+        assertThat(offSession.isSetupFutureUsageSet("card")).isTrue()
+
+        val onSession = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+            setupFutureUsage = StripeIntent.Usage.OnSession,
+        )
+        assertThat(onSession.isSetupFutureUsageSet("card")).isTrue()
+
+        val oneTime = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+            setupFutureUsage = StripeIntent.Usage.OneTime,
+        )
+        assertThat(oneTime.isSetupFutureUsageSet("card")).isFalse()
+
+        val none = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+            setupFutureUsage = null,
+        )
+        assertThat(none.isSetupFutureUsageSet("card")).isFalse()
+    }
+
+    @Test
+    fun `Determines SFU correctly if setup_future_usage exists in payment method options`() {
         val paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
             paymentMethodOptionsJsonString = """
                 {
@@ -232,12 +255,12 @@ class PaymentIntentTest {
             """.trimIndent()
         )
 
-        val result = paymentIntent.isLpmLevelSetupFutureUsageSet("card")
+        val result = paymentIntent.isSetupFutureUsageSet("card")
         assertThat(result).isTrue()
     }
 
     @Test
-    fun `Determines LPM-level SFU correctly if setup_future_usage does not exist`() {
+    fun `Determines SFU correctly if setup_future_usage does not exist in payment method options`() {
         val paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
             paymentMethodOptionsJsonString = """
                 {
@@ -248,7 +271,7 @@ class PaymentIntentTest {
             """.trimIndent()
         )
 
-        val result = paymentIntent.isLpmLevelSetupFutureUsageSet("card")
+        val result = paymentIntent.isSetupFutureUsageSet("card")
         assertThat(result).isFalse()
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentIntentTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentIntentTest.kt
@@ -219,4 +219,36 @@ class PaymentIntentTest {
         assertThat(PaymentIntent.ClientSecret("pi_a1b2c3_secret_x7y8z9").value)
             .isEqualTo("pi_a1b2c3_secret_x7y8z9")
     }
+
+    @Test
+    fun `Determines LPM-level SFU correctly if setup_future_usage exists`() {
+        val paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+            paymentMethodOptionsJsonString = """
+                {
+                  "card": {
+                    "setup_future_usage": ""
+                  }
+                }
+            """.trimIndent()
+        )
+
+        val result = paymentIntent.isLpmLevelSetupFutureUsageSet("card")
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `Determines LPM-level SFU correctly if setup_future_usage does not exist`() {
+        val paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+            paymentMethodOptionsJsonString = """
+                {
+                  "card": {
+                    "some_other_key_that_has_nothing_to_do_with_sfu": ""
+                  }
+                }
+            """.trimIndent()
+        )
+
+        val result = paymentIntent.isLpmLevelSetupFutureUsageSet("card")
+        assertThat(result).isFalse()
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethodKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethodKtx.kt
@@ -59,8 +59,7 @@ internal fun SupportedPaymentMethod.getSpecWithFullfilledRequirements(
 
     return when (stripeIntent) {
         is PaymentIntent -> {
-            val isSetupFutureUsageSet = stripeIntent.isTopLevelSetupFutureUsageSet() ||
-                stripeIntent.isLpmLevelSetupFutureUsageSet(code)
+            val isSetupFutureUsageSet = stripeIntent.isSetupFutureUsageSet(code)
 
             if (isSetupFutureUsageSet) {
                 if (supportsPaymentIntentSfuSet(stripeIntent, config)) {
@@ -73,8 +72,7 @@ internal fun SupportedPaymentMethod.getSpecWithFullfilledRequirements(
                     supportsPaymentIntentSfuSettable(
                         stripeIntent,
                         config
-                    )
-                    -> userSelectableSave
+                    ) -> userSelectableSave
                     supportsPaymentIntentSfuNotSettable(
                         stripeIntent,
                         config

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethodKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SupportedPaymentMethodKtx.kt
@@ -59,7 +59,10 @@ internal fun SupportedPaymentMethod.getSpecWithFullfilledRequirements(
 
     return when (stripeIntent) {
         is PaymentIntent -> {
-            if (stripeIntent.isLpmLevelSetupFutureUsageSet(code)) {
+            val isSetupFutureUsageSet = stripeIntent.isTopLevelSetupFutureUsageSet() ||
+                stripeIntent.isLpmLevelSetupFutureUsageSet(code)
+
+            if (isSetupFutureUsageSet) {
                 if (supportsPaymentIntentSfuSet(stripeIntent, config)) {
                     merchantRequestedSave
                 } else {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where PaymentSheet would incorrectly assume that a merchant requested SFU for payment intents where `payment_method_options[code]` was set, even if `payment_method_options[code]["setup_future_usage"]` didn’t exist.

~This is a short-term patch. Thinking longer-term, we should align this logic with iOS (which doesn’t use `payment_method_options` at all).~

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[RUN_MOBILESDK-2223](https://jira.corp.stripe.com/browse/RUN_MOBILESDK-2223)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

```
[FIXED] Fixed an issue where the `Save this card for future payments` checkbox wasn’t displayed even though it should have been
```
