### PR TITLE
[FC - Maestro] Pass parameters using cli option

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -5,8 +5,8 @@ project_type: android
 trigger_map:
   - push_branch: 'master'
     pipeline: main-trigger-pipeline
-  - pull_request_source_branch: '*'
-    pipeline: main-trigger-pipeline
+  - pull_request_source_branch: 'carlosmuvi/fix-maestro-parameter'
+    workflow: maestro-financial-connections
 app:
   envs:
     - GRADLE_OPTS: -Dkotlin.incremental=false

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -5,8 +5,8 @@ project_type: android
 trigger_map:
   - push_branch: 'master'
     pipeline: main-trigger-pipeline
-  - pull_request_source_branch: 'carlosmuvi/fix-maestro-parameter'
-    workflow: maestro-financial-connections
+  - pull_request_source_branch: '*'
+    pipeline: main-trigger-pipeline
 app:
   envs:
     - GRADLE_OPTS: -Dkotlin.incremental=false

--- a/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
+++ b/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
@@ -29,8 +29,6 @@ appId: com.stripe.android.financialconnections.example
 ####### Bypass Chrome on-boarding screen #######
 - runFlow:
     file: ../common/subflow-skip-chrome-welcome.yaml
-    env:
-      APP_ID: com.stripe.android.financialconnections.example
 ###############################################
 # SELECT ALL ACCOUNTS
 - extendedWaitUntil:

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
@@ -21,8 +21,6 @@ appId: com.stripe.android.financialconnections.example
 ####### Bypass Chrome on-boarding screen #######
 - runFlow:
     file: ../common/subflow-skip-chrome-welcome.yaml
-    env:
-      APP_ID: com.stripe.android.financialconnections.example
 ###############################################
 # SELECT ALL ACCOUNTS
 - extendedWaitUntil:

--- a/scripts/execute_maestro_tests.sh
+++ b/scripts/execute_maestro_tests.sh
@@ -15,7 +15,7 @@ maestro -v
 retry=1
 while [ $retry -le 3 ]; do
   echo "Running Maestro tests. Attempt $retry"
-  maestro test --format junit --output maestroReport.xml maestro/financial-connections
+  maestro test -e APP_ID=com.stripe.android.financialconnections.example --format junit --output maestroReport.xml maestro/financial-connections
   if [ $? -eq 0 ]; then
     break
   fi


### PR DESCRIPTION
# Summary
- Javascript validation fails on maestro if parameters are not passed via CLI. See thread: https://mobile-dev-inc.slack.com/archives/C041FU72T54/p1678300712991179
- Successful run after the change: https://app.bitrise.io/build/86dde406-d3bd-4b7a-9f0b-5586b6c94c80
