### PR TITLE
Optimize another network call out.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -120,7 +120,7 @@ internal class PaymentLauncherViewModel @Inject constructor(
                             }
                         }
                     }
-                    if (intent.status == StripeIntent.Status.Succeeded) {
+                    if (!intent.requiresAction()) {
                         paymentLauncherResult.postValue(PaymentResult.Completed)
                     } else {
                         authenticatorRegistry.getAuthenticator(intent).authenticate(

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -120,11 +120,15 @@ internal class PaymentLauncherViewModel @Inject constructor(
                             }
                         }
                     }
-                    authenticatorRegistry.getAuthenticator(intent).authenticate(
-                        host,
-                        intent,
-                        apiRequestOptionsProvider.get()
-                    )
+                    if (intent.status == StripeIntent.Status.Succeeded) {
+                        paymentLauncherResult.postValue(PaymentResult.Completed)
+                    } else {
+                        authenticatorRegistry.getAuthenticator(intent).authenticate(
+                            host,
+                            intent,
+                            apiRequestOptionsProvider.get()
+                        )
+                    }
                 },
                 onFailure = {
                     paymentLauncherResult.postValue(PaymentResult.Failed(it))

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -79,13 +79,6 @@ internal class FlowControllerTest {
             response.testBodyFromFile("payment-intent-confirm.json")
         }
 
-        networkRule.enqueue(
-            method("GET"),
-            path("/v1/payment_intents/pi_example"),
-        ) { response ->
-            response.testBodyFromFile("payment-intent-get-success.json")
-        }
-
         page.clickPrimaryButton()
 
         assertThat(resultCountDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
@@ -146,13 +139,6 @@ internal class FlowControllerTest {
             path("/v1/payment_intents/pi_example/confirm"),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
-        }
-
-        networkRule.enqueue(
-            method("GET"),
-            path("/v1/payment_intents/pi_example"),
-        ) { response ->
-            response.testBodyFromFile("payment-intent-get-success.json")
         }
 
         page.clickPrimaryButton()
@@ -412,13 +398,6 @@ internal class FlowControllerTest {
             path("/v1/payment_intents/pi_example/confirm"),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
-        }
-
-        networkRule.enqueue(
-            method("GET"),
-            path("/v1/payment_intents/pi_example"),
-        ) { response ->
-            response.testBodyFromFile("payment-intent-get-success.json")
         }
 
         page.clickPrimaryButton()

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetBillingConfigurationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetBillingConfigurationTest.kt
@@ -99,13 +99,6 @@ internal class PaymentSheetBillingConfigurationTest {
             response.testBodyFromFile("payment-intent-confirm.json")
         }
 
-        networkRule.enqueue(
-            method("GET"),
-            path("/v1/payment_intents/pi_example"),
-        ) { response ->
-            response.testBodyFromFile("payment-intent-get-success.json")
-        }
-
         page.clickPrimaryButton()
 
         assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
@@ -174,13 +167,6 @@ internal class PaymentSheetBillingConfigurationTest {
             not(bodyPart("payment_method_data%5Bbilling_details%5D%5Baddress%5D%5Bpostal_code%5D", "94111")),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
-        }
-
-        networkRule.enqueue(
-            method("GET"),
-            path("/v1/payment_intents/pi_example"),
-        ) { response ->
-            response.testBodyFromFile("payment-intent-get-success.json")
         }
 
         page.clickPrimaryButton()

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -65,6 +65,49 @@ internal class PaymentSheetTest {
             response.testBodyFromFile("payment-intent-confirm.json")
         }
 
+        page.clickPrimaryButton()
+
+        assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
+    }
+
+    @Test
+    fun testSuccessfulDelayedSuccessPayment() {
+        networkRule.enqueue(
+            method("GET"),
+            path("/v1/elements/sessions"),
+        ) { response ->
+            response.testBodyFromFile("elements-sessions-requires_payment_method.json")
+        }
+
+        val countDownLatch = CountDownLatch(1)
+        val activityScenarioRule = composeTestRule.activityRule
+        val scenario = activityScenarioRule.scenario
+        scenario.moveToState(Lifecycle.State.CREATED)
+        lateinit var paymentSheet: PaymentSheet
+        scenario.onActivity {
+            PaymentConfiguration.init(it, "pk_test_123")
+            paymentSheet = PaymentSheet(it) { result ->
+                assertThat(result).isInstanceOf(PaymentSheetResult.Completed::class.java)
+                countDownLatch.countDown()
+            }
+        }
+        scenario.moveToState(Lifecycle.State.RESUMED)
+        scenario.onActivity {
+            paymentSheet.presentWithPaymentIntent(
+                paymentIntentClientSecret = "pi_example_secret_example",
+                configuration = null,
+            )
+        }
+
+        page.fillOutCardDetails()
+
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/payment_intents/pi_example/confirm"),
+        ) { response ->
+            response.testBodyFromFile("payment-intent-confirm_with-processing-status.json")
+        }
+
         networkRule.enqueue(
             method("GET"),
             path("/v1/payment_intents/pi_example"),
@@ -170,13 +213,6 @@ internal class PaymentSheetTest {
             path("/v1/payment_intents/pi_example/confirm"),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
-        }
-
-        networkRule.enqueue(
-            method("GET"),
-            path("/v1/payment_intents/pi_example"),
-        ) { response ->
-            response.testBodyFromFile("payment-intent-get-success.json")
         }
 
         page.clickPrimaryButton()

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -105,7 +105,7 @@ internal class PaymentSheetTest {
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
         ) { response ->
-            response.testBodyFromFile("payment-intent-confirm_with-processing-status.json")
+            response.testBodyFromFile("payment-intent-confirm_with-requires_action-status.json")
         }
 
         networkRule.enqueue(

--- a/paymentsheet/src/androidTest/resources/payment-intent-confirm_with-processing-status.json
+++ b/paymentsheet/src/androidTest/resources/payment-intent-confirm_with-processing-status.json
@@ -1,0 +1,84 @@
+{
+  "id": "pi_example",
+  "object": "payment_intent",
+  "amount": 5099,
+  "amount_details": {
+    "tip": {}
+  },
+  "automatic_payment_methods": null,
+  "canceled_at": null,
+  "cancellation_reason": null,
+  "capture_method": "automatic",
+  "client_secret": "pi_example_secret_example",
+  "confirmation_method": "automatic",
+  "created": 1674747412,
+  "currency": "usd",
+  "description": null,
+  "last_payment_error": null,
+  "livemode": false,
+  "next_action": null,
+  "payment_method": {
+    "id": "pm_1MUXVpLu5o3P18ZpS2NCqb2F",
+    "object": "payment_method",
+    "billing_details": {
+      "address": {
+        "city": null,
+        "country": "US",
+        "line1": null,
+        "line2": null,
+        "postal_code": "12345",
+        "state": null
+      },
+      "email": null,
+      "name": null,
+      "phone": null
+    },
+    "card": {
+      "brand": "visa",
+      "checks": {
+        "address_line1_check": null,
+        "address_postal_code_check": null,
+        "cvc_check": null
+      },
+      "country": "US",
+      "exp_month": 1,
+      "exp_year": 2032,
+      "funding": "credit",
+      "generated_from": null,
+      "last4": "4242",
+      "networks": {
+        "available": [
+          "visa"
+        ],
+        "preferred": null
+      },
+      "three_d_secure_usage": {
+        "supported": true
+      },
+      "wallet": null
+    },
+    "created": 1674747437,
+    "customer": null,
+    "livemode": false,
+    "type": "card"
+  },
+  "payment_method_options": {
+    "us_bank_account": {
+      "verification_method": "automatic"
+    }
+  },
+  "payment_method_types": [
+    "card",
+    "afterpay_clearpay",
+    "klarna",
+    "us_bank_account",
+    "affirm",
+    "link"
+  ],
+  "processing": null,
+  "receipt_email": null,
+  "setup_future_usage": null,
+  "shipping": null,
+  "source": null,
+  "status": "processing"
+}

--- a/paymentsheet/src/androidTest/resources/payment-intent-confirm_with-requires_action-status.json
+++ b/paymentsheet/src/androidTest/resources/payment-intent-confirm_with-requires_action-status.json
@@ -80,5 +80,5 @@
   "setup_future_usage": null,
   "shipping": null,
   "source": null,
-  "status": "processing"
+  "status": "requires_action"
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Don't call `GET v1/payment_intents/pi_id_here` when the confirm call informs us there are no next actions.

This short circuits the authenticator logic when intent.requiresAction() is false. By short circuiting, we don't launch activities, and handle the result (which calls the GET).

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Reduce network usage and latency (round trips).

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified
