### PR TITLE
Handle update payment method with mandates

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -224,6 +224,11 @@ data class PaymentMethodCreateParams internal constructor(
         metadata = metadata,
     )
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun requiresMandate(): Boolean {
+        return requiresMandate
+    }
+
     override fun toParamMap(): Map<String, Any> {
         return overrideParamMap
             ?: mapOf(

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -765,7 +765,7 @@ public final class com/stripe/android/ui/core/forms/resources/LpmRepository$LpmI
 	public final fun containsKey (Ljava/lang/String;)Z
 	public final fun fromCode (Ljava/lang/String;)Lcom/stripe/android/ui/core/forms/resources/LpmRepository$SupportedPaymentMethod;
 	public final fun putAll (Ljava/util/Map;)V
-	public final fun values ()Ljava/util/Collection;
+	public final fun values ()Ljava/util/List;
 }
 
 public final class com/stripe/android/ui/core/forms/resources/LpmRepository$ServerSpecState$NoServerSpec : com/stripe/android/ui/core/forms/resources/LpmRepository$ServerSpecState {

--- a/payments-ui-core/src/main/java/com/stripe/android/paymentsheet/forms/MandateRequirement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/paymentsheet/forms/MandateRequirement.kt
@@ -1,0 +1,10 @@
+package com.stripe.android.paymentsheet.forms
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+enum class MandateRequirement {
+    Always,
+    Dynamic,
+    Never,
+}

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
@@ -24,6 +24,7 @@ import com.stripe.android.paymentsheet.forms.EpsRequirement
 import com.stripe.android.paymentsheet.forms.GiropayRequirement
 import com.stripe.android.paymentsheet.forms.IdealRequirement
 import com.stripe.android.paymentsheet.forms.KlarnaRequirement
+import com.stripe.android.paymentsheet.forms.MandateRequirement
 import com.stripe.android.paymentsheet.forms.MobilePayRequirement
 import com.stripe.android.paymentsheet.forms.P24Requirement
 import com.stripe.android.paymentsheet.forms.PaymentMethodRequirements
@@ -95,7 +96,7 @@ class LpmRepository constructor(
 
     fun fromCode(code: PaymentMethodCode?) = lpmInitialFormData.fromCode(code)
 
-    fun values() = lpmInitialFormData.values()
+    fun values(): List<SupportedPaymentMethod> = lpmInitialFormData.values()
 
     /**
      * This method will read the [StripeIntent] and their specs as two separate parameters.
@@ -221,6 +222,7 @@ class LpmRepository constructor(
         PaymentMethod.Type.Card.code -> SupportedPaymentMethod(
             code = "card",
             requiresMandate = false,
+            mandateRequirement = MandateRequirement.Never,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_card,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_card,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -236,6 +238,7 @@ class LpmRepository constructor(
         PaymentMethod.Type.Bancontact.code -> SupportedPaymentMethod(
             code = "bancontact",
             requiresMandate = true,
+            mandateRequirement = MandateRequirement.Always,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_bancontact,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_bancontact,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -247,6 +250,7 @@ class LpmRepository constructor(
         PaymentMethod.Type.Sofort.code -> SupportedPaymentMethod(
             code = "sofort",
             requiresMandate = true,
+            mandateRequirement = MandateRequirement.Always,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_sofort,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_klarna,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -258,6 +262,7 @@ class LpmRepository constructor(
         PaymentMethod.Type.Ideal.code -> SupportedPaymentMethod(
             code = "ideal",
             requiresMandate = true,
+            mandateRequirement = MandateRequirement.Always,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_ideal,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_ideal,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -269,6 +274,7 @@ class LpmRepository constructor(
         PaymentMethod.Type.SepaDebit.code -> SupportedPaymentMethod(
             code = "sepa_debit",
             requiresMandate = true,
+            mandateRequirement = MandateRequirement.Always,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_sepa_debit,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_sepa_debit,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -280,6 +286,7 @@ class LpmRepository constructor(
         PaymentMethod.Type.Eps.code -> SupportedPaymentMethod(
             code = "eps",
             requiresMandate = true,
+            mandateRequirement = MandateRequirement.Always,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_eps,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_eps,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -291,6 +298,7 @@ class LpmRepository constructor(
         PaymentMethod.Type.P24.code -> SupportedPaymentMethod(
             code = "p24",
             requiresMandate = false,
+            mandateRequirement = MandateRequirement.Never,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_p24,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_p24,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -302,6 +310,7 @@ class LpmRepository constructor(
         PaymentMethod.Type.Giropay.code -> SupportedPaymentMethod(
             code = "giropay",
             requiresMandate = false,
+            mandateRequirement = MandateRequirement.Never,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_giropay,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_giropay,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -313,6 +322,7 @@ class LpmRepository constructor(
         PaymentMethod.Type.AfterpayClearpay.code -> SupportedPaymentMethod(
             code = "afterpay_clearpay",
             requiresMandate = false,
+            mandateRequirement = MandateRequirement.Never,
             displayNameResource = if (isClearpay()) {
                 R.string.stripe_paymentsheet_payment_method_clearpay
             } else {
@@ -328,6 +338,7 @@ class LpmRepository constructor(
         PaymentMethod.Type.Klarna.code -> SupportedPaymentMethod(
             code = "klarna",
             requiresMandate = false,
+            mandateRequirement = MandateRequirement.Never,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_klarna,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_klarna,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -342,9 +353,11 @@ class LpmRepository constructor(
             } else {
                 emptyList()
             }
+
             SupportedPaymentMethod(
                 code = "paypal",
                 requiresMandate = stripeIntent.payPalRequiresMandate(),
+                mandateRequirement = MandateRequirement.Dynamic,
                 displayNameResource = R.string.stripe_paymentsheet_payment_method_paypal,
                 iconResource = R.drawable.stripe_ic_paymentsheet_pm_paypal,
                 lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -357,6 +370,7 @@ class LpmRepository constructor(
         PaymentMethod.Type.Affirm.code -> SupportedPaymentMethod(
             code = "affirm",
             requiresMandate = false,
+            mandateRequirement = MandateRequirement.Never,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_affirm,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_affirm,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -368,6 +382,7 @@ class LpmRepository constructor(
         PaymentMethod.Type.RevolutPay.code -> SupportedPaymentMethod(
             code = "revolut_pay",
             requiresMandate = false,
+            mandateRequirement = MandateRequirement.Never,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_revolut_pay,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_revolut_pay,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -379,6 +394,7 @@ class LpmRepository constructor(
         PaymentMethod.Type.MobilePay.code -> SupportedPaymentMethod(
             code = "mobilepay",
             requiresMandate = false,
+            mandateRequirement = MandateRequirement.Never,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_mobile_pay,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_mobile_pay,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -390,6 +406,7 @@ class LpmRepository constructor(
         PaymentMethod.Type.Zip.code -> SupportedPaymentMethod(
             code = "zip",
             requiresMandate = false,
+            mandateRequirement = MandateRequirement.Never,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_zip,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_zip,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -401,6 +418,7 @@ class LpmRepository constructor(
         PaymentMethod.Type.AuBecsDebit.code -> SupportedPaymentMethod(
             code = "au_becs_debit",
             requiresMandate = true,
+            mandateRequirement = MandateRequirement.Always,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_au_becs_debit,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_bank,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -414,6 +432,7 @@ class LpmRepository constructor(
                 SupportedPaymentMethod(
                     code = "us_bank_account",
                     requiresMandate = true,
+                    mandateRequirement = MandateRequirement.Always,
                     displayNameResource = R.string.stripe_paymentsheet_payment_method_us_bank_account,
                     iconResource = R.drawable.stripe_ic_paymentsheet_pm_bank,
                     lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -430,6 +449,7 @@ class LpmRepository constructor(
         PaymentMethod.Type.Upi.code -> SupportedPaymentMethod(
             code = "upi",
             requiresMandate = false,
+            mandateRequirement = MandateRequirement.Never,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_upi,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_upi,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -441,6 +461,7 @@ class LpmRepository constructor(
         PaymentMethod.Type.CashAppPay.code -> SupportedPaymentMethod(
             code = "cashapp",
             requiresMandate = false,
+            mandateRequirement = MandateRequirement.Never,
             displayNameResource = R.string.stripe_paymentsheet_payment_method_cashapp,
             iconResource = R.drawable.stripe_ic_paymentsheet_pm_cash_app_pay,
             lightThemeIconUrl = sharedDataSpec.selectorIcon?.lightThemePng,
@@ -469,6 +490,9 @@ class LpmRepository constructor(
 
         /** This describes if the LPM requires a mandate see [ConfirmPaymentIntentParams.mandateDataParams]. */
         val requiresMandate: Boolean,
+
+        /** This describes when the LPM requires a mandate (see [ConfirmPaymentIntentParams.mandateDataParams]). */
+        val mandateRequirement: MandateRequirement,
 
         /** This describes the name that appears under the selector. */
         @StringRes val displayNameResource: Int,
@@ -512,7 +536,7 @@ class LpmRepository constructor(
 
         private var codeToSupportedPaymentMethod = mutableMapOf<String, SupportedPaymentMethod>()
 
-        fun values() = codeToSupportedPaymentMethod.values
+        fun values(): List<SupportedPaymentMethod> = codeToSupportedPaymentMethod.values.toList()
 
         fun fromCode(code: String?) = code?.let { paymentMethodCode ->
             codeToSupportedPaymentMethod[paymentMethodCode]
@@ -565,15 +589,16 @@ class LpmRepository constructor(
                 SaveForFutureUseSpec(),
             )
             return SupportedPaymentMethod(
-                "card",
-                false,
-                R.string.stripe_paymentsheet_payment_method_card,
-                R.drawable.stripe_ic_paymentsheet_pm_card,
-                null,
-                null,
-                true,
-                CardRequirement,
-                LayoutSpec(specs),
+                code = "card",
+                requiresMandate = false,
+                mandateRequirement = MandateRequirement.Never,
+                displayNameResource = R.string.stripe_paymentsheet_payment_method_card,
+                iconResource = R.drawable.stripe_ic_paymentsheet_pm_card,
+                lightThemeIconUrl = null,
+                darkThemeIconUrl = null,
+                tintIconOnSelection = true,
+                requirement = CardRequirement,
+                formSpec = LayoutSpec(specs),
             )
         }
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
@@ -576,7 +576,11 @@ class PaymentSheetPlaygroundActivity : AppCompatActivity() {
             paymentSheet.presentWithIntentConfiguration(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = mode,
-                    paymentMethodTypes = viewModel.paymentMethodTypes.value,
+                    paymentMethodTypes = if (setAutomaticPaymentMethods) {
+                        emptyList()
+                    } else {
+                        viewModel.paymentMethodTypes.value
+                    },
                 ),
                 configuration = makeConfiguration(),
             )
@@ -692,7 +696,11 @@ class PaymentSheetPlaygroundActivity : AppCompatActivity() {
             flowController.configureWithIntentConfiguration(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = mode,
-                    paymentMethodTypes = viewModel.paymentMethodTypes.value,
+                    paymentMethodTypes = if (setAutomaticPaymentMethods) {
+                        emptyList()
+                    } else {
+                        viewModel.paymentMethodTypes.value
+                    },
                 ),
                 configuration = makeConfiguration(),
                 callback = ::onConfigured,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/viewmodel/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/viewmodel/PaymentSheetPlaygroundViewModel.kt
@@ -255,7 +255,9 @@ class PaymentSheetPlaygroundViewModel(
                         clientSecret.postValue(checkoutResponse.intentClientSecret)
 
                         amount.value = checkoutResponse.amount
-                        paymentMethodTypes.value = checkoutResponse.paymentMethodTypes.orEmpty().split(",")
+                        paymentMethodTypes.value = checkoutResponse.paymentMethodTypes
+                            .orEmpty()
+                            .split(",")
                     }
                 }
                 inProgress.postValue(false)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
@@ -90,6 +90,7 @@ internal class FlowControllerConfigurationHandler @Inject constructor(
 
         viewModel.paymentSelection = paymentSelectionUpdater(
             currentSelection = viewModel.paymentSelection,
+            previousConfig = viewModel.state?.config,
             newState = state,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsFixtures.kt
@@ -83,6 +83,8 @@ internal object PaymentMethodCreateParamsFixtures {
         billingDetails = BILLING_DETAILS
     )
 
+    internal val PAYPAL = PaymentMethodCreateParams.createPayPal()
+
     internal val BANCONTACT = PaymentMethodCreateParams.createBancontact(
         billingDetails = BILLING_DETAILS
     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -52,6 +52,7 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.databinding.ActivityPaymentSheetBinding
 import com.stripe.android.paymentsheet.databinding.PrimaryButtonBinding
 import com.stripe.android.paymentsheet.forms.FormViewModel
+import com.stripe.android.paymentsheet.forms.MandateRequirement
 import com.stripe.android.paymentsheet.forms.PaymentMethodRequirements
 import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -1028,15 +1029,16 @@ internal class PaymentSheetActivityTest {
         val lpmRepository = mock<LpmRepository>().apply {
             whenever(fromCode(any())).thenReturn(
                 LpmRepository.SupportedPaymentMethod(
-                    PaymentMethod.Type.Card.code,
-                    false,
-                    com.stripe.android.ui.core.R.string.stripe_paymentsheet_payment_method_card,
-                    com.stripe.android.ui.core.R.drawable.stripe_ic_paymentsheet_pm_card,
-                    null,
-                    null,
-                    true,
-                    PaymentMethodRequirements(emptySet(), emptySet(), true),
-                    LayoutSpec.create(
+                    code = PaymentMethod.Type.Card.code,
+                    requiresMandate = false,
+                    mandateRequirement = MandateRequirement.Never,
+                    displayNameResource = com.stripe.android.ui.core.R.string.stripe_paymentsheet_payment_method_card,
+                    iconResource = com.stripe.android.ui.core.R.drawable.stripe_ic_paymentsheet_pm_card,
+                    lightThemeIconUrl = null,
+                    darkThemeIconUrl = null,
+                    tintIconOnSelection = true,
+                    requirement = PaymentMethodRequirements(emptySet(), emptySet(), true),
+                    formSpec = LayoutSpec.create(
                         EmailSpec(),
                         SaveForFutureUseSpec()
                     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -1123,7 +1123,7 @@ internal class DefaultFlowControllerTest {
             uiContext = testDispatcher,
             eventReporter = eventReporter,
             viewModel = viewModel,
-            paymentSelectionUpdater = { _, newState -> newState.paymentSelection },
+            paymentSelectionUpdater = { _, _, newState -> newState.paymentSelection },
         ),
         intentConfirmationInterceptor = fakeIntentConfirmationInterceptor,
     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
@@ -389,7 +389,7 @@ class FlowControllerConfigurationHandlerTest {
             uiContext = testDispatcher,
             eventReporter = eventReporter,
             viewModel = viewModel,
-            paymentSelectionUpdater = { _, newState -> newState.paymentSelection },
+            paymentSelectionUpdater = { _, _, newState -> newState.paymentSelection },
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -67,15 +67,16 @@ internal class FormViewModelTest {
 
         whenever(mockLpmRepository.fromCode(paymentMethodType.code)).thenReturn(
             LpmRepository.SupportedPaymentMethod(
-                paymentMethodType.code,
-                false,
-                R.string.stripe_paymentsheet_payment_method_card,
-                R.drawable.stripe_ic_paymentsheet_pm_card,
-                null,
-                null,
-                true,
-                PaymentMethodRequirements(emptySet(), emptySet(), true),
-                layoutSpec
+                code = paymentMethodType.code,
+                requiresMandate = false,
+                mandateRequirement = MandateRequirement.Never,
+                displayNameResource = R.string.stripe_paymentsheet_payment_method_card,
+                iconResource = R.drawable.stripe_ic_paymentsheet_pm_card,
+                lightThemeIconUrl = null,
+                darkThemeIconUrl = null,
+                tintIconOnSelection = true,
+                requirement = PaymentMethodRequirements(emptySet(), emptySet(), true),
+                formSpec = layoutSpec
             )
         )
         return mockLpmRepository

--- a/paymentsheet/src/test/java/com/stripe/android/utils/MockPaymentMethodsFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/MockPaymentMethodsFactory.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.utils
 
+import com.stripe.android.paymentsheet.forms.MandateRequirement
 import com.stripe.android.paymentsheet.forms.PaymentMethodRequirements
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.LayoutSpec
@@ -40,8 +41,9 @@ object MockPaymentMethodsFactory {
         tintIconOnSelection: Boolean = false
     ): LpmRepository.SupportedPaymentMethod {
         return LpmRepository.SupportedPaymentMethod(
-            code,
+            code = code,
             requiresMandate = false,
+            mandateRequirement = MandateRequirement.Never,
             displayNameResource = displayNameResource,
             iconResource = iconResource,
             lightThemeIconUrl = null,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This PR addresses the decoupling update flow for payment methods that have mandates. There are two cases:
1. If the current payment method does not require mandate and the new payment method requires mandate, clear the currently selected payment method
2. If the current payment method requires a mandate and the new payment method does not require a mandate, then select the new payment method

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Decoupling

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

