### PR TITLE
Use `Result<T>` for ElementsSession endpoint

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -512,7 +512,7 @@ abstract class StripeRepository {
     abstract suspend fun retrieveElementsSession(
         params: ElementsSessionParams,
         options: ApiRequest.Options,
-    ): ElementsSession?
+    ): Result<ElementsSession>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     abstract suspend fun retrieveCardMetadata(

--- a/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
@@ -422,8 +422,8 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
     override suspend fun retrieveElementsSession(
         params: ElementsSessionParams,
         options: ApiRequest.Options
-    ): ElementsSession? {
-        return null
+    ): Result<ElementsSession> {
+        return Result.failure(NotImplementedError())
     }
 
     override suspend fun retrieveCardMetadata(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
@@ -70,7 +70,7 @@ internal sealed class ElementsSessionRepository {
                 options = requestOptions,
             )
 
-            return elementsSession.takeIfSuccessOrElse { elementsSessionFailure ->
+            return elementsSession.getResultOrElse { elementsSessionFailure ->
                 fallback(params, elementsSessionFailure)
             }
         }
@@ -169,7 +169,7 @@ private fun PaymentSheet.IntentConfiguration.CaptureMethod.toElementsSessionPara
     }
 }
 
-private inline fun <T> Result<T>.takeIfSuccessOrElse(
+private inline fun <T> Result<T>.getResultOrElse(
     transform: (Throwable) -> Result<T>,
 ): Result<T> {
     return exceptionOrNull()?.let(transform) ?: this

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
@@ -22,7 +22,7 @@ internal sealed class ElementsSessionRepository {
 
     abstract suspend fun get(
         initializationMode: PaymentSheet.InitializationMode,
-    ): ElementsSession
+    ): Result<ElementsSession>
 
     /**
      * Retrieve the [StripeIntent] from a static source.
@@ -32,11 +32,13 @@ internal sealed class ElementsSessionRepository {
     ) : ElementsSessionRepository() {
         override suspend fun get(
             initializationMode: PaymentSheet.InitializationMode,
-        ): ElementsSession {
-            return ElementsSession(
-                linkSettings = null,
-                paymentMethodSpecs = null,
-                stripeIntent = stripeIntent,
+        ): Result<ElementsSession> {
+            return Result.success(
+                ElementsSession(
+                    linkSettings = null,
+                    paymentMethodSpecs = null,
+                    stripeIntent = stripeIntent,
+                )
             )
         }
     }
@@ -60,29 +62,34 @@ internal sealed class ElementsSessionRepository {
 
         override suspend fun get(
             initializationMode: PaymentSheet.InitializationMode,
-        ): ElementsSession {
+        ): Result<ElementsSession> {
             val params = initializationMode.toElementsSessionParams()
 
-            val elementsSession = runCatching {
-                stripeRepository.retrieveElementsSession(
-                    params = params,
-                    options = requestOptions,
-                )
-            }.getOrNull()
+            val elementsSession = stripeRepository.retrieveElementsSession(
+                params = params,
+                options = requestOptions,
+            )
 
-            return elementsSession ?: requireNotNull(fallback(params))
+            return elementsSession.takeIfSuccessOrElse { elementsSessionFailure ->
+                fallback(params, elementsSessionFailure)
+            }
         }
 
         private suspend fun fallback(
             params: ElementsSessionParams,
-        ): ElementsSession? = withContext(workContext) {
+            elementsSessionFailure: Throwable,
+        ): Result<ElementsSession> = withContext(workContext) {
             when (params) {
                 is ElementsSessionParams.PaymentIntentType -> {
-                    stripeRepository.retrievePaymentIntent(
-                        clientSecret = params.clientSecret,
-                        options = requestOptions,
-                        expandFields = listOf("payment_method")
-                    )?.let {
+                    runCatching {
+                        requireNotNull(
+                            stripeRepository.retrievePaymentIntent(
+                                clientSecret = params.clientSecret,
+                                options = requestOptions,
+                                expandFields = listOf("payment_method")
+                            )
+                        )
+                    }.map {
                         ElementsSession(
                             linkSettings = null,
                             paymentMethodSpecs = null,
@@ -91,11 +98,15 @@ internal sealed class ElementsSessionRepository {
                     }
                 }
                 is ElementsSessionParams.SetupIntentType -> {
-                    stripeRepository.retrieveSetupIntent(
-                        clientSecret = params.clientSecret,
-                        options = requestOptions,
-                        expandFields = listOf("payment_method")
-                    )?.let {
+                    runCatching {
+                        requireNotNull(
+                            stripeRepository.retrieveSetupIntent(
+                                clientSecret = params.clientSecret,
+                                options = requestOptions,
+                                expandFields = listOf("payment_method")
+                            )
+                        )
+                    }.map {
                         ElementsSession(
                             linkSettings = null,
                             paymentMethodSpecs = null,
@@ -105,7 +116,7 @@ internal sealed class ElementsSessionRepository {
                 }
                 is ElementsSessionParams.DeferredIntentType -> {
                     // We don't have a fallback endpoint for the deferred intent flow
-                    null
+                    Result.failure(elementsSessionFailure)
                 }
             }
         }
@@ -156,4 +167,10 @@ private fun PaymentSheet.IntentConfiguration.CaptureMethod.toElementsSessionPara
         PaymentSheet.IntentConfiguration.CaptureMethod.Automatic -> CaptureMethod.Automatic
         PaymentSheet.IntentConfiguration.CaptureMethod.Manual -> CaptureMethod.Manual
     }
+}
+
+private inline fun <T> Result<T>.takeIfSuccessOrElse(
+    transform: (Throwable) -> Result<T>,
+): Result<T> {
+    return exceptionOrNull()?.let(transform) ?: this
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -212,7 +212,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         initializationMode: PaymentSheet.InitializationMode,
         configuration: PaymentSheet.Configuration?,
     ): StripeIntent {
-        val elementsSession = elementsSessionRepository.get(initializationMode)
+        val elementsSession = elementsSessionRepository.get(initializationMode).getOrThrow()
 
         lpmRepository.update(
             stripeIntent = elementsSession.stripeIntent,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -72,12 +72,10 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
     ): PaymentSheetLoader.Result = withContext(workContext) {
         val isGooglePayReady = isGooglePayReady(paymentSheetConfiguration)
 
-        runCatching {
-            retrieveElementsSession(
-                initializationMode = initializationMode,
-                configuration = paymentSheetConfiguration,
-            )
-        }.fold(
+        retrieveElementsSession(
+            initializationMode = initializationMode,
+            configuration = paymentSheetConfiguration,
+        ).fold(
             onSuccess = { stripeIntent ->
                 create(
                     stripeIntent = stripeIntent,
@@ -211,21 +209,22 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
     private suspend fun retrieveElementsSession(
         initializationMode: PaymentSheet.InitializationMode,
         configuration: PaymentSheet.Configuration?,
-    ): StripeIntent {
-        val elementsSession = elementsSessionRepository.get(initializationMode).getOrThrow()
+    ): Result<StripeIntent> {
+        return elementsSessionRepository.get(initializationMode).map { elementsSession ->
+            lpmRepository.update(
+                stripeIntent = elementsSession.stripeIntent,
+                serverLpmSpecs = elementsSession.paymentMethodSpecs,
+                billingDetailsCollectionConfiguration =
+                configuration?.billingDetailsCollectionConfiguration
+                    ?: BillingDetailsCollectionConfiguration(),
+            )
 
-        lpmRepository.update(
-            stripeIntent = elementsSession.stripeIntent,
-            serverLpmSpecs = elementsSession.paymentMethodSpecs,
-            billingDetailsCollectionConfiguration =
-            configuration?.billingDetailsCollectionConfiguration ?: BillingDetailsCollectionConfiguration(),
-        )
+            if (lpmRepository.serverSpecLoadingState is ServerSpecState.ServerNotParsed) {
+                eventReporter.onLpmSpecFailure()
+            }
 
-        if (lpmRepository.serverSpecLoadingState is ServerSpecState.ServerNotParsed) {
-            eventReporter.onLpmSpecFailure()
+            stripeIntentValidator.requireValid(elementsSession.stripeIntent)
         }
-
-        return stripeIntentValidator.requireValid(elementsSession.stripeIntent)
     }
 
     private suspend fun loadLinkState(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -210,7 +210,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         initializationMode: PaymentSheet.InitializationMode,
         configuration: PaymentSheet.Configuration?,
     ): Result<StripeIntent> {
-        return elementsSessionRepository.get(initializationMode).map { elementsSession ->
+        return elementsSessionRepository.get(initializationMode).mapCatching { elementsSession ->
             lpmRepository.update(
                 stripeIntent = elementsSession.stripeIntent,
                 serverLpmSpecs = elementsSession.paymentMethodSpecs,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue in `ElementsSessionRepository` by using `Result<T>` for its `get` method.

We currently attempt to fetch the session from the ElementsSession endpoint. If that doesn’t succeed, we fallback to the Stripe API. However, we don’t have a corresponding Stripe API endpoint when we’re in the deferred intent flow, meaning that an eventual call to `requireNotNull()` resulted in a `NullPointerException`.

Now, we use `Result<T>` for the call to the ElementsSession endpoint. If this fails, we continue to fallback to the Stripe API for the payment and setup intent flows, but in the deferred intent flow, we now simply return the previously encountered exception.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
