### PR TITLE
Move StripeIntent validation to PaymentSheetLoader

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/StripeIntentValidator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/StripeIntentValidator.kt
@@ -37,6 +37,9 @@ internal class StripeIntentValidator @Inject constructor() {
                     """.trimIndent()
                 )
             }
+            stripeIntent is PaymentIntent && (stripeIntent.amount == null || stripeIntent.currency == null) -> {
+                error("PaymentIntent must contain amount and currency.")
+            }
             stripeIntent is SetupIntent &&
                 (
                     (stripeIntent.status == StripeIntent.Status.Canceled) ||

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -19,6 +19,7 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.StripeIntentValidator
+import com.stripe.android.paymentsheet.model.getPMsToAdd
 import com.stripe.android.paymentsheet.model.getSupportedSavedCustomerPMs
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
@@ -47,7 +48,7 @@ internal interface PaymentSheetLoader {
 
     sealed class Result {
         data class Success(val state: PaymentSheetState.Full) : Result()
-        class Failure(val throwable: Throwable) : Result()
+        data class Failure(val throwable: Throwable) : Result()
     }
 }
 
@@ -171,16 +172,30 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
             }
         }
 
-        return@coroutineScope PaymentSheetLoader.Result.Success(
-            PaymentSheetState.Full(
-                config = config,
-                stripeIntent = stripeIntent,
-                customerPaymentMethods = sortedPaymentMethods.await(),
-                isGooglePayReady = isGooglePayReady,
-                linkState = linkState.await(),
-                paymentSelection = initialPaymentSelection.await(),
+        warnUnactivatedIfNeeded(stripeIntent)
+
+        if (supportsIntent(stripeIntent, config)) {
+            PaymentSheetLoader.Result.Success(
+                PaymentSheetState.Full(
+                    config = config,
+                    stripeIntent = stripeIntent,
+                    customerPaymentMethods = sortedPaymentMethods.await(),
+                    isGooglePayReady = isGooglePayReady,
+                    linkState = linkState.await(),
+                    paymentSelection = initialPaymentSelection.await(),
+                )
             )
-        )
+        } else {
+            val requested = stripeIntent.paymentMethodTypes.joinToString(separator = ", ")
+            val supported = lpmRepository.values().joinToString(separator = ", ") { it.code }
+
+            PaymentSheetLoader.Result.Failure(
+                IllegalArgumentException(
+                    "None of the requested payment methods ($requested) " +
+                        "match the supported payment types ($supported)."
+                )
+            )
+        }
     }
 
     private suspend fun retrieveCustomerPaymentMethods(
@@ -287,6 +302,31 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
             customerBillingCountryCode = config?.defaultBillingDetails?.address?.country,
             shippingValues = shippingAddress
         )
+    }
+
+    private fun warnUnactivatedIfNeeded(stripeIntent: StripeIntent) {
+        if (stripeIntent.unactivatedPaymentMethods.isEmpty()) {
+            return
+        }
+
+        val message = "[Stripe SDK] Warning: Your Intent contains the following payment method " +
+            "types which are activated for test mode but not activated for " +
+            "live mode: ${stripeIntent.unactivatedPaymentMethods}. These payment method types " +
+            "will not be displayed in live mode until they are activated. To activate these " +
+            "payment method types visit your Stripe dashboard." +
+            "More information: https://support.stripe.com/questions/activate-a-new-payment-method"
+
+        logger.warning(message)
+    }
+
+    private fun supportsIntent(
+        stripeIntent: StripeIntent,
+        config: PaymentSheet.Configuration?,
+    ): Boolean {
+        val supportedPaymentMethods = getPMsToAdd(stripeIntent, config, lpmRepository)
+        val requestedTypes = stripeIntent.paymentMethodTypes.toSet()
+        val supportedTypes = supportedPaymentMethods.map { it.code }.toSet()
+        return supportedTypes.intersect(requestedTypes).isNotEmpty()
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -262,54 +262,15 @@ internal abstract class BaseSheetViewModel(
         val pmsToAdd = getPMsToAdd(stripeIntent, config, lpmRepository)
         supportedPaymentMethods = pmsToAdd
 
-        if (stripeIntent != null && supportedPaymentMethods.isEmpty()) {
-            onFatal(
-                IllegalArgumentException(
-                    "None of the requested payment methods" +
-                        " (${stripeIntent.paymentMethodTypes})" +
-                        " match the supported payment types" +
-                        " (${
-                        lpmRepository.values()
-                            .map { it.code }.toList()
-                        })"
-                )
-            )
-        }
-
         if (stripeIntent is PaymentIntent) {
-            runCatching {
-                _amount.value = Amount(
-                    requireNotNull(stripeIntent.amount),
-                    requireNotNull(stripeIntent.currency)
-                )
-            }.onFailure {
-                onFatal(
-                    IllegalStateException("PaymentIntent must contain amount and currency.")
-                )
-            }
-        }
-
-        if (stripeIntent != null) {
-            warnUnactivatedIfNeeded(stripeIntent.unactivatedPaymentMethods)
+            _amount.value = Amount(
+                requireNotNull(stripeIntent.amount),
+                requireNotNull(stripeIntent.currency)
+            )
         }
     }
 
     abstract fun clearErrorMessages()
-
-    private fun warnUnactivatedIfNeeded(unactivatedPaymentMethodTypes: List<String>) {
-        if (unactivatedPaymentMethodTypes.isEmpty()) {
-            return
-        }
-
-        val message = "[Stripe SDK] Warning: Your Intent contains the following payment method " +
-            "types which are activated for test mode but not activated for " +
-            "live mode: $unactivatedPaymentMethodTypes. These payment method types will not be " +
-            "displayed in live mode until they are activated. To activate these payment method " +
-            "types visit your Stripe dashboard." +
-            "More information: https://support.stripe.com/questions/activate-a-new-payment-method"
-
-        logger.warning(message)
-    }
 
     fun updatePrimaryButtonForLinkSignup(viewState: InlineSignupViewState) {
         val uiState = primaryButtonUiState.value ?: return

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -586,23 +586,6 @@ internal class PaymentSheetViewModelTest {
     }
 
     @Test
-    fun `when StripeIntent does not accept any of the supported payment methods should return error`() = runTest {
-        val viewModel = createViewModel(
-            stripeIntent = PAYMENT_INTENT.copy(
-                paymentMethodTypes = listOf("unsupported_payment_type"),
-            ),
-        )
-
-        viewModel.paymentSheetResult.test {
-            assertThat((awaitItem() as? PaymentSheetResult.Failed)?.error?.message)
-                .startsWith(
-                    "None of the requested payment methods ([unsupported_payment_type]) " +
-                        "match the supported payment types "
-                )
-        }
-    }
-
-    @Test
     fun `Verify supported payment methods exclude afterpay if no shipping and no allow flag`() {
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/StripeIntentValidatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/StripeIntentValidatorTest.kt
@@ -89,4 +89,26 @@ class StripeIntentValidatorTest {
             )
         )
     }
+
+    @Test
+    fun `Considers PaymentIntent without amount invalid`() {
+        assertFails {
+            validator.requireValid(
+                PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                    amount = null,
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `Considers PaymentIntent without currency invalid`() {
+        assertFails {
+            validator.requireValid(
+                PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                    currency = null,
+                )
+            )
+        }
+    }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request moves some `StripeIntent` validation logic from `BaseSheetViewModel` to `PaymentSheetLoader`. While this doesn’t have any impact on `PaymentSheet`, it finally makes error handling possible when using `FlowController`.

Previously, configuring `FlowController` with an invalid `StripeIntent` caused it to call `onPaymentOption` with a null payment option. This didn’t provide the merchant with any actionable information.

With this change, an invalid `StripeIntent` will be detected in the `configureWith()` call and return a configuration error to the merchant, which they can log or react to in any other way.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Earlier validation.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
