### PR TITLE
Remove unused parameters from `DeferredIntentParams`

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/DeferredIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/DeferredIntentParams.kt
@@ -11,8 +11,6 @@ data class DeferredIntentParams(
     val mode: Mode,
     val setupFutureUsage: StripeIntent.Usage? = null,
     val captureMethod: CaptureMethod? = null,
-    val customer: String? = null,
-    val onBehalfOf: String? = null,
     val paymentMethodTypes: Set<String> = emptySet()
 ) : StripeModel {
 
@@ -52,8 +50,6 @@ data class DeferredIntentParams(
             "deferred_intent[currency]" to (mode as? Mode.Payment)?.currency,
             "deferred_intent[setup_future_usage]" to setupFutureUsage?.code,
             "deferred_intent[capture_method]" to captureMethod?.code,
-            "deferred_intent[customer]" to customer,
-            "deferred_intent[on_behalf_of]" to onBehalfOf
         ) + paymentMethodTypes.mapIndexed { index, paymentMethodType ->
             "deferred_intent[payment_method_types][$index]" to paymentMethodType
         }

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -2394,8 +2394,6 @@ internal class StripeApiRepositoryTest {
             assertEquals("usd", this["deferred_intent[currency]"])
             assertEquals(null, this["deferred_intent[setup_future_usage]"])
             assertEquals(null, this["deferred_intent[capture_method]"])
-            assertEquals(null, this["deferred_intent[customer]"])
-            assertEquals(null, this["deferred_intent[on_behalf_of]"])
             assertEquals("card", this["deferred_intent[payment_method_types][0]"])
             assertEquals("link", this["deferred_intent[payment_method_types][1]"])
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
@@ -37,7 +37,7 @@ internal class FlowControllerConfigurationHandler @Inject constructor(
             return
         }
 
-        val elementsSessionParams = initializationMode.toElementsSessionParams(configuration)
+        val elementsSessionParams = initializationMode.toElementsSessionParams()
         val previousElementsSessionParams = viewModel.previousElementsSessionParams
         if (elementsSessionParams == previousElementsSessionParams) {
             callback.onConfigured(true, null)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
@@ -22,7 +22,6 @@ internal sealed class ElementsSessionRepository {
 
     abstract suspend fun get(
         initializationMode: PaymentSheet.InitializationMode,
-        configuration: PaymentSheet.Configuration?,
     ): ElementsSession
 
     /**
@@ -33,7 +32,6 @@ internal sealed class ElementsSessionRepository {
     ) : ElementsSessionRepository() {
         override suspend fun get(
             initializationMode: PaymentSheet.InitializationMode,
-            configuration: PaymentSheet.Configuration?,
         ): ElementsSession {
             return ElementsSession(
                 linkSettings = null,
@@ -62,9 +60,8 @@ internal sealed class ElementsSessionRepository {
 
         override suspend fun get(
             initializationMode: PaymentSheet.InitializationMode,
-            configuration: PaymentSheet.Configuration?,
         ): ElementsSession {
-            val params = initializationMode.toElementsSessionParams(configuration)
+            val params = initializationMode.toElementsSessionParams()
 
             val elementsSession = runCatching {
                 stripeRepository.retrieveElementsSession(
@@ -116,9 +113,7 @@ internal sealed class ElementsSessionRepository {
 }
 
 @OptIn(ExperimentalPaymentSheetDecouplingApi::class)
-internal fun PaymentSheet.InitializationMode.toElementsSessionParams(
-    configuration: PaymentSheet.Configuration?,
-): ElementsSessionParams {
+internal fun PaymentSheet.InitializationMode.toElementsSessionParams(): ElementsSessionParams {
     return when (this) {
         is PaymentSheet.InitializationMode.PaymentIntent -> {
             ElementsSessionParams.PaymentIntentType(clientSecret = clientSecret)
@@ -132,7 +127,6 @@ internal fun PaymentSheet.InitializationMode.toElementsSessionParams(
                     mode = intentConfiguration.mode.toElementsSessionParam(),
                     setupFutureUsage = intentConfiguration.setupFutureUse?.toElementsSessionParam(),
                     captureMethod = intentConfiguration.captureMethod?.toElementsSessionParam(),
-                    customer = configuration?.customer?.id,
                     paymentMethodTypes = intentConfiguration.paymentMethodTypes.toSet(),
                 ),
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -212,10 +212,7 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         initializationMode: PaymentSheet.InitializationMode,
         configuration: PaymentSheet.Configuration?,
     ): StripeIntent {
-        val elementsSession = elementsSessionRepository.get(
-            initializationMode = initializationMode,
-            configuration = configuration,
-        )
+        val elementsSession = elementsSessionRepository.get(initializationMode)
 
         lpmRepository.update(
             stripeIntent = elementsSession.stripeIntent,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
@@ -258,10 +258,9 @@ class FlowControllerConfigurationHandlerTest {
 
     private fun createElementsSessionParams(
         clientSecret: String = PaymentSheetFixtures.CLIENT_SECRET,
-        configuration: PaymentSheet.Configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
     ): ElementsSessionParams {
         val initializationMode = PaymentSheet.InitializationMode.PaymentIntent(clientSecret)
-        return initializationMode.toElementsSessionParams(configuration)
+        return initializationMode.toElementsSessionParams()
     }
 
     private fun createConfigurationHandler(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
@@ -46,7 +46,6 @@ internal class ElementsSessionRepositoryTest {
                 initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
                     clientSecret = "client_secret",
                 ),
-                configuration = null,
             )
         }
 
@@ -73,7 +72,6 @@ internal class ElementsSessionRepositoryTest {
                     initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
                         clientSecret = "client_secret",
                     ),
-                    configuration = null,
                 )
             }
 
@@ -97,7 +95,6 @@ internal class ElementsSessionRepositoryTest {
                     initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
                         clientSecret = "client_secret",
                     ),
-                    configuration = null,
                 )
             }
 
@@ -126,7 +123,6 @@ internal class ElementsSessionRepositoryTest {
             initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
                 clientSecret = "client_secret",
             ),
-            configuration = null,
         )
 
         val argumentCaptor: KArgumentCaptor<ElementsSessionParams> = argumentCaptor()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request removes the unused `customer` and `on_behalf_of` parameters from the `DeferredIntentParams`. This became necessary following [this backend change](https://git.corp.stripe.com/stripe-internal/pay-server/pull/586900).

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Bugfix.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
