### PR TITLE
Consider `config` when deciding whether to skip sessions call

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet.flowcontroller
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.SavedStateHandle
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 
@@ -22,30 +21,13 @@ internal class FlowControllerViewModel(
     var paymentSelection: PaymentSelection? = null
 
     // Used to determine if we need to reload the flow controller configuration.
-    var previousInitializationMode: PaymentSheet.InitializationMode? = null
-    var previousConfiguration: PaymentSheet.Configuration? = null
+    var previousConfigureRequest: FlowControllerConfigurationHandler.ConfigureRequest? = null
 
     var state: PaymentSheetState.Full?
         get() = handle[STATE_KEY]
         set(value) {
             handle[STATE_KEY] = value
         }
-
-    fun canSkipLoad(
-        initializationMode: PaymentSheet.InitializationMode,
-        configuration: PaymentSheet.Configuration?,
-    ): Boolean {
-        return previousInitializationMode == initializationMode &&
-            previousConfiguration == configuration
-    }
-
-    fun storeLastInput(
-        initializationMode: PaymentSheet.InitializationMode,
-        configuration: PaymentSheet.Configuration?,
-    ) {
-        previousInitializationMode = initializationMode
-        previousConfiguration = configuration
-    }
 
     private companion object {
         private const val STATE_KEY = "state"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet.flowcontroller
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.SavedStateHandle
-import com.stripe.android.model.ElementsSessionParams
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.PaymentSheetState
@@ -20,18 +19,33 @@ internal class FlowControllerViewModel(
             .flowControllerViewModel(this)
             .build()
 
-    var initializationMode: PaymentSheet.InitializationMode? = null
-
     var paymentSelection: PaymentSelection? = null
 
     // Used to determine if we need to reload the flow controller configuration.
-    var previousElementsSessionParams: ElementsSessionParams? = null
+    var previousInitializationMode: PaymentSheet.InitializationMode? = null
+    var previousConfiguration: PaymentSheet.Configuration? = null
 
     var state: PaymentSheetState.Full?
         get() = handle[STATE_KEY]
         set(value) {
             handle[STATE_KEY] = value
         }
+
+    fun canSkipLoad(
+        initializationMode: PaymentSheet.InitializationMode,
+        configuration: PaymentSheet.Configuration?,
+    ): Boolean {
+        return previousInitializationMode == initializationMode &&
+            previousConfiguration == configuration
+    }
+
+    fun storeLastInput(
+        initializationMode: PaymentSheet.InitializationMode,
+        configuration: PaymentSheet.Configuration?,
+    ) {
+        previousInitializationMode = initializationMode
+        previousConfiguration = configuration
+    }
 
     private companion object {
         private const val STATE_KEY = "state"


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where we wouldn’t call the Elements session endpoint on `configureWith()` again if it was called with the same `ElementsSessionParams`. This was incorrect, because the provided `PaymentSheet.Configuration` also has an impact on the resulting `PaymentSheetState`.

Now, we keep track of both `initializationMode` (which the params are created from) and the `configuration` in `ConfigureRequest` and only skip the call if neither has changed.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
