### PR TITLE
Fix issue where incorrect payment selection was returned

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -191,10 +191,26 @@ internal class PaymentOptionsViewModel @Inject constructor(
         _paymentOptionResult.tryEmit(
             PaymentOptionResult.Canceled(
                 mostRecentError = mostRecentError,
-                paymentSelection = selection.value,
+                paymentSelection = determinePaymentSelectionUponCancel(),
                 paymentMethods = paymentMethods.value,
             )
         )
+    }
+
+    private fun determinePaymentSelectionUponCancel(): PaymentSelection? {
+        val initialSelection = args.state.paymentSelection
+
+        return if (initialSelection is PaymentSelection.Saved) {
+            initialSelection.takeIfStillValid()
+        } else {
+            initialSelection
+        }
+    }
+
+    private fun PaymentSelection.Saved.takeIfStillValid(): PaymentSelection.Saved? {
+        val paymentMethods = paymentMethods.value.orEmpty()
+        val isStillAround = paymentMethods.any { it.id == paymentMethod.id }
+        return this.takeIf { isStillAround }
     }
 
     override fun onFinish() {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue (coming from #6386) where an unconfirmed payment selection might be returned to the merchant in the `paymentOptionCallback` when the user dismisses Payment Sheet.

Instead of passing the current selection in `PaymentOptionResult.Canceled`, we need to use the initially selected payment method if still available. There are two scenarios:
1. The user had an initially selected payment method and has now selected a different payment method, but hasn’t confirmed it by pressing the `Continue` button. Therefore, we need to fallback to the payment method that was initially selected (if still available).
2. The user had an initially selected payment method, but then they deleted it. Now we’re without a selected payment method, meaning that we should return `null` on cancelation.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
