### PR TITLE
Remove view model calls from `PaymentOptionsActivityTest`

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -9,7 +9,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
@@ -41,6 +43,7 @@ import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.ui.PrimaryButton
+import com.stripe.android.paymentsheet.ui.getLabel
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.elements.EmailSpec
 import com.stripe.android.ui.core.elements.LayoutSpec
@@ -104,8 +107,6 @@ internal class PaymentOptionsActivityTest {
         whenever(serverSpecLoadingState).thenReturn(LpmRepository.ServerSpecState.Uninitialized)
     }
 
-    private val viewModel = createViewModel()
-
     private val ActivityPaymentOptionsBinding.continueButton: PrimaryButton
         get() = root.findViewById(R.id.primary_button)
 
@@ -125,17 +126,14 @@ internal class PaymentOptionsActivityTest {
 
     @Test
     fun `click outside of bottom sheet should return cancel result`() {
-        val scenario = activityScenario()
-        scenario.launchForResult(
-            createIntent()
-        ).use {
+        runActivityScenario {
             it.onActivity { activity ->
                 activity.viewBinding.root.performClick()
                 activity.finish()
             }
 
             assertThat(
-                PaymentOptionResult.fromIntent(scenario.getResult().resultData)
+                PaymentOptionResult.fromIntent(it.getResult().resultData)
             ).isEqualTo(
                 PaymentOptionResult.Canceled(null, null, listOf())
             )
@@ -144,19 +142,20 @@ internal class PaymentOptionsActivityTest {
 
     @Test
     fun `click outside of bottom sheet should return cancel result even if there is a selection`() {
-        val scenario = activityScenario()
-        scenario.launchForResult(
-            createIntent()
-        ).use {
+        val args = PAYMENT_OPTIONS_CONTRACT_ARGS.updateState(isGooglePayReady = true)
+
+        runActivityScenario(args) {
             it.onActivity { activity ->
-                viewModel.updateSelection(PaymentSelection.GooglePay)
+                composeTestRule
+                    .onNodeWithTag("${PAYMENT_OPTION_CARD_TEST_TAG}_Google Pay")
+                    .performClick()
 
                 activity.viewBinding.root.performClick()
                 activity.finish()
             }
 
             assertThat(
-                PaymentOptionResult.fromIntent(scenario.getResult().resultData)
+                PaymentOptionResult.fromIntent(it.getResult().resultData)
             ).isEqualTo(
                 PaymentOptionResult.Canceled(null, PaymentSelection.GooglePay, listOf())
             )
@@ -169,37 +168,22 @@ internal class PaymentOptionsActivityTest {
             paymentMethods = PaymentMethodFixtures.createCards(5)
         )
 
-        val scenario = activityScenario(
-            viewModel = createViewModel(args)
-        )
-
-        scenario.launch(createIntent(args)).use {
+        runActivityScenario(args) {
             it.onActivity { activity ->
-                assertThat(activity.viewBinding.continueButton.isVisible)
-                    .isFalse()
+                assertThat(activity.viewBinding.continueButton.isVisible).isFalse()
             }
         }
     }
 
     @Test
     fun `ContinueButton should be visible when showing add payment method form`() {
-        val scenario = activityScenario(
-            createViewModel(
-                args = PAYMENT_OPTIONS_CONTRACT_ARGS.updateState(
-                    stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK
-                )
-            )
+        val args = PAYMENT_OPTIONS_CONTRACT_ARGS.updateState(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK
         )
-        scenario.launch(
-            createIntent(
-                args = PAYMENT_OPTIONS_CONTRACT_ARGS.updateState(
-                    stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK
-                )
-            )
-        ).use {
+
+        runActivityScenario(args) {
             it.onActivity { activity ->
-                assertThat(activity.viewBinding.continueButton.isVisible)
-                    .isTrue()
+                assertThat(activity.viewBinding.continueButton.isVisible).isTrue()
             }
         }
     }
@@ -210,35 +194,28 @@ internal class PaymentOptionsActivityTest {
             paymentMethods = PaymentMethodFixtures.createCards(5)
         )
 
-        val viewModel = createViewModel(args)
-        val scenario = activityScenario(viewModel)
-
-        scenario.launch(createIntent(args)).use {
+        runActivityScenario(args) {
             it.onActivity { activity ->
-                assertThat(activity.viewBinding.continueButton.isVisible)
-                    .isFalse()
+                assertThat(activity.viewBinding.continueButton.isVisible).isFalse()
 
                 // Navigate to "Add Payment Method" fragment
-                viewModel.transitionToAddPaymentScreen()
+                composeTestRule
+                    .onNodeWithTag("${PAYMENT_OPTION_CARD_TEST_TAG}_+ Add")
+                    .performClick()
 
-                assertThat(activity.viewBinding.continueButton.isVisible)
-                    .isTrue()
+                assertThat(activity.viewBinding.continueButton.isVisible).isTrue()
 
                 // Navigate back to payment options list
                 pressBack()
 
-                assertThat(activity.viewBinding.continueButton.isVisible)
-                    .isFalse()
+                assertThat(activity.viewBinding.continueButton.isVisible).isFalse()
             }
         }
     }
 
     @Test
     fun `Verify Ready state updates the add button label`() {
-        val scenario = activityScenario()
-        scenario.launch(
-            createIntent()
-        ).use {
+        runActivityScenario {
             it.onActivity { activity ->
                 val addBinding = PrimaryButtonBinding.bind(activity.viewBinding.continueButton)
 
@@ -255,10 +232,7 @@ internal class PaymentOptionsActivityTest {
 
     @Test
     fun `Verify bottom sheet expands on start`() {
-        val scenario = activityScenario()
-        scenario.launch(
-            createIntent()
-        ).use {
+        runActivityScenario {
             it.onActivity { activity ->
                 assertThat(activity.bottomSheetBehavior.state)
                     .isEqualTo(BottomSheetBehavior.STATE_EXPANDED)
@@ -269,15 +243,17 @@ internal class PaymentOptionsActivityTest {
     }
 
     @Test
-    fun `Verify ProcessResult state closes the sheet`() {
-        val scenario = activityScenario()
-        scenario.launch(
-            createIntent()
-        ).use {
+    fun `Verify selecting a payment method closes the sheet`() {
+        val args = PAYMENT_OPTIONS_CONTRACT_ARGS.updateState(isGooglePayReady = true)
+
+        runActivityScenario(args) {
             it.onActivity { activity ->
-                val paymentSelection = PaymentSelection.GooglePay
-                viewModel.updateSelection(paymentSelection)
-                viewModel.onUserSelection()
+                composeTestRule
+                    .onNodeWithTag("${PAYMENT_OPTION_CARD_TEST_TAG}_Google Pay")
+                    .performClick()
+
+                composeTestRule.waitForIdle()
+
                 idleLooper()
 
                 assertThat(activity.bottomSheetBehavior.state)
@@ -288,23 +264,32 @@ internal class PaymentOptionsActivityTest {
 
     @Test
     fun `notes visibility is set correctly`() {
-        val scenario = activityScenario()
-        scenario.launch(
-            createIntent()
-        ).use {
-            it.onActivity {
-                val text = "a below-button text"
+        val usBankAccount = PaymentMethodFixtures.US_BANK_ACCOUNT
 
-                viewModel.updateBelowButtonText(text)
+        val label = usBankAccount.getLabel(context.resources)
+        val mandateText = "By continuing, you agree to authorize payments pursuant to these terms."
+
+        val args = PAYMENT_OPTIONS_CONTRACT_ARGS.updateState(
+            paymentMethods = listOf(usBankAccount),
+            isGooglePayReady = true,
+        )
+
+        runActivityScenario(args) {
+            it.onActivity {
+                composeTestRule
+                    .onNodeWithTag("${PAYMENT_OPTION_CARD_TEST_TAG}_$label")
+                    .performClick()
 
                 composeTestRule
-                    .onNodeWithText(text)
+                    .onNodeWithText(mandateText)
                     .assertIsDisplayed()
 
-                viewModel.updateBelowButtonText(null)
+                composeTestRule
+                    .onNodeWithTag("${PAYMENT_OPTION_CARD_TEST_TAG}_Google Pay")
+                    .performClick()
 
                 composeTestRule
-                    .onNodeWithText(text)
+                    .onNodeWithText(mandateText)
                     .assertDoesNotExist()
             }
         }
@@ -312,33 +297,24 @@ internal class PaymentOptionsActivityTest {
 
     @Test
     fun `primary button appearance is set`() {
-        val scenario = activityScenario(
-            createViewModel(
-                args = PAYMENT_OPTIONS_CONTRACT_ARGS.updateState(
-                    stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK
-                )
-            )
-        )
-        scenario.launch(
-            createIntent(
-                args = PAYMENT_OPTIONS_CONTRACT_ARGS.updateState(
-                    stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
-                    config = PaymentSheetFixtures.CONFIG_MINIMUM.copy(
-                        appearance = PaymentSheet.Appearance(
-                            primaryButton = PaymentSheet.PrimaryButton(
-                                colorsLight = PaymentSheet.PrimaryButtonColors(
-                                    background = Color.Magenta,
-                                    onBackground = Color.Magenta,
-                                    border = Color.Magenta
-                                ),
-                                shape = PaymentSheet.PrimaryButtonShape(),
-                                typography = PaymentSheet.PrimaryButtonTypography()
-                            )
-                        )
+        val args = PAYMENT_OPTIONS_CONTRACT_ARGS.updateState(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
+            config = PaymentSheetFixtures.CONFIG_MINIMUM.copy(
+                appearance = PaymentSheet.Appearance(
+                    primaryButton = PaymentSheet.PrimaryButton(
+                        colorsLight = PaymentSheet.PrimaryButtonColors(
+                            background = Color.Magenta,
+                            onBackground = Color.Magenta,
+                            border = Color.Magenta
+                        ),
+                        shape = PaymentSheet.PrimaryButtonShape(),
+                        typography = PaymentSheet.PrimaryButtonTypography()
                     )
                 )
-            )
-        ).use {
+            ),
+        )
+
+        runActivityScenario(args) {
             it.onActivity { activity ->
                 assertThat(activity.viewBinding.continueButton.isVisible).isTrue()
                 assertThat(activity.viewBinding.continueButton.defaultTintList).isEqualTo(
@@ -355,53 +331,22 @@ internal class PaymentOptionsActivityTest {
         assertThat(scenario.state).isEqualTo(Lifecycle.State.DESTROYED)
     }
 
-    @Test
-    fun `Clears error on user selection`() {
-        val scenario = activityScenario()
-        scenario.launch(createIntent()).onActivity {
-            val text = "some error"
-            viewModel.onError(text)
-
-            composeTestRule
-                .onNodeWithText(text)
-                .assertIsDisplayed()
-
-            viewModel.onUserSelection()
-
-            composeTestRule
-                .onNodeWithText(text)
-                .assertDoesNotExist()
-        }
-    }
-
-    private fun createIntent(
-        args: PaymentOptionContract.Args = PAYMENT_OPTIONS_CONTRACT_ARGS
-    ): Intent {
-        return Intent(
+    private fun runActivityScenario(
+        args: PaymentOptionContract.Args = PAYMENT_OPTIONS_CONTRACT_ARGS,
+        block: (InjectableActivityScenario<PaymentOptionsActivity>) -> Unit,
+    ) {
+        val intent = Intent(
             ApplicationProvider.getApplicationContext(),
             PaymentOptionsActivity::class.java
         ).putExtras(
             bundleOf(ActivityStarter.Args.EXTRA to args)
         )
-    }
 
-    private fun activityScenario(
-        viewModel: PaymentOptionsViewModel = this.viewModel
-    ): InjectableActivityScenario<PaymentOptionsActivity> {
-        return injectableActivityScenario {
-            injectActivity {
-                viewModelFactory = viewModelFactoryFor(viewModel)
-            }
-        }
-    }
-
-    private fun createViewModel(
-        args: PaymentOptionContract.Args = PAYMENT_OPTIONS_CONTRACT_ARGS
-    ): PaymentOptionsViewModel {
         val linkPaymentLauncher = mock<LinkPaymentLauncher>().stub {
             onBlocking { getAccountStatusFlow(any()) }.thenReturn(flowOf(AccountStatus.SignedOut))
         }
-        return TestViewModelFactory.create(
+
+        val viewModel = TestViewModelFactory.create(
             linkLauncher = linkPaymentLauncher,
         ) { linkHandler, savedStateHandle ->
             registerFormViewModelInjector()
@@ -420,9 +365,17 @@ internal class PaymentOptionsActivityTest {
                 it.injector = injector
             }
         }
+
+        val scenario = injectableActivityScenario<PaymentOptionsActivity> {
+            injectActivity {
+                viewModelFactory = viewModelFactoryFor(viewModel)
+            }
+        }
+
+        scenario.launchForResult(intent).use(block)
     }
 
-    fun registerFormViewModelInjector() {
+    private fun registerFormViewModelInjector() {
         val formViewModel = FormViewModel(
             context = context,
             formArguments = FormArguments(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request removes direct calls to `PaymentOptionsViewModel` from `PaymentOptionsActivityTest`.

The goal is to make these tests more realistic and avoid testing the same thing in the activity test _and_ view model test.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
