### PR TITLE
Downgrade Maestro to 1.23.1 in CI


### DIFF
--- a/scripts/execute_maestro_tests.sh
+++ b/scripts/execute_maestro_tests.sh
@@ -4,7 +4,7 @@ set -o pipefail
 set -x
 
 # Install Maestro
-curl -Ls "https://get.maestro.mobile.dev" | bash
+export MAESTRO_VERSION=1.21.3; curl -Ls "https://get.maestro.mobile.dev" | bash
 export PATH="$PATH":"$HOME/.maestro/bin"
 maestro -v
 


### PR DESCRIPTION
# Summary
- Maestro keeps failing sporadically on newer versions. Example failure: https://app.bitrise.io/build/854e6523-d5e9-4e61-8df2-fe42043d8b2e
- There's an issue opened on maestro's side: https://github.com/mobile-dev-inc/maestro/issues/877
- We've done the same on react native: https://github.com/stripe/stripe-react-native/commit/1ca5e5621dc363a2c1ddbbdee6be76bb19934b74#diff-194218c48b9a0cdd03974145733804c2d992ca818529fe2fa69a501d8b5b1cc3

# Motivation
:notebook_with_decorative_cover: &nbsp;**Downgrade Maestro to 1.23.1 in CI**
:globe_with_meridians: &nbsp;[BANKCON-6524](https://jira.corp.stripe.com/browse/BANKCON-6524)

> Workaround for <https://github.com/mobile-dev-inc/maestro/issues/877>
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified