### PR TITLE
Use KSP instead of KAPT with Showkase


### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ buildscript {
 plugins {
     id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
     id 'io.codearte.nexus-staging' version '0.30.0'
+    id 'com.google.devtools.ksp' version '1.8.0-1.0.9' apply false
 }
 
 apply plugin: "io.gitlab.arturbosch.detekt"

--- a/financial-connections/build.gradle
+++ b/financial-connections/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'checkstyle'
 apply plugin: 'org.jetbrains.kotlin.plugin.parcelize'
 apply plugin: 'kotlinx-serialization'
 apply plugin: 'app.cash.paparazzi'
+apply plugin: 'com.google.devtools.ksp'
 
 android {
     defaultConfig {
@@ -51,7 +52,7 @@ dependencies {
 
     kapt "com.google.dagger:dagger-compiler:$daggerVersion"
 
-    kaptDebug "com.airbnb.android:showkase-processor:$showkaseVersion"
+    kspDebug "com.airbnb.android:showkase-processor:$showkaseVersion"
 
     testImplementation "androidx.arch.core:core-testing:$androidxArchCoreVersion"
     testImplementation "androidx.fragment:fragment-testing:$androidxFragmentVersion"


### PR DESCRIPTION
# Summary
- see https://github.com/airbnb/Showkase/issues/316
- Replaces kapt by ksp for Showkase.

# Motivation
:notebook_with_decorative_cover: &nbsp;**Use KSP instead of KAPT with Showkase**
:globe_with_meridians: &nbsp;[BANKCON-6525](https://jira.corp.stripe.com/browse/BANKCON-6525)
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->