### PR TITLE
[FC] Allow entering custom keys on Playground app

### DIFF
--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
@@ -129,6 +129,7 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
     }
 
     @Composable
+    @Suppress("LongMethod")
     private fun FinancialConnectionsContent(
         state: FinancialConnectionsPlaygroundState,
         onButtonClick: (Mode, Flow, Pair<String, String>) -> Unit

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
@@ -12,7 +12,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -132,9 +134,9 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
     @Suppress("LongMethod")
     private fun FinancialConnectionsContent(
         state: FinancialConnectionsPlaygroundState,
-        onButtonClick: (Mode, Flow, Pair<String, String>) -> Unit
+        onButtonClick: (Merchant, Flow, Pair<String, String>) -> Unit
     ) {
-        val (selectedMode, onModeSelected) = remember { mutableStateOf(Mode.values()[0]) }
+        val (selectedMode, onModeSelected) = remember { mutableStateOf(Merchant.values()[0]) }
         val (selectedFlow, onFlowSelected) = remember { mutableStateOf(Flow.values()[0]) }
         val (publicKey, onPublicKeyChanged) = remember { mutableStateOf("") }
         val (secretKey, onSecretKeyChanged) = remember { mutableStateOf("") }
@@ -148,8 +150,8 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
                         .padding(16.dp)
                 ) {
                     NativeOverrideSection()
-                    ModeSection(selectedMode, onModeSelected)
-                    if (selectedMode == Mode.Other) {
+                    MerchantSection(selectedMode, onModeSelected)
+                    if (selectedMode == Merchant.Other) {
                         OutlinedTextField(
                             value = publicKey,
                             onValueChange = onPublicKeyChanged,
@@ -167,6 +169,7 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
                                 .fillMaxWidth()
                         )
                     }
+                    Spacer(modifier = Modifier.height(8.dp))
                     FlowSection(selectedFlow, onFlowSelected)
                     if (state.loading) {
                         LinearProgressIndicator(
@@ -244,14 +247,14 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
     }
 
     @Composable
-    private fun ModeSection(
-        selectedOption: Mode,
-        onOptionSelected: (Mode) -> Unit
+    private fun MerchantSection(
+        selectedOption: Merchant,
+        onOptionSelected: (Merchant) -> Unit
     ) {
         var expanded by remember { mutableStateOf(false) }
-        val items = Mode.values()
+        val items = Merchant.values()
         Text(
-            text = "Mode",
+            text = "Merchant",
             style = MaterialTheme.typography.h6.merge(),
         )
         val icon = if (expanded) {
@@ -259,6 +262,7 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
         } else {
             Icons.Filled.KeyboardArrowDown
         }
+        Spacer(modifier = Modifier.height(8.dp))
         Box {
             OutlinedTextField(
                 readOnly = true,

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundActivity.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -129,10 +131,12 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
     @Composable
     private fun FinancialConnectionsContent(
         state: FinancialConnectionsPlaygroundState,
-        onButtonClick: (Mode, Flow) -> Unit
+        onButtonClick: (Mode, Flow, Pair<String, String>) -> Unit
     ) {
         val (selectedMode, onModeSelected) = remember { mutableStateOf(Mode.values()[0]) }
         val (selectedFlow, onFlowSelected) = remember { mutableStateOf(Flow.values()[0]) }
+        val (publicKey, onPublicKeyChanged) = remember { mutableStateOf("") }
+        val (secretKey, onSecretKeyChanged) = remember { mutableStateOf("") }
 
         Scaffold(
             topBar = { TopAppBar(title = { Text("Connections Playground") }) },
@@ -144,6 +148,24 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
                 ) {
                     NativeOverrideSection()
                     ModeSection(selectedMode, onModeSelected)
+                    if (selectedMode == Mode.Other) {
+                        OutlinedTextField(
+                            value = publicKey,
+                            onValueChange = onPublicKeyChanged,
+                            placeholder = { Text("pk_...") },
+                            label = { Text("Public key") },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                        )
+                        OutlinedTextField(
+                            value = secretKey,
+                            onValueChange = onSecretKeyChanged,
+                            placeholder = { Text("sk_...") },
+                            label = { Text("Secret key") },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                        )
+                    }
                     FlowSection(selectedFlow, onFlowSelected)
                     if (state.loading) {
                         LinearProgressIndicator(
@@ -158,7 +180,8 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
                         onClick = {
                             onButtonClick(
                                 selectedMode,
-                                selectedFlow
+                                selectedFlow,
+                                publicKey to secretKey
                             )
                         },
                     ) {
@@ -273,6 +296,7 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
         }
     }
 
+    @OptIn(ExperimentalLayoutApi::class)
     @Composable
     private fun FlowSection(
         selectedOption: Flow,
@@ -282,7 +306,7 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
             text = "Flow",
             style = MaterialTheme.typography.h6.merge(),
         )
-        Row(
+        FlowRow(
             verticalAlignment = Alignment.CenterVertically
         ) {
             Flow.values().forEach { text ->
@@ -311,7 +335,7 @@ class FinancialConnectionsPlaygroundActivity : AppCompatActivity() {
                 publishableKey = "pk",
                 status = listOf("Result: Pending")
             ),
-            onButtonClick = { _, _ -> }
+            onButtonClick = { _, _, _ -> }
         )
     }
 }

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
@@ -65,7 +65,11 @@ class FinancialConnectionsPlaygroundViewModel(
                         current.copy(
                             publishableKey = it.publishableKey,
                             loading = true,
-                            status = current.status + "Payment Intent created ${it.intentSecret}, opening FinancialConnectionsSheet."
+                            status = current.status + buildString {
+                                append("Payment Intent created: ${it.intentSecret}")
+                                appendLine()
+                                append("Opening FinancialConnectionsSheet.")
+                            }
                         )
                     }
                     _viewEffect.emit(

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
@@ -38,20 +38,27 @@ class FinancialConnectionsPlaygroundViewModel(
 
     fun startFinancialConnectionsSession(
         mode: Mode,
-        flow: Flow
+        flow: Flow,
+        keys: Pair<String, String>
     ) {
         _state.update { it.copy(status = emptyList()) }
         when (flow) {
-            Flow.Data -> startForData(mode)
-            Flow.Token -> startForToken(mode)
-            Flow.PaymentIntent -> startWithPaymentIntent(mode)
+            Flow.Data -> startForData(mode, keys)
+            Flow.Token -> startForToken(mode, keys)
+            Flow.PaymentIntent -> startWithPaymentIntent(mode, keys)
         }
     }
 
-    private fun startWithPaymentIntent(mode: Mode) {
+    private fun startWithPaymentIntent(mode: Mode, keys: Pair<String, String>) {
         viewModelScope.launch {
             showLoadingWithMessage("Fetching link account session from example backend!")
-            kotlin.runCatching { repository.createPaymentIntent("US", mode.flow) }
+            kotlin.runCatching {
+                repository.createPaymentIntent(
+                    country = "US",
+                    flow = mode.flow,
+                    keys = keys
+                )
+            }
                 // Success creating session: open the financial connections sheet with received secret
                 .onSuccess {
                     _state.update { current ->
@@ -73,10 +80,15 @@ class FinancialConnectionsPlaygroundViewModel(
         }
     }
 
-    private fun startForData(mode: Mode) {
+    private fun startForData(mode: Mode, keys: Pair<String, String>) {
         viewModelScope.launch {
             showLoadingWithMessage("Fetching link account session from example backend!")
-            kotlin.runCatching { repository.createLinkAccountSession(mode.flow) }
+            kotlin.runCatching {
+                repository.createLinkAccountSession(
+                    flow = mode.flow,
+                    keys = keys
+                )
+            }
                 // Success creating session: open the financial connections sheet with received secret
                 .onSuccess {
                     showLoadingWithMessage("Session created, opening FinancialConnectionsSheet.")
@@ -95,10 +107,15 @@ class FinancialConnectionsPlaygroundViewModel(
         }
     }
 
-    private fun startForToken(mode: Mode) {
+    private fun startForToken(mode: Mode, keys: Pair<String, String>) {
         viewModelScope.launch {
             showLoadingWithMessage("Fetching link account session from example backend!")
-            kotlin.runCatching { repository.createLinkAccountSessionForToken(mode.flow) }
+            kotlin.runCatching {
+                repository.createLinkAccountSessionForToken(
+                    flow = mode.flow,
+                    keys = keys
+                )
+            }
                 // Success creating session: open the financial connections sheet with received secret
                 .onSuccess {
                     showLoadingWithMessage("Session created, opening FinancialConnectionsSheet.")
@@ -194,7 +211,7 @@ class FinancialConnectionsPlaygroundViewModel(
 }
 
 enum class Mode(val flow: String) {
-    Test("testmode"), Live("mx"), App2App("app2app")
+    Test("testmode"), Live("mx"), App2App("app2app"), Other("other")
 }
 
 enum class Flow {

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
@@ -37,25 +37,25 @@ class FinancialConnectionsPlaygroundViewModel(
     }
 
     fun startFinancialConnectionsSession(
-        mode: Mode,
+        merchant: Merchant,
         flow: Flow,
         keys: Pair<String, String>
     ) {
         _state.update { it.copy(status = emptyList()) }
         when (flow) {
-            Flow.Data -> startForData(mode, keys)
-            Flow.Token -> startForToken(mode, keys)
-            Flow.PaymentIntent -> startWithPaymentIntent(mode, keys)
+            Flow.Data -> startForData(merchant, keys)
+            Flow.Token -> startForToken(merchant, keys)
+            Flow.PaymentIntent -> startWithPaymentIntent(merchant, keys)
         }
     }
 
-    private fun startWithPaymentIntent(mode: Mode, keys: Pair<String, String>) {
+    private fun startWithPaymentIntent(merchant: Merchant, keys: Pair<String, String>) {
         viewModelScope.launch {
             showLoadingWithMessage("Fetching link account session from example backend!")
             kotlin.runCatching {
                 repository.createPaymentIntent(
                     country = "US",
-                    flow = mode.flow,
+                    flow = merchant.flow,
                     keys = keys
                 )
             }
@@ -84,12 +84,12 @@ class FinancialConnectionsPlaygroundViewModel(
         }
     }
 
-    private fun startForData(mode: Mode, keys: Pair<String, String>) {
+    private fun startForData(merchant: Merchant, keys: Pair<String, String>) {
         viewModelScope.launch {
             showLoadingWithMessage("Fetching link account session from example backend!")
             kotlin.runCatching {
                 repository.createLinkAccountSession(
-                    flow = mode.flow,
+                    flow = merchant.flow,
                     keys = keys
                 )
             }
@@ -111,12 +111,12 @@ class FinancialConnectionsPlaygroundViewModel(
         }
     }
 
-    private fun startForToken(mode: Mode, keys: Pair<String, String>) {
+    private fun startForToken(merchant: Merchant, keys: Pair<String, String>) {
         viewModelScope.launch {
             showLoadingWithMessage("Fetching link account session from example backend!")
             kotlin.runCatching {
                 repository.createLinkAccountSessionForToken(
-                    flow = mode.flow,
+                    flow = merchant.flow,
                     keys = keys
                 )
             }
@@ -214,7 +214,7 @@ class FinancialConnectionsPlaygroundViewModel(
     )
 }
 
-enum class Mode(val flow: String) {
+enum class Merchant(val flow: String) {
     Test("testmode"), Live("mx"), App2App("app2app"), Other("other")
 }
 

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/BackendApiService.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/BackendApiService.kt
@@ -27,7 +27,11 @@ interface BackendApiService {
 @Keep
 data class LinkAccountSessionBody(
     @SerializedName("flow")
-    val flow: String?
+    val flow: String?,
+    @SerializedName("custom_pk")
+    val publishableKey: String?,
+    @SerializedName("custom_sk")
+    val secretKey: String?
 )
 
 @Keep
@@ -39,5 +43,9 @@ data class PaymentIntentBody(
     @SerializedName("customer_id")
     val customerId: String?,
     @SerializedName("supported_payment_methods")
-    val supportedPaymentMethods: String?
+    val supportedPaymentMethods: String?,
+    @SerializedName("custom_pk")
+    val publishableKey: String?,
+    @SerializedName("custom_sk")
+    val secretKey: String?
 )

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/BackendRepository.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/data/BackendRepository.kt
@@ -7,27 +7,42 @@ class BackendRepository(
 ) {
     private val backendService: BackendApiService = BackendApiFactory(settings).create()
 
-    suspend fun createLinkAccountSession(flow: String? = null) =
-        backendService.createLinkAccountSession(
-            LinkAccountSessionBody(flow)
+    suspend fun createLinkAccountSession(
+        flow: String? = null,
+        keys: Pair<String, String>? = null
+    ) = backendService.createLinkAccountSession(
+        LinkAccountSessionBody(
+            flow = flow,
+            publishableKey = keys?.first,
+            secretKey = keys?.second
         )
+    )
 
-    suspend fun createLinkAccountSessionForToken(flow: String? = null) =
-        backendService.createLinkAccountSessionForToken(
-            LinkAccountSessionBody(flow)
+    suspend fun createLinkAccountSessionForToken(
+        flow: String? = null,
+        keys: Pair<String, String>? = null
+    ) = backendService.createLinkAccountSessionForToken(
+        LinkAccountSessionBody(
+            flow = flow,
+            publishableKey = keys?.first,
+            secretKey = keys?.second
         )
+    )
 
     suspend fun createPaymentIntent(
         country: String,
         flow: String? = null,
         customerId: String? = null,
-        supportedPaymentMethods: String? = null
+        supportedPaymentMethods: String? = null,
+        keys: Pair<String, String>? = null
     ): CreateIntentResponse = backendService.createPaymentIntent(
         PaymentIntentBody(
             flow = flow,
             country = country,
             customerId = customerId,
-            supportedPaymentMethods = supportedPaymentMethods
+            supportedPaymentMethods = supportedPaymentMethods,
+            publishableKey = keys?.first,
+            secretKey = keys?.second
         )
     )
 }


### PR DESCRIPTION
# Summary
- Adds custom keys fields to playground app.  
# Motivation
:notebook_with_decorative_cover: &nbsp;**Allow entering custom keys on Playground app**
:globe_with_meridians: &nbsp;[BANKCON-6526](https://jira.corp.stripe.com/browse/BANKCON-6526)
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Manually verified

[Screen_recording_20230405_130717.webm](https://user-images.githubusercontent.com/99293320/230199535-b5ae83e6-1330-4265-a28a-8cb3ac82d1c7.webm)