### PR TITLE
Fail or no-op calls on `FlowController` if configure call in-flight or failed

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -230,9 +230,9 @@ internal class DefaultFlowController @Inject internal constructor(
                 "configureWithIntentConfiguration() before calling presentPaymentOptions()."
         )
 
-        if (configurationHandler.isConfiguring || viewModel.didLastConfigurationFail) {
-            // "Cannot call presentPaymentOptions when the last update call
-            // has not yet finished or failed."
+        if (!configurationHandler.isConfigured) {
+            // For now, we fail silently in these situations. In the future, we should either log
+            // or emit an event in a to-be-added event listener.
             return
         }
 
@@ -254,7 +254,7 @@ internal class DefaultFlowController @Inject internal constructor(
                 "configureWithIntentConfiguration() before calling confirm()."
         )
 
-        if (configurationHandler.isConfiguring || viewModel.didLastConfigurationFail) {
+        if (!configurationHandler.isConfigured) {
             val error = IllegalStateException(
                 "FlowController.confirm() can only be called if the most recent call " +
                     "to configureWithPaymentIntent(), configureWithSetupIntent() or " +

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -226,7 +226,8 @@ internal class DefaultFlowController @Inject internal constructor(
     override fun presentPaymentOptions() {
         val state = viewModel.state ?: error(
             "FlowController must be successfully initialized " +
-                "using ${formattedConfigureMethodNames()} before calling presentPaymentOptions()."
+                "using configureWithPaymentIntent(), configureWithSetupIntent() or " +
+                "configureWithIntentConfiguration() before calling presentPaymentOptions()."
         )
 
         if (configurationHandler.isConfiguring || viewModel.didLastConfigurationFail) {
@@ -249,13 +250,15 @@ internal class DefaultFlowController @Inject internal constructor(
     override fun confirm() {
         val state = viewModel.state ?: error(
             "FlowController must be successfully initialized " +
-                "using ${formattedConfigureMethodNames()} before calling confirm()."
+                "using configureWithPaymentIntent(), configureWithSetupIntent() or " +
+                "configureWithIntentConfiguration() before calling confirm()."
         )
 
         if (configurationHandler.isConfiguring || viewModel.didLastConfigurationFail) {
             val error = IllegalStateException(
                 "FlowController.confirm() can only be called if the most recent call " +
-                    "to ${formattedConfigureMethodNames()} has completed successfully."
+                    "to configureWithPaymentIntent(), configureWithSetupIntent() or " +
+                    "configureWithIntentConfiguration() has completed successfully."
             )
             onPaymentResult(PaymentResult.Failed(error))
             return
@@ -536,26 +539,6 @@ internal class DefaultFlowController @Inject internal constructor(
         is LinkActivityResult.Completed -> PaymentResult.Completed
         is LinkActivityResult.Canceled -> PaymentResult.Canceled
         is LinkActivityResult.Failed -> PaymentResult.Failed(error)
-    }
-
-    @OptIn(ExperimentalPaymentSheetDecouplingApi::class)
-    private fun formattedConfigureMethodNames(): String {
-        val configureMethods = listOf(
-            this::configureWithPaymentIntent,
-            this::configureWithSetupIntent,
-            this::configureWithIntentConfiguration,
-        ).map { it.name }
-
-        return buildString {
-            configureMethods.forEachIndexed { index, method ->
-                append("$method()")
-                if (index == configureMethods.lastIndex - 1) {
-                    append(" or ")
-                } else if (index < configureMethods.lastIndex) {
-                    append(", ")
-                }
-            }
-        }
     }
 
     class GooglePayException(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
@@ -27,8 +27,13 @@ internal class FlowControllerConfigurationHandler @Inject constructor(
 
     private val job: AtomicReference<Job?> = AtomicReference(null)
 
-    val isConfiguring: Boolean
-        get() = job.get()?.let { !it.isCompleted } ?: false
+    private var didLastConfigurationFail: Boolean = false
+
+    val isConfigured: Boolean
+        get() {
+            val isConfiguring = job.get()?.let { !it.isCompleted } ?: false
+            return !isConfiguring && !didLastConfigurationFail
+        }
 
     fun configure(
         scope: CoroutineScope,
@@ -55,7 +60,7 @@ internal class FlowControllerConfigurationHandler @Inject constructor(
     ) {
         suspend fun onConfigured(error: Throwable? = null) {
             withContext(uiContext) {
-                viewModel.didLastConfigurationFail = error != null
+                didLastConfigurationFail = error != null
                 resetJob()
                 callback.onConfigured(success = error == null, error = error)
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
@@ -28,7 +28,7 @@ internal class FlowControllerConfigurationHandler @Inject constructor(
     private val job: AtomicReference<Job?> = AtomicReference(null)
 
     val isConfiguring: Boolean
-        get() = job.get() != null
+        get() = job.get()?.let { !it.isCompleted } ?: false
 
     fun configure(
         scope: CoroutineScope,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
@@ -27,6 +27,9 @@ internal class FlowControllerConfigurationHandler @Inject constructor(
 
     private val job: AtomicReference<Job?> = AtomicReference(null)
 
+    val isConfiguring: Boolean
+        get() = job.get() != null
+
     fun configure(
         scope: CoroutineScope,
         initializationMode: PaymentSheet.InitializationMode,
@@ -52,6 +55,7 @@ internal class FlowControllerConfigurationHandler @Inject constructor(
     ) {
         suspend fun onConfigured(error: Throwable? = null) {
             withContext(uiContext) {
+                viewModel.didLastConfigurationFail = error != null
                 resetJob()
                 callback.onConfigured(success = error == null, error = error)
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
@@ -22,7 +22,6 @@ internal class FlowControllerViewModel(
 
     // Used to determine if we need to reload the flow controller configuration.
     var previousConfigureRequest: FlowControllerConfigurationHandler.ConfigureRequest? = null
-    var didLastConfigurationFail: Boolean = false
 
     var state: PaymentSheetState.Full?
         get() = handle[STATE_KEY]

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
@@ -22,6 +22,7 @@ internal class FlowControllerViewModel(
 
     // Used to determine if we need to reload the flow controller configuration.
     var previousConfigureRequest: FlowControllerConfigurationHandler.ConfigureRequest? = null
+    var didLastConfigurationFail: Boolean = false
 
     var state: PaymentSheetState.Full?
         get() = handle[STATE_KEY]

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -1081,7 +1081,9 @@ internal class DefaultFlowControllerTest {
             configuration = PaymentSheet.Configuration(
                 merchantDisplayName = "Monsters, Inc.",
             ),
-        ) { _, _ -> }
+        ) { _, _ ->
+            throw AssertionError("ConfirmCallback shouldn't have been called")
+        }
 
         flowController.confirm()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
@@ -83,7 +83,7 @@ class FlowControllerConfigurationHandlerTest {
 
         assertThat(configureErrors.awaitItem()).isNull()
         assertThat(viewModel.previousConfigureRequest).isNotNull()
-        assertThat(viewModel.didLastConfigurationFail).isFalse()
+        assertThat(configurationHandler.isConfigured).isTrue()
         assertThat(viewModel.paymentSelection).isEqualTo(PaymentSelection.Link)
         assertThat(viewModel.state).isNotNull()
         verify(eventReporter)
@@ -115,7 +115,7 @@ class FlowControllerConfigurationHandlerTest {
 
         assertThat(configureErrors.awaitItem()).isNull()
         assertThat(viewModel.previousConfigureRequest).isSameInstanceAs(configureRequest)
-        assertThat(viewModel.didLastConfigurationFail).isFalse()
+        assertThat(configurationHandler.isConfigured).isTrue()
         assertThat(viewModel.paymentSelection).isEqualTo(PaymentSelection.GooglePay)
 
         // We're running ONLY the second config run, so we don't expect any interactions.
@@ -150,7 +150,7 @@ class FlowControllerConfigurationHandlerTest {
 
         assertThat(configureErrors.awaitItem()).isNull()
         assertThat(viewModel.previousConfigureRequest).isEqualTo(newConfigureRequest)
-        assertThat(viewModel.didLastConfigurationFail).isFalse()
+        assertThat(configurationHandler.isConfigured).isTrue()
         assertThat(viewModel.paymentSelection).isEqualTo(PaymentSelection.Link)
 
         // We're running a new config, so we DO expect an interaction.
@@ -185,7 +185,7 @@ class FlowControllerConfigurationHandlerTest {
 
         assertThat(configureErrors.awaitItem()).isNull()
         assertThat(viewModel.previousConfigureRequest).isEqualTo(newConfigureRequest)
-        assertThat(viewModel.didLastConfigurationFail).isFalse()
+        assertThat(configurationHandler.isConfigured).isTrue()
         assertThat(viewModel.paymentSelection).isEqualTo(PaymentSelection.Link)
 
         // We're running a new config, so we DO expect an interaction.
@@ -385,7 +385,7 @@ class FlowControllerConfigurationHandlerTest {
         }
 
         assertThat(resultTurbine.awaitItem()).isNotNull()
-        assertThat(viewModel.didLastConfigurationFail).isTrue()
+        assertThat(configurationHandler.isConfigured).isFalse()
     }
 
     private fun defaultPaymentSheetLoader(): PaymentSheetLoader {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
@@ -83,6 +83,7 @@ class FlowControllerConfigurationHandlerTest {
 
         assertThat(configureErrors.awaitItem()).isNull()
         assertThat(viewModel.previousConfigureRequest).isNotNull()
+        assertThat(viewModel.didLastConfigurationFail).isFalse()
         assertThat(viewModel.paymentSelection).isEqualTo(PaymentSelection.Link)
         assertThat(viewModel.state).isNotNull()
         verify(eventReporter)
@@ -114,6 +115,7 @@ class FlowControllerConfigurationHandlerTest {
 
         assertThat(configureErrors.awaitItem()).isNull()
         assertThat(viewModel.previousConfigureRequest).isSameInstanceAs(configureRequest)
+        assertThat(viewModel.didLastConfigurationFail).isFalse()
         assertThat(viewModel.paymentSelection).isEqualTo(PaymentSelection.GooglePay)
 
         // We're running ONLY the second config run, so we don't expect any interactions.
@@ -148,6 +150,7 @@ class FlowControllerConfigurationHandlerTest {
 
         assertThat(configureErrors.awaitItem()).isNull()
         assertThat(viewModel.previousConfigureRequest).isEqualTo(newConfigureRequest)
+        assertThat(viewModel.didLastConfigurationFail).isFalse()
         assertThat(viewModel.paymentSelection).isEqualTo(PaymentSelection.Link)
 
         // We're running a new config, so we DO expect an interaction.
@@ -182,6 +185,7 @@ class FlowControllerConfigurationHandlerTest {
 
         assertThat(configureErrors.awaitItem()).isNull()
         assertThat(viewModel.previousConfigureRequest).isEqualTo(newConfigureRequest)
+        assertThat(viewModel.didLastConfigurationFail).isFalse()
         assertThat(viewModel.paymentSelection).isEqualTo(PaymentSelection.Link)
 
         // We're running a new config, so we DO expect an interaction.
@@ -361,6 +365,27 @@ class FlowControllerConfigurationHandlerTest {
         loader.enqueueSuccess()
 
         resultTurbine.expectNoEvents()
+    }
+
+    @Test
+    fun `Records configuration failure correctly in view model`() = runTest {
+        val resultTurbine = Turbine<Throwable?>()
+        val configurationHandler = createConfigurationHandler(
+            paymentSheetLoader = FakePaymentSheetLoader(shouldFail = true),
+        )
+
+        configurationHandler.configure(
+            scope = this,
+            initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
+                clientSecret = PaymentSheetFixtures.CLIENT_SECRET,
+            ),
+            configuration = null,
+        ) { _, exception ->
+            resultTurbine.add(exception)
+        }
+
+        assertThat(resultTurbine.awaitItem()).isNotNull()
+        assertThat(viewModel.didLastConfigurationFail).isTrue()
     }
 
     private fun defaultPaymentSheetLoader(): PaymentSheetLoader {

--- a/paymentsheet/src/test/java/com/stripe/android/utils/RelayingPaymentSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/RelayingPaymentSheetLoader.kt
@@ -1,0 +1,46 @@
+package com.stripe.android.utils
+
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.state.PaymentSheetLoader
+import com.stripe.android.paymentsheet.state.PaymentSheetState
+import com.stripe.android.testing.PaymentIntentFactory
+import kotlinx.coroutines.channels.Channel
+
+internal class RelayingPaymentSheetLoader : PaymentSheetLoader {
+
+    private val results = Channel<PaymentSheetLoader.Result>(capacity = 1)
+
+    fun enqueueSuccess(
+        stripeIntent: StripeIntent = PaymentIntentFactory.create(),
+    ) {
+        enqueue(
+            PaymentSheetLoader.Result.Success(
+                state = PaymentSheetState.Full(
+                    stripeIntent = stripeIntent,
+                    customerPaymentMethods = emptyList(),
+                    config = null,
+                    isGooglePayReady = false,
+                    paymentSelection = null,
+                    linkState = null,
+                ),
+            )
+        )
+    }
+
+    fun enqueueFailure() {
+        val error = RuntimeException("whoops")
+        enqueue(PaymentSheetLoader.Result.Failure(error))
+    }
+
+    private fun enqueue(result: PaymentSheetLoader.Result) {
+        results.trySend(result)
+    }
+
+    override suspend fun load(
+        initializationMode: PaymentSheet.InitializationMode,
+        paymentSheetConfiguration: PaymentSheet.Configuration?
+    ): PaymentSheetLoader.Result {
+        return results.receive()
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds some new behavior to `FlowController`:

- If the most recent configure call is still in-flight or has failed, we don’t do anything on `presentPaymentOptions()`.
- If the most recent configure call is still in-flight or has failed, we return a `PaymentSheetResult.Failed` on `confirm()`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
