### PR TITLE
[FC Networking] Add new connections-specific consumer endpoints


### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
@@ -22,6 +22,7 @@ import com.stripe.android.financialconnections.repository.FinancialConnectionsCo
 import com.stripe.android.financialconnections.repository.FinancialConnectionsInstitutionsRepository
 import com.stripe.android.financialconnections.repository.FinancialConnectionsManifestRepository
 import com.stripe.android.financialconnections.repository.SaveToLinkWithStripeSucceededRepository
+import com.stripe.android.financialconnections.repository.api.FinancialConnectionsConsumersApiService
 import com.stripe.android.repository.ConsumersApiService
 import com.stripe.android.repository.ConsumersApiServiceImpl
 import com.stripe.android.uicore.image.StripeImageLoader
@@ -99,13 +100,11 @@ internal class FinancialConnectionsSheetNativeModule {
     @Singleton
     @Provides
     fun providesFinancialConnectionsConsumerSessionRepository(
-        consumersApiService: ConsumersApiService,
-        apiOptions: ApiRequest.Options,
+        consumersApiService: FinancialConnectionsConsumersApiService,
         locale: Locale?,
         logger: Logger,
     ) = FinancialConnectionsConsumerSessionRepository(
         consumersApiService = consumersApiService,
-        apiOptions = apiOptions,
         locale = locale ?: Locale.getDefault(),
         logger = logger,
     )
@@ -140,5 +139,16 @@ internal class FinancialConnectionsSheetNativeModule {
     @Provides
     fun providesSaveToLinkWithStripeSucceededRepository() = SaveToLinkWithStripeSucceededRepository(
         CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    )
+
+    @Provides
+    internal fun provideFinancialConnectionsConsumersApiService(
+        requestExecutor: FinancialConnectionsRequestExecutor,
+        apiOptions: ApiRequest.Options,
+        apiRequestFactory: ApiRequest.Factory,
+    ): FinancialConnectionsConsumersApiService = FinancialConnectionsConsumersApiService(
+        apiOptions = apiOptions,
+        apiRequestFactory = apiRequestFactory,
+        requestExecutor = requestExecutor
     )
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetNativeModule.kt
@@ -100,11 +100,15 @@ internal class FinancialConnectionsSheetNativeModule {
     @Singleton
     @Provides
     fun providesFinancialConnectionsConsumerSessionRepository(
-        consumersApiService: FinancialConnectionsConsumersApiService,
+        consumersApiService: ConsumersApiService,
+        apiOptions: ApiRequest.Options,
+        financialConnectionsConsumersApiService: FinancialConnectionsConsumersApiService,
         locale: Locale?,
         logger: Logger,
     ) = FinancialConnectionsConsumerSessionRepository(
+        financialConnectionsConsumersApiService = financialConnectionsConsumersApiService,
         consumersApiService = consumersApiService,
+        apiOptions = apiOptions,
         locale = locale ?: Locale.getDefault(),
         logger = logger,
     )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/LookupAccount.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/LookupAccount.kt
@@ -1,11 +1,13 @@
 package com.stripe.android.financialconnections.domain
 
+import com.stripe.android.financialconnections.FinancialConnectionsSheet
 import com.stripe.android.financialconnections.repository.FinancialConnectionsConsumerSessionRepository
 import com.stripe.android.model.ConsumerSessionLookup
 import javax.inject.Inject
 
 internal class LookupAccount @Inject constructor(
-    private val consumerSessionRepository: FinancialConnectionsConsumerSessionRepository
+    private val consumerSessionRepository: FinancialConnectionsConsumerSessionRepository,
+    val configuration: FinancialConnectionsSheet.Configuration,
 ) {
 
     suspend operator fun invoke(
@@ -13,6 +15,7 @@ internal class LookupAccount @Inject constructor(
     ): ConsumerSessionLookup = requireNotNull(
         consumerSessionRepository.lookupConsumerSession(
             email = email.lowercase().trim(),
+            clientSecret = configuration.financialConnectionsSessionClientSecret
         )
     )
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/network/FinancialConnectionsRequestExecutor.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/network/FinancialConnectionsRequestExecutor.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.financialconnections.network
 
-import android.util.Log
 import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.exception.AuthenticationException
@@ -67,7 +66,6 @@ internal class FinancialConnectionsRequestExecutor @Inject constructor(
         val requestId = response.requestId?.value
         val responseCode = response.code
         val stripeError = StripeErrorJsonParser().parse(response.responseJson())
-        Log.e("ERROR", stripeError.toString())
         throw when (responseCode) {
             HttpURLConnection.HTTP_ACCEPTED,
             HttpURLConnection.HTTP_BAD_REQUEST,
@@ -76,7 +74,6 @@ internal class FinancialConnectionsRequestExecutor @Inject constructor(
                 requestId,
                 responseCode
             )
-
             HttpURLConnection.HTTP_UNAUTHORIZED -> AuthenticationException(stripeError, requestId)
             HttpURLConnection.HTTP_FORBIDDEN -> PermissionException(stripeError, requestId)
             HTTP_TOO_MANY_REQUESTS -> RateLimitException(stripeError, requestId)

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/network/FinancialConnectionsRequestExecutor.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/network/FinancialConnectionsRequestExecutor.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.network
 
+import android.util.Log
 import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.exception.AuthenticationException
@@ -66,6 +67,7 @@ internal class FinancialConnectionsRequestExecutor @Inject constructor(
         val requestId = response.requestId?.value
         val responseCode = response.code
         val stripeError = StripeErrorJsonParser().parse(response.responseJson())
+        Log.e("ERROR", stripeError.toString())
         throw when (responseCode) {
             HttpURLConnection.HTTP_ACCEPTED,
             HttpURLConnection.HTTP_BAD_REQUEST,
@@ -74,6 +76,7 @@ internal class FinancialConnectionsRequestExecutor @Inject constructor(
                 requestId,
                 responseCode
             )
+
             HttpURLConnection.HTTP_UNAUTHORIZED -> AuthenticationException(stripeError, requestId)
             HttpURLConnection.HTTP_FORBIDDEN -> PermissionException(stripeError, requestId)
             HTTP_TOO_MANY_REQUESTS -> RateLimitException(stripeError, requestId)

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepository.kt
@@ -1,12 +1,11 @@
 package com.stripe.android.financialconnections.repository
 
 import com.stripe.android.core.Logger
-import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.financialconnections.repository.api.FinancialConnectionsConsumersApiService
 import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.ConsumerSessionLookup
 import com.stripe.android.model.CustomEmailType
 import com.stripe.android.model.VerificationType
-import com.stripe.android.repository.ConsumersApiService
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.util.Locale
@@ -30,23 +29,20 @@ internal interface FinancialConnectionsConsumerSessionRepository {
 
     companion object {
         operator fun invoke(
-            consumersApiService: ConsumersApiService,
-            apiOptions: ApiRequest.Options,
+            consumersApiService: FinancialConnectionsConsumersApiService,
             locale: Locale?,
             logger: Logger,
         ): FinancialConnectionsConsumerSessionRepository =
             FinancialConnectionsConsumerSessionRepositoryImpl(
-                consumersApiService,
-                apiOptions,
-                locale,
-                logger,
+                consumersApiService = consumersApiService,
+                locale = locale,
+                logger = logger,
             )
     }
 }
 
 private class FinancialConnectionsConsumerSessionRepositoryImpl(
-    private val consumersApiService: ConsumersApiService,
-    private val apiOptions: ApiRequest.Options,
+    private val consumersApiService: FinancialConnectionsConsumersApiService,
     private val locale: Locale?,
     private val logger: Logger,
 ) : FinancialConnectionsConsumerSessionRepository {
@@ -79,7 +75,6 @@ private class FinancialConnectionsConsumerSessionRepositoryImpl(
             requestSurface = CONSUMER_SURFACE,
             type = type,
             customEmailType = customEmailType,
-            requestOptions = apiOptions
         ).also { session ->
             updateCachedConsumerSession("startConsumerVerification", session)
         }
@@ -96,7 +91,6 @@ private class FinancialConnectionsConsumerSessionRepositoryImpl(
             verificationCode = verificationCode,
             type = type,
             requestSurface = CONSUMER_SURFACE,
-            requestOptions = apiOptions
         ).also { session ->
             updateCachedConsumerSession("confirmConsumerVerification", session)
         }
@@ -107,7 +101,6 @@ private class FinancialConnectionsConsumerSessionRepositoryImpl(
             email = email,
             authSessionCookie = null,
             requestSurface = CONSUMER_SURFACE,
-            requestOptions = apiOptions
         )
 
     private fun updateCachedConsumerSession(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepository.kt
@@ -69,7 +69,7 @@ private class FinancialConnectionsConsumerSessionRepositoryImpl(
         email: String,
         clientSecret: String
     ): ConsumerSessionLookup = mutex.withLock {
-        lookupRequest(email, clientSecret).also { lookup ->
+        postConsumerSession(email, clientSecret).also { lookup ->
             updateCachedConsumerSession("lookupConsumerSession", lookup.consumerSession)
         }
     }
@@ -111,12 +111,14 @@ private class FinancialConnectionsConsumerSessionRepositoryImpl(
         }
     }
 
-    private suspend fun lookupRequest(email: String, clientSecret: String): ConsumerSessionLookup =
-        financialConnectionsConsumersApiService.postConsumerSession(
-            email = email,
-            clientSecret = clientSecret,
-            requestSurface = CONSUMER_SURFACE,
-        )
+    private suspend fun postConsumerSession(
+        email: String,
+        clientSecret: String
+    ): ConsumerSessionLookup = financialConnectionsConsumersApiService.postConsumerSession(
+        email = email,
+        clientSecret = clientSecret,
+        requestSurface = CONSUMER_SURFACE,
+    )
 
     private fun updateCachedConsumerSession(
         source: String,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepository.kt
@@ -98,7 +98,7 @@ private class FinancialConnectionsConsumerSessionRepositoryImpl(
         consumerSessionClientSecret: String,
         verificationCode: String,
         type: VerificationType
-    ): ConsumerSession {
+    ): ConsumerSession = mutex.withLock {
         return consumersApiService.confirmConsumerVerification(
             consumerSessionClientSecret = consumerSessionClientSecret,
             authSessionCookie = null,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/api/FinancialConnectionsConsumersApiService.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/api/FinancialConnectionsConsumersApiService.kt
@@ -3,38 +3,17 @@ package com.stripe.android.financialconnections.repository.api
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.financialconnections.network.FinancialConnectionsRequestExecutor
-import com.stripe.android.model.ConsumerSession
+import com.stripe.android.financialconnections.utils.filterNotNullValues
 import com.stripe.android.model.ConsumerSessionLookup
-import com.stripe.android.model.CustomEmailType
-import com.stripe.android.model.VerificationType
-import java.util.Locale
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 internal interface FinancialConnectionsConsumersApiService {
 
-    suspend fun lookupConsumerSession(
-        email: String?,
-        authSessionCookie: String?,
+    suspend fun postConsumerSession(
+        email: String,
+        clientSecret: String,
         requestSurface: String,
     ): ConsumerSessionLookup
-
-    suspend fun startConsumerVerification(
-        consumerSessionClientSecret: String,
-        locale: Locale,
-        authSessionCookie: String?,
-        requestSurface: String,
-        type: VerificationType,
-        customEmailType: CustomEmailType?,
-        connectionsMerchantName: String?,
-    ): ConsumerSession
-
-    suspend fun confirmConsumerVerification(
-        consumerSessionClientSecret: String,
-        verificationCode: String,
-        authSessionCookie: String?,
-        requestSurface: String,
-        type: VerificationType,
-    ): ConsumerSession
 
     companion object {
         operator fun invoke(
@@ -60,30 +39,19 @@ private class FinancialConnectionsConsumersApiServiceImpl(
     /**
      * Retrieves the ConsumerSession if the given email is associated with a Link account.
      */
-    override suspend fun lookupConsumerSession(
-        email: String?,
-        authSessionCookie: String?,
+    override suspend fun postConsumerSession(
+        email: String,
+        clientSecret: String,
         requestSurface: String,
     ): ConsumerSessionLookup {
         val request = apiRequestFactory.createPost(
-            consumerSessionLookupUrl,
+            consumerSessionsUrl,
             apiOptions,
             mapOf(
+                "email_address" to email.lowercase(),
+                "client_secret" to clientSecret,
                 "request_surface" to requestSurface
-            ).plus(
-                email?.let {
-                    mapOf(
-                        "email_address" to it.lowercase()
-                    )
-                } ?: emptyMap()
-            ).plus(
-                authSessionCookie?.let {
-                    mapOf(
-                        "cookies" to
-                            mapOf("verification_session_client_secrets" to listOf(it))
-                    )
-                } ?: emptyMap()
-            )
+            ).filterNotNullValues()
         )
         return requestExecutor.execute(
             request,
@@ -91,103 +59,12 @@ private class FinancialConnectionsConsumersApiServiceImpl(
         )
     }
 
-    /**
-     * Triggers a verification for the consumer corresponding to the given client secret.
-     */
-    override suspend fun startConsumerVerification(
-        consumerSessionClientSecret: String,
-        locale: Locale,
-        authSessionCookie: String?,
-        requestSurface: String,
-        type: VerificationType,
-        customEmailType: CustomEmailType?,
-        connectionsMerchantName: String?,
-    ): ConsumerSession {
-        val request = apiRequestFactory.createPost(
-            startConsumerVerificationUrl,
-            apiOptions,
-            mapOf(
-                "request_surface" to requestSurface,
-                "credentials" to mapOf(
-                    "consumer_session_client_secret" to consumerSessionClientSecret
-                ),
-                "type" to type.value,
-                "custom_email_type" to customEmailType?.value,
-                "connections_merchant_name" to connectionsMerchantName,
-                "locale" to locale.toLanguageTag()
-            )
-                .filterValues { it != null }
-                .plus(
-                    authSessionCookie?.let {
-                        mapOf(
-                            "cookies" to
-                                mapOf("verification_session_client_secrets" to listOf(it))
-                        )
-                    } ?: emptyMap()
-                )
-        )
-        return requestExecutor.execute(
-            request,
-            ConsumerSession.serializer()
-        )
-    }
-
-    /**
-     * Confirms an SMS verification for the consumer corresponding to the given client secret.
-     */
-    override suspend fun confirmConsumerVerification(
-        consumerSessionClientSecret: String,
-        verificationCode: String,
-        authSessionCookie: String?,
-        requestSurface: String,
-        type: VerificationType,
-    ): ConsumerSession {
-        val request = apiRequestFactory.createPost(
-            confirmConsumerVerificationUrl,
-            apiOptions,
-            mapOf(
-                "request_surface" to requestSurface,
-                "credentials" to mapOf(
-                    "consumer_session_client_secret" to consumerSessionClientSecret
-                ),
-                "type" to type.value,
-                "code" to verificationCode
-            ).plus(
-                authSessionCookie?.let {
-                    mapOf(
-                        "cookies" to
-                            mapOf("verification_session_client_secrets" to listOf(it))
-                    )
-                } ?: emptyMap()
-            )
-        )
-
-        return requestExecutor.execute(
-            request,
-            ConsumerSession.serializer()
-        )
-    }
-
     private companion object {
         /**
-         * @return `https://api.stripe.com/v1/consumers/sessions/lookup`
+         * @return `https://api.stripe.com/v1/connections/link_account_sessions/consumer_sessions`
          */
-        val consumerSessionLookupUrl: String
+        val consumerSessionsUrl: String
             @JvmSynthetic
-            get() = "${ApiRequest.API_HOST}/v1/consumers/sessions/lookup"
-
-        /**
-         * @return `https://api.stripe.com/v1/consumers/sessions/start_verification`
-         */
-        val startConsumerVerificationUrl: String
-            @JvmSynthetic
-            get() = "${ApiRequest.API_HOST}/v1/consumers/sessions/start_verification"
-
-        /**
-         * @return `https://api.stripe.com/v1/consumers/sessions/confirm_verification`
-         */
-        val confirmConsumerVerificationUrl: String
-            @JvmSynthetic
-            get() = "${ApiRequest.API_HOST}/v1/consumers/sessions/confirm_verification"
+            get() = "${ApiRequest.API_HOST}/v1/connections/link_account_sessions/consumer_sessions"
     }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/api/FinancialConnectionsConsumersApiService.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/api/FinancialConnectionsConsumersApiService.kt
@@ -1,0 +1,193 @@
+package com.stripe.android.financialconnections.repository.api
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.financialconnections.network.FinancialConnectionsRequestExecutor
+import com.stripe.android.model.ConsumerSession
+import com.stripe.android.model.ConsumerSessionLookup
+import com.stripe.android.model.CustomEmailType
+import com.stripe.android.model.VerificationType
+import java.util.Locale
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
+internal interface FinancialConnectionsConsumersApiService {
+
+    suspend fun lookupConsumerSession(
+        email: String?,
+        authSessionCookie: String?,
+        requestSurface: String,
+    ): ConsumerSessionLookup
+
+    suspend fun startConsumerVerification(
+        consumerSessionClientSecret: String,
+        locale: Locale,
+        authSessionCookie: String?,
+        requestSurface: String,
+        type: VerificationType,
+        customEmailType: CustomEmailType?,
+        connectionsMerchantName: String?,
+    ): ConsumerSession
+
+    suspend fun confirmConsumerVerification(
+        consumerSessionClientSecret: String,
+        verificationCode: String,
+        authSessionCookie: String?,
+        requestSurface: String,
+        type: VerificationType,
+    ): ConsumerSession
+
+    companion object {
+        operator fun invoke(
+            requestExecutor: FinancialConnectionsRequestExecutor,
+            apiOptions: ApiRequest.Options,
+            apiRequestFactory: ApiRequest.Factory,
+        ): FinancialConnectionsConsumersApiService =
+            FinancialConnectionsConsumersApiServiceImpl(
+                requestExecutor,
+                apiOptions,
+                apiRequestFactory,
+            )
+    }
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
+private class FinancialConnectionsConsumersApiServiceImpl(
+    private val requestExecutor: FinancialConnectionsRequestExecutor,
+    private val apiOptions: ApiRequest.Options,
+    private val apiRequestFactory: ApiRequest.Factory
+) : FinancialConnectionsConsumersApiService {
+
+    /**
+     * Retrieves the ConsumerSession if the given email is associated with a Link account.
+     */
+    override suspend fun lookupConsumerSession(
+        email: String?,
+        authSessionCookie: String?,
+        requestSurface: String,
+    ): ConsumerSessionLookup {
+        val request = apiRequestFactory.createPost(
+            consumerSessionLookupUrl,
+            apiOptions,
+            mapOf(
+                "request_surface" to requestSurface
+            ).plus(
+                email?.let {
+                    mapOf(
+                        "email_address" to it.lowercase()
+                    )
+                } ?: emptyMap()
+            ).plus(
+                authSessionCookie?.let {
+                    mapOf(
+                        "cookies" to
+                            mapOf("verification_session_client_secrets" to listOf(it))
+                    )
+                } ?: emptyMap()
+            )
+        )
+        return requestExecutor.execute(
+            request,
+            ConsumerSessionLookup.serializer()
+        )
+    }
+
+    /**
+     * Triggers a verification for the consumer corresponding to the given client secret.
+     */
+    override suspend fun startConsumerVerification(
+        consumerSessionClientSecret: String,
+        locale: Locale,
+        authSessionCookie: String?,
+        requestSurface: String,
+        type: VerificationType,
+        customEmailType: CustomEmailType?,
+        connectionsMerchantName: String?,
+    ): ConsumerSession {
+        val request = apiRequestFactory.createPost(
+            startConsumerVerificationUrl,
+            apiOptions,
+            mapOf(
+                "request_surface" to requestSurface,
+                "credentials" to mapOf(
+                    "consumer_session_client_secret" to consumerSessionClientSecret
+                ),
+                "type" to type.value,
+                "custom_email_type" to customEmailType?.value,
+                "connections_merchant_name" to connectionsMerchantName,
+                "locale" to locale.toLanguageTag()
+            )
+                .filterValues { it != null }
+                .plus(
+                    authSessionCookie?.let {
+                        mapOf(
+                            "cookies" to
+                                mapOf("verification_session_client_secrets" to listOf(it))
+                        )
+                    } ?: emptyMap()
+                )
+        )
+        return requestExecutor.execute(
+            request,
+            ConsumerSession.serializer()
+        )
+    }
+
+    /**
+     * Confirms an SMS verification for the consumer corresponding to the given client secret.
+     */
+    override suspend fun confirmConsumerVerification(
+        consumerSessionClientSecret: String,
+        verificationCode: String,
+        authSessionCookie: String?,
+        requestSurface: String,
+        type: VerificationType,
+    ): ConsumerSession {
+        val request = apiRequestFactory.createPost(
+            confirmConsumerVerificationUrl,
+            apiOptions,
+            mapOf(
+                "request_surface" to requestSurface,
+                "credentials" to mapOf(
+                    "consumer_session_client_secret" to consumerSessionClientSecret
+                ),
+                "type" to type.value,
+                "code" to verificationCode
+            ).plus(
+                authSessionCookie?.let {
+                    mapOf(
+                        "cookies" to
+                            mapOf("verification_session_client_secrets" to listOf(it))
+                    )
+                } ?: emptyMap()
+            )
+        )
+
+        return requestExecutor.execute(
+            request,
+            ConsumerSession.serializer()
+        )
+    }
+
+    private companion object {
+        /**
+         * @return `https://api.stripe.com/v1/consumers/sessions/lookup`
+         */
+        val consumerSessionLookupUrl: String
+            @JvmSynthetic
+            get() = "${ApiRequest.API_HOST}/v1/consumers/sessions/lookup"
+
+        /**
+         * @return `https://api.stripe.com/v1/consumers/sessions/start_verification`
+         */
+        val startConsumerVerificationUrl: String
+            @JvmSynthetic
+            get() = "${ApiRequest.API_HOST}/v1/consumers/sessions/start_verification"
+
+        /**
+         * @return `https://api.stripe.com/v1/consumers/sessions/confirm_verification`
+         */
+        val confirmConsumerVerificationUrl: String
+            @JvmSynthetic
+            get() = "${ApiRequest.API_HOST}/v1/consumers/sessions/confirm_verification"
+    }
+}

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-NetworkingExistingUser.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-NetworkingExistingUser.yaml
@@ -20,18 +20,16 @@ appId: com.stripe.android.financialconnections.example
 - tapOn: "Agree"
 # LOGIN TO NETWORKING
 - tapOn: test@test.com
-- tapOn:
-    text: ●
-    index: 0
+  # 2FA
+- assertVisible: "●"
 - inputText: "111111"
 # SELECT NETWORKED ACCOUNT
 - tapOn: "Success"
 - tapOn: "Connect account"
 # STEP UP AUTHENTICATION
-- tapOn:
-    text: ●
-    index: 0
+- assertVisible: "●"
 - inputText: "111111"
 - assertVisible: "Success!"
+- assertVisible: ".*through Link.*"
 - tapOn: "Done"
 - assertVisible: ".*Intent Confirmed!.*"

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-NetworkingNewUser.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-NetworkingNewUser.yaml
@@ -31,11 +31,13 @@ appId: com.stripe.android.financialconnections.example
     visible: "Success"
     timeout: 60000
 - tapOn: "Success"
-- tapOn: "Confirm"
+- tapOn: "Link Account"
 # ENTER PHONE FOR NEW NETWORKED USER
 - tapOn: "Phone number"
 - inputText: "6223115555"
 - tapOn: "Save to Link"
 # CONFIRM AND COMPLETE
+- assertVisible: "Success!"
+- assertVisible: ".*through Link.*"
 - tapOn: "Done"
 - assertVisible: ".*Intent Confirmed!.*"

--- a/payments-model/api/payments-model.api
+++ b/payments-model/api/payments-model.api
@@ -188,12 +188,42 @@ public final class com/stripe/android/model/CardFunding : java/lang/Enum {
 	public static fun values ()[Lcom/stripe/android/model/CardFunding;
 }
 
+public final class com/stripe/android/model/ConsumerSession$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/model/ConsumerSession$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/model/ConsumerSession;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/model/ConsumerSession;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/model/ConsumerSession$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/stripe/android/model/ConsumerSession$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/model/ConsumerSession;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/model/ConsumerSession;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/ConsumerSession$VerificationSession$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/model/ConsumerSession$VerificationSession$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/model/ConsumerSession$VerificationSession;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/model/ConsumerSession$VerificationSession;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/model/ConsumerSession$VerificationSession$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/stripe/android/model/ConsumerSession$VerificationSession$Creator : android/os/Parcelable$Creator {
@@ -218,6 +248,21 @@ public final class com/stripe/android/model/ConsumerSession$VerificationSession$
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/model/ConsumerSession$VerificationSession$SessionType;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/model/ConsumerSessionLookup$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/stripe/android/model/ConsumerSessionLookup$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/model/ConsumerSessionLookup;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/model/ConsumerSessionLookup;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/stripe/android/model/ConsumerSessionLookup$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/stripe/android/model/ConsumerSessionLookup$Creator : android/os/Parcelable$Creator {

--- a/payments-model/build.gradle
+++ b/payments-model/build.gradle
@@ -1,6 +1,7 @@
 apply from: configs.androidLibrary
 
 apply plugin: 'checkstyle'
+apply plugin: 'kotlinx-serialization'
 apply plugin: 'org.jetbrains.kotlin.plugin.parcelize'
 
 android {
@@ -15,6 +16,7 @@ dependencies {
     implementation project(":stripe-core")
     implementation "androidx.core:core-ktx:$androidxCoreVersion"
     implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinSerializationVersion"
 
     testImplementation project(':network-testing')
     testImplementation "junit:junit:$junitVersion"

--- a/payments-model/src/main/java/com/stripe/android/model/ConsumerSession.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/ConsumerSession.kt
@@ -4,12 +4,14 @@ import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeModel
 import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.Serializable
 
 /**
  * The result of a call to Link consumer sign up.
  */
 @Parcelize
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Serializable
 data class ConsumerSession(
     val clientSecret: String,
     val emailAddress: String,
@@ -21,6 +23,7 @@ data class ConsumerSession(
 
     @Parcelize
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @Serializable
     data class VerificationSession constructor(
         val type: SessionType,
         val state: SessionState

--- a/payments-model/src/main/java/com/stripe/android/model/ConsumerSession.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/ConsumerSession.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeModel
 import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
@@ -13,12 +14,18 @@ import kotlinx.serialization.Serializable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Serializable
 data class ConsumerSession(
-    val clientSecret: String,
+    @SerialName("client_secret")
+    val clientSecret: String = "",
+    @SerialName("email_address")
     val emailAddress: String,
+    @SerialName("redacted_phone_number")
     val redactedPhoneNumber: String,
-    val verificationSessions: List<VerificationSession>,
-    val authSessionClientSecret: String?,
-    val publishableKey: String?
+    @SerialName("verification_sessions")
+    val verificationSessions: List<VerificationSession> = emptyList(),
+    @SerialName("auth_session_client_secret")
+    val authSessionClientSecret: String? = null,
+    @SerialName("publishable_key")
+    val publishableKey: String? = null
 ) : StripeModel {
 
     @Parcelize

--- a/payments-model/src/main/java/com/stripe/android/model/ConsumerSessionLookup.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/ConsumerSessionLookup.kt
@@ -3,6 +3,7 @@ package com.stripe.android.model
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeModel
 import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
@@ -12,7 +13,10 @@ import kotlinx.serialization.Serializable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Serializable
 data class ConsumerSessionLookup(
+    @SerialName("exists")
     val exists: Boolean,
-    val consumerSession: ConsumerSession?,
-    val errorMessage: String?
+    @SerialName("consumer_session")
+    val consumerSession: ConsumerSession? = null,
+    @SerialName("error_message")
+    val errorMessage: String? = null
 ) : StripeModel

--- a/payments-model/src/main/java/com/stripe/android/model/ConsumerSessionLookup.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/ConsumerSessionLookup.kt
@@ -3,12 +3,14 @@ package com.stripe.android.model
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeModel
 import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.Serializable
 
 /**
  * The result of a call to retrieve the [ConsumerSession] for a Link user.
  */
 @Parcelize
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Serializable
 data class ConsumerSessionLookup(
     val exists: Boolean,
     val consumerSession: ConsumerSession?,


### PR DESCRIPTION
# Summary
- Replaces lookup endpoint by new financial connections dedicated endpoint.
- Makes ConsumerSession kotlinx.Serializable.
- Adds tests.
- Fixes Maestro tests

# Test

Run `maestro test -e APP_ID=com.stripe.android.financialconnections.example maestro/financial-connections/`

# Motivation
:notebook_with_decorative_cover: &nbsp;**Add new connections-specific consumer endpoints**
:globe_with_meridians: &nbsp;[BANKCON-6540](https://jira.corp.stripe.com/browse/BANKCON-6540)
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified