### PR TITLE
Move more repository methods to using `Result<T>`

### DIFF
--- a/payment-method-messaging/detekt-baseline.xml
+++ b/payment-method-messaging/detekt-baseline.xml
@@ -1,7 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <SmellBaseline>
   <ManuallySuppressedIssues/>
-  <CurrentIssues>
-    <ID>TooGenericExceptionThrown:PaymentMethodMessagingViewModel.kt$PaymentMethodMessagingViewModel$throw Exception("Could not retrieve message")</ID>
-  </CurrentIssues>
+  <CurrentIssues/>
 </SmellBaseline>

--- a/payment-method-messaging/detekt-baseline.xml
+++ b/payment-method-messaging/detekt-baseline.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>TooGenericExceptionThrown:PaymentMethodMessagingViewModel.kt$PaymentMethodMessagingViewModel$throw Exception("Could not retrieve message")</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/payment-method-messaging/src/main/java/com/stripe/android/paymentmethodmessaging/view/PaymentMethodMessagingViewModel.kt
+++ b/payment-method-messaging/src/main/java/com/stripe/android/paymentmethodmessaging/view/PaymentMethodMessagingViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.PaymentMethodMessage
-import com.stripe.android.networking.StripeApiRepository
+import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentmethodmessaging.view.injection.DaggerPaymentMethodMessagingComponent
 import com.stripe.android.utils.requireApplication
 import kotlinx.coroutines.CoroutineScope
@@ -23,7 +23,7 @@ Deferred<PaymentMethodMessagingData>
 internal class PaymentMethodMessagingViewModel @Inject constructor(
     private val isSystemDarkThemeProvider: () -> Boolean,
     private val config: PaymentMethodMessagingView.Configuration,
-    private val stripeApiRepository: StripeApiRepository,
+    private val stripeRepository: StripeRepository,
     private val mapper: @JvmSuppressWildcards Mapper
 ) : ViewModel() {
 
@@ -45,7 +45,7 @@ internal class PaymentMethodMessagingViewModel @Inject constructor(
     }
 
     private suspend fun retrievePaymentMethodMessage(): Result<PaymentMethodMessage> {
-        return stripeApiRepository.retrievePaymentMethodMessage(
+        return stripeRepository.retrievePaymentMethodMessage(
             paymentMethods = config.paymentMethods.map { it.value },
             amount = config.amount,
             currency = config.currency,

--- a/payment-method-messaging/src/main/java/com/stripe/android/paymentmethodmessaging/view/PaymentMethodMessagingViewModel.kt
+++ b/payment-method-messaging/src/main/java/com/stripe/android/paymentmethodmessaging/view/PaymentMethodMessagingViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
+import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.PaymentMethodMessage
 import com.stripe.android.networking.StripeRepository
@@ -35,7 +36,7 @@ internal class PaymentMethodMessagingViewModel @Inject constructor(
             _messageFlow.update {
                 retrievePaymentMethodMessage().mapCatching { message ->
                     if (message.displayHtml.isBlank() || message.learnMoreUrl.isBlank()) {
-                        throw Exception("Could not retrieve message")
+                        throw APIException(message = "Could not retrieve message")
                     } else {
                         mapper(this, message).await()
                     }

--- a/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/PaymentMethodMessagingViewModelTest.kt
+++ b/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/PaymentMethodMessagingViewModelTest.kt
@@ -167,7 +167,7 @@ class PaymentMethodMessagingViewModelTest {
                 requestOptions = anyOrNull()
             )
         ).thenReturn(
-            paymentMethodMessage
+            Result.success(paymentMethodMessage)
         )
     }
 }

--- a/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/PaymentMethodMessagingViewModelTest.kt
+++ b/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/PaymentMethodMessagingViewModelTest.kt
@@ -3,7 +3,7 @@ package com.stripe.android.paymentmethodmessaging
 import androidx.lifecycle.viewModelScope
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.PaymentMethodMessage
-import com.stripe.android.networking.StripeApiRepository
+import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentmethodmessaging.view.PaymentMethodMessagingData
 import com.stripe.android.paymentmethodmessaging.view.PaymentMethodMessagingView
 import com.stripe.android.paymentmethodmessaging.view.PaymentMethodMessagingViewModel
@@ -24,7 +24,8 @@ import kotlin.test.BeforeTest
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class PaymentMethodMessagingViewModelTest {
-    private val stripeApiRepository = mock<StripeApiRepository>()
+
+    private val stripeRepository = mock<StripeRepository>()
 
     @BeforeTest
     fun setUp() {
@@ -58,7 +59,7 @@ class PaymentMethodMessagingViewModelTest {
             },
             isSystemDarkThemeProvider = { false },
             config = config,
-            stripeApiRepository = stripeApiRepository
+            stripeRepository = stripeRepository
         )
 
         returnsPaymentMethodMessage(
@@ -95,7 +96,7 @@ class PaymentMethodMessagingViewModelTest {
             },
             isSystemDarkThemeProvider = { false },
             config = config,
-            stripeApiRepository = stripeApiRepository
+            stripeRepository = stripeRepository
         )
 
         returnsPaymentMethodMessage(
@@ -130,7 +131,7 @@ class PaymentMethodMessagingViewModelTest {
             },
             isSystemDarkThemeProvider = { false },
             config = config,
-            stripeApiRepository = stripeApiRepository
+            stripeRepository = stripeRepository
         )
 
         returnsPaymentMethodMessage(
@@ -153,11 +154,13 @@ class PaymentMethodMessagingViewModelTest {
         displayHtml: String,
         learnMoreUrl: String
     ) {
-        val paymentMethodMessage = mock<PaymentMethodMessage>()
-        whenever(paymentMethodMessage.displayHtml).thenReturn(displayHtml)
-        whenever(paymentMethodMessage.learnMoreUrl).thenReturn(learnMoreUrl)
+        val paymentMethodMessage = PaymentMethodMessage(
+            displayHtml = displayHtml,
+            learnMoreUrl = learnMoreUrl,
+        )
+
         whenever(
-            stripeApiRepository.retrievePaymentMethodMessage(
+            stripeRepository.retrievePaymentMethodMessage(
                 paymentMethods = anyOrNull(),
                 amount = anyOrNull(),
                 currency = anyOrNull(),

--- a/payments-core/src/main/java/com/stripe/android/CustomerSessionOperationExecutor.kt
+++ b/payments-core/src/main/java/com/stripe/android/CustomerSessionOperationExecutor.kt
@@ -87,19 +87,14 @@ internal class CustomerSessionOperationExecutor(
                 }
             }
             is EphemeralOperation.Customer.AttachPaymentMethod -> {
-                val result = runCatching {
-                    requireNotNull(
-                        stripeRepository.attachPaymentMethod(
-                            ephemeralKey.objectId,
-                            publishableKey,
-                            operation.productUsage,
-                            operation.paymentMethodId,
-                            ApiRequest.Options(ephemeralKey.secret, stripeAccountId)
-                        )
-                    ) {
-                        REQUIRED_ERROR
-                    }
-                }
+                val result = stripeRepository.attachPaymentMethod(
+                    customerId = ephemeralKey.objectId,
+                    publishableKey = publishableKey,
+                    productUsageTokens = operation.productUsage,
+                    paymentMethodId = operation.paymentMethodId,
+                    requestOptions = ApiRequest.Options(ephemeralKey.secret, stripeAccountId),
+                )
+
                 withContext(Dispatchers.Main) {
                     val listener: CustomerSession.PaymentMethodRetrievalListener? = getListener(operation.id)
                     result.fold(
@@ -113,18 +108,13 @@ internal class CustomerSessionOperationExecutor(
                 }
             }
             is EphemeralOperation.Customer.DetachPaymentMethod -> {
-                val result = runCatching {
-                    requireNotNull(
-                        stripeRepository.detachPaymentMethod(
-                            publishableKey,
-                            operation.productUsage,
-                            operation.paymentMethodId,
-                            ApiRequest.Options(ephemeralKey.secret, stripeAccountId)
-                        )
-                    ) {
-                        REQUIRED_ERROR
-                    }
-                }
+                val result = stripeRepository.detachPaymentMethod(
+                    publishableKey = publishableKey,
+                    productUsageTokens = operation.productUsage,
+                    paymentMethodId = operation.paymentMethodId,
+                    requestOptions = ApiRequest.Options(ephemeralKey.secret, stripeAccountId),
+                )
+
                 withContext(Dispatchers.Main) {
                     val listener: CustomerSession.PaymentMethodRetrievalListener? = getListener(operation.id)
                     result.fold(
@@ -138,20 +128,19 @@ internal class CustomerSessionOperationExecutor(
                 }
             }
             is EphemeralOperation.Customer.GetPaymentMethods -> {
-                val result = runCatching {
-                    stripeRepository.getPaymentMethods(
-                        ListPaymentMethodsParams(
-                            customerId = ephemeralKey.objectId,
-                            paymentMethodType = operation.type,
-                            limit = operation.limit,
-                            endingBefore = operation.endingBefore,
-                            startingAfter = operation.startingAfter
-                        ),
-                        publishableKey,
-                        operation.productUsage,
-                        ApiRequest.Options(ephemeralKey.secret, stripeAccountId)
-                    )
-                }
+                val result = stripeRepository.getPaymentMethods(
+                    listPaymentMethodsParams = ListPaymentMethodsParams(
+                        customerId = ephemeralKey.objectId,
+                        paymentMethodType = operation.type,
+                        limit = operation.limit,
+                        endingBefore = operation.endingBefore,
+                        startingAfter = operation.startingAfter,
+                    ),
+                    publishableKey = publishableKey,
+                    productUsageTokens = operation.productUsage,
+                    requestOptions = ApiRequest.Options(ephemeralKey.secret, stripeAccountId),
+                )
+
                 withContext(Dispatchers.Main) {
                     val listener: CustomerSession.PaymentMethodsRetrievalListener? = getListener(operation.id)
                     result.fold(

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodMessage.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodMessage.kt
@@ -6,7 +6,9 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-data class PaymentMethodMessage internal constructor(
+data class PaymentMethodMessage
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+constructor(
     val displayHtml: String,
     val learnMoreUrl: String
 ) : StripeModel

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1532,8 +1532,8 @@ class StripeApiRepository @JvmOverloads internal constructor(
         locale: String,
         logoColor: String,
         requestOptions: ApiRequest.Options
-    ): PaymentMethodMessage? {
-        return fetchStripeModel(
+    ): Result<PaymentMethodMessage> {
+        return fetchStripeModelResult(
             apiRequestFactory.createGet(
                 url = "https://ppm.stripe.com/content",
                 options = requestOptions,

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -698,35 +698,25 @@ class StripeApiRepository @JvmOverloads internal constructor(
     /**
      * Analytics event: [PaymentAnalyticsEvent.CustomerAttachPaymentMethod]
      */
-    @Throws(
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class,
-        AuthenticationException::class,
-        CardException::class
-    )
     override suspend fun attachPaymentMethod(
         customerId: String,
         publishableKey: String,
         productUsageTokens: Set<String>,
         paymentMethodId: String,
         requestOptions: ApiRequest.Options
-    ): PaymentMethod? {
+    ): Result<PaymentMethod> {
         fireFraudDetectionDataRequest()
 
-        return fetchStripeModel(
-            apiRequestFactory.createPost(
-                getAttachPaymentMethodUrl(paymentMethodId),
-                requestOptions,
-                mapOf("customer" to customerId)
+        return fetchStripeModelResult(
+            apiRequest = apiRequestFactory.createPost(
+                url = getAttachPaymentMethodUrl(paymentMethodId),
+                options = requestOptions,
+                params = mapOf("customer" to customerId)
             ),
-            PaymentMethodJsonParser()
+            jsonParser = PaymentMethodJsonParser()
         ) {
             fireAnalyticsRequest(
-                paymentAnalyticsRequestFactory
-                    .createAttachPaymentMethod(
-                        productUsageTokens
-                    )
+                paymentAnalyticsRequestFactory.createAttachPaymentMethod(productUsageTokens)
             )
         }
     }
@@ -746,19 +736,16 @@ class StripeApiRepository @JvmOverloads internal constructor(
         productUsageTokens: Set<String>,
         paymentMethodId: String,
         requestOptions: ApiRequest.Options
-    ): PaymentMethod? {
-        return fetchStripeModel(
-            apiRequestFactory.createPost(
-                getDetachPaymentMethodUrl(paymentMethodId),
-                requestOptions
+    ): Result<PaymentMethod> {
+        return fetchStripeModelResult(
+            apiRequest = apiRequestFactory.createPost(
+                url = getDetachPaymentMethodUrl(paymentMethodId),
+                options = requestOptions,
             ),
-            PaymentMethodJsonParser()
+            jsonParser = PaymentMethodJsonParser()
         ) {
             fireAnalyticsRequest(
-                paymentAnalyticsRequestFactory
-                    .createDetachPaymentMethod(
-                        productUsageTokens
-                    )
+                paymentAnalyticsRequestFactory.createDetachPaymentMethod(productUsageTokens)
             )
         }
     }
@@ -768,20 +755,13 @@ class StripeApiRepository @JvmOverloads internal constructor(
      *
      * Analytics event: [PaymentAnalyticsEvent.CustomerRetrievePaymentMethods]
      */
-    @Throws(
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class,
-        AuthenticationException::class,
-        CardException::class
-    )
     override suspend fun getPaymentMethods(
         listPaymentMethodsParams: ListPaymentMethodsParams,
         publishableKey: String,
         productUsageTokens: Set<String>,
         requestOptions: ApiRequest.Options
-    ): List<PaymentMethod> {
-        val paymentMethodsList = fetchStripeModel(
+    ): Result<List<PaymentMethod>> {
+        return fetchStripeModelResult(
             apiRequestFactory.createGet(
                 paymentMethodsUrl,
                 requestOptions,
@@ -795,9 +775,9 @@ class StripeApiRepository @JvmOverloads internal constructor(
                     productUsageTokens = productUsageTokens
                 )
             )
+        }.map {
+            it.paymentMethods
         }
-
-        return paymentMethodsList?.paymentMethods.orEmpty()
     }
 
     /**

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -762,20 +762,21 @@ class StripeApiRepository @JvmOverloads internal constructor(
         requestOptions: ApiRequest.Options
     ): Result<List<PaymentMethod>> {
         return fetchStripeModelResult(
-            apiRequestFactory.createGet(
-                paymentMethodsUrl,
-                requestOptions,
-                listPaymentMethodsParams.toParamMap()
+            apiRequest = apiRequestFactory.createGet(
+                url = paymentMethodsUrl,
+                options = requestOptions,
+                params = listPaymentMethodsParams.toParamMap(),
             ),
-            PaymentMethodsListJsonParser()
-        ) {
-            fireAnalyticsRequest(
-                paymentAnalyticsRequestFactory.createRequest(
-                    PaymentAnalyticsEvent.CustomerRetrievePaymentMethods,
-                    productUsageTokens = productUsageTokens
+            jsonParser = PaymentMethodsListJsonParser(),
+            onResponse = {
+                fireAnalyticsRequest(
+                    paymentAnalyticsRequestFactory.createRequest(
+                        PaymentAnalyticsEvent.CustomerRetrievePaymentMethods,
+                        productUsageTokens = productUsageTokens
+                    )
                 )
-            )
-        }.map {
+            },
+        ).map {
             it.paymentMethods
         }
     }

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.networking
 
 import androidx.annotation.RestrictTo
-import androidx.annotation.VisibleForTesting
 import com.stripe.android.cards.Bin
 import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.exception.APIException
@@ -220,52 +219,30 @@ abstract class StripeRepository {
         requestOptions: ApiRequest.Options
     ): Source?
 
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class,
-        CardException::class
-    )
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    @VisibleForTesting
     abstract suspend fun attachPaymentMethod(
         customerId: String,
         publishableKey: String,
         productUsageTokens: Set<String>,
         paymentMethodId: String,
         requestOptions: ApiRequest.Options
-    ): PaymentMethod?
+    ): Result<PaymentMethod>
 
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class,
-        CardException::class
-    )
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     abstract suspend fun detachPaymentMethod(
         publishableKey: String,
         productUsageTokens: Set<String>,
         paymentMethodId: String,
         requestOptions: ApiRequest.Options
-    ): PaymentMethod?
+    ): Result<PaymentMethod>
 
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class,
-        CardException::class
-    )
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     abstract suspend fun getPaymentMethods(
         listPaymentMethodsParams: ListPaymentMethodsParams,
         publishableKey: String,
         productUsageTokens: Set<String>,
         requestOptions: ApiRequest.Options
-    ): List<PaymentMethod>
+    ): Result<List<PaymentMethod>>
 
     @Throws(
         AuthenticationException::class,

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -483,7 +483,7 @@ abstract class StripeRepository {
         locale: String,
         logoColor: String,
         requestOptions: ApiRequest.Options
-    ): PaymentMethodMessage?
+    ): Result<PaymentMethodMessage>?
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     abstract suspend fun retrieveElementsSession(

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -483,7 +483,7 @@ abstract class StripeRepository {
         locale: String,
         logoColor: String,
         requestOptions: ApiRequest.Options
-    ): Result<PaymentMethodMessage>?
+    ): Result<PaymentMethodMessage>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     abstract suspend fun retrieveElementsSession(

--- a/payments-core/src/test/java/com/stripe/android/CustomerSessionTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/CustomerSessionTest.kt
@@ -109,8 +109,7 @@ internal class CustomerSessionTest {
                     any(),
                     any()
                 )
-            )
-                .thenReturn(PAYMENT_METHOD)
+            ).thenReturn(Result.success(PAYMENT_METHOD))
 
             whenever(
                 stripeRepository.detachPaymentMethod(
@@ -119,8 +118,7 @@ internal class CustomerSessionTest {
                     any(),
                     any()
                 )
-            )
-                .thenReturn(PAYMENT_METHOD)
+            ).thenReturn(Result.success(PAYMENT_METHOD))
 
             whenever(
                 stripeRepository.getPaymentMethods(
@@ -129,8 +127,7 @@ internal class CustomerSessionTest {
                     any(),
                     any()
                 )
-            )
-                .thenReturn(listOf(PAYMENT_METHOD))
+            ).thenReturn(Result.success(listOf(PAYMENT_METHOD)))
 
             whenever(
                 stripeRepository.setCustomerShippingInfo(
@@ -773,8 +770,9 @@ internal class CustomerSessionTest {
                 any(),
                 any()
             )
+        ).thenReturn(
+            Result.failure(APIException(statusCode = 404, message = "The payment method is invalid"))
         )
-            .thenThrow(APIException(statusCode = 404, message = "The payment method is invalid"))
 
         whenever(
             stripeRepository.detachPaymentMethod(
@@ -783,8 +781,9 @@ internal class CustomerSessionTest {
                 any(),
                 any()
             )
+        ).thenReturn(
+            Result.failure(APIException(statusCode = 404, message = "The payment method does not exist"))
         )
-            .thenThrow(APIException(statusCode = 404, message = "The payment method does not exist"))
 
         whenever(
             stripeRepository.getPaymentMethods(
@@ -793,8 +792,9 @@ internal class CustomerSessionTest {
                 any(),
                 any()
             )
+        ).thenReturn(
+            Result.failure(APIException(statusCode = 404, message = "The payment method does not exist"))
         )
-            .thenThrow(APIException(statusCode = 404, message = "The payment method does not exist"))
     }
 
     private fun createCustomerSession(

--- a/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
@@ -162,8 +162,8 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         productUsageTokens: Set<String>,
         paymentMethodId: String,
         requestOptions: ApiRequest.Options
-    ): PaymentMethod? {
-        return null
+    ): Result<PaymentMethod> {
+        return Result.failure(NotImplementedError())
     }
 
     @Throws(APIException::class)
@@ -172,8 +172,8 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         productUsageTokens: Set<String>,
         paymentMethodId: String,
         requestOptions: ApiRequest.Options
-    ): PaymentMethod? {
-        return null
+    ): Result<PaymentMethod> {
+        return Result.failure(NotImplementedError())
     }
 
     @Throws(APIException::class)
@@ -182,8 +182,8 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         publishableKey: String,
         productUsageTokens: Set<String>,
         requestOptions: ApiRequest.Options
-    ): List<PaymentMethod> {
-        return emptyList()
+    ): Result<List<PaymentMethod>> {
+        return Result.failure(NotImplementedError())
     }
 
     @Throws(APIException::class)

--- a/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
@@ -415,8 +415,8 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         locale: String,
         logoColor: String,
         requestOptions: ApiRequest.Options
-    ): PaymentMethodMessage? {
-        return null
+    ): Result<PaymentMethodMessage> {
+        return Result.failure(NotImplementedError())
     }
 
     override suspend fun retrieveElementsSession(

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -1039,7 +1039,7 @@ internal class StripeApiRepositoryTest {
                 DEFAULT_OPTIONS.apiKey,
                 emptySet(),
                 ApiRequest.Options(ApiKeyFixtures.FAKE_EPHEMERAL_KEY)
-            )
+            ).getOrThrow()
         assertThat(paymentMethods)
             .hasSize(3)
         assertThat(paymentMethods.map { it.id })
@@ -1097,7 +1097,7 @@ internal class StripeApiRepositoryTest {
                 DEFAULT_OPTIONS.apiKey,
                 emptySet(),
                 ApiRequest.Options(ApiKeyFixtures.FAKE_EPHEMERAL_KEY)
-            )
+            ).getOrThrow()
         assertThat(paymentMethods)
             .isEmpty()
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request moves some of the methods in `StripeRepository` to `Result<T>`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Explicit error handling and no swallowing of errors.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
