### PR TITLE
Use `Result<T>` in customer-related methods

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/CustomerSessionOperationExecutor.kt
+++ b/payments-core/src/main/java/com/stripe/android/CustomerSessionOperationExecutor.kt
@@ -34,20 +34,15 @@ internal class CustomerSessionOperationExecutor(
                 }
             }
             is EphemeralOperation.Customer.AddSource -> {
-                val result = runCatching {
-                    requireNotNull(
-                        stripeRepository.addCustomerSource(
-                            ephemeralKey.objectId,
-                            publishableKey,
-                            operation.productUsage,
-                            operation.sourceId,
-                            operation.sourceType,
-                            ApiRequest.Options(ephemeralKey.secret, stripeAccountId)
-                        )
-                    ) {
-                        REQUIRED_ERROR
-                    }
-                }
+                val result = stripeRepository.addCustomerSource(
+                    customerId = ephemeralKey.objectId,
+                    publishableKey = publishableKey,
+                    productUsageTokens = operation.productUsage,
+                    sourceId = operation.sourceId,
+                    sourceType = operation.sourceType,
+                    requestOptions = ApiRequest.Options(ephemeralKey.secret, stripeAccountId),
+                )
+
                 withContext(Dispatchers.Main) {
                     val listener: CustomerSession.SourceRetrievalListener? = getListener(operation.id)
                     result.fold(
@@ -61,19 +56,14 @@ internal class CustomerSessionOperationExecutor(
                 }
             }
             is EphemeralOperation.Customer.DeleteSource -> {
-                val result = runCatching {
-                    requireNotNull(
-                        stripeRepository.deleteCustomerSource(
-                            ephemeralKey.objectId,
-                            publishableKey,
-                            operation.productUsage,
-                            operation.sourceId,
-                            ApiRequest.Options(ephemeralKey.secret, stripeAccountId)
-                        )
-                    ) {
-                        REQUIRED_ERROR
-                    }
-                }
+                val result = stripeRepository.deleteCustomerSource(
+                    customerId = ephemeralKey.objectId,
+                    publishableKey = publishableKey,
+                    productUsageTokens = operation.productUsage,
+                    sourceId = operation.sourceId,
+                    requestOptions = ApiRequest.Options(ephemeralKey.secret, stripeAccountId),
+                )
+
                 withContext(Dispatchers.Main) {
                     val listener: CustomerSession.SourceRetrievalListener? = getListener(operation.id)
                     result.fold(
@@ -154,20 +144,15 @@ internal class CustomerSessionOperationExecutor(
                 }
             }
             is EphemeralOperation.Customer.UpdateDefaultSource -> {
-                val result = runCatching {
-                    requireNotNull(
-                        stripeRepository.setDefaultCustomerSource(
-                            ephemeralKey.objectId,
-                            publishableKey,
-                            operation.productUsage,
-                            operation.sourceId,
-                            operation.sourceType,
-                            ApiRequest.Options(ephemeralKey.secret, stripeAccountId)
-                        )
-                    ) {
-                        REQUIRED_ERROR
-                    }
-                }
+                val result = stripeRepository.setDefaultCustomerSource(
+                    customerId = ephemeralKey.objectId,
+                    publishableKey = publishableKey,
+                    productUsageTokens = operation.productUsage,
+                    sourceId = operation.sourceId,
+                    sourceType = operation.sourceType,
+                    requestOptions = ApiRequest.Options(ephemeralKey.secret, stripeAccountId),
+                )
+
                 withContext(Dispatchers.Main) {
                     onCustomerRetrieved(operation, result)
                 }

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -631,13 +631,6 @@ class StripeApiRepository @JvmOverloads internal constructor(
     /**
      * Analytics event: [PaymentAnalyticsEvent.CustomerAddSource]
      */
-    @Throws(
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class,
-        AuthenticationException::class,
-        CardException::class
-    )
     override suspend fun addCustomerSource(
         customerId: String,
         publishableKey: String,
@@ -645,14 +638,14 @@ class StripeApiRepository @JvmOverloads internal constructor(
         sourceId: String,
         @Source.SourceType sourceType: String,
         requestOptions: ApiRequest.Options
-    ): Source? {
-        return fetchStripeModel(
-            apiRequestFactory.createPost(
-                getAddCustomerSourceUrl(customerId),
-                requestOptions,
-                mapOf("source" to sourceId)
+    ): Result<Source> {
+        return fetchStripeModelResult(
+            apiRequest = apiRequestFactory.createPost(
+                url = getAddCustomerSourceUrl(customerId),
+                options = requestOptions,
+                params = mapOf("source" to sourceId),
             ),
-            SourceJsonParser()
+            jsonParser = SourceJsonParser(),
         ) {
             fireAnalyticsRequest(
                 paymentAnalyticsRequestFactory.createAddSource(
@@ -666,26 +659,19 @@ class StripeApiRepository @JvmOverloads internal constructor(
     /**
      * Analytics event: [PaymentAnalyticsEvent.CustomerDeleteSource]
      */
-    @Throws(
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class,
-        AuthenticationException::class,
-        CardException::class
-    )
     override suspend fun deleteCustomerSource(
         customerId: String,
         publishableKey: String,
         productUsageTokens: Set<String>,
         sourceId: String,
         requestOptions: ApiRequest.Options
-    ): Source? {
-        return fetchStripeModel(
-            apiRequestFactory.createDelete(
-                getDeleteCustomerSourceUrl(customerId, sourceId),
-                requestOptions
+    ): Result<Source> {
+        return fetchStripeModelResult(
+            apiRequest = apiRequestFactory.createDelete(
+                url = getDeleteCustomerSourceUrl(customerId, sourceId),
+                options = requestOptions,
             ),
-            SourceJsonParser()
+            jsonParser = SourceJsonParser(),
         ) {
             fireAnalyticsRequest(
                 paymentAnalyticsRequestFactory.createDeleteSource(
@@ -784,13 +770,6 @@ class StripeApiRepository @JvmOverloads internal constructor(
     /**
      * Analytics event: [PaymentAnalyticsEvent.CustomerSetDefaultSource]
      */
-    @Throws(
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class,
-        AuthenticationException::class,
-        CardException::class
-    )
     override suspend fun setDefaultCustomerSource(
         customerId: String,
         publishableKey: String,
@@ -798,14 +777,14 @@ class StripeApiRepository @JvmOverloads internal constructor(
         sourceId: String,
         @Source.SourceType sourceType: String,
         requestOptions: ApiRequest.Options
-    ): Customer? {
-        return fetchStripeModel(
-            apiRequestFactory.createPost(
-                getRetrieveCustomerUrl(customerId),
-                requestOptions,
-                mapOf("default_source" to sourceId)
+    ): Result<Customer> {
+        return fetchStripeModelResult(
+            apiRequest = apiRequestFactory.createPost(
+                url = getRetrieveCustomerUrl(customerId),
+                options = requestOptions,
+                params = mapOf("default_source" to sourceId),
             ),
-            CustomerJsonParser()
+            jsonParser = CustomerJsonParser(),
         ) {
             fireAnalyticsRequest(
                 paymentAnalyticsRequestFactory.createRequest(

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -799,27 +799,20 @@ class StripeApiRepository @JvmOverloads internal constructor(
     /**
      * Analytics event: [PaymentAnalyticsEvent.CustomerSetShippingInfo]
      */
-    @Throws(
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class,
-        AuthenticationException::class,
-        CardException::class
-    )
     override suspend fun setCustomerShippingInfo(
         customerId: String,
         publishableKey: String,
         productUsageTokens: Set<String>,
         shippingInformation: ShippingInformation,
         requestOptions: ApiRequest.Options
-    ): Customer? {
-        return fetchStripeModel(
-            apiRequestFactory.createPost(
-                getRetrieveCustomerUrl(customerId),
-                requestOptions,
-                mapOf("shipping" to shippingInformation.toParamMap())
+    ): Result<Customer> {
+        return fetchStripeModelResult(
+            apiRequest = apiRequestFactory.createPost(
+                url = getRetrieveCustomerUrl(customerId),
+                options = requestOptions,
+                params = mapOf("shipping" to shippingInformation.toParamMap()),
             ),
-            CustomerJsonParser()
+            jsonParser = CustomerJsonParser(),
         ) {
             fireAnalyticsRequest(
                 paymentAnalyticsRequestFactory.createRequest(
@@ -833,24 +826,17 @@ class StripeApiRepository @JvmOverloads internal constructor(
     /**
      * Analytics event: [PaymentAnalyticsEvent.CustomerRetrieve]
      */
-    @Throws(
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class,
-        AuthenticationException::class,
-        CardException::class
-    )
     override suspend fun retrieveCustomer(
         customerId: String,
         productUsageTokens: Set<String>,
         requestOptions: ApiRequest.Options
-    ): Customer? {
-        return fetchStripeModel(
-            apiRequestFactory.createGet(
-                getRetrieveCustomerUrl(customerId),
-                requestOptions
+    ): Result<Customer> {
+        return fetchStripeModelResult(
+            apiRequest = apiRequestFactory.createGet(
+                url = getRetrieveCustomerUrl(customerId),
+                options = requestOptions,
             ),
-            CustomerJsonParser()
+            jsonParser = CustomerJsonParser(),
         ) {
             fireAnalyticsRequest(
                 paymentAnalyticsRequestFactory.createRequest(

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -188,13 +188,6 @@ abstract class StripeRepository {
         options: ApiRequest.Options
     ): Token?
 
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class,
-        CardException::class
-    )
     internal abstract suspend fun addCustomerSource(
         customerId: String,
         publishableKey: String,
@@ -202,22 +195,15 @@ abstract class StripeRepository {
         sourceId: String,
         @Source.SourceType sourceType: String,
         requestOptions: ApiRequest.Options
-    ): Source?
+    ): Result<Source>
 
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class,
-        CardException::class
-    )
     internal abstract suspend fun deleteCustomerSource(
         customerId: String,
         publishableKey: String,
         productUsageTokens: Set<String>,
         sourceId: String,
         requestOptions: ApiRequest.Options
-    ): Source?
+    ): Result<Source>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     abstract suspend fun attachPaymentMethod(
@@ -244,13 +230,6 @@ abstract class StripeRepository {
         requestOptions: ApiRequest.Options
     ): Result<List<PaymentMethod>>
 
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class,
-        CardException::class
-    )
     internal abstract suspend fun setDefaultCustomerSource(
         customerId: String,
         publishableKey: String,
@@ -258,7 +237,7 @@ abstract class StripeRepository {
         sourceId: String,
         @Source.SourceType sourceType: String,
         requestOptions: ApiRequest.Options
-    ): Customer?
+    ): Result<Customer>
 
     @Throws(
         AuthenticationException::class,

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -239,34 +239,20 @@ abstract class StripeRepository {
         requestOptions: ApiRequest.Options
     ): Result<Customer>
 
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class,
-        CardException::class
-    )
     internal abstract suspend fun setCustomerShippingInfo(
         customerId: String,
         publishableKey: String,
         productUsageTokens: Set<String>,
         shippingInformation: ShippingInformation,
         requestOptions: ApiRequest.Options
-    ): Customer?
+    ): Result<Customer>
 
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class,
-        CardException::class
-    )
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     abstract suspend fun retrieveCustomer(
         customerId: String,
         productUsageTokens: Set<String>,
         requestOptions: ApiRequest.Options
-    ): Customer?
+    ): Result<Customer>
 
     @Throws(
         AuthenticationException::class,

--- a/payments-core/src/test/java/com/stripe/android/CustomerSessionOperationExecutorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/CustomerSessionOperationExecutorTest.kt
@@ -120,7 +120,7 @@ internal class CustomerSessionOperationExecutorTest {
                     sourceId: String,
                     sourceType: String,
                     requestOptions: ApiRequest.Options
-                ): Customer? = CustomerFixtures.CUSTOMER
+                ): Result<Customer> = Result.success(CustomerFixtures.CUSTOMER)
             }
         )
         executor.execute(

--- a/payments-core/src/test/java/com/stripe/android/CustomerSessionTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/CustomerSessionTest.kt
@@ -75,8 +75,7 @@ internal class CustomerSessionTest {
                     any(),
                     any()
                 )
-            )
-                .thenReturn(SourceFixtures.SOURCE_CARD)
+            ).thenReturn(Result.success(SourceFixtures.SOURCE_CARD))
 
             whenever(
                 stripeRepository.deleteCustomerSource(
@@ -86,8 +85,7 @@ internal class CustomerSessionTest {
                     any(),
                     any()
                 )
-            )
-                .thenReturn(SourceFixtures.SOURCE_CARD)
+            ).thenReturn(Result.success(SourceFixtures.SOURCE_CARD))
 
             whenever(
                 stripeRepository.setDefaultCustomerSource(
@@ -98,8 +96,7 @@ internal class CustomerSessionTest {
                     any(),
                     any()
                 )
-            )
-                .thenReturn(SECOND_CUSTOMER)
+            ).thenReturn(Result.success(SECOND_CUSTOMER))
 
             whenever(
                 stripeRepository.attachPaymentMethod(
@@ -736,8 +733,9 @@ internal class CustomerSessionTest {
                 any(),
                 any()
             )
+        ).thenReturn(
+            Result.failure(APIException(statusCode = 404, message = "The card is invalid"))
         )
-            .thenThrow(APIException(statusCode = 404, message = "The card is invalid"))
 
         whenever(
             stripeRepository.deleteCustomerSource(
@@ -747,8 +745,9 @@ internal class CustomerSessionTest {
                 any(),
                 any()
             )
+        ).thenReturn(
+            Result.failure(APIException(statusCode = 404, message = "The card does not exist"))
         )
-            .thenThrow(APIException(statusCode = 404, message = "The card does not exist"))
 
         whenever(
             stripeRepository.setDefaultCustomerSource(
@@ -759,8 +758,7 @@ internal class CustomerSessionTest {
                 any(),
                 any()
             )
-        )
-            .thenThrow(APIException(statusCode = 405, message = "auth error"))
+        ).thenReturn(Result.failure(APIException(statusCode = 405, message = "auth error")))
 
         whenever(
             stripeRepository.attachPaymentMethod(

--- a/payments-core/src/test/java/com/stripe/android/CustomerSessionTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/CustomerSessionTest.kt
@@ -64,7 +64,10 @@ internal class CustomerSessionTest {
         Dispatchers.setMain(testDispatcher)
         runBlocking {
             whenever(stripeRepository.retrieveCustomer(any(), any(), any()))
-                .thenReturn(FIRST_CUSTOMER, SECOND_CUSTOMER)
+                .thenReturn(
+                    Result.success(FIRST_CUSTOMER),
+                    Result.success(SECOND_CUSTOMER),
+                )
 
             whenever(
                 stripeRepository.addCustomerSource(
@@ -134,7 +137,7 @@ internal class CustomerSessionTest {
                     any(),
                     any()
                 )
-            ).thenReturn(FIRST_CUSTOMER)
+            ).thenReturn(Result.success(FIRST_CUSTOMER))
         }
     }
 

--- a/payments-core/src/test/java/com/stripe/android/PaymentSessionTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentSessionTest.kt
@@ -375,8 +375,8 @@ class PaymentSessionTest {
             sourceId: String,
             sourceType: String,
             requestOptions: ApiRequest.Options
-        ): Customer {
-            return SECOND_CUSTOMER
+        ): Result<Customer> {
+            return Result.success(SECOND_CUSTOMER)
         }
 
         override suspend fun retrieveCustomer(

--- a/payments-core/src/test/java/com/stripe/android/PaymentSessionTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentSessionTest.kt
@@ -383,8 +383,8 @@ class PaymentSessionTest {
             customerId: String,
             productUsageTokens: Set<String>,
             requestOptions: ApiRequest.Options
-        ): Customer {
-            return FIRST_CUSTOMER
+        ): Result<Customer> {
+            return Result.success(FIRST_CUSTOMER)
         }
     }
 

--- a/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
@@ -201,16 +201,16 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         productUsageTokens: Set<String>,
         shippingInformation: ShippingInformation,
         requestOptions: ApiRequest.Options
-    ): Customer? {
-        return null
+    ): Result<Customer> {
+        return Result.failure(NotImplementedError())
     }
 
     override suspend fun retrieveCustomer(
         customerId: String,
         productUsageTokens: Set<String>,
         requestOptions: ApiRequest.Options
-    ): Customer? {
-        return null
+    ): Result<Customer> {
+        return Result.failure(NotImplementedError())
     }
 
     override suspend fun retrieveIssuingCardPin(

--- a/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
@@ -132,7 +132,6 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         return null
     }
 
-    @Throws(APIException::class)
     override suspend fun addCustomerSource(
         customerId: String,
         publishableKey: String,
@@ -140,19 +139,18 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         sourceId: String,
         sourceType: String,
         requestOptions: ApiRequest.Options
-    ): Source? {
-        return null
+    ): Result<Source> {
+        return Result.failure(NotImplementedError())
     }
 
-    @Throws(APIException::class)
     override suspend fun deleteCustomerSource(
         customerId: String,
         publishableKey: String,
         productUsageTokens: Set<String>,
         sourceId: String,
         requestOptions: ApiRequest.Options
-    ): Source? {
-        return null
+    ): Result<Source> {
+        return Result.failure(NotImplementedError())
     }
 
     @Throws(APIException::class)
@@ -186,7 +184,6 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         return Result.failure(NotImplementedError())
     }
 
-    @Throws(APIException::class)
     override suspend fun setDefaultCustomerSource(
         customerId: String,
         publishableKey: String,
@@ -194,8 +191,8 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         sourceId: String,
         sourceType: String,
         requestOptions: ApiRequest.Options
-    ): Customer? {
-        return null
+    ): Result<Customer> {
+        return Result.failure(NotImplementedError())
     }
 
     override suspend fun setCustomerShippingInfo(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerApiRepository.kt
@@ -42,7 +42,7 @@ internal class CustomerApiRepository @Inject constructor(
                 ephemeralKeySecret,
                 lazyPaymentConfig.get().stripeAccountId
             )
-        )
+        ).getOrNull()
     }
 
     override suspend fun getPaymentMethods(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request moves the customer-related methods in `StripeRepository` to `Result<T>`. The public behavior of code that uses these methods shouldn’t be any different.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
