### PR TITLE
Refactor IntentConfirmationInterceptor

### DIFF
--- a/link/src/main/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModel.kt
@@ -205,7 +205,7 @@ internal class PaymentMethodViewModel @Inject constructor(
     }
 
     private suspend fun completePayment(linkPaymentDetails: LinkPaymentDetails) {
-        val nextStep = intentConfirmationInterceptor.intercept(
+        val nextStep = intentConfirmationInterceptor.interceptNewPayment(
             clientSecret = stripeIntent.clientSecret,
             paymentMethodCreateParams = linkPaymentDetails.paymentMethodCreateParams,
             shippingValues = args.shippingValues?.toConfirmPaymentIntentShipping(),

--- a/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -155,7 +155,7 @@ internal class WalletViewModel @Inject constructor(
                 linkAccount = linkAccount,
             )
 
-            val nextStep = intentConfirmationInterceptor.intercept(
+            val nextStep = intentConfirmationInterceptor.interceptNewPayment(
                 clientSecret = stripeIntent.clientSecret,
                 paymentMethodCreateParams = params,
                 shippingValues = args.shippingValues?.toConfirmPaymentIntentShipping(),

--- a/link/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModelTest.kt
@@ -200,7 +200,7 @@ class PaymentMethodViewModelTest {
 
         val paramsCaptor = argumentCaptor<ConfirmPaymentIntentParams.Shipping>()
 
-        verify(mockInterceptor).intercept(
+        verify(mockInterceptor).interceptNewPayment(
             clientSecret = anyOrNull(),
             paymentMethodCreateParams = any(),
             shippingValues = paramsCaptor.capture(),

--- a/link/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -198,7 +198,7 @@ class WalletViewModelTest {
 
         val paramsCaptor = argumentCaptor<ConfirmPaymentIntentParams.Shipping>()
 
-        verify(mockInterceptor).intercept(
+        verify(mockInterceptor).interceptNewPayment(
             clientSecret = anyOrNull(),
             paymentMethodCreateParams = any(),
             shippingValues = paramsCaptor.capture(),
@@ -467,7 +467,7 @@ class WalletViewModelTest {
 
         val paramsCaptor = argumentCaptor<PaymentMethodCreateParams>()
 
-        verify(mockInterceptor).intercept(
+        verify(mockInterceptor).interceptNewPayment(
             clientSecret = anyOrNull(),
             paymentMethodCreateParams = paramsCaptor.capture(),
             shippingValues = anyOrNull(),
@@ -496,7 +496,7 @@ class WalletViewModelTest {
         viewModel.onConfirmPayment()
 
         val paramsCaptor = argumentCaptor<PaymentMethodCreateParams>()
-        verify(mockInterceptor).intercept(
+        verify(mockInterceptor).interceptNewPayment(
             clientSecret = anyOrNull(),
             paymentMethodCreateParams = paramsCaptor.capture(),
             shippingValues = anyOrNull(),

--- a/network-testing/src/main/java/com/stripe/android/networktesting/RequestMatchers.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/RequestMatchers.kt
@@ -98,6 +98,20 @@ object RequestMatchers {
         }
     }
 
+    fun bodyPart(name: String, regex: Regex): RequestMatcher {
+        return ToStringRequestMatcher("bodyPart($name, $regex)") { request ->
+            request.bodyText.substringAfter("?")
+                .split("&")
+                .associate {
+                    Pair(
+                        it.substringBefore("="),
+                        it.substringAfter("=")
+                    )
+                }.getOrElse(name) { "" }
+                .matches(regex)
+        }
+    }
+
     fun composite(vararg matchers: RequestMatcher): RequestMatcher {
         val friendlyName = "composite(${matchers.joinToString { it.toString() }})"
         return ToStringRequestMatcher(friendlyName) { request ->

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/FakeIntentConfirmationInterceptor.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/FakeIntentConfirmationInterceptor.kt
@@ -35,7 +35,7 @@ class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor {
         channel.trySend(nextStep)
     }
 
-    override suspend fun intercept(
+    override suspend fun interceptNewPayment(
         clientSecret: String?,
         paymentMethodCreateParams: PaymentMethodCreateParams,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
@@ -44,7 +44,7 @@ class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor {
         return channel.receive()
     }
 
-    override suspend fun intercept(
+    override suspend fun interceptSavedPayment(
         clientSecret: String?,
         paymentMethod: PaymentMethod,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,

--- a/payments-core/src/test/java/com/stripe/android/DefaultIntentConfirmationInterceptorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/DefaultIntentConfirmationInterceptorTest.kt
@@ -44,7 +44,7 @@ class DefaultIntentConfirmationInterceptorTest {
 
         val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
 
-        val nextStep = interceptor.intercept(
+        val nextStep = interceptor.interceptSavedPayment(
             clientSecret = "pi_1234_secret_4321",
             paymentMethod = paymentMethod,
             shippingValues = null,
@@ -69,7 +69,7 @@ class DefaultIntentConfirmationInterceptorTest {
 
         val createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD
 
-        val nextStep = interceptor.intercept(
+        val nextStep = interceptor.interceptNewPayment(
             clientSecret = "pi_1234_secret_4321",
             paymentMethodCreateParams = createParams,
             shippingValues = null,
@@ -93,7 +93,7 @@ class DefaultIntentConfirmationInterceptorTest {
         )
 
         val error = assertFailsWith<IllegalStateException> {
-            interceptor.intercept(
+            interceptor.interceptSavedPayment(
                 clientSecret = null,
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 shippingValues = null,
@@ -123,7 +123,7 @@ class DefaultIntentConfirmationInterceptorTest {
         )
 
         val error = assertFailsWith<IllegalStateException> {
-            interceptor.intercept(
+            interceptor.interceptNewPayment(
                 clientSecret = null,
                 paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 shippingValues = null,
@@ -158,7 +158,7 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeAccountIdProvider = { null },
         )
 
-        val nextStep = interceptor.intercept(
+        val nextStep = interceptor.interceptNewPayment(
             clientSecret = null,
             paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
             shippingValues = null,
@@ -198,7 +198,7 @@ class DefaultIntentConfirmationInterceptorTest {
 
         IntentConfirmationInterceptor.createIntentCallback = succeedingServerSideCallback("pm_123456789")
 
-        val nextStep = interceptor.intercept(
+        val nextStep = interceptor.interceptSavedPayment(
             clientSecret = null,
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             shippingValues = null,
@@ -226,7 +226,7 @@ class DefaultIntentConfirmationInterceptorTest {
             message = "that didn't work…"
         )
 
-        val nextStep = interceptor.intercept(
+        val nextStep = interceptor.interceptSavedPayment(
             clientSecret = null,
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             shippingValues = null,
@@ -252,7 +252,7 @@ class DefaultIntentConfirmationInterceptorTest {
 
         IntentConfirmationInterceptor.createIntentCallback = failingClientSideCallback()
 
-        val nextStep = interceptor.intercept(
+        val nextStep = interceptor.interceptSavedPayment(
             clientSecret = null,
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             shippingValues = null,
@@ -280,7 +280,7 @@ class DefaultIntentConfirmationInterceptorTest {
             message = "that didn't work…"
         )
 
-        val nextStep = interceptor.intercept(
+        val nextStep = interceptor.interceptSavedPayment(
             clientSecret = null,
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             shippingValues = null,
@@ -306,7 +306,7 @@ class DefaultIntentConfirmationInterceptorTest {
 
         IntentConfirmationInterceptor.createIntentCallback = failingServerSideCallback()
 
-        val nextStep = interceptor.intercept(
+        val nextStep = interceptor.interceptSavedPayment(
             clientSecret = null,
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             shippingValues = null,
@@ -335,7 +335,7 @@ class DefaultIntentConfirmationInterceptorTest {
 
         IntentConfirmationInterceptor.createIntentCallback = succeedingClientSideCallback(expectedPaymentMethodId)
 
-        val nextStep = interceptor.intercept(
+        val nextStep = interceptor.interceptSavedPayment(
             clientSecret = null,
             paymentMethod = paymentMethod,
             shippingValues = null,
@@ -367,7 +367,7 @@ class DefaultIntentConfirmationInterceptorTest {
 
         IntentConfirmationInterceptor.createIntentCallback = succeedingServerSideCallback(expectedPaymentMethodId)
 
-        val nextStep = interceptor.intercept(
+        val nextStep = interceptor.interceptSavedPayment(
             clientSecret = null,
             paymentMethod = paymentMethod,
             shippingValues = null,
@@ -403,7 +403,7 @@ class DefaultIntentConfirmationInterceptorTest {
 
         IntentConfirmationInterceptor.createIntentCallback = succeedingServerSideCallback(expectedPaymentMethodId)
 
-        val nextStep = interceptor.intercept(
+        val nextStep = interceptor.interceptSavedPayment(
             clientSecret = null,
             paymentMethod = paymentMethod,
             shippingValues = null,
@@ -448,7 +448,7 @@ class DefaultIntentConfirmationInterceptorTest {
                     observedValues += shouldSavePaymentMethod
                     CreateIntentResult.Success("pi_123_secret_456")
                 }
-            interceptor.intercept(
+            interceptor.interceptSavedPayment(
                 clientSecret = null,
                 paymentMethod = paymentMethod,
                 shippingValues = null,

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -10,6 +10,7 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.method
+import com.stripe.android.networktesting.RequestMatchers.not
 import com.stripe.android.networktesting.RequestMatchers.path
 import com.stripe.android.networktesting.RequestMatchers.query
 import com.stripe.android.networktesting.testBodyFromFile
@@ -401,9 +402,11 @@ internal class FlowControllerTest {
         networkRule.enqueue(
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
-            bodyPart(
-                "payment_method_data%5Bpayment_user_agent%5D",
-                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet.FlowController%3BPaymentSheet")
+            not(
+                bodyPart(
+                    "payment_method_data%5Bpayment_user_agent%5D",
+                    Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet.FlowController%3BPaymentSheet")
+                )
             )
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -8,6 +8,7 @@ import com.stripe.android.CreateIntentResult
 import com.stripe.android.ExperimentalPaymentSheetDecouplingApi
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.path
 import com.stripe.android.networktesting.RequestMatchers.query
@@ -389,6 +390,10 @@ internal class FlowControllerTest {
         networkRule.enqueue(
             method("POST"),
             path("/v1/payment_methods"),
+            bodyPart(
+                "payment_user_agent",
+                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet.FlowController%3BPaymentSheet")
+            ),
         ) { response ->
             response.testBodyFromFile("payment-methods-create.json")
         }
@@ -396,6 +401,10 @@ internal class FlowControllerTest {
         networkRule.enqueue(
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
+            bodyPart(
+                "payment_method_data%5Bpayment_user_agent%5D",
+                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet.FlowController%3BPaymentSheet")
+            )
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -10,6 +10,7 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.method
+import com.stripe.android.networktesting.RequestMatchers.not
 import com.stripe.android.networktesting.RequestMatchers.path
 import com.stripe.android.networktesting.testBodyFromFile
 import org.junit.Rule
@@ -216,9 +217,11 @@ internal class PaymentSheetTest {
         networkRule.enqueue(
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
-            bodyPart(
-                "payment_method_data%5Bpayment_user_agent%5D",
-                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet")
+            not(
+                bodyPart(
+                    "payment_method_data%5Bpayment_user_agent%5D",
+                    Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet")
+                )
             ),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -8,6 +8,7 @@ import com.stripe.android.CreateIntentResult
 import com.stripe.android.ExperimentalPaymentSheetDecouplingApi
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.path
 import com.stripe.android.networktesting.testBodyFromFile
@@ -204,6 +205,10 @@ internal class PaymentSheetTest {
         networkRule.enqueue(
             method("POST"),
             path("/v1/payment_methods"),
+            bodyPart(
+                "payment_user_agent",
+                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet")
+            ),
         ) { response ->
             response.testBodyFromFile("payment-methods-create.json")
         }
@@ -211,6 +216,10 @@ internal class PaymentSheetTest {
         networkRule.enqueue(
             method("POST"),
             path("/v1/payment_intents/pi_example/confirm"),
+            bodyPart(
+                "payment_method_data%5Bpayment_user_agent%5D",
+                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet")
+            ),
         ) { response ->
             response.testBodyFromFile("payment-intent-confirm.json")
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptorKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptorKtx.kt
@@ -18,8 +18,7 @@ internal suspend fun IntentConfirmationInterceptor.intercept(
                 CustomerRequestedSave.RequestNoReuse -> SetupFutureUsage.Blank
                 CustomerRequestedSave.NoRequest -> null
             }
-
-            intercept(
+            interceptNewPayment(
                 clientSecret = clientSecret,
                 paymentMethodCreateParams = paymentSelection.paymentMethodCreateParams,
                 shippingValues = shippingValues,
@@ -27,7 +26,7 @@ internal suspend fun IntentConfirmationInterceptor.intercept(
             )
         }
         is PaymentSelection.Saved -> {
-            intercept(
+            interceptSavedPayment(
                 clientSecret = clientSecret,
                 paymentMethod = paymentSelection.paymentMethod,
                 shippingValues = shippingValues,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Refactor IntentConfirmationInterceptor intercept methods into two separate intercept methods, one for existing payment method, one for creating a new payment method.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Decoupling

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified
