### PR TITLE
Fix inconsistencies in `Save for future use` in ACH

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentMethodFactory.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentMethodFactory.kt
@@ -13,4 +13,14 @@ object PaymentMethodFactory {
             code = PaymentMethod.Type.CashAppPay.code,
         )
     }
+
+    fun usBankAccount(): PaymentMethod {
+        return PaymentMethod(
+            id = "pm_1234",
+            created = 123456789L,
+            liveMode = false,
+            type = PaymentMethod.Type.USBankAccount,
+            code = PaymentMethod.Type.USBankAccount.code,
+        )
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -17,7 +17,12 @@ import kotlinx.parcelize.Parcelize
 internal sealed class PaymentSelection : Parcelable {
 
     abstract val requiresConfirmation: Boolean
-    abstract fun mandateText(context: Context): String?
+
+    abstract fun mandateText(
+        context: Context,
+        merchantName: String,
+        isSaveForFutureUseSelected: Boolean,
+    ): String?
 
     @Parcelize
     object GooglePay : PaymentSelection() {
@@ -25,7 +30,11 @@ internal sealed class PaymentSelection : Parcelable {
         override val requiresConfirmation: Boolean
             get() = false
 
-        override fun mandateText(context: Context): String? {
+        override fun mandateText(
+            context: Context,
+            merchantName: String,
+            isSaveForFutureUseSelected: Boolean,
+        ): String? {
             return null
         }
     }
@@ -36,7 +45,11 @@ internal sealed class PaymentSelection : Parcelable {
         override val requiresConfirmation: Boolean
             get() = false
 
-        override fun mandateText(context: Context): String? {
+        override fun mandateText(
+            context: Context,
+            merchantName: String,
+            isSaveForFutureUseSelected: Boolean,
+        ): String? {
             return null
         }
     }
@@ -50,9 +63,13 @@ internal sealed class PaymentSelection : Parcelable {
         override val requiresConfirmation: Boolean
             get() = paymentMethod.type == USBankAccount
 
-        override fun mandateText(context: Context): String? {
+        override fun mandateText(
+            context: Context,
+            merchantName: String,
+            isSaveForFutureUseSelected: Boolean,
+        ): String? {
             return if (paymentMethod.type == USBankAccount) {
-                ACHText.getContinueMandateText(context)
+                ACHText.getContinueMandateText(context, merchantName, isSaveForFutureUseSelected)
             } else {
                 null
             }
@@ -73,7 +90,11 @@ internal sealed class PaymentSelection : Parcelable {
         override val requiresConfirmation: Boolean
             get() = false
 
-        override fun mandateText(context: Context): String? {
+        override fun mandateText(
+            context: Context,
+            merchantName: String,
+            isSaveForFutureUseSelected: Boolean,
+        ): String? {
             return null
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/ACHText.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/ACHText.kt
@@ -16,9 +16,7 @@ internal object ACHText {
         val text = if (isSaveForFutureUseSelected) {
             context.getString(R.string.stripe_paymentsheet_ach_save_mandate, merchantName)
         } else {
-            context.getString(
-                R.string.stripe_paymentsheet_ach_continue_mandate
-            )
+            context.getString(R.string.stripe_paymentsheet_ach_continue_mandate)
         }
 
         return text.replace(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/ACHText.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/ACHText.kt
@@ -7,22 +7,26 @@ import com.stripe.android.paymentsheet.R
  * Temporary hack to get mandate text to display properly until translations are fixed
  */
 internal object ACHText {
-    fun getContinueMandateText(context: Context): String {
-        return context.getString(
-            R.string.stripe_paymentsheet_ach_continue_mandate
-        ).replace(
-            "<terms>",
-            "<a href=\"https://stripe.com/ach-payments/authorization\">"
-        ).replace("</terms>", "</a>")
-    }
 
-    fun getSaveMandateText(context: Context, merchantName: String): String {
-        return context.getString(
-            R.string.stripe_paymentsheet_ach_save_mandate,
-            merchantName,
+    fun getContinueMandateText(
+        context: Context,
+        merchantName: String,
+        isSaveForFutureUseSelected: Boolean,
+    ): String {
+        val base = if (isSaveForFutureUseSelected) {
+            context.getString(R.string.stripe_paymentsheet_ach_save_mandate, merchantName)
+        } else {
+            context.getString(
+                R.string.stripe_paymentsheet_ach_continue_mandate
+            )
+        }
+
+        return base.replace(
+            oldValue = "<terms>",
+            newValue = "<a href=\"https://stripe.com/ach-payments/authorization\">",
         ).replace(
-            "<terms>",
-            "<a href=\"https://stripe.com/ach-payments/authorization\">"
-        ).replace("</terms>", "</a>")
+            oldValue = "</terms>",
+            newValue = "</a>",
+        )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/ACHText.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/ACHText.kt
@@ -13,7 +13,7 @@ internal object ACHText {
         merchantName: String,
         isSaveForFutureUseSelected: Boolean,
     ): String {
-        val base = if (isSaveForFutureUseSelected) {
+        val text = if (isSaveForFutureUseSelected) {
             context.getString(R.string.stripe_paymentsheet_ach_save_mandate, merchantName)
         } else {
             context.getString(
@@ -21,7 +21,7 @@ internal object ACHText {
             )
         }
 
-        return base.replace(
+        return text.replace(
             oldValue = "<terms>",
             newValue = "<a href=\"https://stripe.com/ach-payments/authorization\">",
         ).replace(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormFragment.kt
@@ -189,16 +189,12 @@ internal class USBankAccountFormFragment : Fragment() {
                 viewModel.saveForFutureUse
                     .filterNot { viewModel.currentScreenState.value is BillingDetailsCollection }
                     .collect { saved ->
-                        updateMandateText(
-                            if (saved) {
-                                ACHText.getSaveMandateText(
-                                    context,
-                                    viewModel.formattedMerchantName(),
-                                )
-                            } else {
-                                ACHText.getContinueMandateText(requireContext())
-                            }
+                        val mandateText = ACHText.getContinueMandateText(
+                            context = requireContext(),
+                            merchantName = viewModel.formattedMerchantName(),
+                            isSaveForFutureUseSelected = saved,
                         )
+                        updateMandateText(mandateText)
                     }
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -212,7 +212,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
     ) as SaveForFutureUseElement
 
     val saveForFutureUse: StateFlow<Boolean> = saveForFutureUseElement.controller.saveForFutureUse
-        .stateIn(viewModelScope, SharingStarted.Lazily, args.formArgs.showCheckbox)
+        .stateIn(viewModelScope, SharingStarted.Lazily, false)
 
     val requiredFields = combine(
         nameController.formFieldValue.map { it.isComplete },

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -207,9 +207,10 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         get() = _currentScreenState
 
     val saveForFutureUseElement: SaveForFutureUseElement = SaveForFutureUseSpec().transform(
-        initialValue = args.formArgs.showCheckbox,
+        initialValue = false,
         merchantName = args.formArgs.merchantName
     ) as SaveForFutureUseElement
+
     val saveForFutureUse: StateFlow<Boolean> = saveForFutureUseElement.controller.saveForFutureUse
         .stateIn(viewModelScope, SharingStarted.Lazily, args.formArgs.showCheckbox)
 
@@ -568,14 +569,11 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
     }
 
     private fun buildMandateText(): String {
-        return if (saveForFutureUse.value) {
-            application.getString(
-                R.string.stripe_paymentsheet_ach_save_mandate,
-                formattedMerchantName()
-            )
-        } else {
-            ACHText.getContinueMandateText(application)
-        }
+        return ACHText.getContinueMandateText(
+            context = application,
+            merchantName = formattedMerchantName(),
+            isSaveForFutureUseSelected = saveForFutureUse.value,
+        )
     }
 
     internal class Factory(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentOptionsScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentOptionsScreen.kt
@@ -48,6 +48,8 @@ internal fun PaymentOptionsScreenContent(
     val notesText by viewModel.notesText.collectAsState()
 
     val showLinkDialog by viewModel.linkHandler.showLinkVerificationDialog.collectAsState()
+
+    val horizontalPadding = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_horizontal)
     val bottomPadding = dimensionResource(R.dimen.stripe_paymentsheet_button_container_spacing_bottom)
 
     Column(
@@ -65,7 +67,7 @@ internal fun PaymentOptionsScreenContent(
                 text = stringResource(text),
                 modifier = Modifier
                     .padding(bottom = 2.dp)
-                    .padding(horizontal = 20.dp),
+                    .padding(horizontal = horizontalPadding),
             )
         }
 
@@ -74,7 +76,9 @@ internal fun PaymentOptionsScreenContent(
         errorMessage?.let { error ->
             ErrorMessage(
                 error = error,
-                modifier = Modifier.padding(vertical = 2.dp),
+                modifier = Modifier
+                    .padding(vertical = 2.dp)
+                    .padding(horizontal = horizontalPadding),
             )
         }
 
@@ -88,7 +92,9 @@ internal fun PaymentOptionsScreenContent(
                 html = text,
                 color = MaterialTheme.stripeColors.subtitle,
                 style = MaterialTheme.typography.body1.copy(textAlign = TextAlign.Center),
-                modifier = Modifier.padding(top = 8.dp),
+                modifier = Modifier
+                    .padding(top = 8.dp)
+                    .padding(horizontal = horizontalPadding),
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -129,7 +129,9 @@ internal fun PaymentSheetScreenContent(
                 html = text,
                 color = MaterialTheme.stripeColors.subtitle,
                 style = MaterialTheme.typography.body1.copy(textAlign = TextAlign.Center),
-                modifier = Modifier.padding(top = 8.dp),
+                modifier = Modifier
+                    .padding(top = 8.dp)
+                    .padding(horizontal = horizontalPadding),
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -23,6 +23,7 @@ import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.PaymentSelection.CustomerRequestedSave.RequestReuse
 import com.stripe.android.paymentsheet.model.currency
 import com.stripe.android.paymentsheet.model.getPMsToAdd
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
@@ -344,9 +345,19 @@ internal abstract class BaseSheetViewModel(
 
         savedStateHandle[SAVE_SELECTION] = selection
 
-        val mandateText = selection?.mandateText(getApplication())
-        updateBelowButtonText(mandateText)
+        val isRequestingReuse = if (selection is PaymentSelection.New) {
+            selection.customerRequestedSave == RequestReuse
+        } else {
+            false
+        }
 
+        val mandateText = selection?.mandateText(
+            context = getApplication(),
+            merchantName = merchantName,
+            isSaveForFutureUseSelected = isRequestingReuse,
+        )
+
+        updateBelowButtonText(mandateText)
         clearErrorMessages()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -45,7 +45,6 @@ import com.stripe.android.paymentsheet.model.StripeIntentValidator
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddAnotherPaymentMethod
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.AddFirstPaymentMethod
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen.SelectSavedPaymentMethods
-import com.stripe.android.paymentsheet.paymentdatacollection.ach.ACHText
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.state.GooglePayState
 import com.stripe.android.paymentsheet.state.LinkState
@@ -771,15 +770,15 @@ internal class PaymentSheetViewModelTest {
     @Test
     fun `updateSelection() posts mandate text when selected payment is us_bank_account`() {
         val viewModel = createViewModel()
+
         viewModel.updateSelection(
-            PaymentSelection.Saved(
-                PaymentMethodFixtures.US_BANK_ACCOUNT
-            )
+            PaymentSelection.Saved(PaymentMethodFixtures.US_BANK_ACCOUNT)
         )
 
         assertThat(viewModel.notesText.value)
             .isEqualTo(
-                ACHText.getContinueMandateText(ApplicationProvider.getApplicationContext())
+                "By continuing, you agree to authorize payments pursuant to " +
+                    "<a href=\"https://stripe.com/ach-payments/authorization\">these terms</a>."
             )
 
         viewModel.updateSelection(
@@ -797,9 +796,7 @@ internal class PaymentSheetViewModelTest {
             .isEqualTo(null)
 
         viewModel.updateSelection(
-            PaymentSelection.Saved(
-                PaymentMethodFixtures.CARD_PAYMENT_METHOD
-            )
+            PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
         )
 
         assertThat(viewModel.notesText.value)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionTest.kt
@@ -1,0 +1,111 @@
+package com.stripe.android.paymentsheet.model
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.testing.PaymentMethodFactory
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PaymentSelectionTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `Doesn't display a mandate for Link`() {
+        val link = PaymentSelection.Link
+        val result = link.mandateText(
+            context = context,
+            merchantName = "Merchant",
+            isSaveForFutureUseSelected = listOf(true, false).random(),
+        )
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `Doesn't display a mandate for Google Pay`() {
+        val googlePay = PaymentSelection.GooglePay
+        val result = googlePay.mandateText(
+            context = context,
+            merchantName = "Merchant",
+            isSaveForFutureUseSelected = listOf(true, false).random(),
+        )
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `Doesn't display a mandate for new US bank accounts`() {
+        // We actually do show a mandate, but it's set independently from the PaymentSelection.
+        val newPaymentSelection = PaymentSelection.New.USBankAccount(
+            labelResource = "Test",
+            iconResource = 0,
+            bankName = "Test",
+            last4 = "Test",
+            financialConnectionsSessionId = "1234",
+            intentId = "1234",
+            paymentMethodCreateParams = mock(),
+            customerRequestedSave = mock(),
+        )
+
+        val result = newPaymentSelection.mandateText(
+            context = context,
+            merchantName = "Merchant",
+            isSaveForFutureUseSelected = listOf(true, false).random(),
+        )
+
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `Displays the correct mandate for a saved US bank account when saving for future use`() {
+        val newPaymentSelection = PaymentSelection.Saved(
+            paymentMethod = PaymentMethodFactory.usBankAccount(),
+        )
+
+        val result = newPaymentSelection.mandateText(
+            context = context,
+            merchantName = "Merchant",
+            isSaveForFutureUseSelected = true,
+        )
+
+        assertThat(result).isEqualTo(
+            "By saving your bank account for Merchant you agree to authorize payments pursuant " +
+                "to <a href=\"https://stripe.com/ach-payments/authorization\">these terms</a>."
+        )
+    }
+
+    @Test
+    fun `Displays the correct mandate for a saved US bank account when not saving for future use`() {
+        val newPaymentSelection = PaymentSelection.Saved(
+            paymentMethod = PaymentMethodFactory.usBankAccount(),
+        )
+
+        val result = newPaymentSelection.mandateText(
+            context = context,
+            merchantName = "Merchant",
+            isSaveForFutureUseSelected = false,
+        )
+
+        assertThat(result).isEqualTo(
+            "By continuing, you agree to authorize payments pursuant to " +
+                "<a href=\"https://stripe.com/ach-payments/authorization\">these terms</a>."
+        )
+    }
+
+    @Test
+    fun `Doesn't display a mandate for a saved payment method that isn't US bank account`() {
+        val newPaymentSelection = PaymentSelection.Saved(
+            paymentMethod = PaymentMethodFactory.cashAppPay(),
+        )
+
+        val result = newPaymentSelection.mandateText(
+            context = context,
+            merchantName = "Merchant",
+            isSaveForFutureUseSelected = listOf(true, false).random(),
+        )
+        assertThat(result).isNull()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionTest.kt
@@ -15,49 +15,51 @@ class PaymentSelectionTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
 
     @Test
-    fun `Doesn't display a mandate for Link`() {
+    fun `Doesn't display a mandate for Link`() = runAllConfigurations { isSaveForFutureUseSelected ->
         val link = PaymentSelection.Link
         val result = link.mandateText(
             context = context,
             merchantName = "Merchant",
-            isSaveForFutureUseSelected = listOf(true, false).random(),
+            isSaveForFutureUseSelected = isSaveForFutureUseSelected,
         )
         assertThat(result).isNull()
     }
 
     @Test
-    fun `Doesn't display a mandate for Google Pay`() {
-        val googlePay = PaymentSelection.GooglePay
-        val result = googlePay.mandateText(
-            context = context,
-            merchantName = "Merchant",
-            isSaveForFutureUseSelected = listOf(true, false).random(),
-        )
-        assertThat(result).isNull()
-    }
+    fun `Doesn't display a mandate for Google Pay`() =
+        runAllConfigurations { isSaveForFutureUseSelected ->
+            val googlePay = PaymentSelection.GooglePay
+            val result = googlePay.mandateText(
+                context = context,
+                merchantName = "Merchant",
+                isSaveForFutureUseSelected = isSaveForFutureUseSelected,
+            )
+            assertThat(result).isNull()
+        }
 
     @Test
-    fun `Doesn't display a mandate for new US bank accounts`() {
-        // We actually do show a mandate, but it's set independently from the PaymentSelection.
-        val newPaymentSelection = PaymentSelection.New.USBankAccount(
-            labelResource = "Test",
-            iconResource = 0,
-            bankName = "Test",
-            last4 = "Test",
-            financialConnectionsSessionId = "1234",
-            intentId = "1234",
-            paymentMethodCreateParams = mock(),
-            customerRequestedSave = mock(),
-        )
+    fun `Doesn't display a mandate for new US bank accounts`() =
+        runAllConfigurations { isSaveForFutureUseSelected ->
+            // We actually do show a mandate, but it's set independently from the PaymentSelection.
+            val newPaymentSelection = PaymentSelection.New.USBankAccount(
+                labelResource = "Test",
+                iconResource = 0,
+                bankName = "Test",
+                last4 = "Test",
+                financialConnectionsSessionId = "1234",
+                intentId = "1234",
+                paymentMethodCreateParams = mock(),
+                customerRequestedSave = mock(),
+            )
 
-        val result = newPaymentSelection.mandateText(
-            context = context,
-            merchantName = "Merchant",
-            isSaveForFutureUseSelected = listOf(true, false).random(),
-        )
+            val result = newPaymentSelection.mandateText(
+                context = context,
+                merchantName = "Merchant",
+                isSaveForFutureUseSelected = isSaveForFutureUseSelected,
+            )
 
-        assertThat(result).isNull()
-    }
+            assertThat(result).isNull()
+        }
 
     @Test
     fun `Displays the correct mandate for a saved US bank account when saving for future use`() {
@@ -96,16 +98,23 @@ class PaymentSelectionTest {
     }
 
     @Test
-    fun `Doesn't display a mandate for a saved payment method that isn't US bank account`() {
-        val newPaymentSelection = PaymentSelection.Saved(
-            paymentMethod = PaymentMethodFactory.cashAppPay(),
-        )
+    fun `Doesn't display a mandate for a saved payment method that isn't US bank account`() =
+        runAllConfigurations { isSaveForFutureUseSelected ->
+            val newPaymentSelection = PaymentSelection.Saved(
+                paymentMethod = PaymentMethodFactory.cashAppPay(),
+            )
 
-        val result = newPaymentSelection.mandateText(
-            context = context,
-            merchantName = "Merchant",
-            isSaveForFutureUseSelected = listOf(true, false).random(),
-        )
-        assertThat(result).isNull()
+            val result = newPaymentSelection.mandateText(
+                context = context,
+                merchantName = "Merchant",
+                isSaveForFutureUseSelected = isSaveForFutureUseSelected,
+            )
+            assertThat(result).isNull()
+        }
+
+    private fun runAllConfigurations(block: (Boolean) -> Unit) {
+        for (isSaveForFutureUseSelected in listOf(true, false)) {
+            block(isSaveForFutureUseSelected)
+        }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -218,26 +218,16 @@ class USBankAccountFormViewModelTest {
         }
 
     @Test
-    fun `when reset, save for future usage should be true`() {
-        runTest(UnconfinedTestDispatcher()) {
-            val viewModel = createViewModel()
-            viewModel.collectBankAccountLauncher = collectBankAccountLauncher
+    fun `when reset, save for future usage should be false`() = runTest {
+        val viewModel = createViewModel()
+        viewModel.collectBankAccountLauncher = collectBankAccountLauncher
 
-            viewModel.saveForFutureUseElement.controller.onValueChange(false)
+        viewModel.saveForFutureUseElement.controller.onValueChange(false)
 
-            assertThat(
-                viewModel.saveForFutureUseElement.controller.saveForFutureUse.stateIn(
-                    viewModel.viewModelScope
-                ).value
-            ).isFalse()
-
+        viewModel.saveForFutureUseElement.controller.saveForFutureUse.test {
+            assertThat(awaitItem()).isFalse()
             viewModel.reset()
-
-            assertThat(
-                viewModel.saveForFutureUseElement.controller.saveForFutureUse.stateIn(
-                    viewModel.viewModelScope
-                ).value
-            ).isTrue()
+            assertThat(awaitItem()).isTrue()
         }
     }
 
@@ -418,6 +408,19 @@ class USBankAccountFormViewModelTest {
         viewModel.addressElement.countryElement.controller.onRawValueChange("CA")
         assertThat(viewModel.phoneController.countryDropdownController.rawFieldValue.first())
             .isEqualTo("CA")
+    }
+
+    @Test
+    fun `Doesn't save for future use by default`() = runTest {
+        val viewModel = createViewModel(
+            args = defaultArgs.copy(
+                formArgs = defaultArgs.formArgs.copy(
+                    showCheckbox = true,
+                    showCheckboxControlledFields = true,
+                ),
+            ),
+        )
+        assertThat(viewModel.saveForFutureUse.value).isFalse()
     }
 
     private fun createViewModel(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes some issues with the `Save for future use` checkbox and the corresponding mandate text, including:

1. Add missing padding to mandate text
2. Make sure the mandate text always includes the link to the terms, not just when the checkbox is unchecked
3. Don’t check the checkbox by default (aligning with iOS here)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Better ACH experience.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
