### PR TITLE
Add `is_server_side_confirmation` to analytics init event

### DIFF
--- a/payments-core-testing/build.gradle
+++ b/payments-core-testing/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     implementation project(":payments-core")
 
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinCoroutinesVersion"
+    implementation "junit:junit:$junitVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$androidxLifecycleVersion"
 
     androidTestImplementation project(':stripe-ui-core') // Resources defined here, but used in payments-core.

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/IntentConfirmationInterceptorTestRule.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/IntentConfirmationInterceptorTestRule.kt
@@ -1,0 +1,18 @@
+package com.stripe.android.testing
+
+import com.stripe.android.IntentConfirmationInterceptor
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+class IntentConfirmationInterceptorTestRule : TestWatcher() {
+
+    override fun starting(description: Description) {
+        super.starting(description)
+        IntentConfirmationInterceptor.createIntentCallback = null
+    }
+
+    override fun finished(description: Description) {
+        IntentConfirmationInterceptor.createIntentCallback = null
+        super.finished(description)
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/DefaultIntentConfirmationInterceptorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/DefaultIntentConfirmationInterceptorTest.kt
@@ -13,25 +13,24 @@ import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.AbsFakeStripeRepository
+import com.stripe.android.testing.IntentConfirmationInterceptorTestRule
 import kotlinx.coroutines.test.runTest
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
 import java.util.Objects
-import kotlin.test.BeforeTest
 import kotlin.test.assertFailsWith
 
 @OptIn(ExperimentalPaymentSheetDecouplingApi::class)
 @RunWith(RobolectricTestRunner::class)
 class DefaultIntentConfirmationInterceptorTest {
 
-    private val context = ApplicationProvider.getApplicationContext<Context>()
+    @get:Rule
+    val intentConfirmationInterceptorTestRule = IntentConfirmationInterceptorTestRule()
 
-    @BeforeTest
-    fun before() {
-        IntentConfirmationInterceptor.createIntentCallback = null
-    }
+    private val context = ApplicationProvider.getApplicationContext<Context>()
 
     @Test
     fun `Returns confirm as next step if invoked with client secret for existing payment method`() = runTest {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -37,7 +37,6 @@ import com.stripe.android.payments.paymentlauncher.PaymentLauncherContract
 import com.stripe.android.payments.paymentlauncher.PaymentResult
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncher
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
-import com.stripe.android.paymentsheet.PaymentSheet.InitializationMode.DeferredIntent
 import com.stripe.android.paymentsheet.addresselement.toConfirmPaymentIntentShipping
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.extensions.registerPollingAuthenticator
@@ -200,8 +199,9 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             }
         }
 
-        val isServerSideConfirmation = args.initializationMode is DeferredIntent &&
-            IntentConfirmationInterceptor.createIntentCallback is CreateIntentCallbackForServerSideConfirmation
+        val isServerSideConfirmation =
+            args.initializationMode is PaymentSheet.InitializationMode.DeferredIntent &&
+                IntentConfirmationInterceptor.createIntentCallback is CreateIntentCallbackForServerSideConfirmation
 
         eventReporter.onInit(
             configuration = config,
@@ -640,7 +640,7 @@ private val PaymentSheet.InitializationMode.isProcessingPayment: Boolean
     get() = when (this) {
         is PaymentSheet.InitializationMode.PaymentIntent -> true
         is PaymentSheet.InitializationMode.SetupIntent -> false
-        is DeferredIntent -> {
+        is PaymentSheet.InitializationMode.DeferredIntent -> {
             intentConfiguration.mode is PaymentSheet.IntentConfiguration.Mode.Payment
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -21,11 +21,15 @@ internal class DefaultEventReporter @Inject internal constructor(
 ) : EventReporter {
     private var paymentSheetShownMillis: Long? = null
 
-    override fun onInit(configuration: PaymentSheet.Configuration?) {
+    override fun onInit(
+        configuration: PaymentSheet.Configuration?,
+        isServerSideConfirmation: Boolean,
+    ) {
         fireEvent(
             PaymentSheetEvent.Init(
                 mode = mode,
-                configuration = configuration
+                configuration = configuration,
+                isServerSideConfirmation = isServerSideConfirmation,
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -4,7 +4,11 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 
 internal interface EventReporter {
-    fun onInit(configuration: PaymentSheet.Configuration?)
+
+    fun onInit(
+        configuration: PaymentSheet.Configuration?,
+        isServerSideConfirmation: Boolean,
+    )
 
     fun onDismiss()
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -11,7 +11,8 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
 
     class Init(
         private val mode: EventReporter.Mode,
-        private val configuration: PaymentSheet.Configuration?
+        private val configuration: PaymentSheet.Configuration?,
+        private val isServerSideConfirmation: Boolean,
     ) : PaymentSheetEvent() {
         override val eventName: String
             get() {
@@ -101,6 +102,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
                     FIELD_APPEARANCE to appearanceConfigMap,
                     FIELD_BILLING_DETAILS_COLLECTION_CONFIGURATION to
                         billingDetailsCollectionConfigMap,
+                    FIELD_IS_SERVER_SIDE_CONFIRMATION to isServerSideConfirmation,
                 )
                 return mapOf(
                     FIELD_MOBILE_PAYMENT_ELEMENT_CONFIGURATION to configurationMap,
@@ -233,6 +235,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         const val FIELD_PRIMARY_BUTTON = "primary_button"
         const val FIELD_BILLING_DETAILS_COLLECTION_CONFIGURATION =
             "billing_details_collection_configuration"
+        const val FIELD_IS_SERVER_SIDE_CONFIRMATION = "is_server_side_confirmation"
         const val FIELD_ATTACH_DEFAULTS = "attach_defaults"
         const val FIELD_COLLECT_NAME = "name"
         const val FIELD_COLLECT_EMAIL = "email"

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -53,6 +53,7 @@ import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.Companion.SAVE_PROCESSING
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel.UserErrorMessage
 import com.stripe.android.testing.FakeIntentConfirmationInterceptor
+import com.stripe.android.testing.IntentConfirmationInterceptorTestRule
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.forms.resources.LpmRepository
@@ -85,6 +86,9 @@ import kotlin.time.Duration
 internal class PaymentSheetViewModelTest {
     @get:Rule
     val rule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val intentConfirmationInterceptorTestRule = IntentConfirmationInterceptorTestRule()
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
@@ -127,7 +131,6 @@ internal class PaymentSheetViewModelTest {
     @BeforeTest
     fun setup() {
         MockitoAnnotations.openMocks(this)
-        IntentConfirmationInterceptor.createIntentCallback = null
     }
 
     @AfterTest

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -45,7 +45,10 @@ class DefaultEventReporterTest {
 
     @Test
     fun `onInit() should fire analytics request with expected event value`() {
-        completeEventReporter.onInit(PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY)
+        completeEventReporter.onInit(
+            configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
+            isServerSideConfirmation = false,
+        )
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
                 req.params["event"] == "mc_complete_init_customer_googlepay" &&

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -19,7 +19,8 @@ class PaymentSheetEventTest {
     fun `Init event with full config should return expected toString()`() {
         val event = PaymentSheetEvent.Init(
             mode = EventReporter.Mode.Complete,
-            configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY
+            configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
+            isServerSideConfirmation = false,
         )
         assertThat(
             event.eventName
@@ -35,7 +36,8 @@ class PaymentSheetEventTest {
     fun `Init event with minimum config should return expected toString()`() {
         val event = PaymentSheetEvent.Init(
             mode = EventReporter.Mode.Complete,
-            configuration = PaymentSheetFixtures.CONFIG_MINIMUM
+            configuration = PaymentSheetFixtures.CONFIG_MINIMUM,
+            isServerSideConfirmation = false,
         )
         assertThat(
             event.eventName
@@ -373,11 +375,13 @@ class PaymentSheetEventTest {
             "allows_delayed_payment_methods" to false,
             "appearance" to expectedAppearance,
             "billing_details_collection_configuration" to expectedBillingDetailsCollection,
+            "is_server_side_confirmation" to false,
         )
         assertThat(
             PaymentSheetEvent.Init(
                 mode = EventReporter.Mode.Complete,
-                configuration = PaymentSheetFixtures.CONFIG_MINIMUM
+                configuration = PaymentSheetFixtures.CONFIG_MINIMUM,
+                isServerSideConfirmation = false,
             ).additionalParams
         ).isEqualTo(
             mapOf(
@@ -421,11 +425,13 @@ class PaymentSheetEventTest {
             "allows_delayed_payment_methods" to true,
             "appearance" to expectedAppearance,
             "billing_details_collection_configuration" to expectedBillingDetailsCollection,
+            "is_server_side_confirmation" to false,
         )
         assertThat(
             PaymentSheetEvent.Init(
                 mode = EventReporter.Mode.Complete,
-                configuration = PaymentSheetFixtures.CONFIG_WITH_EVERYTHING
+                configuration = PaymentSheetFixtures.CONFIG_WITH_EVERYTHING,
+                isServerSideConfirmation = false,
             ).additionalParams
         ).isEqualTo(
             mapOf(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
@@ -19,6 +19,7 @@ import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentSheetLoader
+import com.stripe.android.testing.IntentConfirmationInterceptorTestRule
 import com.stripe.android.utils.DelayingPaymentSheetLoader
 import com.stripe.android.utils.FakePaymentSheetLoader
 import com.stripe.android.view.ActivityScenarioFactory
@@ -33,6 +34,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.isNull
@@ -45,6 +47,9 @@ import kotlin.time.Duration.Companion.seconds
 
 @RunWith(RobolectricTestRunner::class)
 class FlowControllerConfigurationHandlerTest {
+
+    @get:Rule
+    val intentConfirmationInterceptorTestRule = IntentConfirmationInterceptorTestRule()
 
     private val testDispatcher = UnconfinedTestDispatcher()
     private val testScope = TestScope(testDispatcher)
@@ -64,8 +69,6 @@ class FlowControllerConfigurationHandlerTest {
         activityScenario.onActivity { activity ->
             viewModel = ViewModelProvider(activity)[FlowControllerViewModel::class.java]
         }
-
-        IntentConfirmationInterceptor.createIntentCallback = null
     }
 
     @After


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds the `is_server_side_confirmation` field to the `mpe_config` map that’s included in the PaymentSheet init event. It is `true` if the merchant is using an `IntentConfiguration` and has set a `CreateIntentCallbackForServerSideConfirmation`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
