### PR TITLE
Add `is_decoupled` field to events

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -98,6 +98,9 @@ internal class PaymentOptionsViewModel @Inject constructor(
         initialValue = null,
     )
 
+    private val isDecoupling: Boolean
+        get() = args.state.stripeIntent.clientSecret == null
+
     init {
         savedStateHandle[SAVE_GOOGLE_PAY_STATE] = if (args.state.isGooglePayReady) {
             GooglePayState.Available
@@ -141,8 +144,9 @@ internal class PaymentOptionsViewModel @Inject constructor(
             }
             LinkHandler.ProcessingState.Completed -> {
                 eventReporter.onPaymentSuccess(
-                    PaymentSelection.Link,
-                    stripeIntent.value?.currency
+                    paymentSelection = PaymentSelection.Link,
+                    currency = stripeIntent.value?.currency,
+                    isDecoupling = isDecoupling,
                 )
                 prefsRepository.savePaymentSelection(PaymentSelection.Link)
                 onPaymentResult(PaymentResult.Completed)
@@ -229,7 +233,11 @@ internal class PaymentOptionsViewModel @Inject constructor(
 
         selection.value?.let { paymentSelection ->
             // TODO(michelleb-stripe): Should the payment selection in the event be the saved or new item?
-            eventReporter.onSelectPaymentOption(paymentSelection, stripeIntent.value?.currency)
+            eventReporter.onSelectPaymentOption(
+                paymentSelection = paymentSelection,
+                currency = stripeIntent.value?.currency,
+                isDecoupling = isDecoupling,
+            )
 
             when (paymentSelection) {
                 is PaymentSelection.Saved,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -23,21 +23,26 @@ internal class DefaultEventReporter @Inject internal constructor(
 
     override fun onInit(
         configuration: PaymentSheet.Configuration?,
+        isDecoupling: Boolean,
         isServerSideConfirmation: Boolean,
     ) {
         fireEvent(
             PaymentSheetEvent.Init(
                 mode = mode,
                 configuration = configuration,
+                isDecoupled = isDecoupling,
                 isServerSideConfirmation = isServerSideConfirmation,
             )
         )
     }
 
-    override fun onDismiss() {
+    override fun onDismiss(
+        isDecoupling: Boolean,
+    ) {
         fireEvent(
             PaymentSheetEvent.Dismiss(
-                mode = mode
+                mode = mode,
+                isDecoupled = isDecoupling,
             )
         )
     }
@@ -45,7 +50,8 @@ internal class DefaultEventReporter @Inject internal constructor(
     override fun onShowExistingPaymentOptions(
         linkEnabled: Boolean,
         activeLinkSession: Boolean,
-        currency: String?
+        currency: String?,
+        isDecoupling: Boolean,
     ) {
         paymentSheetShownMillis = eventTimeProvider.currentTimeMillis()
         fireEvent(
@@ -53,7 +59,8 @@ internal class DefaultEventReporter @Inject internal constructor(
                 mode = mode,
                 linkEnabled = linkEnabled,
                 activeLinkSession = activeLinkSession,
-                currency = currency
+                currency = currency,
+                isDecoupled = isDecoupling,
             )
         )
     }
@@ -61,7 +68,8 @@ internal class DefaultEventReporter @Inject internal constructor(
     override fun onShowNewPaymentOptionForm(
         linkEnabled: Boolean,
         activeLinkSession: Boolean,
-        currency: String?
+        currency: String?,
+        isDecoupling: Boolean,
     ) {
         paymentSheetShownMillis = eventTimeProvider.currentTimeMillis()
         fireEvent(
@@ -69,27 +77,31 @@ internal class DefaultEventReporter @Inject internal constructor(
                 mode = mode,
                 linkEnabled = linkEnabled,
                 activeLinkSession = activeLinkSession,
-                currency = currency
+                currency = currency,
+                isDecoupled = isDecoupling,
             )
         )
     }
 
     override fun onSelectPaymentOption(
         paymentSelection: PaymentSelection,
-        currency: String?
+        currency: String?,
+        isDecoupling: Boolean,
     ) {
         fireEvent(
             PaymentSheetEvent.SelectPaymentOption(
                 mode = mode,
                 paymentSelection = paymentSelection,
-                currency = currency
+                currency = currency,
+                isDecoupled = isDecoupling,
             )
         )
     }
 
     override fun onPaymentSuccess(
         paymentSelection: PaymentSelection?,
-        currency: String?
+        currency: String?,
+        isDecoupling: Boolean,
     ) {
         // Google Pay is treated as a saved payment method after confirmation, so we need to
         // "reset" to PaymentSelection.GooglePay for accurate reporting
@@ -107,14 +119,16 @@ internal class DefaultEventReporter @Inject internal constructor(
                 paymentSelection = realSelection,
                 durationMillis = durationMillisFrom(paymentSheetShownMillis),
                 result = PaymentSheetEvent.Payment.Result.Success,
-                currency = currency
+                currency = currency,
+                isDecoupled = isDecoupling,
             )
         )
     }
 
     override fun onPaymentFailure(
         paymentSelection: PaymentSelection?,
-        currency: String?
+        currency: String?,
+        isDecoupling: Boolean,
     ) {
         fireEvent(
             PaymentSheetEvent.Payment(
@@ -122,20 +136,29 @@ internal class DefaultEventReporter @Inject internal constructor(
                 paymentSelection = paymentSelection,
                 durationMillis = durationMillisFrom(paymentSheetShownMillis),
                 result = PaymentSheetEvent.Payment.Result.Failure,
-                currency = currency
+                currency = currency,
+                isDecoupled = isDecoupling,
             )
         )
     }
 
-    override fun onLpmSpecFailure() {
+    override fun onLpmSpecFailure(
+        isDecoupling: Boolean,
+    ) {
         fireEvent(
-            PaymentSheetEvent.LpmSerializeFailureEvent()
+            PaymentSheetEvent.LpmSerializeFailureEvent(isDecoupled = isDecoupling)
         )
     }
 
-    override fun onAutofill(type: String) {
+    override fun onAutofill(
+        type: String,
+        isDecoupling: Boolean,
+    ) {
         fireEvent(
-            PaymentSheetEvent.AutofillEvent(type)
+            PaymentSheetEvent.AutofillEvent(
+                type = type,
+                isDecoupled = isDecoupling,
+            )
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -7,41 +7,54 @@ internal interface EventReporter {
 
     fun onInit(
         configuration: PaymentSheet.Configuration?,
+        isDecoupling: Boolean,
         isServerSideConfirmation: Boolean,
     )
 
-    fun onDismiss()
+    fun onDismiss(
+        isDecoupling: Boolean,
+    )
 
     fun onShowExistingPaymentOptions(
         linkEnabled: Boolean,
         activeLinkSession: Boolean,
-        currency: String?
+        currency: String?,
+        isDecoupling: Boolean,
     )
 
     fun onShowNewPaymentOptionForm(
         linkEnabled: Boolean,
         activeLinkSession: Boolean,
-        currency: String?
+        currency: String?,
+        isDecoupling: Boolean,
     )
 
     fun onSelectPaymentOption(
         paymentSelection: PaymentSelection,
-        currency: String?
+        currency: String?,
+        isDecoupling: Boolean,
     )
 
     fun onPaymentSuccess(
         paymentSelection: PaymentSelection?,
-        currency: String?
+        currency: String?,
+        isDecoupling: Boolean,
     )
 
     fun onPaymentFailure(
         paymentSelection: PaymentSelection?,
-        currency: String?
+        currency: String?,
+        isDecoupling: Boolean,
     )
 
-    fun onLpmSpecFailure()
+    fun onLpmSpecFailure(
+        isDecoupling: Boolean,
+    )
 
-    fun onAutofill(type: String)
+    fun onAutofill(
+        type: String,
+        isDecoupling: Boolean,
+    )
 
     enum class Mode(val code: String) {
         Complete("complete"),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
@@ -103,11 +103,13 @@ internal class FlowControllerConfigurationHandler @Inject constructor(
         state: PaymentSheetState.Full,
         configureRequest: ConfigureRequest,
     ) {
-        val isServerSideConfirmation = configureRequest.initializationMode is DeferredIntent &&
+        val isDecoupling = configureRequest.initializationMode is DeferredIntent
+        val isServerSideConfirmation = isDecoupling &&
             IntentConfirmationInterceptor.createIntentCallback is CreateIntentCallbackForServerSideConfirmation
 
         eventReporter.onInit(
             configuration = state.config,
+            isDecoupling = isDecoupling,
             isServerSideConfirmation = isServerSideConfirmation,
         )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -12,6 +12,7 @@ import com.stripe.android.model.PaymentMethod.Type.Link
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.core.injection.APP_NAME
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheet.InitializationMode.DeferredIntent
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.addresselement.toIdentifierMap
@@ -235,7 +236,9 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
             )
 
             if (lpmRepository.serverSpecLoadingState is ServerSpecState.ServerNotParsed) {
-                eventReporter.onLpmSpecFailure()
+                eventReporter.onLpmSpecFailure(
+                    isDecoupling = initializationMode is DeferredIntent,
+                )
             }
 
             stripeIntentValidator.requireValid(elementsSession.stripeIntent)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -88,7 +88,7 @@ internal fun AddPaymentMethod(
 
     Column(modifier = modifier.fillMaxWidth()) {
         CompositionLocalProvider(
-            LocalAutofillEventReporter provides sheetViewModel.eventReporter::onAutofill
+            LocalAutofillEventReporter provides sheetViewModel::reportAutofillEvent
         ) {
             PaymentElement(
                 sheetViewModel = sheetViewModel,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -242,7 +242,8 @@ internal abstract class BaseSheetViewModel(
                 eventReporter.onShowExistingPaymentOptions(
                     linkEnabled = linkHandler.isLinkEnabled.value == true,
                     activeLinkSession = linkHandler.activeLinkSession.value,
-                    currency = stripeIntent.value?.currency
+                    currency = stripeIntent.value?.currency,
+                    isDecoupling = stripeIntent.value?.clientSecret == null,
                 )
             }
             AddFirstPaymentMethod,
@@ -250,7 +251,8 @@ internal abstract class BaseSheetViewModel(
                 eventReporter.onShowNewPaymentOptionForm(
                     linkEnabled = linkHandler.isLinkEnabled.value == true,
                     activeLinkSession = linkHandler.activeLinkSession.value,
-                    currency = stripeIntent.value?.currency
+                    currency = stripeIntent.value?.currency,
+                    isDecoupling = stripeIntent.value?.clientSecret == null,
                 )
             }
         }
@@ -450,6 +452,10 @@ internal abstract class BaseSheetViewModel(
         // Reset the selection to the one from before opening the add payment method screen
         val paymentOptionsState = paymentOptionsState.value
         updateSelection(paymentOptionsState.selectedItem?.toPaymentSelection())
+    }
+
+    fun reportAutofillEvent(type: String) {
+        eventReporter.onAutofill(type, isDecoupling = stripeIntent.value?.clientSecret == null)
     }
 
     abstract fun onPaymentResult(paymentResult: PaymentResult)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -67,7 +67,8 @@ internal class PaymentOptionsViewModelTest {
             verify(eventReporter)
                 .onSelectPaymentOption(
                     paymentSelection = SELECTION_SAVED_PAYMENT_METHOD,
-                    currency = "usd"
+                    currency = "usd",
+                    isDecoupling = false,
                 )
         }
 
@@ -91,7 +92,8 @@ internal class PaymentOptionsViewModelTest {
             verify(eventReporter)
                 .onSelectPaymentOption(
                     paymentSelection = NEW_REQUEST_DONT_SAVE_PAYMENT_SELECTION,
-                    currency = "usd"
+                    currency = "usd",
+                    isDecoupling = false,
                 )
             assertThat(prefsRepository.getSavedSelection(true, true))
                 .isEqualTo(SavedSelection.None)
@@ -112,7 +114,8 @@ internal class PaymentOptionsViewModelTest {
                 verify(eventReporter)
                     .onSelectPaymentOption(
                         paymentSelection = paymentOptionResultSucceeded.paymentSelection,
-                        currency = "usd"
+                        currency = "usd",
+                        isDecoupling = false,
                     )
                 ensureAllEventsConsumed()
             }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -144,6 +144,7 @@ internal class PaymentSheetViewModelTest {
         verify(eventReporter).onInit(
             configuration = eq(PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY),
             isServerSideConfirmation = any(),
+            isDecoupling = eq(false),
         )
     }
 
@@ -461,7 +462,8 @@ internal class PaymentSheetViewModelTest {
             verify(eventReporter)
                 .onPaymentSuccess(
                     paymentSelection = selection,
-                    currency = "usd"
+                    currency = "usd",
+                    isDecoupling = false,
                 )
             assertThat(prefsRepository.paymentSelectionArgs)
                 .containsExactly(selection)
@@ -509,7 +511,8 @@ internal class PaymentSheetViewModelTest {
             verify(eventReporter)
                 .onPaymentSuccess(
                     paymentSelection = selection,
-                    currency = "usd"
+                    currency = "usd",
+                    isDecoupling = false,
                 )
 
             assertThat(prefsRepository.paymentSelectionArgs).isEmpty()
@@ -535,7 +538,8 @@ internal class PaymentSheetViewModelTest {
             verify(eventReporter)
                 .onPaymentFailure(
                     paymentSelection = selection,
-                    currency = "usd"
+                    currency = "usd",
+                    isDecoupling = false,
                 )
 
             val stripeIntent = awaitItem()
@@ -966,7 +970,8 @@ internal class PaymentSheetViewModelTest {
         verify(eventReporter).onShowNewPaymentOptionForm(
             linkEnabled = eq(false),
             activeLinkSession = eq(false),
-            currency = eq("usd")
+            currency = eq("usd"),
+            isDecoupling = eq(false),
         )
 
         receiver.cancelAndIgnoreRemainingEvents()
@@ -989,7 +994,8 @@ internal class PaymentSheetViewModelTest {
         verify(eventReporter).onShowNewPaymentOptionForm(
             linkEnabled = eq(true),
             activeLinkSession = eq(false),
-            currency = eq("usd")
+            currency = eq("usd"),
+            isDecoupling = eq(false),
         )
 
         receiver.cancelAndIgnoreRemainingEvents()
@@ -1012,7 +1018,8 @@ internal class PaymentSheetViewModelTest {
         verify(eventReporter).onShowNewPaymentOptionForm(
             linkEnabled = eq(true),
             activeLinkSession = eq(true),
-            currency = eq("usd")
+            currency = eq("usd"),
+            isDecoupling = eq(false),
         )
 
         receiver.cancelAndIgnoreRemainingEvents()
@@ -1030,7 +1037,8 @@ internal class PaymentSheetViewModelTest {
         verify(eventReporter).onShowExistingPaymentOptions(
             linkEnabled = eq(false),
             activeLinkSession = eq(false),
-            currency = eq("usd")
+            currency = eq("usd"),
+            isDecoupling = eq(false),
         )
 
         viewModel.transitionToAddPaymentScreen()
@@ -1038,7 +1046,8 @@ internal class PaymentSheetViewModelTest {
         verify(eventReporter).onShowNewPaymentOptionForm(
             linkEnabled = eq(false),
             activeLinkSession = eq(false),
-            currency = eq("usd")
+            currency = eq("usd"),
+            isDecoupling = eq(false),
         )
 
         receiver.cancelAndIgnoreRemainingEvents()
@@ -1284,6 +1293,7 @@ internal class PaymentSheetViewModelTest {
         verify(eventReporter).onInit(
             configuration = anyOrNull(),
             isServerSideConfirmation = eq(false),
+            isDecoupling = eq(false),
         )
     }
 
@@ -1298,6 +1308,7 @@ internal class PaymentSheetViewModelTest {
 
         verify(eventReporter).onInit(
             configuration = anyOrNull(),
+            isDecoupling = eq(true),
             isServerSideConfirmation = eq(false),
         )
     }
@@ -1314,6 +1325,7 @@ internal class PaymentSheetViewModelTest {
 
         verify(eventReporter).onInit(
             configuration = anyOrNull(),
+            isDecoupling = eq(true),
             isServerSideConfirmation = eq(true),
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -47,6 +47,7 @@ class DefaultEventReporterTest {
     fun `onInit() should fire analytics request with expected event value`() {
         completeEventReporter.onInit(
             configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
+            isDecoupling = false,
             isServerSideConfirmation = false,
         )
         verify(analyticsRequestExecutor).executeAsync(
@@ -62,7 +63,8 @@ class DefaultEventReporterTest {
         completeEventReporter.onShowExistingPaymentOptions(
             linkEnabled = true,
             activeLinkSession = false,
-            currency = "usd"
+            currency = "usd",
+            isDecoupling = false,
         )
 
         verify(analyticsRequestExecutor).executeAsync(
@@ -81,7 +83,8 @@ class DefaultEventReporterTest {
         completeEventReporter.onShowNewPaymentOptionForm(
             linkEnabled = false,
             activeLinkSession = true,
-            currency = "usd"
+            currency = "usd",
+            isDecoupling = false,
         )
 
         verify(analyticsRequestExecutor).executeAsync(
@@ -101,14 +104,16 @@ class DefaultEventReporterTest {
         completeEventReporter.onShowExistingPaymentOptions(
             linkEnabled = false,
             activeLinkSession = false,
-            currency = "usd"
+            currency = "usd",
+            isDecoupling = false,
         )
         reset(analyticsRequestExecutor)
         whenever(eventTimeProvider.currentTimeMillis()).thenReturn(2000L)
 
         completeEventReporter.onPaymentSuccess(
             paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
-            currency = "usd"
+            currency = "usd",
+            isDecoupling = false,
         )
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
@@ -127,6 +132,7 @@ class DefaultEventReporterTest {
             linkEnabled = false,
             activeLinkSession = false,
             currency = "usd",
+            isDecoupling = false,
         )
 
         reset(analyticsRequestExecutor)
@@ -138,6 +144,7 @@ class DefaultEventReporterTest {
                 isGooglePay = true,
             ),
             currency = "usd",
+            isDecoupling = false,
         )
 
         verify(analyticsRequestExecutor).executeAsync(
@@ -154,14 +161,16 @@ class DefaultEventReporterTest {
         completeEventReporter.onShowExistingPaymentOptions(
             linkEnabled = false,
             activeLinkSession = false,
-            currency = "usd"
+            currency = "usd",
+            isDecoupling = false,
         )
         reset(analyticsRequestExecutor)
         whenever(eventTimeProvider.currentTimeMillis()).thenReturn(2000L)
 
         completeEventReporter.onPaymentFailure(
             paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
-            currency = "usd"
+            currency = "usd",
+            isDecoupling = false,
         )
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
@@ -177,7 +186,8 @@ class DefaultEventReporterTest {
     fun `onSelectPaymentOption() should fire analytics request with expected event value`() {
         customEventReporter.onSelectPaymentOption(
             paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
-            currency = "usd"
+            currency = "usd",
+            isDecoupling = false,
         )
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -20,6 +20,7 @@ class PaymentSheetEventTest {
         val event = PaymentSheetEvent.Init(
             mode = EventReporter.Mode.Complete,
             configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
+            isDecoupled = false,
             isServerSideConfirmation = false,
         )
         assertThat(
@@ -37,6 +38,7 @@ class PaymentSheetEventTest {
         val event = PaymentSheetEvent.Init(
             mode = EventReporter.Mode.Complete,
             configuration = PaymentSheetFixtures.CONFIG_MINIMUM,
+            isDecoupled = false,
             isServerSideConfirmation = false,
         )
         assertThat(
@@ -60,7 +62,8 @@ class PaymentSheetEventTest {
             ),
             durationMillis = 1L,
             result = PaymentSheetEvent.Payment.Result.Success,
-            currency = "usd"
+            currency = "usd",
+            isDecoupled = false,
         )
         assertThat(
             newPMEvent.eventName
@@ -73,7 +76,8 @@ class PaymentSheetEventTest {
             mapOf(
                 "locale" to "en_US",
                 "currency" to "usd",
-                "duration" to 0.001F
+                "duration" to 0.001F,
+                "is_decoupled" to false,
             )
         )
     }
@@ -85,7 +89,8 @@ class PaymentSheetEventTest {
             paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
             durationMillis = 1L,
             result = PaymentSheetEvent.Payment.Result.Success,
-            currency = "usd"
+            currency = "usd",
+            isDecoupled = false,
         )
         assertThat(
             savedPMEvent.eventName
@@ -98,7 +103,8 @@ class PaymentSheetEventTest {
             mapOf(
                 "locale" to "en_US",
                 "currency" to "usd",
-                "duration" to 0.001F
+                "duration" to 0.001F,
+                "is_decoupled" to false,
             )
         )
     }
@@ -110,7 +116,8 @@ class PaymentSheetEventTest {
             paymentSelection = PaymentSelection.GooglePay,
             durationMillis = 1L,
             result = PaymentSheetEvent.Payment.Result.Success,
-            currency = "usd"
+            currency = "usd",
+            isDecoupled = false,
         )
         assertThat(
             googlePayEvent.eventName
@@ -123,7 +130,8 @@ class PaymentSheetEventTest {
             mapOf(
                 "locale" to "en_US",
                 "currency" to "usd",
-                "duration" to 0.001F
+                "duration" to 0.001F,
+                "is_decoupled" to false,
             )
         )
     }
@@ -135,7 +143,8 @@ class PaymentSheetEventTest {
             paymentSelection = PaymentSelection.Link,
             durationMillis = 1L,
             result = PaymentSheetEvent.Payment.Result.Success,
-            currency = "usd"
+            currency = "usd",
+            isDecoupled = false,
         )
         assertThat(
             linkEvent.eventName
@@ -148,7 +157,8 @@ class PaymentSheetEventTest {
             mapOf(
                 "locale" to "en_US",
                 "currency" to "usd",
-                "duration" to 0.001F
+                "duration" to 0.001F,
+                "is_decoupled" to false,
             )
         )
     }
@@ -166,7 +176,8 @@ class PaymentSheetEventTest {
             ),
             durationMillis = 1L,
             result = PaymentSheetEvent.Payment.Result.Success,
-            currency = "usd"
+            currency = "usd",
+            isDecoupled = false,
         )
         assertThat(
             inlineLinkEvent.eventName
@@ -179,7 +190,8 @@ class PaymentSheetEventTest {
             mapOf(
                 "locale" to "en_US",
                 "currency" to "usd",
-                "duration" to 0.001F
+                "duration" to 0.001F,
+                "is_decoupled" to false,
             )
         )
     }
@@ -195,7 +207,8 @@ class PaymentSheetEventTest {
             ),
             durationMillis = 1L,
             result = PaymentSheetEvent.Payment.Result.Failure,
-            currency = "usd"
+            currency = "usd",
+            isDecoupled = false,
         )
         assertThat(
             newPMEvent.eventName
@@ -208,7 +221,8 @@ class PaymentSheetEventTest {
             mapOf(
                 "locale" to "en_US",
                 "currency" to "usd",
-                "duration" to 0.001F
+                "duration" to 0.001F,
+                "is_decoupled" to false,
             )
         )
     }
@@ -220,7 +234,8 @@ class PaymentSheetEventTest {
             paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
             durationMillis = 1L,
             result = PaymentSheetEvent.Payment.Result.Failure,
-            currency = "usd"
+            currency = "usd",
+            isDecoupled = false,
         )
         assertThat(
             savedPMEvent.eventName
@@ -233,7 +248,8 @@ class PaymentSheetEventTest {
             mapOf(
                 "locale" to "en_US",
                 "currency" to "usd",
-                "duration" to 0.001F
+                "duration" to 0.001F,
+                "is_decoupled" to false,
             )
         )
     }
@@ -245,7 +261,8 @@ class PaymentSheetEventTest {
             paymentSelection = PaymentSelection.GooglePay,
             durationMillis = 1L,
             result = PaymentSheetEvent.Payment.Result.Failure,
-            currency = "usd"
+            currency = "usd",
+            isDecoupled = false,
         )
         assertThat(
             googlePayEvent.eventName
@@ -258,7 +275,8 @@ class PaymentSheetEventTest {
             mapOf(
                 "locale" to "en_US",
                 "currency" to "usd",
-                "duration" to 0.001F
+                "duration" to 0.001F,
+                "is_decoupled" to false,
             )
         )
     }
@@ -270,7 +288,8 @@ class PaymentSheetEventTest {
             paymentSelection = PaymentSelection.Link,
             durationMillis = 1L,
             result = PaymentSheetEvent.Payment.Result.Failure,
-            currency = "usd"
+            currency = "usd",
+            isDecoupled = false,
         )
         assertThat(
             linkEvent.eventName
@@ -283,7 +302,8 @@ class PaymentSheetEventTest {
             mapOf(
                 "locale" to "en_US",
                 "currency" to "usd",
-                "duration" to 0.001F
+                "duration" to 0.001F,
+                "is_decoupled" to false,
             )
         )
     }
@@ -301,7 +321,8 @@ class PaymentSheetEventTest {
             ),
             durationMillis = 1L,
             result = PaymentSheetEvent.Payment.Result.Failure,
-            currency = "usd"
+            currency = "usd",
+            isDecoupled = false,
         )
         assertThat(
             inlineLinkEvent.eventName
@@ -314,7 +335,8 @@ class PaymentSheetEventTest {
             mapOf(
                 "locale" to "en_US",
                 "currency" to "usd",
-                "duration" to 0.001F
+                "duration" to 0.001F,
+                "is_decoupled" to false,
             )
         )
     }
@@ -324,7 +346,8 @@ class PaymentSheetEventTest {
         val event = PaymentSheetEvent.SelectPaymentOption(
             mode = EventReporter.Mode.Custom,
             paymentSelection = PaymentSelection.GooglePay,
-            currency = "usd"
+            currency = "usd",
+            isDecoupled = false,
         )
         assertThat(
             event.eventName
@@ -337,6 +360,7 @@ class PaymentSheetEventTest {
             mapOf(
                 "locale" to "en_US",
                 "currency" to "usd",
+                "is_decoupled" to false,
             )
         )
     }
@@ -381,12 +405,14 @@ class PaymentSheetEventTest {
             PaymentSheetEvent.Init(
                 mode = EventReporter.Mode.Complete,
                 configuration = PaymentSheetFixtures.CONFIG_MINIMUM,
+                isDecoupled = false,
                 isServerSideConfirmation = false,
             ).additionalParams
         ).isEqualTo(
             mapOf(
                 "mpe_config" to expectedConfigMap,
-                "locale" to "en_US"
+                "locale" to "en_US",
+                "is_decoupled" to false,
             )
         )
     }
@@ -431,12 +457,14 @@ class PaymentSheetEventTest {
             PaymentSheetEvent.Init(
                 mode = EventReporter.Mode.Complete,
                 configuration = PaymentSheetFixtures.CONFIG_WITH_EVERYTHING,
+                isDecoupled = false,
                 isServerSideConfirmation = false,
             ).additionalParams
         ).isEqualTo(
             mapOf(
                 "mpe_config" to expectedConfigMap,
-                "locale" to "en_US"
+                "locale" to "en_US",
+                "is_decoupled" to false,
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -210,7 +210,8 @@ internal class DefaultFlowControllerTest {
         verify(eventReporter)
             .onPaymentSuccess(
                 paymentSelection = isA<PaymentSelection.New>(),
-                currency = eq("usd")
+                currency = eq("usd"),
+                isDecoupling = eq(false),
             )
     }
 
@@ -233,7 +234,8 @@ internal class DefaultFlowControllerTest {
         verify(eventReporter)
             .onPaymentFailure(
                 paymentSelection = isA<PaymentSelection.New>(),
-                currency = eq("usd")
+                currency = eq("usd"),
+                isDecoupling = eq(false),
             )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
@@ -98,6 +98,7 @@ class FlowControllerConfigurationHandlerTest {
         assertThat(viewModel.state).isNotNull()
         verify(eventReporter).onInit(
             configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
+            isDecoupling = false,
             isServerSideConfirmation = false,
         )
     }
@@ -133,6 +134,7 @@ class FlowControllerConfigurationHandlerTest {
         // We're running ONLY the second config run, so we don't expect any interactions.
         verify(eventReporter, never()).onInit(
             configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
+            isDecoupling = false,
             isServerSideConfirmation = false,
         )
     }
@@ -170,6 +172,7 @@ class FlowControllerConfigurationHandlerTest {
         // We're running a new config, so we DO expect an interaction.
         verify(eventReporter).onInit(
             configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
+            isDecoupling = false,
             isServerSideConfirmation = false,
         )
     }
@@ -208,6 +211,7 @@ class FlowControllerConfigurationHandlerTest {
         // We're running a new config, so we DO expect an interaction.
         verify(eventReporter).onInit(
             configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
+            isDecoupling = false,
             isServerSideConfirmation = false,
         )
     }
@@ -425,6 +429,7 @@ class FlowControllerConfigurationHandlerTest {
 
         verify(eventReporter).onInit(
             configuration = isNull(),
+            isDecoupling = eq(false),
             isServerSideConfirmation = eq(false),
         )
     }
@@ -458,6 +463,7 @@ class FlowControllerConfigurationHandlerTest {
 
         verify(eventReporter).onInit(
             configuration = isNull(),
+            isDecoupling = eq(true),
             isServerSideConfirmation = eq(false),
         )
     }
@@ -492,6 +498,7 @@ class FlowControllerConfigurationHandlerTest {
 
         verify(eventReporter).onInit(
             configuration = isNull(),
+            isDecoupling = eq(true),
             isServerSideConfirmation = eq(true),
         )
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds the `is_decoupled` field to our analytics events.

For now, we’re passing this value with each event. Pulling this information into DI has proven a little difficult, but I’ll aim to do this as a follow-up task.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Decoupling private beta.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
