### PR TITLE
[FC] Record video on maestro end2end tests in CI

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -5,8 +5,8 @@ project_type: android
 trigger_map:
   - push_branch: 'master'
     pipeline: main-trigger-pipeline
-  - pull_request_source_branch: 'carlosmuvi/maestro-record'
-    workflow: maestro-financial-connections
+  - pull_request_source_branch: '*'
+    pipeline: main-trigger-pipeline
 app:
   envs:
     - GRADLE_OPTS: -Dkotlin.incremental=false

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -5,8 +5,8 @@ project_type: android
 trigger_map:
   - push_branch: 'master'
     pipeline: main-trigger-pipeline
-  - pull_request_source_branch: '*'
-    pipeline: main-trigger-pipeline
+  - pull_request_source_branch: 'carlosmuvi/maestro-record'
+    workflow: maestro-financial-connections
 app:
   envs:
     - GRADLE_OPTS: -Dkotlin.incremental=false

--- a/scripts/execute_maestro_tests.sh
+++ b/scripts/execute_maestro_tests.sh
@@ -11,8 +11,8 @@ maestro -v
 # Compile and install APK.
 ./gradlew -PSTRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL=$STRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL :financial-connections-example:installDebug
 
-# Start screen record (adb screenrecord has a 3 min limit, for now take consequent recordings.
-adb shell "screenrecord /sdcard/$now-1.mp4; screenrecord /sdcard/$now-2.mp4; screenrecord /sdcard/$now-3.mp4; screenrecord /sdcard/$now-4.mp4" &
+# Start screen record (adb screenrecord has a 3 min limit).
+adb shell "screenrecord /sdcard/$now-1.mp4" &
 
 # Store the process ID
 childpid=$!
@@ -28,11 +28,9 @@ wait "$childpid"
 # Sleep for a short duration to allow the process to finalize the video file
 sleep 3
 
+# Pull the video file from the device
 mkdir -p /tmp/test_results
 cd /tmp/test_results
 adb pull "/sdcard/$now-1.mp4" || true
-adb pull "/sdcard/$now-2.mp4" || true
-adb pull "/sdcard/$now-3.mp4" || true
-adb pull "/sdcard/$now-4.mp4" || true
 
 exit "$result"

--- a/scripts/execute_maestro_tests.sh
+++ b/scripts/execute_maestro_tests.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+set -e
+set -o pipefail
+set -x
 
 now=$(date +%F_%H-%M-%S)
 echo $now

--- a/scripts/execute_maestro_tests.sh
+++ b/scripts/execute_maestro_tests.sh
@@ -3,17 +3,13 @@
 now=$(date +%F_%H-%M-%S)
 echo $now
 
-# Install ffmpeg
-sudo apt-get update
-sudo apt-get install ffmpeg
-
 # Install Maestro
 export MAESTRO_VERSION=1.21.3; curl -Ls "https://get.maestro.mobile.dev" | bash
 export PATH="$PATH":"$HOME/.maestro/bin"
 maestro -v
 
 # Compile and install APK.
-#./gradlew -PSTRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL=$STRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL :financial-connections-example:installDebug
+./gradlew -PSTRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL=$STRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL :financial-connections-example:installDebug
 
 # Start screen record (adb screenrecord has a 3 min limit, for now take consequent recordings.
 adb shell "screenrecord /sdcard/$now-1.mp4; screenrecord /sdcard/$now-2.mp4; screenrecord /sdcard/$now-3.mp4; screenrecord /sdcard/$now-4.mp4" &

--- a/scripts/execute_maestro_tests.sh
+++ b/scripts/execute_maestro_tests.sh
@@ -3,21 +3,55 @@ set -e
 set -o pipefail
 set -x
 
+reports_path="financial-connections-example/build/reports"
+now=$(date +%F_%H-%M-%S)
+echo $now
+
+# Create folder for reports
+mkdir -p $reports_path
+
 # Install Maestro
 export MAESTRO_VERSION=1.21.3; curl -Ls "https://get.maestro.mobile.dev" | bash
 export PATH="$PATH":"$HOME/.maestro/bin"
 maestro -v
 
-# Compile and install APK.
-./gradlew -PSTRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL=$STRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL :financial-connections-example:installDebug
+# Install FFmpeg
+sudo apt-get update
+sudo apt-get install -y ffmpeg
 
-# Run tests with retry.
-retry=1
-while [ $retry -le 3 ]; do
-  echo "Running Maestro tests. Attempt $retry"
-  maestro test -e APP_ID=com.stripe.android.financialconnections.example --format junit --output maestroReport.xml maestro/financial-connections
-  if [ $? -eq 0 ]; then
-    break
-  fi
-  retry=$((retry+1))
-done
+# Compile and install APK.
+./gradlew \
+-PSTRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL=$STRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL \
+:financial-connections-example:installDebug
+
+# Start screen record (adb screenrecord has a 3 min limit, for now take consequent recordings.
+adb shell "screenrecord /sdcard/$now-1.mp4; screenrecord /sdcard/$now-2.mp4; screenrecord /sdcard/$now-3.mp4; screenrecord /sdcard/$now-4.mp4" &
+childpid=$!
+
+# Execute Maestro tests
+maestro test -e APP_ID=com.stripe.android.financialconnections.example --format junit --output maestroReport.xml maestro/financial-connections
+result=$?
+
+# Stop video recording and pull record parts.
+kill "$childpid"
+wait "$childpid"
+cd $reports_path/
+adb pull "/sdcard/$now-1.mp4" || true
+adb pull "/sdcard/$now-2.mp4" || true
+adb pull "/sdcard/$now-3.mp4" || true
+adb pull "/sdcard/$now-4.mp4" || true
+
+# Create a list of video files to concatenate
+echo "file '$now-1.mp4'" > video_list.txt
+echo "file '$now-2.mp4'" >> video_list.txt
+echo "file '$now-3.mp4'" >> video_list.txt
+echo "file '$now-4.mp4'" >> video_list.txt
+
+# Use FFmpeg to concatenate the video files
+output_file="${now}-combined.mp4"
+ffmpeg -f concat -safe 0 -i video_list.txt -c copy $output_file
+
+# Remove individual video files and video_list.txt
+rm "$now-1.mp4" "$now-2.mp4" "$now-3.mp4" "$now-4.mp4" video_list.txt
+
+exit "$result"

--- a/scripts/execute_maestro_tests.sh
+++ b/scripts/execute_maestro_tests.sh
@@ -3,6 +3,10 @@
 now=$(date +%F_%H-%M-%S)
 echo $now
 
+# Install ffmpeg
+sudo apt-get update
+sudo apt-get install ffmpeg
+
 # Install Maestro
 export MAESTRO_VERSION=1.21.3; curl -Ls "https://get.maestro.mobile.dev" | bash
 export PATH="$PATH":"$HOME/.maestro/bin"
@@ -35,5 +39,9 @@ echo "file '$now-1.mp4'" > concat-list.txt
 
 ffmpeg -f concat -safe 0 -i concat-list.txt -c copy merged-$now.mp4
 rm concat-list.txt
+
+# Move the merged mp4 file to /tmp/test_results/
+mkdir -p /tmp/test_results
+mv merged-$now.mp4 /tmp/test_results/
 
 exit "$result"

--- a/scripts/execute_maestro_tests.sh
+++ b/scripts/execute_maestro_tests.sh
@@ -13,15 +13,20 @@ maestro -v
 
 # Start screen record (adb screenrecord has a 3 min limit, for now take consequent recordings.
 adb shell "screenrecord /sdcard/$now-1.mp4; screenrecord /sdcard/$now-2.mp4; screenrecord /sdcard/$now-3.mp4; screenrecord /sdcard/$now-4.mp4" &
+
+# Store the process ID
 childpid=$!
 
 # Clear and start collecting logs
 maestro test -e APP_ID=com.stripe.android.financialconnections.example --format junit --output maestroReport.xml maestro/financial-connections/
 result=$?
 
-# Stop video recording and pull record parts.
+# Wait for the recording process to finish
 kill -2 "$childpid"
 wait "$childpid"
+
+# Sleep for a short duration to allow the process to finalize the video file
+sleep 3
 
 mkdir -p /tmp/test_results
 cd /tmp/test_results

--- a/scripts/execute_maestro_tests.sh
+++ b/scripts/execute_maestro_tests.sh
@@ -1,57 +1,39 @@
 #!/usr/bin/env bash
-set -e
-set -o pipefail
-set -x
 
-reports_path="financial-connections-example/build/reports"
 now=$(date +%F_%H-%M-%S)
 echo $now
-
-# Create folder for reports
-mkdir -p $reports_path
 
 # Install Maestro
 export MAESTRO_VERSION=1.21.3; curl -Ls "https://get.maestro.mobile.dev" | bash
 export PATH="$PATH":"$HOME/.maestro/bin"
 maestro -v
 
-# Install FFmpeg
-sudo apt-get update
-sudo apt-get install -y ffmpeg
-
 # Compile and install APK.
-./gradlew \
--PSTRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL=$STRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL \
-:financial-connections-example:installDebug
+#./gradlew -PSTRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL=$STRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL :financial-connections-example:installDebug
 
 # Start screen record (adb screenrecord has a 3 min limit, for now take consequent recordings.
 adb shell "screenrecord /sdcard/$now-1.mp4; screenrecord /sdcard/$now-2.mp4; screenrecord /sdcard/$now-3.mp4; screenrecord /sdcard/$now-4.mp4" &
 childpid=$!
 
-# Execute Maestro tests
-maestro test -e APP_ID=com.stripe.android.financialconnections.example --format junit --output maestroReport.xml maestro/financial-connections
+# Clear and start collecting logs
+maestro test -e APP_ID=com.stripe.android.financialconnections.example --format junit --output maestroReport.xml maestro/financial-connections/
 result=$?
 
 # Stop video recording and pull record parts.
 kill "$childpid"
 wait "$childpid"
-cd $reports_path/
 adb pull "/sdcard/$now-1.mp4" || true
 adb pull "/sdcard/$now-2.mp4" || true
 adb pull "/sdcard/$now-3.mp4" || true
 adb pull "/sdcard/$now-4.mp4" || true
 
-# Create a list of video files to concatenate
-echo "file '$now-1.mp4'" > video_list.txt
-echo "file '$now-2.mp4'" >> video_list.txt
-echo "file '$now-3.mp4'" >> video_list.txt
-echo "file '$now-4.mp4'" >> video_list.txt
+# Merge the pulled mp4 files
+echo "file '$now-1.mp4'" > concat-list.txt
+[ -f "$now-2.mp4" ] && echo "file '$now-2.mp4'" >> concat-list.txt
+[ -f "$now-3.mp4" ] && echo "file '$now-3.mp4'" >> concat-list.txt
+[ -f "$now-4.mp4" ] && echo "file '$now-4.mp4'" >> concat-list.txt
 
-# Use FFmpeg to concatenate the video files
-output_file="${now}-combined.mp4"
-ffmpeg -f concat -safe 0 -i video_list.txt -c copy $output_file
-
-# Remove individual video files and video_list.txt
-rm "$now-1.mp4" "$now-2.mp4" "$now-3.mp4" "$now-4.mp4" video_list.txt
+ffmpeg -f concat -safe 0 -i concat-list.txt -c copy merged-$now.mp4
+rm concat-list.txt
 
 exit "$result"

--- a/scripts/execute_maestro_tests.sh
+++ b/scripts/execute_maestro_tests.sh
@@ -20,7 +20,7 @@ maestro test -e APP_ID=com.stripe.android.financialconnections.example --format 
 result=$?
 
 # Stop video recording and pull record parts.
-kill "$childpid"
+kill -2 "$childpid"
 wait "$childpid"
 
 mkdir -p /tmp/test_results

--- a/scripts/execute_maestro_tests.sh
+++ b/scripts/execute_maestro_tests.sh
@@ -26,22 +26,12 @@ result=$?
 # Stop video recording and pull record parts.
 kill "$childpid"
 wait "$childpid"
+
+mkdir -p /tmp/test_results
+cd /tmp/test_results
 adb pull "/sdcard/$now-1.mp4" || true
 adb pull "/sdcard/$now-2.mp4" || true
 adb pull "/sdcard/$now-3.mp4" || true
 adb pull "/sdcard/$now-4.mp4" || true
-
-# Merge the pulled mp4 files
-echo "file '$now-1.mp4'" > concat-list.txt
-[ -f "$now-2.mp4" ] && echo "file '$now-2.mp4'" >> concat-list.txt
-[ -f "$now-3.mp4" ] && echo "file '$now-3.mp4'" >> concat-list.txt
-[ -f "$now-4.mp4" ] && echo "file '$now-4.mp4'" >> concat-list.txt
-
-ffmpeg -f concat -safe 0 -i concat-list.txt -c copy merged-$now.mp4
-rm concat-list.txt
-
-# Move the merged mp4 file to /tmp/test_results/
-mkdir -p /tmp/test_results
-mv merged-$now.mp4 /tmp/test_results/
 
 exit "$result"


### PR DESCRIPTION
# Summary
- Record video on maestro end2end tests in CI
- See a build recording a video and deploying it as an artifact: https://app.bitrise.io/build/abfbc23b-4566-4a63-8c60-8fff587bde1c?tab=artifacts

# Motivation
[BANKCON-6564](https://jira.corp.stripe.com/browse/BANKCON-6564)
