### PR TITLE
Update Klarna currency countries

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/KlarnaHelper.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/KlarnaHelper.kt
@@ -7,15 +7,21 @@ import java.util.Locale
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 object KlarnaHelper {
     private val currencyToAllowedCountries = mapOf(
-        "eur" to setOf("AT", "FI", "DE", "NL", "BE", "ES", "IT", "FR"),
+        "eur" to setOf("AT", "FI", "DE", "NL", "BE", "ES", "IT", "FR", "GR", "IE", "PT"),
         "dkk" to setOf("DK"),
         "nok" to setOf("NO"),
         "sek" to setOf("SE"),
         "gbp" to setOf("GB"),
-        "usd" to setOf("US")
+        "usd" to setOf("US"),
+        "aud" to setOf("AU"),
+        "cad" to setOf("CA"),
+        "czk" to setOf("CZ"),
+        "nzd" to setOf("NZ"),
+        "pln" to setOf("PL"),
+        "chf" to setOf("CH"),
     )
 
-    private val buyNowCountries = setOf("AT", "BE", "DE", "IT", "NL", "ES", "SE")
+    private val buyNowCountries = setOf("AT", "BE", "DE", "IT", "NL", "ES", "SE", "CA", "AU", "PL", "PT", "CH")
 
     fun getAllowedCountriesForCurrency(currencyCode: String?) =
         currencyToAllowedCountries[currencyCode].orEmpty()

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/KlarnaHelperTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/KlarnaHelperTest.kt
@@ -24,7 +24,16 @@ class KlarnaHelperTest {
             "ES" to R.string.klarna_buy_now_pay_later,
             "SE" to R.string.klarna_buy_now_pay_later,
             "GB" to R.string.klarna_pay_later,
-            "US" to R.string.klarna_pay_later
+            "US" to R.string.klarna_pay_later,
+            "GR" to R.string.klarna_pay_later,
+            "IE" to R.string.klarna_pay_later,
+            "PT" to R.string.klarna_buy_now_pay_later,
+            "AU" to R.string.klarna_buy_now_pay_later,
+            "CA" to R.string.klarna_buy_now_pay_later,
+            "CZ" to R.string.klarna_pay_later,
+            "NZ" to R.string.klarna_pay_later,
+            "PL" to R.string.klarna_buy_now_pay_later,
+            "CH" to R.string.klarna_buy_now_pay_later,
         )
 
         for (entry in testMap) {
@@ -42,12 +51,18 @@ class KlarnaHelperTest {
     @Test
     fun `supported klarna currency returns correct countries`() {
         assertThat(KlarnaHelper.getAllowedCountriesForCurrency("eur"))
-            .containsExactly("AT", "FI", "DE", "NL", "BE", "ES", "IT", "FR")
+            .containsExactly("AT", "FI", "DE", "NL", "BE", "ES", "IT", "FR", "GR", "IE", "PT")
 
         assertThat(KlarnaHelper.getAllowedCountriesForCurrency("dkk")).containsExactly("DK")
         assertThat(KlarnaHelper.getAllowedCountriesForCurrency("nok")).containsExactly("NO")
         assertThat(KlarnaHelper.getAllowedCountriesForCurrency("sek")).containsExactly("SE")
         assertThat(KlarnaHelper.getAllowedCountriesForCurrency("gbp")).containsExactly("GB")
         assertThat(KlarnaHelper.getAllowedCountriesForCurrency("usd")).containsExactly("US")
+        assertThat(KlarnaHelper.getAllowedCountriesForCurrency("aud")).containsExactly("AU")
+        assertThat(KlarnaHelper.getAllowedCountriesForCurrency("cad")).containsExactly("CA")
+        assertThat(KlarnaHelper.getAllowedCountriesForCurrency("czk")).containsExactly("CZ")
+        assertThat(KlarnaHelper.getAllowedCountriesForCurrency("nzd")).containsExactly("NZ")
+        assertThat(KlarnaHelper.getAllowedCountriesForCurrency("pln")).containsExactly("PL")
+        assertThat(KlarnaHelper.getAllowedCountriesForCurrency("chf")).containsExactly("CH")
     }
 }


### PR DESCRIPTION
## Summary
Updates the list of supported Klarna currency mappings to the latest found here: https://stripe.com/docs/payments/klarna

## Motivation
https://www.linkedin.com/posts/stripe_were-expanding-support-for-more-buy-now-activity-7052340412929245184-b-v9?utm_source=share&utm_medium=member_desktop

## Testing
Updated unit tests

## Changelog
N/A