### PR TITLE
Use `Result<T>` for retrieving intents

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
@@ -59,16 +59,16 @@ abstract class AbsFakeStripeRepository : StripeRepository {
     override suspend fun retrievePaymentIntent(
         clientSecret: String,
         options: ApiRequest.Options,
-        expandFields: List<String>
-    ): PaymentIntent? {
-        TODO("Not yet implemented")
+        expandFields: List<String>,
+    ): Result<PaymentIntent> {
+        return Result.failure(NotImplementedError())
     }
 
     override suspend fun refreshPaymentIntent(
         clientSecret: String,
-        options: ApiRequest.Options
-    ): PaymentIntent? {
-        TODO("Not yet implemented")
+        options: ApiRequest.Options,
+    ): Result<PaymentIntent> {
+        return Result.failure(NotImplementedError())
     }
 
     override suspend fun cancelPaymentIntentSource(
@@ -90,9 +90,9 @@ abstract class AbsFakeStripeRepository : StripeRepository {
     override suspend fun retrieveSetupIntent(
         clientSecret: String,
         options: ApiRequest.Options,
-        expandFields: List<String>
-    ): SetupIntent? {
-        TODO("Not yet implemented")
+        expandFields: List<String>,
+    ): Result<SetupIntent> {
+        return Result.failure(NotImplementedError())
     }
 
     override suspend fun cancelSetupIntentSource(

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentIntentFactory.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentIntentFactory.kt
@@ -12,6 +12,7 @@ object PaymentIntentFactory {
         paymentMethodTypes: List<String> = listOf("card"),
         setupFutureUsage: StripeIntent.Usage? = null,
         confirmationMethod: PaymentIntent.ConfirmationMethod = PaymentIntent.ConfirmationMethod.Automatic,
+        status: StripeIntent.Status = StripeIntent.Status.RequiresConfirmation,
     ): PaymentIntent = PaymentIntent(
         created = 500L,
         amount = 1000L,
@@ -22,7 +23,7 @@ object PaymentIntentFactory {
         currency = "usd",
         countryCode = null,
         paymentMethodTypes = paymentMethodTypes,
-        status = StripeIntent.Status.RequiresConfirmation,
+        status = status,
         unactivatedPaymentMethods = emptyList(),
         setupFutureUsage = setupFutureUsage,
         confirmationMethod = confirmationMethod,

--- a/payments-core/src/main/java/com/stripe/android/PaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/PaymentController.kt
@@ -40,25 +40,12 @@ internal interface PaymentController {
      * @param requestOptions a [ApiRequest.Options] to associate with this request
      *
      * @return a [PaymentIntentResult] object
-     *
-     * @throws AuthenticationException failure to properly authenticate yourself (check your key)
-     * @throws InvalidRequestException your request has invalid parameters
-     * @throws APIConnectionException failure to connect to Stripe's API
-     * @throws APIException any other type of problem (for instance, a temporary issue with Stripe's servers)
-     * @throws IllegalArgumentException if the PaymentIntent response's JsonParser returns null
      */
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class,
-        IllegalArgumentException::class
-    )
     suspend fun confirmAndAuthenticateAlipay(
         confirmPaymentIntentParams: ConfirmPaymentIntentParams,
         authenticator: AlipayAuthenticator,
         requestOptions: ApiRequest.Options
-    ): PaymentIntentResult
+    ): Result<PaymentIntentResult>
 
     /**
      * Confirm the Stripe Intent for WeChat Pay, return WeChat Pay params from intent's next action

--- a/payments-core/src/main/java/com/stripe/android/Stripe.kt
+++ b/payments-core/src/main/java/com/stripe/android/Stripe.kt
@@ -414,7 +414,7 @@ class Stripe internal constructor(
         expand: List<String> = emptyList(),
         callback: ApiResultCallback<PaymentIntent>
     ) {
-        executeAsync(callback) {
+        executeAsyncForResult(callback) {
             stripeRepository.retrievePaymentIntent(
                 clientSecret,
                 ApiRequest.Options(
@@ -460,7 +460,7 @@ class Stripe internal constructor(
                     stripeAccount = stripeAccountId
                 ),
                 expand,
-            )
+            ).getOrThrow()
         }
     }
 
@@ -710,7 +710,7 @@ class Stripe internal constructor(
         expand: List<String> = emptyList(),
         callback: ApiResultCallback<SetupIntent>
     ) {
-        executeAsync(callback) {
+        executeAsyncForResult(callback) {
             stripeRepository.retrieveSetupIntent(
                 clientSecret,
                 ApiRequest.Options(
@@ -756,7 +756,7 @@ class Stripe internal constructor(
                     stripeAccount = stripeAccountId
                 ),
                 expand,
-            )
+            ).getOrThrow()
         }
     }
 

--- a/payments-core/src/main/java/com/stripe/android/Stripe.kt
+++ b/payments-core/src/main/java/com/stripe/android/Stripe.kt
@@ -451,7 +451,7 @@ class Stripe internal constructor(
         clientSecret: String,
         stripeAccountId: String? = this.stripeAccountId,
         expand: List<String> = emptyList(),
-    ): PaymentIntent? {
+    ): PaymentIntent {
         return runBlocking {
             stripeRepository.retrievePaymentIntent(
                 PaymentIntent.ClientSecret(clientSecret).value,
@@ -747,7 +747,7 @@ class Stripe internal constructor(
         clientSecret: String,
         stripeAccountId: String? = this.stripeAccountId,
         expand: List<String> = emptyList(),
-    ): SetupIntent? {
+    ): SetupIntent {
         return runBlocking {
             stripeRepository.retrieveSetupIntent(
                 SetupIntent.ClientSecret(clientSecret).value,
@@ -1101,7 +1101,7 @@ class Stripe internal constructor(
         @Size(min = 1) sourceId: String,
         @Size(min = 1) clientSecret: String,
         stripeAccountId: String? = this.stripeAccountId
-    ): Source? {
+    ): Source {
         return runBlocking {
             stripeRepository.retrieveSource(
                 sourceId,

--- a/payments-core/src/main/java/com/stripe/android/Stripe.kt
+++ b/payments-core/src/main/java/com/stripe/android/Stripe.kt
@@ -199,7 +199,7 @@ class Stripe internal constructor(
         stripeAccountId: String? = this.stripeAccountId,
         callback: ApiResultCallback<PaymentIntentResult>
     ) {
-        executeAsync(callback) {
+        executeAsyncForResult(callback) {
             paymentController.confirmAndAuthenticateAlipay(
                 confirmPaymentIntentParams,
                 authenticator,

--- a/payments-core/src/main/java/com/stripe/android/StripeKtx.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripeKtx.kt
@@ -59,15 +59,15 @@ suspend fun Stripe.confirmAlipayPayment(
     confirmPaymentIntentParams: ConfirmPaymentIntentParams,
     authenticator: AlipayAuthenticator,
     stripeAccountId: String? = this.stripeAccountId
-): PaymentIntentResult = runApiRequest {
-    paymentController.confirmAndAuthenticateAlipay(
+): PaymentIntentResult {
+    return paymentController.confirmAndAuthenticateAlipay(
         confirmPaymentIntentParams,
         authenticator,
         ApiRequest.Options(
             apiKey = publishableKey,
             stripeAccount = stripeAccountId
         )
-    )
+    ).getOrElse { throw StripeException.create(it) }
 }
 
 /**

--- a/payments-core/src/main/java/com/stripe/android/StripeKtx.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripeKtx.kt
@@ -482,15 +482,15 @@ suspend fun Stripe.retrievePaymentIntent(
     clientSecret: String,
     stripeAccountId: String? = this.stripeAccountId,
     expand: List<String> = emptyList(),
-): PaymentIntent = runApiRequest {
-    stripeRepository.retrievePaymentIntent(
+): PaymentIntent {
+    return stripeRepository.retrievePaymentIntent(
         clientSecret,
         ApiRequest.Options(
             apiKey = publishableKey,
             stripeAccount = stripeAccountId
         ),
         expand,
-    )
+    ).getOrThrow()
 }
 
 /**
@@ -521,15 +521,15 @@ suspend fun Stripe.retrieveSetupIntent(
     clientSecret: String,
     stripeAccountId: String? = this.stripeAccountId,
     expand: List<String> = emptyList(),
-): SetupIntent = runApiRequest {
-    stripeRepository.retrieveSetupIntent(
+): SetupIntent {
+    return stripeRepository.retrieveSetupIntent(
         clientSecret,
         ApiRequest.Options(
             apiKey = publishableKey,
             stripeAccount = stripeAccountId
         ),
         expand,
-    )
+    ).getOrThrow()
 }
 
 /**

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherActivity.kt
@@ -62,9 +62,7 @@ internal class GooglePayLauncherActivity : AppCompatActivity() {
 
         if (!viewModel.hasLaunched) {
             lifecycleScope.launch {
-                runCatching {
-                    viewModel.createLoadPaymentDataTask()
-                }.fold(
+                viewModel.createLoadPaymentDataTask().fold(
                     onSuccess = {
                         payWithGoogle(it)
                         viewModel.hasLaunched = true

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
@@ -76,28 +76,22 @@ internal class GooglePayLauncherViewModel(
     ): JSONObject {
         val transactionInfo = when (args) {
             is GooglePayLauncherContract.PaymentIntentArgs -> {
-                val paymentIntent = requireNotNull(
-                    stripeRepository.retrievePaymentIntent(
-                        args.clientSecret,
-                        requestOptions
-                    )
-                ) {
-                    "Could not retrieve PaymentIntent."
-                }
+                val paymentIntent = stripeRepository.retrievePaymentIntent(
+                    args.clientSecret,
+                    requestOptions
+                ).getOrThrow()
+
                 createTransactionInfo(
                     paymentIntent,
                     paymentIntent.currency.orEmpty()
                 )
             }
             is GooglePayLauncherContract.SetupIntentArgs -> {
-                val setupIntent = requireNotNull(
-                    stripeRepository.retrieveSetupIntent(
-                        args.clientSecret,
-                        requestOptions
-                    )
-                ) {
-                    "Could not retrieve SetupIntent."
-                }
+                val setupIntent = stripeRepository.retrieveSetupIntent(
+                    args.clientSecret,
+                    requestOptions
+                ).getOrThrow()
+
                 createTransactionInfo(
                     setupIntent,
                     args.currencyCode

--- a/payments-core/src/main/java/com/stripe/android/networking/AlipayRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/AlipayRepository.kt
@@ -10,5 +10,5 @@ internal interface AlipayRepository {
         paymentIntent: PaymentIntent,
         authenticator: AlipayAuthenticator,
         requestOptions: ApiRequest.Options
-    ): AlipayAuthResult
+    ): Result<AlipayAuthResult>
 }

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -180,18 +180,10 @@ class StripeApiRepository @JvmOverloads internal constructor(
     ): StripeIntent {
         return when {
             PaymentIntent.ClientSecret.isMatch(clientSecret) -> {
-                requireNotNull(
-                    retrievePaymentIntent(clientSecret, options, expandFields)
-                ) {
-                    "Could not retrieve PaymentIntent."
-                }
+                retrievePaymentIntent(clientSecret, options, expandFields).getOrThrow()
             }
             SetupIntent.ClientSecret.isMatch(clientSecret) -> {
-                requireNotNull(
-                    retrieveSetupIntent(clientSecret, options, expandFields)
-                ) {
-                    "Could not retrieve SetupIntent."
-                }
+                retrieveSetupIntent(clientSecret, options, expandFields).getOrThrow()
             }
             else -> {
                 error("Invalid client secret.")
@@ -270,17 +262,11 @@ class StripeApiRepository @JvmOverloads internal constructor(
      *
      * @param clientSecret client_secret of the PaymentIntent to retrieve
      */
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class
-    )
     override suspend fun retrievePaymentIntent(
         clientSecret: String,
         options: ApiRequest.Options,
         expandFields: List<String>
-    ): PaymentIntent? {
+    ): Result<PaymentIntent> {
         val paymentIntentId = PaymentIntent.ClientSecret(clientSecret).paymentIntentId
         val params: Map<String, Any?> =
             if (options.apiKeyIsUserKey) {
@@ -291,13 +277,13 @@ class StripeApiRepository @JvmOverloads internal constructor(
 
         fireFraudDetectionDataRequest()
 
-        return fetchStripeModel(
-            apiRequestFactory.createGet(
-                getRetrievePaymentIntentUrl(paymentIntentId),
-                options,
-                params
+        return fetchStripeModelResult(
+            apiRequest = apiRequestFactory.createGet(
+                url = getRetrievePaymentIntentUrl(paymentIntentId),
+                options = options,
+                params = params,
             ),
-            PaymentIntentJsonParser()
+            jsonParser = PaymentIntentJsonParser(),
         ) {
             fireAnalyticsRequest(
                 paymentAnalyticsRequestFactory.createRequest(PaymentAnalyticsEvent.PaymentIntentRetrieve)
@@ -312,27 +298,25 @@ class StripeApiRepository @JvmOverloads internal constructor(
      *
      * @param clientSecret client_secret of the PaymentIntent to retrieve
      */
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class
-    )
     override suspend fun refreshPaymentIntent(
         clientSecret: String,
         options: ApiRequest.Options
-    ): PaymentIntent? {
-        val paymentIntentId = PaymentIntent.ClientSecret(clientSecret).paymentIntentId
+    ): Result<PaymentIntent> {
+        val paymentIntentId = runCatching {
+            PaymentIntent.ClientSecret(clientSecret).paymentIntentId
+        }.getOrElse {
+            return Result.failure(it)
+        }
 
         fireFraudDetectionDataRequest()
 
-        return fetchStripeModel(
-            apiRequestFactory.createPost(
-                getRefreshPaymentIntentUrl(paymentIntentId),
-                options,
-                createClientSecretParam(clientSecret, emptyList())
+        return fetchStripeModelResult(
+            apiRequest = apiRequestFactory.createPost(
+                url = getRefreshPaymentIntentUrl(paymentIntentId),
+                options = options,
+                params = createClientSecretParam(clientSecret, emptyList()),
             ),
-            PaymentIntentJsonParser()
+            jsonParser = PaymentIntentJsonParser(),
         ) {
             fireAnalyticsRequest(
                 paymentAnalyticsRequestFactory.createRequest(PaymentAnalyticsEvent.PaymentIntentRefresh)
@@ -423,28 +407,26 @@ class StripeApiRepository @JvmOverloads internal constructor(
      *
      * @param clientSecret client_secret of the SetupIntent to retrieve
      */
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class
-    )
     override suspend fun retrieveSetupIntent(
         clientSecret: String,
         options: ApiRequest.Options,
         expandFields: List<String>
-    ): SetupIntent? {
-        val setupIntentId = SetupIntent.ClientSecret(clientSecret).setupIntentId
+    ): Result<SetupIntent> {
+        val setupIntentId = runCatching {
+            SetupIntent.ClientSecret(clientSecret).setupIntentId
+        }.getOrElse {
+            return Result.failure(it)
+        }
 
         fireFraudDetectionDataRequest()
 
-        return fetchStripeModel(
-            apiRequestFactory.createGet(
-                getRetrieveSetupIntentUrl(setupIntentId),
-                options,
-                createClientSecretParam(clientSecret, expandFields)
+        return fetchStripeModelResult(
+            apiRequest = apiRequestFactory.createGet(
+                url = getRetrieveSetupIntentUrl(setupIntentId),
+                options = options,
+                params = createClientSecretParam(clientSecret, expandFields),
             ),
-            SetupIntentJsonParser()
+            jsonParser = SetupIntentJsonParser(),
         ) {
             fireAnalyticsRequest(
                 paymentAnalyticsRequestFactory.createRequest(PaymentAnalyticsEvent.SetupIntentRetrieve)

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -69,30 +69,18 @@ interface StripeRepository {
         expandFields: List<String> = emptyList()
     ): PaymentIntent?
 
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class
-    )
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun retrievePaymentIntent(
         clientSecret: String,
         options: ApiRequest.Options,
         expandFields: List<String> = emptyList()
-    ): PaymentIntent?
+    ): Result<PaymentIntent>
 
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class
-    )
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun refreshPaymentIntent(
         clientSecret: String,
         options: ApiRequest.Options
-    ): PaymentIntent?
+    ): Result<PaymentIntent>
 
     @Throws(
         AuthenticationException::class,
@@ -120,18 +108,12 @@ interface StripeRepository {
         expandFields: List<String> = emptyList()
     ): SetupIntent?
 
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class
-    )
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     suspend fun retrieveSetupIntent(
         clientSecret: String,
         options: ApiRequest.Options,
         expandFields: List<String> = emptyList()
-    ): SetupIntent?
+    ): Result<SetupIntent>
 
     @Throws(
         AuthenticationException::class,

--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
@@ -310,13 +310,11 @@ internal class PaymentIntentFlowResultProcessor @Inject constructor(
         clientSecret: String,
         requestOptions: ApiRequest.Options,
         expandFields: List<String>
-    ): Result<PaymentIntent> = runCatching {
-        requireNotNull(
-            stripeRepository.retrievePaymentIntent(
-                clientSecret,
-                requestOptions,
-                expandFields,
-            )
+    ): Result<PaymentIntent> {
+        return stripeRepository.retrievePaymentIntent(
+            clientSecret,
+            requestOptions,
+            expandFields,
         )
     }
 
@@ -324,12 +322,10 @@ internal class PaymentIntentFlowResultProcessor @Inject constructor(
         clientSecret: String,
         requestOptions: ApiRequest.Options,
         expandFields: List<String>
-    ): Result<PaymentIntent> = runCatching {
-        requireNotNull(
-            stripeRepository.refreshPaymentIntent(
-                clientSecret,
-                requestOptions,
-            )
+    ): Result<PaymentIntent> {
+        return stripeRepository.refreshPaymentIntent(
+            clientSecret,
+            requestOptions,
         )
     }
 
@@ -380,13 +376,11 @@ internal class SetupIntentFlowResultProcessor @Inject constructor(
         clientSecret: String,
         requestOptions: ApiRequest.Options,
         expandFields: List<String>
-    ): Result<SetupIntent> = runCatching {
-        requireNotNull(
-            stripeRepository.retrieveSetupIntent(
-                clientSecret,
-                requestOptions,
-                expandFields
-            )
+    ): Result<SetupIntent> {
+        return stripeRepository.retrieveSetupIntent(
+            clientSecret,
+            requestOptions,
+            expandFields
         )
     }
 
@@ -394,13 +388,11 @@ internal class SetupIntentFlowResultProcessor @Inject constructor(
         clientSecret: String,
         requestOptions: ApiRequest.Options,
         expandFields: List<String>
-    ): Result<SetupIntent> = runCatching {
-        requireNotNull(
-            stripeRepository.retrieveSetupIntent(
-                clientSecret,
-                requestOptions,
-                expandFields
-            )
+    ): Result<SetupIntent> {
+        return stripeRepository.retrieveSetupIntent(
+            clientSecret,
+            requestOptions,
+            expandFields
         )
     }
 

--- a/payments-core/src/main/java/com/stripe/android/polling/DefaultIntentStatusPoller.kt
+++ b/payments-core/src/main/java/com/stripe/android/polling/DefaultIntentStatusPoller.kt
@@ -54,15 +54,13 @@ class DefaultIntentStatusPoller @Inject constructor(
 
     private suspend fun fetchIntentStatus(): StripeIntent.Status? {
         val paymentConfig = paymentConfigProvider.get()
-        val paymentIntent = runCatching {
-            stripeRepository.retrievePaymentIntent(
-                clientSecret = config.clientSecret,
-                options = ApiRequest.Options(
-                    publishableKeyProvider = { paymentConfig.publishableKey },
-                    stripeAccountIdProvider = { paymentConfig.stripeAccountId },
-                ),
-            )
-        }
+        val paymentIntent = stripeRepository.retrievePaymentIntent(
+            clientSecret = config.clientSecret,
+            options = ApiRequest.Options(
+                publishableKeyProvider = { paymentConfig.publishableKey },
+                stripeAccountIdProvider = { paymentConfig.stripeAccountId },
+            ),
+        )
         return paymentIntent.getOrNull()?.status
     }
 

--- a/payments-core/src/test/java/com/stripe/android/StripeKtxTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripeKtxTest.kt
@@ -387,7 +387,7 @@ internal class StripeKtxTest {
         runTest {
             whenever(
                 mockPaymentController.confirmAndAuthenticateAlipay(any(), any(), any())
-            ).thenThrow(mock<AuthenticationException>())
+            ).thenReturn(Result.failure(mock<AuthenticationException>()))
 
             assertFailsWith<AuthenticationException> {
                 stripe.confirmAlipayPayment(
@@ -405,7 +405,7 @@ internal class StripeKtxTest {
 
             whenever(
                 mockPaymentController.confirmAndAuthenticateAlipay(any(), any(), any())
-            ).thenReturn(expectedApiObj)
+            ).thenReturn(Result.success(expectedApiObj))
 
             val actualObj = stripe.confirmAlipayPayment(
                 mock(),

--- a/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -190,9 +190,7 @@ internal class StripePaymentControllerTest {
     fun `confirmAndAuthenticateAlipay() should return expected outcome`() =
         runTest {
             whenever(alipayRepository.authenticate(any(), any(), any())).thenReturn(
-                AlipayAuthResult(
-                    StripeIntentResult.Outcome.SUCCEEDED
-                )
+                Result.success(AlipayAuthResult(StripeIntentResult.Outcome.SUCCEEDED))
             )
             stripeRepository.retrievePaymentIntentResponse =
                 PaymentIntentFixtures.ALIPAY_REQUIRES_ACTION
@@ -204,7 +202,7 @@ internal class StripePaymentControllerTest {
                 ),
                 mock(),
                 REQUEST_OPTIONS
-            )
+            ).getOrThrow()
 
             assertThat(stripeRepository.confirmPaymentIntentArgs).hasSize(1)
             assertThat(stripeRepository.confirmPaymentIntentArgs[0].first.shouldUseStripeSdk()).isTrue()

--- a/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -247,17 +247,17 @@ internal class StripePaymentControllerTest {
             clientSecret: String,
             options: ApiRequest.Options,
             expandFields: List<String>
-        ) = SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT
+        ) = Result.success(SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT)
 
         override suspend fun retrievePaymentIntent(
             clientSecret: String,
             options: ApiRequest.Options,
             expandFields: List<String>
-        ): PaymentIntent {
+        ): Result<PaymentIntent> {
             retrievePaymentIntentArgs.add(
                 Triple(clientSecret, options, expandFields)
             )
-            return retrievePaymentIntentResponse
+            return Result.success(retrievePaymentIntentResponse)
         }
 
         override suspend fun retrieveSource(

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModelTest.kt
@@ -36,7 +36,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
-import kotlin.test.assertFailsWith
 
 @RunWith(RobolectricTestRunner::class)
 class GooglePayLauncherViewModelTest {
@@ -70,18 +69,17 @@ class GooglePayLauncherViewModelTest {
         runTest {
             googlePayRepository.value = false
 
-            val error = assertFailsWith<IllegalStateException> {
-                viewModel.createLoadPaymentDataTask()
-            }
-            assertThat(error.message)
+            val result = viewModel.createLoadPaymentDataTask()
+
+            assertThat(result.exceptionOrNull()).isInstanceOf(IllegalStateException::class.java)
+            assertThat(result.exceptionOrNull()?.message)
                 .isEqualTo("Google Pay is unavailable.")
         }
 
     @Test
     fun `createLoadPaymentDataTask() should return task when Google Pay is available`() =
         runTest {
-            assertThat(viewModel.createLoadPaymentDataTask())
-                .isNotNull()
+            assertThat(viewModel.createLoadPaymentDataTask().isSuccess).isTrue()
         }
 
     @Test

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModelTest.kt
@@ -276,16 +276,16 @@ class GooglePayLauncherViewModelTest {
             clientSecret: String,
             options: ApiRequest.Options,
             expandFields: List<String>
-        ): PaymentIntent {
-            return PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
+        ): Result<PaymentIntent> {
+            return Result.success(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
         }
 
         override suspend fun retrieveSetupIntent(
             clientSecret: String,
             options: ApiRequest.Options,
             expandFields: List<String>
-        ): SetupIntent {
-            return SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD
+        ): Result<SetupIntent> {
+            return Result.success(SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD)
         }
     }
 

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -1240,15 +1240,14 @@ internal class StripeApiRepositoryTest {
                 sdkVersion = "AndroidBindings/13.0.0"
             )
 
-            val ex = assertFailsWith<InvalidRequestException> {
-                stripeRepository.retrieveSetupIntent(
-                    "seti_1CkiBMLENEVhOs7YMtUehLau_secret_invalid",
-                    DEFAULT_OPTIONS
-                )
-            }
+            val result = stripeRepository.retrieveSetupIntent(
+                "seti_1CkiBMLENEVhOs7YMtUehLau_secret_invalid",
+                DEFAULT_OPTIONS
+            )
+
             assertEquals(
                 "No such setupintent: 'seti_1CkiBMLENEVhOs7YMtUehLau'",
-                ex.stripeError?.message
+                result.exceptionOrNull()?.message,
             )
         }
 

--- a/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
@@ -354,9 +354,9 @@ internal class PaymentIntentFlowResultProcessorTest {
             val succeededIntent = requiresActionIntent.copy(status = StripeIntent.Status.Succeeded)
 
             whenever(mockStripeRepository.retrievePaymentIntent(any(), any(), any())).thenReturn(
-                requiresActionIntent,
-                requiresActionIntent,
-                succeededIntent,
+                Result.success(requiresActionIntent),
+                Result.success(requiresActionIntent),
+                Result.success(succeededIntent),
             )
 
             val clientSecret = requireNotNull(requiresActionIntent.clientSecret)

--- a/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
@@ -26,6 +26,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
+import java.io.IOException
 
 @RunWith(RobolectricTestRunner::class)
 internal class PaymentIntentFlowResultProcessorTest {
@@ -45,7 +46,7 @@ internal class PaymentIntentFlowResultProcessorTest {
     fun `processPaymentIntent() when shouldCancelSource=true should return canceled PaymentIntent`() =
         runTest {
             whenever(mockStripeRepository.retrievePaymentIntent(any(), any(), any())).thenReturn(
-                PaymentIntentFixtures.PI_REQUIRES_REDIRECT
+                Result.success(PaymentIntentFixtures.PI_REQUIRES_REDIRECT)
             )
             whenever(
                 mockStripeRepository.cancelPaymentIntentSource(
@@ -78,7 +79,7 @@ internal class PaymentIntentFlowResultProcessorTest {
     fun `when 3DS2 data contains intentId and publishableKey then they are used on source cancel`() =
         runTest {
             whenever(mockStripeRepository.retrievePaymentIntent(any(), any(), any()))
-                .thenReturn(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2)
+                .thenReturn(Result.success(PaymentIntentFixtures.PI_REQUIRES_MASTERCARD_3DS2))
             whenever(mockStripeRepository.cancelPaymentIntentSource(any(), any(), any()))
                 .thenReturn(PaymentIntentFixtures.PAYMENT_INTENT_WITH_CANCELED_3DS2_SOURCE)
 
@@ -102,10 +103,10 @@ internal class PaymentIntentFlowResultProcessorTest {
     fun `no refresh when user cancels the payment`() =
         runTest {
             whenever(mockStripeRepository.retrievePaymentIntent(any(), any(), any())).thenReturn(
-                PaymentIntentFixtures.PI_REQUIRES_WECHAT_PAY_AUTHORIZE
+                Result.success(PaymentIntentFixtures.PI_REQUIRES_WECHAT_PAY_AUTHORIZE)
             )
             whenever(mockStripeRepository.refreshPaymentIntent(any(), any())).thenReturn(
-                PaymentIntentFixtures.PI_REFRESH_RESPONSE_WECHAT_PAY_SUCCESS
+                Result.success(PaymentIntentFixtures.PI_REFRESH_RESPONSE_WECHAT_PAY_SUCCESS)
             )
 
             val clientSecret = "pi_3JkCxKBNJ02ErVOj0kNqBMAZ_secret_bC6oXqo976LFM06Z9rlhmzUQq"
@@ -144,10 +145,10 @@ internal class PaymentIntentFlowResultProcessorTest {
     fun `refresh succeeds when user confirms the payment`() =
         runTest {
             whenever(mockStripeRepository.retrievePaymentIntent(any(), any(), any())).thenReturn(
-                PaymentIntentFixtures.PI_REQUIRES_WECHAT_PAY_AUTHORIZE
+                Result.success(PaymentIntentFixtures.PI_REQUIRES_WECHAT_PAY_AUTHORIZE)
             )
             whenever(mockStripeRepository.refreshPaymentIntent(any(), any())).thenReturn(
-                PaymentIntentFixtures.PI_REFRESH_RESPONSE_WECHAT_PAY_SUCCESS
+                Result.success(PaymentIntentFixtures.PI_REFRESH_RESPONSE_WECHAT_PAY_SUCCESS)
             )
 
             val clientSecret = "pi_3JkCxKBNJ02ErVOj0kNqBMAZ_secret_bC6oXqo976LFM06Z9rlhmzUQq"
@@ -184,10 +185,10 @@ internal class PaymentIntentFlowResultProcessorTest {
     fun `refresh reaches max retry user confirms the payment`() =
         runTest(testDispatcher) {
             whenever(mockStripeRepository.retrievePaymentIntent(any(), any(), any())).thenReturn(
-                PaymentIntentFixtures.PI_REQUIRES_WECHAT_PAY_AUTHORIZE
+                Result.success(PaymentIntentFixtures.PI_REQUIRES_WECHAT_PAY_AUTHORIZE)
             )
             whenever(mockStripeRepository.refreshPaymentIntent(any(), any())).thenReturn(
-                PaymentIntentFixtures.PI_REFRESH_RESPONSE_REQUIRES_WECHAT_PAY_AUTHORIZE
+                Result.success(PaymentIntentFixtures.PI_REFRESH_RESPONSE_REQUIRES_WECHAT_PAY_AUTHORIZE)
             )
 
             val clientSecret = "pi_3JkCxKBNJ02ErVOj0kNqBMAZ_secret_bC6oXqo976LFM06Z9rlhmzUQq"
@@ -264,7 +265,7 @@ internal class PaymentIntentFlowResultProcessorTest {
                 status = StripeIntent.Status.RequiresAction
             )
             whenever(mockStripeRepository.retrievePaymentIntent(any(), any(), any())).thenReturn(
-                intent
+                Result.success(intent)
             )
 
             val clientSecret = requireNotNull(
@@ -307,10 +308,10 @@ internal class PaymentIntentFlowResultProcessorTest {
         val succeededIntent = processingIntent.copy(status = StripeIntent.Status.Succeeded)
 
         whenever(mockStripeRepository.retrievePaymentIntent(any(), any(), any())).thenReturn(
-            processingIntent,
-            null,
-            null,
-            succeededIntent,
+            Result.success(processingIntent),
+            Result.failure(IOException()),
+            Result.failure(IOException()),
+            Result.success(succeededIntent),
         )
 
         val clientSecret = requireNotNull(processingIntent.clientSecret)
@@ -382,8 +383,8 @@ internal class PaymentIntentFlowResultProcessorTest {
         expectedIntent: PaymentIntent = refreshedIntent
     ) {
         whenever(mockStripeRepository.retrievePaymentIntent(any(), any(), any())).thenReturn(
-            initialIntent,
-            refreshedIntent
+            Result.success(initialIntent),
+            Result.success(refreshedIntent),
         )
 
         val clientSecret = requireNotNull(initialIntent.clientSecret)

--- a/payments-core/src/test/java/com/stripe/android/payments/SetupIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/SetupIntentFlowResultProcessorTest.kt
@@ -42,7 +42,7 @@ internal class SetupIntentFlowResultProcessorTest {
     fun `processResult() when shouldCancelSource=true should return canceled SetupIntent`() =
         runTest {
             whenever(mockStripeRepository.retrieveSetupIntent(any(), any(), any())).thenReturn(
-                SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT
+                Result.success(SetupIntentFixtures.SI_NEXT_ACTION_REDIRECT)
             )
             whenever(mockStripeRepository.cancelSetupIntentSource(any(), any(), any())).thenReturn(
                 SetupIntentFixtures.CANCELLED
@@ -69,8 +69,8 @@ internal class SetupIntentFlowResultProcessorTest {
     fun `3ds2 canceled with processing intent should succeed`() =
         runTest {
             whenever(mockStripeRepository.retrieveSetupIntent(any(), any(), any())).thenReturn(
-                SetupIntentFixtures.SI_3DS2_PROCESSING,
-                SetupIntentFixtures.SI_3DS2_SUCCEEDED
+                Result.success(SetupIntentFixtures.SI_3DS2_PROCESSING),
+                Result.success(SetupIntentFixtures.SI_3DS2_SUCCEEDED),
             )
 
             val clientSecret = "pi_3L8WOsLu5o3P18Zp191FpRSy_secret_5JIwIT1ooCwRm28AwreUAc6N4"
@@ -106,7 +106,7 @@ internal class SetupIntentFlowResultProcessorTest {
     fun `3ds2 canceled with succeeded intent should succeed`() =
         runTest {
             whenever(mockStripeRepository.retrieveSetupIntent(any(), any(), any())).thenReturn(
-                SetupIntentFixtures.SI_3DS2_SUCCEEDED
+                Result.success(SetupIntentFixtures.SI_3DS2_SUCCEEDED)
             )
 
             val clientSecret = "pi_3L8WOsLu5o3P18Zp191FpRSy_secret_5JIwIT1ooCwRm28AwreUAc6N4"
@@ -142,7 +142,7 @@ internal class SetupIntentFlowResultProcessorTest {
                 status = StripeIntent.Status.RequiresAction
             )
             whenever(mockStripeRepository.retrieveSetupIntent(any(), any(), any())).thenReturn(
-                intent
+                Result.success(intent)
             )
 
             val clientSecret = requireNotNull(

--- a/payments-core/src/test/java/com/stripe/android/payments/SetupIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/SetupIntentFlowResultProcessorTest.kt
@@ -188,9 +188,9 @@ internal class SetupIntentFlowResultProcessorTest {
             val succeededIntent = requiresActionIntent.copy(status = StripeIntent.Status.Succeeded)
 
             whenever(mockStripeRepository.retrieveSetupIntent(any(), any(), any())).thenReturn(
-                requiresActionIntent,
-                requiresActionIntent,
-                succeededIntent,
+                Result.success(requiresActionIntent),
+                Result.success(requiresActionIntent),
+                Result.success(succeededIntent),
             )
 
             val clientSecret = requireNotNull(requiresActionIntent.clientSecret)

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/AbsPaymentController.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/AbsPaymentController.kt
@@ -28,8 +28,8 @@ internal abstract class AbsPaymentController : PaymentController {
         confirmPaymentIntentParams: ConfirmPaymentIntentParams,
         authenticator: AlipayAuthenticator,
         requestOptions: ApiRequest.Options
-    ): PaymentIntentResult {
-        TODO("Not yet implemented")
+    ): Result<PaymentIntentResult> {
+        return Result.failure(NotImplementedError())
     }
 
     override suspend fun confirmWeChatPay(

--- a/payments-core/src/test/java/com/stripe/android/polling/DefaultIntentStatusPollerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/polling/DefaultIntentStatusPollerTest.kt
@@ -40,6 +40,8 @@ class DefaultIntentStatusPollerTest {
 
         advanceTimeBy(nextDelay())
         assertThat(poller.state.value).isEqualTo(Succeeded)
+
+        poller.stopPolling()
     }
 
     @Test
@@ -131,5 +133,7 @@ class DefaultIntentStatusPollerTest {
 
         poller.startPolling(scope = this@runTest)
         assertThat(poller.state.value).isEqualTo(Succeeded)
+
+        poller.stopPolling()
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/polling/PollingTestUtils.kt
+++ b/payments-core/src/test/java/com/stripe/android/polling/PollingTestUtils.kt
@@ -5,9 +5,8 @@ import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.testing.AbsFakeStripeRepository
+import com.stripe.android.testing.PaymentIntentFactory
 import kotlinx.coroutines.CoroutineDispatcher
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
 
 internal fun exponentialDelayProvider(): () -> Long {
     var attempt = 1
@@ -20,7 +19,7 @@ internal fun exponentialDelayProvider(): () -> Long {
 }
 
 internal fun createIntentStatusPoller(
-    enqueuedStatuses: List<StripeIntent.Status?>,
+    enqueuedStatuses: List<StripeIntent.Status>,
     dispatcher: CoroutineDispatcher,
     maxAttempts: Int = 10,
 ): DefaultIntentStatusPoller {
@@ -41,7 +40,7 @@ internal fun createIntentStatusPoller(
 }
 
 private class FakeStripeRepository(
-    enqueuedStatuses: List<StripeIntent.Status?>
+    enqueuedStatuses: List<StripeIntent.Status>
 ) : AbsFakeStripeRepository() {
 
     private val queue = enqueuedStatuses.toMutableList()
@@ -50,10 +49,8 @@ private class FakeStripeRepository(
         clientSecret: String,
         options: ApiRequest.Options,
         expandFields: List<String>
-    ): PaymentIntent {
+    ): Result<PaymentIntent> {
         val intentStatus = queue.removeFirst()
-        return mock {
-            on { status } doReturn intentStatus
-        }
+        return Result.success(PaymentIntentFactory.create(status = intentStatus))
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
@@ -81,37 +81,29 @@ internal sealed class ElementsSessionRepository {
         ): Result<ElementsSession> = withContext(workContext) {
             when (params) {
                 is ElementsSessionParams.PaymentIntentType -> {
-                    runCatching {
-                        requireNotNull(
-                            stripeRepository.retrievePaymentIntent(
-                                clientSecret = params.clientSecret,
-                                options = requestOptions,
-                                expandFields = listOf("payment_method")
-                            )
-                        )
-                    }.map {
+                    stripeRepository.retrievePaymentIntent(
+                        clientSecret = params.clientSecret,
+                        options = requestOptions,
+                        expandFields = listOf("payment_method"),
+                    ).map { stripeIntent ->
                         ElementsSession(
                             linkSettings = null,
                             paymentMethodSpecs = null,
-                            stripeIntent = it,
                             merchantCountry = null,
+                            stripeIntent = stripeIntent,
                         )
                     }
                 }
                 is ElementsSessionParams.SetupIntentType -> {
-                    runCatching {
-                        requireNotNull(
-                            stripeRepository.retrieveSetupIntent(
-                                clientSecret = params.clientSecret,
-                                options = requestOptions,
-                                expandFields = listOf("payment_method")
-                            )
-                        )
-                    }.map {
+                    stripeRepository.retrieveSetupIntent(
+                        clientSecret = params.clientSecret,
+                        options = requestOptions,
+                        expandFields = listOf("payment_method"),
+                    ).map { stripeIntent ->
                         ElementsSession(
                             linkSettings = null,
                             paymentMethodSpecs = null,
-                            stripeIntent = it,
+                            stripeIntent = stripeIntent,
                             merchantCountry = null,
                         )
                     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
@@ -69,7 +69,7 @@ internal class ElementsSessionRepositoryTest {
             ).thenReturn(Result.failure(APIException()))
 
             whenever(stripeRepository.retrievePaymentIntent(any(), any(), any()))
-                .thenReturn(PaymentIntentFixtures.PI_WITH_SHIPPING)
+                .thenReturn(Result.success(PaymentIntentFixtures.PI_WITH_SHIPPING))
 
             val session = withLocale(Locale.ITALY) {
                 createRepository().get(
@@ -92,7 +92,7 @@ internal class ElementsSessionRepositoryTest {
             ).thenReturn(Result.failure(RuntimeException()))
 
             whenever(stripeRepository.retrievePaymentIntent(any(), any(), any()))
-                .thenReturn(PaymentIntentFixtures.PI_WITH_SHIPPING)
+                .thenReturn(Result.success(PaymentIntentFixtures.PI_WITH_SHIPPING))
 
             val session = withLocale(Locale.ITALY) {
                 createRepository().get(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request switches several `retrieve()` methods to `Result<T>`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

`Result<T>` migration.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
