### PR TITLE
Change phone country only if empty

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/BillingDetailsHelpers.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/BillingDetailsHelpers.kt
@@ -143,8 +143,10 @@ internal object BillingDetailsHelpers {
 
             countryElement?.controller?.rawFieldValue ?: emptyFlow()
         }.collect {
-            it?.let {
-                phoneNumberElement?.controller?.countryDropdownController?.onRawValueChange(it)
+            if (phoneNumberElement?.controller?.getLocalNumber().isNullOrBlank()) {
+                it?.let {
+                    phoneNumberElement?.controller?.countryDropdownController?.onRawValueChange(it)
+                }
             }
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -714,95 +714,109 @@ internal class FormViewModelTest {
     }
 
     @Test
-    fun `Test phone country changes with AddressElement country`() = runBlocking {
-        val billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
-            name = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-            email = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-            phone = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-            address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
-            attachDefaultsToPaymentMethod = false,
-        )
+    fun `Test phone country changes with AddressElement country`() =
+        runBlocking {
+            val billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
+                name = BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                email = BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                phone = BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+                attachDefaultsToPaymentMethod = false,
+            )
 
-        val args = COMPOSE_FRAGMENT_ARGS.copy(
-            PaymentMethod.Type.Card.code,
-            billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
-        )
-        val formViewModel = createViewModel(
-            args,
-            createLpmRepositorySupportedPaymentMethod(
-                PaymentMethod.Type.Card,
-                LpmRepository.hardcodedCardSpec(billingDetailsCollectionConfiguration).formSpec,
-            ),
-        )
+            val args = COMPOSE_FRAGMENT_ARGS.copy(
+                PaymentMethod.Type.Card.code,
+                billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
+                billingDetails = PaymentSheet.BillingDetails(),
+            )
+            val formViewModel = createViewModel(
+                args,
+                createLpmRepositorySupportedPaymentMethod(
+                    PaymentMethod.Type.Card,
+                    LpmRepository.hardcodedCardSpec(billingDetailsCollectionConfiguration).formSpec,
+                ),
+            )
 
-        val elements = formViewModel.elementsFlow.first()
-        val countryElement = elements
-            .filterIsInstance<SectionElement>()
-            .flatMap { it.fields }
-            .filterIsInstance<AddressElement>()
-            .firstOrNull()
-            ?.countryElement
-        val phoneElement = elements
-            .filterIsInstance<SectionElement>()
-            .flatMap { it.fields }
-            .filterIsInstance<PhoneNumberElement>()
-            .firstOrNull()
+            val elements = formViewModel.elementsFlow.first()
+            val countryElement = elements
+                .filterIsInstance<SectionElement>()
+                .flatMap { it.fields }
+                .filterIsInstance<AddressElement>()
+                .firstOrNull()
+                ?.countryElement
+            val phoneElement = elements
+                .filterIsInstance<SectionElement>()
+                .flatMap { it.fields }
+                .filterIsInstance<PhoneNumberElement>()
+                .firstOrNull()
 
-        assertThat(countryElement).isNotNull()
-        assertThat(phoneElement).isNotNull()
-        countryElement?.controller?.onRawValueChange("CA")
-        assertThat(phoneElement?.controller?.countryDropdownController?.rawFieldValue?.first())
-            .isEqualTo("CA")
-    }
+            assertThat(countryElement).isNotNull()
+            assertThat(phoneElement).isNotNull()
+            countryElement?.controller?.onRawValueChange("CA")
+            assertThat(phoneElement?.controller?.countryDropdownController?.rawFieldValue?.first())
+                .isEqualTo("CA")
+            phoneElement?.controller?.onValueChange("+13105551234")
+            countryElement?.controller?.onRawValueChange("US")
+            // Phone number shouldn't change because it is already filled.
+            assertThat(phoneElement?.controller?.countryDropdownController?.rawFieldValue?.first())
+                .isEqualTo("CA")
+        }
 
     @Test
-    fun `Test phone country changes with standalone CountryElement`() = runBlocking {
-        val billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
-            name = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-            email = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-            phone = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-            address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
-            attachDefaultsToPaymentMethod = false,
-        )
+    fun `Test phone country changes with standalone CountryElement`() =
+        runBlocking {
+            val billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
+                name = BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                email = BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                phone = BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+                attachDefaultsToPaymentMethod = false,
+            )
 
-        val args = COMPOSE_FRAGMENT_ARGS.copy(
-            PaymentMethod.Type.Sofort.code,
-            billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
-        )
-        val formViewModel = createViewModel(
-            args,
-            createLpmRepositorySupportedPaymentMethod(
-                PaymentMethod.Type.Sofort,
-                LayoutSpec(
-                    listOf(
-                        NameSpec(),
-                        EmailSpec(),
-                        PhoneSpec(),
-                        CountrySpec(),
-                        AddressSpec(hideCountry = true),
-                    ),
-                )
-            ),
-        )
+            val args = COMPOSE_FRAGMENT_ARGS.copy(
+                PaymentMethod.Type.Sofort.code,
+                billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
+                billingDetails = PaymentSheet.BillingDetails(),
+            )
+            val formViewModel = createViewModel(
+                args,
+                createLpmRepositorySupportedPaymentMethod(
+                    PaymentMethod.Type.Sofort,
+                    LayoutSpec(
+                        listOf(
+                            NameSpec(),
+                            EmailSpec(),
+                            PhoneSpec(),
+                            CountrySpec(),
+                            AddressSpec(hideCountry = true),
+                        ),
+                    )
+                ),
+            )
 
-        val elements = formViewModel.elementsFlow.first()
-        val countryElement = elements
-            .filterIsInstance<SectionElement>()
-            .flatMap { it.fields }
-            .filterIsInstance<CountryElement>()
-            .firstOrNull()
-        val phoneElement = elements
-            .filterIsInstance<SectionElement>()
-            .flatMap { it.fields }
-            .filterIsInstance<PhoneNumberElement>()
-            .firstOrNull()
+            val elements = formViewModel.elementsFlow.first()
+            val countryElement = elements
+                .filterIsInstance<SectionElement>()
+                .flatMap { it.fields }
+                .filterIsInstance<CountryElement>()
+                .firstOrNull()
+            val phoneElement = elements
+                .filterIsInstance<SectionElement>()
+                .flatMap { it.fields }
+                .filterIsInstance<PhoneNumberElement>()
+                .firstOrNull()
 
-        assertThat(countryElement).isNotNull()
-        assertThat(phoneElement).isNotNull()
-        countryElement?.controller?.onRawValueChange("CA")
-        assertThat(phoneElement?.controller?.countryDropdownController?.rawFieldValue?.first())
-            .isEqualTo("CA")
-    }
+            assertThat(countryElement).isNotNull()
+            assertThat(phoneElement).isNotNull()
+            countryElement?.controller?.onRawValueChange("CA")
+            assertThat(phoneElement?.controller?.countryDropdownController?.rawFieldValue?.first())
+                .isEqualTo("CA")
+            phoneElement?.controller?.onValueChange("+13105551234")
+            countryElement?.controller?.onRawValueChange("US")
+            // Phone number shouldn't change because it is already filled.
+            assertThat(phoneElement?.controller?.countryDropdownController?.rawFieldValue?.first())
+                .isEqualTo("CA")
+        }
 
     private suspend fun getSectionFieldTextControllerWithLabel(
         formViewModel: FormViewModel,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberController.kt
@@ -99,6 +99,8 @@ class PhoneNumberController constructor(
     fun getE164PhoneNumber(phoneNumber: String) =
         phoneNumberFormatter.value.toE164Format(phoneNumber)
 
+    fun getLocalNumber() = _fieldValue.value.removePrefix(phoneNumberFormatter.value.prefix)
+
     fun onSelectedCountryIndex(index: Int) = countryConfig.countries[index].takeIf {
         it.code.value != phoneNumberFormatter.value.countryCode
     }?.let {


### PR DESCRIPTION
# Summary
Change the phone number country when address country changes, only if the phone number is empty.

# Motivation
It's annoying to fill your phone number, then change the country and have the phone number change the country, so only changing the phone country if the phone number is empty.
This matches the behavior on iOS.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [X] Modified tests
- [X] Manually verified

