### PR TITLE
[FC] Integrate PagerDuty on e2e test failures.

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -5,8 +5,8 @@ project_type: android
 trigger_map:
   - push_branch: 'master'
     pipeline: main-trigger-pipeline
-  - pull_request_source_branch: '*'
-    pipeline: main-trigger-pipeline
+  - pull_request_source_branch: 'carlosmuvi/page-aux-on-e2e-failures'
+    workflow: maestro-financial-connections
 app:
   envs:
     - GRADLE_OPTS: -Dkotlin.incremental=false

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -5,8 +5,8 @@ project_type: android
 trigger_map:
   - push_branch: 'master'
     pipeline: main-trigger-pipeline
-  - pull_request_source_branch: 'carlosmuvi/page-aux-on-e2e-failures'
-    workflow: maestro-financial-connections
+  - pull_request_source_branch: '*'
+    pipeline: main-trigger-pipeline
 app:
   envs:
     - GRADLE_OPTS: -Dkotlin.incremental=false

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -79,6 +79,12 @@ workflows:
                 RUN_BANKCON_MOBILE
           is_always_run: true
           run_if: ".IsBuildFailed"
+      - pagerduty@0:
+          inputs:
+            - event_description: Android E2E tests failing! $BITRISE_BUILD_URL.
+            - integration_key: $AUX_PAGERDUTY_INTEGRATION_KEY
+          is_always_run: true
+          run_if: .IsBuildFailed
       - custom-test-results-export@0:
           inputs:
             - search_pattern: '*/maestroReport.xml'

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsLauncherActivity.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsLauncherActivity.kt
@@ -54,10 +54,11 @@ class FinancialConnectionsLauncherActivity : AppCompatActivity() {
                 activity.getString(R.string.collect_bank_account_for_data_compose),
                 FinancialConnectionsComposeExampleActivity::class.java
             ),
-            Item(
-                "Playground",
-                FinancialConnectionsPlaygroundActivity::class.java
-            )
+//            HIDES PLAYGROUND TO TEST FAILURES.
+//            Item(
+//                "Playground",
+//                FinancialConnectionsPlaygroundActivity::class.java
+//            )
         )
 
         override fun onCreateViewHolder(viewGroup: ViewGroup, i: Int): ExamplesViewHolder {

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsLauncherActivity.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsLauncherActivity.kt
@@ -54,11 +54,10 @@ class FinancialConnectionsLauncherActivity : AppCompatActivity() {
                 activity.getString(R.string.collect_bank_account_for_data_compose),
                 FinancialConnectionsComposeExampleActivity::class.java
             ),
-//            HIDES PLAYGROUND TO TEST FAILURES.
-//            Item(
-//                "Playground",
-//                FinancialConnectionsPlaygroundActivity::class.java
-//            )
+            Item(
+                "Playground",
+                FinancialConnectionsPlaygroundActivity::class.java
+            )
         )
 
         override fun onCreateViewHolder(viewGroup: ViewGroup, i: Int): ExamplesViewHolder {


### PR DESCRIPTION
# Summary

- Adds PagerDuty Bitrise step to Maestro tests.
- See PagerDuty Integration [here](https://not-a-startup.pagerduty.com/services/PBS6Z8C/integrations/PSNGA60). 
- More details in this [doc](https://docs.google.com/document/d/1dTmcPAoXxWGPdYuwKBtWbS9Gqahm97GemwBiSvrhIng/edit#).

