### PR TITLE
Stabilize nightly browserstack tests.

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/CleanupChromeRule.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/CleanupChromeRule.kt
@@ -1,0 +1,25 @@
+package com.stripe.android.utils
+
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+// Kills Chrome once the test is over.
+// This is to prevent the Chrome process from preventing future tests to fail.
+internal object CleanupChromeRule : TestRule {
+    override fun apply(base: Statement, description: Description): Statement {
+        return object : Statement() {
+            @Throws
+            override fun evaluate() {
+                try {
+                    base.evaluate()
+                } finally {
+                    val command = "am force-stop com.android.chrome"
+                    val uiAutomation = InstrumentationRegistry.getInstrumentation().uiAutomation
+                    uiAutomation.executeShellCommand(command).close()
+                }
+            }
+        }
+    }
+}

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/CleanupChromeRule.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/CleanupChromeRule.kt
@@ -6,7 +6,7 @@ import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
 // Kills Chrome once the test is over.
-// This is to prevent the Chrome process from preventing future tests to fail.
+// This is to prevent the Chrome process from causing future tests to fail.
 internal object CleanupChromeRule : TestRule {
     override fun apply(base: Statement, description: Description): Statement {
         return object : Statement() {

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/TestRules.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/TestRules.kt
@@ -34,19 +34,18 @@ class TestRules private constructor(
             val composeTestRule = createEmptyComposeRule()
 
             val chain = RuleChain.emptyRuleChain()
-                .around(RetryRule(retryCount))
-                .around(RuleChain
-                    .outerRule(Timeout.seconds(INDIVIDUAL_TEST_TIMEOUT_SECONDS))
-                    .around(composeTestRule)
-                    .around(TestWatcher())
-                    .let { chain ->
-                        if (disableAnimations) {
-                            chain.around(DisableAnimationsRule())
-                        } else {
-                            chain
-                        }
+                .around(composeTestRule)
+                .let { chain ->
+                    if (disableAnimations) {
+                        chain.around(DisableAnimationsRule())
+                    } else {
+                        chain
                     }
-                    .around(CleanupChromeRule))
+                }
+                .around(RetryRule(retryCount))
+                .around(Timeout.seconds(INDIVIDUAL_TEST_TIMEOUT_SECONDS))
+                .around(TestWatcher())
+                .around(CleanupChromeRule)
 
             return TestRules(chain, composeTestRule)
         }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/TestRules.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/TestRules.kt
@@ -33,19 +33,20 @@ class TestRules private constructor(
         ): TestRules {
             val composeTestRule = createEmptyComposeRule()
 
-            val chain = RuleChain
-                .outerRule(Timeout.seconds(INDIVIDUAL_TEST_TIMEOUT_SECONDS))
-                .around(composeTestRule)
-                .around(TestWatcher())
-                .let { chain ->
-                    if (disableAnimations) {
-                        chain.around(DisableAnimationsRule())
-                    } else {
-                        chain
-                    }
-                }
-                .around(CleanupChromeRule)
+            val chain = RuleChain.emptyRuleChain()
                 .around(RetryRule(retryCount))
+                .around(RuleChain
+                    .outerRule(Timeout.seconds(INDIVIDUAL_TEST_TIMEOUT_SECONDS))
+                    .around(composeTestRule)
+                    .around(TestWatcher())
+                    .let { chain ->
+                        if (disableAnimations) {
+                            chain.around(DisableAnimationsRule())
+                        } else {
+                            chain
+                        }
+                    }
+                    .around(CleanupChromeRule))
 
             return TestRules(chain, composeTestRule)
         }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/TestRules.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/utils/TestRules.kt
@@ -44,6 +44,7 @@ class TestRules private constructor(
                         chain
                     }
                 }
+                .around(CleanupChromeRule)
                 .around(RetryRule(retryCount))
 
             return TestRules(chain, composeTestRule)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Retries tests with a timeout per retry, allowing retries when timeouts occur.

Also kills chrome after each test.


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Our tests have been VERY flakey. Working on stabilizing them!
