### PR TITLE
Move `BillingDetailsCollectionConfiguration` into `PaymentSheet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## XX.XX.XX - 2023-XX-XX
 
+## 20.23.1 - 2023-04-17
+
+### PaymentSheet
+* [FIXED][6551](https://github.com/stripe/stripe-android/pull/6551) Fixed a build issue where `BillingDetailsCollectionConfiguration` couldn't be found in the classpath. If you worked around this issue by importing `payments-ui-core` directly, you can undo this change and need to update the import of `BillingDetailsCollectionConfiguration`.
+
 ## 20.23.0 - 2023-04-17
 
 ### PaymentSheet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 20.23.1 - 2023-04-17
 
 ### PaymentSheet
-* [FIXED][6551](https://github.com/stripe/stripe-android/pull/6551) Fixed a build issue where `BillingDetailsCollectionConfiguration` couldn't be found in the classpath. If you worked around this issue by importing `payments-ui-core` directly, you can undo this change and need to update the import of `BillingDetailsCollectionConfiguration`.
+* [FIXED][6551](https://github.com/stripe/stripe-android/pull/6551) Fixed a build issue where `BillingDetailsCollectionConfiguration` couldn't be found in the classpath. If you worked around this issue by importing `payments-ui-core` directly, undo this change and update the import of `BillingDetailsCollectionConfiguration` to `com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration`.
 
 ## 20.23.0 - 2023-04-17
 

--- a/payments-core/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentMethodEndToEndTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
@@ -22,6 +23,7 @@ internal class PaymentMethodEndToEndTest {
     private val context = ApplicationProvider.getApplicationContext<Context>()
     private val testDispatcher = UnconfinedTestDispatcher()
 
+    @Ignore("Ignore while this is broken on the backend.")
     @Test
     fun createPaymentMethod_withBacsDebit_shouldCreateObject() {
         val params = PaymentMethodCreateParamsFixtures.BACS_DEBIT

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -22,35 +22,19 @@ public final class com/stripe/android/ui/core/Amount$Creator : android/os/Parcel
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/ui/core/BillingDetailsCollectionConfiguration$AddressCollectionMode : java/lang/Enum {
-	public static final field Automatic Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$AddressCollectionMode;
-	public static final field Full Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$AddressCollectionMode;
-	public static final field Never Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$AddressCollectionMode;
-	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$AddressCollectionMode;
-	public static fun values ()[Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$AddressCollectionMode;
-}
-
-public final class com/stripe/android/ui/core/BillingDetailsCollectionConfiguration$CollectionMode : java/lang/Enum {
-	public static final field Always Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$CollectionMode;
-	public static final field Automatic Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$CollectionMode;
-	public static final field Never Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$CollectionMode;
-	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$CollectionMode;
-	public static fun values ()[Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$CollectionMode;
-}
-
-public final class com/stripe/android/ui/core/BillingDetailsCollectionConfiguration$Creator : android/os/Parcelable$Creator {
-	public fun <init> ()V
-	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration;
-	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
-	public final fun newArray (I)[Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration;
-	public synthetic fun newArray (I)[Ljava/lang/Object;
-}
-
 public final class com/stripe/android/ui/core/BuildConfig {
 	public static final field BUILD_TYPE Ljava/lang/String;
 	public static final field DEBUG Z
 	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
 	public fun <init> ()V
+}
+
+public final class com/stripe/android/ui/core/CardBillingDetailsCollectionConfiguration$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/ui/core/CardBillingDetailsCollectionConfiguration;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/ui/core/CardBillingDetailsCollectionConfiguration;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/ui/core/FieldValuesToParamsMapConverter$Companion {

--- a/payments-ui-core/api/payments-ui-core.api
+++ b/payments-ui-core/api/payments-ui-core.api
@@ -22,31 +22,6 @@ public final class com/stripe/android/ui/core/Amount$Creator : android/os/Parcel
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/ui/core/BillingDetailsCollectionConfiguration : android/os/Parcelable {
-	public static final field $stable I
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> ()V
-	public fun <init> (Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$AddressCollectionMode;Z)V
-	public synthetic fun <init> (Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$AddressCollectionMode;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$CollectionMode;
-	public final fun component2 ()Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$CollectionMode;
-	public final fun component3 ()Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$CollectionMode;
-	public final fun component4 ()Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$AddressCollectionMode;
-	public final fun component5 ()Z
-	public final fun copy (Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$AddressCollectionMode;Z)Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration;
-	public static synthetic fun copy$default (Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration;Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$AddressCollectionMode;ZILjava/lang/Object;)Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration;
-	public fun describeContents ()I
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAddress ()Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$AddressCollectionMode;
-	public final fun getAttachDefaultsToPaymentMethod ()Z
-	public final fun getEmail ()Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$CollectionMode;
-	public final fun getName ()Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$CollectionMode;
-	public final fun getPhone ()Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$CollectionMode;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
 public final class com/stripe/android/ui/core/BillingDetailsCollectionConfiguration$AddressCollectionMode : java/lang/Enum {
 	public static final field Automatic Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$AddressCollectionMode;
 	public static final field Full Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration$AddressCollectionMode;

--- a/payments-ui-core/detekt-baseline.xml
+++ b/payments-ui-core/detekt-baseline.xml
@@ -5,12 +5,12 @@
     <ID>ConstructorParameterNaming:CardNumberElement.kt$CardNumberElement$val _identifier: IdentifierSpec</ID>
     <ID>ConstructorParameterNaming:CvcElement.kt$CvcElement$val _identifier: IdentifierSpec</ID>
     <ID>CyclomaticComplexMethod:FormItemSpec.kt$FormItemSpecSerializer$override fun selectDeserializer(element: JsonElement): DeserializationStrategy&lt;out FormItemSpec></ID>
-    <ID>CyclomaticComplexMethod:LpmRepository.kt$LpmRepository$private fun convertToSupportedPaymentMethod( stripeIntent: StripeIntent, sharedDataSpec: SharedDataSpec, billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration, )</ID>
+    <ID>CyclomaticComplexMethod:LpmRepository.kt$LpmRepository$private fun convertToSupportedPaymentMethod( stripeIntent: StripeIntent, sharedDataSpec: SharedDataSpec, cardBillingDetailsCollectionConfiguration: CardBillingDetailsCollectionConfiguration, )</ID>
     <ID>CyclomaticComplexMethod:TransformGoogleToStripeAddress.kt$@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun Place.transformGoogleToStripeAddress( context: Context ): com.stripe.android.model.Address</ID>
     <ID>CyclomaticComplexMethod:TransformSpecToElements.kt$TransformSpecToElements$fun transform(list: List&lt;FormItemSpec>): List&lt;FormElement></ID>
     <ID>EmptyFunctionBlock:CardNumberViewOnlyController.kt$CardNumberViewOnlyController${}</ID>
     <ID>ForbiddenComment:Menu.kt$// TODO: Make sure this gets the rounded corner values</ID>
-    <ID>LongMethod:LpmRepository.kt$LpmRepository$private fun convertToSupportedPaymentMethod( stripeIntent: StripeIntent, sharedDataSpec: SharedDataSpec, billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration, )</ID>
+    <ID>LongMethod:LpmRepository.kt$LpmRepository$private fun convertToSupportedPaymentMethod( stripeIntent: StripeIntent, sharedDataSpec: SharedDataSpec, cardBillingDetailsCollectionConfiguration: CardBillingDetailsCollectionConfiguration, )</ID>
     <ID>LongMethod:Menu.kt$@Suppress("ModifierParameter") @Composable internal fun DropdownMenuContent( expandedStates: MutableTransitionState&lt;Boolean>, transformOriginState: MutableState&lt;TransformOrigin>, initialFirstVisibleItemIndex: Int, modifier: Modifier = Modifier, content: LazyListScope.() -> Unit )</ID>
     <ID>LongMethod:TransformGoogleToStripeAddress.kt$@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun Place.transformGoogleToStripeAddress( context: Context ): com.stripe.android.model.Address</ID>
     <ID>LongMethod:TransformGoogleToStripeAddressTest.kt$TransformGoogleToStripeAddressTest$@Test fun `test JP address`()</ID>

--- a/payments-ui-core/detekt-baseline.xml
+++ b/payments-ui-core/detekt-baseline.xml
@@ -5,12 +5,12 @@
     <ID>ConstructorParameterNaming:CardNumberElement.kt$CardNumberElement$val _identifier: IdentifierSpec</ID>
     <ID>ConstructorParameterNaming:CvcElement.kt$CvcElement$val _identifier: IdentifierSpec</ID>
     <ID>CyclomaticComplexMethod:FormItemSpec.kt$FormItemSpecSerializer$override fun selectDeserializer(element: JsonElement): DeserializationStrategy&lt;out FormItemSpec></ID>
-    <ID>CyclomaticComplexMethod:LpmRepository.kt$LpmRepository$private fun convertToSupportedPaymentMethod( stripeIntent: StripeIntent, sharedDataSpec: SharedDataSpec, billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration() )</ID>
+    <ID>CyclomaticComplexMethod:LpmRepository.kt$LpmRepository$private fun convertToSupportedPaymentMethod( stripeIntent: StripeIntent, sharedDataSpec: SharedDataSpec, billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration, )</ID>
     <ID>CyclomaticComplexMethod:TransformGoogleToStripeAddress.kt$@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun Place.transformGoogleToStripeAddress( context: Context ): com.stripe.android.model.Address</ID>
     <ID>CyclomaticComplexMethod:TransformSpecToElements.kt$TransformSpecToElements$fun transform(list: List&lt;FormItemSpec>): List&lt;FormElement></ID>
     <ID>EmptyFunctionBlock:CardNumberViewOnlyController.kt$CardNumberViewOnlyController${}</ID>
     <ID>ForbiddenComment:Menu.kt$// TODO: Make sure this gets the rounded corner values</ID>
-    <ID>LongMethod:LpmRepository.kt$LpmRepository$private fun convertToSupportedPaymentMethod( stripeIntent: StripeIntent, sharedDataSpec: SharedDataSpec, billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration() )</ID>
+    <ID>LongMethod:LpmRepository.kt$LpmRepository$private fun convertToSupportedPaymentMethod( stripeIntent: StripeIntent, sharedDataSpec: SharedDataSpec, billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration, )</ID>
     <ID>LongMethod:Menu.kt$@Suppress("ModifierParameter") @Composable internal fun DropdownMenuContent( expandedStates: MutableTransitionState&lt;Boolean>, transformOriginState: MutableState&lt;TransformOrigin>, initialFirstVisibleItemIndex: Int, modifier: Modifier = Modifier, content: LazyListScope.() -> Unit )</ID>
     <ID>LongMethod:TransformGoogleToStripeAddress.kt$@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun Place.transformGoogleToStripeAddress( context: Context ): com.stripe.android.model.Address</ID>
     <ID>LongMethod:TransformGoogleToStripeAddressTest.kt$TransformGoogleToStripeAddressTest$@Test fun `test JP address`()</ID>

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/BillingDetailsCollectionConfiguration.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/BillingDetailsCollectionConfiguration.kt
@@ -1,11 +1,13 @@
 package com.stripe.android.ui.core
 
 import android.os.Parcelable
+import androidx.annotation.RestrictTo
 import kotlinx.parcelize.Parcelize
 
 /**
  * Configuration for how billing details are collected during checkout.
  */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Parcelize
 data class BillingDetailsCollectionConfiguration(
     /**

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/BillingDetailsCollectionConfiguration.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/BillingDetailsCollectionConfiguration.kt
@@ -4,80 +4,21 @@ import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import kotlinx.parcelize.Parcelize
 
-/**
- * Configuration for how billing details are collected during checkout.
- */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Parcelize
 data class BillingDetailsCollectionConfiguration(
-    /**
-     * How to collect the name field.
-     */
-    val name: CollectionMode = CollectionMode.Automatic,
-
-    /**
-     * How to collect the phone field.
-     */
-    val phone: CollectionMode = CollectionMode.Automatic,
-
-    /**
-     * How to collect the email field.
-     */
-    val email: CollectionMode = CollectionMode.Automatic,
-
-    /**
-     * How to collect the billing address.
-     */
+    val collectName: Boolean = false,
+    val collectEmail: Boolean = false,
+    val collectPhone: Boolean = false,
     val address: AddressCollectionMode = AddressCollectionMode.Automatic,
-
-    /**
-     * Whether the values included in `PaymentSheet.Configuration.defaultBillingDetails`
-     * should be attached to the payment method, this includes fields that aren't displayed in the form.
-     *
-     * If `false` (the default), those values will only be used to prefill the corresponding fields in the form.
-     */
-    val attachDefaultsToPaymentMethod: Boolean = false,
 ) : Parcelable {
 
-    /**
-     * Billing details fields collection options.
-     */
-    enum class CollectionMode {
-        /**
-         * The field will be collected depending on the Payment Method's requirements.
-         */
-        Automatic,
+    val collectAddress: Boolean
+        get() = address != AddressCollectionMode.Never
 
-        /**
-         * The field will never be collected.
-         * If this field is required by the Payment Method, you must provide it as part of `defaultBillingDetails`.
-         */
-        Never,
-
-        /**
-         * The field will always be collected, even if it isn't required for the Payment Method.
-         */
-        Always,
-    }
-
-    /**
-     * Billing address collection options.
-     */
     enum class AddressCollectionMode {
-        /**
-         * Only the fields required by the Payment Method will be collected, this may be none.
-         */
         Automatic,
-
-        /**
-         * Address will never be collected.
-         * If the Payment Method requires a billing address, you must provide it as part of `defaultBillingDetails`.
-         */
         Never,
-
-        /**
-         * Collect the full billing address, regardless of the Payment Method requirements.
-         */
         Full,
     }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/CardBillingDetailsCollectionConfiguration.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/CardBillingDetailsCollectionConfiguration.kt
@@ -6,7 +6,7 @@ import kotlinx.parcelize.Parcelize
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Parcelize
-data class BillingDetailsCollectionConfiguration(
+data class CardBillingDetailsCollectionConfiguration(
     val collectName: Boolean = false,
     val collectEmail: Boolean = false,
     val collectPhone: Boolean = false,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/CardBillingDetailsCollectionConfiguration.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/CardBillingDetailsCollectionConfiguration.kt
@@ -16,6 +16,7 @@ data class CardBillingDetailsCollectionConfiguration(
     val collectAddress: Boolean
         get() = address != AddressCollectionMode.Never
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     enum class AddressCollectionMode {
         Automatic,
         Never,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingAddressElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingAddressElement.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
+import com.stripe.android.ui.core.CardBillingDetailsCollectionConfiguration
 import com.stripe.android.uicore.address.AddressRepository
 import com.stripe.android.uicore.address.FieldType
 import com.stripe.android.uicore.elements.AddressElement
@@ -30,8 +30,8 @@ class CardBillingAddressElement(
     ),
     sameAsShippingElement: SameAsShippingElement?,
     shippingValuesMap: Map<IdentifierSpec, String?>?,
-    private val collectionMode: BillingDetailsCollectionConfiguration.AddressCollectionMode =
-        BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+    private val collectionMode: CardBillingDetailsCollectionConfiguration.AddressCollectionMode =
+        CardBillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
 ) : AddressElement(
     identifier,
     addressRepository,
@@ -47,15 +47,15 @@ class CardBillingAddressElement(
     val hiddenIdentifiers: Flow<Set<IdentifierSpec>> =
         countryDropdownFieldController.rawFieldValue.map { countryCode ->
             when (collectionMode) {
-                BillingDetailsCollectionConfiguration.AddressCollectionMode.Never -> {
+                CardBillingDetailsCollectionConfiguration.AddressCollectionMode.Never -> {
                     FieldType.values()
                         .map { it.identifierSpec }
                         .toSet()
                 }
-                BillingDetailsCollectionConfiguration.AddressCollectionMode.Full -> {
+                CardBillingDetailsCollectionConfiguration.AddressCollectionMode.Full -> {
                     emptySet()
                 }
-                BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic -> {
+                CardBillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic -> {
                     when (countryCode) {
                         "US", "GB", "CA" -> {
                             FieldType.values()

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardBillingSpec.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
+import com.stripe.android.ui.core.CardBillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.address.AddressRepository
 import com.stripe.android.uicore.elements.IdentifierSpec
@@ -20,15 +20,15 @@ data class CardBillingSpec(
     @SerialName("allowed_country_codes")
     val allowedCountryCodes: Set<String> = supportedBillingCountries,
     @SerialName("collection_mode")
-    val collectionMode: BillingDetailsCollectionConfiguration.AddressCollectionMode =
-        BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+    val collectionMode: CardBillingDetailsCollectionConfiguration.AddressCollectionMode =
+        CardBillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
 ) : FormItemSpec() {
     fun transform(
         initialValues: Map<IdentifierSpec, String?>,
         addressRepository: AddressRepository,
         shippingValues: Map<IdentifierSpec, String?>?,
     ): SectionElement? {
-        if (collectionMode == BillingDetailsCollectionConfiguration.AddressCollectionMode.Never) {
+        if (collectionMode == CardBillingDetailsCollectionConfiguration.AddressCollectionMode.Never) {
             return null
         }
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
@@ -36,6 +36,8 @@ import com.stripe.android.paymentsheet.forms.USBankAccountRequirement
 import com.stripe.android.paymentsheet.forms.UpiRequirement
 import com.stripe.android.paymentsheet.forms.ZipRequirement
 import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
+import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never
+import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration.CollectionMode.Always
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.AfterpayClearpayHeaderElement.Companion.isClearpay
 import com.stripe.android.ui.core.elements.CardBillingSpec
@@ -216,8 +218,7 @@ class LpmRepository constructor(
     private fun convertToSupportedPaymentMethod(
         stripeIntent: StripeIntent,
         sharedDataSpec: SharedDataSpec,
-        billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration =
-            BillingDetailsCollectionConfiguration()
+        billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration,
     ) = when (sharedDataSpec.type) {
         PaymentMethod.Type.Card.code -> SupportedPaymentMethod(
             code = "card",
@@ -571,20 +572,16 @@ class LpmRepository constructor(
             val specs = listOfNotNull(
                 ContactInformationSpec(
                     collectName = false,
-                    collectEmail = billingDetailsCollectionConfiguration.email ==
-                        BillingDetailsCollectionConfiguration.CollectionMode.Always,
-                    collectPhone = billingDetailsCollectionConfiguration.phone ==
-                        BillingDetailsCollectionConfiguration.CollectionMode.Always
+                    collectEmail = billingDetailsCollectionConfiguration.email == Always,
+                    collectPhone = billingDetailsCollectionConfiguration.phone == Always,
                 ),
                 CardDetailsSectionSpec(
-                    collectName = billingDetailsCollectionConfiguration.name ==
-                        BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                    collectName = billingDetailsCollectionConfiguration.name == Always,
                 ),
                 CardBillingSpec(
                     collectionMode = billingDetailsCollectionConfiguration.address,
                 ).takeIf {
-                    billingDetailsCollectionConfiguration.address !=
-                        BillingDetailsCollectionConfiguration.AddressCollectionMode.Never
+                    billingDetailsCollectionConfiguration.address != Never
                 },
                 SaveForFutureUseSpec(),
             )

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
@@ -36,8 +36,6 @@ import com.stripe.android.paymentsheet.forms.USBankAccountRequirement
 import com.stripe.android.paymentsheet.forms.UpiRequirement
 import com.stripe.android.paymentsheet.forms.ZipRequirement
 import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration.CollectionMode.Always
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.AfterpayClearpayHeaderElement.Companion.isClearpay
 import com.stripe.android.ui.core.elements.CardBillingSpec
@@ -572,16 +570,16 @@ class LpmRepository constructor(
             val specs = listOfNotNull(
                 ContactInformationSpec(
                     collectName = false,
-                    collectEmail = billingDetailsCollectionConfiguration.email == Always,
-                    collectPhone = billingDetailsCollectionConfiguration.phone == Always,
+                    collectEmail = billingDetailsCollectionConfiguration.collectEmail,
+                    collectPhone = billingDetailsCollectionConfiguration.collectPhone,
                 ),
                 CardDetailsSectionSpec(
-                    collectName = billingDetailsCollectionConfiguration.name == Always,
+                    collectName = billingDetailsCollectionConfiguration.collectName,
                 ),
                 CardBillingSpec(
                     collectionMode = billingDetailsCollectionConfiguration.address,
                 ).takeIf {
-                    billingDetailsCollectionConfiguration.address != Never
+                    billingDetailsCollectionConfiguration.collectAddress
                 },
                 SaveForFutureUseSpec(),
             )

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
@@ -35,7 +35,7 @@ import com.stripe.android.paymentsheet.forms.SofortRequirement
 import com.stripe.android.paymentsheet.forms.USBankAccountRequirement
 import com.stripe.android.paymentsheet.forms.UpiRequirement
 import com.stripe.android.paymentsheet.forms.ZipRequirement
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
+import com.stripe.android.ui.core.CardBillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.AfterpayClearpayHeaderElement.Companion.isClearpay
 import com.stripe.android.ui.core.elements.CardBillingSpec
@@ -115,8 +115,8 @@ class LpmRepository constructor(
     fun update(
         stripeIntent: StripeIntent,
         serverLpmSpecs: String?,
-        billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration =
-            BillingDetailsCollectionConfiguration(),
+        cardBillingDetailsCollectionConfiguration: CardBillingDetailsCollectionConfiguration =
+            CardBillingDetailsCollectionConfiguration(),
     ) {
         val expectedLpms = stripeIntent.paymentMethodTypes
 
@@ -127,7 +127,7 @@ class LpmRepository constructor(
             if (serverLpmObjects.isNotEmpty()) {
                 serverSpecLoadingState = ServerSpecState.ServerParsed(serverLpmSpecs)
             }
-            update(stripeIntent, serverLpmObjects, billingDetailsCollectionConfiguration)
+            update(stripeIntent, serverLpmObjects, cardBillingDetailsCollectionConfiguration)
         }
 
         // If the server does not return specs, or they are not parsed successfully
@@ -145,7 +145,7 @@ class LpmRepository constructor(
                 lpmsNotParsedFromServerSpec
                     .mapNotNull { mapFromDisk?.get(it) }
                     .mapNotNull {
-                        convertToSupportedPaymentMethod(stripeIntent, it, billingDetailsCollectionConfiguration)
+                        convertToSupportedPaymentMethod(stripeIntent, it, cardBillingDetailsCollectionConfiguration)
                     }
                     .associateBy { it.code }
             )
@@ -169,8 +169,8 @@ class LpmRepository constructor(
     private fun update(
         stripeIntent: StripeIntent,
         lpms: List<SharedDataSpec>?,
-        billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration =
-            BillingDetailsCollectionConfiguration(),
+        cardBillingDetailsCollectionConfiguration: CardBillingDetailsCollectionConfiguration =
+            CardBillingDetailsCollectionConfiguration(),
     ) {
         val parsedSharedData = lpms
             ?.filter { supportsPaymentMethod(it.type) }
@@ -182,7 +182,7 @@ class LpmRepository constructor(
         // By mapNotNull we will not accept any LPMs that are not known by the platform.
         parsedSharedData
             ?.mapNotNull {
-                convertToSupportedPaymentMethod(stripeIntent, it, billingDetailsCollectionConfiguration)
+                convertToSupportedPaymentMethod(stripeIntent, it, cardBillingDetailsCollectionConfiguration)
             }
             ?.toMutableList()
             ?.let {
@@ -216,7 +216,7 @@ class LpmRepository constructor(
     private fun convertToSupportedPaymentMethod(
         stripeIntent: StripeIntent,
         sharedDataSpec: SharedDataSpec,
-        billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration,
+        cardBillingDetailsCollectionConfiguration: CardBillingDetailsCollectionConfiguration,
     ) = when (sharedDataSpec.type) {
         PaymentMethod.Type.Card.code -> SupportedPaymentMethod(
             code = "card",
@@ -229,7 +229,7 @@ class LpmRepository constructor(
             tintIconOnSelection = true,
             requirement = CardRequirement,
             formSpec = if (sharedDataSpec.fields.isEmpty() || sharedDataSpec.fields == listOf(EmptyFormSpec)) {
-                hardcodedCardSpec(billingDetailsCollectionConfiguration).formSpec
+                hardcodedCardSpec(cardBillingDetailsCollectionConfiguration).formSpec
             } else {
                 LayoutSpec(sharedDataSpec.fields)
             }
@@ -561,11 +561,11 @@ class LpmRepository constructor(
             }
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        val HardcodedCard = hardcodedCardSpec(BillingDetailsCollectionConfiguration())
+        val HardcodedCard = hardcodedCardSpec(CardBillingDetailsCollectionConfiguration())
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         fun hardcodedCardSpec(
-            billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration
+            billingDetailsCollectionConfiguration: CardBillingDetailsCollectionConfiguration
         ): SupportedPaymentMethod {
             val specs = listOfNotNull(
                 ContactInformationSpec(

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/resources/LpmRepositoryTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/resources/LpmRepositoryTest.kt
@@ -367,9 +367,9 @@ class LpmRepositoryTest {
          ]
             """.trimIndent(),
             BillingDetailsCollectionConfiguration(
-                name = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-                email = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-                phone = BillingDetailsCollectionConfiguration.CollectionMode.Never,
+                collectName = true,
+                collectEmail = true,
+                collectPhone = false,
                 address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
             )
         )

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/resources/LpmRepositoryTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/resources/LpmRepositoryTest.kt
@@ -7,7 +7,7 @@ import com.stripe.android.model.PaymentMethod.Type.Card
 import com.stripe.android.model.PaymentMethod.Type.CashAppPay
 import com.stripe.android.paymentsheet.forms.Delayed
 import com.stripe.android.testing.PaymentIntentFactory
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
+import com.stripe.android.ui.core.CardBillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.CardBillingSpec
 import com.stripe.android.ui.core.elements.CardDetailsSectionSpec
@@ -366,11 +366,11 @@ class LpmRepositoryTest {
             }
          ]
             """.trimIndent(),
-            BillingDetailsCollectionConfiguration(
+            CardBillingDetailsCollectionConfiguration(
                 collectName = true,
                 collectEmail = true,
                 collectPhone = false,
-                address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+                address = CardBillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
             )
         )
 
@@ -393,6 +393,6 @@ class LpmRepositoryTest {
 
         val addressSpec = card.formSpec.items[2] as CardBillingSpec
         assertThat(addressSpec.collectionMode)
-            .isEqualTo(BillingDetailsCollectionConfiguration.AddressCollectionMode.Full)
+            .isEqualTo(CardBillingDetailsCollectionConfiguration.AddressCollectionMode.Full)
     }
 }

--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -17,7 +17,6 @@ dependencies {
     implementation project(':paymentsheet')
     implementation project(':stripecardscan')
     implementation project(':financial-connections')
-    implementation project(':payments-ui-core')
 
     implementation "com.google.android.libraries.places:places:$placesVersion"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$androidxLifecycleVersion"

--- a/paymentsheet-example/detekt-baseline.xml
+++ b/paymentsheet-example/detekt-baseline.xml
@@ -37,18 +37,18 @@
     <ID>MaxLineLength:PaymentSheetPlaygroundActivity.kt$PaymentSheetPlaygroundActivity$InitializationType.Normal.value -> viewBinding.initializationRadioGroup.check(R.id.normal_initialization_button)</ID>
     <ID>MaxLineLength:PaymentSheetPlaygroundActivity.kt$PaymentSheetPlaygroundActivity$false -> viewBinding.allowsDelayedPaymentMethodsRadioGroup.check(R.id.allowsDelayedPaymentMethods_off_button)</ID>
     <ID>MaxLineLength:PaymentSheetPlaygroundActivity.kt$PaymentSheetPlaygroundActivity$get() = viewBinding.allowsDelayedPaymentMethodsRadioGroup.checkedRadioButtonId == R.id.allowsDelayedPaymentMethods_on_button</ID>
-    <ID>MaximumLineLength:com.stripe.android.paymentsheet.example.playground.activity.PaymentSheetPlaygroundActivity.kt:147</ID>
+    <ID>MaximumLineLength:com.stripe.android.paymentsheet.example.playground.activity.PaymentSheetPlaygroundActivity.kt:146</ID>
+    <ID>MaximumLineLength:com.stripe.android.paymentsheet.example.playground.activity.PaymentSheetPlaygroundActivity.kt:445</ID>
     <ID>MaximumLineLength:com.stripe.android.paymentsheet.example.playground.activity.PaymentSheetPlaygroundActivity.kt:446</ID>
-    <ID>MaximumLineLength:com.stripe.android.paymentsheet.example.playground.activity.PaymentSheetPlaygroundActivity.kt:447</ID>
-    <ID>MaximumLineLength:com.stripe.android.paymentsheet.example.playground.activity.PaymentSheetPlaygroundActivity.kt:497</ID>
-    <ID>MaximumLineLength:com.stripe.android.paymentsheet.example.playground.activity.PaymentSheetPlaygroundActivity.kt:507</ID>
+    <ID>MaximumLineLength:com.stripe.android.paymentsheet.example.playground.activity.PaymentSheetPlaygroundActivity.kt:496</ID>
+    <ID>MaximumLineLength:com.stripe.android.paymentsheet.example.playground.activity.PaymentSheetPlaygroundActivity.kt:506</ID>
+    <ID>MaximumLineLength:com.stripe.android.paymentsheet.example.playground.activity.PaymentSheetPlaygroundActivity.kt:512</ID>
     <ID>MaximumLineLength:com.stripe.android.paymentsheet.example.playground.activity.PaymentSheetPlaygroundActivity.kt:513</ID>
-    <ID>MaximumLineLength:com.stripe.android.paymentsheet.example.playground.activity.PaymentSheetPlaygroundActivity.kt:514</ID>
+    <ID>MaximumLineLength:com.stripe.android.paymentsheet.example.playground.activity.PaymentSheetPlaygroundActivity.kt:518</ID>
     <ID>MaximumLineLength:com.stripe.android.paymentsheet.example.playground.activity.PaymentSheetPlaygroundActivity.kt:519</ID>
-    <ID>MaximumLineLength:com.stripe.android.paymentsheet.example.playground.activity.PaymentSheetPlaygroundActivity.kt:520</ID>
+    <ID>MaximumLineLength:com.stripe.android.paymentsheet.example.playground.activity.PaymentSheetPlaygroundActivity.kt:523</ID>
     <ID>MaximumLineLength:com.stripe.android.paymentsheet.example.playground.activity.PaymentSheetPlaygroundActivity.kt:524</ID>
     <ID>MaximumLineLength:com.stripe.android.paymentsheet.example.playground.activity.PaymentSheetPlaygroundActivity.kt:525</ID>
-    <ID>MaximumLineLength:com.stripe.android.paymentsheet.example.playground.activity.PaymentSheetPlaygroundActivity.kt:526</ID>
     <ID>PackageNaming:CompleteFlowActivity.kt$package com.stripe.android.paymentsheet.example.samples.ui.complete_flow</ID>
     <ID>PackageNaming:CompleteFlowViewModel.kt$package com.stripe.android.paymentsheet.example.samples.ui.complete_flow</ID>
     <ID>PackageNaming:CompleteFlowViewState.kt$package com.stripe.android.paymentsheet.example.samples.ui.complete_flow</ID>

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/TestHardCodedLpms.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/TestHardCodedLpms.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.Automatic
 import com.stripe.android.test.core.Billing
@@ -97,10 +97,10 @@ class TestHardCodedLpms {
                 saveForFutureUseCheckboxVisible = true,
                 saveCheckboxValue = false,
                 attachDefaults = false,
-                collectName = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-                collectEmail = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-                collectPhone = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-                collectAddress = BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+                collectName = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                collectEmail = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                collectPhone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                collectAddress = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
             ),
         )
     }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
@@ -2,7 +2,6 @@ package com.stripe.android.test.core
 
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.forms.resources.LpmRepository.SupportedPaymentMethod
 
 /**

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
@@ -32,10 +32,10 @@ data class TestParameters(
     val supportedPaymentMethods: List<PaymentMethodCode> = listOf(),
     val customPrimaryButtonLabel: String? = null,
     val attachDefaults: Boolean = false,
-    val collectName: BillingDetailsCollectionConfiguration.CollectionMode = BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
-    val collectEmail: BillingDetailsCollectionConfiguration.CollectionMode = BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
-    val collectPhone: BillingDetailsCollectionConfiguration.CollectionMode = BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
-    val collectAddress: BillingDetailsCollectionConfiguration.AddressCollectionMode = BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+    val collectName: PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
+    val collectEmail: PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
+    val collectPhone: PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
+    val collectAddress: PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
 )
 
 /**

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
@@ -20,6 +20,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.model.CountryUtils
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.R
 import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.Automatic
@@ -34,7 +35,6 @@ import com.stripe.android.test.core.IntentType
 import com.stripe.android.test.core.LinkState
 import com.stripe.android.test.core.Shipping
 import com.stripe.android.test.core.TestParameters
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.elements.SAVE_FOR_FUTURE_CHECKBOX_TEST_TAG
 import java.util.Locale
 
@@ -114,27 +114,27 @@ class Selectors(
     }
 
     val collectName = when (testParameters.collectName) {
-        BillingDetailsCollectionConfiguration.CollectionMode.Automatic -> EspressoIdButton(R.id.collect_name_radio_auto)
-        BillingDetailsCollectionConfiguration.CollectionMode.Always -> EspressoIdButton(R.id.collect_name_radio_always)
-        BillingDetailsCollectionConfiguration.CollectionMode.Never -> EspressoIdButton(R.id.collect_name_radio_never)
+        PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic -> EspressoIdButton(R.id.collect_name_radio_auto)
+        PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always -> EspressoIdButton(R.id.collect_name_radio_always)
+        PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never -> EspressoIdButton(R.id.collect_name_radio_never)
     }
 
     val collectEmail = when (testParameters.collectEmail) {
-        BillingDetailsCollectionConfiguration.CollectionMode.Automatic -> EspressoIdButton(R.id.collect_email_radio_auto)
-        BillingDetailsCollectionConfiguration.CollectionMode.Always -> EspressoIdButton(R.id.collect_email_radio_always)
-        BillingDetailsCollectionConfiguration.CollectionMode.Never -> EspressoIdButton(R.id.collect_email_radio_never)
+        PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic -> EspressoIdButton(R.id.collect_email_radio_auto)
+        PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always -> EspressoIdButton(R.id.collect_email_radio_always)
+        PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never -> EspressoIdButton(R.id.collect_email_radio_never)
     }
 
     val collectPhone = when (testParameters.collectPhone) {
-        BillingDetailsCollectionConfiguration.CollectionMode.Automatic -> EspressoIdButton(R.id.collect_phone_radio_auto)
-        BillingDetailsCollectionConfiguration.CollectionMode.Always -> EspressoIdButton(R.id.collect_phone_radio_always)
-        BillingDetailsCollectionConfiguration.CollectionMode.Never -> EspressoIdButton(R.id.collect_phone_radio_never)
+        PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic -> EspressoIdButton(R.id.collect_phone_radio_auto)
+        PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always -> EspressoIdButton(R.id.collect_phone_radio_always)
+        PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never -> EspressoIdButton(R.id.collect_phone_radio_never)
     }
 
     val collectAddress = when (testParameters.collectAddress) {
-        BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic -> EspressoIdButton(R.id.collect_address_radio_auto)
-        BillingDetailsCollectionConfiguration.AddressCollectionMode.Full -> EspressoIdButton(R.id.collect_address_radio_full)
-        BillingDetailsCollectionConfiguration.AddressCollectionMode.Never -> EspressoIdButton(R.id.collect_address_radio_never)
+        PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic -> EspressoIdButton(R.id.collect_address_radio_auto)
+        PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full -> EspressoIdButton(R.id.collect_address_radio_full)
+        PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never -> EspressoIdButton(R.id.collect_address_radio_never)
     }
 
     val baseScreenshotFilenamePrefix = "info-" +

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
@@ -43,7 +43,6 @@ import com.stripe.android.paymentsheet.example.playground.viewmodel.ConfirmInten
 import com.stripe.android.paymentsheet.example.playground.viewmodel.ConfirmIntentNetworkException
 import com.stripe.android.paymentsheet.example.playground.viewmodel.PaymentSheetPlaygroundViewModel
 import com.stripe.android.paymentsheet.model.PaymentOption
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import kotlinx.coroutines.launch
 import java.util.Locale
 
@@ -102,8 +101,8 @@ class PaymentSheetPlaygroundActivity : AppCompatActivity() {
             else -> null
         }
 
-    private val billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration
-        get() = BillingDetailsCollectionConfiguration(
+    private val billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration
+        get() = PaymentSheet.BillingDetailsCollectionConfiguration(
             name = collectName.asBillingDetailsCollectionConfigurationMode,
             email = collectEmail.asBillingDetailsCollectionConfigurationMode,
             phone = collectPhone.asBillingDetailsCollectionConfigurationMode,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.paymentsheet.example.playground.model
 
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
+import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -204,6 +204,55 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$BillingDetails$C
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration : android/os/Parcelable {
+	public static final field $stable I
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public fun <init> ()V
+	public fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;Z)V
+	public synthetic fun <init> (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;
+	public final fun component2 ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;
+	public final fun component3 ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;
+	public final fun component4 ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;
+	public final fun component5 ()Z
+	public final fun copy (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;Z)Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;ZILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;
+	public fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAddress ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;
+	public final fun getAttachDefaultsToPaymentMethod ()Z
+	public final fun getEmail ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;
+	public final fun getName ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;
+	public final fun getPhone ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode : java/lang/Enum {
+	public static final field Automatic Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;
+	public static final field Full Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;
+	public static final field Never Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;
+	public static fun values ()[Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$AddressCollectionMode;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode : java/lang/Enum {
+	public static final field Always Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;
+	public static final field Automatic Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;
+	public static final field Never Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;
+	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;
+	public static fun values ()[Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$CollectionMode;
+}
+
+public final class com/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
 public final class com/stripe/android/paymentsheet/PaymentSheet$Colors : android/os/Parcelable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
@@ -271,11 +320,11 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration : 
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZ)V
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;)V
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;)V
-	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration;)V
-	public synthetic fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Ljava/lang/String;
-	public final fun component11 ()Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration;
+	public final fun component11 ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;
 	public final fun component2 ()Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;
 	public final fun component3 ()Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
 	public final fun component4 ()Landroid/content/res/ColorStateList;
@@ -284,14 +333,14 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration : 
 	public final fun component7 ()Z
 	public final fun component8 ()Z
 	public final fun component9 ()Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;
-	public final fun copy (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
-	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
+	public final fun copy (Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
+	public static synthetic fun copy$default (Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;Landroid/content/res/ColorStateList;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;Lcom/stripe/android/paymentsheet/addresselement/AddressDetails;ZZLcom/stripe/android/paymentsheet/PaymentSheet$Appearance;Ljava/lang/String;Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;ILjava/lang/Object;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAllowsDelayedPaymentMethods ()Z
 	public final fun getAllowsPaymentMethodsRequiringShippingAddress ()Z
 	public final fun getAppearance ()Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;
-	public final fun getBillingDetailsCollectionConfiguration ()Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration;
+	public final fun getBillingDetailsCollectionConfiguration ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;
 	public final fun getCustomer ()Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;
 	public final fun getDefaultBillingDetails ()Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;
 	public final fun getGooglePay ()Lcom/stripe/android/paymentsheet/PaymentSheet$GooglePayConfiguration;
@@ -310,7 +359,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration$Bu
 	public final fun allowsDelayedPaymentMethods (Z)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun allowsPaymentMethodsRequiringShippingAddress (Z)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun appearance (Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
-	public final fun billingDetailsCollectionConfiguration (Lcom/stripe/android/ui/core/BillingDetailsCollectionConfiguration;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
+	public final fun billingDetailsCollectionConfiguration (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun build ()Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;
 	public final fun customer (Lcom/stripe/android/paymentsheet/PaymentSheet$CustomerConfiguration;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun defaultBillingDetails (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetails;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -8,9 +8,11 @@ apply plugin: 'app.cash.paparazzi'
 dependencies {
     implementation project(":link")
     implementation project(":payments-core")
-    implementation project(':payments-ui-core')
     implementation project(':stripe-ui-core')
     compileOnly project(':financial-connections')
+
+    // Using api so that BillingDetailsCollectionConfiguration is accessible
+    api project(':payments-ui-core')
 
     implementation "androidx.annotation:annotation:$androidxAnnotationVersion"
     implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -8,11 +8,9 @@ apply plugin: 'app.cash.paparazzi'
 dependencies {
     implementation project(":link")
     implementation project(":payments-core")
+    implementation project(':payments-ui-core')
     implementation project(':stripe-ui-core')
     compileOnly project(':financial-connections')
-
-    // Using api so that BillingDetailsCollectionConfiguration is accessible
-    api project(':payments-ui-core')
 
     implementation "androidx.annotation:annotation:$androidxAnnotationVersion"
     implementation "androidx.appcompat:appcompat:$androidxAppcompatVersion"

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -40,7 +40,6 @@
     <ID>MagicNumber:PrimaryButton.kt$PrimaryButton$0.5f</ID>
     <ID>MagicNumber:USBankAccountFormFragment.kt$USBankAccountFormFragment$0.5f</ID>
     <ID>MaxLineLength:BillingAddressViewTest.kt$BillingAddressViewTest$fun</ID>
-    <ID>MaxLineLength:CustomerRepositoryTest.kt$CustomerRepositoryTest$onBlocking { detachPaymentMethod(anyString(), any(), anyString(), any()) }.doThrow(InvalidParameterException("error"))</ID>
     <ID>MaxLineLength:DefaultFlowControllerTest.kt$DefaultFlowControllerTest$fun</ID>
     <ID>MaxLineLength:DefaultPaymentSheetLoaderTest.kt$DefaultPaymentSheetLoaderTest$fun</ID>
     <ID>MaxLineLength:FlowControllerConfigurationHandlerTest.kt$FlowControllerConfigurationHandlerTest$.</ID>
@@ -61,7 +60,6 @@
     <ID>MaxLineLength:SupportedPaymentMethodTest.kt$SupportedPaymentMethodTest.PaymentIntentTestInput$fun toCsv()</ID>
     <ID>MaxLineLength:SupportedPaymentMethodTest.kt$SupportedPaymentMethodTest.PaymentIntentTestInput.Companion$fun toCsvHeader()</ID>
     <ID>MaxLineLength:SupportedPaymentMethodTest.kt$SupportedPaymentMethodTest.TestOutput.Companion$formShowsSaveCheckbox == false &amp;&amp; formShowsCheckboxControlledFields == true -> "merchantRequiredSave"</ID>
-    <ID>MaxLineLength:USBankAccountFormViewModelTest.kt$USBankAccountFormViewModelTest$viewModel.handlePrimaryButtonClick(currentScreenState as USBankAccountFormScreenState.NameAndEmailCollection)</ID>
     <ID>MaxLineLength:USBankAccountFormViewModelTest.kt$USBankAccountFormViewModelTest$viewModel.handlePrimaryButtonClick(currentScreenState as USBankAccountFormScreenState.VerifyWithMicrodeposits)</ID>
     <ID>NestedBlockDepth:SupportedPaymentMethodTest.kt$SupportedPaymentMethodTest$private fun generatePaymentIntentScenarios(): List&lt;PaymentIntentTestInput></ID>
     <ID>ReturnCount:AddressUtils.kt$internal fun CharSequence.levenshtein(other: CharSequence): Int</ID>

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetBillingConfigurationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetBillingConfigurationTest.kt
@@ -11,7 +11,6 @@ import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.not
 import com.stripe.android.networktesting.RequestMatchers.path
 import com.stripe.android.networktesting.testBodyFromFile
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -71,11 +70,11 @@ internal class PaymentSheetBillingConfigurationTest {
                             country = "US",
                         ),
                     ),
-                    billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
-                        name = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-                        email = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-                        phone = BillingDetailsCollectionConfiguration.CollectionMode.Never,
-                        address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
+                    billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                        name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                        email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                        phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
+                        address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
                         attachDefaultsToPaymentMethod = true,
                     ),
                 ),
@@ -147,8 +146,8 @@ internal class PaymentSheetBillingConfigurationTest {
                             country = "US",
                         ),
                     ),
-                    billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
-                        address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
+                    billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                        address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
                         attachDefaultsToPaymentMethod = false,
                     ),
                 ),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -21,7 +21,6 @@ import com.stripe.android.paymentsheet.flowcontroller.FlowControllerFactory
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentOption
 import com.stripe.android.paymentsheet.model.SetupIntentClientSecret
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.uicore.StripeThemeDefaults
 import com.stripe.android.uicore.getRawValueFromDimenResource
 import kotlinx.parcelize.Parcelize
@@ -960,6 +959,83 @@ class PaymentSheet internal constructor(
             fun phone(phone: String?) = apply { this.phone = phone }
 
             fun build() = BillingDetails(address, email, name, phone)
+        }
+    }
+
+    /**
+     * Configuration for how billing details are collected during checkout.
+     */
+    @Parcelize
+    data class BillingDetailsCollectionConfiguration(
+        /**
+         * How to collect the name field.
+         */
+        val name: CollectionMode = CollectionMode.Automatic,
+
+        /**
+         * How to collect the phone field.
+         */
+        val phone: CollectionMode = CollectionMode.Automatic,
+
+        /**
+         * How to collect the email field.
+         */
+        val email: CollectionMode = CollectionMode.Automatic,
+
+        /**
+         * How to collect the billing address.
+         */
+        val address: AddressCollectionMode = AddressCollectionMode.Automatic,
+
+        /**
+         * Whether the values included in `PaymentSheet.Configuration.defaultBillingDetails`
+         * should be attached to the payment method, this includes fields that aren't displayed in the form.
+         *
+         * If `false` (the default), those values will only be used to prefill the corresponding fields in the form.
+         */
+        val attachDefaultsToPaymentMethod: Boolean = false,
+    ) : Parcelable {
+
+        /**
+         * Billing details fields collection options.
+         */
+        enum class CollectionMode {
+            /**
+             * The field will be collected depending on the Payment Method's requirements.
+             */
+            Automatic,
+
+            /**
+             * The field will never be collected.
+             * If this field is required by the Payment Method, you must provide it as part of `defaultBillingDetails`.
+             */
+            Never,
+
+            /**
+             * The field will always be collected, even if it isn't required for the Payment Method.
+             */
+            Always,
+        }
+
+        /**
+         * Billing address collection options.
+         */
+        enum class AddressCollectionMode {
+            /**
+             * Only the fields required by the Payment Method will be collected, this may be none.
+             */
+            Automatic,
+
+            /**
+             * Address will never be collected.
+             * If the Payment Method requires a billing address, you must provide it as part of `defaultBillingDetails`.
+             */
+            Never,
+
+            /**
+             * Collect the full billing address, regardless of the Payment Method requirements.
+             */
+            Full,
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -988,7 +988,7 @@ class PaymentSheet internal constructor(
         val address: AddressCollectionMode = AddressCollectionMode.Automatic,
 
         /**
-         * Whether the values included in `PaymentSheet.Configuration.defaultBillingDetails`
+         * Whether the values included in [PaymentSheet.Configuration.defaultBillingDetails]
          * should be attached to the payment method, this includes fields that aren't displayed in the form.
          *
          * If `false` (the default), those values will only be used to prefill the corresponding fields in the form.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/BillingDetailsHelpers.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/BillingDetailsHelpers.kt
@@ -1,9 +1,9 @@
 package com.stripe.android.paymentsheet.forms
 
 import androidx.annotation.VisibleForTesting
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration.AddressCollectionMode
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration.CollectionMode
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
+import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode
 import com.stripe.android.ui.core.elements.AddressSpec
 import com.stripe.android.ui.core.elements.EmailSpec
 import com.stripe.android.ui.core.elements.FormItemSpec
@@ -17,10 +17,8 @@ import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.PhoneNumberElement
 import com.stripe.android.uicore.elements.SectionElement
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.map
 
@@ -30,9 +28,9 @@ internal object BillingDetailsHelpers {
      */
     internal fun specsForConfiguration(
         specs: List<FormItemSpec>,
-        configuration: BillingDetailsCollectionConfiguration,
+        configuration: PaymentSheet.BillingDetailsCollectionConfiguration,
     ): List<FormItemSpec> {
-        var billingDetailsPlaceholders = mutableListOf(
+        val billingDetailsPlaceholders = mutableListOf(
             PlaceholderField.Name,
             PlaceholderField.Email,
             PlaceholderField.Phone,
@@ -88,7 +86,7 @@ internal object BillingDetailsHelpers {
     @VisibleForTesting
     internal fun specForPlaceholderField(
         field: PlaceholderField,
-        configuration: BillingDetailsCollectionConfiguration,
+        configuration: PaymentSheet.BillingDetailsCollectionConfiguration,
     ) = when (field) {
         PlaceholderField.Name -> NameSpec().takeIf {
             configuration.name == CollectionMode.Always

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactory.kt
@@ -6,7 +6,6 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.getPMAddForm
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.ui.core.Amount
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 
 internal object FormArgumentsFactory {
@@ -54,7 +53,7 @@ internal object FormArgumentsFactory {
             shippingDetails = config?.shippingDetails,
             initialPaymentMethodCreateParams = initialParams,
             billingDetailsCollectionConfiguration = config?.billingDetailsCollectionConfiguration
-                ?: BillingDetailsCollectionConfiguration()
+                ?: PaymentSheet.BillingDetailsCollectionConfiguration()
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormArguments.kt
@@ -6,7 +6,6 @@ import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.ui.core.Amount
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.forms.convertToFormValuesMap
 import com.stripe.android.uicore.elements.IdentifierSpec
 import kotlinx.parcelize.Parcelize
@@ -21,8 +20,8 @@ internal data class FormArguments(
     val billingDetails: PaymentSheet.BillingDetails? = null,
     val shippingDetails: AddressDetails? = null,
     val initialPaymentMethodCreateParams: PaymentMethodCreateParams? = null,
-    val billingDetailsCollectionConfiguration: BillingDetailsCollectionConfiguration =
-        BillingDetailsCollectionConfiguration(),
+    val billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration =
+        PaymentSheet.BillingDetailsCollectionConfiguration(),
 ) : Parcelable
 
 internal fun FormArguments.getInitialValuesMap(): Map<IdentifierSpec, String?> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormFragment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormFragment.kt
@@ -40,6 +40,8 @@ import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.paymentsheet.PaymentOptionsActivity
 import com.stripe.android.paymentsheet.PaymentOptionsViewModel
+import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
+import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode
 import com.stripe.android.paymentsheet.PaymentSheetActivity
 import com.stripe.android.paymentsheet.PaymentSheetViewModel
 import com.stripe.android.paymentsheet.R
@@ -51,8 +53,6 @@ import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.utils.launchAndCollectIn
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration.AddressCollectionMode
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration.CollectionMode
 import com.stripe.android.ui.core.elements.SaveForFutureUseElementUI
 import com.stripe.android.ui.core.elements.SimpleDialogElementUI
 import com.stripe.android.uicore.StripeTheme

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -29,6 +29,8 @@ import com.stripe.android.payments.bankaccount.CollectBankAccountConfiguration
 import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResult
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
+import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.addresselement.toConfirmPaymentIntentShipping
@@ -41,8 +43,6 @@ import com.stripe.android.paymentsheet.model.create
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.di.DaggerUSBankAccountFormComponent
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.di.USBankAccountFormViewModelSubcomponent
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration.AddressCollectionMode
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration.CollectionMode
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
 import com.stripe.android.ui.core.elements.SaveForFutureUseSpec
 import com.stripe.android.uicore.address.AddressRepository

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -25,7 +25,7 @@ import com.stripe.android.paymentsheet.model.getPMsToAdd
 import com.stripe.android.paymentsheet.model.getSupportedSavedCustomerPMs
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
+import com.stripe.android.ui.core.CardBillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 import com.stripe.android.ui.core.forms.resources.LpmRepository.ServerSpecState
 import kotlinx.coroutines.async
@@ -230,12 +230,12 @@ internal class DefaultPaymentSheetLoader @Inject constructor(
         return elementsSessionRepository.get(initializationMode).mapCatching { elementsSession ->
             val billingDetailsCollectionConfig =
                 configuration?.billingDetailsCollectionConfiguration?.toInternal()
-                    ?: BillingDetailsCollectionConfiguration()
+                    ?: CardBillingDetailsCollectionConfiguration()
 
             lpmRepository.update(
                 stripeIntent = elementsSession.stripeIntent,
                 serverLpmSpecs = elementsSession.paymentMethodSpecs,
-                billingDetailsCollectionConfiguration = billingDetailsCollectionConfig,
+                cardBillingDetailsCollectionConfiguration = billingDetailsCollectionConfig,
             )
 
             if (lpmRepository.serverSpecLoadingState is ServerSpecState.ServerNotParsed) {
@@ -351,20 +351,20 @@ private fun PaymentMethod.toPaymentSelection(): PaymentSelection.Saved {
     return PaymentSelection.Saved(this, isGooglePay = false)
 }
 
-private fun PaymentSheet.BillingDetailsCollectionConfiguration.toInternal(): BillingDetailsCollectionConfiguration {
-    return BillingDetailsCollectionConfiguration(
+private fun PaymentSheet.BillingDetailsCollectionConfiguration.toInternal(): CardBillingDetailsCollectionConfiguration {
+    return CardBillingDetailsCollectionConfiguration(
         collectName = name == Always,
         collectEmail = email == Always,
         collectPhone = phone == Always,
         address = when (address) {
             PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic -> {
-                BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
+                CardBillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
             }
             PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never -> {
-                BillingDetailsCollectionConfiguration.AddressCollectionMode.Never
+                CardBillingDetailsCollectionConfiguration.AddressCollectionMode.Never
             }
             PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full -> {
-                BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
+                CardBillingDetailsCollectionConfiguration.AddressCollectionMode.Full
             }
         },
     )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentSheetLoader.kt
@@ -12,6 +12,7 @@ import com.stripe.android.model.PaymentMethod.Type.Link
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.core.injection.APP_NAME
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always
 import com.stripe.android.paymentsheet.PaymentSheet.InitializationMode.DeferredIntent
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
@@ -352,38 +353,19 @@ private fun PaymentMethod.toPaymentSelection(): PaymentSelection.Saved {
 
 private fun PaymentSheet.BillingDetailsCollectionConfiguration.toInternal(): BillingDetailsCollectionConfiguration {
     return BillingDetailsCollectionConfiguration(
-        name = name.toInternal(),
-        phone = phone.toInternal(),
-        email = email.toInternal(),
-        address = address.toInternal(),
-        attachDefaultsToPaymentMethod = attachDefaultsToPaymentMethod,
+        collectName = name == Always,
+        collectEmail = email == Always,
+        collectPhone = phone == Always,
+        address = when (address) {
+            PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic -> {
+                BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
+            }
+            PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never -> {
+                BillingDetailsCollectionConfiguration.AddressCollectionMode.Never
+            }
+            PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full -> {
+                BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
+            }
+        },
     )
-}
-
-private fun PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.toInternal(): BillingDetailsCollectionConfiguration.CollectionMode {
-    return when (this) {
-        PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic -> {
-            BillingDetailsCollectionConfiguration.CollectionMode.Automatic
-        }
-        PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never -> {
-            BillingDetailsCollectionConfiguration.CollectionMode.Never
-        }
-        PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always -> {
-            BillingDetailsCollectionConfiguration.CollectionMode.Always
-        }
-    }
-}
-
-private fun PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.toInternal(): BillingDetailsCollectionConfiguration.AddressCollectionMode {
-    return when (this) {
-        PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic -> {
-            BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
-        }
-        PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never -> {
-            BillingDetailsCollectionConfiguration.AddressCollectionMode.Never
-        }
-        PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full -> {
-            BillingDetailsCollectionConfiguration.AddressCollectionMode.Full
-        }
-    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetFixtures.kt
@@ -12,7 +12,6 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentSheetState
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import org.mockito.kotlin.mock
 
 internal object PaymentSheetFixtures {
@@ -64,11 +63,11 @@ internal object PaymentSheetFixtures {
                 )
             )
         ),
-        billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
-            name = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-            email = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-            phone = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-            address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+        billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+            name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
             attachDefaultsToPaymentMethod = true,
         )
     )
@@ -94,11 +93,11 @@ internal object PaymentSheetFixtures {
 
     internal val CONFIG_BILLING_DETAILS_COLLECTION = PaymentSheet.Configuration(
         merchantDisplayName = MERCHANT_DISPLAY_NAME,
-        billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
-            name = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-            email = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-            phone = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-            address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+        billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+            name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
             attachDefaultsToPaymentMethod = true,
         )
     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/BillingDetailsHelpersTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/BillingDetailsHelpersTest.kt
@@ -1,10 +1,10 @@
 package com.stripe.android.paymentsheet.forms
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.forms.BillingDetailsHelpers.removeCorrespondingPlaceholder
 import com.stripe.android.paymentsheet.forms.BillingDetailsHelpers.specForPlaceholderField
 import com.stripe.android.paymentsheet.forms.BillingDetailsHelpers.specsForConfiguration
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.AddressSpec
 import com.stripe.android.ui.core.elements.EmailSpec
@@ -22,11 +22,11 @@ import org.robolectric.RobolectricTestRunner
 class BillingDetailsHelpersTest {
     @Test
     fun `Test unused elements are removed`() {
-        val billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
-            name = BillingDetailsCollectionConfiguration.CollectionMode.Never,
-            email = BillingDetailsCollectionConfiguration.CollectionMode.Never,
-            phone = BillingDetailsCollectionConfiguration.CollectionMode.Never,
-            address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
+        val billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+            name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
+            email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
+            phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
+            address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
             attachDefaultsToPaymentMethod = false,
         )
 
@@ -44,11 +44,11 @@ class BillingDetailsHelpersTest {
 
     @Test
     fun `Test placeholders are not added in Automatic collection mode`() {
-        val billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
-            name = BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
-            email = BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
-            phone = BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
-            address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+        val billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+            name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
+            email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
+            phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
+            address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
             attachDefaultsToPaymentMethod = false,
         )
 
@@ -66,11 +66,11 @@ class BillingDetailsHelpersTest {
 
     @Test
     fun `Test billing details elements are added where they should`() {
-        val billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
-            name = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-            email = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-            phone = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-            address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+        val billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+            name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
             attachDefaultsToPaymentMethod = false,
         )
 
@@ -104,11 +104,11 @@ class BillingDetailsHelpersTest {
     @Suppress("LongMethod")
     @Test
     fun `Test correct spec is returned for placeholder fields`() {
-        val billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
-            name = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-            email = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-            phone = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-            address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+        val billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+            name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
             attachDefaultsToPaymentMethod = false,
         )
 
@@ -146,11 +146,11 @@ class BillingDetailsHelpersTest {
 
     @Test
     fun `Test null specs returned when not collecting field`() {
-        val billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
-            name = BillingDetailsCollectionConfiguration.CollectionMode.Never,
-            email = BillingDetailsCollectionConfiguration.CollectionMode.Never,
-            phone = BillingDetailsCollectionConfiguration.CollectionMode.Never,
-            address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
+        val billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+            name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
+            email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
+            phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never,
+            address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never,
             attachDefaultsToPaymentMethod = false,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactoryTest.kt
@@ -14,7 +14,6 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.ui.core.Amount
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -107,11 +106,11 @@ class FormArgumentsFactoryTest {
         )
 
         assertThat(actualFromArguments.billingDetailsCollectionConfiguration).isEqualTo(
-            BillingDetailsCollectionConfiguration(
-                name = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-                email = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-                phone = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-                address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+            PaymentSheet.BillingDetailsCollectionConfiguration(
+                name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
                 attachDefaultsToPaymentMethod = true,
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -533,7 +533,7 @@ internal class FormViewModelTest {
                     postalCode = "94111"
                 ),
             ),
-            billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
+            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                 attachDefaultsToPaymentMethod = true,
             )
         )
@@ -573,7 +573,7 @@ internal class FormViewModelTest {
                     postalCode = "94111"
                 ),
             ),
-            billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
+            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                 attachDefaultsToPaymentMethod = true,
             )
         )
@@ -613,7 +613,7 @@ internal class FormViewModelTest {
                     postalCode = "94111"
                 ),
             ),
-            billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
+            billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                 attachDefaultsToPaymentMethod = false,
             )
         )
@@ -631,11 +631,11 @@ internal class FormViewModelTest {
 
     @Test
     fun `Test placeholder specs are transformed correctly`() = runBlocking {
-        val billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
-            name = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-            email = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-            phone = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-            address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+        val billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+            name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
             attachDefaultsToPaymentMethod = false,
         )
         val specs = listOf(
@@ -682,11 +682,11 @@ internal class FormViewModelTest {
 
     @Test
     fun `Test address without country placeholder produces correct element`() = runBlocking {
-        val billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
-            name = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-            email = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-            phone = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-            address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+        val billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+            name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+            address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
             attachDefaultsToPaymentMethod = false,
         )
 
@@ -716,12 +716,19 @@ internal class FormViewModelTest {
     @Test
     fun `Test phone country changes with AddressElement country`() =
         runBlocking {
-            val billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
-                name = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-                email = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-                phone = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-                address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+            val billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
                 attachDefaultsToPaymentMethod = false,
+            )
+
+            val internalBillingDetailsCollectionConfig = BillingDetailsCollectionConfiguration(
+                collectName = true,
+                collectEmail = true,
+                collectPhone = true,
+                address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
             )
 
             val args = COMPOSE_FRAGMENT_ARGS.copy(
@@ -729,11 +736,12 @@ internal class FormViewModelTest {
                 billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
                 billingDetails = PaymentSheet.BillingDetails(),
             )
+
             val formViewModel = createViewModel(
                 args,
                 createLpmRepositorySupportedPaymentMethod(
                     PaymentMethod.Type.Card,
-                    LpmRepository.hardcodedCardSpec(billingDetailsCollectionConfiguration).formSpec,
+                    LpmRepository.hardcodedCardSpec(internalBillingDetailsCollectionConfig).formSpec,
                 ),
             )
 
@@ -765,11 +773,11 @@ internal class FormViewModelTest {
     @Test
     fun `Test phone country changes with standalone CountryElement`() =
         runBlocking {
-            val billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
-                name = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-                email = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-                phone = BillingDetailsCollectionConfiguration.CollectionMode.Always,
-                address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+            val billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
+                name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+                address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
                 attachDefaultsToPaymentMethod = false,
             )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -12,7 +12,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.COMPOSE_FRAGMENT_ARGS
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
+import com.stripe.android.ui.core.CardBillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.AddressSpec
 import com.stripe.android.ui.core.elements.CountrySpec
@@ -724,11 +724,11 @@ internal class FormViewModelTest {
                 attachDefaultsToPaymentMethod = false,
             )
 
-            val internalBillingDetailsCollectionConfig = BillingDetailsCollectionConfiguration(
+            val internalBillingDetailsCollectionConfig = CardBillingDetailsCollectionConfiguration(
                 collectName = true,
                 collectEmail = true,
                 collectPhone = true,
-                address = BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
+                address = CardBillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
             )
 
             val args = COMPOSE_FRAGMENT_ARGS.copy(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -18,13 +18,12 @@ import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResponse
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResult
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
+import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.ui.core.Amount
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration.AddressCollectionMode
-import com.stripe.android.ui.core.BillingDetailsCollectionConfiguration.CollectionMode
 import com.stripe.android.uicore.address.AddressRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
@@ -332,7 +331,7 @@ class USBankAccountFormViewModelTest {
                             phone = CUSTOMER_PHONE,
                             address = CUSTOMER_ADDRESS,
                         ),
-                        billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
+                        billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                             attachDefaultsToPaymentMethod = true,
                             name = CollectionMode.Never,
                             email = CollectionMode.Never,
@@ -366,7 +365,7 @@ class USBankAccountFormViewModelTest {
                             phone = CUSTOMER_PHONE,
                             address = CUSTOMER_ADDRESS,
                         ),
-                        billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
+                        billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                             attachDefaultsToPaymentMethod = false,
                             name = CollectionMode.Always,
                             email = CollectionMode.Always,
@@ -398,7 +397,7 @@ class USBankAccountFormViewModelTest {
                             phone = CUSTOMER_PHONE,
                             address = CUSTOMER_ADDRESS,
                         ),
-                        billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
+                        billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                             attachDefaultsToPaymentMethod = false,
                             name = CollectionMode.Automatic,
                             email = CollectionMode.Automatic,
@@ -428,7 +427,7 @@ class USBankAccountFormViewModelTest {
                             name = CUSTOMER_NAME,
                             email = CUSTOMER_EMAIL,
                         ),
-                        billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
+                        billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                             attachDefaultsToPaymentMethod = true,
                             name = CollectionMode.Always,
                             email = CollectionMode.Always,
@@ -450,7 +449,7 @@ class USBankAccountFormViewModelTest {
 
     @Test
     fun `Test phone country changes with country`() = runTest(UnconfinedTestDispatcher()) {
-        val billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration(
+        val billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
             name = CollectionMode.Always,
             email = CollectionMode.Always,
             phone = CollectionMode.Always,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request moves `BillingDetailsCollectionConfiguration` into `PaymentSheet` to solve a build issue we’ve been seeing in version 20.23.0.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Build issue in 20.23.0.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

Fixed a build issue where `BillingDetailsCollectionConfiguration` couldn't be found in the classpath. If you worked around this issue by importing `payments-ui-core` directly, you can undo this change and need to update the import of `BillingDetailsCollectionConfiguration`.
