### PR TITLE
Fix AddressElement sheet opening animation

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
@@ -365,7 +365,6 @@ class PaymentSheetPlaygroundActivity : AppCompatActivity() {
                 viewModel.readyToCheckout.collect { isReady ->
                     if (isReady) {
                         viewBinding.completeCheckoutButton.isEnabled = true
-                        viewBinding.shippingAddressButton.isEnabled = true
                         configureCustomCheckout()
                     } else {
                         disableViews()

--- a/paymentsheet-example/src/main/res/layout/activity_payment_sheet_playground.xml
+++ b/paymentsheet-example/src/main/res/layout/activity_payment_sheet_playground.xml
@@ -875,7 +875,7 @@
                 android:layout_height="48dp"
                 android:layout_gravity="center"
                 android:layout_marginTop="8dp"
-                android:enabled="false"
+                android:enabled="true"
                 android:layout_marginBottom="8dp" />
 
             <LinearLayout

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementNavigator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementNavigator.kt
@@ -30,15 +30,15 @@ internal class AddressElementNavigator @Inject constructor() {
             .filterNotNull()
     }
 
-    fun dismiss(result: AddressLauncherResult = AddressLauncherResult.Canceled) =
-        onDismiss?.let {
-            it(result)
-        }
+    fun dismiss(result: AddressLauncherResult = AddressLauncherResult.Canceled) {
+        onDismiss?.invoke(result)
+    }
 
-    fun onBack() =
+    fun onBack() {
         navigationController?.let { navController ->
             if (!navController.popBackStack()) {
                 dismiss()
             }
         }
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementScreen.kt
@@ -6,6 +6,11 @@ package com.stripe.android.paymentsheet.addresselement
 internal sealed class AddressElementScreen(
     open val route: String
 ) {
+
+    object Loading : AddressElementScreen("Loading")
+
+    object InputAddress : AddressElementScreen("InputAddress")
+
     class Autocomplete(
         val country: String
     ) : AddressElementScreen(
@@ -16,6 +21,4 @@ internal sealed class AddressElementScreen(
             const val route = "Autocomplete?$countryArg={$countryArg}"
         }
     }
-
-    object InputAddress : AddressElementScreen("InputAddress")
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where the AddressElement would open to half-expanded instead of expanded. To make the animation look a little smoother, I added a new loading screen that is displayed until the sheet is done expanding.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Polish.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
