### PR TITLE
Move to `Result<T>` for code depending on flow processor

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/PaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/PaymentController.kt
@@ -119,21 +119,8 @@ internal interface PaymentController {
      *
      * @param data the result Intent
      * @return the [PaymentIntentResult] object
-     *
-     * @throws AuthenticationException failure to properly authenticate yourself (check your key)
-     * @throws InvalidRequestException your request has invalid parameters
-     * @throws APIConnectionException failure to connect to Stripe's API
-     * @throws APIException any other type of problem (for instance, a temporary issue with Stripe's servers)
-     * @throws IllegalArgumentException if the PaymentIntent response's JsonParser returns null
      */
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class,
-        IllegalArgumentException::class
-    )
-    suspend fun getPaymentIntentResult(data: Intent): PaymentIntentResult
+    suspend fun getPaymentIntentResult(data: Intent): Result<PaymentIntentResult>
 
     /**
      * Get the SetupIntent's client_secret from [data] and use to retrieve
@@ -141,21 +128,8 @@ internal interface PaymentController {
      *
      * @param data the result Intent
      * @return the [SetupIntentResult] object
-     *
-     * @throws AuthenticationException failure to properly authenticate yourself (check your key)
-     * @throws InvalidRequestException your request has invalid parameters
-     * @throws APIConnectionException failure to connect to Stripe's API
-     * @throws APIException any other type of problem (for instance, a temporary issue with Stripe's servers)
-     * @throws IllegalArgumentException if the SetupIntent response's JsonParser returns null
      */
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class,
-        IllegalArgumentException::class
-    )
-    suspend fun getSetupIntentResult(data: Intent): SetupIntentResult
+    suspend fun getSetupIntentResult(data: Intent): Result<SetupIntentResult>
 
     /**
      * Get the Source's client_secret from [data] and use to retrieve
@@ -163,21 +137,8 @@ internal interface PaymentController {
      *
      * @param data the result Intent
      * @return the [Source] object
-     *
-     * @throws AuthenticationException failure to properly authenticate yourself (check your key)
-     * @throws InvalidRequestException your request has invalid parameters
-     * @throws APIConnectionException failure to connect to Stripe's API
-     * @throws APIException any other type of problem (for instance, a temporary issue with Stripe's servers)
-     * @throws IllegalArgumentException if the Source response's JsonParser returns null
      */
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class,
-        IllegalArgumentException::class
-    )
-    suspend fun getAuthenticateSourceResult(data: Intent): Source
+    suspend fun getAuthenticateSourceResult(data: Intent): Result<Source>
 
     /**
      * Determine which authentication mechanism should be used, or bypass authentication

--- a/payments-core/src/main/java/com/stripe/android/Stripe.kt
+++ b/payments-core/src/main/java/com/stripe/android/Stripe.kt
@@ -385,7 +385,7 @@ class Stripe internal constructor(
         callback: ApiResultCallback<PaymentIntentResult>
     ): Boolean {
         return if (data != null && isPaymentResult(requestCode, data)) {
-            executeAsync(callback) {
+            executeAsyncForResult(callback) {
                 paymentController.getPaymentIntentResult(data)
             }
             true
@@ -675,7 +675,7 @@ class Stripe internal constructor(
         callback: ApiResultCallback<SetupIntentResult>
     ): Boolean {
         return if (data != null && isSetupResult(requestCode, data)) {
-            executeAsync(callback) {
+            executeAsyncForResult(callback) {
                 paymentController.getSetupIntentResult(data)
             }
             true
@@ -951,7 +951,7 @@ class Stripe internal constructor(
         data: Intent,
         callback: ApiResultCallback<Source>
     ) {
-        executeAsync(callback) {
+        executeAsyncForResult(callback) {
             paymentController.getAuthenticateSourceResult(data)
         }
     }
@@ -1058,7 +1058,7 @@ class Stripe internal constructor(
         stripeAccountId: String? = this.stripeAccountId,
         callback: ApiResultCallback<Source>
     ) {
-        executeAsync(callback) {
+        executeAsyncForResult(callback) {
             stripeRepository.retrieveSource(
                 sourceId,
                 clientSecret,
@@ -1110,7 +1110,7 @@ class Stripe internal constructor(
                     apiKey = publishableKey,
                     stripeAccount = stripeAccountId
                 )
-            )
+            ).getOrThrow()
         }
     }
 

--- a/payments-core/src/main/java/com/stripe/android/StripeKtx.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripeKtx.kt
@@ -560,15 +560,15 @@ suspend fun Stripe.retrieveSource(
     @Size(min = 1) sourceId: String,
     @Size(min = 1) clientSecret: String,
     stripeAccountId: String? = this.stripeAccountId
-): Source = runApiRequest {
-    stripeRepository.retrieveSource(
+): Source {
+    return stripeRepository.retrieveSource(
         sourceId,
         clientSecret,
         ApiRequest.Options(
             apiKey = publishableKey,
             stripeAccount = stripeAccountId
         )
-    )
+    ).getOrElse { throw StripeException.create(it) }
 }
 
 /**
@@ -721,7 +721,7 @@ suspend fun Stripe.getPaymentIntentResult(
             requestCode,
             data
         )
-    ) { paymentController.getPaymentIntentResult(data) }
+    ) { paymentController.getPaymentIntentResult(data).getOrThrow() }
 }
 
 /**
@@ -753,7 +753,7 @@ suspend fun Stripe.getSetupIntentResult(
             requestCode,
             data
         )
-    ) { paymentController.getSetupIntentResult(data) }
+    ) { paymentController.getSetupIntentResult(data).getOrThrow() }
 }
 
 /**
@@ -784,7 +784,7 @@ suspend fun Stripe.getAuthenticateSourceResult(
             requestCode,
             data
         )
-    ) { paymentController.getAuthenticateSourceResult(data) }
+    ) { paymentController.getAuthenticateSourceResult(data).getOrThrow() }
 }
 
 /**

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -526,24 +526,18 @@ class StripeApiRepository @JvmOverloads internal constructor(
      * @return a [Source] if one could be retrieved for the input params, or `null` if
      * no such Source could be found.
      */
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class
-    )
     override suspend fun retrieveSource(
         sourceId: String,
         clientSecret: String,
         options: ApiRequest.Options
-    ): Source? {
-        return fetchStripeModel(
-            apiRequestFactory.createGet(
-                getRetrieveSourceApiUrl(sourceId),
-                options,
-                SourceParams.createRetrieveSourceParams(clientSecret)
+    ): Result<Source> {
+        return fetchStripeModelResult(
+            apiRequest = apiRequestFactory.createGet(
+                url = getRetrieveSourceApiUrl(sourceId),
+                options = options,
+                params = SourceParams.createRetrieveSourceParams(clientSecret),
             ),
-            SourceJsonParser()
+            jsonParser = SourceJsonParser(),
         ) {
             fireAnalyticsRequest(
                 paymentAnalyticsRequestFactory.createRequest(PaymentAnalyticsEvent.SourceRetrieve)

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -152,17 +152,11 @@ abstract class StripeRepository {
         options: ApiRequest.Options
     ): Source?
 
-    @Throws(
-        AuthenticationException::class,
-        InvalidRequestException::class,
-        APIConnectionException::class,
-        APIException::class
-    )
     internal abstract suspend fun retrieveSource(
         sourceId: String,
         clientSecret: String,
         options: ApiRequest.Options
-    ): Source?
+    ): Result<Source>
 
     @Throws(
         AuthenticationException::class,

--- a/payments-core/src/test/java/com/stripe/android/StripeKtxTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripeKtxTest.kt
@@ -297,7 +297,7 @@ internal class StripeKtxTest {
         val expectedApiObj = mock<Source>()
         whenever(
             mockApiRepository.retrieveSource(any(), any(), any())
-        ).thenReturn(expectedApiObj)
+        ).thenReturn(Result.success(expectedApiObj))
         val actualObj = stripe.retrieveSource(
             "param11",
             "param12",
@@ -312,25 +312,9 @@ internal class StripeKtxTest {
         runTest {
             whenever(
                 mockApiRepository.retrieveSource(any(), any(), any())
-            ).thenThrow(mock<AuthenticationException>())
+            ).thenReturn(Result.failure(mock<AuthenticationException>()))
 
             assertFailsWith<AuthenticationException> {
-                stripe.retrieveSource(
-                    "param11",
-                    "param12",
-                    TEST_STRIPE_ACCOUNT_ID
-                )
-            }
-        }
-
-    @Test
-    fun `When repository returns null then retrieveSource should throw InvalidRequestException`(): Unit =
-        runTest {
-            whenever(
-                mockApiRepository.retrieveSource(any(), any(), any())
-            ).thenReturn(null)
-
-            assertFailsWithMessage<InvalidRequestException>("Failed to parse Source.") {
                 stripe.retrieveSource(
                     "param11",
                     "param12",
@@ -877,7 +861,7 @@ internal class StripeKtxTest {
     private inline fun <reified ApiObject : StripeModel>
     `Given controller returns non-empty value when calling getAPI then returns correct result`(
         crossinline controllerCheckBlock: (Int, Intent?) -> Boolean,
-        crossinline controllerInvocationBlock: suspend (Intent) -> ApiObject,
+        crossinline controllerInvocationBlock: suspend (Intent) -> Result<ApiObject>,
         crossinline getAPIInvocationBlock: suspend (Int, Intent) -> ApiObject
     ) = runTest {
         val expectedApiObj = mock<ApiObject>()
@@ -888,7 +872,7 @@ internal class StripeKtxTest {
 
         whenever(
             controllerInvocationBlock(any())
-        ).thenReturn(expectedApiObj)
+        ).thenReturn(Result.success(expectedApiObj))
 
         val actualObj = getAPIInvocationBlock(
             TEST_REQUEST_CODE,
@@ -901,7 +885,7 @@ internal class StripeKtxTest {
     private inline fun <ApiObject : StripeModel>
     `Given controller returns exception when calling getAPI then throws same exception`(
         crossinline controllerCheckBlock: (Int, Intent?) -> Boolean,
-        crossinline controllerInvocationBlock: suspend (Intent) -> ApiObject,
+        crossinline controllerInvocationBlock: suspend (Intent) -> Result<ApiObject>,
         crossinline getAPIInvocationBlock: suspend (Int, Intent) -> ApiObject
     ): Unit = runTest {
         whenever(
@@ -910,7 +894,7 @@ internal class StripeKtxTest {
 
         whenever(
             controllerInvocationBlock(any())
-        ).thenThrow(mock<AuthenticationException>())
+        ).thenReturn(Result.failure(mock<AuthenticationException>()))
 
         assertFailsWith<AuthenticationException> {
             getAPIInvocationBlock(

--- a/payments-core/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripePaymentAuthTest.kt
@@ -2,7 +2,7 @@ package com.stripe.android
 
 import android.content.Intent
 import androidx.test.core.app.ApplicationProvider
-import com.stripe.android.core.exception.InvalidRequestException
+import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.SetupIntentFixtures
@@ -13,7 +13,7 @@ import com.stripe.android.utils.TestUtils.idleLooper
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
-import org.mockito.kotlin.isA
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -44,7 +44,7 @@ internal class StripePaymentAuthTest {
                 paymentController.getPaymentIntentResult(
                     data
                 )
-            ).thenReturn(result)
+            ).thenReturn(Result.success(result))
 
             val stripe = createStripe()
             stripe.onPaymentResult(
@@ -59,20 +59,23 @@ internal class StripePaymentAuthTest {
         }
 
     @Test
-    fun onPaymentResult_whenShouldHandleResultAndControllerReturnsNull_shouldThrowException() =
+    fun onPaymentResult_whenShouldHandleResultAndControllerReturnsFailure_shouldThrowException() =
         runTest {
             val data = Intent()
+            val exception = APIException()
+
             whenever(
                 paymentController.shouldHandlePaymentResult(
                     StripePaymentController.PAYMENT_REQUEST_CODE,
                     data
                 )
             ).thenReturn(true)
+
             whenever(
                 paymentController.getPaymentIntentResult(
                     data
                 )
-            ).thenReturn(null)
+            ).thenReturn(Result.failure(exception))
 
             val stripe = createStripe()
             stripe.onPaymentResult(
@@ -83,7 +86,7 @@ internal class StripePaymentAuthTest {
 
             idleLooper()
 
-            verify(paymentCallback).onError(isA<InvalidRequestException>())
+            verify(paymentCallback).onError(eq(exception))
         }
 
     @Test
@@ -101,7 +104,7 @@ internal class StripePaymentAuthTest {
                 paymentController.getSetupIntentResult(
                     data
                 )
-            ).thenReturn(result)
+            ).thenReturn(Result.success(result))
 
             val stripe = createStripe()
             stripe.onSetupResult(
@@ -115,20 +118,23 @@ internal class StripePaymentAuthTest {
         }
 
     @Test
-    fun onSetupResult_whenShouldHandleResultAndControllerReturnsNull_shouldThrowException() =
+    fun onSetupResult_whenShouldHandleResultAndControllerReturnsFailure_shouldThrowException() =
         runTest {
             val data = Intent()
+            val exception = APIException()
+
             whenever(
                 paymentController.shouldHandleSetupResult(
                     StripePaymentController.SETUP_REQUEST_CODE,
                     data
                 )
             ).thenReturn(true)
+
             whenever(
                 paymentController.getSetupIntentResult(
                     data
                 )
-            ).thenReturn(null)
+            ).thenReturn(Result.failure(exception))
 
             val stripe = createStripe()
             stripe.onSetupResult(
@@ -139,7 +145,7 @@ internal class StripePaymentAuthTest {
 
             idleLooper()
 
-            verify(setupCallback).onError(isA<InvalidRequestException>())
+            verify(setupCallback).onError(eq(exception))
         }
 
     @Test
@@ -151,7 +157,7 @@ internal class StripePaymentAuthTest {
                 paymentController.getAuthenticateSourceResult(
                     data
                 )
-            ).thenReturn(source)
+            ).thenReturn(Result.success(source))
 
             val stripe = createStripe()
             stripe.onAuthenticateSourceResult(
@@ -165,14 +171,16 @@ internal class StripePaymentAuthTest {
         }
 
     @Test
-    fun onAuthenticateSourceResult_whenControllerReturnsNull_shouldThrowException() =
+    fun onAuthenticateSourceResult_whenControllerReturnsFailure_shouldThrowException() =
         runTest {
             val data = Intent()
+            val exception = APIException()
+
             whenever(
                 paymentController.getAuthenticateSourceResult(
                     data
                 )
-            ).thenReturn(null)
+            ).thenReturn(Result.failure(exception))
 
             val stripe = createStripe()
             stripe.onAuthenticateSourceResult(
@@ -182,7 +190,7 @@ internal class StripePaymentAuthTest {
 
             idleLooper()
 
-            verify(sourceCallback).onError(isA<InvalidRequestException>())
+            verify(sourceCallback).onError(eq(exception))
         }
 
     private fun createStripe(): Stripe {

--- a/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -127,7 +127,7 @@ internal class StripePaymentControllerTest {
                 ).toBundle()
             )
 
-            val paymentIntentResult = controller.getPaymentIntentResult(intent)
+            val paymentIntentResult = controller.getPaymentIntentResult(intent).getOrThrow()
 
             assertThat(stripeRepository.retrievePaymentIntentArgs)
                 .containsExactly(
@@ -264,7 +264,9 @@ internal class StripePaymentControllerTest {
             sourceId: String,
             clientSecret: String,
             options: ApiRequest.Options
-        ) = SourceFixtures.SOURCE_CARD.copy(status = Source.Status.Chargeable)
+        ): Result<Source> {
+            return Result.success(SourceFixtures.SOURCE_CARD.copy(status = Source.Status.Chargeable))
+        }
 
         override suspend fun cancelPaymentIntentSource(
             paymentIntentId: String,

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModelTest.kt
@@ -250,20 +250,24 @@ class GooglePayLauncherViewModelTest {
 
         override suspend fun getPaymentIntentResult(
             data: Intent
-        ): PaymentIntentResult {
-            val paymentFlowResult = PaymentFlowResult.Unvalidated.fromIntent(data).validate()
-            return PaymentIntentResult(
-                PaymentIntentFixtures.PI_SUCCEEDED,
-                outcomeFromFlow = paymentFlowResult.flowOutcome
-            )
+        ): Result<PaymentIntentResult> {
+            return runCatching {
+                val paymentFlowResult = PaymentFlowResult.Unvalidated.fromIntent(data).validate()
+                PaymentIntentResult(
+                    intent = PaymentIntentFixtures.PI_SUCCEEDED,
+                    outcomeFromFlow = paymentFlowResult.flowOutcome
+                )
+            }
         }
 
-        override suspend fun getSetupIntentResult(data: Intent): SetupIntentResult {
-            val paymentFlowResult = PaymentFlowResult.Unvalidated.fromIntent(data).validate()
-            return SetupIntentResult(
-                SetupIntentFixtures.SI_SUCCEEDED,
-                outcomeFromFlow = paymentFlowResult.flowOutcome
-            )
+        override suspend fun getSetupIntentResult(data: Intent): Result<SetupIntentResult> {
+            return runCatching {
+                val paymentFlowResult = PaymentFlowResult.Unvalidated.fromIntent(data).validate()
+                SetupIntentResult(
+                    intent = SetupIntentFixtures.SI_SUCCEEDED,
+                    outcomeFromFlow = paymentFlowResult.flowOutcome
+                )
+            }
         }
     }
 

--- a/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
@@ -114,8 +114,8 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         sourceId: String,
         clientSecret: String,
         options: ApiRequest.Options
-    ): Source? {
-        return null
+    ): Result<Source> {
+        return Result.failure(NotImplementedError())
     }
 
     override suspend fun createPaymentMethod(

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -418,13 +418,11 @@ internal class StripeApiRepositoryTest {
             .thenReturn(stripeResponse)
 
         val sourceId = "src_19t3xKBZqEXluyI4uz2dxAfQ"
-        val source = requireNotNull(
-            create().retrieveSource(
-                sourceId,
-                "mocked",
-                DEFAULT_OPTIONS
-            )
-        )
+        val source = create().retrieveSource(
+            sourceId,
+            "mocked",
+            DEFAULT_OPTIONS
+        ).getOrThrow()
 
         assertThat(source.id)
             .isEqualTo(sourceId)

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/AbsPaymentController.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/AbsPaymentController.kt
@@ -66,16 +66,16 @@ internal abstract class AbsPaymentController : PaymentController {
         return false
     }
 
-    override suspend fun getPaymentIntentResult(data: Intent): PaymentIntentResult {
-        TODO("Not yet implemented")
+    override suspend fun getPaymentIntentResult(data: Intent): Result<PaymentIntentResult> {
+        return Result.failure(NotImplementedError())
     }
 
-    override suspend fun getSetupIntentResult(data: Intent): SetupIntentResult {
-        TODO("Not yet implemented")
+    override suspend fun getSetupIntentResult(data: Intent): Result<SetupIntentResult> {
+        return Result.failure(NotImplementedError())
     }
 
-    override suspend fun getAuthenticateSourceResult(data: Intent): Source {
-        TODO("Not yet implemented")
+    override suspend fun getAuthenticateSourceResult(data: Intent): Result<Source> {
+        return Result.failure(NotImplementedError())
     }
 
     override suspend fun handleNextAction(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request continues the `Result<T>` migration and converts code that depends on `PaymentFlowResultProcessor`, which was converted in https://github.com/stripe/stripe-android/pull/6535.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
