### PR TITLE
[FC] Maestro tests - keep executing script on failures 

### DIFF
--- a/scripts/execute_maestro_tests.sh
+++ b/scripts/execute_maestro_tests.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -e
 set -o pipefail
 set -x
 


### PR DESCRIPTION
# Summary
- Removes set -e so that if Maestro tests fail the script keeps executing.
- Doing this so that screen record is pulled from the device on maestro test failures.
