### PR TITLE
Fix Klarna tests in `SourceEndToEndTest`

### DIFF
--- a/payments-core/src/test/java/com/stripe/android/SourceEndToEndTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/SourceEndToEndTest.kt
@@ -56,7 +56,7 @@ internal class SourceEndToEndTest {
             returnUrl = RETURN_URL,
             currency = "GBP",
             klarnaParams = KlarnaSourceParams(
-                purchaseCountry = "UK",
+                purchaseCountry = "GB",
                 lineItems = LINE_ITEMS,
                 billingPhone = "02012267709",
                 billingEmail = "test@example.com",
@@ -82,9 +82,9 @@ internal class SourceEndToEndTest {
     fun createKlarnaParamsWithCustomPaymentMethods() {
         val sourceParams = SourceParams.createKlarna(
             returnUrl = RETURN_URL,
-            currency = "USD",
+            currency = "EUR",
             klarnaParams = KlarnaSourceParams(
-                purchaseCountry = "US",
+                purchaseCountry = "DE",
                 lineItems = LINE_ITEMS,
                 customPaymentMethods = setOf(
                     KlarnaSourceParams.CustomPaymentMethods.Installments,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes broken tests in `SourceEndToEndTest`. They broke because validation was turned on for test mode transactions yesterday, and two tests used invalid countries.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
