### PR TITLE
[FC] Networking: Treat OTP errors as non-terminal

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/FinancialConnectionsEvent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/analytics/FinancialConnectionsEvent.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.analytics
 
+import com.stripe.android.financialconnections.domain.ConfirmVerification.OTPError
 import com.stripe.android.financialconnections.exception.FinancialConnectionsError
 import com.stripe.android.financialconnections.model.FinancialConnectionsSessionManifest.Pane
 import com.stripe.android.financialconnections.utils.filterNotNullValues
@@ -254,7 +255,11 @@ internal sealed class FinancialConnectionsEvent(
         pane: Pane,
         exception: Throwable
     ) : FinancialConnectionsEvent(
-        name = if (exception is FinancialConnectionsError) "error.expected" else "error.unexpected",
+        name = when (exception) {
+            is FinancialConnectionsError,
+            is OTPError -> "error.expected"
+            else -> "error.unexpected"
+        },
         params = (
             mapOf("pane" to pane.value)
                 .plus(exception.toEventParams())

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/ConfirmVerification.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/ConfirmVerification.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.financialconnections.domain
 
+import com.stripe.android.core.exception.StripeException
 import com.stripe.android.financialconnections.repository.FinancialConnectionsConsumerSessionRepository
 import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.VerificationType
@@ -13,10 +14,15 @@ internal class ConfirmVerification @Inject constructor(
         consumerSessionClientSecret: String,
         verificationCode: String,
     ): ConsumerSession = requireNotNull(
-        consumerSessionRepository.confirmConsumerVerification(
-            consumerSessionClientSecret = consumerSessionClientSecret,
-            verificationCode = verificationCode,
-            type = VerificationType.SMS
+        kotlin.runCatching {
+            consumerSessionRepository.confirmConsumerVerification(
+                consumerSessionClientSecret = consumerSessionClientSecret,
+                verificationCode = verificationCode,
+                type = VerificationType.SMS
+            )
+        }.fold(
+            onSuccess = { it },
+            onFailure = { throw it.toDomainException(VerificationType.SMS) }
         )
     )
 
@@ -24,10 +30,48 @@ internal class ConfirmVerification @Inject constructor(
         consumerSessionClientSecret: String,
         verificationCode: String,
     ): ConsumerSession = requireNotNull(
-        consumerSessionRepository.confirmConsumerVerification(
-            consumerSessionClientSecret = consumerSessionClientSecret,
-            verificationCode = verificationCode,
-            type = VerificationType.EMAIL
+        kotlin.runCatching {
+            consumerSessionRepository.confirmConsumerVerification(
+                consumerSessionClientSecret = consumerSessionClientSecret,
+                verificationCode = verificationCode,
+                type = VerificationType.EMAIL
+            )
+        }.fold(
+            onSuccess = { it },
+            onFailure = { throw it.toDomainException(VerificationType.EMAIL) }
         )
+
     )
+
+    /**
+     * Convert Exception to [OTPError] (a soft error related to OTP verification) or
+     * returns the original exception.
+     */
+    private fun Throwable.toDomainException(verificationCode: VerificationType): Throwable {
+        return when (val code = (this as? StripeException)?.stripeError?.code ?: "") {
+            "consumer_verification_code_invalid" -> OTPError(code, OTPError.Type.CODE_INVALID)
+            "consumer_session_expired",
+            "consumer_verification_expired",
+            "consumer_verification_max_attempts_exceeded" -> when (verificationCode) {
+                VerificationType.EMAIL -> OTPError(code, OTPError.Type.EMAIL_CODE_EXPIRED)
+                VerificationType.SMS -> OTPError(code, OTPError.Type.SMS_CODE_EXPIRED)
+            }
+
+            else -> this
+        }
+    }
+
+    /**
+     * A soft error related to OTP verification.
+     */
+    class OTPError(
+        message: String,
+        val type: Type
+    ) : Throwable(message = message) {
+        enum class Type {
+            EMAIL_CODE_EXPIRED,
+            SMS_CODE_EXPIRED,
+            CODE_INVALID,
+        }
+    }
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/ConfirmVerification.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/ConfirmVerification.kt
@@ -47,18 +47,18 @@ internal class ConfirmVerification @Inject constructor(
      * Convert Exception to [OTPError] (a soft error related to OTP verification) or
      * returns the original exception.
      */
-    private fun Throwable.toDomainException(verificationCode: VerificationType): Throwable {
-        return when (val code = (this as? StripeException)?.stripeError?.code ?: "") {
-            "consumer_verification_code_invalid" -> OTPError(code, OTPError.Type.CODE_INVALID)
-            "consumer_session_expired",
-            "consumer_verification_expired",
-            "consumer_verification_max_attempts_exceeded" -> when (verificationCode) {
-                VerificationType.EMAIL -> OTPError(code, OTPError.Type.EMAIL_CODE_EXPIRED)
-                VerificationType.SMS -> OTPError(code, OTPError.Type.SMS_CODE_EXPIRED)
-            }
-
-            else -> this
+    private fun Throwable.toDomainException(
+        verificationCode: VerificationType
+    ): Throwable = when (val code = (this as? StripeException)?.stripeError?.code ?: "") {
+        "consumer_verification_code_invalid" -> OTPError(code, OTPError.Type.CODE_INVALID)
+        "consumer_session_expired",
+        "consumer_verification_expired",
+        "consumer_verification_max_attempts_exceeded" -> when (verificationCode) {
+            VerificationType.EMAIL -> OTPError(code, OTPError.Type.EMAIL_CODE_EXPIRED)
+            VerificationType.SMS -> OTPError(code, OTPError.Type.SMS_CODE_EXPIRED)
         }
+
+        else -> this
     }
 
     /**

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/ConfirmVerification.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/ConfirmVerification.kt
@@ -13,34 +13,29 @@ internal class ConfirmVerification @Inject constructor(
     suspend fun sms(
         consumerSessionClientSecret: String,
         verificationCode: String,
-    ): ConsumerSession = requireNotNull(
-        kotlin.runCatching {
-            consumerSessionRepository.confirmConsumerVerification(
-                consumerSessionClientSecret = consumerSessionClientSecret,
-                verificationCode = verificationCode,
-                type = VerificationType.SMS
-            )
-        }.fold(
-            onSuccess = { it },
-            onFailure = { throw it.toDomainException(VerificationType.SMS) }
+    ): ConsumerSession = kotlin.runCatching {
+        consumerSessionRepository.confirmConsumerVerification(
+            consumerSessionClientSecret = consumerSessionClientSecret,
+            verificationCode = verificationCode,
+            type = VerificationType.SMS
         )
+    }.fold(
+        onSuccess = { it },
+        onFailure = { throw it.toDomainException(VerificationType.SMS) }
     )
 
     suspend fun email(
         consumerSessionClientSecret: String,
         verificationCode: String,
-    ): ConsumerSession = requireNotNull(
-        kotlin.runCatching {
-            consumerSessionRepository.confirmConsumerVerification(
-                consumerSessionClientSecret = consumerSessionClientSecret,
-                verificationCode = verificationCode,
-                type = VerificationType.EMAIL
-            )
-        }.fold(
-            onSuccess = { it },
-            onFailure = { throw it.toDomainException(VerificationType.EMAIL) }
+    ): ConsumerSession = kotlin.runCatching {
+        consumerSessionRepository.confirmConsumerVerification(
+            consumerSessionClientSecret = consumerSessionClientSecret,
+            verificationCode = verificationCode,
+            type = VerificationType.EMAIL
         )
-
+    }.fold(
+        onSuccess = { it },
+        onFailure = { throw it.toDomainException(VerificationType.EMAIL) }
     )
 
     /**

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/StartVerification.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/StartVerification.kt
@@ -12,24 +12,22 @@ internal class StartVerification @Inject constructor(
 
     suspend fun sms(
         consumerSessionClientSecret: String,
-    ): ConsumerSession = requireNotNull(
-        consumerSessionRepository.startConsumerVerification(
-            consumerSessionClientSecret = consumerSessionClientSecret,
-            connectionsMerchantName = null,
-            customEmailType = null,
-            type = VerificationType.SMS,
-        )
+    ): ConsumerSession = consumerSessionRepository.startConsumerVerification(
+        consumerSessionClientSecret = consumerSessionClientSecret,
+        connectionsMerchantName = null,
+        customEmailType = null,
+        type = VerificationType.SMS,
     )
+
 
     suspend fun email(
         consumerSessionClientSecret: String,
         businessName: String?,
-    ): ConsumerSession = requireNotNull(
-        consumerSessionRepository.startConsumerVerification(
-            consumerSessionClientSecret = consumerSessionClientSecret,
-            customEmailType = CustomEmailType.NETWORKED_CONNECTIONS_OTP_EMAIL,
-            connectionsMerchantName = businessName,
-            type = VerificationType.EMAIL,
-        )
+    ): ConsumerSession = consumerSessionRepository.startConsumerVerification(
+        consumerSessionClientSecret = consumerSessionClientSecret,
+        customEmailType = CustomEmailType.NETWORKED_CONNECTIONS_OTP_EMAIL,
+        connectionsMerchantName = businessName,
+        type = VerificationType.EMAIL,
     )
+
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/StartVerification.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/StartVerification.kt
@@ -19,7 +19,6 @@ internal class StartVerification @Inject constructor(
         type = VerificationType.SMS,
     )
 
-
     suspend fun email(
         consumerSessionClientSecret: String,
         businessName: String?,
@@ -29,5 +28,4 @@ internal class StartVerification @Inject constructor(
         connectionsMerchantName = businessName,
         type = VerificationType.EMAIL,
     )
-
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkstepupverification/LinkStepUpVerificationScreen.kt
@@ -50,7 +50,6 @@ import com.stripe.android.financialconnections.ui.components.FinancialConnection
 import com.stripe.android.financialconnections.ui.components.StringAnnotation
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme.colors
-import com.stripe.android.model.VerificationType
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.OTPController
 import com.stripe.android.uicore.elements.OTPElement
@@ -141,7 +140,6 @@ private fun LinkStepUpVerificationLoaded(
             focusRequester = focusRequester,
             otpElement = payload.otpElement,
             enabled = confirmVerificationAsync !is Loading,
-            verificationType = VerificationType.EMAIL,
             confirmVerificationError = (confirmVerificationAsync as? Fail)?.error
         )
         Spacer(modifier = Modifier.size(24.dp))

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationScreen.kt
@@ -45,7 +45,6 @@ import com.stripe.android.financialconnections.ui.components.FinancialConnection
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsTopAppBar
 import com.stripe.android.financialconnections.ui.components.StringAnnotation
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
-import com.stripe.android.model.VerificationType
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.OTPController
 import com.stripe.android.uicore.elements.OTPElement
@@ -131,8 +130,7 @@ private fun NetworkingLinkVerificationLoaded(
             focusRequester = focusRequester,
             otpElement = payload.otpElement,
             enabled = confirmVerificationAsync !is Loading,
-            confirmVerificationError = (confirmVerificationAsync as? Fail)?.error,
-            verificationType = VerificationType.SMS
+            confirmVerificationError = (confirmVerificationAsync as? Fail)?.error
         )
         Spacer(modifier = Modifier.size(24.dp))
         EmailSubtext(payload.email)

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationScreen.kt
@@ -29,9 +29,9 @@ import com.airbnb.mvrx.Success
 import com.airbnb.mvrx.Uninitialized
 import com.airbnb.mvrx.compose.collectAsState
 import com.airbnb.mvrx.compose.mavericksViewModel
-import com.stripe.android.core.StripeError
-import com.stripe.android.core.exception.APIException
 import com.stripe.android.financialconnections.R
+import com.stripe.android.financialconnections.domain.ConfirmVerification
+import com.stripe.android.financialconnections.domain.ConfirmVerification.OTPError.Type
 import com.stripe.android.financialconnections.features.common.LoadingContent
 import com.stripe.android.financialconnections.features.common.UnclassifiedErrorContent
 import com.stripe.android.financialconnections.features.common.VerificationSection
@@ -216,12 +216,9 @@ internal fun NetworkingLinkVerificationScreenWithErrorPreview() {
         NetworkingLinkVerificationContent(
             state = NetworkingLinkVerificationState(
                 confirmVerification = Fail(
-                    APIException(
-                        stripeError = StripeError(
-                            code = "consumer_verification_max_attempts_exceeded"
-                        ),
-                        statusCode = 400,
-                        message = "auth error"
+                    ConfirmVerification.OTPError(
+                        message = "consumer_verification_max_attempts_exceeded",
+                        type = Type.SMS_CODE_EXPIRED
                     )
                 ),
                 payload = Success(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationScreen.kt
@@ -46,7 +46,6 @@ import com.stripe.android.financialconnections.ui.components.FinancialConnection
 import com.stripe.android.financialconnections.ui.components.FinancialConnectionsTopAppBar
 import com.stripe.android.financialconnections.ui.components.StringAnnotation
 import com.stripe.android.financialconnections.ui.theme.FinancialConnectionsTheme
-import com.stripe.android.model.VerificationType
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.OTPController
 import com.stripe.android.uicore.elements.OTPElement
@@ -134,9 +133,8 @@ private fun NetworkingSaveToLinkVerificationLoaded(
         VerificationSection(
             focusRequester = focusRequester,
             otpElement = payload.otpElement,
-            confirmVerificationError = (confirmVerificationAsync as? Fail)?.error,
-            verificationType = VerificationType.SMS,
-            enabled = confirmVerificationAsync !is Loading
+            enabled = confirmVerificationAsync !is Loading,
+            confirmVerificationError = (confirmVerificationAsync as? Fail)?.error
         )
         Spacer(modifier = Modifier.size(24.dp))
         EmailSubtext(payload.email)

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModel.kt
@@ -15,6 +15,7 @@ import com.stripe.android.financialconnections.analytics.FinancialConnectionsEve
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.VerificationError.Error.StartVerificationSessionError
 import com.stripe.android.financialconnections.analytics.FinancialConnectionsEvent.VerificationSuccess
 import com.stripe.android.financialconnections.domain.ConfirmVerification
+import com.stripe.android.financialconnections.domain.ConfirmVerification.OTPError
 import com.stripe.android.financialconnections.domain.GetCachedAccounts
 import com.stripe.android.financialconnections.domain.GetCachedConsumerSession
 import com.stripe.android.financialconnections.domain.GoNext
@@ -87,10 +88,12 @@ internal class NetworkingSaveToLinkVerificationViewModel @Inject constructor(
                 goNext(Pane.SUCCESS)
             },
             onFail = { error ->
-                saveToLinkWithStripeSucceeded.set(false)
-                logger.error("Error confirming verification", error)
-                eventTracker.track(Error(PANE, error))
-                goNext(Pane.SUCCESS)
+                if (error !is OTPError) {
+                    saveToLinkWithStripeSucceeded.set(false)
+                    logger.error("Error confirming verification", error)
+                    eventTracker.track(Error(PANE, error))
+                    goNext(Pane.SUCCESS)
+                }
             },
         )
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModel.kt
@@ -88,10 +88,10 @@ internal class NetworkingSaveToLinkVerificationViewModel @Inject constructor(
                 goNext(Pane.SUCCESS)
             },
             onFail = { error ->
+                logger.error("Error confirming verification", error)
+                eventTracker.track(Error(PANE, error))
                 if (error !is OTPError) {
                     saveToLinkWithStripeSucceeded.set(false)
-                    logger.error("Error confirming verification", error)
-                    eventTracker.track(Error(PANE, error))
                     goNext(Pane.SUCCESS)
                 }
             },

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/ConfirmVerificationTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/ConfirmVerificationTest.kt
@@ -1,0 +1,181 @@
+package com.stripe.android.financialconnections.domain
+
+import com.stripe.android.core.StripeError
+import com.stripe.android.core.exception.InvalidRequestException
+import com.stripe.android.financialconnections.domain.ConfirmVerification.OTPError
+import com.stripe.android.financialconnections.repository.FinancialConnectionsConsumerSessionRepository
+import com.stripe.android.model.ConsumerSession
+import com.stripe.android.model.VerificationType
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@ExperimentalCoroutinesApi
+internal class ConfirmVerificationTest {
+
+    private val consumerSessionRepository: FinancialConnectionsConsumerSessionRepository = mock()
+    private lateinit var confirmVerification: ConfirmVerification
+
+    @Before
+    fun setUp() {
+        confirmVerification = ConfirmVerification(consumerSessionRepository)
+    }
+
+    @Test
+    fun `test SMS verification success`() = runTest {
+        val clientSecret = "client_secret"
+        val verificationCode = "123456"
+        val consumerSession: ConsumerSession = mock()
+
+        whenever(
+            consumerSessionRepository.confirmConsumerVerification(
+                clientSecret, verificationCode, VerificationType.SMS
+            )
+        ).thenReturn(consumerSession)
+
+        val result = confirmVerification.sms(clientSecret, verificationCode)
+
+        verify(consumerSessionRepository).confirmConsumerVerification(
+            clientSecret,
+            verificationCode,
+            VerificationType.SMS
+        )
+        assertEquals(consumerSession, result)
+    }
+
+    @Test
+    fun `test Email verification success`() = runTest {
+        val clientSecret = "client_secret"
+        val verificationCode = "123456"
+        val consumerSession: ConsumerSession = mock()
+
+        whenever(
+            consumerSessionRepository.confirmConsumerVerification(
+                clientSecret, verificationCode, VerificationType.EMAIL
+            )
+        ).thenReturn(consumerSession)
+
+        val result = confirmVerification.email(clientSecret, verificationCode)
+
+        verify(consumerSessionRepository).confirmConsumerVerification(
+            clientSecret,
+            verificationCode,
+            VerificationType.EMAIL
+        )
+        assertEquals(consumerSession, result)
+    }
+
+    @Test
+    fun `test SMS verification invalid code`() = runTest {
+        val clientSecret = "client_secret"
+        val verificationCode = "123456"
+        val errorMessage = "consumer_verification_code_invalid"
+
+        whenever(
+            consumerSessionRepository.confirmConsumerVerification(
+                clientSecret, verificationCode, VerificationType.SMS
+            )
+        ).thenAnswer {
+            throw InvalidRequestException(
+                StripeError(
+                    code = errorMessage,
+                    message = errorMessage
+                )
+            )
+        }
+
+        val exception: OTPError =
+            runCatching { confirmVerification.sms(clientSecret, verificationCode) }
+                .exceptionOrNull() as OTPError
+
+        assertEquals(errorMessage, exception.message)
+        assertEquals(OTPError.Type.CODE_INVALID, exception.type)
+    }
+
+    @Test
+    fun `test Email verification invalid code`() = runTest {
+        val clientSecret = "client_secret"
+        val verificationCode = "123456"
+        val errorMessage = "consumer_verification_code_invalid"
+
+        whenever(
+            consumerSessionRepository.confirmConsumerVerification(
+                clientSecret, verificationCode, VerificationType.EMAIL
+            )
+        ).thenAnswer {
+            throw InvalidRequestException(
+                StripeError(
+                    code = errorMessage,
+                    message = errorMessage
+                )
+            )
+        }
+
+        val exception: OTPError =
+            runCatching { confirmVerification.email(clientSecret, verificationCode) }
+                .exceptionOrNull() as OTPError
+
+        assertEquals(errorMessage, exception.message)
+        assertEquals(OTPError.Type.CODE_INVALID, exception.type)
+    }
+
+    @Test
+    fun `test SMS verification expired`() = runTest {
+        val clientSecret = "client_secret"
+        val verificationCode = "123456"
+        val errorMessage = "consumer_verification_expired"
+
+        whenever(
+            consumerSessionRepository.confirmConsumerVerification(
+                clientSecret, verificationCode, VerificationType.SMS
+            )
+        ).thenAnswer {
+            throw InvalidRequestException(
+                StripeError(
+                    code = errorMessage,
+                    message = errorMessage
+                )
+            )
+        }
+
+        val exception: OTPError =
+            runCatching { confirmVerification.sms(clientSecret, verificationCode) }
+                .exceptionOrNull() as OTPError
+
+        assertEquals(errorMessage, exception.message)
+        assertEquals(OTPError.Type.SMS_CODE_EXPIRED, exception.type)
+    }
+
+    @Test
+    fun `test Email verification expired`() = runTest {
+        val clientSecret = "client_secret"
+        val verificationCode = "123456"
+        val errorMessage = "consumer_verification_expired"
+
+        whenever(
+            consumerSessionRepository.confirmConsumerVerification(
+                clientSecret, verificationCode, VerificationType.EMAIL
+            )
+        ).thenAnswer {
+            throw InvalidRequestException(
+                StripeError(
+                    code = errorMessage,
+                    message = errorMessage
+                )
+            )
+        }
+
+        val exception: OTPError =
+            runCatching { confirmVerification.email(clientSecret, verificationCode) }
+                .exceptionOrNull() as OTPError
+
+        assertEquals(errorMessage, exception.message)
+        assertEquals(OTPError.Type.EMAIL_CODE_EXPIRED, exception.type)
+    }
+
+}

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/ConfirmVerificationTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/ConfirmVerificationTest.kt
@@ -34,7 +34,9 @@ internal class ConfirmVerificationTest {
 
         whenever(
             consumerSessionRepository.confirmConsumerVerification(
-                clientSecret, verificationCode, VerificationType.SMS
+                consumerSessionClientSecret = clientSecret,
+                verificationCode = verificationCode,
+                type = VerificationType.SMS
             )
         ).thenReturn(consumerSession)
 
@@ -56,7 +58,9 @@ internal class ConfirmVerificationTest {
 
         whenever(
             consumerSessionRepository.confirmConsumerVerification(
-                clientSecret, verificationCode, VerificationType.EMAIL
+                consumerSessionClientSecret = clientSecret,
+                verificationCode = verificationCode,
+                type = VerificationType.EMAIL
             )
         ).thenReturn(consumerSession)
 
@@ -78,7 +82,9 @@ internal class ConfirmVerificationTest {
 
         whenever(
             consumerSessionRepository.confirmConsumerVerification(
-                clientSecret, verificationCode, VerificationType.SMS
+                consumerSessionClientSecret = clientSecret,
+                verificationCode = verificationCode,
+                type = VerificationType.SMS
             )
         ).thenAnswer {
             throw InvalidRequestException(
@@ -105,7 +111,9 @@ internal class ConfirmVerificationTest {
 
         whenever(
             consumerSessionRepository.confirmConsumerVerification(
-                clientSecret, verificationCode, VerificationType.EMAIL
+                consumerSessionClientSecret = clientSecret,
+                verificationCode = verificationCode,
+                type = VerificationType.EMAIL
             )
         ).thenAnswer {
             throw InvalidRequestException(
@@ -132,7 +140,9 @@ internal class ConfirmVerificationTest {
 
         whenever(
             consumerSessionRepository.confirmConsumerVerification(
-                clientSecret, verificationCode, VerificationType.SMS
+                consumerSessionClientSecret = clientSecret,
+                verificationCode = verificationCode,
+                type = VerificationType.SMS
             )
         ).thenAnswer {
             throw InvalidRequestException(
@@ -159,7 +169,9 @@ internal class ConfirmVerificationTest {
 
         whenever(
             consumerSessionRepository.confirmConsumerVerification(
-                clientSecret, verificationCode, VerificationType.EMAIL
+                consumerSessionClientSecret = clientSecret,
+                verificationCode = verificationCode,
+                type = VerificationType.EMAIL
             )
         ).thenAnswer {
             throw InvalidRequestException(
@@ -177,5 +189,4 @@ internal class ConfirmVerificationTest {
         assertEquals(errorMessage, exception.message)
         assertEquals(OTPError.Type.EMAIL_CODE_EXPIRED, exception.type)
     }
-
 }


### PR DESCRIPTION
# Summary
- OTP errors were treated as "terminal" errors, navigating to the success screen and showing the not saved to link warning.
- This separates OTP errors from the rest, and does not navigate to success screen on OTP errors. It'd instead show the corresponding error under the otp field (See video)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [X] Manually verified

# Video

- See both cases: First, a regular OTP error just shows an error message. Then a terminal error (no internet) navigates to success and shows the "not saved to Link" warning. 

https://user-images.githubusercontent.com/99293320/233207125-2eedb3f0-d829-4118-b55b-97f7e195e8c8.mp4


