### PR TITLE
Add decoupled flow to FC payments-core

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -6558,12 +6558,21 @@ public final class com/stripe/android/payments/bankaccount/CollectBankAccountLau
 }
 
 public final class com/stripe/android/payments/bankaccount/CollectBankAccountLauncher$DefaultImpls {
+	public static synthetic fun presentWithDeferredIntent$default (Lcom/stripe/android/payments/bankaccount/CollectBankAccountLauncher;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/model/ElementsSession;Lcom/stripe/android/payments/bankaccount/CollectBankAccountConfiguration;ILjava/lang/Object;)V
 	public static synthetic fun presentWithPaymentIntent$default (Lcom/stripe/android/payments/bankaccount/CollectBankAccountLauncher;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/payments/bankaccount/CollectBankAccountConfiguration;ILjava/lang/Object;)V
 	public static synthetic fun presentWithSetupIntent$default (Lcom/stripe/android/payments/bankaccount/CollectBankAccountLauncher;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/stripe/android/payments/bankaccount/CollectBankAccountConfiguration;ILjava/lang/Object;)V
 }
 
 public final class com/stripe/android/payments/bankaccount/navigation/CollectBankAccountContract$Args$Companion {
 	public final fun fromIntent (Landroid/content/Intent;)Lcom/stripe/android/payments/bankaccount/navigation/CollectBankAccountContract$Args;
+}
+
+public final class com/stripe/android/payments/bankaccount/navigation/CollectBankAccountContract$Args$ForDeferredIntent$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/payments/bankaccount/navigation/CollectBankAccountContract$Args$ForDeferredIntent;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/payments/bankaccount/navigation/CollectBankAccountContract$Args$ForDeferredIntent;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class com/stripe/android/payments/bankaccount/navigation/CollectBankAccountContract$Args$ForPaymentIntent$Creator : android/os/Parcelable$Creator {

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -1286,6 +1286,24 @@ class StripeApiRepository @JvmOverloads internal constructor(
         }
     }
 
+    override suspend fun createDeferredFinancialConnectionsSession(
+        uniqueId: String,
+        requestOptions: ApiRequest.Options
+    ): Result<FinancialConnectionsSession> {
+        return fetchStripeModelResult(
+            apiRequestFactory.createPost(
+                url = deferredFinancialConnectionsSessionUrl,
+                options = requestOptions,
+                params = mapOf(
+                    "unique_id" to uniqueId
+                )
+            ),
+            FinancialConnectionsSessionJsonParser()
+        ) {
+            // no-op
+        }
+    }
+
     override suspend fun createPaymentIntentFinancialConnectionsSession(
         paymentIntentId: String,
         params: CreateFinancialConnectionsSessionParams,
@@ -1898,6 +1916,13 @@ class StripeApiRepository @JvmOverloads internal constructor(
         internal val linkFinancialConnectionsSessionUrl: String
             @JvmSynthetic
             get() = getApiUrl("consumers/link_account_sessions")
+
+        /**
+         * @return `https://api.stripe.com/v1/connections/link_account_sessions_for_deferred_payment`
+         */
+        internal val deferredFinancialConnectionsSessionUrl: String
+            @JvmSynthetic
+            get() = getApiUrl("connections/link_account_sessions_for_deferred_payment")
 
         /**
          * @return `https://api.stripe.com/v1/consumers/payment_details/:id`

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -373,6 +373,11 @@ abstract class StripeRepository {
 
     // ACHv2 endpoints
 
+    internal abstract suspend fun createDeferredFinancialConnectionsSession(
+        uniqueId: String,
+        requestOptions: ApiRequest.Options
+    ): Result<FinancialConnectionsSession>
+
     internal abstract suspend fun createPaymentIntentFinancialConnectionsSession(
         paymentIntentId: String,
         params: CreateFinancialConnectionsSessionParams,

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountLauncher.kt
@@ -3,7 +3,9 @@ package com.stripe.android.payments.bankaccount
 import android.os.Parcelable
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
+import androidx.annotation.RestrictTo
 import androidx.fragment.app.Fragment
+import com.stripe.android.model.ElementsSession
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountContract
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResult
 import kotlinx.parcelize.Parcelize
@@ -26,6 +28,14 @@ interface CollectBankAccountLauncher {
         publishableKey: String,
         stripeAccountId: String? = null,
         clientSecret: String,
+        configuration: CollectBankAccountConfiguration
+    )
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun presentWithDeferredIntent(
+        publishableKey: String,
+        stripeAccountId: String? = null,
+        elementsSession: ElementsSession,
         configuration: CollectBankAccountConfiguration
     )
 
@@ -100,6 +110,23 @@ internal class StripeCollectBankAccountLauncher constructor(
                 clientSecret = clientSecret,
                 configuration = configuration,
                 attachToIntent = true
+            )
+        )
+    }
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    override fun presentWithDeferredIntent(
+        publishableKey: String,
+        stripeAccountId: String?,
+        elementsSession: ElementsSession,
+        configuration: CollectBankAccountConfiguration
+    ) {
+        hostActivityLauncher.launch(
+            CollectBankAccountContract.Args.ForDeferredIntent(
+                publishableKey = publishableKey,
+                stripeAccountId = stripeAccountId,
+                elementsSession = elementsSession,
+                configuration = configuration
             )
         )
     }

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/domain/CreateFinancialConnectionsSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/domain/CreateFinancialConnectionsSession.kt
@@ -6,6 +6,7 @@ import com.stripe.android.model.FinancialConnectionsSession
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.networking.StripeRepository
+import java.util.UUID
 import javax.inject.Inject
 
 internal class CreateFinancialConnectionsSession @Inject constructor(
@@ -70,5 +71,21 @@ internal class CreateFinancialConnectionsSession @Inject constructor(
                 )
             ).getOrThrow()
         }
+    }
+
+    /**
+     * Creates a [FinancialConnectionsSession] for the given publishable key.
+     */
+    suspend fun forDeferredIntent(
+        publishableKey: String,
+        stripeAccountId: String?
+    ): Result<FinancialConnectionsSession> {
+        return stripeRepository.createDeferredFinancialConnectionsSession(
+            uniqueId = UUID.randomUUID().toString(),
+            requestOptions = ApiRequest.Options(
+                publishableKey,
+                stripeAccountId
+            )
+        )
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/navigation/CollectBankAccountContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/navigation/CollectBankAccountContract.kt
@@ -8,6 +8,7 @@ import androidx.activity.result.contract.ActivityResultContract
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import androidx.core.os.bundleOf
+import com.stripe.android.model.ElementsSession
 import com.stripe.android.payments.bankaccount.CollectBankAccountConfiguration
 import com.stripe.android.payments.bankaccount.ui.CollectBankAccountActivity
 import kotlinx.parcelize.Parcelize
@@ -36,12 +37,14 @@ class CollectBankAccountContract :
 
     /**
      * @param attachToIntent enable this to attach the link account session to the given intent
+     * @param elementsSession pass an [ElementsSession] when a client secret is not available
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     sealed class Args(
         open val publishableKey: String,
         open val stripeAccountId: String?,
-        open val clientSecret: String,
+        open val clientSecret: String?,
+        open val elementsSession: ElementsSession?,
         open val configuration: CollectBankAccountConfiguration,
         open val attachToIntent: Boolean
     ) : Parcelable {
@@ -59,6 +62,7 @@ class CollectBankAccountContract :
             publishableKey = publishableKey,
             stripeAccountId = stripeAccountId,
             clientSecret = clientSecret,
+            elementsSession = null,
             configuration = configuration,
             attachToIntent = attachToIntent
         )
@@ -75,8 +79,25 @@ class CollectBankAccountContract :
             publishableKey = publishableKey,
             stripeAccountId = stripeAccountId,
             clientSecret = clientSecret,
+            elementsSession = null,
             configuration = configuration,
             attachToIntent = attachToIntent
+        )
+
+        @Parcelize
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        data class ForDeferredIntent(
+            override val publishableKey: String,
+            override val stripeAccountId: String?,
+            override val elementsSession: ElementsSession?,
+            override val configuration: CollectBankAccountConfiguration,
+        ) : Args(
+            publishableKey = publishableKey,
+            stripeAccountId = stripeAccountId,
+            clientSecret = null,
+            elementsSession = elementsSession,
+            configuration = configuration,
+            attachToIntent = false
         )
 
         companion object {

--- a/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ElementsSessionFixtures.kt
@@ -1,7 +1,9 @@
 package com.stripe.android.model
 
+import com.stripe.android.model.parsers.ElementsSessionJsonParser
 import org.json.JSONObject
 
+@Suppress("LargeClass")
 internal object ElementsSessionFixtures {
     val EXPANDED_PAYMENT_INTENT_JSON = JSONObject(
         """
@@ -606,4 +608,19 @@ internal object ElementsSessionFixtures {
             }
         """.trimIndent()
     )
+
+    val DEFERRED_INTENT = ElementsSessionJsonParser(
+        ElementsSessionParams.DeferredIntentType(
+            deferredIntentParams = DeferredIntentParams(
+                mode = DeferredIntentParams.Mode.Payment(
+                    amount = 2000,
+                    currency = "usd"
+                )
+            )
+        ),
+        apiKey = "test",
+        timeProvider = { 1 }
+    ).parse(
+        DEFERRED_INTENT_JSON
+    )!!
 }

--- a/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/AbsFakeStripeRepository.kt
@@ -354,6 +354,13 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         return Result.failure(NotImplementedError())
     }
 
+    override suspend fun createDeferredFinancialConnectionsSession(
+        uniqueId: String,
+        requestOptions: ApiRequest.Options
+    ): Result<FinancialConnectionsSession> {
+        return Result.failure(NotImplementedError())
+    }
+
     override suspend fun createPaymentIntentFinancialConnectionsSession(
         paymentIntentId: String,
         params: CreateFinancialConnectionsSessionParams,

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -260,6 +260,14 @@ internal class StripeApiRepositoryTest {
     }
 
     @Test
+    fun testDeferredFinancialConnectionsSessionUrlUrl() {
+        assertEquals(
+            "https://api.stripe.com/v1/connections/link_account_sessions_for_deferred_payment",
+            StripeApiRepository.deferredFinancialConnectionsSessionUrl
+        )
+    }
+
+    @Test
     fun testConsumerPaymentDetailsUrl() {
         assertEquals(
             "https://api.stripe.com/v1/consumers/payment_details",
@@ -1709,6 +1717,31 @@ internal class StripeApiRepositoryTest {
                 withNestedParams("credentials") {
                     assertEquals(this["consumer_session_client_secret"], clientSecret)
                 }
+            }
+        }
+
+    @Test
+    fun `createDeferredFinancialConnectionsSession() sends all parameters`() =
+        runTest {
+            val stripeResponse = StripeResponse(
+                200,
+                FinancialConnectionsFixtures.SESSION.toString(),
+                emptyMap()
+            )
+            whenever(stripeNetworkClient.executeRequest(any<ApiRequest>()))
+                .thenReturn(stripeResponse)
+
+            val uuid = "some_uuid"
+            create().createDeferredFinancialConnectionsSession(
+                uuid,
+                DEFAULT_OPTIONS
+            )
+
+            verify(stripeNetworkClient).executeRequest(apiRequestArgumentCaptor.capture())
+            val params = requireNotNull(apiRequestArgumentCaptor.firstValue.params)
+
+            with(params) {
+                assertEquals(uuid, this["unique_id"])
             }
         }
 

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/StripeCollectBankAccountLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/StripeCollectBankAccountLauncherTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.payments.bankaccount
 
 import androidx.activity.result.ActivityResultLauncher
+import com.stripe.android.model.ElementsSessionFixtures
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountContract
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -52,6 +53,25 @@ class StripeCollectBankAccountLauncherTest {
                 clientSecret = CLIENT_SECRET,
                 configuration = CONFIGURATION,
                 attachToIntent = true
+            )
+        )
+    }
+
+    @Test
+    fun `presentWithDeferredIntent - launches CollectBankAccountActivity with correct arguments`() {
+        launcher.presentWithDeferredIntent(
+            publishableKey = PUBLISHABLE_KEY,
+            stripeAccountId = STRIPE_ACCOUNT_ID,
+            configuration = CONFIGURATION,
+            elementsSession = ElementsSessionFixtures.DEFERRED_INTENT
+        )
+
+        verify(mockHostActivityLauncher).launch(
+            CollectBankAccountContract.Args.ForDeferredIntent(
+                publishableKey = PUBLISHABLE_KEY,
+                stripeAccountId = STRIPE_ACCOUNT_ID,
+                elementsSession = ElementsSessionFixtures.DEFERRED_INTENT,
+                configuration = CONFIGURATION,
             )
         )
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

- Add decoupled flow to FC payments-core
- Add `presentWithDeferredIntent` to `CollectBankAccountLauncher` which will create a FC session for the decoupled flow which does not have a client secret. It will generate a UUID on behalf of the caller. This flow does not attach the session to the intent, since there is no intent. This flow will create the session and return it to the caller.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Decoupling StripeIntent from ACHv2 flow

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified
