### PR TITLE
Add dagger to stripe-ui-core to prevent duplicate class issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 2023-XX-XX
 
+### All SDKs
+* [FIXED][6602](https://github.com/stripe/stripe-android/pull/6602) Fixed an issue which caused a compiler error (duplicate class) when including payments *and* identity SDKs.
+
 ## 20.24.0 - 2023-04-24
 
 ### PaymentSheet

--- a/stripe-ui-core/build.gradle
+++ b/stripe-ui-core/build.gradle
@@ -40,11 +40,14 @@ dependencies {
     implementation libs.compose.material
     implementation libs.compose.ui
     implementation libs.compose.uiToolingPreview
-    implementation libs.dagger
     implementation libs.diskLruCache
     implementation libs.kotlin.coroutines
     implementation libs.kotlin.coroutinesAndroid
     implementation libs.kotlin.serialization
+
+    // DI
+    implementation libs.dagger
+    kapt libs.daggerCompiler
 
     debugImplementation libs.compose.uiTestManifest
     debugImplementation libs.compose.uiTooling


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Dagger generates a factory class `com.stripe.android.uicore.address.AddressRepository_Factory` when the compiler runs over classes with `@Inject` constructors. If the dagger compiler doesn't run in a module, downstream modules will generate the factory so the class can be instantiated. In our case, 2 modules were generating the same class because the upstream module wasn't generating the factory. This led to duplicate class issues when both modules were included in a merchant application.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
#6590

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

Ideally we have a sample that integrates ALL of our SDKs, and that would have caught this issue before a user reported it.

I manually verified this fix by including identity in the paymentsheet-example project (and also removing card scan).
