### PR TITLE
Use createFinancialConnectionsSessionForDeferredPayments

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/domain/CreateFinancialConnectionsSession.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/domain/CreateFinancialConnectionsSession.kt
@@ -1,10 +1,12 @@
 package com.stripe.android.payments.bankaccount.domain
 
 import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.model.CreateFinancialConnectionsSessionForDeferredPaymentParams
 import com.stripe.android.model.CreateFinancialConnectionsSessionParams
 import com.stripe.android.model.FinancialConnectionsSession
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
+import com.stripe.android.model.VerificationMethodParam
 import com.stripe.android.networking.StripeRepository
 import javax.inject.Inject
 
@@ -70,5 +72,37 @@ internal class CreateFinancialConnectionsSession @Inject constructor(
                 )
             ).getOrThrow()
         }
+    }
+
+    /**
+     * Creates a [FinancialConnectionsSession] for deferred payments.
+     *
+     * @param elementsSessionId the elements session id
+     *
+     * The params below are only used for payment intents
+     * @param amount the amount of the payment
+     * @param currency the currency of the payment
+     */
+    suspend fun forDeferredPayments(
+        publishableKey: String,
+        stripeAccountId: String?,
+        elementsSessionId: String,
+        customerId: String?,
+        amount: Int?,
+        currency: String?
+    ): Result<FinancialConnectionsSession> {
+        return stripeRepository.createFinancialConnectionsSessionForDeferredPayments(
+            params = CreateFinancialConnectionsSessionForDeferredPaymentParams(
+                uniqueId = elementsSessionId,
+                verificationMethod = VerificationMethodParam.Automatic,
+                customer = customerId,
+                amount = amount,
+                currency = currency
+            ),
+            requestOptions = ApiRequest.Options(
+                publishableKey,
+                stripeAccountId
+            )
+        )
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/domain/CreateFinancialConnectionsSessionTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/domain/CreateFinancialConnectionsSessionTest.kt
@@ -3,13 +3,16 @@ package com.stripe.android.payments.bankaccount.domain
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.model.CreateFinancialConnectionsSessionForDeferredPaymentParams
 import com.stripe.android.model.CreateFinancialConnectionsSessionParams
 import com.stripe.android.model.FinancialConnectionsSession
+import com.stripe.android.model.VerificationMethodParam
 import com.stripe.android.networking.StripeRepository
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -207,6 +210,102 @@ class CreateFinancialConnectionsSessionTest {
         }
     }
 
+    @Test
+    fun `forDeferredIntent - given repository succeeds, linkedSession created for deferred intent`() {
+        runTest {
+            // Given
+            val publishableKey = "publishable_key"
+            val stripeAccountId = "accountId"
+            val elementsSessionId = "unique_id"
+            val customerId = "customer_id"
+            val amount = 1000
+            val currency = "usd"
+            givenCreateSessionWithDeferredIntentReturns { Result.success(linkedAccountSession) }
+
+            // When
+            val deferredIntent: Result<FinancialConnectionsSession> =
+                createFinancialConnectionsSession.forDeferredPayments(
+                    publishableKey = publishableKey,
+                    stripeAccountId = stripeAccountId,
+                    elementsSessionId = elementsSessionId,
+                    customerId = customerId,
+                    amount = amount,
+                    currency = currency
+                )
+
+            // Then
+            verify(stripeRepository).createFinancialConnectionsSessionForDeferredPayments(
+                params = eq(
+                    CreateFinancialConnectionsSessionForDeferredPaymentParams(
+                        uniqueId = elementsSessionId,
+                        initialInstitution = null,
+                        manualEntryOnly = null,
+                        searchSession = null,
+                        verificationMethod = VerificationMethodParam.Automatic,
+                        customer = customerId,
+                        onBehalfOf = null,
+                        amount = amount,
+                        currency = currency
+                    )
+                ),
+                requestOptions = eq(
+                    ApiRequest.Options(
+                        apiKey = publishableKey,
+                        stripeAccount = stripeAccountId
+                    )
+                )
+            )
+            assertThat((deferredIntent)).isEqualTo(Result.success(linkedAccountSession))
+        }
+    }
+
+    @Test
+    fun `forDeferredIntent - given repository throws exception, results in internal error failure`() {
+        runTest {
+            // Given
+            val publishableKey = "publishable_key"
+            val elementsSessionId = "unique_id"
+            val customerId = "customer_id"
+            val amount = 1000
+            val currency = "usd"
+
+            val expectedException = APIException()
+            givenCreateSessionWithDeferredIntentReturns { Result.failure(expectedException) }
+
+            // When
+            val paymentIntent: Result<FinancialConnectionsSession> =
+                createFinancialConnectionsSession.forDeferredPayments(
+                    publishableKey = publishableKey,
+                    stripeAccountId = null,
+                    elementsSessionId = elementsSessionId,
+                    customerId = customerId,
+                    amount = amount,
+                    currency = currency
+                )
+
+            // Then
+            verify(stripeRepository).createFinancialConnectionsSessionForDeferredPayments(
+                params = eq(
+                    CreateFinancialConnectionsSessionForDeferredPaymentParams(
+                        uniqueId = elementsSessionId,
+                        initialInstitution = null,
+                        manualEntryOnly = null,
+                        searchSession = null,
+                        verificationMethod = VerificationMethodParam.Automatic,
+                        customer = customerId,
+                        onBehalfOf = null,
+                        amount = amount,
+                        currency = currency
+                    )
+                ),
+                requestOptions = eq(
+                    ApiRequest.Options(publishableKey)
+                )
+            )
+            assertThat(paymentIntent.exceptionOrNull()!!).isEqualTo(expectedException)
+        }
+    }
+
     private suspend fun givenCreateSessionWithPaymentIntentReturns(
         session: () -> Result<FinancialConnectionsSession>,
     ) {
@@ -227,6 +326,17 @@ class CreateFinancialConnectionsSessionTest {
                 any(),
                 any(),
                 any()
+            )
+        ).doReturn(session())
+    }
+
+    private suspend fun givenCreateSessionWithDeferredIntentReturns(
+        session: () -> Result<FinancialConnectionsSession>,
+    ) {
+        whenever(
+            stripeRepository.createFinancialConnectionsSessionForDeferredPayments(
+                any(),
+                any(),
             )
         ).doReturn(session())
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Use `createFinancialConnectionsSessionForDeferredPayments` in `CreateFinancialConnectionsSession` to expose a way to create a session using `forDeferredPayments`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

ACHv2 decoupling

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

