### PR TITLE
Fetch translations for `BDCC` fields

### DIFF
--- a/payments-ui-core/res/values-b+es+419/strings.xml
+++ b/payments-ui-core/res/values-b+es+419/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Atrás</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Dirección de facturación</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Información de contacto</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Continuar</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Compra ahora y paga después con Klarna.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Paga después con Klarna.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Nombre del titular de la tarjeta</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Banco Przelewy24</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-ca-rES/strings.xml
+++ b/payments-ui-core/res/values-ca-rES/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Tornar</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Adreça de facturació</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Informació de contacte</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Continua</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Compra ara o paga més endavant amb Klarna.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Paga més endavant amb Klarna.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Nom a la targeta</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Banc Przelewy24</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-cs-rCZ/strings.xml
+++ b/payments-ui-core/res/values-cs-rCZ/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Zpět</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Fakturační adresa</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Kontaktní údaje</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Pokračovat</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Kupte nyní nebo zaplaťte později pomocí Klarna</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Zaplaťte později pomocí Klarna.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Jméno na kartě</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Przelewy24 Bank</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-da/strings.xml
+++ b/payments-ui-core/res/values-da/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Tilbage</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Faktureringsadresse</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Kontaktoplysninger</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Fortsæt</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Køb nu, eller betal senere med Klarna.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Betal senere med Klarna.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Kortholderens navn</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Przelewy24 Bank</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-de/strings.xml
+++ b/payments-ui-core/res/values-de/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Zurück</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Rechnungsadresse</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Kontaktinformationen</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Weiter</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Jetzt kaufen oder später mit Klarna bezahlen.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Später mit Klarna bezahlen.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Name auf Karte</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Przelewy24 Bank</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-el-rGR/strings.xml
+++ b/payments-ui-core/res/values-el-rGR/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Πίσω</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Διεύθυνση χρέωσης</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Στοιχεία επικοινωνίας</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Συνέχεια</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Αγορά τώρα ή πληρωμή αργότερα με Klarna.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Πληρωμή αργότερα με Klarna.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Όνομα στην κάρτα</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Τράπεζα Przelewy24</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-en-rGB/strings.xml
+++ b/payments-ui-core/res/values-en-rGB/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Back</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Billing address</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Contact information</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Continue</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Buy now or pay later with Klarna.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Pay later with Klarna.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Name on card</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Przelewy24 Bank</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-es/strings.xml
+++ b/payments-ui-core/res/values-es/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Atrás</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Dirección de facturación</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Datos de contacto</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Continuar</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Compra ahora y paga después con Klarna.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Paga después con Klarna.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Nombre del titular de la tarjeta</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Banco que opera con Przelewy24</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-et-rEE/strings.xml
+++ b/payments-ui-core/res/values-et-rEE/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Tagasi</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Arveldusaadress</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Kontaktandmed</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Jätka</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Ostke nüüd või makske hiljem Klarnaga.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Makske hiljem Klarnaga.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Nimi kaardil</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Przelewy24 Bank</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-fi/strings.xml
+++ b/payments-ui-core/res/values-fi/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Takaisin</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Laskutusosoite</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Yhteystiedot</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Jatka</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Osta nyt tai maksa myöhemmin Klarnalla.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Maksa myöhemmin Klarnalla.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Kortissa oleva nimi</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Przelewy24 Bank</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-fil/strings.xml
+++ b/payments-ui-core/res/values-fil/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Bumalik</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Adres para sa billing</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Impormasyon sa pakikipag-ugnayan</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Magpatuloy</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Bumili ngayon o magbayad sa ibang pagkakataon gamit ang Klarna.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Magbayad sa ibang pagkakataon gamit ang Klarna.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Pangalan sa kard</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Bangko ng Przelewy24</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-fr-rCA/strings.xml
+++ b/payments-ui-core/res/values-fr-rCA/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Retour</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Adresse de facturation</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Coordonnées</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Continuer</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Payez maintenant ou plus tard avec Klarna.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Payez plus tard avec Klarna.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Nom du titulaire de la carte</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Banque Przelewy24</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-fr/strings.xml
+++ b/payments-ui-core/res/values-fr/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Retour</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Adresse de facturation</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Coordonnées</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Continuer</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Paiement différé avec Klarna.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Payer plus tard avec Klarna.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Nom du titulaire de la carte</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Banque Przelewy24</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-hr/strings.xml
+++ b/payments-ui-core/res/values-hr/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Natrag</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Adresa za naplatu</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Podaci za kontakt</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Nastavi</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Kupite sada ili platite kasnije pomoću Klarne</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Platite kasnije pomoću Klarne.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Ime na kartici</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Banka Przelewy24</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-hu/strings.xml
+++ b/payments-ui-core/res/values-hu/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Vissza</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Számlázási cím</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Kapcsolattartási adatok</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Folytatás</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Megvásárlás most, vagy fizetés később Klarnával.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Fizetés később Klarnával.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">A kártyán szereplő név</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Przelewy24 Bank</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-in/strings.xml
+++ b/payments-ui-core/res/values-in/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Kembali</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Alamat tagihan</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Informasi kontak</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Lanjutkan</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Beli sekarang atau bayar nanti dengan Klarna.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Bayar nanti dengan Klarna.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Nama pada kartu</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Bank Przelewy24</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-it/strings.xml
+++ b/payments-ui-core/res/values-it/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Indietro</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Indirizzo di fatturazione</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Informazioni di contatto</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Continua</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Acquista ora o paga dopo con Klarna.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Paga dopo con Klarna.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Nome sulla carta</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Banca Przelewy24</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-ja/strings.xml
+++ b/payments-ui-core/res/values-ja/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">戻る</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">請求先住所</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">連絡先情報</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">続ける</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Klarna で後払いします。</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Klarna での後払いにします。</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">カード名義人</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Przelewy24 銀行</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-ko/strings.xml
+++ b/payments-ui-core/res/values-ko/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">뒤로</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">청구 주소</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">연락처 정보</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">계속</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">지금 구매하거나 Klarna로 나중에 결제</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Klarna로 나중에 결제</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">카드 명의자</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Przelewy24 은행</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-lt-rLT/strings.xml
+++ b/payments-ui-core/res/values-lt-rLT/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Atgal</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Atsiskaitymo adresas</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Kontaktinė informacija</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Tęsti</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Pirkite dabar arba mokėkite vėliau naudodami \"Klarna\".</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Mokėkite vėliau naudodami \"Klarna\".</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Ant kortelės nurodytas vardas ir pavardė</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Przelewy24 Bank</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-lv-rLV/strings.xml
+++ b/payments-ui-core/res/values-lv-rLV/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Atpakaļ</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Norēķinu adrese</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Kontaktinformācija</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Turpināt</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Pērciet tagad vai maksājiet vēlāk ar Klarna.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Maksāt vēlāk ar Klarna.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Uz kartes norādītais vārds</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Przelewy24 banka</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-ms-rMY/strings.xml
+++ b/payments-ui-core/res/values-ms-rMY/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Undur</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Alamat pengebilan</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Maklumat hubungan</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Teruskan</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Beli sekarang atau bayar kemudian dengan Klarna.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Bayar kemudian dengan Klarna.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Nama pada kad</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Bank Przelewy24</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-mt/strings.xml
+++ b/payments-ui-core/res/values-mt/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Lura</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Indirizz tal-kont</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Id-dettalji tal-kuntatt</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Kompli</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Ixtri issa jew ħallas iktar tard bil-Klarna.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Ħlas aktar tard bil-Klarna.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">L-isem fuq il-karta</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Bank Przelewy24</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-nb/strings.xml
+++ b/payments-ui-core/res/values-nb/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Tilbake</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Fakturaadresse</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Kontaktinformasjon</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Fortsett</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Kjøp nå eller betal senere med Klarna.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Betal senere med Klarna.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Navn på kort</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Przelewy24 Bank</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-nl/strings.xml
+++ b/payments-ui-core/res/values-nl/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Terug</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Factuuradres</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Contactgegevens</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Doorgaan</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Koop nu of betaal later met Klarna.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Betaal later met Klarna.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Naam op betaalkaart</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Przelewy24 Bank</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-nn-rNO/strings.xml
+++ b/payments-ui-core/res/values-nn-rNO/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Tilbake</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Fakturaadresse</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Kontaktopplysningar</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Fortsett</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Kjøp no eller betal seinare med Klarna.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Betal seinare med Klarna.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Namn på kort</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Przelewy24 Bank</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-pl-rPL/strings.xml
+++ b/payments-ui-core/res/values-pl-rPL/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Wstecz</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Adres rozliczeniowy</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Dane kontaktowe</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Kontynuuj</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Kup teraz lub zapłać za pomocą Klarna później.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Zapłać później za pomocą Klarna.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Imię i nazwisko na karcie</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Bank - Przelewy24</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-pt-rBR/strings.xml
+++ b/payments-ui-core/res/values-pt-rBR/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Voltar</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Endereço de cobrança</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Dados de contato</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Continuar</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Compre agora ou pague depois com Klarna.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Pagar depois com Klarna.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Nome no cartão</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Banco Przelewy24</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-pt-rPT/strings.xml
+++ b/payments-ui-core/res/values-pt-rPT/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Voltar</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Endereço de faturação</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Informações de contacto</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Continuar</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Comprar agora ou pagar mais tarde com Klarna.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Pagar mais tarde com Klarna.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Nome no cartão</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Banco Przelewy24</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-ro-rRO/strings.xml
+++ b/payments-ui-core/res/values-ro-rRO/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Înapoi</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Adresă de facturare</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Informații de contact</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Continuare</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Cumpărați acum sau plătiți mai târziu folosind Klarna.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Plătiți mai târziu folosind Klarna.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Numele titularului</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Banca Przelewy24</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-ru/strings.xml
+++ b/payments-ui-core/res/values-ru/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Назад</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Адрес для выставления счета</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Контактные данные</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Продолжить</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Купить немедленно или оплатить позже через систему Klarna.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Оплатить позже через систему Klarna.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Имя и фамилия, указанные на карте</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Банк Przelewy24</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-sk-rSK/strings.xml
+++ b/payments-ui-core/res/values-sk-rSK/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Späť</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Fakturačná adresa</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Kontaktné informácie</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Pokračovať</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Kúpte teraz alebo zaplaťte neskôr pomocou služby Klarna.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Zaplatiť neskôr pomocou služby Klarna</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Meno na karte</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Przelewy24 Bank</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-sl-rSI/strings.xml
+++ b/payments-ui-core/res/values-sl-rSI/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Nazaj</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Naslov plačnika računa</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Podatki za stik</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Nadaljuj</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Kupite zdaj ali pa plačajte pozneje s storitvijo Klarna.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Plačajte pozneje s storitvijo Klarna.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Ime na kartici</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Przelewy24 Bank</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-sv/strings.xml
+++ b/payments-ui-core/res/values-sv/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Tillbaka</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Faktureringsadress</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Kontaktinformation</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Fortsätt</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Köp nu eller betala senare med Klarna.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Betala senare med Klarna.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Namn på kortet</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Przelewy24 Bank</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-th/strings.xml
+++ b/payments-ui-core/res/values-th/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">ย้อนกลับ</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">ที่อยู่ในการเรียกเก็บเงิน</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">ข้อมูลติดต่อ</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">ดำเนินการต่อ</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">ซื้อตอนนี้หรือจ่ายทีหลังด้วย Klarna</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">จ่ายทีหลังด้วย Klarna</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">ชื่อบนบัตร</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">ธนาคาร Przelewy24</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-tr/strings.xml
+++ b/payments-ui-core/res/values-tr/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Geri</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Fatura adresi</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">İletişim bilgileri</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Devam et</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Şimdi satın alın veya daha sonra Klarna ile ödeyin.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Daha sonra Klarna ile ödeyin.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Karttaki isim</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Przelewy24 Bank</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-vi/strings.xml
+++ b/payments-ui-core/res/values-vi/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Quay lại</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Địa chỉ thanh toán</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Thông tin liên lạc</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Tiếp tục</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Mua ngay hoặc thanh toán sau bằng Klarna.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Thanh toán sau bằng Klarna.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Tên trên thẻ</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Ngân hàng Przelewy24</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-zh-rHK/strings.xml
+++ b/payments-ui-core/res/values-zh-rHK/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">上一步</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">帳單地址</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">聯絡資訊</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">繼續</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">用 Klarna 先買後付。</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">用 Klarna 延後支付。</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">卡上的姓名</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Przelewy24 銀行</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-zh-rTW/strings.xml
+++ b/payments-ui-core/res/values-zh-rTW/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">上一步</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">帳單地址</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">聯絡資訊</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">繼續</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">用 Klarna 先買後付。</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">用 Klarna 延後支付。</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">卡上的姓名</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Przelewy24 銀行</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values-zh/strings.xml
+++ b/payments-ui-core/res/values-zh/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">返回</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">账单地址</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">联系信息</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">继续</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">用 Klarna 先买后付。</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">用 Klarna 延后支付。</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">卡上的姓名</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Przelewy24 银行</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values/strings.xml
+++ b/payments-ui-core/res/values/strings.xml
@@ -6,6 +6,8 @@
   <string name="stripe_back">Back</string>
   <!-- Billing address section title for card form entry. -->
   <string name="stripe_billing_details">Billing address</string>
+  <!-- Title for the contact information section -->
+  <string name="stripe_contact_information">Contact information</string>
   <!-- Text for continue button -->
   <string name="stripe_continue_button_label">Continue</string>
   <!-- Label for the field containing the dropdown of EPS Banks -->
@@ -25,6 +27,8 @@
   <string name="stripe_klarna_buy_now_pay_later">Buy now or pay later with Klarna.</string>
   <!-- Klarna pay later copy -->
   <string name="stripe_klarna_pay_later">Pay later with Klarna.</string>
+  <!-- Label for name on card field -->
+  <string name="stripe_name_on_card">Name on card</string>
   <!-- Label on the dropdown to select the Przelewy24 Bank -->
   <string name="stripe_p24_bank">Przelewy24 Bank</string>
   <!-- Label of a button that initiates payment when tapped -->

--- a/payments-ui-core/res/values/totranslate.xml
+++ b/payments-ui-core/res/values/totranslate.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    <!-- Cash App mandate text -->
-    <string name="cashapp_mandate">By continuing, you authorize %1$s to debit your Cash App account for this payment and future payments in accordance with %2$s\'s terms, until this authorization is revoked. You can change this anytime in your Cash App Settings.</string>
-
-    <!-- Billing details collection -->
-    <string name="name_on_card">Name on card</string>
-    <string name="contact_information">Contact information</string>
-</resources>

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
@@ -30,7 +30,7 @@ internal class CardDetailsController constructor(
         SimpleTextElement(
             controller = SimpleTextFieldController(
                 textFieldConfig = SimpleTextFieldConfig(
-                    label = R.string.name_on_card,
+                    label = R.string.stripe_name_on_card,
                     capitalization = KeyboardCapitalization.Words,
                     keyboard = androidx.compose.ui.text.input.KeyboardType.Text
                 ),

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/ContactInformationSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/ContactInformationSpec.kt
@@ -31,7 +31,7 @@ data class ContactInformationSpec(
             SimpleTextElement(
                 controller = SimpleTextFieldController(
                     textFieldConfig = SimpleTextFieldConfig(
-                        label = R.string.name_on_card,
+                        label = R.string.stripe_name_on_card,
                         capitalization = KeyboardCapitalization.Words,
                         keyboard = KeyboardType.Text
                     ),
@@ -51,7 +51,7 @@ data class ContactInformationSpec(
         if (elements.isEmpty()) return null
 
         return createSectionElement(
-            label = R.string.contact_information,
+            label = R.string.stripe_contact_information,
             sectionFieldElements = elements,
         )
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds the translations for the `Name on card` and `Contact information` labels that were added as part of the billing details collection configuration.

It also removes the unused `cashapp_mandate` string, as we still don’t support it for PI+SFU or SI.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
