### PR TITLE
Add `AutomaticAsync` as a capture method

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -3187,6 +3187,7 @@ public final class com/stripe/android/model/PaymentIntent$CancellationReason : j
 
 public final class com/stripe/android/model/PaymentIntent$CaptureMethod : java/lang/Enum {
 	public static final field Automatic Lcom/stripe/android/model/PaymentIntent$CaptureMethod;
+	public static final field AutomaticAsync Lcom/stripe/android/model/PaymentIntent$CaptureMethod;
 	public static final field Manual Lcom/stripe/android/model/PaymentIntent$CaptureMethod;
 	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/model/PaymentIntent$CaptureMethod;
 	public static fun values ()[Lcom/stripe/android/model/PaymentIntent$CaptureMethod;

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
@@ -396,6 +396,13 @@ constructor(
         Automatic("automatic"),
 
         /**
+         * Stripe asynchronously captures funds when the customer authorizes the payment.
+         * Recommended over [Automatic] due to improved latency, but may require additional
+         * integration changes.
+         */
+        AutomaticAsync("automatic_async"),
+
+        /**
          * Place a hold on the funds when the customer authorizes the payment, but don’t capture
          * the funds until later. (Not all payment methods support this.)
          */


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds `AutomaticAsync` as a capture method to `PaymentIntent`.

We’ll also need it for https://github.com/stripe/stripe-android/pull/6615.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Alignment with the Stripe API.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
