### PR TITLE
Use correct `ImeAction` depending on `lastTextFieldIdentifier`

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
@@ -235,7 +235,11 @@ internal fun BillingDetailsForm(
                     textFieldController = emailController.apply {
                         onRawValueChange(email ?: "")
                     },
-                    imeAction = ImeAction.Next,
+                    imeAction = if (lastTextFieldIdentifier == IdentifierSpec.Email) {
+                        ImeAction.Done
+                    } else {
+                        ImeAction.Next
+                    },
                     enabled = !processing
                 )
             }
@@ -244,7 +248,11 @@ internal fun BillingDetailsForm(
             PhoneSection(
                 processing = processing,
                 phoneController = phoneController,
-                imeAction = ImeAction.Next,
+                imeAction = if (lastTextFieldIdentifier == IdentifierSpec.Phone) {
+                    ImeAction.Done
+                } else {
+                    ImeAction.Next
+                },
             )
         }
         if (formArgs.billingDetailsCollectionConfiguration.address == AddressCollectionMode.Full) {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where the keyboard in the US Bank Account screen didn’t show the correct `ImeAction` for each text field. Instead of using the `addressElement`’s last text field identifier, we now select the identifier dynamically based on the `collectionConfiguration`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Polish.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
