### PR TITLE
Add multiprocessor support for decoupled flow

### DIFF
--- a/link/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModelTest.kt
+++ b/link/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModelTest.kt
@@ -460,7 +460,7 @@ class PaymentMethodViewModelTest {
         val viewModel = createViewModel()
         viewModel.startPayment(cardFormFieldValues)
 
-        intentConfirmationInterceptor.enqueueCompleteStep(StripeIntentFixtures.PI_SUCCEEDED)
+        intentConfirmationInterceptor.enqueueCompleteStep()
 
         advanceTimeBy(PrimaryButtonState.COMPLETED_DELAY_MS + 1)
         verify(navigator).dismiss(eq(LinkActivityResult.Completed))

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/FakeIntentConfirmationInterceptor.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/FakeIntentConfirmationInterceptor.kt
@@ -5,7 +5,6 @@ import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
-import com.stripe.android.model.StripeIntent
 import kotlinx.coroutines.channels.Channel
 
 class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor {
@@ -17,9 +16,10 @@ class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor {
         channel.trySend(nextStep)
     }
 
-    fun enqueueCompleteStep(stripeIntent: StripeIntent) {
-        val nextStep = IntentConfirmationInterceptor.NextStep.Complete(stripeIntent)
-        channel.trySend(nextStep)
+    fun enqueueCompleteStep(
+        isForceSuccess: Boolean = false,
+    ) {
+        channel.trySend(IntentConfirmationInterceptor.NextStep.Complete(isForceSuccess))
     }
 
     fun enqueueNextActionStep(clientSecret: String) {

--- a/payments-core/src/main/java/com/stripe/android/CreateIntentCallback.kt
+++ b/payments-core/src/main/java/com/stripe/android/CreateIntentCallback.kt
@@ -34,10 +34,10 @@ fun interface CreateIntentCallback : AbsCreateIntentCallback {
 sealed interface CreateIntentResult {
 
     @ExperimentalPaymentSheetDecouplingApi
-    data class Success(val clientSecret: String) : CreateIntentResult
+    class Success(val clientSecret: String) : CreateIntentResult
 
     @ExperimentalPaymentSheetDecouplingApi
-    data class Failure @JvmOverloads constructor(
+    class Failure @JvmOverloads constructor(
         internal val cause: Exception,
         internal val displayMessage: String? = null,
     ) : CreateIntentResult

--- a/payments-core/src/main/java/com/stripe/android/CreateIntentCallback.kt
+++ b/payments-core/src/main/java/com/stripe/android/CreateIntentCallback.kt
@@ -34,7 +34,7 @@ fun interface CreateIntentCallback : AbsCreateIntentCallback {
 sealed interface CreateIntentResult {
 
     @ExperimentalPaymentSheetDecouplingApi
-    class Success(val clientSecret: String) : CreateIntentResult
+    class Success(internal val clientSecret: String) : CreateIntentResult
 
     @ExperimentalPaymentSheetDecouplingApi
     class Failure @JvmOverloads constructor(

--- a/payments-core/src/main/java/com/stripe/android/CreateIntentCallback.kt
+++ b/payments-core/src/main/java/com/stripe/android/CreateIntentCallback.kt
@@ -21,10 +21,9 @@ fun interface CreateIntentCallback : AbsCreateIntentCallback {
      * Your implementation should create a [PaymentIntent] or [SetupIntent] on your server and
      * return its client secret or an error if one occurred.
      *
-     * @param paymentMethodId The ID of the [PaymentMethod] representing the customer's payment
-     * details
+     * @param paymentMethod The [PaymentMethod] representing the customer's payment details
      */
-    suspend fun onCreateIntent(paymentMethodId: String): CreateIntentResult
+    suspend fun onCreateIntent(paymentMethod: PaymentMethod): CreateIntentResult
 }
 
 /**
@@ -57,14 +56,13 @@ fun interface CreateIntentCallbackForServerSideConfirmation : AbsCreateIntentCal
      * Your implementation should create and confirm a [PaymentIntent] or [SetupIntent] on your
      * server and return its client secret or an error if one occurred.
      *
-     * @param paymentMethodId The ID of the [PaymentMethod] representing the customer's payment
-     * details
+     * @param paymentMethod The [PaymentMethod] representing the customer's payment details
      * @param shouldSavePaymentMethod This is `true` if the customer selected the
      * "Save this payment method for future use" checkbox. Set `setup_future_usage` on the
      * [PaymentIntent] to `off_session` if this is `true`.
      */
     suspend fun onCreateIntent(
-        paymentMethodId: String,
+        paymentMethod: PaymentMethod,
         shouldSavePaymentMethod: Boolean,
     ): CreateIntentResult
 }

--- a/payments-core/src/main/java/com/stripe/android/DelicatePaymentSheetApi.kt
+++ b/payments-core/src/main/java/com/stripe/android/DelicatePaymentSheetApi.kt
@@ -1,0 +1,12 @@
+package com.stripe.android
+
+import androidx.annotation.RestrictTo
+
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "This is a delicate API that is only intended for advanced users and not required " +
+        "for most integrations.",
+)
+@Retention(AnnotationRetention.BINARY)
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+annotation class DelicatePaymentSheetApi

--- a/payments-core/src/main/java/com/stripe/android/IntentConfirmationInterceptor.kt
+++ b/payments-core/src/main/java/com/stripe/android/IntentConfirmationInterceptor.kt
@@ -168,9 +168,7 @@ class DefaultIntentConfirmationInterceptor @Inject constructor(
         paymentMethod: PaymentMethod,
         shippingValues: ConfirmPaymentIntentParams.Shipping?
     ): NextStep {
-        return when (
-            val result = createIntentCallback.onCreateIntent(paymentMethod)
-        ) {
+        return when (val result = createIntentCallback.onCreateIntent(paymentMethod)) {
             is CreateIntentResult.Success -> {
                 if (result.clientSecret == IntentConfirmationInterceptor.DISMISS_WITH_SUCCESS) {
                     NextStep.Complete(isForceSuccess = true)

--- a/payments-core/src/main/java/com/stripe/android/IntentConfirmationInterceptor.kt
+++ b/payments-core/src/main/java/com/stripe/android/IntentConfirmationInterceptor.kt
@@ -165,9 +165,7 @@ class DefaultIntentConfirmationInterceptor @Inject constructor(
         paymentMethod: PaymentMethod,
         shippingValues: ConfirmPaymentIntentParams.Shipping?
     ): IntentConfirmationInterceptor.NextStep {
-        return when (
-            val result = createIntentCallback.onCreateIntent(paymentMethodId = paymentMethod.id!!)
-        ) {
+        return when (val result = createIntentCallback.onCreateIntent(paymentMethod)) {
             is CreateIntentResult.Success -> {
                 createConfirmStep(result.clientSecret, shippingValues, paymentMethod)
             }
@@ -187,8 +185,8 @@ class DefaultIntentConfirmationInterceptor @Inject constructor(
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
     ): IntentConfirmationInterceptor.NextStep {
         val result = createIntentCallback.onCreateIntent(
-            paymentMethodId = paymentMethod.id!!,
-            shouldSavePaymentMethod = shouldSavePaymentMethod
+            paymentMethod = paymentMethod,
+            shouldSavePaymentMethod = shouldSavePaymentMethod,
         )
 
         return when (result) {

--- a/payments-core/src/test/java/com/stripe/android/DefaultIntentConfirmationInterceptorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/DefaultIntentConfirmationInterceptorTest.kt
@@ -174,6 +174,8 @@ class DefaultIntentConfirmationInterceptorTest {
 
     @Test
     fun `Fails if retrieving intent did not succeed`() = runTest {
+        val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+
         val apiException = APIException(
             requestId = "req_123",
             statusCode = 500,
@@ -195,7 +197,7 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeAccountIdProvider = { null },
         )
 
-        IntentConfirmationInterceptor.createIntentCallback = succeedingServerSideCallback("pm_123456789")
+        IntentConfirmationInterceptor.createIntentCallback = succeedingServerSideCallback(paymentMethod)
 
         val nextStep = interceptor.intercept(
             clientSecret = null,
@@ -323,7 +325,6 @@ class DefaultIntentConfirmationInterceptorTest {
     @Test
     fun `Returns confirm as next step after creating an unconfirmed intent`() = runTest {
         val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
-        val expectedPaymentMethodId = requireNotNull(paymentMethod.id)
 
         val interceptor = DefaultIntentConfirmationInterceptor(
             context = context,
@@ -332,7 +333,7 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeAccountIdProvider = { null },
         )
 
-        IntentConfirmationInterceptor.createIntentCallback = succeedingClientSideCallback(expectedPaymentMethodId)
+        IntentConfirmationInterceptor.createIntentCallback = succeedingClientSideCallback(paymentMethod)
 
         val nextStep = interceptor.intercept(
             clientSecret = null,
@@ -347,7 +348,6 @@ class DefaultIntentConfirmationInterceptorTest {
     @Test
     fun `Returns complete as next step after creating and confirming a succeeded intent`() = runTest {
         val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
-        val expectedPaymentMethodId = requireNotNull(paymentMethod.id)
 
         val interceptor = DefaultIntentConfirmationInterceptor(
             context = context,
@@ -364,7 +364,7 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeAccountIdProvider = { null },
         )
 
-        IntentConfirmationInterceptor.createIntentCallback = succeedingServerSideCallback(expectedPaymentMethodId)
+        IntentConfirmationInterceptor.createIntentCallback = succeedingServerSideCallback(paymentMethod)
 
         val nextStep = interceptor.intercept(
             clientSecret = null,
@@ -381,7 +381,6 @@ class DefaultIntentConfirmationInterceptorTest {
     @Test
     fun `Returns handleNextAction as next step after creating and confirming a non-succeeded intent`() = runTest {
         val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
-        val expectedPaymentMethodId = requireNotNull(paymentMethod.id)
 
         val interceptor = DefaultIntentConfirmationInterceptor(
             context = context,
@@ -400,7 +399,7 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeAccountIdProvider = { null },
         )
 
-        IntentConfirmationInterceptor.createIntentCallback = succeedingServerSideCallback(expectedPaymentMethodId)
+        IntentConfirmationInterceptor.createIntentCallback = succeedingServerSideCallback(paymentMethod)
 
         val nextStep = interceptor.intercept(
             clientSecret = null,
@@ -459,19 +458,19 @@ class DefaultIntentConfirmationInterceptorTest {
     }
 
     private fun succeedingClientSideCallback(
-        expectedPaymentMethodId: String,
+        expectedPaymentMethod: PaymentMethod,
     ): CreateIntentCallback {
-        return CreateIntentCallback { paymentMethodId ->
-            assertThat(paymentMethodId).isEqualTo(expectedPaymentMethodId)
+        return CreateIntentCallback { paymentMethod ->
+            assertThat(paymentMethod).isEqualTo(expectedPaymentMethod)
             CreateIntentResult.Success(clientSecret = "pi_123_secret_456")
         }
     }
 
     private fun succeedingServerSideCallback(
-        expectedPaymentMethodId: String,
+        expectedPaymentMethod: PaymentMethod,
     ): CreateIntentCallbackForServerSideConfirmation {
-        return CreateIntentCallbackForServerSideConfirmation { paymentMethodId, _ ->
-            assertThat(paymentMethodId).isEqualTo(expectedPaymentMethodId)
+        return CreateIntentCallbackForServerSideConfirmation { paymentMethod, _ ->
+            assertThat(paymentMethod).isEqualTo(expectedPaymentMethod)
             CreateIntentResult.Success(clientSecret = "pi_123_secret_456")
         }
     }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -323,7 +323,7 @@ class PlaygroundTestDriver(
         selectors.customer.click()
         selectors.automatic.click()
 
-        selectors.initializationType.click()
+        selectors.setInitializationType(testParameters.initializationType)
 
         // Set the country first because it will update the default currency value
         selectors.setMerchantCountry(testParameters.merchantCountryCode)

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/TestParameters.kt
@@ -2,6 +2,7 @@ package com.stripe.android.test.core
 
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.example.playground.model.InitializationType
 import com.stripe.android.ui.core.forms.resources.LpmRepository.SupportedPaymentMethod
 
 /**
@@ -35,14 +36,6 @@ data class TestParameters(
     val collectPhone: PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic,
     val collectAddress: PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
 )
-
-/**
- * Indicates if we use the normal or deferred payment sheet initialization
- */
-enum class InitializationType {
-    Normal,
-    Deferred,
-}
 
 /**
  * Indicates if automatic payment methods are used on the payment intent

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
@@ -17,6 +17,7 @@ import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.model.CountryUtils
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.R
+import com.stripe.android.paymentsheet.example.playground.model.InitializationType
 import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.Automatic
 import com.stripe.android.test.core.Billing
@@ -25,7 +26,6 @@ import com.stripe.android.test.core.Customer
 import com.stripe.android.test.core.DelayedPMs
 import com.stripe.android.test.core.GooglePayState
 import com.stripe.android.test.core.HOOKS_PAGE_LOAD_TIMEOUT
-import com.stripe.android.test.core.InitializationType
 import com.stripe.android.test.core.IntentType
 import com.stripe.android.test.core.LinkState
 import com.stripe.android.test.core.Shipping
@@ -93,11 +93,6 @@ class Selectors(
     val automatic = when (testParameters.automatic) {
         Automatic.Off -> EspressoIdButton(R.id.automatic_pm_off_button)
         Automatic.On -> EspressoIdButton(R.id.automatic_pm_on_button)
-    }
-
-    val initializationType = when (testParameters.initializationType) {
-        InitializationType.Normal -> EspressoIdButton(R.id.normal_initialization_button)
-        InitializationType.Deferred -> EspressoIdButton(R.id.deferred_initialization_button)
     }
 
     val paymentSelection = PaymentSelection(
@@ -285,6 +280,11 @@ class Selectors(
             StripeR.string.stripe_cvc_number_hint
         )
     )
+
+    fun setInitializationType(initializationType: InitializationType) {
+        EspressoIdButton(R.id.initialization_type_spinner).click()
+        EspressoText(initializationType.value).click()
+    }
 
     fun setCurrency(currency: Currency) {
         EspressoIdButton(R.id.currency_spinner).click()

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
@@ -203,9 +203,9 @@ class PaymentSheetPlaygroundActivity : AppCompatActivity() {
 
         paymentSheet = PaymentSheet(
             activity = this,
-            createIntentCallback = { paymentMethodId ->
+            createIntentCallback = { paymentMethod ->
                 viewModel.createIntent(
-                    paymentMethodId = paymentMethodId,
+                    paymentMethodId = paymentMethod.id!!,
                     merchantCountryCode = merchantCountryCode.value,
                     mode = mode.value,
                     returnUrl = returnUrl,
@@ -218,9 +218,9 @@ class PaymentSheetPlaygroundActivity : AppCompatActivity() {
         flowController = PaymentSheet.FlowController.create(
             activity = this,
             paymentOptionCallback = ::onPaymentOption,
-            createIntentCallbackForServerSideConfirmation = { paymentMethodId, shouldSavePaymentMethod ->
+            createIntentCallbackForServerSideConfirmation = { paymentMethod, shouldSavePaymentMethod ->
                 viewModel.createAndConfirmIntent(
-                    paymentMethodId = paymentMethodId,
+                    paymentMethodId = paymentMethod.id!!,
                     shouldSavePaymentMethod = shouldSavePaymentMethod,
                     merchantCountryCode = merchantCountryCode.value,
                     mode = mode.value,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/model/PlaygroundCheckoutModel.kt
@@ -6,8 +6,11 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 enum class InitializationType(val value: String) {
-    Normal("normal"),
-    Deferred("deferred"),
+    Normal("Normal"),
+    DeferredClientSideConfirmation("Deferred CSC"),
+    DeferredServerSideConfirmation("Deferred SSC"),
+    DeferredManualConfirmation("Deferred SSC + MC"),
+    DeferredMultiprocessor("Deferred SSC + MP"),
 }
 
 enum class CheckoutMode(val value: String) {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/viewmodel/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/viewmodel/PaymentSheetPlaygroundViewModel.kt
@@ -10,6 +10,7 @@ import com.github.kittinunf.fuel.Fuel
 import com.github.kittinunf.fuel.core.extensions.jsonBody
 import com.github.kittinunf.result.Result
 import com.stripe.android.CreateIntentResult
+import com.stripe.android.DelicatePaymentSheetApi
 import com.stripe.android.ExperimentalPaymentSheetDecouplingApi
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.model.CountryCode
@@ -52,7 +53,10 @@ class PaymentSheetPlaygroundViewModel(
     ) { type, secret ->
         when (type) {
             InitializationType.Normal -> secret != null
-            InitializationType.Deferred -> paymentMethodTypes.value.isNotEmpty()
+            InitializationType.DeferredClientSideConfirmation,
+            InitializationType.DeferredServerSideConfirmation,
+            InitializationType.DeferredManualConfirmation,
+            InitializationType.DeferredMultiprocessor -> paymentMethodTypes.value.isNotEmpty()
         }
     }
 
@@ -62,7 +66,6 @@ class PaymentSheetPlaygroundViewModel(
     private val sharedPreferencesName = "playgroundToggles"
 
     suspend fun storeToggleState(
-        initializationType: String,
         customer: String,
         link: Boolean,
         googlePay: Boolean,
@@ -85,7 +88,7 @@ class PaymentSheetPlaygroundViewModel(
         )
 
         sharedPreferences.edit {
-            putString(Toggle.Initialization.key, initializationType)
+            putString(Toggle.Initialization.key, initializationType.value.value)
             putString(Toggle.Customer.key, customer)
             putBoolean(Toggle.Link.key, link)
             putBoolean(Toggle.GooglePay.key, googlePay)
@@ -200,7 +203,6 @@ class PaymentSheetPlaygroundViewModel(
      * that will be confirmed on the client using Payment Sheet.
      */
     fun prepareCheckout(
-        initializationType: InitializationType,
         customer: CheckoutCustomer,
         currency: CheckoutCurrency,
         merchantCountry: CountryCode,
@@ -209,12 +211,14 @@ class PaymentSheetPlaygroundViewModel(
         setShippingAddress: Boolean,
         setAutomaticPaymentMethod: Boolean,
         backendUrl: String,
-        supportedPaymentMethods: List<String>?
+        supportedPaymentMethods: List<String>?,
     ) {
         customerConfig.value = null
         clientSecret.value = null
 
         inProgress.postValue(true)
+
+        val initializationType = initializationType.value
 
         val requestBody = CheckoutRequest(
             initialization = initializationType.value,
@@ -264,7 +268,7 @@ class PaymentSheetPlaygroundViewModel(
             }
     }
 
-    @OptIn(ExperimentalPaymentSheetDecouplingApi::class)
+    @OptIn(ExperimentalPaymentSheetDecouplingApi::class, DelicatePaymentSheetApi::class)
     @Suppress("UNUSED_PARAMETER")
     fun createIntent(
         paymentMethodId: String,
@@ -273,13 +277,44 @@ class PaymentSheetPlaygroundViewModel(
         returnUrl: String,
         backendUrl: String,
     ): CreateIntentResult {
-        // Note: This is not how you'd do this in a real application. Instead, your app would
-        // call your backend and create (and optionally confirm) a payment or setup intent.
-        return CreateIntentResult.Success(clientSecret = clientSecret.value!!)
+        val initializationType = initializationType.value
+
+        val clientSecret = if (initializationType == InitializationType.DeferredMultiprocessor) {
+            PaymentSheet.IntentConfiguration.DISMISS_WITH_SUCCESS
+        } else {
+            // Note: This is not how you'd do this in a real application. Instead, your app would
+            // call your backend and create (and optionally confirm) a payment or setup intent.
+            clientSecret.value!!
+        }
+
+        return CreateIntentResult.Success(clientSecret)
+    }
+
+    @OptIn(ExperimentalPaymentSheetDecouplingApi::class, DelicatePaymentSheetApi::class)
+    suspend fun createAndConfirmIntent(
+        paymentMethodId: String,
+        shouldSavePaymentMethod: Boolean,
+        merchantCountryCode: String,
+        mode: String,
+        returnUrl: String,
+        backendUrl: String,
+    ): CreateIntentResult {
+        return if (initializationType.value == InitializationType.DeferredMultiprocessor) {
+            CreateIntentResult.Success(PaymentSheet.IntentConfiguration.DISMISS_WITH_SUCCESS)
+        } else {
+            createAndConfirmIntentInternal(
+                paymentMethodId = paymentMethodId,
+                shouldSavePaymentMethod = shouldSavePaymentMethod,
+                merchantCountryCode = merchantCountryCode,
+                mode = mode,
+                returnUrl = returnUrl,
+                backendUrl = backendUrl,
+            )
+        }
     }
 
     @OptIn(ExperimentalPaymentSheetDecouplingApi::class)
-    suspend fun createAndConfirmIntent(
+    private suspend fun createAndConfirmIntentInternal(
         paymentMethodId: String,
         shouldSavePaymentMethod: Boolean,
         merchantCountryCode: String,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/complete_flow/ServerSideConfirmationCompleteFlowViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/complete_flow/ServerSideConfirmationCompleteFlowViewModel.kt
@@ -9,6 +9,7 @@ import com.github.kittinunf.fuel.core.requests.suspendable
 import com.stripe.android.CreateIntentResult
 import com.stripe.android.ExperimentalPaymentSheetDecouplingApi
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheetResult
 import com.stripe.android.paymentsheet.example.samples.model.CartProduct
 import com.stripe.android.paymentsheet.example.samples.model.CartState
@@ -69,11 +70,11 @@ internal class ServerSideConfirmationCompleteFlowViewModel(
 
     @OptIn(ExperimentalPaymentSheetDecouplingApi::class)
     suspend fun createAndConfirmIntent(
-        paymentMethodId: String,
+        paymentMethod: PaymentMethod,
         shouldSavePaymentMethod: Boolean,
     ): CreateIntentResult = withContext(Dispatchers.IO) {
         val request = state.value.cartState.toCreateIntentRequest(
-            paymentMethodId = paymentMethodId,
+            paymentMethodId = paymentMethod.id!!,
             shouldSavePaymentMethod = shouldSavePaymentMethod,
             returnUrl = "stripesdk://payment_return_url/com.stripe.android.paymentsheet.example",
         )

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/custom_flow/ServerSideConfirmationCustomFlowViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/custom_flow/ServerSideConfirmationCustomFlowViewModel.kt
@@ -9,6 +9,7 @@ import com.github.kittinunf.fuel.core.requests.suspendable
 import com.stripe.android.CreateIntentResult
 import com.stripe.android.ExperimentalPaymentSheetDecouplingApi
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheetResult
 import com.stripe.android.paymentsheet.example.samples.model.CartProduct
 import com.stripe.android.paymentsheet.example.samples.model.CartState
@@ -91,11 +92,11 @@ internal class ServerSideConfirmationCustomFlowViewModel(
 
     @OptIn(ExperimentalPaymentSheetDecouplingApi::class)
     suspend fun createAndConfirmIntent(
-        paymentMethodId: String,
+        paymentMethod: PaymentMethod,
         shouldSavePaymentMethod: Boolean,
     ): CreateIntentResult = withContext(Dispatchers.IO) {
         val request = state.value.cartState.toCreateIntentRequest(
-            paymentMethodId = paymentMethodId,
+            paymentMethodId = paymentMethod.id!!,
             shouldSavePaymentMethod = shouldSavePaymentMethod,
             returnUrl = "stripesdk://payment_return_url/com.stripe.android.paymentsheet.example",
         )

--- a/paymentsheet-example/src/main/res/layout/activity_payment_sheet_playground.xml
+++ b/paymentsheet-example/src/main/res/layout/activity_payment_sheet_playground.xml
@@ -20,30 +20,14 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <RadioGroup
-            android:id="@+id/initialization_radio_group"
-            android:layout_width="wrap_content"
+        <Spinner
+            android:id="@+id/initialization_type_spinner"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:layout_marginStart="16dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.0"
+            android:layout_marginHorizontal="16dp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/initialization">
-
-            <RadioButton
-                android:id="@+id/normal_initialization_button"
-                android:text="Normal"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:checked="true" />
-
-            <RadioButton
-                android:id="@+id/deferred_initialization_button"
-                android:text="Deferred"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
-        </RadioGroup>
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/initialization" />
 
         <TextView
             android:id="@+id/customer_text_view"
@@ -54,7 +38,7 @@
             android:layout_marginTop="16dp"
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/initialization_radio_group" />
+            app:layout_constraintTop_toBottomOf="@id/initialization_type_spinner" />
 
         <RadioGroup
             android:id="@+id/customer_radio_group"

--- a/paymentsheet-example/src/main/res/layout/activity_payment_sheet_playground.xml
+++ b/paymentsheet-example/src/main/res/layout/activity_payment_sheet_playground.xml
@@ -23,7 +23,7 @@
         <Spinner
             android:id="@+id/initialization_type_spinner"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="48dp"
             android:layout_marginHorizontal="16dp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'app.cash.paparazzi'
 
 dependencies {
     implementation project(":link")
-    implementation project(":payments-core")
+    api project(":payments-core")
     implementation project(':payments-ui-core')
     implementation project(':stripe-ui-core')
     compileOnly project(':financial-connections')

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.CreateIntentResult
+import com.stripe.android.DelicatePaymentSheetApi
 import com.stripe.android.ExperimentalPaymentSheetDecouplingApi
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.networktesting.NetworkRule
@@ -491,5 +492,74 @@ internal class FlowControllerTest {
         assertThat(resultCountDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
         assertThat((paymentSheetResult as PaymentSheetResult.Failed).error.message)
             .isEqualTo("We don't accept visa")
+    }
+
+    @OptIn(ExperimentalPaymentSheetDecouplingApi::class, DelicatePaymentSheetApi::class)
+    @Test
+    fun testDeferredIntentCardPaymentWithForcedSuccess() {
+        networkRule.enqueue(
+            method("GET"),
+            path("/v1/elements/sessions"),
+        ) { response ->
+            response.testBodyFromFile("elements-sessions-deferred_payment_intent.json")
+        }
+
+        val resultCountDownLatch = CountDownLatch(1)
+        val activityScenarioRule = composeTestRule.activityRule
+        val scenario = activityScenarioRule.scenario
+        scenario.moveToState(Lifecycle.State.CREATED)
+        lateinit var flowController: PaymentSheet.FlowController
+        scenario.onActivity {
+            PaymentConfiguration.init(it, "pk_test_123")
+            flowController = PaymentSheet.FlowController.create(
+                activity = it,
+                paymentOptionCallback = { paymentOption ->
+                    assertThat(paymentOption?.label).endsWith("4242")
+                    flowController.confirm()
+                },
+                createIntentCallback = {
+                    CreateIntentResult.Success(PaymentSheet.IntentConfiguration.DISMISS_WITH_SUCCESS)
+                },
+                paymentResultCallback = { result ->
+                    assertThat(result).isInstanceOf(PaymentSheetResult.Completed::class.java)
+                    resultCountDownLatch.countDown()
+                },
+            )
+        }
+        scenario.moveToState(Lifecycle.State.RESUMED)
+        scenario.onActivity {
+            flowController.configureWithIntentConfiguration(
+                intentConfiguration = PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                        amount = 2000,
+                        currency = "usd"
+                    )
+                ),
+                configuration = null,
+                callback = { success, error ->
+                    assertThat(success).isTrue()
+                    assertThat(error).isNull()
+                    flowController.presentPaymentOptions()
+                }
+            )
+        }
+
+        page.addPaymentMethod()
+        page.fillOutCardDetails()
+
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/payment_methods"),
+            bodyPart(
+                "payment_user_agent",
+                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet.FlowController%3BPaymentSheet%3Bdeferred-intent")
+            ),
+        ) { response ->
+            response.testBodyFromFile("payment-methods-create.json")
+        }
+
+        page.clickPrimaryButton()
+
+        assertThat(resultCountDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.CreateIntentResult
+import com.stripe.android.DelicatePaymentSheetApi
 import com.stripe.android.ExperimentalPaymentSheetDecouplingApi
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.networktesting.NetworkRule
@@ -288,5 +289,63 @@ internal class PaymentSheetTest {
 
         page.clickPrimaryButton()
         page.waitForText("We don't accept visa")
+    }
+
+    @OptIn(ExperimentalPaymentSheetDecouplingApi::class, DelicatePaymentSheetApi::class)
+    @Test
+    fun testDeferredIntentCardPaymentWithForcedSuccess() {
+        networkRule.enqueue(
+            method("GET"),
+            path("/v1/elements/sessions"),
+        ) { response ->
+            response.testBodyFromFile("elements-sessions-deferred_payment_intent.json")
+        }
+
+        val countDownLatch = CountDownLatch(1)
+        val activityScenarioRule = composeTestRule.activityRule
+        val scenario = activityScenarioRule.scenario
+        scenario.moveToState(Lifecycle.State.CREATED)
+        lateinit var paymentSheet: PaymentSheet
+        scenario.onActivity {
+            PaymentConfiguration.init(it, "pk_test_123")
+            paymentSheet = PaymentSheet(
+                activity = it,
+                createIntentCallback = {
+                    CreateIntentResult.Success(PaymentSheet.IntentConfiguration.DISMISS_WITH_SUCCESS)
+                }
+            ) { result ->
+                assertThat(result).isInstanceOf(PaymentSheetResult.Completed::class.java)
+                countDownLatch.countDown()
+            }
+        }
+        scenario.moveToState(Lifecycle.State.RESUMED)
+        scenario.onActivity {
+            paymentSheet.presentWithIntentConfiguration(
+                intentConfiguration = PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                        amount = 2000,
+                        currency = "usd"
+                    )
+                ),
+                configuration = null,
+            )
+        }
+
+        page.fillOutCardDetails()
+
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/payment_methods"),
+            bodyPart(
+                "payment_user_agent",
+                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet%3Bdeferred-intent")
+            ),
+        ) { response ->
+            response.testBodyFromFile("payment-methods-create.json")
+        }
+
+        page.clickPrimaryButton()
+
+        assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -6,11 +6,14 @@ import android.os.Parcelable
 import androidx.activity.ComponentActivity
 import androidx.annotation.ColorInt
 import androidx.annotation.FontRes
+import androidx.annotation.RestrictTo
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.fragment.app.Fragment
 import com.stripe.android.CreateIntentCallback
 import com.stripe.android.CreateIntentCallbackForServerSideConfirmation
+import com.stripe.android.CreateIntentResult
+import com.stripe.android.DelicatePaymentSheetApi
 import com.stripe.android.ExperimentalPaymentSheetDecouplingApi
 import com.stripe.android.IntentConfirmationInterceptor
 import com.stripe.android.link.account.CookieStore
@@ -350,6 +353,19 @@ class PaymentSheet internal constructor(
              * **Note**: Not all payment methods support this.
              */
             Manual,
+        }
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        companion object {
+
+            /**
+             * Pass this as the client secret into [CreateIntentResult.Success] to force
+             * [PaymentSheet] to show success and dismiss.
+             *
+             * **Note**: Only for advanced users, not required for most integrations.
+             */
+            @DelicatePaymentSheetApi
+            const val DISMISS_WITH_SUCCESS = IntentConfirmationInterceptor.DISMISS_WITH_SUCCESS
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -361,8 +361,6 @@ class PaymentSheet internal constructor(
             /**
              * Pass this as the client secret into [CreateIntentResult.Success] to force
              * [PaymentSheet] to show success and dismiss.
-             *
-             * **Note**: Only for advanced users, not required for most integrations.
              */
             @DelicatePaymentSheetApi
             const val DISMISS_WITH_SUCCESS = IntentConfirmationInterceptor.DISMISS_WITH_SUCCESS

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -491,6 +491,9 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                     onError(nextStep.message)
                 }
                 is IntentConfirmationInterceptor.NextStep.Complete -> {
+                    if (nextStep.isForceSuccess) {
+                        eventReporter.onForceSuccess()
+                    }
                     processPayment(stripeIntent, PaymentResult.Completed)
                 }
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -162,6 +162,10 @@ internal class DefaultEventReporter @Inject internal constructor(
         )
     }
 
+    override fun onForceSuccess() {
+        fireEvent(PaymentSheetEvent.ForceSuccess)
+    }
+
     private fun fireEvent(event: PaymentSheetEvent) {
         CoroutineScope(workContext).launch {
             analyticsRequestExecutor.executeAsync(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -56,6 +56,8 @@ internal interface EventReporter {
         isDecoupling: Boolean,
     )
 
+    fun onForceSuccess()
+
     enum class Mode(val code: String) {
         Complete("complete"),
         Custom("custom");

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -224,6 +224,13 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         )
     }
 
+    object ForceSuccess : PaymentSheetEvent() {
+        override val eventName: String = "mc_force_success"
+        override val additionalParams: Map<String, Any?> = mapOf(
+            FIELD_IS_DECOUPLED to true,
+        )
+    }
+
     internal companion object {
         private fun analyticsValue(
             paymentSelection: PaymentSelection?

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -312,6 +312,9 @@ internal class DefaultFlowController @Inject internal constructor(
                     )
                 }
                 is IntentConfirmationInterceptor.NextStep.Complete -> {
+                    if (nextStep.isForceSuccess) {
+                        eventReporter.onForceSuccess()
+                    }
                     onPaymentResult(PaymentResult.Completed)
                 }
             }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1251,7 +1251,7 @@ internal class PaymentSheetViewModelTest {
             viewModel.updateSelection(savedSelection)
             viewModel.checkout()
 
-            fakeIntentConfirmationInterceptor.enqueueCompleteStep(PaymentIntentFixtures.PI_SUCCEEDED)
+            fakeIntentConfirmationInterceptor.enqueueCompleteStep()
 
             val finishingState = viewModel.viewState.value as PaymentSheetViewState.FinishProcessing
             finishingState.onComplete()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -68,7 +68,6 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.runner.RunWith
-import org.mockito.Mockito
 import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.MockitoAnnotations

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -968,7 +968,7 @@ internal class DefaultFlowControllerTest {
             )
         )
 
-        fakeIntentConfirmationInterceptor.enqueueCompleteStep(PaymentIntentFixtures.PI_SUCCEEDED)
+        fakeIntentConfirmationInterceptor.enqueueCompleteStep()
 
         flowController.confirm()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -13,7 +13,11 @@ import app.cash.turbine.Turbine
 import app.cash.turbine.plusAssign
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.CreateIntentCallback
+import com.stripe.android.CreateIntentResult
+import com.stripe.android.DelicatePaymentSheetApi
 import com.stripe.android.ExperimentalPaymentSheetDecouplingApi
+import com.stripe.android.IntentConfirmationInterceptor
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContract
@@ -55,6 +59,7 @@ import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentSheetLoader
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 import com.stripe.android.testing.FakeIntentConfirmationInterceptor
+import com.stripe.android.testing.IntentConfirmationInterceptorTestRule
 import com.stripe.android.uicore.image.StripeImageLoader
 import com.stripe.android.utils.FakePaymentSheetLoader
 import com.stripe.android.utils.RelayingPaymentSheetLoader
@@ -66,8 +71,10 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import org.junit.Rule
 import org.junit.runner.RunWith
 import org.mockito.Mockito.never
+import org.mockito.Mockito.times
 import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argWhere
@@ -77,6 +84,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.isA
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
@@ -89,6 +97,10 @@ import kotlin.test.assertFailsWith
 @Suppress("DEPRECATION")
 @RunWith(RobolectricTestRunner::class)
 internal class DefaultFlowControllerTest {
+
+    @get:Rule
+    val intentConfirmationInterceptorRule = IntentConfirmationInterceptorTestRule()
+
     private val paymentOptionCallback = mock<PaymentOptionCallback>()
     private val paymentResultCallback = mock<PaymentSheetResultCallback>()
 
@@ -1121,6 +1133,36 @@ internal class DefaultFlowControllerTest {
         flowController.presentPaymentOptions()
 
         verify(paymentOptionActivityLauncher, never()).launch(any())
+    }
+
+    @OptIn(ExperimentalPaymentSheetDecouplingApi::class, DelicatePaymentSheetApi::class)
+    @Test
+    fun `Sends correct analytics event based on force-success usage`() = runTest {
+        val clientSecrets = listOf(
+            PaymentSheet.IntentConfiguration.DISMISS_WITH_SUCCESS to times(1),
+            "real_client_secret" to never(),
+        )
+
+        for ((clientSecret, verificationMode) in clientSecrets) {
+            IntentConfirmationInterceptor.createIntentCallback = CreateIntentCallback { _ ->
+                CreateIntentResult.Success(clientSecret)
+            }
+
+            val flowController = createAndConfigureFlowControllerForDeferredIntent()
+
+            flowController.onPaymentOptionResult(
+                PaymentOptionResult.Succeeded(
+                    PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+                )
+            )
+            flowController.confirm()
+
+            val isForceSuccess = clientSecret == PaymentSheet.IntentConfiguration.DISMISS_WITH_SUCCESS
+            fakeIntentConfirmationInterceptor.enqueueCompleteStep(isForceSuccess)
+
+            verify(eventReporter, verificationMode).onForceSuccess()
+            reset(eventReporter)
+        }
     }
 
     @OptIn(ExperimentalPaymentSheetDecouplingApi::class)


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds the `DISMISS_WITH_SUCCESS` fake client secret that’s intended to be used in multiprocessor use cases. We annotate the field with `DelicatePaymentSheetApi` to make it clear that this should be used carefully.

For now, `DISMISS_WITH_SUCCESS` is restricted to our library group. We’ll make it public once we’ve agreed on the final constant name.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Multiprocessor support.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
