### PR TITLE
Fix crash when opening ACH form

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/CollectBankAccountLauncher.kt
@@ -3,6 +3,7 @@ package com.stripe.android.payments.bankaccount
 import android.os.Parcelable
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.ActivityResultRegistryOwner
 import androidx.annotation.RestrictTo
 import androidx.fragment.app.Fragment
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountContract
@@ -52,8 +53,13 @@ interface CollectBankAccountLauncher {
         customerId: String?,
     )
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun unregister()
+
     companion object {
 
+        private const val LAUNCHER_KEY = "CollectBankAccountLauncher"
+
         /**
          * Create a [CollectBankAccountLauncher] instance with [ComponentActivity].
          *
@@ -121,6 +127,20 @@ interface CollectBankAccountLauncher {
                 fragment.registerForActivityResult(CollectBankAccountContract()) {
                     callback(it)
                 }
+            )
+        }
+
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        fun create(
+            activityResultRegistryOwner: ActivityResultRegistryOwner,
+            callback: (CollectBankAccountResultInternal) -> Unit,
+        ): CollectBankAccountLauncher {
+            return StripeCollectBankAccountLauncher(
+                activityResultRegistryOwner.activityResultRegistry.register(
+                    LAUNCHER_KEY,
+                    CollectBankAccountContract(),
+                    callback,
+                )
             )
         }
     }
@@ -202,6 +222,10 @@ internal class StripeCollectBankAccountLauncher constructor(
                 customerId = customerId,
             )
         )
+    }
+
+    override fun unregister() {
+        hostActivityLauncher.unregister()
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
@@ -1,8 +1,6 @@
 package com.stripe.android.paymentsheet.paymentdatacollection.ach
 
-import android.content.Context
-import android.content.ContextWrapper
-import androidx.activity.ComponentActivity
+import androidx.activity.compose.LocalActivityResultRegistryOwner
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -66,6 +64,7 @@ internal fun USBankAccountForm(
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
+    val activityResultRegistryOwner = LocalActivityResultRegistryOwner.current
 
     val viewModel = viewModel<USBankAccountFormViewModel>(
         factory = USBankAccountFormViewModel.Factory {
@@ -91,7 +90,7 @@ internal fun USBankAccountForm(
     )
 
     DisposableEffect(Unit) {
-        viewModel.register(context.requireActivity())
+        viewModel.register(activityResultRegistryOwner!!)
 
         onDispose {
             sheetViewModel.resetUSBankPrimaryButton()
@@ -552,15 +551,4 @@ private fun AccountDetailsForm(
             }
         )
     }
-}
-
-private fun Context.requireActivity(): ComponentActivity {
-    var currentContext = this
-    while (currentContext is ContextWrapper) {
-        if (currentContext is ComponentActivity) {
-            return currentContext
-        }
-        currentContext = currentContext.baseContext
-    }
-    error("Failed to find an Activity from the current Context")
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -15,8 +15,8 @@ import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher
-import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResponse
-import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResult
+import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResponseInternal
+import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResultInternal
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode
@@ -571,7 +571,7 @@ class USBankAccountFormViewModelTest {
         )
     }
 
-    private suspend fun mockUnverifiedBankAccount(): CollectBankAccountResult.Completed {
+    private suspend fun mockUnverifiedBankAccount(): CollectBankAccountResultInternal.Completed {
         val paymentIntent = mock<PaymentIntent>()
         val financialConnectionsSession = mock<FinancialConnectionsSession>()
         whenever(paymentIntent.id).thenReturn(defaultArgs.clientSecret?.value)
@@ -594,15 +594,15 @@ class USBankAccountFormViewModelTest {
             )
         ).thenReturn(Result.success(paymentIntent))
 
-        return CollectBankAccountResult.Completed(
-            CollectBankAccountResponse(
+        return CollectBankAccountResultInternal.Completed(
+            CollectBankAccountResponseInternal(
                 intent = paymentIntent,
                 financialConnectionsSession = financialConnectionsSession
             )
         )
     }
 
-    private suspend fun mockVerifiedBankAccount(): CollectBankAccountResult.Completed {
+    private suspend fun mockVerifiedBankAccount(): CollectBankAccountResultInternal.Completed {
         val paymentIntent = mock<PaymentIntent>()
         val financialConnectionsSession = mock<FinancialConnectionsSession>()
         whenever(paymentIntent.id).thenReturn(defaultArgs.clientSecret?.value)
@@ -627,8 +627,8 @@ class USBankAccountFormViewModelTest {
             )
         ).thenReturn(Result.success(paymentIntent))
 
-        return CollectBankAccountResult.Completed(
-            CollectBankAccountResponse(
+        return CollectBankAccountResultInternal.Completed(
+            CollectBankAccountResponseInternal(
                 intent = paymentIntent,
                 financialConnectionsSession = financialConnectionsSession
             )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes a crash when opening the ACH form. Turns out the second commit in https://github.com/stripe/stripe-android/pull/6619 broke things by registering an activity result listener when in the wrong lifecycle state.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
