### PR TITLE
[FC] Maestro - Use identifiers on Consent screen

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentScreen.kt
@@ -1,4 +1,7 @@
-@file:OptIn(ExperimentalMaterialApi::class, ExperimentalMaterialApi::class)
+@file:OptIn(
+    ExperimentalMaterialApi::class, ExperimentalMaterialApi::class,
+    ExperimentalComposeUiApi::class
+)
 @file:Suppress("LongMethod", "TooManyFunctions")
 
 package com.stripe.android.financialconnections.features.consent
@@ -32,11 +35,15 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -398,7 +405,8 @@ private fun ConsentFooter(
             loading = acceptConsent is Loading,
             onClick = onContinueClick,
             modifier = Modifier
-                .fillMaxWidth()
+                .semantics { testTagsAsResourceId = true }
+                .testTag("consent_cta")
         ) {
             Text(text = consent.cta)
         }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentScreen.kt
@@ -407,6 +407,7 @@ private fun ConsentFooter(
             modifier = Modifier
                 .semantics { testTagsAsResourceId = true }
                 .testTag("consent_cta")
+                .fillMaxWidth()
         ) {
             Text(text = consent.cta)
         }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentScreen.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/consent/ConsentScreen.kt
@@ -1,5 +1,5 @@
 @file:OptIn(
-    ExperimentalMaterialApi::class, ExperimentalMaterialApi::class,
+    ExperimentalMaterialApi::class,
     ExperimentalComposeUiApi::class
 )
 @file:Suppress("LongMethod", "TooManyFunctions")

--- a/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
+++ b/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
@@ -13,9 +13,11 @@ appId: com.stripe.android.financialconnections.example
 - tapOn: "Connect Accounts!"
 # Common: web AuthFlow - connect OAuth institution
 - extendedWaitUntil:
-    visible: "Agree"
+    visible:
+      id: "consent_cta"
     timeout: 30000
-- tapOn: "Agree"
+- tapOn:
+    id: "consent_cta"
 - assertVisible: "Test OAuth Institution"
 # ERRORS
 - tapOn: ".*unknown error.*"

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
@@ -13,9 +13,11 @@ appId: com.stripe.android.financialconnections.example
 - tapOn: "Connect Accounts!"
 # Common: web AuthFlow - connect OAuth institution
 - extendedWaitUntil:
-    visible: "Agree"
-    timeout: 30000
-- tapOn: "Agree"
+      visible:
+          id: "consent_cta"
+      timeout: 30000
+- tapOn:
+      id: "consent_cta"
 # SELECT LEGACY INSTITUTION
 - tapOn: "Test Institution"
 ####### Bypass Chrome on-boarding screen #######

--- a/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
+++ b/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
@@ -13,7 +13,8 @@ appId: com.stripe.android.financialconnections.example
 - tapOn: "Connect Accounts!"
 # Common: web AuthFlow - connect OAuth institution
 - extendedWaitUntil:
-    visible: "Agree"
+    visible:
+      id: "consent_cta"
     timeout: 30000
 - tapOn: "Enter account details manually instead"
 - assertVisible: "Enter bank account details"


### PR DESCRIPTION
# Summary
- Since consent content is dynamic, use identifiers to avoid tests failing on content updates. 