### PR TITLE
Fix save for future use regression in ACH

### DIFF
--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -25,9 +25,8 @@
     <ID>LongMethod:PaymentOptionFactory.kt$PaymentOptionFactory$fun create(selection: PaymentSelection): PaymentOption</ID>
     <ID>LongMethod:PaymentSheetConfigurationKtx.kt$internal fun PaymentSheet.Appearance.parseAppearance()</ID>
     <ID>LongMethod:PaymentSheetLoader.kt$DefaultPaymentSheetLoader$private suspend fun create( stripeIntent: StripeIntent, customerConfig: PaymentSheet.CustomerConfiguration?, config: PaymentSheet.Configuration?, isGooglePayReady: Boolean, ): PaymentSheetLoader.Result</ID>
-    <ID>LongMethod:USBankAccountForm.kt$@Composable internal fun BillingDetailsForm( formArgs: FormArguments, processing: Boolean, name: String, email: String?, nameController: TextFieldController, emailController: TextFieldController, phoneController: PhoneNumberController, addressController: AddressController, lastTextFieldIdentifier: IdentifierSpec?, sameAsShippingElement: SameAsShippingElement?, )</ID>
     <ID>LongMethod:USBankAccountForm.kt$@Composable internal fun USBankAccountForm( formArgs: FormArguments, sheetViewModel: BaseSheetViewModel, modifier: Modifier = Modifier, )</ID>
-    <ID>LongMethod:USBankAccountForm.kt$@Composable private fun AccountDetailsForm( formArgs: FormArguments, processing: Boolean, bankName: String?, last4: String?, saveForFutureUsage: Boolean, saveForFutureUseElement: SaveForFutureUseElement, onRemoveAccount: () -> Unit, )</ID>
+    <ID>LongMethod:USBankAccountForm.kt$@Composable private fun AccountDetailsForm( formArgs: FormArguments, processing: Boolean, bankName: String?, last4: String?, saveForFutureUseElement: SaveForFutureUseElement, onRemoveAccount: () -> Unit, )</ID>
     <ID>LongMethod:USBankAccountFormViewModel.kt$USBankAccountFormViewModel$private fun attachFinancialAccountToIntent( clientSecret: ClientSecret, intentId: String, linkAccountId: String, bankName: String?, last4: String? )</ID>
     <ID>MagicNumber:AutocompleteScreen.kt$0.07f</ID>
     <ID>MagicNumber:GooglePayButton.kt$GooglePayButton$0.5f</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
@@ -231,7 +231,6 @@ internal fun MandateCollectionScreen(
             processing = processing,
             bankName = screenState.paymentAccount.institutionName,
             last4 = screenState.paymentAccount.last4,
-            saveForFutureUsage = screenState.saveForFutureUsage,
             saveForFutureUseElement = saveForFutureUseElement,
             onRemoveAccount = onRemoveAccount,
         )
@@ -268,7 +267,6 @@ internal fun VerifyWithMicrodepositsScreen(
             processing = processing,
             bankName = screenState.paymentAccount.bankName,
             last4 = screenState.paymentAccount.last4,
-            saveForFutureUsage = screenState.saveForFutureUsage,
             saveForFutureUseElement = saveForFutureUseElement,
             onRemoveAccount = onRemoveAccount,
         )
@@ -305,7 +303,6 @@ internal fun SavedAccountScreen(
             processing = processing,
             bankName = screenState.bankName,
             last4 = screenState.last4,
-            saveForFutureUsage = screenState.saveForFutureUsage,
             saveForFutureUseElement = saveForFutureUseElement,
             onRemoveAccount = onRemoveAccount,
         )
@@ -463,7 +460,6 @@ private fun AccountDetailsForm(
     processing: Boolean,
     bankName: String?,
     last4: String?,
-    saveForFutureUsage: Boolean,
     saveForFutureUseElement: SaveForFutureUseElement,
     onRemoveAccount: () -> Unit,
 ) {
@@ -519,9 +515,7 @@ private fun AccountDetailsForm(
         if (formArgs.showCheckbox) {
             SaveForFutureUseElementUI(
                 enabled = true,
-                element = saveForFutureUseElement.apply {
-                    this.controller.onValueChange(saveForFutureUsage)
-                },
+                element = saveForFutureUseElement,
                 modifier = Modifier.padding(top = 8.dp)
             )
         }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes a regression from https://github.com/stripe/stripe-android/pull/6619 where the `Save for future use` toggle wouldn’t respond to taps.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
