### PR TITLE
Add script to automate Lokalize translations

### DIFF
--- a/.github/workflows/fetch_translations.yml
+++ b/.github/workflows/fetch_translations.yml
@@ -8,22 +8,16 @@ jobs:
   fetch-lokalize-translations:
     runs-on: macos-latest
     steps:
-      # Check out the current state
-      - uses: actions/checkout@v3
-
-      # Fetch translations
-      - name: Run build script
+      - name: Check out the current state
+        uses: actions/checkout@v3
+      - name: Fetch translations
         run: cd scripts && ./localize.sh
         shell: bash
         env:
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
-
-      # Create timestamp
-      - name: Get timestamp
+      - name: Compute timestamp
         id: timestamp
         run: echo "TIMESTAMP=$(date +'%Y%m%d-%H%M%S')" >> $GITHUB_OUTPUT
-
-      # Create the pull request
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:

--- a/.github/workflows/fetch_translations.yml
+++ b/.github/workflows/fetch_translations.yml
@@ -1,0 +1,38 @@
+name: Fetch Lokalize translations
+on:
+  workflow_dispatch:
+  # Temporary for testing
+  push:
+    branches:
+      - tillh/automate-lokalize
+  schedule:
+    # Every Monday at 10 AM East Coast time / 7 AM West Coast time / 2 PM UTC
+    - cron: "0 14 * * 1"
+jobs:
+  fetch-lokalize-translations:
+    runs-on: macos-latest
+    steps:
+      # Install Brew so that we can use the Lokalize CLI
+      - run: brew tap lokalise/cli-2
+      - run: brew install lokalise2
+
+      # Check out the current state
+      - uses: actions/checkout@v3
+
+      # Fetch translations
+      # Note: The environment variable points to tillh's Lokalize username and token.
+      - name: Run build script
+        run: cd scripts && ./localize.sh
+        shell: bash
+        env:
+          LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
+
+      # Create the pull request
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: Fetch latest Lokalize translations
+          title: Fetch latest Lokalize translations
+          body: This pull request automatically fetched the latest translations from Lokalize.
+          branch: update-translations-${{ steps.date.outputs.date }}
+          base: master

--- a/.github/workflows/fetch_translations.yml
+++ b/.github/workflows/fetch_translations.yml
@@ -1,10 +1,6 @@
 name: Fetch Lokalize translations
 on:
   workflow_dispatch:
-  # Temporary for testing
-  push:
-    branches:
-      - tillh/automate-lokalize
   schedule:
     # Every Monday at 10 AM East Coast time / 7 AM West Coast time / 2 PM UTC
     - cron: "0 14 * * 1"

--- a/.github/workflows/fetch_translations.yml
+++ b/.github/workflows/fetch_translations.yml
@@ -8,27 +8,27 @@ jobs:
   fetch-lokalize-translations:
     runs-on: macos-latest
     steps:
-      # Install Brew so that we can use the Lokalize CLI
-      - run: brew tap lokalise/cli-2
-      - run: brew install lokalise2
-
       # Check out the current state
       - uses: actions/checkout@v3
 
       # Fetch translations
-      # Note: The environment variable points to tillh's Lokalize username and token.
       - name: Run build script
         run: cd scripts && ./localize.sh
         shell: bash
         env:
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
 
+      # Create timestamp
+      - name: Get timestamp
+        id: timestamp
+        run: echo "TIMESTAMP=$(date +'%Y%m%d-%H%M%S')" >> $GITHUB_OUTPUT
+
       # Create the pull request
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
           commit-message: Fetch latest Lokalize translations
-          title: Fetch latest Lokalize translations
-          body: This pull request automatically fetched the latest translations from Lokalize.
-          branch: update-translations-${{ steps.date.outputs.date }}
+          title: Update translations
+          body: This pull request contains the latest translations from Lokalize.
+          branch: update-translations-${{ steps.timestamp.outputs.TIMESTAMP }}
           base: master

--- a/scripts/localize.sh
+++ b/scripts/localize.sh
@@ -45,7 +45,6 @@ echo "DOWNLOADING LANGUAGES: ${LANGUAGES}"
 for MODULE in ${MODULES[@]}
 do
     echo ""
-    echo ""
     echo "----------------------------------------------------------"
     echo "DOWNLOADING STRINGS in $MODULE MODULE: $MODULE/strings.xml"
     echo "----------------------------------------------------------"

--- a/scripts/localize.sh
+++ b/scripts/localize.sh
@@ -37,17 +37,10 @@ FINAL_STATUS_ID=587
 
 rm -rf android/*
 
-echo "AVAILABLE LANGUAGES: "
-lokalise2 --token $API_TOKEN --project-id $PROJECT_ID language list | grep iso
-
-echo "DOWNLOADING LANGUAGES: ${LANGUAGES}"
-
 for MODULE in ${MODULES[@]}
 do
     echo ""
-    echo "----------------------------------------------------------"
-    echo "DOWNLOADING STRINGS in $MODULE MODULE: $MODULE/strings.xml"
-    echo "----------------------------------------------------------"
+    echo "Downloading strings for $MODULE/strings.xml"
     lokalise2 --token $API_TOKEN \
           --project-id $PROJECT_ID \
           file download \
@@ -87,11 +80,6 @@ do
 
     # Copy in the new strings files
     cp -R  android/$MODULE/* ../$MODULE/res/
-
-    echo ""
-    echo "TRANSLATED STRINGS (country codes): "
-    echo "----------------------------------------------------------"
-    ls -1 android/$MODULE/ | paste -sd "," - | sed 's/[,]*values[-]*//g'
 done
 
 rm -rf android/*


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds a new GitHub Action that automatically fetches new translations from Lokalize. The script will run on Monday morning before our typical release time.

Here’s an example from running this action earlier today after adding a new test key (creatively named `till_test_key`) to Lokalize: https://github.com/stripe/stripe-android/pull/6634

With this change, we should change where we define strings during development. Instead of putting them in `totranslate.xml`, we should just add them to `strings.xml` so that Lokalize will be able to pick them up.

To finish off, I also cleaned up the output of `localize.sh` 💅

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

No more need to manually do this.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
