### PR TITLE
[FC] Maestro Networking tests in CI

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -5,8 +5,8 @@ project_type: android
 trigger_map:
   - push_branch: 'master'
     pipeline: main-trigger-pipeline
-  - pull_request_source_branch: '*'
-    pipeline: main-trigger-pipeline
+  - pull_request_source_branch: 'carlosmuvi/maestro-networking-tests'
+    workflow: maestro-financial-connections
 app:
   envs:
     - GRADLE_OPTS: -Dkotlin.incremental=false
@@ -63,28 +63,28 @@ workflows:
           inputs:
             - webhook_url: $WEBHOOK_SLACK_CARLOSMUVI_MAESTRO
             - webhook_url_on_error: $WEBHOOK_SLACK_CARLOSMUVI_MAESTRO
-      - script@1:
-          title: Notify failure endpoint
-          inputs:
-            - content: |
-                #!/usr/bin/env bash
-                set -e
-                set -o pipefail
-                set -x
-                
-                ruby ./scripts/notify_failure_endpoint.rb \
-                $SDK_FAILURE_NOTIFICATION_ENDPOINT \
-                $SDK_FAILURE_NOTIFICATION_ENDPOINT_HMAC_KEY \
-                $BITRISE_BUILD_URL \
-                RUN_BANKCON_MOBILE
-          is_always_run: true
-          run_if: ".IsBuildFailed"
-      - pagerduty@0:
-          inputs:
-            - event_description: Android E2E tests failing! $BITRISE_BUILD_URL.
-            - integration_key: $AUX_PAGERDUTY_INTEGRATION_KEY
-          is_always_run: true
-          run_if: .IsBuildFailed
+#      - script@1:
+#          title: Notify failure endpoint
+#          inputs:
+#            - content: |
+#                #!/usr/bin/env bash
+#                set -e
+#                set -o pipefail
+#                set -x
+#
+#                ruby ./scripts/notify_failure_endpoint.rb \
+#                $SDK_FAILURE_NOTIFICATION_ENDPOINT \
+#                $SDK_FAILURE_NOTIFICATION_ENDPOINT_HMAC_KEY \
+#                $BITRISE_BUILD_URL \
+#                RUN_BANKCON_MOBILE
+#          is_always_run: true
+#          run_if: ".IsBuildFailed"
+#      - pagerduty@0:
+#          inputs:
+#            - event_description: Android E2E tests failing! $BITRISE_BUILD_URL.
+#            - integration_key: $AUX_PAGERDUTY_INTEGRATION_KEY
+#          is_always_run: true
+#          run_if: .IsBuildFailed
       - custom-test-results-export@0:
           inputs:
             - search_pattern: '*/maestroReport.xml'

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -52,7 +52,9 @@ workflows:
     after_run:
       - conclude_all
     steps:
-      - avd-manager@1: { }
+      - avd-manager@1:
+          inputs:
+            - profile: "Pixel 3a"
       - wait-for-android-emulator@1: { }
       - script-runner@0:
           title: Execute Maestro tests
@@ -63,28 +65,28 @@ workflows:
           inputs:
             - webhook_url: $WEBHOOK_SLACK_CARLOSMUVI_MAESTRO
             - webhook_url_on_error: $WEBHOOK_SLACK_CARLOSMUVI_MAESTRO
-#      - script@1:
-#          title: Notify failure endpoint
-#          inputs:
-#            - content: |
-#                #!/usr/bin/env bash
-#                set -e
-#                set -o pipefail
-#                set -x
-#
-#                ruby ./scripts/notify_failure_endpoint.rb \
-#                $SDK_FAILURE_NOTIFICATION_ENDPOINT \
-#                $SDK_FAILURE_NOTIFICATION_ENDPOINT_HMAC_KEY \
-#                $BITRISE_BUILD_URL \
-#                RUN_BANKCON_MOBILE
-#          is_always_run: true
-#          run_if: ".IsBuildFailed"
-#      - pagerduty@0:
-#          inputs:
-#            - event_description: Android E2E tests failing! $BITRISE_BUILD_URL.
-#            - integration_key: $AUX_PAGERDUTY_INTEGRATION_KEY
-#          is_always_run: true
-#          run_if: .IsBuildFailed
+      #      - script@1:
+      #          title: Notify failure endpoint
+      #          inputs:
+      #            - content: |
+      #                #!/usr/bin/env bash
+      #                set -e
+      #                set -o pipefail
+      #                set -x
+      #
+      #                ruby ./scripts/notify_failure_endpoint.rb \
+      #                $SDK_FAILURE_NOTIFICATION_ENDPOINT \
+      #                $SDK_FAILURE_NOTIFICATION_ENDPOINT_HMAC_KEY \
+      #                $BITRISE_BUILD_URL \
+      #                RUN_BANKCON_MOBILE
+      #          is_always_run: true
+      #          run_if: ".IsBuildFailed"
+      #      - pagerduty@0:
+      #          inputs:
+      #            - event_description: Android E2E tests failing! $BITRISE_BUILD_URL.
+      #            - integration_key: $AUX_PAGERDUTY_INTEGRATION_KEY
+      #          is_always_run: true
+      #          run_if: .IsBuildFailed
       - custom-test-results-export@0:
           inputs:
             - search_pattern: '*/maestroReport.xml'

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -54,7 +54,7 @@ workflows:
     steps:
       - avd-manager@1:
           inputs:
-            - profile: "Pixel 3"
+            - profile: "pixel_3a"
       - wait-for-android-emulator@1: { }
       - script-runner@0:
           title: Execute Maestro tests

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -5,8 +5,8 @@ project_type: android
 trigger_map:
   - push_branch: 'master'
     pipeline: main-trigger-pipeline
-  - pull_request_source_branch: 'carlosmuvi/maestro-networking-tests'
-    workflow: maestro-financial-connections
+  - pull_request_source_branch: '*'
+    pipeline: main-trigger-pipeline
 app:
   envs:
     - GRADLE_OPTS: -Dkotlin.incremental=false
@@ -65,28 +65,28 @@ workflows:
           inputs:
             - webhook_url: $WEBHOOK_SLACK_CARLOSMUVI_MAESTRO
             - webhook_url_on_error: $WEBHOOK_SLACK_CARLOSMUVI_MAESTRO
-      #      - script@1:
-      #          title: Notify failure endpoint
-      #          inputs:
-      #            - content: |
-      #                #!/usr/bin/env bash
-      #                set -e
-      #                set -o pipefail
-      #                set -x
-      #
-      #                ruby ./scripts/notify_failure_endpoint.rb \
-      #                $SDK_FAILURE_NOTIFICATION_ENDPOINT \
-      #                $SDK_FAILURE_NOTIFICATION_ENDPOINT_HMAC_KEY \
-      #                $BITRISE_BUILD_URL \
-      #                RUN_BANKCON_MOBILE
-      #          is_always_run: true
-      #          run_if: ".IsBuildFailed"
-      #      - pagerduty@0:
-      #          inputs:
-      #            - event_description: Android E2E tests failing! $BITRISE_BUILD_URL.
-      #            - integration_key: $AUX_PAGERDUTY_INTEGRATION_KEY
-      #          is_always_run: true
-      #          run_if: .IsBuildFailed
+      - script@1:
+          title: Notify failure endpoint
+          inputs:
+            - content: |
+                #!/usr/bin/env bash
+                set -e
+                set -o pipefail
+                set -x
+                
+                ruby ./scripts/notify_failure_endpoint.rb \
+                $SDK_FAILURE_NOTIFICATION_ENDPOINT \
+                $SDK_FAILURE_NOTIFICATION_ENDPOINT_HMAC_KEY \
+                $BITRISE_BUILD_URL \
+                RUN_BANKCON_MOBILE
+          is_always_run: true
+          run_if: ".IsBuildFailed"
+      - pagerduty@0:
+          inputs:
+            - event_description: Android E2E tests failing! $BITRISE_BUILD_URL.
+            - integration_key: $AUX_PAGERDUTY_INTEGRATION_KEY
+          is_always_run: true
+          run_if: .IsBuildFailed
       - custom-test-results-export@0:
           inputs:
             - search_pattern: '*/maestroReport.xml'

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -54,7 +54,7 @@ workflows:
     steps:
       - avd-manager@1:
           inputs:
-            - profile: "Pixel 3a"
+            - profile: "Pixel 3"
       - wait-for-android-emulator@1: { }
       - script-runner@0:
           title: Execute Maestro tests

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
@@ -235,7 +235,6 @@ enum class Merchant(val flow: String) {
     Live("mx"),
     App2App("app2app"),
     Networking("networking"),
-    Strash("strash"),
     NetworkingTestMode("networking_testmode"),
     Other("other")
 }

--- a/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
+++ b/financial-connections-example/src/main/java/com/stripe/android/financialconnections/example/FinancialConnectionsPlaygroundViewModel.kt
@@ -235,6 +235,7 @@ enum class Merchant(val flow: String) {
     Live("mx"),
     App2App("app2app"),
     Networking("networking"),
+    Strash("strash"),
     NetworkingTestMode("networking_testmode"),
     Other("other")
 }

--- a/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
+++ b/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
@@ -38,7 +38,9 @@ appId: com.stripe.android.financialconnections.example
     timeout: 60000
 - tapOn: "Select all accounts" # select all accounts
 - tapOn: "Link accounts"
+  retryTapIfNoChange: false
 # CONFIRM AND COMPLETE
 - assertVisible: "Link another account"
 - tapOn: "Done"
 - assertVisible: ".*Completed!.*"
+- assertVisible: ".*StripeBank.*"

--- a/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
+++ b/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
@@ -37,8 +37,9 @@ appId: com.stripe.android.financialconnections.example
     visible: "Select all accounts"
     timeout: 60000
 - tapOn: "Select all accounts" # select all accounts
-- tapOn: "Link accounts"
-  retryTapIfNoChange: false
+- tapOn:
+    text: "Link accounts"
+    retryTapIfNoChange: false
 # CONFIRM AND COMPLETE
 - assertVisible: "Link another account"
 - tapOn: "Done"

--- a/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
+++ b/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
@@ -42,4 +42,3 @@ appId: com.stripe.android.financialconnections.example
 - assertVisible: "Link another account"
 - tapOn: "Done"
 - assertVisible: ".*Completed!.*"
-- assertVisible: ".*StripeBank.*"

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-Networking.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-Networking.yaml
@@ -40,9 +40,9 @@ appId: com.stripe.android.financialconnections.example
 - tapOn: "Success"
 - tapOn: "Link Account"
 # ENTER PHONE FOR NEW NETWORKED USER
+- hideKeyboard
 - tapOn: "Phone number"
 - inputText: "6223115555"
-- hideKeyboard
 - tapOn: "Save to Link"
 # CONFIRM AND COMPLETE
 - assertVisible: "Success!"

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-Networking.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-Networking.yaml
@@ -40,7 +40,6 @@ appId: com.stripe.android.financialconnections.example
 - tapOn: "Success"
 - tapOn: "Link Account"
 # ENTER PHONE FOR NEW NETWORKED USER
-- hideKeyboard
 - tapOn: "Phone number"
 - inputText: "6223115555"
 - tapOn: "Save to Link"

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-Networking.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution-Networking.yaml
@@ -40,7 +40,7 @@ appId: com.stripe.android.financialconnections.example
 - tapOn: "Success"
 - tapOn: "Link Account"
 # ENTER PHONE FOR NEW NETWORKED USER
-- tapOn: "Phone number"
+- waitForAnimationToEnd
 - inputText: "6223115555"
 - tapOn: "Save to Link"
 # CONFIRM AND COMPLETE

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
@@ -13,11 +13,11 @@ appId: com.stripe.android.financialconnections.example
 - tapOn: "Connect Accounts!"
 # Common: web AuthFlow - connect OAuth institution
 - extendedWaitUntil:
-      visible:
-          id: "consent_cta"
-      timeout: 30000
-- tapOn:
+    visible:
       id: "consent_cta"
+    timeout: 30000
+- tapOn:
+    id: "consent_cta"
 # SELECT LEGACY INSTITUTION
 - tapOn: "Test Institution"
 ####### Bypass Chrome on-boarding screen #######
@@ -29,8 +29,9 @@ appId: com.stripe.android.financialconnections.example
     visible: "Success"
     timeout: 60000
 - tapOn: "Success" # select all accounts
-- tapOn: "Link account"
-  retryTapIfNoChange: false
+- tapOn:
+    text: "Link account"
+    retryTapIfNoChange: false
 # CONFIRM AND COMPLETE
 - tapOn: "Done"
 - assertVisible: ".*Intent Confirmed!.*"

--- a/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
+++ b/maestro/financial-connections/Testmode-PaymentIntent-TestInstitution.yaml
@@ -30,6 +30,7 @@ appId: com.stripe.android.financialconnections.example
     timeout: 60000
 - tapOn: "Success" # select all accounts
 - tapOn: "Link account"
+  retryTapIfNoChange: false
 # CONFIRM AND COMPLETE
 - tapOn: "Done"
 - assertVisible: ".*Intent Confirmed!.*"

--- a/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
+++ b/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
@@ -31,7 +31,8 @@ appId: com.stripe.android.financialconnections.example
 - tapOn:
     id: "ConfirmAccountInput"
 - inputText: "000123456789"
-- tapOn: "Continue"
-  retryTapIfNoChange: false
+- tapOn:
+    text: "Continue"
+    retryTapIfNoChange: false
 - tapOn: "Done"
 - assertVisible: ".*Completed!.*"

--- a/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
+++ b/maestro/financial-connections/Testmode-Token-ManualEntry.yaml
@@ -4,12 +4,12 @@ appId: com.stripe.android.financialconnections.example
 # Android specific: Navigate to example
 - tapOn: "Playground"
 - tapOn:
-      id: "Native_checkbox"
+    id: "Native_checkbox"
 - tapOn: "Mode_Dropdown_Icon"
 - tapOn:
-      id: "Test_checkbox"
+    id: "Test_checkbox"
 - tapOn:
-      id: "Token_checkbox"
+    id: "Token_checkbox"
 - tapOn: "Connect Accounts!"
 # Common: web AuthFlow - connect OAuth institution
 - extendedWaitUntil:
@@ -32,5 +32,6 @@ appId: com.stripe.android.financialconnections.example
     id: "ConfirmAccountInput"
 - inputText: "000123456789"
 - tapOn: "Continue"
+  retryTapIfNoChange: false
 - tapOn: "Done"
 - assertVisible: ".*Completed!.*"


### PR DESCRIPTION
# Summary
New introduced tests in CI required some changes:
- Use a larger device for the playground activity to fit all content
- Wait for phone number display animation to finish to start typing
- Prevent double clicks on buttons that have no feedback (see https://maestro.mobile.dev/troubleshooting/known-issues#android-accidental-double-tap)
