### PR TITLE
Re-enable `CoroutineCreationDuringComposition` and `UnrememberedMutableState`

### DIFF
--- a/build-configuration/android-library.gradle
+++ b/build-configuration/android-library.gradle
@@ -51,7 +51,6 @@ android {
 
     lint {
         enable 'Interoperability'
-        disable 'CoroutineCreationDuringComposition'
         lintConfig file('../settings/lint.xml')
     }
 

--- a/payments-ui-core/build.gradle
+++ b/payments-ui-core/build.gradle
@@ -78,9 +78,6 @@ android {
     composeOptions {
         kotlinCompilerExtensionVersion "${versions.androidxComposeCompiler}"
     }
-    lint {
-        disable 'UnrememberedMutableState'
-    }
 
     kotlinOptions {
         freeCompilerArgs += ["-opt-in=kotlinx.coroutines.FlowPreview", "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"]

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -125,9 +125,6 @@ android {
     composeOptions {
         kotlinCompilerExtensionVersion "${versions.androidxComposeCompiler}"
     }
-    lint {
-        disable 'UnrememberedMutableState'
-    }
 
     kotlinOptions {
         freeCompilerArgs += ["-opt-in=kotlinx.coroutines.FlowPreview"]

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -39,11 +39,7 @@ internal fun AddPaymentMethod(
     val showCheckboxFlow = remember { MutableStateFlow(false) }
 
     val processing by sheetViewModel.processing.collectAsState(false)
-
-    val linkConfig by linkHandler.linkConfiguration.collectAsState()
-    val linkAccountStatus by linkConfig?.let {
-        linkHandler.linkLauncher.getAccountStatusFlow(it).collectAsState(null)
-    } ?: mutableStateOf(null)
+    val linkAccountStatus by linkHandler.accountStatus.collectAsState(initial = null)
 
     var selectedPaymentMethodCode: String by rememberSaveable {
         mutableStateOf(sheetViewModel.initiallySelectedPaymentMethodType)

--- a/stripecardscan/build.gradle
+++ b/stripecardscan/build.gradle
@@ -55,9 +55,6 @@ android {
             pickFirsts += ['META-INF/AL2.0', 'META-INF/LGPL2.1']
         }
     }
-    lint {
-        disable 'UnrememberedMutableState'
-    }
 }
 
 ext {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request re-enables two lint checks that have been disabled: `CoroutineCreationDuringComposition` and `UnrememberedMutableState`.

As a consequence, it also updates how we expose the account status from `LinkHandler`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
