### PR TITLE
Add build flags to match AGP 8 defaults.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,8 +11,11 @@ POM_DEVELOPER_ID=stripe
 POM_DEVELOPER_NAME=Stripe
 POM_DEVELOPER_EMAIL=support+android@stripe.com
 
+android.defaults.buildfeatures.buildconfig=true
+android.disableAutomaticComponentCreation=true
 android.enableJetifier=false
 android.enableR8.fullMode=true
+android.nonFinalResIds=false
 android.nonTransitiveRClass=true
 android.useAndroidX=true
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Update build flags (compatible with AGP 7) to AGP 8 defaults. This is an iterative change in preparation of AGP 8.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Prepare for AGP 8

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified
