### PR TITLE
Remove style clobbering in cardscan.

### DIFF
--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
@@ -4,6 +4,7 @@ import androidx.appcompat.view.ContextThemeWrapper
 import androidx.lifecycle.asLiveData
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.stripecardscan.R
 import com.stripe.android.uicore.elements.FieldError
 import com.stripe.android.utils.TestUtils.idleLooper
 import org.junit.Test
@@ -16,7 +17,7 @@ import com.stripe.android.uicore.R as UiCoreR
 class CardDetailsControllerTest {
 
     private val context =
-        ContextThemeWrapper(ApplicationProvider.getApplicationContext(), StripeR.style.StripeDefaultTheme)
+        ContextThemeWrapper(ApplicationProvider.getApplicationContext(), R.style.StripeCardScanDefaultTheme)
 
     @Test
     fun `Verify the first field in error is returned in error flow`() {

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsElementTest.kt
@@ -5,19 +5,19 @@ import androidx.test.core.app.ApplicationProvider
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.CardBrand
+import com.stripe.android.stripecardscan.R
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.forms.FormFieldEntry
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import com.stripe.android.R as StripeR
 
 @RunWith(RobolectricTestRunner::class)
 class CardDetailsElementTest {
 
     private val context =
-        ContextThemeWrapper(ApplicationProvider.getApplicationContext(), StripeR.style.StripeDefaultTheme)
+        ContextThemeWrapper(ApplicationProvider.getApplicationContext(), R.style.StripeCardScanDefaultTheme)
 
     @Test
     fun `test form field values returned and expiration date parsing`() = runTest {

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/TransformSpecToElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/TransformSpecToElementTest.kt
@@ -41,15 +41,15 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
-import com.stripe.android.R as StripeR
 import com.stripe.android.core.R as CoreR
+import com.stripe.android.stripecardscan.R as CardScanR
 
 @RunWith(RobolectricTestRunner::class)
 internal class TransformSpecToElementTest {
 
     private val context = ContextThemeWrapper(
         ApplicationProvider.getApplicationContext(),
-        StripeR.style.StripeDefaultTheme
+        CardScanR.style.StripeCardScanDefaultTheme
     )
 
     private val nameSection = NameSpec()

--- a/stripecardscan/res/values/styles.xml
+++ b/stripecardscan/res/values/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="StripeBaseTheme" parent="@style/Theme.AppCompat.Light.NoActionBar">
+    <style name="StripeCardScanBaseTheme" parent="@style/Theme.AppCompat.Light.NoActionBar">
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowActionBar">false</item>
         <item name="android:windowFullscreen">true</item>
@@ -9,7 +9,7 @@
     </style>
 
     <!-- Base application theme. -->
-    <style name="StripeDefaultTheme" parent="StripeBaseTheme">
+    <style name="StripeCardScanDefaultTheme" parent="StripeCardScanBaseTheme">
         <item name="background">@color/stripeNotFoundBackground</item>
 
         <item name="stripeNotFoundBackgroundColor">@color/stripeNotFoundBackground</item>

--- a/stripecardscan/src/main/AndroidManifest.xml
+++ b/stripecardscan/src/main/AndroidManifest.xml
@@ -13,11 +13,11 @@
         <activity
             android:name=".cardimageverification.CardImageVerificationActivity"
             android:screenOrientation="nosensor"
-            android:theme="@style/StripeDefaultTheme" />
+            android:theme="@style/StripeCardScanDefaultTheme" />
 
         <activity
             android:name=".cardscan.CardScanActivity"
             android:screenOrientation="nosensor"
-            android:theme="@style/StripeDefaultTheme" />
+            android:theme="@style/StripeCardScanDefaultTheme" />
     </application>
 </manifest>


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Cardscan wanted its own unique style, not to override those used in payments.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
conductor-onset incident

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

