### PR TITLE
Add polling for Cash App Pay flow result processing

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/StripeIntentKtx.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/StripeIntentKtx.kt
@@ -1,24 +1,21 @@
 package com.stripe.android.model
 
 import com.stripe.android.StripePaymentController
-import com.stripe.android.model.PaymentMethod.Type.CashAppPay
-import com.stripe.android.model.PaymentMethod.Type.WeChatPay
 
 fun StripeIntent.getRequestCode() = StripePaymentController.getRequestCode(this)
 
 /**
  * Check if this [StripeIntent] needs to be refreshed until it moves out "requires_action" state.
  */
-internal fun StripeIntent.shouldRefresh(): Boolean {
-    return requiresAction() && paymentMethod?.type in refreshablePaymentMethods
-}
+internal fun StripeIntent.shouldRefresh() =
+    this is PaymentIntent &&
+        REFRESHABLE_PAYMENT_METHODS.contains(this.paymentMethod?.type) &&
+        this.requiresAction()
 
 /**
- * A set of PMs that don't transfer the intent status immediately after confirmation. Needs to poll
- * the refresh endpoint until the intent status transfers out of "requires_action".
+ * A set of PMs that don't transfer the PI status immediately after confirmation, needs to poll
+ * the refresh endpoint until the PI status transfers out of "requires_action".
  */
-private val StripeIntent.refreshablePaymentMethods: Set<PaymentMethod.Type>
-    get() = when (this) {
-        is PaymentIntent -> setOf(WeChatPay, CashAppPay)
-        is SetupIntent -> setOf(CashAppPay)
-    }
+internal val REFRESHABLE_PAYMENT_METHODS = setOf(
+    PaymentMethod.Type.WeChatPay
+)

--- a/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
@@ -363,7 +363,7 @@ internal class PaymentIntentFlowResultProcessorTest {
             val result = processor.processResult(
                 PaymentFlowResult.Unvalidated(
                     clientSecret = clientSecret,
-                    flowOutcome = StripeIntentResult.Outcome.SUCCEEDED,
+                    flowOutcome = StripeIntentResult.Outcome.UNKNOWN,
                 )
             ).getOrThrow()
 

--- a/payments-core/src/test/java/com/stripe/android/payments/SetupIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/SetupIntentFlowResultProcessorTest.kt
@@ -198,7 +198,7 @@ internal class SetupIntentFlowResultProcessorTest {
             val result = processor.processResult(
                 PaymentFlowResult.Unvalidated(
                     clientSecret = clientSecret,
-                    flowOutcome = StripeIntentResult.Outcome.SUCCEEDED,
+                    flowOutcome = StripeIntentResult.Outcome.UNKNOWN,
                 )
             ).getOrThrow()
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds polling for Cash App Pay payments in the `PaymentFlowResultProcessor` to adapt to [the backend changes](https://git.corp.stripe.com/stripe-internal/pay-server/pull/620649).

(cc @porter-stripe)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

More resilient Cash App Pay payments.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
