### PR TITLE
Provide entire `PaymentMethod` in `CreateIntentCallback`

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/CreateIntentCallback.kt
+++ b/payments-core/src/main/java/com/stripe/android/CreateIntentCallback.kt
@@ -21,10 +21,9 @@ fun interface CreateIntentCallback : AbsCreateIntentCallback {
      * Your implementation should create a [PaymentIntent] or [SetupIntent] on your server and
      * return its client secret or an error if one occurred.
      *
-     * @param paymentMethodId The ID of the [PaymentMethod] representing the customer's payment
-     * details
+     * @param paymentMethod The [PaymentMethod] representing the customer's payment details
      */
-    suspend fun onCreateIntent(paymentMethodId: String): CreateIntentResult
+    suspend fun onCreateIntent(paymentMethod: PaymentMethod): CreateIntentResult
 }
 
 /**
@@ -57,14 +56,13 @@ fun interface CreateIntentCallbackForServerSideConfirmation : AbsCreateIntentCal
      * Your implementation should create and confirm a [PaymentIntent] or [SetupIntent] on your
      * server and return its client secret or an error if one occurred.
      *
-     * @param paymentMethodId The ID of the [PaymentMethod] representing the customer's payment
-     * details
+     * @param paymentMethod The [PaymentMethod] representing the customer's payment details
      * @param shouldSavePaymentMethod This is `true` if the customer selected the
      * "Save this payment method for future use" checkbox. Set `setup_future_usage` on the
      * [PaymentIntent] to `off_session` if this is `true`.
      */
     suspend fun onCreateIntent(
-        paymentMethodId: String,
+        paymentMethod: PaymentMethod,
         shouldSavePaymentMethod: Boolean,
     ): CreateIntentResult
 }

--- a/payments-core/src/main/java/com/stripe/android/IntentConfirmationInterceptor.kt
+++ b/payments-core/src/main/java/com/stripe/android/IntentConfirmationInterceptor.kt
@@ -165,9 +165,7 @@ class DefaultIntentConfirmationInterceptor @Inject constructor(
         paymentMethod: PaymentMethod,
         shippingValues: ConfirmPaymentIntentParams.Shipping?
     ): IntentConfirmationInterceptor.NextStep {
-        return when (
-            val result = createIntentCallback.onCreateIntent(paymentMethodId = paymentMethod.id!!)
-        ) {
+        return when (val result = createIntentCallback.onCreateIntent(paymentMethod)) {
             is CreateIntentResult.Success -> {
                 createConfirmStep(result.clientSecret, shippingValues, paymentMethod)
             }
@@ -187,8 +185,8 @@ class DefaultIntentConfirmationInterceptor @Inject constructor(
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
     ): IntentConfirmationInterceptor.NextStep {
         val result = createIntentCallback.onCreateIntent(
-            paymentMethodId = paymentMethod.id!!,
-            shouldSavePaymentMethod = shouldSavePaymentMethod
+            paymentMethod = paymentMethod,
+            shouldSavePaymentMethod = shouldSavePaymentMethod,
         )
 
         return when (result) {

--- a/payments-core/src/test/java/com/stripe/android/DefaultIntentConfirmationInterceptorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/DefaultIntentConfirmationInterceptorTest.kt
@@ -174,6 +174,8 @@ class DefaultIntentConfirmationInterceptorTest {
 
     @Test
     fun `Fails if retrieving intent did not succeed`() = runTest {
+        val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+
         val apiException = APIException(
             requestId = "req_123",
             statusCode = 500,
@@ -195,7 +197,7 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeAccountIdProvider = { null },
         )
 
-        IntentConfirmationInterceptor.createIntentCallback = succeedingServerSideCallback("pm_123456789")
+        IntentConfirmationInterceptor.createIntentCallback = succeedingServerSideCallback(paymentMethod)
 
         val nextStep = interceptor.intercept(
             clientSecret = null,
@@ -323,7 +325,6 @@ class DefaultIntentConfirmationInterceptorTest {
     @Test
     fun `Returns confirm as next step after creating an unconfirmed intent`() = runTest {
         val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
-        val expectedPaymentMethodId = requireNotNull(paymentMethod.id)
 
         val interceptor = DefaultIntentConfirmationInterceptor(
             context = context,
@@ -332,7 +333,7 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeAccountIdProvider = { null },
         )
 
-        IntentConfirmationInterceptor.createIntentCallback = succeedingClientSideCallback(expectedPaymentMethodId)
+        IntentConfirmationInterceptor.createIntentCallback = succeedingClientSideCallback(paymentMethod)
 
         val nextStep = interceptor.intercept(
             clientSecret = null,
@@ -347,7 +348,6 @@ class DefaultIntentConfirmationInterceptorTest {
     @Test
     fun `Returns complete as next step after creating and confirming a succeeded intent`() = runTest {
         val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
-        val expectedPaymentMethodId = requireNotNull(paymentMethod.id)
 
         val interceptor = DefaultIntentConfirmationInterceptor(
             context = context,
@@ -364,7 +364,7 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeAccountIdProvider = { null },
         )
 
-        IntentConfirmationInterceptor.createIntentCallback = succeedingServerSideCallback(expectedPaymentMethodId)
+        IntentConfirmationInterceptor.createIntentCallback = succeedingServerSideCallback(paymentMethod)
 
         val nextStep = interceptor.intercept(
             clientSecret = null,
@@ -381,7 +381,6 @@ class DefaultIntentConfirmationInterceptorTest {
     @Test
     fun `Returns handleNextAction as next step after creating and confirming a non-succeeded intent`() = runTest {
         val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
-        val expectedPaymentMethodId = requireNotNull(paymentMethod.id)
 
         val interceptor = DefaultIntentConfirmationInterceptor(
             context = context,
@@ -400,7 +399,7 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeAccountIdProvider = { null },
         )
 
-        IntentConfirmationInterceptor.createIntentCallback = succeedingServerSideCallback(expectedPaymentMethodId)
+        IntentConfirmationInterceptor.createIntentCallback = succeedingServerSideCallback(paymentMethod)
 
         val nextStep = interceptor.intercept(
             clientSecret = null,
@@ -459,19 +458,19 @@ class DefaultIntentConfirmationInterceptorTest {
     }
 
     private fun succeedingClientSideCallback(
-        expectedPaymentMethodId: String,
+        expectedPaymentMethod: PaymentMethod,
     ): CreateIntentCallback {
-        return CreateIntentCallback { paymentMethodId ->
-            assertThat(paymentMethodId).isEqualTo(expectedPaymentMethodId)
+        return CreateIntentCallback { paymentMethod ->
+            assertThat(paymentMethod).isEqualTo(expectedPaymentMethod)
             CreateIntentResult.Success(clientSecret = "pi_123_secret_456")
         }
     }
 
     private fun succeedingServerSideCallback(
-        expectedPaymentMethodId: String,
+        expectedPaymentMethod: PaymentMethod,
     ): CreateIntentCallbackForServerSideConfirmation {
-        return CreateIntentCallbackForServerSideConfirmation { paymentMethodId, _ ->
-            assertThat(paymentMethodId).isEqualTo(expectedPaymentMethodId)
+        return CreateIntentCallbackForServerSideConfirmation { paymentMethod, _ ->
+            assertThat(paymentMethod).isEqualTo(expectedPaymentMethod)
             CreateIntentResult.Success(clientSecret = "pi_123_secret_456")
         }
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/activity/PaymentSheetPlaygroundActivity.kt
@@ -203,9 +203,9 @@ class PaymentSheetPlaygroundActivity : AppCompatActivity() {
 
         paymentSheet = PaymentSheet(
             activity = this,
-            createIntentCallback = { paymentMethodId ->
+            createIntentCallback = { paymentMethod ->
                 viewModel.createIntent(
-                    paymentMethodId = paymentMethodId,
+                    paymentMethodId = paymentMethod.id!!,
                     merchantCountryCode = merchantCountryCode.value,
                     mode = mode.value,
                     returnUrl = returnUrl,
@@ -218,9 +218,9 @@ class PaymentSheetPlaygroundActivity : AppCompatActivity() {
         flowController = PaymentSheet.FlowController.create(
             activity = this,
             paymentOptionCallback = ::onPaymentOption,
-            createIntentCallbackForServerSideConfirmation = { paymentMethodId, shouldSavePaymentMethod ->
+            createIntentCallbackForServerSideConfirmation = { paymentMethod, shouldSavePaymentMethod ->
                 viewModel.createAndConfirmIntent(
-                    paymentMethodId = paymentMethodId,
+                    paymentMethodId = paymentMethod.id!!,
                     shouldSavePaymentMethod = shouldSavePaymentMethod,
                     merchantCountryCode = merchantCountryCode.value,
                     mode = mode.value,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/complete_flow/ServerSideConfirmationCompleteFlowViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/complete_flow/ServerSideConfirmationCompleteFlowViewModel.kt
@@ -9,6 +9,7 @@ import com.github.kittinunf.fuel.core.requests.suspendable
 import com.stripe.android.CreateIntentResult
 import com.stripe.android.ExperimentalPaymentSheetDecouplingApi
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheetResult
 import com.stripe.android.paymentsheet.example.samples.model.CartProduct
 import com.stripe.android.paymentsheet.example.samples.model.CartState
@@ -69,11 +70,11 @@ internal class ServerSideConfirmationCompleteFlowViewModel(
 
     @OptIn(ExperimentalPaymentSheetDecouplingApi::class)
     suspend fun createAndConfirmIntent(
-        paymentMethodId: String,
+        paymentMethod: PaymentMethod,
         shouldSavePaymentMethod: Boolean,
     ): CreateIntentResult = withContext(Dispatchers.IO) {
         val request = state.value.cartState.toCreateIntentRequest(
-            paymentMethodId = paymentMethodId,
+            paymentMethodId = paymentMethod.id!!,
             shouldSavePaymentMethod = shouldSavePaymentMethod,
             returnUrl = "stripesdk://payment_return_url/com.stripe.android.paymentsheet.example",
         )

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/custom_flow/ServerSideConfirmationCustomFlowViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/server_side_confirm/custom_flow/ServerSideConfirmationCustomFlowViewModel.kt
@@ -9,6 +9,7 @@ import com.github.kittinunf.fuel.core.requests.suspendable
 import com.stripe.android.CreateIntentResult
 import com.stripe.android.ExperimentalPaymentSheetDecouplingApi
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheetResult
 import com.stripe.android.paymentsheet.example.samples.model.CartProduct
 import com.stripe.android.paymentsheet.example.samples.model.CartState
@@ -91,11 +92,11 @@ internal class ServerSideConfirmationCustomFlowViewModel(
 
     @OptIn(ExperimentalPaymentSheetDecouplingApi::class)
     suspend fun createAndConfirmIntent(
-        paymentMethodId: String,
+        paymentMethod: PaymentMethod,
         shouldSavePaymentMethod: Boolean,
     ): CreateIntentResult = withContext(Dispatchers.IO) {
         val request = state.value.cartState.toCreateIntentRequest(
-            paymentMethodId = paymentMethodId,
+            paymentMethodId = paymentMethod.id!!,
             shouldSavePaymentMethod = shouldSavePaymentMethod,
             returnUrl = "stripesdk://payment_return_url/com.stripe.android.paymentsheet.example",
         )

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'app.cash.paparazzi'
 
 dependencies {
     implementation project(":link")
-    implementation project(":payments-core")
+    api project(":payments-core")
     implementation project(':payments-ui-core')
     implementation project(':stripe-ui-core')
     compileOnly project(':financial-connections')


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates `CreateIntentCallback` to expose the full `PaymentMethod` object instead of just the ID.

(cc @yuki-stripe @porter-stripe)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Beta feedback.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
