### PR TITLE
Keep overridden toString in stripe classes.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/model/Source.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/Source.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.model
 
+import androidx.annotation.Keep
 import androidx.annotation.StringDef
 import com.stripe.android.core.model.StripeModel
 import com.stripe.android.model.Source.Flow
@@ -188,6 +189,7 @@ data class Source internal constructor(
         Failed("failed"),
         Pending("pending");
 
+        @Keep
         override fun toString(): String = code
 
         internal companion object {
@@ -204,6 +206,7 @@ data class Source internal constructor(
         Reusable("reusable"),
         SingleUse("single_use");
 
+        @Keep
         override fun toString(): String = code
 
         internal companion object {
@@ -220,6 +223,7 @@ data class Source internal constructor(
         CodeVerification("code_verification"),
         None("none");
 
+        @Keep
         override fun toString(): String = code
 
         internal companion object {
@@ -260,6 +264,7 @@ data class Source internal constructor(
             NotRequired("not_required"),
             Failed("failed");
 
+            @Keep
             override fun toString(): String = code
 
             internal companion object {
@@ -294,6 +299,7 @@ data class Source internal constructor(
             Succeeded("succeeded"),
             Failed("failed");
 
+            @Keep
             override fun toString(): String = code
 
             internal companion object {

--- a/payments-core/src/main/java/com/stripe/android/model/SourceTypeModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/SourceTypeModel.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.model
 
+import androidx.annotation.Keep
 import com.stripe.android.core.model.StripeModel
 import kotlinx.parcelize.Parcelize
 
@@ -29,6 +30,7 @@ sealed class SourceTypeModel : StripeModel {
             Recommended("recommended"),
             Unknown("unknown");
 
+            @Keep
             override fun toString(): String = code
 
             internal companion object {

--- a/payments-core/src/main/java/com/stripe/android/model/StripeIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/StripeIntent.kt
@@ -2,6 +2,7 @@ package com.stripe.android.model
 
 import android.net.Uri
 import android.os.Parcelable
+import androidx.annotation.Keep
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeModel
 import com.stripe.android.utils.StripeUrlUtils
@@ -87,6 +88,7 @@ sealed interface StripeIntent : StripeModel {
         UpiAwaitNotification("upi_await_notification"),
         CashAppRedirect("cashapp_handle_redirect_or_display_qr_code");
 
+        @Keep
         override fun toString(): String {
             return code
         }
@@ -114,6 +116,7 @@ sealed interface StripeIntent : StripeModel {
         // only applies to Payment Intents
         RequiresCapture("requires_capture");
 
+        @Keep
         override fun toString(): String {
             return code
         }
@@ -143,6 +146,7 @@ sealed interface StripeIntent : StripeModel {
 
         OneTime("one_time");
 
+        @Keep
         override fun toString(): String {
             return code
         }

--- a/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsEvent.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsEvent.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.networking
 
+import androidx.annotation.Keep
 import com.stripe.android.core.networking.AnalyticsEvent
 
 internal enum class PaymentAnalyticsEvent(val code: String) : AnalyticsEvent {
@@ -97,6 +98,7 @@ internal enum class PaymentAnalyticsEvent(val code: String) : AnalyticsEvent {
     CardMetadataLoadFailure("card_metadata_load_failure"),
     CardMetadataMissingRange("card_metadata_missing_range");
 
+    @Keep
     override fun toString(): String {
         return "$PREFIX.$code"
     }

--- a/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsRequestFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsRequestFactory.kt
@@ -3,6 +3,7 @@ package com.stripe.android.networking
 import android.content.Context
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
+import androidx.annotation.Keep
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
@@ -239,6 +240,7 @@ class PaymentAnalyticsRequestFactory @VisibleForTesting internal constructor(
         Oob("04", "oob"),
         Html("05", "html");
 
+        @Keep
         override fun toString(): String = typeName
 
         companion object {

--- a/payments-model/src/main/java/com/stripe/android/model/BankAccount.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/BankAccount.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.model
 
+import androidx.annotation.Keep
 import androidx.annotation.RestrictTo
 import androidx.annotation.Size
 import com.stripe.android.core.model.StripeModel
@@ -105,6 +106,7 @@ constructor(
         Company("company"),
         Individual("individual");
 
+        @Keep
         override fun toString(): String = code
 
         internal companion object {
@@ -119,6 +121,7 @@ constructor(
         VerificationFailed("verification_failed"),
         Errored("errored");
 
+        @Keep
         override fun toString(): String = code
 
         internal companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.analytics
 
+import androidx.annotation.Keep
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 
@@ -60,6 +61,7 @@ internal interface EventReporter {
         Complete("complete"),
         Custom("custom");
 
+        @Keep
         override fun toString(): String = code
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.analytics
 
+import androidx.annotation.Keep
 import com.stripe.android.core.networking.AnalyticsEvent
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -196,6 +197,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
             Success("success"),
             Failure("failure");
 
+            @Keep
             override fun toString(): String = code
         }
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Keep custom toString methods in stripe SDKs.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
We recognized a behavior change in our analytics, but only sometimes! So some merchants are using proguard, and others aren't. One example -- the ones that are using proguard were getting `mc_complete_newpm_Success `, while merchants not using proguard were getting `mc_complete_newpm_success`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

