### PR TITLE
Add us_bank_account LPM filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## XX.XX.XX - 2023-XX-XX
 
 ### PaymentSheet
+* [CHANGED][6687](https://github.com/stripe/stripe-android/pull/6687) Show the US Bank Account payment method if the specified verification method is either automatic or instant. Otherwise, hide the payment method.
 * [FIXED][6736](https://github.com/stripe/stripe-android/pull/6736) Fixed an issue where Google Places caused errors with R8.
 
 ## 20.25.2 - 2023-05-15
@@ -22,9 +23,6 @@
 ### All SDKs
 * [CHANGED][6635](https://github.com/stripe/stripe-android/pull/6635) Use non transitive R classes.
 * [CHANGED][6676](https://github.com/stripe/stripe-android/pull/6676) Updated Compose BOM to 2023.05.00.
-
-### PaymentSheet
-* [CHANGED][6687](https://github.com/stripe/stripe-android/pull/6687) Show the US Bank Account payment method if the specified verification method is either automatic or instant, otherwise, hide the payment method.
 
 ### Identity
 * [ADDED][6642](https://github.com/stripe/stripe-android/pull/6642) Support Test mode M1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
 * [CHANGED][6635](https://github.com/stripe/stripe-android/pull/6635) Use non transitive R classes.
 * [CHANGED][6676](https://github.com/stripe/stripe-android/pull/6676) Updated Compose BOM to 2023.05.00.
 
+### PaymentSheet
+* [CHANGED][6687](https://github.com/stripe/stripe-android/pull/6687) Show the US Bank Account payment method if the specified verification method is either automatic or instant, otherwise, hide the payment method.
+
 ### Identity
 * [ADDED][6642](https://github.com/stripe/stripe-android/pull/6642) Support Test mode M1.
  

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -3157,7 +3157,7 @@ public final class com/stripe/android/model/PaymentIntent : com/stripe/android/m
 	public fun getNextActionType ()Lcom/stripe/android/model/StripeIntent$NextActionType;
 	public fun getPaymentMethod ()Lcom/stripe/android/model/PaymentMethod;
 	public fun getPaymentMethodId ()Ljava/lang/String;
-	public final fun getPaymentMethodOptions ()Ljava/util/Map;
+	public fun getPaymentMethodOptions ()Ljava/util/Map;
 	public fun getPaymentMethodTypes ()Ljava/util/List;
 	public final fun getReceiptEmail ()Ljava/lang/String;
 	public final fun getSetupFutureUsage ()Lcom/stripe/android/model/StripeIntent$Usage;
@@ -4860,8 +4860,8 @@ public final class com/stripe/android/model/SetupIntent : com/stripe/android/mod
 	public final fun component7 ()Z
 	public final fun component8 ()Lcom/stripe/android/model/PaymentMethod;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Lcom/stripe/android/model/SetupIntent$CancellationReason;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$Status;Lcom/stripe/android/model/StripeIntent$Usage;Lcom/stripe/android/model/SetupIntent$Error;Ljava/util/List;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$NextActionData;)Lcom/stripe/android/model/SetupIntent;
-	public static synthetic fun copy$default (Lcom/stripe/android/model/SetupIntent;Ljava/lang/String;Lcom/stripe/android/model/SetupIntent$CancellationReason;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$Status;Lcom/stripe/android/model/StripeIntent$Usage;Lcom/stripe/android/model/SetupIntent$Error;Ljava/util/List;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$NextActionData;ILjava/lang/Object;)Lcom/stripe/android/model/SetupIntent;
+	public final fun copy (Ljava/lang/String;Lcom/stripe/android/model/SetupIntent$CancellationReason;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$Status;Lcom/stripe/android/model/StripeIntent$Usage;Lcom/stripe/android/model/SetupIntent$Error;Ljava/util/List;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$NextActionData;Ljava/lang/String;)Lcom/stripe/android/model/SetupIntent;
+	public static synthetic fun copy$default (Lcom/stripe/android/model/SetupIntent;Ljava/lang/String;Lcom/stripe/android/model/SetupIntent$CancellationReason;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLcom/stripe/android/model/PaymentMethod;Ljava/lang/String;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$Status;Lcom/stripe/android/model/StripeIntent$Usage;Lcom/stripe/android/model/SetupIntent$Error;Ljava/util/List;Ljava/util/List;Lcom/stripe/android/model/StripeIntent$NextActionData;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/model/SetupIntent;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Lorg/json/JSONObject;)Lcom/stripe/android/model/SetupIntent;

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
@@ -152,11 +152,11 @@ constructor(
 
     override val nextActionData: StripeIntent.NextActionData? = null,
 
-    private val paymentMethodOptionsJsonString: String? = null
+    private val paymentMethodOptionsJsonString: String? = null,
 
 ) : StripeIntent {
 
-    fun getPaymentMethodOptions() = paymentMethodOptionsJsonString?.let {
+    override fun getPaymentMethodOptions() = paymentMethodOptionsJsonString?.let {
         StripeJsonUtils.jsonObjectToMap(JSONObject(it))
     } ?: emptyMap()
 

--- a/payments-core/src/main/java/com/stripe/android/model/SetupIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/SetupIntent.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.model.StripeJsonUtils
 import com.stripe.android.core.model.StripeModel
 import com.stripe.android.model.parsers.SetupIntentJsonParser
 import kotlinx.parcelize.Parcelize
@@ -103,8 +104,15 @@ data class SetupIntent internal constructor(
      */
     override val linkFundingSources: List<String>,
 
-    override val nextActionData: StripeIntent.NextActionData?
+    override val nextActionData: StripeIntent.NextActionData?,
+
+    private val paymentMethodOptionsJsonString: String? = null,
 ) : StripeIntent {
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    override fun getPaymentMethodOptions() = paymentMethodOptionsJsonString?.let {
+        StripeJsonUtils.jsonObjectToMap(JSONObject(it))
+    } ?: emptyMap()
 
     override val nextActionType: StripeIntent.NextActionType?
         get() = when (nextActionData) {

--- a/payments-core/src/main/java/com/stripe/android/model/StripeIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/StripeIntent.kt
@@ -74,6 +74,9 @@ sealed interface StripeIntent : StripeModel {
 
     fun requiresConfirmation(): Boolean
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun getPaymentMethodOptions(): Map<String, Any?>
+
     /**
      * Type of the next action to perform.
      */

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/SetupIntentJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/SetupIntentJsonParser.kt
@@ -30,6 +30,8 @@ class SetupIntentJsonParser : ModelJsonParser<SetupIntent> {
         val linkFundingSources = jsonArrayToList(json.optJSONArray(FIELD_LINK_FUNDING_SOURCES))
             .map { it.lowercase() }
 
+        val paymentMethodOptions = json.optJSONObject(FIELD_PAYMENT_METHOD_OPTIONS)?.toString()
+
         return SetupIntent(
             id = optString(json, FIELD_ID),
             created = json.optLong(FIELD_CREATED),
@@ -54,7 +56,8 @@ class SetupIntentJsonParser : ModelJsonParser<SetupIntent> {
             linkFundingSources = linkFundingSources,
             nextActionData = json.optJSONObject(FIELD_NEXT_ACTION)?.let {
                 NextActionDataParser().parse(it)
-            }
+            },
+            paymentMethodOptionsJsonString = paymentMethodOptions
         )
     }
 
@@ -104,5 +107,6 @@ class SetupIntentJsonParser : ModelJsonParser<SetupIntent> {
         private const val FIELD_UNACTIVATED_PAYMENT_METHOD_TYPES =
             "unactivated_payment_method_types"
         private const val FIELD_LINK_FUNDING_SOURCES = "link_funding_sources"
+        private const val FIELD_PAYMENT_METHOD_OPTIONS = "payment_method_options"
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentIntentTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentIntentTest.kt
@@ -274,4 +274,44 @@ class PaymentIntentTest {
         val result = paymentIntent.isSetupFutureUsageSet("card")
         assertThat(result).isFalse()
     }
+
+    @Test
+    fun `getPaymentMethodOptions returns expected results`() {
+        val paymentIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+            paymentMethodOptionsJsonString = """
+                {
+                    "card": {
+                        "mandate_options": null,
+                        "network": null,
+                        "request_three_d_secure": "automatic"
+                    },
+                    "us_bank_account": {
+                        "financial_connections": {
+                            "permissions": "balances"
+                        },
+                        "setup_future_usage": "on_session",
+                        "verification_method": "automatic"
+                    }
+                }
+            """.trimIndent()
+        )
+
+        assertThat(paymentIntent.getPaymentMethodOptions())
+            .isEqualTo(
+                mapOf(
+                    "card" to mapOf(
+                        "mandate_options" to null,
+                        "network" to null,
+                        "request_three_d_secure" to "automatic"
+                    ),
+                    "us_bank_account" to mapOf(
+                        "financial_connections" to mapOf(
+                            "permissions" to "balances"
+                        ),
+                        "setup_future_usage" to "on_session",
+                        "verification_method" to "automatic"
+                    )
+                )
+            )
+    }
 }

--- a/payments-core/src/test/java/com/stripe/android/model/SetupIntentTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/SetupIntentTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.model
 
 import android.net.Uri
+import com.google.common.truth.Truth.assertThat
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
@@ -152,5 +153,45 @@ class SetupIntentTest {
             "seti_a1b2c3_secret_x7y8z9",
             SetupIntent.ClientSecret("seti_a1b2c3_secret_x7y8z9").value
         )
+    }
+
+    @Test
+    fun `getPaymentMethodOptions returns expected results`() {
+        val setupIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD.copy(
+            paymentMethodOptionsJsonString = """
+                {
+                    "card": {
+                        "mandate_options": null,
+                        "network": null,
+                        "request_three_d_secure": "automatic"
+                    },
+                    "us_bank_account": {
+                        "financial_connections": {
+                            "permissions": "balances"
+                        },
+                        "setup_future_usage": "on_session",
+                        "verification_method": "automatic"
+                    }
+                }
+            """.trimIndent()
+        )
+
+        assertThat(setupIntent.getPaymentMethodOptions())
+            .isEqualTo(
+                mapOf(
+                    "card" to mapOf(
+                        "mandate_options" to null,
+                        "network" to null,
+                        "request_three_d_secure" to "automatic"
+                    ),
+                    "us_bank_account" to mapOf(
+                        "financial_connections" to mapOf(
+                            "permissions" to "balances"
+                        ),
+                        "setup_future_usage" to "on_session",
+                        "verification_method" to "automatic"
+                    )
+                )
+            )
     }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
@@ -428,7 +428,14 @@ class LpmRepository constructor(
             formSpec = LayoutSpec(sharedDataSpec.fields)
         )
         PaymentMethod.Type.USBankAccount.code -> {
-            if (stripeIntent.clientSecret != null || arguments.enableACHV2InDeferredFlow) {
+            val pmo = stripeIntent.getPaymentMethodOptions()[PaymentMethod.Type.USBankAccount.code]
+            val verificationMethod = (pmo as? Map<*, *>)?.get("verification_method") as? String
+            val supportsVerificationMethod = verificationMethod == "instant" ||
+                verificationMethod == "automatic"
+            val supported =
+                (stripeIntent.clientSecret != null || arguments.enableACHV2InDeferredFlow) &&
+                    supportsVerificationMethod
+            if (supported) {
                 SupportedPaymentMethod(
                     code = "us_bank_account",
                     requiresMandate = true,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
@@ -435,6 +435,18 @@ class LpmRepository constructor(
             val supported =
                 (stripeIntent.clientSecret != null || arguments.enableACHV2InDeferredFlow) &&
                     supportsVerificationMethod
+            /**
+             * US Bank Account requires the payment method option to have either automatic or
+             * instant verification method in order to be a supported payment method. For example,
+             * the intent should include:
+             * {
+             *     "payment_method_options" : {
+             *         "us_bank_account": {
+             *             "verification_method": "automatic"
+             *         }
+             *     }
+             * }
+             */
             if (supported) {
                 SupportedPaymentMethod(
                     code = "us_bank_account",

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/resources/LpmRepositoryTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/resources/LpmRepositoryTest.kt
@@ -365,7 +365,7 @@ class LpmRepositoryTest {
     }
 
     @Test
-    fun `Verify LpmRepository filters out USBankAccount if verification method is unsupported`() = runTest {
+    fun `Verify LpmRepository does not filter out USBankAccount if verification method is unsupported`() = runTest {
         val lpmRepository = LpmRepository(
             lpmInitialFormData = LpmRepository.LpmInitialFormData(),
             arguments = LpmRepository.LpmRepositoryArguments(

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/resources/LpmRepositoryTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/forms/resources/LpmRepositoryTest.kt
@@ -365,7 +365,7 @@ class LpmRepositoryTest {
     }
 
     @Test
-    fun `Verify LpmRepository does not filter out USBankAccount if verification method is unsupported`() = runTest {
+    fun `Verify LpmRepository filters out USBankAccount if verification method is unsupported`() = runTest {
         val lpmRepository = LpmRepository(
             lpmInitialFormData = LpmRepository.LpmInitialFormData(),
             arguments = LpmRepository.LpmRepositoryArguments(
@@ -397,7 +397,7 @@ class LpmRepositoryTest {
     }
 
     @Test
-    fun `Verify LpmRepository filters out USBankAccount if verification method is supported`() = runTest {
+    fun `Verify LpmRepository does not filter out USBankAccount if verification method is supported`() = runTest {
         val lpmRepository = LpmRepository(
             lpmInitialFormData = LpmRepository.LpmInitialFormData(),
             arguments = LpmRepository.LpmRepositoryArguments(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -100,13 +100,17 @@ internal class PaymentSheetViewModelTest {
     private val application = ApplicationProvider.getApplicationContext<Application>()
 
     private val lpmRepository = LpmRepository(
-        arguments = LpmRepository.LpmRepositoryArguments(application.resources),
+        arguments = LpmRepository.LpmRepositoryArguments(
+            resources = application.resources,
+            enableACHV2InDeferredFlow = true,
+        ),
     ).apply {
         this.update(
             PaymentIntentFactory.create(
                 paymentMethodTypes = listOf(
                     PaymentMethod.Type.Card.code,
                     PaymentMethod.Type.USBankAccount.code,
+                    PaymentMethod.Type.CashAppPay.code,
                     PaymentMethod.Type.Ideal.code,
                     PaymentMethod.Type.SepaDebit.code,
                     PaymentMethod.Type.Sofort.code,
@@ -1188,7 +1192,7 @@ internal class PaymentSheetViewModelTest {
 
     @Test
     fun `Shows the correct divider text if intent supports multiple payment method types`() = runTest {
-        val intent = PAYMENT_INTENT.copy(paymentMethodTypes = listOf("card", "us_bank_account"))
+        val intent = PAYMENT_INTENT.copy(paymentMethodTypes = listOf("card", "cashapp"))
         val viewModel = createViewModel(
             args = ARGS_CUSTOMER_WITH_GOOGLEPAY.copy(
                 config = ARGS_CUSTOMER_WITH_GOOGLEPAY.config?.copy(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -100,10 +100,7 @@ internal class PaymentSheetViewModelTest {
     private val application = ApplicationProvider.getApplicationContext<Application>()
 
     private val lpmRepository = LpmRepository(
-        arguments = LpmRepository.LpmRepositoryArguments(
-            resources = application.resources,
-            enableACHV2InDeferredFlow = true,
-        ),
+        arguments = LpmRepository.LpmRepositoryArguments(application.resources),
     ).apply {
         this.update(
             PaymentIntentFactory.create(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentSheetLoaderTest.kt
@@ -58,8 +58,9 @@ internal class DefaultPaymentSheetLoaderTest {
             PaymentIntentFactory.create(
                 paymentMethodTypes = listOf(
                     PaymentMethod.Type.Card.code,
-                    PaymentMethod.Type.USBankAccount.code
-                )
+                    PaymentMethod.Type.USBankAccount.code,
+                    PaymentMethod.Type.CashAppPay.code,
+                ),
             ),
             null
         )
@@ -533,7 +534,7 @@ internal class DefaultPaymentSheetLoaderTest {
         ) as? PaymentSheetLoader.Result.Failure
 
         val expectedMessage = "None of the requested payment methods (gold, silver, bronze) " +
-            "match the supported payment types (card, us_bank_account)."
+            "match the supported payment types (card, cashapp)."
         assertThat(result?.throwable?.message).isEqualTo(expectedMessage)
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
- Changes the logic to show or hide the `us_bank_account` payment method
- Add LPM filter for `us_bank_account`, specifically for its requested verification method. If the desired verification method is `instant` or `automatic`, as described in the [docs](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-payment_method_options-us_bank_account-verification_method), then we can display the payment method, hide it otherwise.

Can verify this with your own server.

```
// Create the PaymentIntent
args.payment_method_options = {
  us_bank_account: {
    verification_method: 'instant', // or microdeposits
    financial_connections: {permissions: ['payment_method', 'balances']},
  },
}
const paymentIntent = await stripe.paymentIntents.create(args, headers);
```


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Hide the payment method when verification method is microdeposits as this would cause the user to not be able to complete payment.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

- [Changed] Show the US Bank Account payment method if the specified verification method is either `automatic` or `instant`, otherwise, hide the payment method.