### PR TITLE
[Identity] Improve timeout algorithm

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/camera/IdentityAggregator.kt
+++ b/identity/src/main/java/com/stripe/android/identity/camera/IdentityAggregator.kt
@@ -2,7 +2,6 @@ package com.stripe.android.identity.camera
 
 import com.stripe.android.camera.framework.AggregateResultListener
 import com.stripe.android.camera.framework.ResultAggregator
-import com.stripe.android.camera.framework.time.Clock
 import com.stripe.android.camera.framework.time.milliseconds
 import com.stripe.android.identity.ml.AnalyzerInput
 import com.stripe.android.identity.ml.AnalyzerOutput
@@ -42,7 +41,7 @@ internal class IdentityAggregator(
             )
         } else {
             IDDetectorTransitioner(
-                timeoutAt = Clock.markNow() + verificationPage.documentCapture.autocaptureTimeout.milliseconds,
+                timeout = verificationPage.documentCapture.autocaptureTimeout.milliseconds,
                 iouThreshold = verificationPage.documentCapture.motionBlurMinIou,
                 timeRequired = verificationPage.documentCapture.motionBlurMinDuration
             )

--- a/identity/src/main/java/com/stripe/android/identity/states/FaceDetectorTransitioner.kt
+++ b/identity/src/main/java/com/stripe/android/identity/states/FaceDetectorTransitioner.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.identity.states
 
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import com.stripe.android.camera.framework.time.Clock
 import com.stripe.android.camera.framework.time.ClockMark
 import com.stripe.android.camera.framework.time.milliseconds
@@ -30,23 +31,34 @@ import kotlin.math.sqrt
  *
  * To transition from [Found] state -
  * * Check if it's timeout since the start of the scan.
- * * Wait for an internal between two Found state, if the interval is not reached, keep waiting.
+ * * Wait for an interval between two Found state, if the interval is not reached, keep waiting.
  * * Check if a valid face is present, save the frame and check if enough frames have been collected
- *  * If so, transition to Satisfied
- *  * Otherwise stay in [Found]
+ *  * If so, transition to [Satisfied]
+ *  * Otherwise check how long it's been since the last transition to [Found]
+ *  *   If it's within [stayInFoundDuration], stay in [Found]
+ *  *   Otherwise transition to [Unsatisfied]
  *
  * To transition from [Satisfied] state -
  * * Directly transitions to [Finished]
  *
- * Note FaceDetector doesn't have a [Unsatisfied] state.
- *
+ * To transition from [Unsatisfied] state -
+ * * Directly transitions to [Initial]
  */
 internal class FaceDetectorTransitioner(
     private val selfieCapturePage: VerificationPageStaticContentSelfieCapturePage,
-    internal val timeoutAt: ClockMark =
-        Clock.markNow() + selfieCapturePage.autoCaptureTimeout.milliseconds,
-    internal val selfieFrameSaver: SelfieFrameSaver = SelfieFrameSaver()
+    internal val selfieFrameSaver: SelfieFrameSaver = SelfieFrameSaver(),
+    private val stayInFoundDuration: Int = DEFAULT_STAY_IN_FOUND_DURATION
 ) : IdentityScanStateTransitioner {
+    @VisibleForTesting
+    var timeoutAt: ClockMark =
+        Clock.markNow() + selfieCapturePage.autoCaptureTimeout.milliseconds
+
+    @VisibleForTesting
+    fun resetAndReturn(): FaceDetectorTransitioner {
+        timeoutAt = Clock.markNow() + selfieCapturePage.autoCaptureTimeout.milliseconds
+        return this
+    }
+
     internal val filteredFrames: List<Pair<AnalyzerInput, FaceDetectorOutput>>
         get() {
             val savedFrames = requireNotNull(selfieFrameSaver.getSavedFrames()[SELFIES]) {
@@ -122,6 +134,7 @@ internal class FaceDetectorTransitioner(
                 Log.d(TAG, "Timeout in Initial state: $initialState")
                 IdentityScanState.TimeOut(initialState.type, this)
             }
+
             isFaceValid(analyzerOutput) -> {
                 Log.d(TAG, "Valid face found, transition to Found")
                 selfieFrameSaver.saveFrame(
@@ -130,6 +143,7 @@ internal class FaceDetectorTransitioner(
                 )
                 Found(initialState.type, this)
             }
+
             else -> {
                 Log.d(TAG, "Valid face not found, stay in Initial")
                 initialState
@@ -142,14 +156,13 @@ internal class FaceDetectorTransitioner(
         analyzerInput: AnalyzerInput,
         analyzerOutput: AnalyzerOutput
     ): IdentityScanState {
-        require(analyzerOutput is FaceDetectorOutput) {
-            "Unexpected output type: $analyzerOutput"
-        }
+        require(analyzerOutput is FaceDetectorOutput) { "Unexpected output type: $analyzerOutput" }
         return when {
             timeoutAt.hasPassed() -> {
                 Log.d(TAG, "Timeout in Found state: $foundState")
                 IdentityScanState.TimeOut(foundState.type, this)
             }
+
             foundState.reachedStateAt.elapsedSince() < selfieCapturePage.sampleInterval.milliseconds -> {
                 Log.d(
                     TAG,
@@ -158,11 +171,9 @@ internal class FaceDetectorTransitioner(
                 )
                 foundState
             }
+
             isFaceValid(analyzerOutput) -> {
-                selfieFrameSaver.saveFrame(
-                    (analyzerInput to analyzerOutput),
-                    analyzerOutput
-                )
+                selfieFrameSaver.saveFrame((analyzerInput to analyzerOutput), analyzerOutput)
                 if (selfieFrameSaver.selfieCollected() >= selfieCapturePage.numSamples) {
                     Log.d(
                         TAG,
@@ -179,13 +190,29 @@ internal class FaceDetectorTransitioner(
                     Found(foundState.type, this)
                 }
             }
+
+            foundState.reachedStateAt.elapsedSince() < stayInFoundDuration.milliseconds -> {
+                Log.d(
+                    TAG,
+                    "Get an invalid selfie in Found state, but not enough time " +
+                        "passed(${foundState.reachedStateAt.elapsedSince()}), stays in Found. " +
+                        "Current selfieCollected: ${selfieFrameSaver.selfieCollected()}"
+                )
+                foundState
+            }
+
             else -> {
                 Log.d(
                     TAG,
-                    "Get an invalid selfie in Found state, stays in Found. " +
-                        "Current selfieCollected: ${selfieFrameSaver.selfieCollected()}"
+                    "Didn't get a valid selfie in Found state after $stayInFoundDuration " +
+                        "milliseconds, transition to Unsatisfied"
                 )
-                return Found(foundState.type, this)
+                return Unsatisfied(
+                    "Didn't get a valid selfie in Found state after " +
+                        "$stayInFoundDuration milliseconds",
+                    foundState.type,
+                    foundState.transitioner
+                )
             }
         }
     }
@@ -203,7 +230,7 @@ internal class FaceDetectorTransitioner(
         analyzerInput: AnalyzerInput,
         analyzerOutput: AnalyzerOutput
     ): IdentityScanState {
-        throw IllegalStateException("Unsatisfied state not allowed for FaceDetector.")
+        return Initial(unsatisfiedState.type, this.resetAndReturn())
     }
 
     private fun isFaceValid(analyzerOutput: FaceDetectorOutput) =
@@ -218,8 +245,10 @@ internal class FaceDetectorTransitioner(
      * within corresponding threshold of center of image in both dimensions.
      */
     private fun isFaceCentered(boundingBox: BoundingBox): Boolean {
-        return abs(1 - (boundingBox.top + boundingBox.top + boundingBox.height)) < selfieCapturePage.maxCenteredThresholdY &&
-            abs(1 - (boundingBox.left + boundingBox.left + boundingBox.width)) < selfieCapturePage.maxCenteredThresholdX
+        return abs(1 - (boundingBox.top + boundingBox.top + boundingBox.height)) <
+            selfieCapturePage.maxCenteredThresholdY &&
+            abs(1 - (boundingBox.left + boundingBox.left + boundingBox.width)) <
+                selfieCapturePage.maxCenteredThresholdX
     }
 
     /**
@@ -266,5 +295,6 @@ internal class FaceDetectorTransitioner(
         const val VALUE_FIRST = "first"
         const val VALUE_LAST = "last"
         const val VALUE_BEST = "best"
+        const val DEFAULT_STAY_IN_FOUND_DURATION = 2000
     }
 }

--- a/identity/src/main/java/com/stripe/android/identity/states/IDDetectorTransitioner.kt
+++ b/identity/src/main/java/com/stripe/android/identity/states/IDDetectorTransitioner.kt
@@ -1,8 +1,10 @@
 package com.stripe.android.identity.states
 
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import com.stripe.android.camera.framework.time.Clock
 import com.stripe.android.camera.framework.time.ClockMark
+import com.stripe.android.camera.framework.time.Duration
 import com.stripe.android.camera.framework.time.milliseconds
 import com.stripe.android.identity.ml.AnalyzerInput
 import com.stripe.android.identity.ml.AnalyzerOutput
@@ -30,7 +32,7 @@ import kotlin.math.min
  * [timeRequired], then transitions to [Satisfied], otherwise stays in [Found].
  */
 internal class IDDetectorTransitioner(
-    private val timeoutAt: ClockMark,
+    private val timeout: Duration,
     private val iouThreshold: Float = DEFAULT_IOU_THRESHOLD,
     private val timeRequired: Int = DEFAULT_TIME_REQUIRED,
     private val allowedUnmatchedFrames: Int = DEFAULT_ALLOWED_UNMATCHED_FRAME,
@@ -39,6 +41,22 @@ internal class IDDetectorTransitioner(
 ) : IdentityScanStateTransitioner {
     private var previousBoundingBox: BoundingBox? = null
     private var unmatchedFrame = 0
+
+    @VisibleForTesting
+    var timeoutAt: ClockMark = Clock.markNow() + timeout
+
+    /**
+     * Rest internal state and return itself.
+     */
+    @VisibleForTesting
+    fun resetAndReturn(): IDDetectorTransitioner {
+        previousBoundingBox = null
+        unmatchedFrame = 0
+        timeoutAt = Clock.markNow() + timeout
+        Log.d(TAG, "Reset! timeoutAt: $timeoutAt")
+        return this
+    }
+
     override suspend fun transitionFromInitial(
         initialState: Initial,
         analyzerInput: AnalyzerInput,
@@ -51,6 +69,7 @@ internal class IDDetectorTransitioner(
             timeoutAt.hasPassed() -> {
                 IdentityScanState.TimeOut(initialState.type, this)
             }
+
             analyzerOutput.category.matchesScanType(initialState.type) -> {
                 Log.d(
                     TAG,
@@ -59,6 +78,7 @@ internal class IDDetectorTransitioner(
                 )
                 Found(initialState.type, this)
             }
+
             else -> {
                 Log.d(
                     TAG,
@@ -82,16 +102,19 @@ internal class IDDetectorTransitioner(
             timeoutAt.hasPassed() -> {
                 IdentityScanState.TimeOut(foundState.type, foundState.transitioner)
             }
+
             !outputMatchesTargetType(analyzerOutput.category, foundState.type) -> Unsatisfied(
                 "Type ${analyzerOutput.category} doesn't match ${foundState.type}",
                 foundState.type,
                 foundState.transitioner
             )
+
             !iOUCheckPass(analyzerOutput.boundingBox) -> {
                 // reset timer of the foundState
                 foundState.reachedStateAt = Clock.markNow()
                 foundState
             }
+
             moreResultsRequired(foundState) -> foundState
             else -> {
                 Satisfied(foundState.type, foundState.transitioner)
@@ -121,13 +144,16 @@ internal class IDDetectorTransitioner(
             timeoutAt.hasPassed() -> {
                 IdentityScanState.TimeOut(unsatisfiedState.type, this)
             }
+
             unsatisfiedState.reachedStateAt.elapsedSince() > displayUnsatisfiedDuration.milliseconds -> {
                 Log.d(
                     TAG,
-                    "Scan for ${unsatisfiedState.type} Unsatisfied with reason ${unsatisfiedState.reason}, transition to Initial."
+                    "Scan for ${unsatisfiedState.type} Unsatisfied with reason " +
+                        "${unsatisfiedState.reason}, transition to Initial."
                 )
-                Initial(unsatisfiedState.type, this)
+                Initial(unsatisfiedState.type, this.resetAndReturn())
             }
+
             else -> {
                 unsatisfiedState
             }

--- a/identity/src/test/java/com/stripe/android/identity/states/IDDetectorTransitionerTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/states/IDDetectorTransitionerTest.kt
@@ -11,6 +11,8 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 
@@ -30,7 +32,8 @@ internal class IDDetectorTransitionerTest {
 
     @Test
     fun `Found transitions to Found when iOUCheckPass failed`() = runBlocking {
-        val transitioner = IDDetectorTransitioner(mockNeverTimeoutClockMark)
+        val transitioner = IDDetectorTransitioner(TIMEOUT_DURATION)
+        transitioner.timeoutAt = mockNeverTimeoutClockMark
 
         val foundState = IdentityScanState.Found(
             ScanType.ID_FRONT,
@@ -58,9 +61,10 @@ internal class IDDetectorTransitionerTest {
         runBlocking {
             val timeRequired = 500
             val transitioner = IDDetectorTransitioner(
-                timeoutAt = mockNeverTimeoutClockMark,
+                timeout = TIMEOUT_DURATION,
                 timeRequired = timeRequired
             )
+            transitioner.timeoutAt = mockNeverTimeoutClockMark
 
             val mockFoundState = mock<IdentityScanState.Found>().also {
                 whenever(it.type).thenReturn(ScanType.ID_FRONT)
@@ -100,10 +104,11 @@ internal class IDDetectorTransitionerTest {
             val timeRequired = 500
             val allowedUnmatchedFrames = 2
             val transitioner = IDDetectorTransitioner(
-                timeoutAt = mockNeverTimeoutClockMark,
+                timeout = TIMEOUT_DURATION,
                 timeRequired = timeRequired,
                 allowedUnmatchedFrames = allowedUnmatchedFrames
             )
+            transitioner.timeoutAt = mockNeverTimeoutClockMark
 
             // never meets required time
             whenever(mockReachedStateAt.elapsedSince()).thenReturn((timeRequired - 10).milliseconds)
@@ -143,10 +148,11 @@ internal class IDDetectorTransitionerTest {
             val timeRequired = 500
             val allowedUnmatchedFrames = 2
             val transitioner = IDDetectorTransitioner(
-                timeoutAt = mockNeverTimeoutClockMark,
+                timeout = TIMEOUT_DURATION,
                 timeRequired = timeRequired,
                 allowedUnmatchedFrames = allowedUnmatchedFrames
             )
+            transitioner.timeoutAt = mockNeverTimeoutClockMark
 
             // never meets required time
             whenever(mockReachedStateAt.elapsedSince()).thenReturn((timeRequired - 10).milliseconds)
@@ -198,10 +204,11 @@ internal class IDDetectorTransitionerTest {
             val timeRequired = 500
             val allowedUnmatchedFrames = 2
             val transitioner = IDDetectorTransitioner(
-                timeoutAt = mockNeverTimeoutClockMark,
+                timeout = TIMEOUT_DURATION,
                 timeRequired = timeRequired,
                 allowedUnmatchedFrames = allowedUnmatchedFrames
             )
+            transitioner.timeoutAt = mockNeverTimeoutClockMark
 
             // never meets required time
             whenever(mockReachedStateAt.elapsedSince()).thenReturn((timeRequired - 10).milliseconds)
@@ -249,8 +256,9 @@ internal class IDDetectorTransitionerTest {
     @Test
     fun `Initial transitions to Timeout when timeout`() = runBlocking {
         val transitioner = IDDetectorTransitioner(
-            timeoutAt = mockAlwaysTimeoutClockMark
+            timeout = TIMEOUT_DURATION
         )
+        transitioner.timeoutAt = mockAlwaysTimeoutClockMark
 
         val initialState = IdentityScanState.Initial(
             ScanType.ID_FRONT,
@@ -269,8 +277,9 @@ internal class IDDetectorTransitionerTest {
     @Test
     fun `Initial stays in Initial if type doesn't match`() = runBlocking {
         val transitioner = IDDetectorTransitioner(
-            timeoutAt = mockNeverTimeoutClockMark
+            timeout = TIMEOUT_DURATION
         )
+        transitioner.timeoutAt = mockNeverTimeoutClockMark
 
         val initialState = IdentityScanState.Initial(
             ScanType.ID_FRONT,
@@ -289,8 +298,9 @@ internal class IDDetectorTransitionerTest {
     @Test
     fun `Initial transitions to Found if type does match`() = runBlocking {
         val transitioner = IDDetectorTransitioner(
-            timeoutAt = mockNeverTimeoutClockMark
+            timeout = TIMEOUT_DURATION
         )
+        transitioner.timeoutAt = mockNeverTimeoutClockMark
 
         val initialState = IdentityScanState.Initial(
             ScanType.ID_FRONT,
@@ -313,9 +323,10 @@ internal class IDDetectorTransitionerTest {
             whenever(mockReachAtClockMark.elapsedSince()).thenReturn((DEFAULT_DISPLAY_SATISFIED_DURATION + 1).milliseconds)
 
             val transitioner = IDDetectorTransitioner(
-                timeoutAt = mockNeverTimeoutClockMark,
+                timeout = TIMEOUT_DURATION,
                 displaySatisfiedDuration = DEFAULT_DISPLAY_SATISFIED_DURATION
             )
+            transitioner.timeoutAt = mockNeverTimeoutClockMark
 
             assertThat(
                 transitioner.transitionFromSatisfied(
@@ -337,9 +348,10 @@ internal class IDDetectorTransitionerTest {
             whenever(mockReachAtClockMark.elapsedSince()).thenReturn((DEFAULT_DISPLAY_SATISFIED_DURATION - 1).milliseconds)
 
             val transitioner = IDDetectorTransitioner(
-                timeoutAt = mockNeverTimeoutClockMark,
+                timeout = TIMEOUT_DURATION,
                 displaySatisfiedDuration = DEFAULT_DISPLAY_SATISFIED_DURATION
             )
+            transitioner.timeoutAt = mockNeverTimeoutClockMark
 
             val satisfiedState =
                 IdentityScanState.Satisfied(
@@ -356,9 +368,10 @@ internal class IDDetectorTransitionerTest {
     @Test
     fun `Unsatisfied transitions to Timeout when timeout`() = runBlocking {
         val transitioner = IDDetectorTransitioner(
-            timeoutAt = mockAlwaysTimeoutClockMark,
+            timeout = TIMEOUT_DURATION,
             displaySatisfiedDuration = DEFAULT_DISPLAY_SATISFIED_DURATION
         )
+        transitioner.timeoutAt = mockAlwaysTimeoutClockMark
 
         assertThat(
             transitioner.transitionFromUnsatisfied(
@@ -380,9 +393,10 @@ internal class IDDetectorTransitionerTest {
             whenever(mockReachAtClockMark.elapsedSince()).thenReturn((DEFAULT_DISPLAY_UNSATISFIED_DURATION - 1).milliseconds)
 
             val transitioner = IDDetectorTransitioner(
-                timeoutAt = mockNeverTimeoutClockMark,
+                timeout = TIMEOUT_DURATION,
                 displayUnsatisfiedDuration = DEFAULT_DISPLAY_UNSATISFIED_DURATION
             )
+            transitioner.timeoutAt = mockNeverTimeoutClockMark
 
             val unsatisfiedState =
                 IdentityScanState.Unsatisfied(
@@ -409,25 +423,29 @@ internal class IDDetectorTransitionerTest {
             whenever(mockReachAtClockMark.elapsedSince()).thenReturn((DEFAULT_DISPLAY_UNSATISFIED_DURATION + 1).milliseconds)
 
             val transitioner = IDDetectorTransitioner(
-                timeoutAt = mockNeverTimeoutClockMark,
+                timeout = TIMEOUT_DURATION,
                 displayUnsatisfiedDuration = DEFAULT_DISPLAY_UNSATISFIED_DURATION
             )
+            transitioner.timeoutAt = mockNeverTimeoutClockMark
+
+            val transitionerSpy = spy(transitioner)
 
             val unsatisfiedState =
                 IdentityScanState.Unsatisfied(
                     "reason",
                     ScanType.ID_FRONT,
-                    transitioner,
+                    transitionerSpy,
                     reachedStateAt = mockReachAtClockMark
                 )
 
             val resultState =
-                transitioner.transitionFromUnsatisfied(
+                transitionerSpy.transitionFromUnsatisfied(
                     unsatisfiedState,
                     mock(),
                     mock()
                 )
 
+            verify(transitionerSpy).resetAndReturn()
             assertThat(resultState).isInstanceOf(IdentityScanState.Initial::class.java)
         }
 
@@ -478,5 +496,7 @@ internal class IDDetectorTransitionerTest {
 
         const val DEFAULT_DISPLAY_SATISFIED_DURATION = 1000
         const val DEFAULT_DISPLAY_UNSATISFIED_DURATION = 1000
+
+        val TIMEOUT_DURATION = 8000.milliseconds
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Introduce an improved timeout logic in IDDetector and FaceDetetor that when state returns to `Initial`, reset the timer.
So that user has more time to complete the flow from scratch again, this logic is similar to the web flow logic.

Similar iOS change: https://github.com/stripe/stripe-ios/pull/2550

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Improve scan success rate



# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
