### PR TITLE
[FC] Maestro - Remove link more accounts check 

### DIFF
--- a/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
+++ b/maestro/financial-connections/Testmode-Data-TestOauthInstitution.yaml
@@ -41,7 +41,7 @@ appId: com.stripe.android.financialconnections.example
     text: "Link accounts"
     retryTapIfNoChange: false
 # CONFIRM AND COMPLETE
-- assertVisible: "Link another account"
+- assertVisible: ".*Success.*"
 - tapOn: "Done"
 - assertVisible: ".*Completed!.*"
 - assertVisible: ".*StripeBank.*"


### PR DESCRIPTION
# Summary

Removes link more account button check from Maestro after merging https://github.com/stripe/stripe-android/pull/6691
