### PR TITLE
Revert "Use Compose BOM for Compose related dependencies"

### DIFF
--- a/.idea/codestyles/Project.xml
+++ b/.idea/codestyles/Project.xml
@@ -32,6 +32,8 @@
           <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
         </value>
       </option>
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <MarkdownNavigatorCodeStyleSettings>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
 ## XX.XX.XX - 2023-XX-XX
+* [CHANGED][6676](https://github.com/stripe/stripe-android/pull/6676) Revert BOM change and use compose 1.4.3. 
+
 
 ## 20.25.0 - 2023-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## XX.XX.XX - 2023-XX-XX
-* [CHANGED][6676](https://github.com/stripe/stripe-android/pull/6676) Revert BOM change and use compose 1.4.3. 
+* [CHANGED][6697](https://github.com/stripe/stripe-android/pull/6697) Revert BOM change and use compose 1.4.3. 
 
 
 ## 20.25.0 - 2023-05-08

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -11,7 +11,10 @@ ext.versions = [
         androidxAppcompat           : '1.6.1',
         androidxArchCore            : '2.2.0',
         androidxBrowser             : '1.5.0',
+        androidxCompose             : '1.4.3',
         androidxComposeCompiler     : '1.4.1',
+        androidxComposeRuntime      : '1.4.3',
+        androidxComposeUi           : '1.4.3',
         androidxConstraintlayout    : '2.1.4',
         androidxCore                : '1.9.0',
         androidxFragment            : '1.5.5',
@@ -86,12 +89,6 @@ ext.configs = [
         androidApplication: "${project.rootDir}/build-configuration/android-application.gradle",
 ]
 
-ext.boms = [
-        androidx: [
-                compose: "androidx.compose:compose-bom:2023.05.00"
-        ],
-]
-
 ext.libs = [
         accompanist                         : [
                 flowLayout         : "com.google.accompanist:accompanist-flowlayout:${versions.accompanist}",
@@ -127,18 +124,18 @@ ext.libs = [
         ],
         compose                             : [
                 activity             : "androidx.activity:activity-compose:${versions.androidxActivity}",
-                foundation           : "androidx.compose.foundation:foundation",
-                liveData             : "androidx.compose.runtime:runtime-livedata",
-                material             : "androidx.compose.material:material",
-                materialIcons        : "androidx.compose.material:material-icons-core",
-                materialIconsExtended: "androidx.compose.material:material-icons-extended",
+                foundation           : "androidx.compose.foundation:foundation:${versions.androidxCompose}",
+                liveData             : "androidx.compose.runtime:runtime-livedata:${versions.androidxComposeRuntime}",
+                material             : "androidx.compose.material:material:${versions.androidxCompose}",
+                materialIcons        : "androidx.compose.material:material-icons-core:${versions.androidxCompose}",
+                materialIconsExtended: "androidx.compose.material:material-icons-extended:${versions.androidxCompose}",
                 navigation           : "androidx.navigation:navigation-compose:${versions.androidxNavigation}",
-                runtime              : "androidx.compose.runtime:runtime",
-                ui                   : "androidx.compose.ui:ui",
-                uiTestManifest       : "androidx.compose.ui:ui-test-manifest",
-                uiTooling            : "androidx.compose.ui:ui-tooling",
-                uiToolingPreview     : "androidx.compose.ui:ui-tooling-preview",
-                uiViewBinding        : "androidx.compose.ui:ui-viewbinding",
+                runtime              : "androidx.compose.runtime:runtime:${versions.androidxComposeRuntime}",
+                ui                   : "androidx.compose.ui:ui:${versions.androidxComposeUi}",
+                uiTestManifest       : "androidx.compose.ui:ui-test-manifest:${versions.androidxComposeUi}",
+                uiTooling            : "androidx.compose.ui:ui-tooling:${versions.androidxComposeUi}",
+                uiToolingPreview     : "androidx.compose.ui:ui-tooling-preview:${versions.androidxComposeUi}",
+                uiViewBinding        : "androidx.compose.ui:ui-viewbinding:${versions.androidxComposeUi}",
                 viewModels           : "androidx.lifecycle:lifecycle-viewmodel-compose:${versions.androidxLifecycle}",
         ],
         dagger                              : "com.google.dagger:dagger:${versions.dagger}",
@@ -183,7 +180,7 @@ ext.testLibs = [
                 junit      : "androidx.test.ext:junit:${versions.androidTestJunit}",
                 junitKtx   : "androidx.test.ext:junit-ktx:${versions.androidTestJunit}",
                 fragment   : "androidx.fragment:fragment-testing:${versions.androidxFragment}",
-                composeUi  : "androidx.compose.ui:ui-test-junit4",
+                composeUi  : "androidx.compose.ui:ui-test-junit4:${versions.androidxComposeUi}",
                 lifecycle  : "androidx.lifecycle:lifecycle-runtime-testing:${versions.androidxLifecycle}",
                 testRules  : "androidx.test:rules:${versions.androidTest}",
                 testRunner : "androidx.test:runner:${versions.androidTestRunner}",

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -19,8 +19,6 @@ dependencies {
     implementation project(':payments')
     implementation project(':financial-connections')
 
-    implementation platform(boms.androidx.compose)
-
     implementation libs.accompanist.themeAdapter
     implementation libs.alipay
     implementation libs.androidx.appCompat

--- a/financial-connections-example/build.gradle
+++ b/financial-connections-example/build.gradle
@@ -44,9 +44,6 @@ dependencies {
     implementation project(':financial-connections')
     implementation project(':payments-core')
 
-    implementation platform(boms.androidx.compose)
-    androidTestImplementation platform(boms.androidx.compose)
-
     implementation libs.androidx.activity
     implementation libs.androidx.appCompat
     implementation libs.androidx.coreKtx

--- a/financial-connections/build.gradle
+++ b/financial-connections/build.gradle
@@ -20,12 +20,9 @@ android {
 }
 
 dependencies {
-
     api project(":stripe-core")
     api project(":stripe-ui-core")
     api project(":payments-model")
-
-    implementation platform(boms.androidx.compose)
 
     implementation libs.accompanist.webView
     implementation libs.androidx.activity

--- a/identity-example/build.gradle
+++ b/identity-example/build.gradle
@@ -47,8 +47,6 @@ android {
 dependencies {
     implementation project(':identity')
 
-    implementation platform(boms.androidx.compose)
-
     implementation libs.accompanist.themeAdapter
     implementation libs.androidx.appCompat
     implementation libs.androidx.browser

--- a/identity/build.gradle
+++ b/identity/build.gradle
@@ -10,8 +10,6 @@ dependencies {
     implementation project(":stripe-ui-core")
     implementation project(":ml-core:default")
 
-    implementation platform(boms.androidx.compose)
-
     implementation libs.accompanist.themeAdapter
     implementation libs.androidx.activity
     implementation libs.androidx.appCompat

--- a/identity/src/main/java/com/stripe/android/identity/ui/IdentityTheme.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/IdentityTheme.kt
@@ -5,14 +5,12 @@ import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.text.TextStyle
 import com.google.accompanist.themeadapter.material.createMdcTheme
 import com.stripe.android.uicore.LocalColors
 import com.stripe.android.uicore.LocalShapes
@@ -95,35 +93,6 @@ internal fun IdentityTheme(content: @Composable () -> Unit) {
         )
     }
 }
-private fun Typography.makeCopy(
-    h1: TextStyle = this.h1,
-    h2: TextStyle = this.h2,
-    h3: TextStyle = this.h3,
-    h4: TextStyle = this.h4,
-    h5: TextStyle = this.h5,
-    h6: TextStyle = this.h6,
-    subtitle1: TextStyle = this.subtitle1,
-    subtitle2: TextStyle = this.subtitle2,
-    body1: TextStyle = this.body1,
-    body2: TextStyle = this.body2,
-    button: TextStyle = this.button,
-    caption: TextStyle = this.caption,
-    overline: TextStyle = this.overline
-): Typography = Typography(
-    h1 = h1,
-    h2 = h2,
-    h3 = h3,
-    h4 = h4,
-    h5 = h5,
-    h6 = h6,
-    subtitle1 = subtitle1,
-    subtitle2 = subtitle2,
-    body1 = body1,
-    body2 = body2,
-    button = button,
-    caption = caption,
-    overline = overline
-)
 
 /**
  * Copied from MdcTheme.kt

--- a/identity/src/main/java/com/stripe/android/identity/ui/IdentityTheme.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/IdentityTheme.kt
@@ -5,12 +5,14 @@ import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.text.TextStyle
 import com.google.accompanist.themeadapter.material.createMdcTheme
 import com.stripe.android.uicore.LocalColors
 import com.stripe.android.uicore.LocalShapes
@@ -93,6 +95,35 @@ internal fun IdentityTheme(content: @Composable () -> Unit) {
         )
     }
 }
+private fun Typography.makeCopy(
+    h1: TextStyle = this.h1,
+    h2: TextStyle = this.h2,
+    h3: TextStyle = this.h3,
+    h4: TextStyle = this.h4,
+    h5: TextStyle = this.h5,
+    h6: TextStyle = this.h6,
+    subtitle1: TextStyle = this.subtitle1,
+    subtitle2: TextStyle = this.subtitle2,
+    body1: TextStyle = this.body1,
+    body2: TextStyle = this.body2,
+    button: TextStyle = this.button,
+    caption: TextStyle = this.caption,
+    overline: TextStyle = this.overline
+): Typography = Typography(
+    h1 = h1,
+    h2 = h2,
+    h3 = h3,
+    h4 = h4,
+    h5 = h5,
+    h6 = h6,
+    subtitle1 = subtitle1,
+    subtitle2 = subtitle2,
+    body1 = body1,
+    body2 = body2,
+    button = button,
+    caption = caption,
+    overline = overline
+)
 
 /**
  * Copied from MdcTheme.kt

--- a/link/build.gradle
+++ b/link/build.gradle
@@ -11,8 +11,6 @@ dependencies {
     implementation project(':financial-connections')
     implementation project(':stripe-ui-core')
 
-    implementation platform(boms.androidx.compose)
-
     implementation libs.androidx.appCompat
     implementation libs.androidx.constraintLayout
     implementation libs.androidx.liveDataKtx

--- a/payment-method-messaging/build.gradle
+++ b/payment-method-messaging/build.gradle
@@ -23,8 +23,6 @@ android {
 }
 
 dependencies {
-    implementation platform(boms.androidx.compose)
-
     implementation project(":stripe-core")
     implementation project(":payments-core")
     implementation project(":payments-ui-core")

--- a/payments-core/build.gradle
+++ b/payments-core/build.gradle
@@ -9,8 +9,6 @@ dependencies {
     api project(":payments-model")
     compileOnly project(':financial-connections')
 
-    implementation platform(boms.androidx.compose)
-
     implementation libs.androidx.activity
     implementation libs.androidx.annotation
     implementation libs.androidx.appCompat

--- a/payments-ui-core/build.gradle
+++ b/payments-ui-core/build.gradle
@@ -11,8 +11,6 @@ dependencies {
     compileOnly project(":stripecardscan")
     compileOnly libs.places
 
-    implementation platform(boms.androidx.compose)
-
     implementation libs.androidx.constraintLayout
     implementation libs.androidx.coreKtx
     implementation libs.androidx.annotation

--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -17,8 +17,6 @@ dependencies {
     implementation project(':stripecardscan')
     implementation project(':financial-connections')
 
-    implementation platform(boms.androidx.compose)
-
     implementation libs.androidx.activity
     implementation libs.androidx.appCompat
     implementation libs.androidx.constraintLayout

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -12,8 +12,6 @@ dependencies {
     implementation project(':stripe-ui-core')
     compileOnly project(':financial-connections')
 
-    implementation platform(boms.androidx.compose)
-
     // Kotlin
     implementation libs.kotlin.coroutines
     implementation libs.kotlin.coroutinesAndroid

--- a/stripe-ui-core/build.gradle
+++ b/stripe-ui-core/build.gradle
@@ -34,9 +34,6 @@ android {
 
 dependencies {
     implementation project(":stripe-core")
-
-    implementation platform(boms.androidx.compose)
-
     implementation libs.androidx.annotation
     implementation libs.androidx.coreKtx
     implementation libs.compose.foundation


### PR DESCRIPTION
# Summary
- Revert the bom change in https://github.com/stripe/stripe-android/pull/6676
- Manually upgrade compose to 1.4.3
- Compose compiler is not included on the BOM as it depends on the project Kotlin version

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
The bom change breaks React Native SDK, filed a issue [here](https://issuetracker.google.com/issues/281589080)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified
