### PR TITLE
[Android] ImageDecoder: Exception in invokeOnCancellation handler


### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## XX.XX.XX - 2023-XX-XX
 * [CHANGED][6697](https://github.com/stripe/stripe-android/pull/6697) Revert BOM change and use compose 1.4.3. 
+* [FIXED][6698](https://github.com/stripe/stripe-android/pull/6698) ImageDecoder: Exception in invokeOnCancellation handler.
 
 
 ## 20.25.0 - 2023-05-08

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/NetworkImageDecoder.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/image/NetworkImageDecoder.kt
@@ -47,7 +47,7 @@ class NetworkImageDecoder {
     ): Bitmap? = suspendCancellableCoroutine { cont ->
         kotlin.runCatching {
             URL(url).stream()
-                .also { stream -> cont.invokeOnCancellation { stream.close() } }
+                .also { stream -> cont.invokeOnCancellation { runCatching { stream.close() } } }
                 .use { BitmapFactory.decodeStream(it, null, this) }
         }.fold(
             onSuccess = { cont.resume(it) },


### PR DESCRIPTION
# Summary
- Problem: we're seeing some crashes when the cancellation logic of our internal `ImageDecoder` throws an exception.
  - On coroutine cancellation, we attempt to close the `InputStream` fetching the image.
  - This cancellation can fail (example failure we're sometimes seeing: [Okhttp throws unbalanced enter/exit](https://github.com/square/okhttp/issues/7381))
- Solution: we should be ignoring errors happening 
  - [Coil follows a similar approach](https://github.com/coil-kt/coil/blob/f92832d0cfcf70426bcb80c02d01a5d688865c4d/coil-base/src/main/java/coil/util/Calls.kt#L38C12-L42).

# Motivation
:notebook_with_decorative_cover: &nbsp;**[Android] ImageDecoder: Exception in invokeOnCancellation handler**
:globe_with_meridians: &nbsp;[BANKCON-6830](https://jira.corp.stripe.com/browse/BANKCON-6830)
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Changelog
    - [Fixed] ImageDecoder: Exception in invokeOnCancellation handler