### PR TITLE
Prevent the flash from toggling in an invalid camera state

### DIFF
--- a/camera-core/src/main/java/com/stripe/android/camera/Camera1Adapter.kt
+++ b/camera-core/src/main/java/com/stripe/android/camera/Camera1Adapter.kt
@@ -98,14 +98,16 @@ class Camera1Adapter(
 
     override fun setTorchState(on: Boolean) {
         mCamera?.apply {
-            val parameters = parameters
-            if (on) {
-                parameters.flashMode = Camera.Parameters.FLASH_MODE_TORCH
-            } else {
-                parameters.flashMode = Camera.Parameters.FLASH_MODE_OFF
+            if (isFlashSupported(this)) {
+                val parameters = parameters
+                if (on) {
+                    parameters.flashMode = Camera.Parameters.FLASH_MODE_TORCH
+                } else {
+                    parameters.flashMode = Camera.Parameters.FLASH_MODE_OFF
+                }
+                setCameraParameters(this, parameters)
+                startCameraPreview()
             }
-            setCameraParameters(this, parameters)
-            startCameraPreview()
         }
     }
 


### PR DESCRIPTION
# Summary
Many devices have one camera that supports flash, and one or more that do not. Prevent the user from toggling flash on a camera that does not support it.

# Motivation
https://github.com/stripe/stripe-android/issues/6714

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified
