### PR TITLE
[Bitrise] Start emulator before prepare_all

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -48,13 +48,11 @@ workflows:
             - content: ./gradlew testDebugUnitTest verifyPaparazziDebug -x :stripe-test-e2e:testDebugUnitTest
   maestro-financial-connections:
     before_run:
+      - start_emulator
       - prepare_all
     after_run:
       - conclude_all
     steps:
-      - avd-manager@1:
-          inputs:
-            - profile: "pixel_3a"
       - wait-for-android-emulator@1: { }
       - script-runner@0:
           title: Execute Maestro tests
@@ -78,13 +76,11 @@ workflows:
       - deploy-to-bitrise-io@2: { }
   maestro-edge-financial-connections:
     before_run:
+      - start_emulator
       - prepare_all
     after_run:
       - conclude_all
     steps:
-      - avd-manager@1:
-          inputs:
-            - profile: "pixel_3a"
       - wait-for-android-emulator@1: { }
       - script-runner@0:
           title: Execute Maestro tests
@@ -102,15 +98,12 @@ workflows:
       - deploy-to-bitrise-io@2: { }
   maestro-paymentsheet:
     before_run:
+      - start_emulator
       - prepare_all
     after_run:
       - conclude_all
     steps:
-      - avd-manager@1:
-          inputs:
-            - profile: "pixel_3a"
-            - api_level: 30
-            - tag: "google_apis_playstore"
+
       - wait-for-android-emulator@1: { }
       - script-runner@0:
           title: Execute Maestro tests
@@ -139,6 +132,13 @@ workflows:
           title: Execute instrumentation tests
           inputs:
             - file_path: ./scripts/execute_instrumentation_tests.sh
+  start_emulator:
+    steps:
+      - avd-manager@1:
+          inputs:
+            - profile: "pixel_3a"
+            - api_level: 30
+            - tag: "google_apis_playstore"
   prepare_all:
     steps:
       - activate-ssh-key@4:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -53,7 +53,9 @@ workflows:
     after_run:
       - conclude_all
     steps:
-      - wait-for-android-emulator@1: { }
+      - wait-for-android-emulator@1:
+          inputs:
+            - boot_timeout: 600
       - script-runner@0:
           title: Execute Maestro tests
           inputs:
@@ -81,7 +83,9 @@ workflows:
     after_run:
       - conclude_all
     steps:
-      - wait-for-android-emulator@1: { }
+      - wait-for-android-emulator@1:
+          inputs:
+            - boot_timeout: 600
       - script-runner@0:
           title: Execute Maestro tests
           inputs:
@@ -103,8 +107,9 @@ workflows:
     after_run:
       - conclude_all
     steps:
-
-      - wait-for-android-emulator@1: { }
+      - wait-for-android-emulator@1:
+          inputs:
+            - boot_timeout: 600
       - script-runner@0:
           title: Execute Maestro tests
           inputs:
@@ -122,12 +127,14 @@ workflows:
       - deploy-to-bitrise-io@2: { }
   run-instrumentation-tests:
     before_run:
+      - start_emulator
       - prepare_all
     after_run:
       - conclude_all
     steps:
-      - avd-manager@1: { }
-      - wait-for-android-emulator@1: { }
+      - wait-for-android-emulator@1:
+          inputs:
+            - boot_timeout: 600
       - script-runner@0:
           title: Execute instrumentation tests
           inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -127,11 +127,11 @@ workflows:
       - deploy-to-bitrise-io@2: { }
   run-instrumentation-tests:
     before_run:
-      - start_emulator
       - prepare_all
     after_run:
       - conclude_all
     steps:
+      - avd-manager@1: { }
       - wait-for-android-emulator@1:
           inputs:
             - boot_timeout: 600


### PR DESCRIPTION
# Summary
- Problem: we're seeing some builds fail due to emulators timing out
- Recommended solutions from Bitrise team
  - Start emulator before any other step runs
  - Extend emulator wait time to 600.