### PR TITLE
Prevent CAP polling on canceled payment attempt

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -6487,29 +6487,6 @@ public final class com/stripe/android/networking/FraudDetectionData$Creator : an
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/payments/PaymentFlowResult$Unvalidated : android/os/Parcelable {
-	public static final field $stable I
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public static final field Companion Lcom/stripe/android/payments/PaymentFlowResult$Unvalidated$Companion;
-	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;ILcom/stripe/android/core/exception/StripeException;ZLjava/lang/String;Lcom/stripe/android/model/Source;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;ILcom/stripe/android/core/exception/StripeException;ZLjava/lang/String;Lcom/stripe/android/model/Source;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()I
-	public final fun component3 ()Lcom/stripe/android/core/exception/StripeException;
-	public final fun copy (Ljava/lang/String;ILcom/stripe/android/core/exception/StripeException;ZLjava/lang/String;Lcom/stripe/android/model/Source;Ljava/lang/String;)Lcom/stripe/android/payments/PaymentFlowResult$Unvalidated;
-	public static synthetic fun copy$default (Lcom/stripe/android/payments/PaymentFlowResult$Unvalidated;Ljava/lang/String;ILcom/stripe/android/core/exception/StripeException;ZLjava/lang/String;Lcom/stripe/android/model/Source;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/payments/PaymentFlowResult$Unvalidated;
-	public fun describeContents ()I
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getClientSecret ()Ljava/lang/String;
-	public final fun getException ()Lcom/stripe/android/core/exception/StripeException;
-	public final fun getFlowOutcome ()I
-	public fun hashCode ()I
-	public final synthetic fun toBundle ()Landroid/os/Bundle;
-	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
 public final class com/stripe/android/payments/PaymentFlowResult$Unvalidated$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/payments/PaymentFlowResult$Unvalidated;

--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResult.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResult.kt
@@ -22,6 +22,8 @@ import kotlinx.parcelize.Parcelize
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 sealed class PaymentFlowResult {
+
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
     data class Unvalidated constructor(
         val clientSecret: String? = null,

--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResult.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResult.kt
@@ -30,7 +30,8 @@ sealed class PaymentFlowResult {
         internal val canCancelSource: Boolean = false,
         internal val sourceId: String? = null,
         internal val source: Source? = null,
-        internal val stripeAccountId: String? = null
+        internal val stripeAccountId: String? = null,
+        internal val didUserCancel: Boolean = false,
     ) : Parcelable {
         @JvmSynthetic
         fun toBundle() = bundleOf(EXTRA to this)
@@ -63,7 +64,8 @@ sealed class PaymentFlowResult {
                     canCancelSource = parcel.readInt() == 1,
                     sourceId = parcel.readString(),
                     source = parcel.readParcelable(Source::class.java.classLoader),
-                    stripeAccountId = parcel.readString()
+                    stripeAccountId = parcel.readString(),
+                    didUserCancel = parcel.readInt() == 1,
                 )
             }
 
@@ -71,10 +73,11 @@ sealed class PaymentFlowResult {
                 parcel.writeString(clientSecret)
                 parcel.writeInt(flowOutcome)
                 parcel.writeSerializable(exception)
-                parcel.writeInt(1.takeIf { canCancelSource } ?: 0)
+                parcel.writeInt(if (canCancelSource) 1 else 0)
                 parcel.writeString(sourceId)
                 parcel.writeParcelable(source, flags)
                 parcel.writeString(stripeAccountId)
+                parcel.writeInt(if (didUserCancel) 1 else 0)
             }
 
             @JvmSynthetic

--- a/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherActivity.kt
@@ -37,18 +37,17 @@ internal class StripeBrowserLauncherActivity : AppCompatActivity() {
             return
         }
 
-        setResult(
-            Activity.RESULT_OK,
-            viewModel.getResultIntent(args)
-        )
+        val defaultResult = viewModel.getResultIntent(args)
+        setResult(Activity.RESULT_OK, defaultResult)
 
         if (viewModel.hasLaunched) {
             finish()
         } else {
             val launcher = registerForActivityResult(
                 ActivityResultContracts.StartActivityForResult(),
-                ::onResult
-            )
+            ) { activityResult ->
+                onResult(activityResult, args)
+            }
 
             launcher.launch(
                 viewModel.createLaunchIntent(args)
@@ -58,9 +57,13 @@ internal class StripeBrowserLauncherActivity : AppCompatActivity() {
         }
     }
 
-    private fun onResult(activityResult: ActivityResult) {
+    private fun onResult(
+        activityResult: ActivityResult,
+        args: PaymentBrowserAuthContract.Args,
+    ) {
         // always dismiss the activity when a result is available
-
+        val defaultResult = viewModel.getResultIntent(args, activityResult)
+        setResult(Activity.RESULT_OK, defaultResult)
         finish()
     }
 

--- a/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherViewModel.kt
@@ -1,7 +1,9 @@
 package com.stripe.android.payments
 
+import android.app.Activity
 import android.content.Intent
 import android.net.Uri
+import androidx.activity.result.ActivityResult
 import androidx.browser.customtabs.CustomTabColorSchemeParams
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.lifecycle.SavedStateHandle
@@ -73,14 +75,18 @@ internal class StripeBrowserLauncherViewModel(
         }
     }
 
-    fun getResultIntent(args: PaymentBrowserAuthContract.Args): Intent {
+    fun getResultIntent(
+        args: PaymentBrowserAuthContract.Args,
+        activityResult: ActivityResult? = null,
+    ): Intent {
         val url = Uri.parse(args.url)
         return Intent().putExtras(
             PaymentFlowResult.Unvalidated(
                 clientSecret = args.clientSecret,
                 sourceId = url.lastPathSegment.orEmpty(),
                 stripeAccountId = args.stripeAccountId,
-                canCancelSource = args.shouldCancelSource
+                canCancelSource = args.shouldCancelSource,
+                didUserCancel = activityResult?.resultCode == Activity.RESULT_CANCELED,
             ).toBundle()
         )
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request prevents polling if a Cash App Pay payment has been canceled.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
