### PR TITLE
Fix an issue where google places caused errors with R8.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## XX.XX.XX - 2023-XX-XX
 
+### PaymentSheet
+* [FIXED][6735](https://github.com/stripe/stripe-android/pull/6735) Fixed an issue where google places caused errors with R8.
+
 ## 20.25.2 - 2023-05-15
 
 ### PaymentSheet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## XX.XX.XX - 2023-XX-XX
 
 ### PaymentSheet
-* [FIXED][6735](https://github.com/stripe/stripe-android/pull/6735) Fixed an issue where google places caused errors with R8.
+* [FIXED][6736](https://github.com/stripe/stripe-android/pull/6736) Fixed an issue where Google Places caused errors with R8.
 
 ## 20.25.2 - 2023-05-15
 

--- a/payments-ui-core/consumer-rules.txt
+++ b/payments-ui-core/consumer-rules.txt
@@ -1,4 +1,4 @@
 # Google Places SDK is compile only in the build.gradle.
--dontwarn com.google.android.libraries.places.api.**
+-dontwarn com.google.android.libraries.places.**
 # Stripe Card Scan SDK is compile only in the build.gradle.
 -dontwarn com.stripe.android.stripecardscan.**


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
The R class is not in the API package, which caused errors with R8.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
#6735

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
