### PR TITLE
Rename `DISMISS_WITH_SUCCESS` to `COMPLETE_WITHOUT_CONFIRMING_INTENT`

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/IntentConfirmationInterceptor.kt
+++ b/payments-core/src/main/java/com/stripe/android/IntentConfirmationInterceptor.kt
@@ -57,7 +57,7 @@ interface IntentConfirmationInterceptor {
     companion object {
         var createIntentCallback: AbsCreateIntentCallback? = null
 
-        const val DISMISS_WITH_SUCCESS = "DISMISS_WITH_SUCCESS"
+        const val COMPLETE_WITHOUT_CONFIRMING_INTENT = "COMPLETE_WITHOUT_CONFIRMING_INTENT"
     }
 }
 
@@ -170,7 +170,7 @@ class DefaultIntentConfirmationInterceptor @Inject constructor(
     ): NextStep {
         return when (val result = createIntentCallback.onCreateIntent(paymentMethod)) {
             is CreateIntentResult.Success -> {
-                if (result.clientSecret == IntentConfirmationInterceptor.DISMISS_WITH_SUCCESS) {
+                if (result.clientSecret == IntentConfirmationInterceptor.COMPLETE_WITHOUT_CONFIRMING_INTENT) {
                     NextStep.Complete(isForceSuccess = true)
                 } else {
                     createConfirmStep(result.clientSecret, shippingValues, paymentMethod)
@@ -198,7 +198,7 @@ class DefaultIntentConfirmationInterceptor @Inject constructor(
 
         return when (result) {
             is CreateIntentResult.Success -> {
-                if (result.clientSecret == IntentConfirmationInterceptor.DISMISS_WITH_SUCCESS) {
+                if (result.clientSecret == IntentConfirmationInterceptor.COMPLETE_WITHOUT_CONFIRMING_INTENT) {
                     NextStep.Complete(isForceSuccess = true)
                 } else {
                     handleServerSideConfirmationSuccess(

--- a/payments-core/src/test/java/com/stripe/android/DefaultIntentConfirmationInterceptorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/DefaultIntentConfirmationInterceptorTest.kt
@@ -474,7 +474,7 @@ class DefaultIntentConfirmationInterceptorTest {
         )
 
         IntentConfirmationInterceptor.createIntentCallback = CreateIntentCallback { _ ->
-            CreateIntentResult.Success(IntentConfirmationInterceptor.DISMISS_WITH_SUCCESS)
+            CreateIntentResult.Success(IntentConfirmationInterceptor.COMPLETE_WITHOUT_CONFIRMING_INTENT)
         }
 
         val nextStep = interceptor.intercept(
@@ -505,7 +505,7 @@ class DefaultIntentConfirmationInterceptorTest {
 
         IntentConfirmationInterceptor.createIntentCallback =
             CreateIntentCallbackForServerSideConfirmation { _, _ ->
-                CreateIntentResult.Success(IntentConfirmationInterceptor.DISMISS_WITH_SUCCESS)
+                CreateIntentResult.Success(IntentConfirmationInterceptor.COMPLETE_WITHOUT_CONFIRMING_INTENT)
             }
 
         val nextStep = interceptor.intercept(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/viewmodel/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/viewmodel/PaymentSheetPlaygroundViewModel.kt
@@ -280,7 +280,7 @@ class PaymentSheetPlaygroundViewModel(
         val initializationType = initializationType.value
 
         val clientSecret = if (initializationType == InitializationType.DeferredMultiprocessor) {
-            PaymentSheet.IntentConfiguration.DISMISS_WITH_SUCCESS
+            PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT
         } else {
             // Note: This is not how you'd do this in a real application. Instead, your app would
             // call your backend and create (and optionally confirm) a payment or setup intent.
@@ -300,7 +300,7 @@ class PaymentSheetPlaygroundViewModel(
         backendUrl: String,
     ): CreateIntentResult {
         return if (initializationType.value == InitializationType.DeferredMultiprocessor) {
-            CreateIntentResult.Success(PaymentSheet.IntentConfiguration.DISMISS_WITH_SUCCESS)
+            CreateIntentResult.Success(PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT)
         } else {
             createAndConfirmIntentInternal(
                 paymentMethodId = paymentMethodId,

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -518,7 +518,7 @@ internal class FlowControllerTest {
                     flowController.confirm()
                 },
                 createIntentCallback = {
-                    CreateIntentResult.Success(PaymentSheet.IntentConfiguration.DISMISS_WITH_SUCCESS)
+                    CreateIntentResult.Success(PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT)
                 },
                 paymentResultCallback = { result ->
                     assertThat(result).isInstanceOf(PaymentSheetResult.Completed::class.java)

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -311,7 +311,7 @@ internal class PaymentSheetTest {
             paymentSheet = PaymentSheet(
                 activity = it,
                 createIntentCallback = {
-                    CreateIntentResult.Success(PaymentSheet.IntentConfiguration.DISMISS_WITH_SUCCESS)
+                    CreateIntentResult.Success(PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT)
                 }
             ) { result ->
                 assertThat(result).isInstanceOf(PaymentSheetResult.Completed::class.java)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -359,10 +359,18 @@ class PaymentSheet internal constructor(
 
             /**
              * Pass this as the client secret into [CreateIntentResult.Success] to force
-             * [PaymentSheet] to show success and dismiss.
+             * [PaymentSheet] to show success, dismiss the sheet without confirming the intent, and
+             * return [PaymentSheetResult.Completed].
+             *
+             * **Note**: If provided, the SDK performs no action to complete the payment or setup.
+             * It doesn't confirm a [PaymentIntent] or [SetupIntent] or handle next actions. You
+             * should only use this if your integration can't create a [PaymentIntent] or
+             * [SetupIntent]. It is your responsibility to ensure that you only pass this value if
+             * the payment or setup is successful.
              */
             @DelicatePaymentSheetApi
-            const val DISMISS_WITH_SUCCESS = IntentConfirmationInterceptor.DISMISS_WITH_SUCCESS
+            const val COMPLETE_WITHOUT_CONFIRMING_INTENT =
+                IntentConfirmationInterceptor.COMPLETE_WITHOUT_CONFIRMING_INTENT
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -1336,7 +1336,7 @@ internal class PaymentSheetViewModelTest {
     @Test
     fun `Sends correct analytics event based on force-success usage`() = runTest {
         val clientSecrets = listOf(
-            PaymentSheet.IntentConfiguration.DISMISS_WITH_SUCCESS to times(1),
+            PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT to times(1),
             "real_client_secret" to never(),
         )
 
@@ -1351,7 +1351,7 @@ internal class PaymentSheetViewModelTest {
             viewModel.updateSelection(savedSelection)
             viewModel.checkout()
 
-            val isForceSuccess = clientSecret == PaymentSheet.IntentConfiguration.DISMISS_WITH_SUCCESS
+            val isForceSuccess = clientSecret == PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT
             fakeIntentConfirmationInterceptor.enqueueCompleteStep(isForceSuccess)
 
             verify(eventReporter, verificationMode).onForceSuccess()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -1139,7 +1139,7 @@ internal class DefaultFlowControllerTest {
     @Test
     fun `Sends correct analytics event based on force-success usage`() = runTest {
         val clientSecrets = listOf(
-            PaymentSheet.IntentConfiguration.DISMISS_WITH_SUCCESS to times(1),
+            PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT to times(1),
             "real_client_secret" to never(),
         )
 
@@ -1157,7 +1157,7 @@ internal class DefaultFlowControllerTest {
             )
             flowController.confirm()
 
-            val isForceSuccess = clientSecret == PaymentSheet.IntentConfiguration.DISMISS_WITH_SUCCESS
+            val isForceSuccess = clientSecret == PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT
             fakeIntentConfirmationInterceptor.enqueueCompleteStep(isForceSuccess)
 
             verify(eventReporter, verificationMode).onForceSuccess()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request follows [the iOS example](https://github.com/stripe/stripe-ios/pull/2583) and renames the multiprocessor fake client secret to `COMPLETE_WITHOUT_CONFIRMING_INTENT`.

(cc @porter-stripe)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
