### PR TITLE
Temporary fix for Cash App Pay test failure

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/BuyButton.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/BuyButton.kt
@@ -9,9 +9,15 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.test.platform.app.InstrumentationRegistry
 import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import com.stripe.android.ui.core.R as StripeUiCoreR
 
-class BuyButton(private val composeTestRule: ComposeTestRule) {
+class BuyButton(
+    private val composeTestRule: ComposeTestRule,
+    private val processingCompleteTimeout: Duration = 5.seconds,
+) {
+
     fun click() {
         composeTestRule.onNode(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG))
             .performScrollTo()
@@ -37,7 +43,7 @@ class BuyButton(private val composeTestRule: ComposeTestRule) {
         val expectedText = InstrumentationRegistry.getInstrumentation().targetContext.resources.getString(
             StripeUiCoreR.string.stripe_pay_button_amount
         ).replace("%s", "")
-        composeTestRule.waitUntil(timeoutMillis = 5000L) {
+        composeTestRule.waitUntil(timeoutMillis = processingCompleteTimeout.inWholeMilliseconds) {
             runCatching {
                 composeTestRule.onNode(hasText(text = expectedText, substring = true))
                     .assertIsDisplayed()

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
@@ -15,6 +15,7 @@ import androidx.test.uiautomator.Until
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.model.CountryUtils
+import com.stripe.android.model.PaymentMethod.Type.CashAppPay
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.R
 import com.stripe.android.paymentsheet.example.playground.model.InitializationType
@@ -32,6 +33,7 @@ import com.stripe.android.test.core.Shipping
 import com.stripe.android.test.core.TestParameters
 import com.stripe.android.ui.core.elements.SAVE_FOR_FUTURE_CHECKBOX_TEST_TAG
 import java.util.Locale
+import kotlin.time.Duration.Companion.seconds
 import com.stripe.android.R as StripeR
 import com.stripe.android.core.R as CoreR
 import com.stripe.android.uicore.R as UiCoreR
@@ -130,12 +132,16 @@ class Selectors(
         PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Never -> EspressoIdButton(R.id.collect_address_radio_never)
     }
 
-    val baseScreenshotFilenamePrefix = "info-" +
-        getResourceString(paymentSelection.label) +
-        "-" +
-        testParameters.intentType.name
-
-    val buyButton = BuyButton(composeTestRule)
+    val buyButton = BuyButton(
+        composeTestRule = composeTestRule,
+        processingCompleteTimeout = if (testParameters.paymentMethod.code == CashAppPay.code) {
+            // We're using a longer timeout for Cash App Pay until we fix an issue where we
+            // needlessly poll after a canceled payment attempt.
+            15.seconds
+        } else {
+            5.seconds
+        }
+    )
 
     val addPaymentMethodButton = AddPaymentMethodButton(device)
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request fixes a test failure that was introduced with the Cash App Pay polling changes last week. We extend the timeout duration to account for the additional polling delay.

BrowserStack run: https://app-automate.browserstack.com/dashboard/v2/builds/c4f853c39eef43699931f70d74a014c9da3cf7be

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
