### PR TITLE
Remove canCreateSetupIntents from StripeCustomerAdapter

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/StripeCustomerAdapterComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/StripeCustomerAdapterComponent.kt
@@ -29,8 +29,6 @@ import javax.inject.Named
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
-internal const val CAN_CREATE_SETUP_INTENT = "canCreateSetupIntent"
-
 @Singleton
 @Component(
     modules = [
@@ -57,11 +55,6 @@ internal interface StripeCustomerAdapterComponent {
         @BindsInstance
         fun setupIntentClientSecretProvider(
             setupIntentClientSecretProvider: SetupIntentClientSecretProvider?
-        ): Builder
-
-        @BindsInstance
-        fun canCreateSetupIntents(
-            @Named(CAN_CREATE_SETUP_INTENT) canCreateSetupIntents: Boolean
         ): Builder
 
         fun build(): StripeCustomerAdapterComponent

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerAdapter.kt
@@ -73,19 +73,16 @@ interface CustomerAdapter {
          * @param setupIntentClientSecretProvider, a callback to retrieve the setup intent client
          * secret. The client secret is used in this adapter to attach a payment method with a
          * setup intent.
-         * @param canCreateSetupIntents, whether or not this adapter can create setup intents
          */
         fun create(
             context: Context,
             customerEphemeralKeyProvider: CustomerEphemeralKeyProvider,
             setupIntentClientSecretProvider: SetupIntentClientSecretProvider?,
-            canCreateSetupIntents: Boolean,
         ): CustomerAdapter {
             val component = DaggerStripeCustomerAdapterComponent.builder()
                 .context(context)
                 .customerEphemeralKeyProvider(customerEphemeralKeyProvider)
                 .setupIntentClientSecretProvider(setupIntentClientSecretProvider)
-                .canCreateSetupIntents(canCreateSetupIntents)
                 .build()
             return component.stripeCustomerAdapter
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/StripeCustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/StripeCustomerAdapter.kt
@@ -5,7 +5,6 @@ import com.stripe.android.ExperimentalSavedPaymentMethodsApi
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PrefsRepository
 import javax.inject.Inject
-import javax.inject.Named
 
 /**
  * The default implementation of [CustomerAdapter]. This adapter uses the customer ID and ephemeral

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/StripeCustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/StripeCustomerAdapter.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import com.stripe.android.ExperimentalSavedPaymentMethodsApi
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PrefsRepository
-import com.stripe.android.paymentsheet.injection.CAN_CREATE_SETUP_INTENT
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -20,7 +19,6 @@ internal class StripeCustomerAdapter @Inject constructor(
     private val context: Context,
     private val customerEphemeralKeyProvider: CustomerEphemeralKeyProvider,
     private val setupIntentClientSecretProvider: SetupIntentClientSecretProvider?,
-    @Named(CAN_CREATE_SETUP_INTENT) private val canCreateSetupIntents: Boolean,
     private val timeProvider: () -> Long,
     private val customerRepository: CustomerRepository,
     private val prefsRepositoryFactory: (CustomerEphemeralKey) -> PrefsRepository,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerAdapterTest.kt
@@ -121,14 +121,12 @@ class CustomerAdapterTest {
             SetupIntentClientSecretProvider {
                 Result.success("seti_123")
             },
-        canCreateSetupIntents: Boolean = true,
         timeProvider: () -> Long = { 1L }
     ): StripeCustomerAdapter {
         return StripeCustomerAdapter(
             context = context,
             customerEphemeralKeyProvider = customerEphemeralKeyProvider,
             setupIntentClientSecretProvider = setupIntentClientSecretProvider,
-            canCreateSetupIntents = canCreateSetupIntents,
             timeProvider = timeProvider,
             customerRepository = customerRepository,
             prefsRepositoryFactory = { FakePrefsRepository() }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerAdapterTest.kt
@@ -48,8 +48,7 @@ class CustomerAdapterTest {
         val adapter = CustomerAdapter.create(
             context = context,
             customerEphemeralKeyProvider = customerEphemeralKeyProvider,
-            setupIntentClientSecretProvider = setupIntentClientSecretProvider,
-            canCreateSetupIntents = true
+            setupIntentClientSecretProvider = setupIntentClientSecretProvider
         )
 
         assertThat(adapter).isNotNull()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Remove canCreateSetupIntents from StripeCustomerAdapter

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

This field can be computed via `setupIntentClientSecretProvider`

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified
