### PR TITLE
Refactor customer repository detach to return non null result

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerAdapter.kt
@@ -36,8 +36,9 @@ interface CustomerAdapter {
     /**
      * Detaches the given payment method from a customer
      * @param paymentMethodId, the payment method to detach from the customer
+     * @return the modified [PaymentMethod].
      */
-    suspend fun detachPaymentMethod(paymentMethodId: String)
+    suspend fun detachPaymentMethod(paymentMethodId: String): Result<PaymentMethod>
 
     /**
      * Set the selected payment method option.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerApiRepository.kt
@@ -76,7 +76,7 @@ internal class CustomerApiRepository @Inject constructor(
     override suspend fun detachPaymentMethod(
         customerConfig: PaymentSheet.CustomerConfiguration,
         paymentMethodId: String
-    ): PaymentMethod? =
+    ): Result<PaymentMethod> =
         stripeRepository.detachPaymentMethod(
             publishableKey = lazyPaymentConfig.get().publishableKey,
             productUsageTokens = productUsageTokens,
@@ -87,7 +87,7 @@ internal class CustomerApiRepository @Inject constructor(
             )
         ).onFailure {
             logger.error("Failed to detach payment method $paymentMethodId.", it)
-        }.getOrNull()
+        }
 
     override suspend fun attachPaymentMethod(
         customerConfig: PaymentSheet.CustomerConfiguration,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerRepository.kt
@@ -27,12 +27,11 @@ internal interface CustomerRepository {
 
     /**
      * Detach a payment method from the Customer and return the modified [PaymentMethod].
-     * Silently handle failures by returning null.
      */
     suspend fun detachPaymentMethod(
         customerConfig: PaymentSheet.CustomerConfiguration,
         paymentMethodId: String
-    ): PaymentMethod?
+    ): Result<PaymentMethod>
 
     /**
      * Attach a payment method to the Customer and return the modified [PaymentMethod].

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/StripeCustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/StripeCustomerAdapter.kt
@@ -59,7 +59,7 @@ internal class StripeCustomerAdapter @Inject constructor(
         }
     }
 
-    override suspend fun detachPaymentMethod(paymentMethodId: String) {
+    override suspend fun detachPaymentMethod(paymentMethodId: String): Result<PaymentMethod> {
         TODO()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
@@ -124,11 +124,11 @@ internal class CustomerRepositoryTest {
                 "payment_method_id"
             )
 
-            assertThat(result).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+            assertThat(result.getOrNull()).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
         }
 
     @Test
-    fun `detachPaymentMethod() should return null on failure`() =
+    fun `detachPaymentMethod() should return exception on failure`() =
         runTest {
             givenDetachPaymentMethodReturns(
                 Result.failure(InvalidParameterException("error"))
@@ -142,7 +142,7 @@ internal class CustomerRepositoryTest {
                 "payment_method_id"
             )
 
-            assertThat(result).isNull()
+            assertThat(result.isFailure).isTrue()
         }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
@@ -8,6 +8,9 @@ import com.stripe.android.paymentsheet.repositories.CustomerRepository
 internal class FakeCustomerRepository(
     private val paymentMethods: List<PaymentMethod> = emptyList(),
     private val customer: Customer? = null,
+    private val onDetachPaymentMethod: () -> Result<PaymentMethod> = {
+        Result.failure(NotImplementedError())
+    },
     private val onAttachPaymentMethod: () -> Result<PaymentMethod> = {
         Result.failure(NotImplementedError())
     },
@@ -28,7 +31,7 @@ internal class FakeCustomerRepository(
     override suspend fun detachPaymentMethod(
         customerConfig: PaymentSheet.CustomerConfiguration,
         paymentMethodId: String
-    ): PaymentMethod? = null
+    ): Result<PaymentMethod> = onDetachPaymentMethod()
 
     override suspend fun attachPaymentMethod(
         customerConfig: PaymentSheet.CustomerConfiguration,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Refactor customer repository detach to return non null result

Only usage is in `BaseSheetViewModel` which ignores the result anyways.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

CustomerAdapter usage

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

