### PR TITLE
Refactor PrefsRepository

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultPrefsRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultPrefsRepository.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
+import com.stripe.android.paymentsheet.model.toSavedSelection
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 
@@ -32,12 +33,14 @@ internal class DefaultPrefsRepository(
     }
 
     override fun savePaymentSelection(paymentSelection: PaymentSelection?) {
-        when (paymentSelection) {
-            PaymentSelection.GooglePay -> "google_pay"
-            PaymentSelection.Link -> "link"
-            is PaymentSelection.Saved -> {
-                "payment_method:${paymentSelection.paymentMethod.id.orEmpty()}"
-            }
+        setSavedSelection(paymentSelection?.toSavedSelection())
+    }
+
+    override fun setSavedSelection(savedSelection: SavedSelection?) {
+        when (savedSelection) {
+            SavedSelection.GooglePay -> "google_pay"
+            SavedSelection.Link -> "link"
+            is SavedSelection.PaymentMethod -> "payment_method:${savedSelection.id}"
             else -> null
         }?.let { value ->
             write(value)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PrefsRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PrefsRepository.kt
@@ -9,5 +9,7 @@ internal interface PrefsRepository {
         isLinkAvailable: Boolean
     ): SavedSelection
 
+    fun setSavedSelection(savedSelection: SavedSelection?)
+
     fun savePaymentSelection(paymentSelection: PaymentSelection?)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SavedSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/SavedSelection.kt
@@ -18,3 +18,12 @@ internal sealed class SavedSelection : Parcelable {
     @Parcelize
     object None : SavedSelection()
 }
+
+internal fun PaymentSelection.toSavedSelection(): SavedSelection? {
+    return when (this) {
+        is PaymentSelection.GooglePay -> SavedSelection.GooglePay
+        is PaymentSelection.Link -> SavedSelection.Link
+        is PaymentSelection.Saved -> SavedSelection.PaymentMethod(paymentMethod.id.orEmpty())
+        else -> null
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultPrefsRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultPrefsRepositoryTest.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
+import com.stripe.android.paymentsheet.model.toSavedSelection
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
@@ -78,6 +79,32 @@ internal class DefaultPrefsRepositoryTest {
             SavedSelection.PaymentMethod(
                 id = "pm_123456789"
             )
+        )
+    }
+
+    @Test
+    fun `setSavedSelection should return the saved payment method`() = runTest {
+        prefsRepository.setSavedSelection(
+            PaymentSelection.Saved(
+                PaymentMethodFixtures.CARD_PAYMENT_METHOD
+            ).toSavedSelection()
+        )
+        assertThat(
+            prefsRepository.getSavedSelection(isGooglePayReady, isLinkAvailable)
+        ).isEqualTo(
+            SavedSelection.PaymentMethod(
+                id = "pm_123456789"
+            )
+        )
+    }
+
+    @Test
+    fun `setSavedSelection null should return none`() = runTest {
+        prefsRepository.setSavedSelection(null)
+        assertThat(
+            prefsRepository.getSavedSelection(isGooglePayReady, isLinkAvailable)
+        ).isEqualTo(
+            SavedSelection.None
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FakePrefsRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FakePrefsRepository.kt
@@ -11,6 +11,12 @@ internal class FakePrefsRepository : PrefsRepository {
     override suspend fun getSavedSelection(isGooglePayAvailable: Boolean, isLinkAvailable: Boolean): SavedSelection =
         savedSelection
 
+    override fun setSavedSelection(savedSelection: SavedSelection?) {
+        savedSelection?.let {
+            this.savedSelection = it
+        }
+    }
+
     override fun savePaymentSelection(paymentSelection: PaymentSelection?) {
         paymentSelectionArgs.add(paymentSelection)
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Add `setSavedSelection` to `PrefsRepository` and refactor the `DefaultPrefsRepository#savePaymentSelection` to call `setSavedSelection` with extension method.

This is an internal API change.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Allow `CustomerAdapter` to set the saved selection through `PrefsRepository`.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

