### PR TITLE
Refactor PaymentOptionsUI

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -1392,6 +1392,13 @@ public final class com/stripe/android/paymentsheet/state/PaymentSheetState$Loadi
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/paymentsheet/ui/ComposableSingletons$PaymentOptionsUIKt {
+	public static final field INSTANCE Lcom/stripe/android/paymentsheet/ui/ComposableSingletons$PaymentOptionsUIKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$paymentsheet_release ()Lkotlin/jvm/functions/Function2;
+}
+
 public final class com/stripe/android/paymentsheet/ui/ComposableSingletons$PaymentSheetTopBarKt {
 	public static final field INSTANCE Lcom/stripe/android/paymentsheet/ui/ComposableSingletons$PaymentSheetTopBarKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function2;

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/PaymentSheetScreen.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import com.stripe.android.paymentsheet.ui.AddPaymentMethod
 import com.stripe.android.paymentsheet.ui.PaymentOptions
@@ -33,7 +34,22 @@ internal sealed interface PaymentSheetScreen {
 
         @Composable
         override fun Content(viewModel: BaseSheetViewModel, modifier: Modifier) {
-            PaymentOptions(viewModel, modifier)
+            val state = viewModel.paymentOptionsState.collectAsState().value
+            val isEditing = viewModel.editing.collectAsState().value
+            val isProcessing = viewModel.processing.collectAsState().value
+            val onAddCardPressed = viewModel::transitionToAddPaymentScreen
+            val onItemSelected = viewModel::handlePaymentMethodSelected
+            val onItemRemoved = viewModel::removePaymentMethod
+
+            PaymentOptions(
+                state = state,
+                isEditing = isEditing,
+                isProcessing = isProcessing,
+                onAddCardPressed = onAddCardPressed,
+                onItemSelected = onItemSelected,
+                onItemRemoved = onItemRemoved,
+                modifier = modifier
+            )
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentOptionsUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentOptionsUI.kt
@@ -9,8 +9,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -20,8 +18,10 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentOptionUi
 import com.stripe.android.paymentsheet.PaymentOptionsItem
@@ -29,30 +29,10 @@ import com.stripe.android.paymentsheet.PaymentOptionsState
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.toPaymentSelection
-import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
+import com.stripe.android.uicore.DefaultStripeTheme
 import com.stripe.android.uicore.shouldUseDarkDynamicColor
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.R as StripeR
-
-@Composable
-internal fun PaymentOptions(
-    viewModel: BaseSheetViewModel,
-    modifier: Modifier = Modifier,
-) {
-    val state by viewModel.paymentOptionsState.collectAsState()
-    val isEditing by viewModel.editing.collectAsState()
-    val isProcessing by viewModel.processing.collectAsState()
-
-    PaymentOptions(
-        state = state,
-        isEditing = isEditing,
-        isProcessing = isProcessing,
-        onAddCardPressed = viewModel::transitionToAddPaymentScreen,
-        onItemSelected = viewModel::handlePaymentMethodSelected,
-        onItemRemoved = viewModel::removePaymentMethod,
-        modifier = modifier,
-    )
-}
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
@@ -93,6 +73,42 @@ internal fun PaymentOptions(
                 )
             }
         }
+    }
+}
+
+@Preview
+@Composable
+private fun PaymentOptionsPreview() {
+    DefaultStripeTheme {
+        PaymentOptions(
+            state = PaymentOptionsState(
+                items = listOf(
+                    PaymentOptionsItem.AddCard,
+                    PaymentOptionsItem.Link,
+                    PaymentOptionsItem.GooglePay,
+                    PaymentOptionsItem.SavedPaymentMethod(
+                        displayName = "4242",
+                        paymentMethod = PaymentMethod(
+                            id = "id",
+                            created = null,
+                            liveMode = false,
+                            code = PaymentMethod.Type.Card.code,
+                            type = PaymentMethod.Type.Card,
+                            card = PaymentMethod.Card(
+                                brand = CardBrand.Visa,
+                                last4 = "4242",
+                            )
+                        )
+                    ),
+                ),
+                selectedIndex = 1
+            ),
+            isEditing = false,
+            isProcessing = false,
+            onAddCardPressed = { },
+            onItemSelected = { },
+            onItemRemoved = { },
+        )
     }
 }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

- Refactor `PaymentOptionsUI` so that it does not depend on `BaseSheetViewModel`.
- Added a compose preview for `PaymentOptions`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

CustomerSheet will not depend on BaseSheet

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots

<img src="https://github.com/stripe/stripe-android/assets/99316447/c5b9d2c3-f2a8-4a1e-a202-ddaa95d3bc56" height=600/>



