### PR TITLE
[stripe-ui-core] Fix phone number length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## XX.XX.XX - 2023-XX-XX
 ### All SDKs
-* [FIXED][6771](https://github.com/stripe/stripe-android/pull/6771) Fixed the length of phone number.
+* [FIXED][6771](https://github.com/stripe/stripe-android/pull/6771) Fixed the length of phone number field.
 
 ## 20.25.3 - 2023-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
 ## XX.XX.XX - 2023-XX-XX
+### All SDKs
+* [FIXED][6771](https://github.com/stripe/stripe-android/pull/6771) Fixed the length of phone number.
 
 ## 20.25.3 - 2023-05-23
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberElementUI.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.focus.onFocusEvent
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -38,6 +39,9 @@ import com.stripe.android.uicore.R
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import com.stripe.android.core.R as CoreR
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+const val PHONE_NUMBER_TEXT_FIELD_TAG = "PhoneNumberTextField"
 
 @Preview
 @Composable
@@ -114,7 +118,8 @@ fun PhoneNumberElementUI(
                     controller.onFocusChange(it.isFocused)
                 }
                 hasFocus = it.isFocused
-            },
+            }
+            .testTag(PHONE_NUMBER_TEXT_FIELD_TAG),
         enabled = enabled,
         label = {
             FormLabel(
@@ -163,3 +168,6 @@ fun PhoneNumberElementUI(
         }
     }
 }
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+const val PHONE_NUMBER_FIELD_TAG = "phone_number"

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
@@ -55,10 +55,7 @@ internal sealed class PhoneNumberFormatter {
         override val placeholder = metadata.pattern.replace('#', '5')
         override val countryCode = metadata.regionCode
 
-        // Maximum number of digits for the subscriber number for this region.
         private val maxSubscriberDigits = metadata.pattern.count { it == '#' }
-//        private val maxSubscriberDigits = E164_MAX_DIGITS -
-//            (prefix.length - 1) // prefix minus the '+'
 
         override fun userInputFilter(input: String) =
             input.filter { VALID_INPUT_RANGE.contains(it) }.run {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberFormatter.kt
@@ -56,8 +56,9 @@ internal sealed class PhoneNumberFormatter {
         override val countryCode = metadata.regionCode
 
         // Maximum number of digits for the subscriber number for this region.
-        private val maxSubscriberDigits = E164_MAX_DIGITS -
-            (prefix.length - 1) // prefix minus the '+'
+        private val maxSubscriberDigits = metadata.pattern.count { it == '#' }
+//        private val maxSubscriberDigits = E164_MAX_DIGITS -
+//            (prefix.length - 1) // prefix minus the '+'
 
         override fun userInputFilter(input: String) =
             input.filter { VALID_INPUT_RANGE.contains(it) }.run {

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/PhoneNumberFormatterTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/PhoneNumberFormatterTest.kt
@@ -44,6 +44,24 @@ internal class PhoneNumberFormatterTest {
             .isEqualTo("+123456789012345")
     }
 
+    @Test
+    fun `WithRegion correctly formats`() {
+        val pattern = "(###)-###+#####!#"
+        val formatter = PhoneNumberFormatter.WithRegion(
+            PhoneNumberFormatter.Metadata(
+                "prefix",
+                "regionCode",
+                pattern
+            )
+        )
+
+        assertThat(formatter.format("123")).isEqualTo("(123")
+        assertThat(formatter.format("1234567")).isEqualTo("(123)-456+7")
+        assertThat(formatter.format("123456789012")).isEqualTo("(123)-456+78901!2")
+        assertThat(formatter.format("123456789012456")).isEqualTo("(123)-456+78901!2")
+
+    }
+
     private fun PhoneNumberFormatter.format(input: String) =
         visualTransformation.filter(AnnotatedString(userInputFilter(input))).text.text
 }

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/PhoneNumberFormatterTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/PhoneNumberFormatterTest.kt
@@ -45,7 +45,7 @@ internal class PhoneNumberFormatterTest {
     }
 
     @Test
-    fun `WithRegion correctly formats`() {
+    fun `WithRegion correctly formats with pattern`() {
         val pattern = "(###)-###+#####!#"
         val formatter = PhoneNumberFormatter.WithRegion(
             PhoneNumberFormatter.Metadata(

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/PhoneNumberFormatterTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/PhoneNumberFormatterTest.kt
@@ -59,7 +59,6 @@ internal class PhoneNumberFormatterTest {
         assertThat(formatter.format("1234567")).isEqualTo("(123)-456+7")
         assertThat(formatter.format("123456789012")).isEqualTo("(123)-456+78901!2")
         assertThat(formatter.format("123456789012456")).isEqualTo("(123)-456+78901!2")
-
     }
 
     private fun PhoneNumberFormatter.format(input: String) =

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/PhoneNumberFormatterTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/PhoneNumberFormatterTest.kt
@@ -8,7 +8,7 @@ internal class PhoneNumberFormatterTest {
 
     @Test
     fun `Phone number is correctly formatted for US locale`() {
-        val formatter = PhoneNumberFormatter.forCountry("US")
+        val formatter = PhoneNumberFormatter.forCountry("US") // "(###) ###-####"
 
         assertThat(formatter.format("123")).isEqualTo("(123")
         assertThat(formatter.format("1234")).isEqualTo("(123) 4")
@@ -17,21 +17,21 @@ internal class PhoneNumberFormatterTest {
         assertThat(formatter.format("1234567890")).isEqualTo("(123) 456-7890")
         // prefix has 1 digit so full number must be at most 14 digits
         assertThat(formatter.format("12345asdfg678901234567890"))
-            .isEqualTo("(123) 456-7890 1234")
+            .isEqualTo("(123) 456-7890")
     }
 
     @Test
     fun `Phone number is correctly formatted for FI locale`() {
-        val formatter = PhoneNumberFormatter.forCountry("FI")
+        val formatter = PhoneNumberFormatter.forCountry("FI") // "## ### ## ##"
 
         assertThat(formatter.format("123")).isEqualTo("12 3")
         assertThat(formatter.format("1234")).isEqualTo("12 34")
         assertThat(formatter.format("123456")).isEqualTo("12 345 6")
         assertThat(formatter.format("1234567")).isEqualTo("12 345 67")
-        assertThat(formatter.format("1234567890")).isEqualTo("12 345 67 89 0")
+        assertThat(formatter.format("1234567890")).isEqualTo("12 345 67 89")
         // prefix has 3 digits so full number must be at most 12 digits
         assertThat(formatter.format("12345asdfg678901234567890"))
-            .isEqualTo("12 345 67 89 012")
+            .isEqualTo("12 345 67 89")
     }
 
     @Test


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Correctly calculate the phone number based on the pattern for known regions.


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![phone](https://github.com/stripe/stripe-android/assets/79880926/4d793f21-1efb-45ca-a642-6827bcf81287)  | ![phoneAfter](https://github.com/stripe/stripe-android/assets/79880926/1e243a80-326e-4bb9-b141-1d6c910b9d80) |






# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
[Fixed] Fixed the length of phone number field.