### PR TITLE
Disable ACHv2 in decoupled

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/resources/LpmRepository.kt
@@ -35,7 +35,6 @@ import com.stripe.android.paymentsheet.forms.SofortRequirement
 import com.stripe.android.paymentsheet.forms.USBankAccountRequirement
 import com.stripe.android.paymentsheet.forms.UpiRequirement
 import com.stripe.android.paymentsheet.forms.ZipRequirement
-import com.stripe.android.ui.core.BuildConfig
 import com.stripe.android.ui.core.CardBillingDetailsCollectionConfiguration
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.AfterpayClearpayHeaderElement.Companion.isClearpay
@@ -632,7 +631,7 @@ class LpmRepository constructor(
             DefaultIsFinancialConnectionsAvailable(),
         // Whether to enable ACHv2 in the deferred flow.
         // To be deleted when https://jira.corp.stripe.com/browse/BANKCON-6731 is completed.
-        val enableACHV2InDeferredFlow: Boolean = BuildConfig.DEBUG,
+        val enableACHV2InDeferredFlow: Boolean = false,
     )
 }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Disable ACHv2 in decoupled. Previously it was enabled for debug builds only, but we don't want merchants to be confused.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

