### PR TITLE
Rename PersistablePaymentMethodOption to CustomerAdapter.PaymentOptions

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerAdapter.kt
@@ -44,8 +44,8 @@ interface CustomerAdapter {
 
     /**
      * Saves the payment option to a data store.
-     * @param paymentOption, the [PaymentOption] to save to the data store. If
-     * null, the selected payment method option will be cleared from the data store.
+     * @param paymentOption, the [PaymentOption] to save to the data store. If null, the selected
+     * payment method option will be cleared from the data store.
      */
     suspend fun setSelectedPaymentOption(paymentOption: PaymentOption?)
 
@@ -53,11 +53,11 @@ interface CustomerAdapter {
      * Fetch the saved payment method option from a data store. If null, the customer does not have
      * a default saved payment method.
      */
-    suspend fun fetchSelectedPaymentMethodOption(): Result<PaymentOption?>
+    suspend fun fetchSelectedPaymentOption(): Result<PaymentOption?>
 
     /**
-     * Returns a [SetupIntent] client secret to attach a new payment method to a customer.
-     * This will call your backend to retrieve a client secret if you have provided a
+     * Returns a [SetupIntent] client secret to attach a new payment method to a customer. This will
+     * call your backend to retrieve a client secret if you have provided a
      * [setupIntentClientSecretProvider] in the [CustomerAdapter.create] call.
      */
     suspend fun setupIntentClientSecretForCustomerAttach(): Result<String>
@@ -92,50 +92,50 @@ interface CustomerAdapter {
             return component.stripeCustomerAdapter
         }
     }
-}
 
-/**
- * A representation of a saved payment method, used for persisting the user's default payment
- * method.
- */
-@ExperimentalCustomerSheetApi
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-sealed class PaymentOption(
-    open val id: String
-) {
-
-    internal object GooglePay : PaymentOption("google_pay")
-
-    internal object Link : PaymentOption("link")
-
-    internal data class StripeId(override val id: String) : PaymentOption(id)
-
+    /**
+     * A representation of a saved payment method, used for persisting the user's default payment
+     * method.
+     */
     @ExperimentalCustomerSheetApi
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    companion object {
-        fun fromId(id: String): PaymentOption {
-            return when (id) {
-                "google_pay" -> GooglePay
-                "link" -> Link
-                else -> StripeId(id)
-            }
-        }
+    sealed class PaymentOption(
+        open val id: String
+    ) {
 
-        internal fun PaymentOption.toSavedSelection(): SavedSelection {
-            return when (this) {
-                is GooglePay -> SavedSelection.GooglePay
-                is Link -> SavedSelection.Link
-                is StripeId -> SavedSelection.PaymentMethod(id)
-            }
-        }
+        internal object GooglePay : PaymentOption("google_pay")
 
-        internal fun SavedSelection.toPaymentOption():
-            PaymentOption? {
-            return when (this) {
-                is SavedSelection.GooglePay -> GooglePay
-                is SavedSelection.Link -> Link
-                is SavedSelection.None -> null
-                is SavedSelection.PaymentMethod -> StripeId(id)
+        internal object Link : PaymentOption("link")
+
+        internal data class StripeId(override val id: String) : PaymentOption(id)
+
+        @ExperimentalCustomerSheetApi
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        companion object {
+            fun fromId(id: String): PaymentOption {
+                return when (id) {
+                    "google_pay" -> GooglePay
+                    "link" -> Link
+                    else -> StripeId(id)
+                }
+            }
+
+            internal fun PaymentOption.toSavedSelection(): SavedSelection {
+                return when (this) {
+                    is GooglePay -> SavedSelection.GooglePay
+                    is Link -> SavedSelection.Link
+                    is StripeId -> SavedSelection.PaymentMethod(id)
+                }
+            }
+
+            internal fun SavedSelection.toPaymentOption():
+                PaymentOption? {
+                return when (this) {
+                    is SavedSelection.GooglePay -> GooglePay
+                    is SavedSelection.Link -> Link
+                    is SavedSelection.None -> null
+                    is SavedSelection.PaymentMethod -> StripeId(id)
+                }
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerAdapter.kt
@@ -44,16 +44,16 @@ interface CustomerAdapter {
 
     /**
      * Saves the payment option to a data store.
-     * @param paymentOption, the [PersistablePaymentMethodOption] to save to the . If
+     * @param paymentOption, the [PaymentOption] to save to the data store. If
      * null, the selected payment method option will be cleared from the data store.
      */
-    suspend fun setSelectedPaymentMethodOption(paymentOption: PersistablePaymentMethodOption?)
+    suspend fun setSelectedPaymentOption(paymentOption: PaymentOption?)
 
     /**
-     * Retrieves the saved payment option from a data store. If null, the customer does not have a
-     * default saved payment method.
+     * Fetch the saved payment method option from a data store. If null, the customer does not have
+     * a default saved payment method.
      */
-    suspend fun fetchSelectedPaymentMethodOption(): Result<PersistablePaymentMethodOption?>
+    suspend fun fetchSelectedPaymentMethodOption(): Result<PaymentOption?>
 
     /**
      * Returns a [SetupIntent] client secret to attach a new payment method to a customer.
@@ -100,20 +100,20 @@ interface CustomerAdapter {
  */
 @ExperimentalCustomerSheetApi
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-sealed class PersistablePaymentMethodOption(
+sealed class PaymentOption(
     open val id: String
 ) {
 
-    internal object GooglePay : PersistablePaymentMethodOption("google_pay")
+    internal object GooglePay : PaymentOption("google_pay")
 
-    internal object Link : PersistablePaymentMethodOption("link")
+    internal object Link : PaymentOption("link")
 
-    internal data class StripeId(override val id: String) : PersistablePaymentMethodOption(id)
+    internal data class StripeId(override val id: String) : PaymentOption(id)
 
     @ExperimentalCustomerSheetApi
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
-        fun fromId(id: String): PersistablePaymentMethodOption {
+        fun fromId(id: String): PaymentOption {
             return when (id) {
                 "google_pay" -> GooglePay
                 "link" -> Link
@@ -121,7 +121,7 @@ sealed class PersistablePaymentMethodOption(
             }
         }
 
-        internal fun PersistablePaymentMethodOption.toSavedSelection(): SavedSelection {
+        internal fun PaymentOption.toSavedSelection(): SavedSelection {
             return when (this) {
                 is GooglePay -> SavedSelection.GooglePay
                 is Link -> SavedSelection.Link
@@ -129,8 +129,8 @@ sealed class PersistablePaymentMethodOption(
             }
         }
 
-        internal fun SavedSelection.toPersistablePaymentMethodOption():
-            PersistablePaymentMethodOption? {
+        internal fun SavedSelection.toPaymentOption():
+            PaymentOption? {
             return when (this) {
                 is SavedSelection.GooglePay -> GooglePay
                 is SavedSelection.Link -> Link

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/StripeCustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/StripeCustomerAdapter.kt
@@ -5,8 +5,8 @@ import com.stripe.android.ExperimentalCustomerSheetApi
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PrefsRepository
-import com.stripe.android.paymentsheet.repositories.PersistablePaymentMethodOption.Companion.toPersistablePaymentMethodOption
-import com.stripe.android.paymentsheet.repositories.PersistablePaymentMethodOption.Companion.toSavedSelection
+import com.stripe.android.paymentsheet.repositories.PaymentOption.Companion.toPaymentOption
+import com.stripe.android.paymentsheet.repositories.PaymentOption.Companion.toSavedSelection
 import java.lang.IllegalArgumentException
 import javax.inject.Inject
 
@@ -76,21 +76,21 @@ internal class StripeCustomerAdapter @Inject constructor(
         }
     }
 
-    override suspend fun setSelectedPaymentMethodOption(paymentOption: PersistablePaymentMethodOption?) {
+    override suspend fun setSelectedPaymentOption(paymentOption: PaymentOption?) {
         getCustomerEphemeralKey().getOrNull()?.let { customerEphemeralKey ->
             val prefsRepository = prefsRepositoryFactory(customerEphemeralKey)
             prefsRepository.setSavedSelection(paymentOption?.toSavedSelection())
         }
     }
 
-    override suspend fun fetchSelectedPaymentMethodOption(): Result<PersistablePaymentMethodOption?> {
+    override suspend fun retrieveSelectedPaymentOption(): Result<PaymentOption?> {
         return getCustomerEphemeralKey().mapCatching { customerEphemeralKey ->
             val prefsRepository = prefsRepositoryFactory(customerEphemeralKey)
             val savedSelection = prefsRepository.getSavedSelection(
                 isGooglePayAvailable = false,
                 isLinkAvailable = false,
             )
-            savedSelection.toPersistablePaymentMethodOption()
+            savedSelection.toPaymentOption()
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/StripeCustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/StripeCustomerAdapter.kt
@@ -13,7 +13,9 @@ import javax.inject.Inject
 /**
  * The default implementation of [CustomerAdapter]. This adapter uses the customer ID and ephemeral
  * key provided by [CustomerEphemeralKeyProvider] to read, update, or delete the customer's
- * default saved payment method using Android [SharedPreferences].
+ * default saved payment method using Android [SharedPreferences]. By default, this adapter saves
+ * the customer's selected payment method to [SharedPreferences], which is used by [PaymentSheet]
+ * to load the customer's default saved payment method.
  */
 @OptIn(ExperimentalCustomerSheetApi::class)
 @Suppress("unused")

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/StripeCustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/StripeCustomerAdapter.kt
@@ -5,8 +5,8 @@ import com.stripe.android.ExperimentalCustomerSheetApi
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PrefsRepository
-import com.stripe.android.paymentsheet.repositories.PaymentOption.Companion.toPaymentOption
-import com.stripe.android.paymentsheet.repositories.PaymentOption.Companion.toSavedSelection
+import com.stripe.android.paymentsheet.repositories.CustomerAdapter.PaymentOption.Companion.toPaymentOption
+import com.stripe.android.paymentsheet.repositories.CustomerAdapter.PaymentOption.Companion.toSavedSelection
 import java.lang.IllegalArgumentException
 import javax.inject.Inject
 
@@ -76,14 +76,14 @@ internal class StripeCustomerAdapter @Inject constructor(
         }
     }
 
-    override suspend fun setSelectedPaymentOption(paymentOption: PaymentOption?) {
+    override suspend fun setSelectedPaymentOption(paymentOption: CustomerAdapter.PaymentOption?) {
         getCustomerEphemeralKey().getOrNull()?.let { customerEphemeralKey ->
             val prefsRepository = prefsRepositoryFactory(customerEphemeralKey)
             prefsRepository.setSavedSelection(paymentOption?.toSavedSelection())
         }
     }
 
-    override suspend fun retrieveSelectedPaymentOption(): Result<PaymentOption?> {
+    override suspend fun fetchSelectedPaymentOption(): Result<CustomerAdapter.PaymentOption?> {
         return getCustomerEphemeralKey().mapCatching { customerEphemeralKey ->
             val prefsRepository = prefsRepositoryFactory(customerEphemeralKey)
             val savedSelection = prefsRepository.getSavedSelection(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerAdapterTest.kt
@@ -10,8 +10,8 @@ import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.FakePrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.model.SavedSelection
-import com.stripe.android.paymentsheet.repositories.PaymentOption.Companion.toPaymentOption
-import com.stripe.android.paymentsheet.repositories.PaymentOption.Companion.toSavedSelection
+import com.stripe.android.paymentsheet.repositories.CustomerAdapter.PaymentOption.Companion.toPaymentOption
+import com.stripe.android.paymentsheet.repositories.CustomerAdapter.PaymentOption.Companion.toSavedSelection
 import com.stripe.android.paymentsheet.repositories.StripeCustomerAdapter.Companion.CACHED_CUSTOMER_MAX_AGE_MILLIS
 import com.stripe.android.utils.FakeCustomerRepository
 import kotlinx.coroutines.test.advanceTimeBy
@@ -214,11 +214,11 @@ class CustomerAdapterTest {
             }
         )
         adapter.setSelectedPaymentOption(
-            paymentOption = PaymentOption.StripeId("pm_1234")
+            paymentOption = CustomerAdapter.PaymentOption.StripeId("pm_1234")
         )
         val result = adapter.retrieveSelectedPaymentOption()
         assertThat(result.getOrNull()).isEqualTo(
-            PaymentOption.StripeId("pm_1234")
+            CustomerAdapter.PaymentOption.StripeId("pm_1234")
         )
     }
 
@@ -250,22 +250,22 @@ class CustomerAdapterTest {
 
     @Test
     fun `PersistablePaymentMethodOption to SavedSelection`() {
-        assertThat(PaymentOption.GooglePay.toSavedSelection())
+        assertThat(CustomerAdapter.PaymentOption.GooglePay.toSavedSelection())
             .isEqualTo(SavedSelection.GooglePay)
-        assertThat(PaymentOption.Link.toSavedSelection())
+        assertThat(CustomerAdapter.PaymentOption.Link.toSavedSelection())
             .isEqualTo(SavedSelection.Link)
-        assertThat(PaymentOption.StripeId("pm_1234").toSavedSelection())
+        assertThat(CustomerAdapter.PaymentOption.StripeId("pm_1234").toSavedSelection())
             .isEqualTo(SavedSelection.PaymentMethod("pm_1234"))
     }
 
     @Test
     fun `SavedSelection to PersistablePaymentMethodOption`() {
         assertThat(SavedSelection.GooglePay.toPaymentOption())
-            .isEqualTo(PaymentOption.GooglePay)
+            .isEqualTo(CustomerAdapter.PaymentOption.GooglePay)
         assertThat(SavedSelection.Link.toPaymentOption())
-            .isEqualTo(PaymentOption.Link)
+            .isEqualTo(CustomerAdapter.PaymentOption.Link)
         assertThat(SavedSelection.PaymentMethod("pm_1234").toPaymentOption())
-            .isEqualTo(PaymentOption.StripeId("pm_1234"))
+            .isEqualTo(CustomerAdapter.PaymentOption.StripeId("pm_1234"))
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerAdapterTest.kt
@@ -10,8 +10,8 @@ import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.FakePrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.model.SavedSelection
-import com.stripe.android.paymentsheet.repositories.PersistablePaymentMethodOption.Companion.toPersistablePaymentMethodOption
-import com.stripe.android.paymentsheet.repositories.PersistablePaymentMethodOption.Companion.toSavedSelection
+import com.stripe.android.paymentsheet.repositories.PaymentOption.Companion.toPaymentOption
+import com.stripe.android.paymentsheet.repositories.PaymentOption.Companion.toSavedSelection
 import com.stripe.android.paymentsheet.repositories.StripeCustomerAdapter.Companion.CACHED_CUSTOMER_MAX_AGE_MILLIS
 import com.stripe.android.utils.FakeCustomerRepository
 import kotlinx.coroutines.test.advanceTimeBy
@@ -213,12 +213,12 @@ class CustomerAdapterTest {
                 )
             }
         )
-        adapter.setSelectedPaymentMethodOption(
-            paymentOption = PersistablePaymentMethodOption.StripeId("pm_1234")
+        adapter.setSelectedPaymentOption(
+            paymentOption = PaymentOption.StripeId("pm_1234")
         )
-        val result = adapter.fetchSelectedPaymentMethodOption()
+        val result = adapter.retrieveSelectedPaymentOption()
         assertThat(result.getOrNull()).isEqualTo(
-            PersistablePaymentMethodOption.StripeId("pm_1234")
+            PaymentOption.StripeId("pm_1234")
         )
     }
 
@@ -241,31 +241,31 @@ class CustomerAdapterTest {
                 )
             }
         )
-        adapter.setSelectedPaymentMethodOption(
+        adapter.setSelectedPaymentOption(
             paymentOption = null
         )
-        val result = adapter.fetchSelectedPaymentMethodOption()
+        val result = adapter.retrieveSelectedPaymentOption()
         assertThat(result.getOrNull()).isNull()
     }
 
     @Test
     fun `PersistablePaymentMethodOption to SavedSelection`() {
-        assertThat(PersistablePaymentMethodOption.GooglePay.toSavedSelection())
+        assertThat(PaymentOption.GooglePay.toSavedSelection())
             .isEqualTo(SavedSelection.GooglePay)
-        assertThat(PersistablePaymentMethodOption.Link.toSavedSelection())
+        assertThat(PaymentOption.Link.toSavedSelection())
             .isEqualTo(SavedSelection.Link)
-        assertThat(PersistablePaymentMethodOption.StripeId("pm_1234").toSavedSelection())
+        assertThat(PaymentOption.StripeId("pm_1234").toSavedSelection())
             .isEqualTo(SavedSelection.PaymentMethod("pm_1234"))
     }
 
     @Test
     fun `SavedSelection to PersistablePaymentMethodOption`() {
-        assertThat(SavedSelection.GooglePay.toPersistablePaymentMethodOption())
-            .isEqualTo(PersistablePaymentMethodOption.GooglePay)
-        assertThat(SavedSelection.Link.toPersistablePaymentMethodOption())
-            .isEqualTo(PersistablePaymentMethodOption.Link)
-        assertThat(SavedSelection.PaymentMethod("pm_1234").toPersistablePaymentMethodOption())
-            .isEqualTo(PersistablePaymentMethodOption.StripeId("pm_1234"))
+        assertThat(SavedSelection.GooglePay.toPaymentOption())
+            .isEqualTo(PaymentOption.GooglePay)
+        assertThat(SavedSelection.Link.toPaymentOption())
+            .isEqualTo(PaymentOption.Link)
+        assertThat(SavedSelection.PaymentMethod("pm_1234").toPaymentOption())
+            .isEqualTo(PaymentOption.StripeId("pm_1234"))
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerAdapterTest.kt
@@ -216,7 +216,7 @@ class CustomerAdapterTest {
         adapter.setSelectedPaymentOption(
             paymentOption = CustomerAdapter.PaymentOption.StripeId("pm_1234")
         )
-        val result = adapter.retrieveSelectedPaymentOption()
+        val result = adapter.fetchSelectedPaymentOption()
         assertThat(result.getOrNull()).isEqualTo(
             CustomerAdapter.PaymentOption.StripeId("pm_1234")
         )
@@ -244,7 +244,7 @@ class CustomerAdapterTest {
         adapter.setSelectedPaymentOption(
             paymentOption = null
         )
-        val result = adapter.retrieveSelectedPaymentOption()
+        val result = adapter.fetchSelectedPaymentOption()
         assertThat(result.getOrNull()).isNull()
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Rename PersistablePaymentMethodOption to PaymentOptions

# Motivation

Discussion about naming
