### PR TITLE
[stripe-ui-core] Fix OTPElementUI

### DIFF
--- a/stripe-ui-core/detekt-baseline.xml
+++ b/stripe-ui-core/detekt-baseline.xml
@@ -13,7 +13,7 @@
     <ID>FunctionParameterNaming:IdentifierSpec.kt$IdentifierSpec.Companion$_value: String</ID>
     <ID>LongMethod:DropdownFieldUI.kt$@Composable @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun DropDown( controller: DropdownFieldController, enabled: Boolean, modifier: Modifier = Modifier )</ID>
     <ID>LongMethod:Html.kt$@Composable @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun annotatedStringResource( text: String, imageGetter: Map&lt;String, EmbeddableImage> = emptyMap(), urlSpanStyle: SpanStyle = SpanStyle(textDecoration = TextDecoration.Underline) ): AnnotatedString</ID>
-    <ID>LongMethod:PhoneNumberElementUI.kt$@Composable @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun PhoneNumberElementUI( enabled: Boolean, controller: PhoneNumberController, requestFocusWhenShown: Boolean = false, imeAction: ImeAction = ImeAction.Done )</ID>
+    <ID>LongMethod:OTPElementUI.kt$@Composable @OptIn(ExperimentalMaterialApi::class) private fun OTPInputBox( value: String, isSelected: Boolean, element: OTPElement, index: Int, focusManager: FocusManager, modifier: Modifier, enabled: Boolean, colors: OTPElementColors )</ID>
     <ID>LongMethod:TextFieldUI.kt$@OptIn(ExperimentalComposeUiApi::class) @Composable fun TextField( textFieldController: TextFieldController, enabled: Boolean, imeAction: ImeAction, modifier: Modifier = Modifier, onTextStateChanged: (TextFieldState?) -> Unit = {}, nextFocusDirection: FocusDirection = FocusDirection.Next, previousFocusDirection: FocusDirection = FocusDirection.Previous )</ID>
     <ID>MagicNumber:DateConfig.kt$DateConfig$4</ID>
     <ID>MagicNumber:DateConfig.kt$DateConfig.Companion$100</ID>

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/OTPController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/OTPController.kt
@@ -29,7 +29,7 @@ class OTPController(val otpLength: Int = 6) : Controller {
      */
     fun onValueChanged(index: Int, text: String): Int {
         if (text == fieldValues[index].value) {
-            return 0
+            return 1
         }
 
         if (text.isEmpty()) {
@@ -49,6 +49,10 @@ class OTPController(val otpLength: Int = 6) : Controller {
         }
 
         return inputLength
+    }
+
+    fun reset() {
+        fieldValues.forEach { it.value = "" }
     }
 
     private fun filter(userTyped: String) = userTyped.filter { VALID_INPUT_RANGES.contains(it) }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/OTPElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/OTPElementUI.kt
@@ -199,11 +199,7 @@ private fun OTPInputBox(
             // If the OTPInputBox already has a value, it would be the first character of it.text
             // remove it before passing it to the controller.
             val newValue =
-                if (value.isNotBlank() && it.text.isNotBlank()) {
-                    it.text.substring(1)
-                } else {
-                    it.text
-                }
+                if (value.isNotBlank() && it.text.isNotBlank()) { it.text.substring(1) } else { it.text }
             val inputLength = element.controller.onValueChanged(index, newValue)
             (0 until inputLength).forEach { _ -> focusManager.moveFocus(FocusDirection.Next) }
         },

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/OTPElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/OTPElementUI.kt
@@ -196,7 +196,15 @@ private fun OTPInputBox(
             selection = if (isSelected) { TextRange(value.length) } else { TextRange.Zero }
         ),
         onValueChange = {
-            val inputLength = element.controller.onValueChanged(index, it.text)
+            // If the OTPInputBox already has a value, it would be the first character of it.text
+            // remove it before passing it to the controller.
+            val newValue =
+                if (value.isNotBlank() && it.text.isNotBlank()) {
+                    it.text.substring(1)
+                } else {
+                    it.text
+                }
+            val inputLength = element.controller.onValueChanged(index, newValue)
             (0 until inputLength).forEach { _ -> focusManager.moveFocus(FocusDirection.Next) }
         },
         modifier = modifier,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Fix the logic to request focus to next field. Please see explains in line


# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
See recording
# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| ![otpBefore](https://github.com/stripe/stripe-android/assets/79880926/68abcde1-6428-42d2-879a-2f3291ecb44c)  | ![otpAfter](https://github.com/stripe/stripe-android/assets/79880926/f5d58ea1-f030-48b2-ae25-cf66af598806) |








# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
