### PR TITLE
Move `AbsFakeStripeRepository` to `payments-core-testing`

### DIFF
--- a/payments-core-testing/detekt-baseline.xml
+++ b/payments-core-testing/detekt-baseline.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>TooManyFunctions:AbsFakeStripeRepository.kt$AbsFakeStripeRepository : StripeRepository</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/AbsFakeStripeRepository.kt
@@ -1,4 +1,4 @@
-package com.stripe.android.networking
+package com.stripe.android.testing
 
 import com.stripe.android.cards.Bin
 import com.stripe.android.core.exception.APIException
@@ -7,7 +7,6 @@ import com.stripe.android.core.model.StripeFileParams
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.StripeResponse
 import com.stripe.android.model.BankStatuses
-import com.stripe.android.model.BinFixtures
 import com.stripe.android.model.CardMetadata
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
@@ -33,13 +32,14 @@ import com.stripe.android.model.ShippingInformation
 import com.stripe.android.model.Source
 import com.stripe.android.model.SourceParams
 import com.stripe.android.model.Stripe3ds2AuthParams
-import com.stripe.android.model.Stripe3ds2AuthResultFixtures
+import com.stripe.android.model.Stripe3ds2AuthResult
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.Token
 import com.stripe.android.model.TokenParams
+import com.stripe.android.networking.StripeRepository
 import java.util.Locale
 
-internal abstract class AbsFakeStripeRepository : StripeRepository() {
+abstract class AbsFakeStripeRepository : StripeRepository {
 
     override suspend fun retrieveStripeIntent(
         clientSecret: String,
@@ -54,7 +54,7 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         options: ApiRequest.Options,
         expandFields: List<String>
     ): PaymentIntent? {
-        return null
+        TODO("Not yet implemented")
     }
 
     override suspend fun retrievePaymentIntent(
@@ -62,14 +62,14 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         options: ApiRequest.Options,
         expandFields: List<String>
     ): PaymentIntent? {
-        return null
+        TODO("Not yet implemented")
     }
 
     override suspend fun refreshPaymentIntent(
         clientSecret: String,
         options: ApiRequest.Options
     ): PaymentIntent? {
-        return null
+        TODO("Not yet implemented")
     }
 
     override suspend fun cancelPaymentIntentSource(
@@ -77,7 +77,7 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         sourceId: String,
         options: ApiRequest.Options
     ): PaymentIntent? {
-        return null
+        TODO("Not yet implemented")
     }
 
     override suspend fun confirmSetupIntent(
@@ -85,7 +85,7 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         options: ApiRequest.Options,
         expandFields: List<String>
     ): SetupIntent? {
-        return null
+        TODO("Not yet implemented")
     }
 
     override suspend fun retrieveSetupIntent(
@@ -93,7 +93,7 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         options: ApiRequest.Options,
         expandFields: List<String>
     ): SetupIntent? {
-        return null
+        TODO("Not yet implemented")
     }
 
     override suspend fun cancelSetupIntentSource(
@@ -101,14 +101,14 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         sourceId: String,
         options: ApiRequest.Options
     ): SetupIntent? {
-        return null
+        TODO("Not yet implemented")
     }
 
     override suspend fun createSource(
         sourceParams: SourceParams,
         options: ApiRequest.Options
     ): Source? {
-        return null
+        TODO("Not yet implemented")
     }
 
     override suspend fun retrieveSource(
@@ -123,14 +123,14 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         paymentMethodCreateParams: PaymentMethodCreateParams,
         options: ApiRequest.Options
     ): PaymentMethod? {
-        return null
+        TODO("Not yet implemented")
     }
 
     override suspend fun createToken(
         tokenParams: TokenParams,
         options: ApiRequest.Options
     ): Token? {
-        return null
+        TODO("Not yet implemented")
     }
 
     override suspend fun addCustomerSource(
@@ -220,7 +220,7 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         userOneTimeCode: String,
         requestOptions: ApiRequest.Options
     ): String? {
-        return ""
+        TODO("Not yet implemented")
     }
 
     override suspend fun updateIssuingCardPin(
@@ -230,43 +230,52 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         userOneTimeCode: String,
         requestOptions: ApiRequest.Options
     ) {
+        TODO("Not yet implemented")
     }
 
     override suspend fun getFpxBankStatus(
         options: ApiRequest.Options
-    ) = BankStatuses()
+    ): BankStatuses {
+        TODO("Not yet implemented")
+    }
 
-    override suspend fun getCardMetadata(bin: Bin, options: ApiRequest.Options) =
-        CardMetadata(
-            BinFixtures.VISA,
-            emptyList()
-        )
+    override suspend fun getCardMetadata(bin: Bin, options: ApiRequest.Options): CardMetadata {
+        TODO("Not yet implemented")
+    }
 
     override suspend fun start3ds2Auth(
         authParams: Stripe3ds2AuthParams,
         requestOptions: ApiRequest.Options
-    ) = Stripe3ds2AuthResultFixtures.ARES_CHALLENGE_FLOW
+    ): Stripe3ds2AuthResult? {
+        TODO("Not yet implemented")
+    }
 
     override suspend fun complete3ds2Auth(
         sourceId: String,
         requestOptions: ApiRequest.Options
-    ) = Stripe3ds2AuthResultFixtures.CHALLENGE_COMPLETION
+    ): Stripe3ds2AuthResult? {
+        TODO("Not yet implemented")
+    }
 
     override suspend fun createFile(
         fileParams: StripeFileParams,
         requestOptions: ApiRequest.Options
     ): StripeFile {
-        return StripeFile()
+        TODO("Not yet implemented")
     }
 
     override suspend fun retrieveObject(
         url: String,
         requestOptions: ApiRequest.Options
-    ) = StripeResponse(1, "response")
+    ): StripeResponse<String> {
+        TODO("Not yet implemented")
+    }
 
     override suspend fun createRadarSession(
         requestOptions: ApiRequest.Options
-    ) = RadarSession("rse_abc123")
+    ): RadarSession {
+        TODO("Not yet implemented")
+    }
 
     override suspend fun consumerSignUp(
         email: String,
@@ -278,7 +287,7 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         consentAction: ConsumerSignUpConsentAction,
         requestOptions: ApiRequest.Options
     ): ConsumerSession? {
-        return null
+        TODO("Not yet implemented")
     }
 
     override suspend fun logoutConsumer(
@@ -286,14 +295,14 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         authSessionCookie: String?,
         requestOptions: ApiRequest.Options
     ): ConsumerSession? {
-        return null
+        TODO("Not yet implemented")
     }
 
     override suspend fun createLinkFinancialConnectionsSession(
         consumerSessionClientSecret: String,
         requestOptions: ApiRequest.Options
     ): FinancialConnectionsSession? {
-        return null
+        TODO("Not yet implemented")
     }
 
     override suspend fun createPaymentDetails(
@@ -301,7 +310,7 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         financialConnectionsAccountId: String,
         requestOptions: ApiRequest.Options
     ): ConsumerPaymentDetails? {
-        return null
+        TODO("Not yet implemented")
     }
 
     override suspend fun createPaymentDetails(
@@ -309,7 +318,7 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         paymentDetailsCreateParams: ConsumerPaymentDetailsCreateParams,
         requestOptions: ApiRequest.Options
     ): ConsumerPaymentDetails? {
-        return null
+        TODO("Not yet implemented")
     }
 
     override suspend fun listPaymentDetails(
@@ -317,7 +326,7 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         paymentMethodTypes: Set<String>,
         requestOptions: ApiRequest.Options
     ): ConsumerPaymentDetails? {
-        return null
+        TODO("Not yet implemented")
     }
 
     override suspend fun deletePaymentDetails(
@@ -325,6 +334,7 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         paymentDetailsId: String,
         requestOptions: ApiRequest.Options
     ) {
+        TODO("Not yet implemented")
     }
 
     override suspend fun updatePaymentDetails(
@@ -332,7 +342,7 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         paymentDetailsUpdateParams: ConsumerPaymentDetailsUpdateParams,
         requestOptions: ApiRequest.Options
     ): ConsumerPaymentDetails? {
-        return null
+        TODO("Not yet implemented")
     }
 
     override suspend fun attachFinancialConnectionsSessionToPaymentIntent(
@@ -435,6 +445,6 @@ internal abstract class AbsFakeStripeRepository : StripeRepository() {
         cardNumber: String,
         requestOptions: ApiRequest.Options
     ): CardMetadata? {
-        return null
+        TODO("Not yet implemented")
     }
 }

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -6490,6 +6490,14 @@ public final class com/stripe/android/networking/FraudDetectionData$Creator : an
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
+public final class com/stripe/android/networking/StripeRepository$DefaultImpls {
+	public static synthetic fun confirmPaymentIntent$default (Lcom/stripe/android/networking/StripeRepository;Lcom/stripe/android/model/ConfirmPaymentIntentParams;Lcom/stripe/android/core/networking/ApiRequest$Options;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun confirmSetupIntent$default (Lcom/stripe/android/networking/StripeRepository;Lcom/stripe/android/model/ConfirmSetupIntentParams;Lcom/stripe/android/core/networking/ApiRequest$Options;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun retrievePaymentIntent$default (Lcom/stripe/android/networking/StripeRepository;Ljava/lang/String;Lcom/stripe/android/core/networking/ApiRequest$Options;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun retrieveSetupIntent$default (Lcom/stripe/android/networking/StripeRepository;Ljava/lang/String;Lcom/stripe/android/core/networking/ApiRequest$Options;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun retrieveStripeIntent$default (Lcom/stripe/android/networking/StripeRepository;Ljava/lang/String;Lcom/stripe/android/core/networking/ApiRequest$Options;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
 public final class com/stripe/android/payments/PaymentFlowResult$Unvalidated : android/os/Parcelable {
 	public static final field $stable I
 	public static final field CREATOR Landroid/os/Parcelable$Creator;

--- a/payments-core/detekt-baseline.xml
+++ b/payments-core/detekt-baseline.xml
@@ -12,7 +12,6 @@
     <ID>CyclomaticComplexMethod:SourceJsonParser.kt$SourceJsonParser.Companion$@Source.SourceType private fun asSourceType(sourceType: String?): String</ID>
     <ID>CyclomaticComplexMethod:SourceJsonParser.kt$SourceJsonParser.Companion$private inline fun &lt;reified T : StripeModel> optStripeJsonModel( jsonObject: JSONObject, @Size(min = 1) key: String ): T?</ID>
     <ID>CyclomaticComplexMethod:StripeErrorMapping.kt$internal fun Context.mapErrorCodeToLocalizedMessage(code: String?): String?</ID>
-    <ID>EmptyFunctionBlock:AbsFakeStripeRepository.kt$AbsFakeStripeRepository${ }</ID>
     <ID>EmptyFunctionBlock:AbsPaymentController.kt$AbsPaymentController${ }</ID>
     <ID>EmptyFunctionBlock:CardWidgetProgressView.kt$CardWidgetProgressView.&lt;no name provided>${ }</ID>
     <ID>EmptyFunctionBlock:CustomerSessionTest.kt$CustomerSessionTest.&lt;no name provided>${ }</ID>

--- a/payments-core/src/main/java/com/stripe/android/model/BankStatuses.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/BankStatuses.kt
@@ -1,12 +1,14 @@
 package com.stripe.android.model
 
+import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeModel
 import com.stripe.android.view.Bank
 import kotlinx.parcelize.Parcelize
 import org.jetbrains.annotations.TestOnly
 
 @Parcelize
-internal data class BankStatuses internal constructor(
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class BankStatuses internal constructor(
     private val statuses: Map<String, Boolean> = emptyMap()
 ) : StripeModel {
     @TestOnly

--- a/payments-core/src/main/java/com/stripe/android/model/CreateFinancialConnectionsSessionForDeferredPaymentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/CreateFinancialConnectionsSessionForDeferredPaymentParams.kt
@@ -1,6 +1,9 @@
 package com.stripe.android.model
 
-internal data class CreateFinancialConnectionsSessionForDeferredPaymentParams(
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class CreateFinancialConnectionsSessionForDeferredPaymentParams(
     val uniqueId: String,
     val initialInstitution: String? = null,
     val manualEntryOnly: Boolean? = null,
@@ -40,7 +43,8 @@ internal data class CreateFinancialConnectionsSessionForDeferredPaymentParams(
     }
 }
 
-internal enum class VerificationMethodParam(val value: String) {
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+enum class VerificationMethodParam(val value: String) {
     Automatic("automatic"),
     Skip("skip"),
     Microdeposits("microdeposits"),

--- a/payments-core/src/main/java/com/stripe/android/model/CreateFinancialConnectionsSessionForDeferredPaymentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/CreateFinancialConnectionsSessionForDeferredPaymentParams.kt
@@ -30,16 +30,16 @@ data class CreateFinancialConnectionsSessionForDeferredPaymentParams(
         )
     }
 
-    companion object {
-        private const val PARAM_UNIQUE_ID = "unique_id"
-        private const val PARAM_INITIAL_INSTITUTION = "initial_institution"
-        private const val PARAM_MANUAL_ENTRY_ONLY = "manual_entry_only"
-        private const val PARAM_SEARCH_SESSION = "search_session"
-        private const val PARAM_VERIFICATION_METHOD = "verification_method"
-        private const val PARAM_CUSTOMER = "customer"
-        private const val PARAM_ON_BEHALF_OF = "on_behalf_of"
-        private const val PARAM_AMOUNT = "amount"
-        private const val PARAM_CURRENCY = "currency"
+    private companion object {
+        const val PARAM_UNIQUE_ID = "unique_id"
+        const val PARAM_INITIAL_INSTITUTION = "initial_institution"
+        const val PARAM_MANUAL_ENTRY_ONLY = "manual_entry_only"
+        const val PARAM_SEARCH_SESSION = "search_session"
+        const val PARAM_VERIFICATION_METHOD = "verification_method"
+        const val PARAM_CUSTOMER = "customer"
+        const val PARAM_ON_BEHALF_OF = "on_behalf_of"
+        const val PARAM_AMOUNT = "amount"
+        const val PARAM_CURRENCY = "currency"
     }
 }
 

--- a/payments-core/src/main/java/com/stripe/android/model/CreateFinancialConnectionsSessionParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/CreateFinancialConnectionsSessionParams.kt
@@ -21,8 +21,8 @@ data class CreateFinancialConnectionsSessionParams(
         )
     }
 
-    companion object {
-        private const val PARAM_CLIENT_SECRET = "client_secret"
-        private const val PARAM_PAYMENT_METHOD_DATA = "payment_method_data"
+    private companion object {
+        const val PARAM_CLIENT_SECRET = "client_secret"
+        const val PARAM_PAYMENT_METHOD_DATA = "payment_method_data"
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/model/CreateFinancialConnectionsSessionParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/CreateFinancialConnectionsSessionParams.kt
@@ -1,6 +1,9 @@
 package com.stripe.android.model
 
-internal data class CreateFinancialConnectionsSessionParams(
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class CreateFinancialConnectionsSessionParams(
     val clientSecret: String,
     val customerName: String,
     val customerEmailAddress: String?

--- a/payments-core/src/main/java/com/stripe/android/model/Stripe3ds2AuthParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/Stripe3ds2AuthParams.kt
@@ -1,13 +1,15 @@
 package com.stripe.android.model
 
 import android.os.Parcelable
+import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import kotlinx.parcelize.Parcelize
 import org.json.JSONArray
 import org.json.JSONObject
 
 @Parcelize
-internal data class Stripe3ds2AuthParams(
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class Stripe3ds2AuthParams(
     private val sourceId: String,
     private val sdkAppId: String,
     private val sdkReferenceNumber: String,

--- a/payments-core/src/main/java/com/stripe/android/model/Stripe3ds2AuthResult.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/Stripe3ds2AuthResult.kt
@@ -1,10 +1,12 @@
 package com.stripe.android.model
 
+import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeModel
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-internal data class Stripe3ds2AuthResult internal constructor(
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class Stripe3ds2AuthResult internal constructor(
     val id: String?,
     val ares: Ares? = null,
     val created: Long?,
@@ -15,8 +17,10 @@ internal data class Stripe3ds2AuthResult internal constructor(
     val fallbackRedirectUrl: String? = null,
     val creq: String? = null
 ) : StripeModel {
+
     @Parcelize
-    internal data class Ares internal constructor(
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    data class Ares internal constructor(
         internal val threeDSServerTransId: String?,
         private val acsChallengeMandated: String?,
         internal val acsSignedContent: String? = null,

--- a/payments-core/src/main/java/com/stripe/android/model/Stripe3ds2AuthResult.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/Stripe3ds2AuthResult.kt
@@ -61,6 +61,7 @@ data class Stripe3ds2AuthResult internal constructor(
     ) : StripeModel
 
     @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class ThreeDS2Error internal constructor(
         val threeDSServerTransId: String?,
         val acsTransId: String?,

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -134,7 +134,7 @@ class StripeApiRepository @JvmOverloads internal constructor(
     betas: Set<StripeApiBeta> = emptySet(),
     apiVersion: String = ApiVersion(betas = betas.map { it.code }.toSet()).code,
     sdkVersion: String = StripeSdkVersion.VERSION
-) : StripeRepository() {
+) : StripeRepository {
 
     @Inject
     constructor(

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeRepository.kt
@@ -48,9 +48,10 @@ import java.util.Locale
  * An interface for data operations on Stripe API objects.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) // originally made public for paymentsheet
-abstract class StripeRepository {
+interface StripeRepository {
 
-    internal abstract suspend fun retrieveStripeIntent(
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun retrieveStripeIntent(
         clientSecret: String,
         options: ApiRequest.Options,
         expandFields: List<String> = emptyList()
@@ -62,7 +63,8 @@ abstract class StripeRepository {
         APIConnectionException::class,
         APIException::class
     )
-    internal abstract suspend fun confirmPaymentIntent(
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun confirmPaymentIntent(
         confirmPaymentIntentParams: ConfirmPaymentIntentParams,
         options: ApiRequest.Options,
         expandFields: List<String> = emptyList()
@@ -75,7 +77,7 @@ abstract class StripeRepository {
         APIException::class
     )
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    abstract suspend fun retrievePaymentIntent(
+    suspend fun retrievePaymentIntent(
         clientSecret: String,
         options: ApiRequest.Options,
         expandFields: List<String> = emptyList()
@@ -88,7 +90,7 @@ abstract class StripeRepository {
         APIException::class
     )
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    internal abstract suspend fun refreshPaymentIntent(
+    suspend fun refreshPaymentIntent(
         clientSecret: String,
         options: ApiRequest.Options
     ): PaymentIntent?
@@ -99,7 +101,8 @@ abstract class StripeRepository {
         APIConnectionException::class,
         APIException::class
     )
-    internal abstract suspend fun cancelPaymentIntentSource(
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun cancelPaymentIntentSource(
         paymentIntentId: String,
         sourceId: String,
         options: ApiRequest.Options
@@ -111,7 +114,8 @@ abstract class StripeRepository {
         APIConnectionException::class,
         APIException::class
     )
-    internal abstract suspend fun confirmSetupIntent(
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun confirmSetupIntent(
         confirmSetupIntentParams: ConfirmSetupIntentParams,
         options: ApiRequest.Options,
         expandFields: List<String> = emptyList()
@@ -124,7 +128,7 @@ abstract class StripeRepository {
         APIException::class
     )
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    abstract suspend fun retrieveSetupIntent(
+    suspend fun retrieveSetupIntent(
         clientSecret: String,
         options: ApiRequest.Options,
         expandFields: List<String> = emptyList()
@@ -136,7 +140,8 @@ abstract class StripeRepository {
         APIConnectionException::class,
         APIException::class
     )
-    internal abstract suspend fun cancelSetupIntentSource(
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun cancelSetupIntentSource(
         setupIntentId: String,
         sourceId: String,
         options: ApiRequest.Options
@@ -148,12 +153,14 @@ abstract class StripeRepository {
         APIConnectionException::class,
         APIException::class
     )
-    internal abstract suspend fun createSource(
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun createSource(
         sourceParams: SourceParams,
         options: ApiRequest.Options
     ): Source?
 
-    internal abstract suspend fun retrieveSource(
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun retrieveSource(
         sourceId: String,
         clientSecret: String,
         options: ApiRequest.Options
@@ -166,7 +173,7 @@ abstract class StripeRepository {
         APIException::class
     )
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    abstract suspend fun createPaymentMethod(
+    suspend fun createPaymentMethod(
         paymentMethodCreateParams: PaymentMethodCreateParams,
         options: ApiRequest.Options
     ): PaymentMethod?
@@ -178,12 +185,14 @@ abstract class StripeRepository {
         APIException::class,
         CardException::class
     )
-    internal abstract suspend fun createToken(
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun createToken(
         tokenParams: TokenParams,
         options: ApiRequest.Options
     ): Token?
 
-    internal abstract suspend fun addCustomerSource(
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun addCustomerSource(
         customerId: String,
         publishableKey: String,
         productUsageTokens: Set<String>,
@@ -192,7 +201,8 @@ abstract class StripeRepository {
         requestOptions: ApiRequest.Options
     ): Result<Source>
 
-    internal abstract suspend fun deleteCustomerSource(
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun deleteCustomerSource(
         customerId: String,
         publishableKey: String,
         productUsageTokens: Set<String>,
@@ -201,7 +211,7 @@ abstract class StripeRepository {
     ): Result<Source>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    abstract suspend fun attachPaymentMethod(
+    suspend fun attachPaymentMethod(
         customerId: String,
         publishableKey: String,
         productUsageTokens: Set<String>,
@@ -210,7 +220,7 @@ abstract class StripeRepository {
     ): Result<PaymentMethod>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    abstract suspend fun detachPaymentMethod(
+    suspend fun detachPaymentMethod(
         publishableKey: String,
         productUsageTokens: Set<String>,
         paymentMethodId: String,
@@ -218,14 +228,15 @@ abstract class StripeRepository {
     ): Result<PaymentMethod>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    abstract suspend fun getPaymentMethods(
+    suspend fun getPaymentMethods(
         listPaymentMethodsParams: ListPaymentMethodsParams,
         publishableKey: String,
         productUsageTokens: Set<String>,
         requestOptions: ApiRequest.Options
     ): Result<List<PaymentMethod>>
 
-    internal abstract suspend fun setDefaultCustomerSource(
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun setDefaultCustomerSource(
         customerId: String,
         publishableKey: String,
         productUsageTokens: Set<String>,
@@ -234,7 +245,8 @@ abstract class StripeRepository {
         requestOptions: ApiRequest.Options
     ): Result<Customer>
 
-    internal abstract suspend fun setCustomerShippingInfo(
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun setCustomerShippingInfo(
         customerId: String,
         publishableKey: String,
         productUsageTokens: Set<String>,
@@ -243,7 +255,7 @@ abstract class StripeRepository {
     ): Result<Customer>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    abstract suspend fun retrieveCustomer(
+    suspend fun retrieveCustomer(
         customerId: String,
         productUsageTokens: Set<String>,
         requestOptions: ApiRequest.Options
@@ -257,7 +269,8 @@ abstract class StripeRepository {
         CardException::class,
         JSONException::class
     )
-    internal abstract suspend fun retrieveIssuingCardPin(
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun retrieveIssuingCardPin(
         cardId: String,
         verificationId: String,
         userOneTimeCode: String,
@@ -271,7 +284,8 @@ abstract class StripeRepository {
         APIException::class,
         CardException::class
     )
-    internal abstract suspend fun updateIssuingCardPin(
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun updateIssuingCardPin(
         cardId: String,
         newPin: String,
         verificationId: String,
@@ -279,41 +293,48 @@ abstract class StripeRepository {
         requestOptions: ApiRequest.Options
     )
 
-    internal abstract suspend fun getFpxBankStatus(options: ApiRequest.Options): BankStatuses
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun getFpxBankStatus(options: ApiRequest.Options): BankStatuses
 
-    internal abstract suspend fun getCardMetadata(
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun getCardMetadata(
         bin: Bin,
         options: ApiRequest.Options
     ): CardMetadata?
 
-    internal abstract suspend fun start3ds2Auth(
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun start3ds2Auth(
         authParams: Stripe3ds2AuthParams,
         requestOptions: ApiRequest.Options
     ): Stripe3ds2AuthResult?
 
-    internal abstract suspend fun complete3ds2Auth(
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun complete3ds2Auth(
         sourceId: String,
         requestOptions: ApiRequest.Options
     ): Stripe3ds2AuthResult?
 
-    internal abstract suspend fun createFile(
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun createFile(
         fileParams: StripeFileParams,
         requestOptions: ApiRequest.Options
     ): StripeFile
 
-    internal abstract suspend fun retrieveObject(
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun retrieveObject(
         url: String,
         requestOptions: ApiRequest.Options
     ): StripeResponse<String>
 
-    internal abstract suspend fun createRadarSession(
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun createRadarSession(
         requestOptions: ApiRequest.Options
     ): RadarSession?
 
     // Link endpoints
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Suppress("LongParameterList")
-    abstract suspend fun consumerSignUp(
+    suspend fun consumerSignUp(
         email: String,
         phoneNumber: String,
         country: String,
@@ -325,48 +346,48 @@ abstract class StripeRepository {
     ): ConsumerSession?
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    abstract suspend fun logoutConsumer(
+    suspend fun logoutConsumer(
         consumerSessionClientSecret: String,
         authSessionCookie: String?,
         requestOptions: ApiRequest.Options
     ): ConsumerSession?
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    abstract suspend fun createLinkFinancialConnectionsSession(
+    suspend fun createLinkFinancialConnectionsSession(
         consumerSessionClientSecret: String,
         requestOptions: ApiRequest.Options
     ): FinancialConnectionsSession?
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    abstract suspend fun createPaymentDetails(
+    suspend fun createPaymentDetails(
         consumerSessionClientSecret: String,
         financialConnectionsAccountId: String,
         requestOptions: ApiRequest.Options
     ): ConsumerPaymentDetails?
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    abstract suspend fun createPaymentDetails(
+    suspend fun createPaymentDetails(
         consumerSessionClientSecret: String,
         paymentDetailsCreateParams: ConsumerPaymentDetailsCreateParams,
         requestOptions: ApiRequest.Options
     ): ConsumerPaymentDetails?
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    abstract suspend fun listPaymentDetails(
+    suspend fun listPaymentDetails(
         consumerSessionClientSecret: String,
         paymentMethodTypes: Set<String>,
         requestOptions: ApiRequest.Options
     ): ConsumerPaymentDetails?
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    abstract suspend fun deletePaymentDetails(
+    suspend fun deletePaymentDetails(
         consumerSessionClientSecret: String,
         paymentDetailsId: String,
         requestOptions: ApiRequest.Options
     )
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    abstract suspend fun updatePaymentDetails(
+    suspend fun updatePaymentDetails(
         consumerSessionClientSecret: String,
         paymentDetailsUpdateParams: ConsumerPaymentDetailsUpdateParams,
         requestOptions: ApiRequest.Options
@@ -374,25 +395,28 @@ abstract class StripeRepository {
 
     // ACHv2 endpoints
 
-    internal abstract suspend fun createFinancialConnectionsSessionForDeferredPayments(
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun createFinancialConnectionsSessionForDeferredPayments(
         params: CreateFinancialConnectionsSessionForDeferredPaymentParams,
         requestOptions: ApiRequest.Options
     ): Result<FinancialConnectionsSession>
 
-    internal abstract suspend fun createPaymentIntentFinancialConnectionsSession(
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun createPaymentIntentFinancialConnectionsSession(
         paymentIntentId: String,
         params: CreateFinancialConnectionsSessionParams,
         requestOptions: ApiRequest.Options
     ): Result<FinancialConnectionsSession>
 
-    internal abstract suspend fun createSetupIntentFinancialConnectionsSession(
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    suspend fun createSetupIntentFinancialConnectionsSession(
         setupIntentId: String,
         params: CreateFinancialConnectionsSessionParams,
         requestOptions: ApiRequest.Options
     ): Result<FinancialConnectionsSession>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    abstract suspend fun attachFinancialConnectionsSessionToPaymentIntent(
+    suspend fun attachFinancialConnectionsSessionToPaymentIntent(
         clientSecret: String,
         paymentIntentId: String,
         financialConnectionsSessionId: String,
@@ -401,7 +425,7 @@ abstract class StripeRepository {
     ): Result<PaymentIntent>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    abstract suspend fun attachFinancialConnectionsSessionToSetupIntent(
+    suspend fun attachFinancialConnectionsSessionToSetupIntent(
         clientSecret: String,
         setupIntentId: String,
         financialConnectionsSessionId: String,
@@ -410,7 +434,7 @@ abstract class StripeRepository {
     ): Result<SetupIntent>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    abstract suspend fun verifyPaymentIntentWithMicrodeposits(
+    suspend fun verifyPaymentIntentWithMicrodeposits(
         clientSecret: String,
         firstAmount: Int,
         secondAmount: Int,
@@ -418,14 +442,14 @@ abstract class StripeRepository {
     ): Result<PaymentIntent>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    abstract suspend fun verifyPaymentIntentWithMicrodeposits(
+    suspend fun verifyPaymentIntentWithMicrodeposits(
         clientSecret: String,
         descriptorCode: String,
         requestOptions: ApiRequest.Options
     ): Result<PaymentIntent>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    abstract suspend fun verifySetupIntentWithMicrodeposits(
+    suspend fun verifySetupIntentWithMicrodeposits(
         clientSecret: String,
         firstAmount: Int,
         secondAmount: Int,
@@ -433,14 +457,14 @@ abstract class StripeRepository {
     ): Result<SetupIntent>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    abstract suspend fun verifySetupIntentWithMicrodeposits(
+    suspend fun verifySetupIntentWithMicrodeposits(
         clientSecret: String,
         descriptorCode: String,
         requestOptions: ApiRequest.Options
     ): Result<SetupIntent>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    abstract suspend fun retrievePaymentMethodMessage(
+    suspend fun retrievePaymentMethodMessage(
         paymentMethods: List<String>,
         amount: Int,
         currency: String,
@@ -451,13 +475,13 @@ abstract class StripeRepository {
     ): Result<PaymentMethodMessage>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    abstract suspend fun retrieveElementsSession(
+    suspend fun retrieveElementsSession(
         params: ElementsSessionParams,
         options: ApiRequest.Options,
     ): Result<ElementsSession>
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    abstract suspend fun retrieveCardMetadata(
+    suspend fun retrieveCardMetadata(
         cardNumber: String,
         requestOptions: ApiRequest.Options
     ): CardMetadata?

--- a/payments-core/src/test/java/com/stripe/android/CustomerSessionOperationExecutorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/CustomerSessionOperationExecutorTest.kt
@@ -7,8 +7,8 @@ import com.stripe.android.model.CustomerFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.Source
-import com.stripe.android.networking.AbsFakeStripeRepository
 import com.stripe.android.networking.StripeRepository
+import com.stripe.android.testing.AbsFakeStripeRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain

--- a/payments-core/src/test/java/com/stripe/android/DefaultIntentConfirmationInterceptorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/DefaultIntentConfirmationInterceptorTest.kt
@@ -12,8 +12,8 @@ import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.networking.AbsFakeStripeRepository
 import com.stripe.android.networking.StripeRepository
+import com.stripe.android.testing.AbsFakeStripeRepository
 import com.stripe.android.testing.IntentConfirmationInterceptorTestRule
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule

--- a/payments-core/src/test/java/com/stripe/android/IssuingCardPinServiceTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/IssuingCardPinServiceTest.kt
@@ -4,8 +4,8 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.InvalidRequestException
 import com.stripe.android.core.networking.ApiRequest
-import com.stripe.android.networking.AbsFakeStripeRepository
 import com.stripe.android.testharness.TestEphemeralKeyProvider
+import com.stripe.android.testing.AbsFakeStripeRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain

--- a/payments-core/src/test/java/com/stripe/android/PaymentSessionTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentSessionTest.kt
@@ -14,9 +14,9 @@ import com.stripe.android.model.CustomerFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodFixtures
-import com.stripe.android.networking.AbsFakeStripeRepository
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.testharness.TestEphemeralKeyProvider
+import com.stripe.android.testing.AbsFakeStripeRepository
 import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.view.ActivityScenarioFactory
 import com.stripe.android.view.ActivityStarter

--- a/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -18,12 +18,12 @@ import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.Source
 import com.stripe.android.model.SourceFixtures
 import com.stripe.android.model.Stripe3ds2Fixtures
-import com.stripe.android.networking.AbsFakeStripeRepository
 import com.stripe.android.networking.AlipayRepository
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.stripe3ds2.transaction.SdkTransactionId
 import com.stripe.android.stripe3ds2.transaction.Transaction
+import com.stripe.android.testing.AbsFakeStripeRepository
 import com.stripe.android.utils.ParcelUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking

--- a/payments-core/src/test/java/com/stripe/android/cards/RemoteCardAccountRangeSourceTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/cards/RemoteCardAccountRangeSourceTest.kt
@@ -10,9 +10,9 @@ import com.stripe.android.model.AccountRange
 import com.stripe.android.model.BinFixtures
 import com.stripe.android.model.BinRange
 import com.stripe.android.model.CardMetadata
-import com.stripe.android.networking.AbsFakeStripeRepository
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.networking.StripeRepository
+import com.stripe.android.testing.AbsFakeStripeRepository
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModelTest.kt
@@ -23,9 +23,9 @@ import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.SetupIntentFixtures
-import com.stripe.android.networking.AbsFakeStripeRepository
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.payments.core.authentication.AbsPaymentController
+import com.stripe.android.testing.AbsFakeStripeRepository
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
 import org.mockito.kotlin.KArgumentCaptor

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
@@ -29,7 +29,7 @@ import com.stripe.android.model.GooglePayFixtures
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodFixtures
-import com.stripe.android.networking.AbsFakeStripeRepository
+import com.stripe.android.testing.AbsFakeStripeRepository
 import com.stripe.android.testing.fakeCreationExtras
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/StripeGooglePayViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/StripeGooglePayViewModelTest.kt
@@ -10,7 +10,7 @@ import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.GooglePayFixtures.GOOGLE_PAY_RESULT_WITH_NO_BILLING_ADDRESS
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
-import com.stripe.android.networking.AbsFakeStripeRepository
+import com.stripe.android.testing.AbsFakeStripeRepository
 import kotlinx.coroutines.test.StandardTestDispatcher
 import org.json.JSONObject
 import org.junit.runner.RunWith

--- a/payments-core/src/test/java/com/stripe/android/model/Stripe3ds2AuthResultFixtures.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/Stripe3ds2AuthResultFixtures.kt
@@ -2,65 +2,9 @@ package com.stripe.android.model
 
 import com.stripe.android.model.parsers.Stripe3ds2AuthResultJsonParser
 import org.json.JSONObject
-import java.util.UUID
 
 @Suppress("MaxLineLength")
 internal object Stripe3ds2AuthResultFixtures {
-    internal val ARES_CHALLENGE_FLOW = Stripe3ds2AuthResult(
-        id = "threeds2_1FDy0vCRMbs6",
-        source = "src_1FDy0uCRMb",
-        created = 1567363381,
-        ares = Stripe3ds2AuthResult.Ares(
-            acsChallengeMandated = "Y",
-            acsTransId = UUID.randomUUID().toString(),
-            sdkTransId = UUID.randomUUID().toString(),
-            threeDSServerTransId = UUID.randomUUID().toString(),
-            transStatus = Stripe3ds2AuthResult.Ares.VALUE_CHALLENGE,
-            messageType = "ARes",
-            messageVersion = "2.1.0"
-        )
-    )
-
-    internal val ARES_FRICTIONLESS_FLOW = Stripe3ds2AuthResult(
-        id = "threeds2_1Ecwz3CRMbs6FrXfThtfogua",
-        liveMode = false,
-        created = 1558541285L,
-        source = "src_1Ecwz1CRMbs6FrXfUwt98lxf",
-        ares = Stripe3ds2AuthResult.Ares(
-            acsChallengeMandated = "N",
-            acsTransId = UUID.randomUUID().toString(),
-            sdkTransId = UUID.randomUUID().toString(),
-            threeDSServerTransId = UUID.randomUUID().toString(),
-            messageVersion = "2.1.0",
-            messageType = "ARes"
-        )
-    )
-
-    internal val ERROR = Stripe3ds2AuthResult(
-        id = "threeds2_1FDy0vCRMbs6",
-        source = "src_1FDy0uCRMb",
-        created = 1567363381,
-        error = Stripe3ds2AuthResult.ThreeDS2Error(
-            acsTransId = UUID.randomUUID().toString(),
-            dsTransId = UUID.randomUUID().toString(),
-            sdkTransId = UUID.randomUUID().toString(),
-            threeDSServerTransId = UUID.randomUUID().toString(),
-            messageVersion = "2.1.0",
-            messageType = "Erro",
-            errorComponent = "D",
-            errorCode = "302",
-            errorDescription = "Data could not be decrypted by the receiving system due to technical or other reason.",
-            errorMessageType = "AReq"
-        )
-    )
-
-    internal val FALLBACK_REDIRECT_URL = Stripe3ds2AuthResult(
-        id = "threeds2_1FDy0vCRMbs6",
-        source = "src_1FDy0uCRMb",
-        created = 1567363381,
-        fallbackRedirectUrl = "https://hooks.stripe.com/3d_secure_2_eap/begin_test/" +
-            "src_1Ecve7CRMbs6FrXfm8AxXMIh/src_client_secret_F79yszOBAiuaZTuIhbn3LPUW"
-    )
 
     internal val CHALLENGE_COMPLETION_JSON = JSONObject(
         """

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/DefaultStripe3ds2ChallengeResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/DefaultStripe3ds2ChallengeResultProcessorTest.kt
@@ -14,12 +14,12 @@ import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.RetryDelaySupplier
 import com.stripe.android.model.Stripe3ds2AuthResult
 import com.stripe.android.model.Stripe3ds2AuthResultFixtures
-import com.stripe.android.networking.AbsFakeStripeRepository
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.stripe3ds2.transaction.ChallengeResult
 import com.stripe.android.stripe3ds2.transaction.IntentData
 import com.stripe.android.stripe3ds2.transactions.UiType
+import com.stripe.android.testing.AbsFakeStripeRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain

--- a/payments-core/src/test/java/com/stripe/android/polling/PollingTestUtils.kt
+++ b/payments-core/src/test/java/com/stripe/android/polling/PollingTestUtils.kt
@@ -4,7 +4,7 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.networking.AbsFakeStripeRepository
+import com.stripe.android.testing.AbsFakeStripeRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock

--- a/payments-core/src/test/java/com/stripe/android/view/FpxViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/FpxViewModelTest.kt
@@ -5,7 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.BankStatuses
-import com.stripe.android.networking.AbsFakeStripeRepository
+import com.stripe.android.testing.AbsFakeStripeRepository
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request moves `AbsFakeStripeRepository` from `payments-core` to `payments-core-testing`. This allows other modules to use the same abstract class in their own tests.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Preparation for https://github.com/stripe/stripe-android/pull/6810.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
