### PR TITLE
No-op Update .gitignore for pay commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ example/bin
 example/target
 example/gen
 
+# Stripe-internal `pay` commands
+.pay/*


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

Ignores pay command configs (needed for stripe internal pay commands). 

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[RUN_CODE-2796](https://jira.corp.stripe.com/browse/RUN_CODE-2796)

## Changelog
No-op
