### PR TITLE
[FC] Crash after authenticating when R8 full-mode is enabled


### DIFF
--- a/financial-connections-example/build.gradle
+++ b/financial-connections-example/build.gradle
@@ -27,10 +27,6 @@ android {
                 groups = "financial-connections"
             }
         }
-        release {
-            minifyEnabled true
-            shrinkResources true
-        }
     }
 
     buildFeatures {

--- a/financial-connections-example/build.gradle
+++ b/financial-connections-example/build.gradle
@@ -27,6 +27,10 @@ android {
                 groups = "financial-connections"
             }
         }
+        release {
+            minifyEnabled true
+            shrinkResources true
+        }
     }
 
     buildFeatures {

--- a/financial-connections-example/gradle.properties
+++ b/financial-connections-example/gradle.properties
@@ -1,1 +1,2 @@
 STRIPE_ANDROID_NAMESPACE=com.stripe.android.financialconnections.example
+android.enableR8.fullMode=true

--- a/financial-connections-example/gradle.properties
+++ b/financial-connections-example/gradle.properties
@@ -1,2 +1,1 @@
 STRIPE_ANDROID_NAMESPACE=com.stripe.android.financialconnections.example
-android.enableR8.fullMode=true

--- a/financial-connections/consumer-rules.txt
+++ b/financial-connections/consumer-rules.txt
@@ -13,3 +13,25 @@
 -keep,allowobfuscation class ** implements com.airbnb.mvrx.MavericksViewModelFactory
 
 -dontwarn com.google.crypto.tink.subtle.XChaCha20Poly1305
+
+
+# MavericksViewModel loads the Companion class via reflection and thus we need to make sure we keep
+# the name of the Companion object.
+-keepclassmembers class ** extends com.airbnb.mvrx.MavericksViewModel {
+    ** Companion;
+}
+
+# Members of the Kotlin data classes used as the state in Mavericks are read via Kotlin reflection which cause trouble
+# with Proguard if they are not kept.
+# During reflection cache warming also the types are accessed via reflection. Need to keep them too.
+-keepclassmembers,includedescriptorclasses,allowobfuscation class ** implements com.airbnb.mvrx.MavericksState {
+   *;
+}
+
+# The MavericksState object and the names classes that implement the MavericksState interface need to be
+# kept as they are accessed via reflection.
+-keepnames class com.airbnb.mvrx.MavericksState
+-keepnames class * implements com.airbnb.mvrx.MavericksState
+
+# MavericksViewModelFactory is referenced via reflection using the Companion class name.
+-keepnames class * implements com.airbnb.mvrx.MavericksViewModelFactory


### PR DESCRIPTION
# Summary
- Issue: When enabling R8 full-mode on the host app, a class we use reflection on gets obfuscated resulting on the AuthFlow to fail after authenticating with an institution
- Solution: Add proguard rules to the SDK to avoid obfuscating this class, and preventing similar classes to be obfuscated in the future. 

# Motivation
:notebook_with_decorative_cover: &nbsp;**[Android] Crash after authenticating when R8 full-mode is enabled***
:globe_with_meridians: &nbsp;[BANKCON-7040](https://jira.corp.stripe.com/browse/BANKCON-7040)
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified (We'll be adding release mode e2e tests soon!)