### PR TITLE
[FC] Run Maestro tests against release builds

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -83,10 +83,12 @@ workflows:
       - wait-for-android-emulator@1:
           inputs:
             - boot_timeout: 600
-      - script-runner@0:
-          title: Execute Maestro tests
+      - script@1:
+          title: Execute Maestro tests (debug)
           inputs:
-            - file_path: ./scripts/execute_maestro_tests.sh
+            - content: |-
+                #!/usr/bin/env bash
+                bash ./scripts/execute_maestro_tests.sh debug
       - slack@3:
           is_always_run: true
           inputs:
@@ -107,10 +109,12 @@ workflows:
       - wait-for-android-emulator@1:
           inputs:
             - boot_timeout: 600
-      - script-runner@0:
-          title: Execute Maestro tests
+      - script@1:
+          title: Execute Maestro tests (release)
           inputs:
-            - file_path: ./scripts/execute_maestro_paymentsheet_tests.sh
+            - content: |-
+                #!/usr/bin/env bash
+                bash ./scripts/execute_maestro_tests.sh release
       - slack@3:
           is_always_run: true
           run_if: .IsBuildFailed

--- a/scripts/execute_maestro_tests.sh
+++ b/scripts/execute_maestro_tests.sh
@@ -2,6 +2,18 @@
 set -o pipefail
 set -x
 
+# Get the first command line argument as the parameter
+buildType=$1
+
+if [ "$buildType" == "debug" ]; then
+  task="installDebug"
+elif [ "$buildType" == "release" ]; then
+  task="installRelease"
+else
+  echo "Invalid parameter. Please use 'debug' or 'release'."
+  exit 1
+fi
+
 now=$(date +%F_%H-%M-%S)
 echo $now
 
@@ -11,7 +23,7 @@ export PATH="$PATH":"$HOME/.maestro/bin"
 maestro -v
 
 # Compile and install APK.
-./gradlew -PSTRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL=$STRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL :financial-connections-example:installDebug
+./gradlew -PSTRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL=$STRIPE_FINANCIAL_CONNECTIONS_EXAMPLE_BACKEND_URL :financial-connections-example:$task
 
 # Start screen record (adb screenrecord has a 3 min limit).
 adb shell "screenrecord /sdcard/$now-1.mp4" &


### PR DESCRIPTION
# Summary
- Currently Maestro tests run against debug builds
- We've had obfuscation related issues that have reached production
- This PR compiles the example app in release mode with R8 enabled.  
- Edge e2e tests keep building with debug build type. We're constrained on build times there, plus edge testing attempts to catch backend issues with mobile, for which debug builds are enough.  

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified

