### PR TITLE
[FC] Reload Auth Session instead of entire PartnerAuth Pane on cancellations

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
@@ -59,6 +59,10 @@ internal class PartnerAuthViewModel @Inject constructor(
     init {
         logErrors()
         observePayload()
+        createAuthSession()
+    }
+
+    private fun createAuthSession() {
         suspend {
             val launchedEvent = Launched(Date())
             val manifest: FinancialConnectionsSessionManifest = getManifest()
@@ -182,12 +186,10 @@ internal class PartnerAuthViewModel @Inject constructor(
                 logger.debug("Creating a new session for this OAuth institution")
                 // Send retry event as we're presenting the prepane again.
                 postAuthSessionEvent(authSession.id, AuthSessionEvent.Retry(Date()))
-                val manifest = getManifest()
-                val newSession = createAuthorizationSession(
-                    institution = requireNotNull(manifest.activeInstitution),
-                    allowManualEntry = manifest.allowManualEntry
-                )
-                goNext(newSession.nextPane)
+                // for OAuth institutions, we remain on the pre-pane,
+                // but create a brand new auth session
+                setState { copy(authenticationStatus = Uninitialized) }
+                createAuthSession()
             } else {
                 // For OAuth institutions, navigate to Session cancellation's next pane.
                 postAuthSessionEvent(authSession.id, AuthSessionEvent.Cancel(Date()))

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
@@ -39,7 +39,6 @@ import kotlinx.coroutines.launch
 import java.util.Date
 import javax.inject.Inject
 import javax.inject.Named
-
 @Suppress("LongParameterList")
 internal class PartnerAuthViewModel @Inject constructor(
     private val completeAuthorizationSession: CompleteAuthorizationSession,
@@ -56,6 +55,7 @@ internal class PartnerAuthViewModel @Inject constructor(
     private val logger: Logger,
     initialState: PartnerAuthState
 ) : MavericksViewModel<PartnerAuthState>(initialState) {
+
     init {
         logErrors()
         observePayload()
@@ -70,6 +70,7 @@ internal class PartnerAuthViewModel @Inject constructor(
                 institution = requireNotNull(manifest.activeInstitution),
                 allowManualEntry = manifest.allowManualEntry
             )
+            logger.debug("HOLA")
             Payload(
                 authSession = authSession,
                 institution = requireNotNull(manifest.activeInstitution),
@@ -83,6 +84,9 @@ internal class PartnerAuthViewModel @Inject constructor(
                 )
             }
         }.execute {
+            if (payload is Fail) {
+                logger.debug(it.toString())
+            }
             copy(payload = it)
         }
     }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/partnerauth/PartnerAuthViewModel.kt
@@ -70,7 +70,6 @@ internal class PartnerAuthViewModel @Inject constructor(
                 institution = requireNotNull(manifest.activeInstitution),
                 allowManualEntry = manifest.allowManualEntry
             )
-            logger.debug("HOLA")
             Payload(
                 authSession = authSession,
                 institution = requireNotNull(manifest.activeInstitution),
@@ -83,12 +82,7 @@ internal class PartnerAuthViewModel @Inject constructor(
                     listOfNotNull(launchedEvent, loadedEvent)
                 )
             }
-        }.execute {
-            if (payload is Fail) {
-                logger.debug(it.toString())
-            }
-            copy(payload = it)
-        }
+        }.execute { copy(payload = it) }
     }
 
     private fun observePayload() {


### PR DESCRIPTION
# Summary

Issue: When cancelling an AuthSession (ie. closing the browser while authenticating) we:
1. Create a new AuthSession
2. emit a Retry AuthSession event
3. Navigate to the newly created AuthSession nextPane, which on OAuth sessions will be the same pane, PartnerAuth, causing a  "Reload"

On these situations Android creates two AuthSessions, one in 2. and another one when reloading in 3.

This PR updates the code to what iOS does - creating a new auth session but staying in the pane. 

# Motivation
https://jira.corp.stripe.com/browse/BANKCON-7103

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [X] Manually verified