### PR TITLE
Add deferred intent validator

### DIFF
--- a/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentIntentFactory.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentIntentFactory.kt
@@ -11,6 +11,7 @@ object PaymentIntentFactory {
         paymentMethod: PaymentMethod? = createCardPaymentMethod(),
         paymentMethodTypes: List<String> = listOf("card"),
         setupFutureUsage: StripeIntent.Usage? = null,
+        confirmationMethod: PaymentIntent.ConfirmationMethod = PaymentIntent.ConfirmationMethod.Automatic,
     ): PaymentIntent = PaymentIntent(
         created = 500L,
         amount = 1000L,
@@ -24,6 +25,7 @@ object PaymentIntentFactory {
         status = StripeIntent.Status.RequiresConfirmation,
         unactivatedPaymentMethods = emptyList(),
         setupFutureUsage = setupFutureUsage,
+        confirmationMethod = confirmationMethod,
     )
 
     private fun createCardPaymentMethod(): PaymentMethod = PaymentMethod(

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentIntentFactory.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentIntentFactory.kt
@@ -10,6 +10,7 @@ object PaymentIntentFactory {
     fun create(
         paymentMethod: PaymentMethod? = createCardPaymentMethod(),
         paymentMethodTypes: List<String> = listOf("card"),
+        setupFutureUsage: StripeIntent.Usage? = null,
     ): PaymentIntent = PaymentIntent(
         created = 500L,
         amount = 1000L,
@@ -22,6 +23,7 @@ object PaymentIntentFactory {
         paymentMethodTypes = paymentMethodTypes,
         status = StripeIntent.Status.RequiresConfirmation,
         unactivatedPaymentMethods = emptyList(),
+        setupFutureUsage = setupFutureUsage,
     )
 
     private fun createCardPaymentMethod(): PaymentMethod = PaymentMethod(

--- a/payments-core/src/main/java/com/stripe/android/model/DeferredIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/DeferredIntentParams.kt
@@ -26,7 +26,7 @@ data class DeferredIntentParams(
             val amount: Long,
             override val currency: String,
             override val setupFutureUsage: StripeIntent.Usage?,
-            val captureMethod: CaptureMethod,
+            val captureMethod: PaymentIntent.CaptureMethod,
         ) : Mode {
             override val code: String get() = "payment"
         }
@@ -39,13 +39,6 @@ data class DeferredIntentParams(
         ) : Mode {
             override val code: String get() = "setup"
         }
-    }
-
-    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    enum class CaptureMethod(val code: String) {
-        Automatic("automatic"),
-        AutomaticAsync("automatic_async"),
-        Manual("manual"),
     }
 
     fun toQueryParams(): Map<String, Any?> {

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentIntent.kt
@@ -389,7 +389,10 @@ constructor(
     /**
      * Controls when the funds will be captured from the customer’s account.
      */
-    enum class CaptureMethod(private val code: String) {
+    enum class CaptureMethod(
+        @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        val code: String,
+    ) {
         /**
          * (Default) Stripe automatically captures funds when the customer authorizes the payment.
          */

--- a/payments-core/src/main/java/com/stripe/android/model/parsers/DeferredPaymentIntentJsonParser.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/parsers/DeferredPaymentIntentJsonParser.kt
@@ -30,9 +30,9 @@ class DeferredPaymentIntentJsonParser(
         val countryCode = optString(json, FIELD_COUNTRY_CODE)
 
         val captureMethod = when (paymentMode.captureMethod) {
-            DeferredIntentParams.CaptureMethod.Automatic -> PaymentIntent.CaptureMethod.Automatic
-            DeferredIntentParams.CaptureMethod.AutomaticAsync -> PaymentIntent.CaptureMethod.AutomaticAsync
-            DeferredIntentParams.CaptureMethod.Manual -> PaymentIntent.CaptureMethod.Manual
+            PaymentIntent.CaptureMethod.Automatic -> PaymentIntent.CaptureMethod.Automatic
+            PaymentIntent.CaptureMethod.AutomaticAsync -> PaymentIntent.CaptureMethod.AutomaticAsync
+            PaymentIntent.CaptureMethod.Manual -> PaymentIntent.CaptureMethod.Manual
         }
 
         return PaymentIntent(

--- a/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/parsers/ElementsSessionJsonParserTest.kt
@@ -248,7 +248,7 @@ class ElementsSessionJsonParserTest {
                     mode = DeferredIntentParams.Mode.Payment(
                         amount = 2000,
                         currency = "usd",
-                        captureMethod = DeferredIntentParams.CaptureMethod.Automatic,
+                        captureMethod = PaymentIntent.CaptureMethod.Automatic,
                         setupFutureUsage = null,
                     ),
                     paymentMethodTypes = emptyList(),

--- a/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/networking/StripeApiRepositoryTest.kt
@@ -2278,7 +2278,7 @@ internal class StripeApiRepositoryTest {
                     mode = DeferredIntentParams.Mode.Payment(
                         amount = 2000,
                         currency = "usd",
-                        captureMethod = DeferredIntentParams.CaptureMethod.Automatic,
+                        captureMethod = PaymentIntent.CaptureMethod.Automatic,
                         setupFutureUsage = null,
                     ),
                     paymentMethodTypes = listOf("card", "link"),

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -9,6 +9,8 @@
     <ID>FunctionNaming:PaymentOptionUi.kt$@Preview(name = "Selected payment option") @Composable private fun PaymentOptionUi_Selected()</ID>
     <ID>FunctionNaming:PaymentSheetTopBar.kt$@Preview @Composable internal fun PaymentSheetTopBar_Preview()</ID>
     <ID>FunctionNaming:PaymentSheetTopBar.kt$@Preview @Composable internal fun TestModeBadge_Preview()</ID>
+    <ID>FunctionOnlyReturningConstant:FlowControllerModule.kt$FlowControllerModule$@Provides @Singleton @Named(IS_FLOW_CONTROLLER) fun provideIsFlowController()</ID>
+    <ID>FunctionOnlyReturningConstant:PaymentSheetLauncherModule.kt$PaymentSheetLauncherModule.Companion$@Provides @Singleton @Named(IS_FLOW_CONTROLLER) fun provideIsFlowController()</ID>
     <ID>FunctionOnlyReturningConstant:SupportedPaymentMethodTest.kt$SupportedPaymentMethodTest.PaymentIntentTestInput.Companion$fun toCsvHeader()</ID>
     <ID>FunctionOnlyReturningConstant:SupportedPaymentMethodTest.kt$SupportedPaymentMethodTest.TestOutput.Companion$fun toCsvHeader()</ID>
     <ID>LargeClass:DefaultFlowControllerTest.kt$DefaultFlowControllerTest</ID>

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -566,4 +566,86 @@ internal class FlowControllerTest {
 
         assertThat(resultCountDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
     }
+
+    @OptIn(ExperimentalPaymentSheetDecouplingApi::class)
+    @Test
+    fun testDeferredIntentCardPaymentWithInvalidStripeIntent() {
+        networkRule.enqueue(
+            method("GET"),
+            path("/v1/elements/sessions"),
+        ) { response ->
+            response.testBodyFromFile("elements-sessions-deferred_payment_intent.json")
+        }
+
+        val resultCountDownLatch = CountDownLatch(1)
+        val activityScenarioRule = composeTestRule.activityRule
+        val scenario = activityScenarioRule.scenario
+        scenario.moveToState(Lifecycle.State.CREATED)
+        lateinit var flowController: PaymentSheet.FlowController
+        scenario.onActivity {
+            PaymentConfiguration.init(it, "pk_test_123")
+            flowController = PaymentSheet.FlowController.create(
+                activity = it,
+                paymentOptionCallback = { paymentOption ->
+                    assertThat(paymentOption?.label).endsWith("4242")
+                    flowController.confirm()
+                },
+                createIntentCallback = { _, _ ->
+                    CreateIntentResult.Success(clientSecret = "pi_example_secret_example")
+                },
+                paymentResultCallback = { result ->
+                    val failureResult = result as? PaymentSheetResult.Failed
+                    assertThat(failureResult?.error?.message).isEqualTo(
+                        "Your PaymentIntent amount (5099) does not match " +
+                            "the PaymentSheet.IntentConfiguration amount (2000)."
+                    )
+                    resultCountDownLatch.countDown()
+                },
+            )
+        }
+        scenario.moveToState(Lifecycle.State.RESUMED)
+        scenario.onActivity {
+            flowController.configureWithIntentConfiguration(
+                intentConfiguration = PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                        // This amount is different from the $50.99 in the created intent, which
+                        // will cause the validator to fail this transaction.
+                        amount = 2000,
+                        currency = "usd"
+                    )
+                ),
+                configuration = null,
+                callback = { success, error ->
+                    assertThat(success).isTrue()
+                    assertThat(error).isNull()
+                    flowController.presentPaymentOptions()
+                }
+            )
+        }
+
+        page.addPaymentMethod()
+        page.fillOutCardDetails()
+
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/payment_methods"),
+            bodyPart(
+                "payment_user_agent",
+                Regex("stripe-android%2F\\d*.\\d*.\\d*%3BPaymentSheet.FlowController%3BPaymentSheet%3Bdeferred-intent")
+            ),
+        ) { response ->
+            response.testBodyFromFile("payment-methods-create.json")
+        }
+
+        networkRule.enqueue(
+            method("GET"),
+            path("/v1/payment_intents/pi_example"),
+        ) { response ->
+            response.testBodyFromFile("payment-intent-get-requires_payment_method.json")
+        }
+
+        page.clickPrimaryButton()
+
+        assertThat(resultCountDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
+    }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -596,8 +596,8 @@ internal class FlowControllerTest {
                 paymentResultCallback = { result ->
                     val failureResult = result as? PaymentSheetResult.Failed
                     assertThat(failureResult?.error?.message).isEqualTo(
-                        "Your PaymentIntent amount (5099) does not match " +
-                            "the PaymentSheet.IntentConfiguration amount (2000)."
+                        "Your PaymentIntent currency (usd) does not match " +
+                            "the PaymentSheet.IntentConfiguration currency (cad)."
                     )
                     resultCountDownLatch.countDown()
                 },
@@ -608,10 +608,10 @@ internal class FlowControllerTest {
             flowController.configureWithIntentConfiguration(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
-                        // This amount is different from the $50.99 in the created intent, which
+                        // This currency is different from USD in the created intent, which
                         // will cause the validator to fail this transaction.
-                        amount = 2000,
-                        currency = "usd"
+                        amount = 5099,
+                        currency = "cad",
                     )
                 ),
                 configuration = null,

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -370,7 +370,7 @@ internal class FlowControllerTest {
             flowController.configureWithIntentConfiguration(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
-                        amount = 2000,
+                        amount = 5099,
                         currency = "usd"
                     )
                 ),
@@ -464,7 +464,7 @@ internal class FlowControllerTest {
             flowController.configureWithIntentConfiguration(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
-                        amount = 2000,
+                        amount = 5099,
                         currency = "usd"
                     )
                 ),

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -191,7 +191,7 @@ internal class PaymentSheetTest {
             paymentSheet.presentWithIntentConfiguration(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
-                        amount = 2000,
+                        amount = 5099,
                         currency = "usd"
                     )
                 ),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DeferredIntentValidator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DeferredIntentValidator.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet
 import com.stripe.android.model.DeferredIntentParams
 import com.stripe.android.model.ElementsSessionParams
 import com.stripe.android.model.PaymentIntent
-import com.stripe.android.model.PaymentIntent.CaptureMethod
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.repositories.toElementsSessionParams
@@ -50,7 +49,7 @@ internal object DeferredIntentValidator {
                 // the final step of confirmation. Showing a successful payment in the complete flow
                 // may be misleading when merchants still need to do a final confirmation which
                 // could fail.
-                require(stripeIntent.captureMethod != CaptureMethod.Manual || isFlowController) {
+                require(stripeIntent.confirmationMethod != PaymentIntent.ConfirmationMethod.Manual || isFlowController) {
                     "Your PaymentIntent confirmationMethod (${stripeIntent.confirmationMethod}) " +
                         "can only be used with PaymentSheet.FlowController."
                 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DeferredIntentValidator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DeferredIntentValidator.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet
 import com.stripe.android.model.DeferredIntentParams
 import com.stripe.android.model.ElementsSessionParams
 import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentIntent.ConfirmationMethod.Manual
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.paymentsheet.repositories.toElementsSessionParams
@@ -49,7 +50,7 @@ internal object DeferredIntentValidator {
                 // the final step of confirmation. Showing a successful payment in the complete flow
                 // may be misleading when merchants still need to do a final confirmation which
                 // could fail.
-                require(stripeIntent.confirmationMethod != PaymentIntent.ConfirmationMethod.Manual || isFlowController) {
+                require(stripeIntent.confirmationMethod != Manual || isFlowController) {
                     "Your PaymentIntent confirmationMethod (${stripeIntent.confirmationMethod}) " +
                         "can only be used with PaymentSheet.FlowController."
                 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DeferredIntentValidator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DeferredIntentValidator.kt
@@ -40,11 +40,6 @@ internal object DeferredIntentValidator {
                         "setupFutureUsage (${paymentMode.setupFutureUsage})."
                 }
 
-                require(paymentMode.amount == stripeIntent.amount) {
-                    "Your PaymentIntent amount (${stripeIntent.amount}) does not match " +
-                        "the PaymentSheet.IntentConfiguration amount (${paymentMode.amount})."
-                }
-
                 require(paymentMode.captureMethod == stripeIntent.captureMethod) {
                     "Your PaymentIntent captureMethod (${stripeIntent.captureMethod}) does not " +
                         "match the PaymentSheet.IntentConfiguration " +

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DeferredIntentValidator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DeferredIntentValidator.kt
@@ -25,7 +25,7 @@ internal object DeferredIntentValidator {
 
                 require(paymentMode.currency == stripeIntent.currency) {
                     "Your PaymentIntent currency (${stripeIntent.currency}) does not match " +
-                        "the PaymentSheet.IntentConfiguration currency (${paymentMode.currency}))."
+                        "the PaymentSheet.IntentConfiguration currency (${paymentMode.currency})."
                 }
 
                 require(paymentMode.setupFutureUsage == stripeIntent.setupFutureUsage) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DeferredIntentValidator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DeferredIntentValidator.kt
@@ -1,0 +1,71 @@
+package com.stripe.android.paymentsheet
+
+import com.stripe.android.model.DeferredIntentParams
+import com.stripe.android.model.ElementsSessionParams
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.SetupIntent
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentsheet.repositories.toElementsSessionParams
+
+@OptIn(ExperimentalPaymentSheetDecouplingApi::class)
+internal object DeferredIntentValidator {
+
+    fun validate(
+        stripeIntent: StripeIntent,
+        intentConfiguration: PaymentSheet.IntentConfiguration,
+    ): StripeIntent {
+        val params = mapToDeferredIntentParams(intentConfiguration)
+
+        when (stripeIntent) {
+            is PaymentIntent -> {
+                val paymentMode = requireNotNull(params.mode as? DeferredIntentParams.Mode.Payment) {
+                    "You returned a PaymentIntent client secret " +
+                        "but used a PaymentSheet.IntentConfiguration in setup mode."
+                }
+
+                require(paymentMode.currency == stripeIntent.currency) {
+                    "Your PaymentIntent currency (${stripeIntent.currency}) does not match " +
+                        "the PaymentSheet.IntentConfiguration currency (${paymentMode.currency}))."
+                }
+
+                require(paymentMode.setupFutureUsage == stripeIntent.setupFutureUsage) {
+                    "Your PaymentIntent setupFutureUsage (${stripeIntent.setupFutureUsage}) " +
+                        "does not match the PaymentSheet.IntentConfiguration " +
+                        "setupFutureUsage (${paymentMode.setupFutureUsage})."
+                }
+
+                require(paymentMode.amount == stripeIntent.amount) {
+                    "Your PaymentIntent amount (${stripeIntent.amount}) does not match " +
+                        "the PaymentSheet.IntentConfiguration amount (${paymentMode.amount})."
+                }
+
+                require(paymentMode.captureMethod == stripeIntent.captureMethod) {
+                    "Your PaymentIntent captureMethod (${stripeIntent.captureMethod}) does not " +
+                        "match the PaymentSheet.IntentConfiguration " +
+                        "captureMethod (${paymentMode.captureMethod})."
+                }
+            }
+            is SetupIntent -> {
+                val setupMode = requireNotNull(params.mode as? DeferredIntentParams.Mode.Setup) {
+                    "You returned a SetupIntent client secret " +
+                        "but used a PaymentSheet.IntentConfiguration in payment mode."
+                }
+
+                require(setupMode.setupFutureUsage == stripeIntent.usage) {
+                    "Your SetupIntent usage (${stripeIntent.usage}) does not match " +
+                        "the PaymentSheet.IntentConfiguration usage (${stripeIntent.usage})."
+                }
+            }
+        }
+
+        return stripeIntent
+    }
+
+    private fun mapToDeferredIntentParams(
+        intentConfiguration: PaymentSheet.IntentConfiguration,
+    ): DeferredIntentParams {
+        val initializationMode = PaymentSheet.InitializationMode.DeferredIntent(intentConfiguration)
+        val params = initializationMode.toElementsSessionParams()
+        return (params as ElementsSessionParams.DeferredIntentType).deferredIntentParams
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DeferredIntentValidator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DeferredIntentValidator.kt
@@ -11,6 +11,10 @@ import com.stripe.android.paymentsheet.repositories.toElementsSessionParams
 @OptIn(ExperimentalPaymentSheetDecouplingApi::class)
 internal object DeferredIntentValidator {
 
+    /**
+     * Validates that the created [StripeIntent] matches the [PaymentSheet.IntentConfiguration] that
+     * was provided to [PaymentSheet].
+     */
     fun validate(
         stripeIntent: StripeIntent,
         intentConfiguration: PaymentSheet.IntentConfiguration,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptorKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptorKtx.kt
@@ -9,6 +9,7 @@ internal suspend fun IntentConfirmationInterceptor.intercept(
     initializationMode: PaymentSheet.InitializationMode,
     paymentSelection: PaymentSelection?,
     shippingValues: ConfirmPaymentIntentParams.Shipping?,
+    isFlowController: Boolean,
 ): IntentConfirmationInterceptor.NextStep {
     return when (paymentSelection) {
         is PaymentSelection.New -> {
@@ -23,6 +24,7 @@ internal suspend fun IntentConfirmationInterceptor.intercept(
                 paymentMethodCreateParams = paymentSelection.paymentMethodCreateParams,
                 shippingValues = shippingValues,
                 setupForFutureUsage = setupFutureUsage,
+                isFlowController = isFlowController,
             )
         }
         is PaymentSelection.Saved -> {
@@ -31,6 +33,7 @@ internal suspend fun IntentConfirmationInterceptor.intercept(
                 paymentMethod = paymentSelection.paymentMethod,
                 shippingValues = shippingValues,
                 setupForFutureUsage = null,
+                isFlowController = isFlowController,
             )
         }
         else -> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptorKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptorKtx.kt
@@ -9,7 +9,6 @@ internal suspend fun IntentConfirmationInterceptor.intercept(
     initializationMode: PaymentSheet.InitializationMode,
     paymentSelection: PaymentSelection?,
     shippingValues: ConfirmPaymentIntentParams.Shipping?,
-    isFlowController: Boolean,
 ): IntentConfirmationInterceptor.NextStep {
     return when (paymentSelection) {
         is PaymentSelection.New -> {
@@ -24,7 +23,6 @@ internal suspend fun IntentConfirmationInterceptor.intercept(
                 paymentMethodCreateParams = paymentSelection.paymentMethodCreateParams,
                 shippingValues = shippingValues,
                 setupForFutureUsage = setupFutureUsage,
-                isFlowController = isFlowController,
             )
         }
         is PaymentSelection.Saved -> {
@@ -33,7 +31,6 @@ internal suspend fun IntentConfirmationInterceptor.intercept(
                 paymentMethod = paymentSelection.paymentMethod,
                 shippingValues = shippingValues,
                 setupForFutureUsage = null,
-                isFlowController = isFlowController,
             )
         }
         else -> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptorKtx.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/IntentConfirmationInterceptorKtx.kt
@@ -6,7 +6,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSelection.CustomerRequestedSave
 
 internal suspend fun IntentConfirmationInterceptor.intercept(
-    clientSecret: String?,
+    initializationMode: PaymentSheet.InitializationMode,
     paymentSelection: PaymentSelection?,
     shippingValues: ConfirmPaymentIntentParams.Shipping?,
 ): IntentConfirmationInterceptor.NextStep {
@@ -19,7 +19,7 @@ internal suspend fun IntentConfirmationInterceptor.intercept(
             }
 
             intercept(
-                clientSecret = clientSecret,
+                initializationMode = initializationMode,
                 paymentMethodCreateParams = paymentSelection.paymentMethodCreateParams,
                 shippingValues = shippingValues,
                 setupForFutureUsage = setupFutureUsage,
@@ -27,7 +27,7 @@ internal suspend fun IntentConfirmationInterceptor.intercept(
         }
         is PaymentSelection.Saved -> {
             intercept(
-                clientSecret = clientSecret,
+                initializationMode = initializationMode,
                 paymentMethod = paymentSelection.paymentMethod,
                 shippingValues = shippingValues,
                 setupForFutureUsage = null,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -468,7 +468,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                 initializationMode = args.initializationMode,
                 paymentSelection = paymentSelection,
                 shippingValues = args.config?.shippingDetails?.toConfirmPaymentIntentShipping(),
-                isFlowController = false,
             )
 
             when (nextStep) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -465,7 +465,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             val stripeIntent = requireNotNull(stripeIntent.value)
 
             val nextStep = intentConfirmationInterceptor.intercept(
-                clientSecret = stripeIntent.clientSecret,
+                initializationMode = args.initializationMode,
                 paymentSelection = paymentSelection,
                 shippingValues = args.config?.shippingDetails?.toConfirmPaymentIntentShipping(),
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -468,6 +468,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                 initializationMode = args.initializationMode,
                 paymentSelection = paymentSelection,
                 shippingValues = args.config?.shippingDetails?.toConfirmPaymentIntentShipping(),
+                isFlowController = false,
             )
 
             when (nextStep) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -292,6 +292,7 @@ internal class DefaultFlowController @Inject internal constructor(
                 initializationMode = initializationMode!!,
                 paymentSelection = paymentSelection,
                 shippingValues = state.config?.shippingDetails?.toConfirmPaymentIntentShipping(),
+                isFlowController = true,
             )
 
             when (nextStep) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -102,11 +102,11 @@ internal class DefaultFlowController @Inject internal constructor(
 
     private var paymentLauncher: StripePaymentLauncher? = null
 
+    private val initializationMode: PaymentSheet.InitializationMode?
+        get() = viewModel.previousConfigureRequest?.initializationMode
+
     private val isDecoupling: Boolean
-        get() {
-            val initMode = viewModel.previousConfigureRequest?.initializationMode
-            return initMode is PaymentSheet.InitializationMode.DeferredIntent
-        }
+        get() = initializationMode is PaymentSheet.InitializationMode.DeferredIntent
 
     override var shippingDetails: AddressDetails?
         get() = viewModel.state?.config?.shippingDetails
@@ -289,7 +289,7 @@ internal class DefaultFlowController @Inject internal constructor(
             val stripeIntent = requireNotNull(state.stripeIntent)
 
             val nextStep = intentConfirmationInterceptor.intercept(
-                clientSecret = stripeIntent.clientSecret,
+                initializationMode = initializationMode!!,
                 paymentSelection = paymentSelection,
                 shippingValues = state.config?.shippingDetails?.toConfirmPaymentIntentShipping(),
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -292,7 +292,6 @@ internal class DefaultFlowController @Inject internal constructor(
                 initializationMode = initializationMode!!,
                 paymentSelection = paymentSelection,
                 shippingValues = state.config?.shippingDetails?.toConfirmPaymentIntentShipping(),
-                isFlowController = true,
             )
 
             when (nextStep) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerModule.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
+import com.stripe.android.paymentsheet.injection.IS_FLOW_CONTROLLER
 import com.stripe.android.paymentsheet.injection.PaymentOptionsViewModelSubcomponent
 import com.stripe.android.uicore.image.StripeImageLoader
 import dagger.Module
@@ -41,4 +42,9 @@ internal object FlowControllerModule {
     fun provideStripeImageLoader(context: Context): StripeImageLoader {
         return StripeImageLoader(context)
     }
+
+    @Provides
+    @Singleton
+    @Named(IS_FLOW_CONTROLLER)
+    fun provideIsFlowController() = true
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/NamedConstants.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/NamedConstants.kt
@@ -1,0 +1,9 @@
+package com.stripe.android.paymentsheet.injection
+
+import androidx.annotation.RestrictTo
+
+/**
+ * Whether the integration is using PaymentSheet or FlowController.
+ */
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+const val IS_FLOW_CONTROLLER = "IS_FLOW_CONTROLLER"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/NamedConstants.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/NamedConstants.kt
@@ -1,3 +1,5 @@
+@file:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+
 package com.stripe.android.paymentsheet.injection
 
 import androidx.annotation.RestrictTo

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherModule.kt
@@ -29,5 +29,10 @@ internal abstract class PaymentSheetLauncherModule {
         @Singleton
         @Named(PRODUCT_USAGE)
         fun provideProductUsageTokens() = setOf("PaymentSheet")
+
+        @Provides
+        @Singleton
+        @Named(IS_FLOW_CONTROLLER)
+        fun provideIsFlowController() = false
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
@@ -4,10 +4,10 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.DeferredIntentParams
-import com.stripe.android.model.DeferredIntentParams.CaptureMethod
 import com.stripe.android.model.DeferredIntentParams.Mode
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.ElementsSessionParams
+import com.stripe.android.model.PaymentIntent.CaptureMethod
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.StripeIntent.Usage
 import com.stripe.android.networking.StripeRepository

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.StripeRepository
+import com.stripe.android.paymentsheet.PaymentSheet.InitializationMode
 import com.stripe.android.testing.AbsFakeStripeRepository
 import com.stripe.android.utils.IntentConfirmationInterceptorTestRule
 import kotlinx.coroutines.test.runTest
@@ -48,7 +49,7 @@ class DefaultIntentConfirmationInterceptorTest {
         val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
 
         val nextStep = interceptor.intercept(
-            clientSecret = "pi_1234_secret_4321",
+            initializationMode = InitializationMode.PaymentIntent("pi_1234_secret_4321"),
             paymentMethod = paymentMethod,
             shippingValues = null,
             setupForFutureUsage = null,
@@ -73,7 +74,7 @@ class DefaultIntentConfirmationInterceptorTest {
         val createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD
 
         val nextStep = interceptor.intercept(
-            clientSecret = "pi_1234_secret_4321",
+            initializationMode = InitializationMode.PaymentIntent("pi_1234_secret_4321"),
             paymentMethodCreateParams = createParams,
             shippingValues = null,
             setupForFutureUsage = null,
@@ -97,7 +98,7 @@ class DefaultIntentConfirmationInterceptorTest {
 
         val error = assertFailsWith<IllegalStateException> {
             interceptor.intercept(
-                clientSecret = null,
+                initializationMode = InitializationMode.DeferredIntent(mock()),
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 shippingValues = null,
                 setupForFutureUsage = null,
@@ -127,7 +128,7 @@ class DefaultIntentConfirmationInterceptorTest {
 
         val error = assertFailsWith<IllegalStateException> {
             interceptor.intercept(
-                clientSecret = null,
+                initializationMode = InitializationMode.DeferredIntent(mock()),
                 paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 shippingValues = null,
                 setupForFutureUsage = null,
@@ -162,7 +163,7 @@ class DefaultIntentConfirmationInterceptorTest {
         )
 
         val nextStep = interceptor.intercept(
-            clientSecret = null,
+            initializationMode = InitializationMode.DeferredIntent(mock()),
             paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
             shippingValues = null,
             setupForFutureUsage = null,
@@ -204,7 +205,7 @@ class DefaultIntentConfirmationInterceptorTest {
         IntentConfirmationInterceptor.createIntentCallback = succeedingCreateIntentCallback(paymentMethod)
 
         val nextStep = interceptor.intercept(
-            clientSecret = null,
+            initializationMode = InitializationMode.DeferredIntent(mock()),
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             shippingValues = null,
             setupForFutureUsage = null,
@@ -232,7 +233,7 @@ class DefaultIntentConfirmationInterceptorTest {
         )
 
         val nextStep = interceptor.intercept(
-            clientSecret = null,
+            initializationMode = InitializationMode.DeferredIntent(mock()),
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             shippingValues = null,
             setupForFutureUsage = null,
@@ -258,7 +259,7 @@ class DefaultIntentConfirmationInterceptorTest {
         IntentConfirmationInterceptor.createIntentCallback = failingCreateIntentCallback()
 
         val nextStep = interceptor.intercept(
-            clientSecret = null,
+            initializationMode = InitializationMode.DeferredIntent(mock()),
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             shippingValues = null,
             setupForFutureUsage = null,
@@ -296,7 +297,7 @@ class DefaultIntentConfirmationInterceptorTest {
         IntentConfirmationInterceptor.createIntentCallback = succeedingCreateIntentCallback(paymentMethod)
 
         val nextStep = interceptor.intercept(
-            clientSecret = null,
+            initializationMode = InitializationMode.DeferredIntent(mock()),
             paymentMethod = paymentMethod,
             shippingValues = null,
             setupForFutureUsage = null,
@@ -327,7 +328,7 @@ class DefaultIntentConfirmationInterceptorTest {
         IntentConfirmationInterceptor.createIntentCallback = succeedingCreateIntentCallback(paymentMethod)
 
         val nextStep = interceptor.intercept(
-            clientSecret = null,
+            initializationMode = InitializationMode.DeferredIntent(mock()),
             paymentMethod = paymentMethod,
             shippingValues = null,
             setupForFutureUsage = null,
@@ -362,7 +363,7 @@ class DefaultIntentConfirmationInterceptorTest {
         IntentConfirmationInterceptor.createIntentCallback = succeedingCreateIntentCallback(paymentMethod)
 
         val nextStep = interceptor.intercept(
-            clientSecret = null,
+            initializationMode = InitializationMode.DeferredIntent(mock()),
             paymentMethod = paymentMethod,
             shippingValues = null,
             setupForFutureUsage = null,
@@ -408,7 +409,7 @@ class DefaultIntentConfirmationInterceptorTest {
                 }
 
             interceptor.intercept(
-                clientSecret = null,
+                initializationMode = InitializationMode.DeferredIntent(mock()),
                 paymentMethod = paymentMethod,
                 shippingValues = null,
                 setupForFutureUsage = input,
@@ -435,7 +436,7 @@ class DefaultIntentConfirmationInterceptorTest {
         }
 
         val nextStep = interceptor.intercept(
-            clientSecret = null,
+            initializationMode = InitializationMode.DeferredIntent(mock()),
             paymentMethod = paymentMethod,
             shippingValues = null,
             setupForFutureUsage = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
@@ -53,6 +53,7 @@ class DefaultIntentConfirmationInterceptorTest {
             paymentMethod = paymentMethod,
             shippingValues = null,
             setupForFutureUsage = null,
+            isFlowController = false,
         )
 
         val confirmNextStep = nextStep as? IntentConfirmationInterceptor.NextStep.Confirm
@@ -78,6 +79,7 @@ class DefaultIntentConfirmationInterceptorTest {
             paymentMethodCreateParams = createParams,
             shippingValues = null,
             setupForFutureUsage = null,
+            isFlowController = false,
         )
 
         val confirmNextStep = nextStep as? IntentConfirmationInterceptor.NextStep.Confirm
@@ -102,6 +104,7 @@ class DefaultIntentConfirmationInterceptorTest {
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 shippingValues = null,
                 setupForFutureUsage = null,
+                isFlowController = false,
             )
         }
 
@@ -132,6 +135,7 @@ class DefaultIntentConfirmationInterceptorTest {
                 paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 shippingValues = null,
                 setupForFutureUsage = null,
+                isFlowController = false,
             )
         }
 
@@ -167,6 +171,7 @@ class DefaultIntentConfirmationInterceptorTest {
             paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
             shippingValues = null,
             setupForFutureUsage = null,
+            isFlowController = false,
         )
 
         assertThat(nextStep).isEqualTo(
@@ -209,6 +214,7 @@ class DefaultIntentConfirmationInterceptorTest {
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             shippingValues = null,
             setupForFutureUsage = null,
+            isFlowController = false,
         )
 
         assertThat(nextStep).isEqualTo(
@@ -237,6 +243,7 @@ class DefaultIntentConfirmationInterceptorTest {
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             shippingValues = null,
             setupForFutureUsage = null,
+            isFlowController = false,
         )
 
         assertThat(nextStep).isEqualTo(
@@ -263,6 +270,7 @@ class DefaultIntentConfirmationInterceptorTest {
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             shippingValues = null,
             setupForFutureUsage = null,
+            isFlowController = false,
         )
 
         assertThat(nextStep).isEqualTo(
@@ -301,6 +309,7 @@ class DefaultIntentConfirmationInterceptorTest {
             paymentMethod = paymentMethod,
             shippingValues = null,
             setupForFutureUsage = null,
+            isFlowController = false,
         )
 
         assertThat(nextStep).isInstanceOf(IntentConfirmationInterceptor.NextStep.Confirm::class.java)
@@ -332,6 +341,7 @@ class DefaultIntentConfirmationInterceptorTest {
             paymentMethod = paymentMethod,
             shippingValues = null,
             setupForFutureUsage = null,
+            isFlowController = false,
         )
 
         assertThat(nextStep).isEqualTo(
@@ -367,6 +377,7 @@ class DefaultIntentConfirmationInterceptorTest {
             paymentMethod = paymentMethod,
             shippingValues = null,
             setupForFutureUsage = null,
+            isFlowController = false,
         )
 
         assertThat(nextStep).isEqualTo(
@@ -413,6 +424,7 @@ class DefaultIntentConfirmationInterceptorTest {
                 paymentMethod = paymentMethod,
                 shippingValues = null,
                 setupForFutureUsage = input,
+                isFlowController = false,
             )
         }
 
@@ -440,6 +452,7 @@ class DefaultIntentConfirmationInterceptorTest {
             paymentMethod = paymentMethod,
             shippingValues = null,
             setupForFutureUsage = null,
+            isFlowController = false,
         )
 
         verify(stripeRepository, never()).retrieveStripeIntent(any(), any(), any())

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
@@ -44,6 +44,7 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeRepository = object : AbsFakeStripeRepository() {},
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
+            isFlowController = false,
         )
 
         val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
@@ -53,7 +54,6 @@ class DefaultIntentConfirmationInterceptorTest {
             paymentMethod = paymentMethod,
             shippingValues = null,
             setupForFutureUsage = null,
-            isFlowController = false,
         )
 
         val confirmNextStep = nextStep as? IntentConfirmationInterceptor.NextStep.Confirm
@@ -70,6 +70,7 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeRepository = object : AbsFakeStripeRepository() {},
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
+            isFlowController = false,
         )
 
         val createParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD
@@ -79,7 +80,6 @@ class DefaultIntentConfirmationInterceptorTest {
             paymentMethodCreateParams = createParams,
             shippingValues = null,
             setupForFutureUsage = null,
-            isFlowController = false,
         )
 
         val confirmNextStep = nextStep as? IntentConfirmationInterceptor.NextStep.Confirm
@@ -96,6 +96,7 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeRepository = object : AbsFakeStripeRepository() {},
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
+            isFlowController = false,
         )
 
         val error = assertFailsWith<IllegalStateException> {
@@ -111,7 +112,6 @@ class DefaultIntentConfirmationInterceptorTest {
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 shippingValues = null,
                 setupForFutureUsage = null,
-                isFlowController = false,
             )
         }
 
@@ -134,6 +134,7 @@ class DefaultIntentConfirmationInterceptorTest {
             },
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
+            isFlowController = false,
         )
 
         val error = assertFailsWith<IllegalStateException> {
@@ -142,7 +143,6 @@ class DefaultIntentConfirmationInterceptorTest {
                 paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
                 shippingValues = null,
                 setupForFutureUsage = null,
-                isFlowController = false,
             )
         }
 
@@ -171,6 +171,7 @@ class DefaultIntentConfirmationInterceptorTest {
             },
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
+            isFlowController = false,
         )
 
         val nextStep = interceptor.intercept(
@@ -178,7 +179,6 @@ class DefaultIntentConfirmationInterceptorTest {
             paymentMethodCreateParams = PaymentMethodCreateParamsFixtures.DEFAULT_CARD,
             shippingValues = null,
             setupForFutureUsage = null,
-            isFlowController = false,
         )
 
         assertThat(nextStep).isEqualTo(
@@ -212,6 +212,7 @@ class DefaultIntentConfirmationInterceptorTest {
             },
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
+            isFlowController = false,
         )
 
         IntentConfirmationInterceptor.createIntentCallback = succeedingCreateIntentCallback(paymentMethod)
@@ -221,7 +222,6 @@ class DefaultIntentConfirmationInterceptorTest {
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             shippingValues = null,
             setupForFutureUsage = null,
-            isFlowController = false,
         )
 
         assertThat(nextStep).isEqualTo(
@@ -239,6 +239,7 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeRepository = mock(),
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
+            isFlowController = false,
         )
 
         IntentConfirmationInterceptor.createIntentCallback = failingCreateIntentCallback(
@@ -250,7 +251,6 @@ class DefaultIntentConfirmationInterceptorTest {
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             shippingValues = null,
             setupForFutureUsage = null,
-            isFlowController = false,
         )
 
         assertThat(nextStep).isEqualTo(
@@ -268,6 +268,7 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeRepository = mock(),
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
+            isFlowController = false,
         )
 
         IntentConfirmationInterceptor.createIntentCallback = failingCreateIntentCallback()
@@ -277,7 +278,6 @@ class DefaultIntentConfirmationInterceptorTest {
             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
             shippingValues = null,
             setupForFutureUsage = null,
-            isFlowController = false,
         )
 
         assertThat(nextStep).isEqualTo(
@@ -307,6 +307,7 @@ class DefaultIntentConfirmationInterceptorTest {
             },
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
+            isFlowController = false,
         )
 
         IntentConfirmationInterceptor.createIntentCallback = succeedingCreateIntentCallback(paymentMethod)
@@ -323,7 +324,6 @@ class DefaultIntentConfirmationInterceptorTest {
             paymentMethod = paymentMethod,
             shippingValues = null,
             setupForFutureUsage = null,
-            isFlowController = false,
         )
 
         assertThat(nextStep).isInstanceOf(IntentConfirmationInterceptor.NextStep.Confirm::class.java)
@@ -346,6 +346,7 @@ class DefaultIntentConfirmationInterceptorTest {
             },
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
+            isFlowController = false,
         )
 
         IntentConfirmationInterceptor.createIntentCallback = succeedingCreateIntentCallback(paymentMethod)
@@ -362,7 +363,6 @@ class DefaultIntentConfirmationInterceptorTest {
             paymentMethod = paymentMethod,
             shippingValues = null,
             setupForFutureUsage = null,
-            isFlowController = false,
         )
 
         assertThat(nextStep).isEqualTo(
@@ -389,6 +389,7 @@ class DefaultIntentConfirmationInterceptorTest {
             },
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
+            isFlowController = false,
         )
 
         IntentConfirmationInterceptor.createIntentCallback = succeedingCreateIntentCallback(paymentMethod)
@@ -405,7 +406,6 @@ class DefaultIntentConfirmationInterceptorTest {
             paymentMethod = paymentMethod,
             shippingValues = null,
             setupForFutureUsage = null,
-            isFlowController = false,
         )
 
         assertThat(nextStep).isEqualTo(
@@ -431,6 +431,7 @@ class DefaultIntentConfirmationInterceptorTest {
             },
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
+            isFlowController = false,
         )
 
         val inputs = listOf(
@@ -459,7 +460,6 @@ class DefaultIntentConfirmationInterceptorTest {
                 paymentMethod = paymentMethod,
                 shippingValues = null,
                 setupForFutureUsage = input,
-                isFlowController = false,
             )
         }
 
@@ -476,6 +476,7 @@ class DefaultIntentConfirmationInterceptorTest {
             stripeRepository = stripeRepository,
             publishableKeyProvider = { "pk" },
             stripeAccountIdProvider = { null },
+            isFlowController = false,
         )
 
         IntentConfirmationInterceptor.createIntentCallback = CreateIntentCallback { _, _ ->
@@ -494,7 +495,6 @@ class DefaultIntentConfirmationInterceptorTest {
             paymentMethod = paymentMethod,
             shippingValues = null,
             setupForFutureUsage = null,
-            isFlowController = false,
         )
 
         verify(stripeRepository, never()).retrieveStripeIntent(any(), any(), any())

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DefaultIntentConfirmationInterceptorTest.kt
@@ -100,7 +100,14 @@ class DefaultIntentConfirmationInterceptorTest {
 
         val error = assertFailsWith<IllegalStateException> {
             interceptor.intercept(
-                initializationMode = InitializationMode.DeferredIntent(mock()),
+                initializationMode = InitializationMode.DeferredIntent(
+                    intentConfiguration = PaymentSheet.IntentConfiguration(
+                        mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                            amount = 1099L,
+                            currency = "usd",
+                        ),
+                    ),
+                ),
                 paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                 shippingValues = null,
                 setupForFutureUsage = null,
@@ -305,7 +312,14 @@ class DefaultIntentConfirmationInterceptorTest {
         IntentConfirmationInterceptor.createIntentCallback = succeedingCreateIntentCallback(paymentMethod)
 
         val nextStep = interceptor.intercept(
-            initializationMode = InitializationMode.DeferredIntent(mock()),
+            initializationMode = InitializationMode.DeferredIntent(
+                intentConfiguration = PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                        amount = 1099L,
+                        currency = "usd",
+                    ),
+                ),
+            ),
             paymentMethod = paymentMethod,
             shippingValues = null,
             setupForFutureUsage = null,
@@ -337,7 +351,14 @@ class DefaultIntentConfirmationInterceptorTest {
         IntentConfirmationInterceptor.createIntentCallback = succeedingCreateIntentCallback(paymentMethod)
 
         val nextStep = interceptor.intercept(
-            initializationMode = InitializationMode.DeferredIntent(mock()),
+            initializationMode = InitializationMode.DeferredIntent(
+                intentConfiguration = PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                        amount = 1099L,
+                        currency = "usd",
+                    ),
+                ),
+            ),
             paymentMethod = paymentMethod,
             shippingValues = null,
             setupForFutureUsage = null,
@@ -373,7 +394,14 @@ class DefaultIntentConfirmationInterceptorTest {
         IntentConfirmationInterceptor.createIntentCallback = succeedingCreateIntentCallback(paymentMethod)
 
         val nextStep = interceptor.intercept(
-            initializationMode = InitializationMode.DeferredIntent(mock()),
+            initializationMode = InitializationMode.DeferredIntent(
+                intentConfiguration = PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                        amount = 1099L,
+                        currency = "usd",
+                    ),
+                ),
+            ),
             paymentMethod = paymentMethod,
             shippingValues = null,
             setupForFutureUsage = null,
@@ -420,7 +448,14 @@ class DefaultIntentConfirmationInterceptorTest {
                 }
 
             interceptor.intercept(
-                initializationMode = InitializationMode.DeferredIntent(mock()),
+                initializationMode = InitializationMode.DeferredIntent(
+                    intentConfiguration = PaymentSheet.IntentConfiguration(
+                        mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                            amount = 1099L,
+                            currency = "usd",
+                        ),
+                    ),
+                ),
                 paymentMethod = paymentMethod,
                 shippingValues = null,
                 setupForFutureUsage = input,
@@ -448,7 +483,14 @@ class DefaultIntentConfirmationInterceptorTest {
         }
 
         val nextStep = interceptor.intercept(
-            initializationMode = InitializationMode.DeferredIntent(mock()),
+            initializationMode = InitializationMode.DeferredIntent(
+                intentConfiguration = PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                        amount = 1099L,
+                        currency = "usd",
+                    ),
+                ),
+            ),
             paymentMethod = paymentMethod,
             shippingValues = null,
             setupForFutureUsage = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DeferredIntentValidatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DeferredIntentValidatorTest.kt
@@ -33,27 +33,6 @@ internal class DeferredIntentValidatorTest {
     }
 
     @Test
-    fun `Fails if PaymentIntent has different amount than IntentConfiguration`() {
-        val paymentIntent = PaymentIntentFactory.create()
-        val intentConfiguration = makeIntentConfigurationForPayment(amount = 4321L)
-
-        val failure = assertThrows(IllegalArgumentException::class.java) {
-            DeferredIntentValidator.validate(
-                stripeIntent = paymentIntent,
-                intentConfiguration = intentConfiguration,
-                isFlowController = false,
-            )
-        }
-
-        assertThat(failure).isInstanceOf(IllegalArgumentException::class.java)
-
-        assertThat(failure).hasMessageThat().isEqualTo(
-            "Your PaymentIntent amount (1000) does not match " +
-                "the PaymentSheet.IntentConfiguration amount (4321)."
-        )
-    }
-
-    @Test
     fun `Fails if PaymentIntent has different currency than IntentConfiguration`() {
         val paymentIntent = PaymentIntentFactory.create()
         val intentConfiguration = makeIntentConfigurationForPayment(currency = "eur")
@@ -218,14 +197,13 @@ internal class DeferredIntentValidatorTest {
     }
 
     private fun makeIntentConfigurationForPayment(
-        amount: Long = 1000L,
         currency: String = "usd",
         setupFutureUse: IntentConfiguration.SetupFutureUse? = null,
         captureMethod: IntentConfiguration.CaptureMethod = IntentConfiguration.CaptureMethod.Automatic,
     ): IntentConfiguration {
         return IntentConfiguration(
             mode = IntentConfiguration.Mode.Payment(
-                amount = amount,
+                amount = 1_000,
                 currency = currency,
                 setupFutureUse = setupFutureUse,
                 captureMethod = captureMethod,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DeferredIntentValidatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DeferredIntentValidatorTest.kt
@@ -20,6 +20,7 @@ internal class DeferredIntentValidatorTest {
             DeferredIntentValidator.validate(
                 stripeIntent = paymentIntent,
                 intentConfiguration = intentConfiguration,
+                isFlowController = false,
             )
         }
 
@@ -40,6 +41,7 @@ internal class DeferredIntentValidatorTest {
             DeferredIntentValidator.validate(
                 stripeIntent = paymentIntent,
                 intentConfiguration = intentConfiguration,
+                isFlowController = false,
             )
         }
 
@@ -60,6 +62,7 @@ internal class DeferredIntentValidatorTest {
             DeferredIntentValidator.validate(
                 stripeIntent = paymentIntent,
                 intentConfiguration = intentConfiguration,
+                isFlowController = false,
             )
         }
 
@@ -84,6 +87,7 @@ internal class DeferredIntentValidatorTest {
             DeferredIntentValidator.validate(
                 stripeIntent = paymentIntent,
                 intentConfiguration = intentConfiguration,
+                isFlowController = false,
             )
         }
 
@@ -106,6 +110,7 @@ internal class DeferredIntentValidatorTest {
             DeferredIntentValidator.validate(
                 stripeIntent = paymentIntent,
                 intentConfiguration = intentConfiguration,
+                isFlowController = false,
             )
         }
 
@@ -118,6 +123,43 @@ internal class DeferredIntentValidatorTest {
     }
 
     @Test
+    fun `Fails if PaymentIntent has manual capture method outside of FlowController`() {
+        val paymentIntent = PaymentIntentFactory.create()
+        val intentConfiguration = makeIntentConfigurationForPayment(
+            captureMethod = IntentConfiguration.CaptureMethod.Manual,
+        )
+
+        val failure = assertThrows(IllegalArgumentException::class.java) {
+            DeferredIntentValidator.validate(
+                stripeIntent = paymentIntent,
+                intentConfiguration = intentConfiguration,
+                isFlowController = true,
+            )
+        }
+
+        assertThat(failure).isInstanceOf(IllegalArgumentException::class.java)
+
+        assertThat(failure).hasMessageThat().isEqualTo(
+            "Your PaymentIntent captureMethod (Automatic) does not match " +
+                "the PaymentSheet.IntentConfiguration captureMethod (Manual)."
+        )
+    }
+
+    @Test
+    fun `Succeeds if PaymentIntent and IntentConfiguration match`() {
+        val paymentIntent = PaymentIntentFactory.create()
+        val intentConfiguration = makeIntentConfigurationForPayment()
+
+        val result = DeferredIntentValidator.validate(
+            stripeIntent = paymentIntent,
+            intentConfiguration = intentConfiguration,
+            isFlowController = true,
+        )
+
+        assertThat(result).isEqualTo(paymentIntent)
+    }
+
+    @Test
     fun `Fails if SetupIntent is validated against IntentConfiguration in payment mode`() {
         val paymentIntent = SetupIntentFixtures.SI_SUCCEEDED
         val intentConfiguration = makeIntentConfigurationForPayment()
@@ -126,6 +168,7 @@ internal class DeferredIntentValidatorTest {
             DeferredIntentValidator.validate(
                 stripeIntent = paymentIntent,
                 intentConfiguration = intentConfiguration,
+                isFlowController = false,
             )
         }
 
@@ -148,6 +191,7 @@ internal class DeferredIntentValidatorTest {
             DeferredIntentValidator.validate(
                 stripeIntent = paymentIntent,
                 intentConfiguration = intentConfiguration,
+                isFlowController = false,
             )
         }
 
@@ -157,6 +201,20 @@ internal class DeferredIntentValidatorTest {
             "Your SetupIntent usage (off_session) does not match " +
                 "the PaymentSheet.IntentConfiguration usage (off_session)."
         )
+    }
+
+    @Test
+    fun `Succeeds if SetupIntent and IntentConfiguration match`() {
+        val paymentIntent = SetupIntentFixtures.SI_SUCCEEDED
+        val intentConfiguration = makeIntentConfigurationForSetup()
+
+        val result = DeferredIntentValidator.validate(
+            stripeIntent = paymentIntent,
+            intentConfiguration = intentConfiguration,
+            isFlowController = true,
+        )
+
+        assertThat(result).isEqualTo(paymentIntent)
     }
 
     private fun makeIntentConfigurationForPayment(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DeferredIntentValidatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DeferredIntentValidatorTest.kt
@@ -1,0 +1,187 @@
+package com.stripe.android.paymentsheet
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.SetupIntentFixtures
+import com.stripe.android.model.StripeIntent
+import com.stripe.android.paymentsheet.PaymentSheet.IntentConfiguration
+import com.stripe.android.testing.PaymentIntentFactory
+import org.junit.Assert.assertThrows
+import kotlin.test.Test
+
+@OptIn(ExperimentalPaymentSheetDecouplingApi::class)
+internal class DeferredIntentValidatorTest {
+
+    @Test
+    fun `Fails if PaymentIntent is validated against IntentConfiguration in setup mode`() {
+        val paymentIntent = PaymentIntentFactory.create()
+        val intentConfiguration = makeIntentConfigurationForSetup()
+
+        val failure = assertThrows(IllegalArgumentException::class.java) {
+            DeferredIntentValidator.validate(
+                stripeIntent = paymentIntent,
+                intentConfiguration = intentConfiguration,
+            )
+        }
+
+        assertThat(failure).isInstanceOf(IllegalArgumentException::class.java)
+
+        assertThat(failure).hasMessageThat().isEqualTo(
+            "You returned a PaymentIntent client secret " +
+                "but used a PaymentSheet.IntentConfiguration in setup mode."
+        )
+    }
+
+    @Test
+    fun `Fails if PaymentIntent has different amount than IntentConfiguration`() {
+        val paymentIntent = PaymentIntentFactory.create()
+        val intentConfiguration = makeIntentConfigurationForPayment(amount = 4321L)
+
+        val failure = assertThrows(IllegalArgumentException::class.java) {
+            DeferredIntentValidator.validate(
+                stripeIntent = paymentIntent,
+                intentConfiguration = intentConfiguration,
+            )
+        }
+
+        assertThat(failure).isInstanceOf(IllegalArgumentException::class.java)
+
+        assertThat(failure).hasMessageThat().isEqualTo(
+            "Your PaymentIntent amount (1000) does not match " +
+                "the PaymentSheet.IntentConfiguration amount (4321)."
+        )
+    }
+
+    @Test
+    fun `Fails if PaymentIntent has different currency than IntentConfiguration`() {
+        val paymentIntent = PaymentIntentFactory.create()
+        val intentConfiguration = makeIntentConfigurationForPayment(currency = "eur")
+
+        val failure = assertThrows(IllegalArgumentException::class.java) {
+            DeferredIntentValidator.validate(
+                stripeIntent = paymentIntent,
+                intentConfiguration = intentConfiguration,
+            )
+        }
+
+        assertThat(failure).isInstanceOf(IllegalArgumentException::class.java)
+
+        assertThat(failure).hasMessageThat().isEqualTo(
+            "Your PaymentIntent currency (usd) does not match " +
+                "the PaymentSheet.IntentConfiguration currency (eur)."
+        )
+    }
+
+    @Test
+    fun `Fails if PaymentIntent has different setupFutureUse than IntentConfiguration`() {
+        val paymentIntent = PaymentIntentFactory.create(
+            setupFutureUsage = StripeIntent.Usage.OnSession,
+        )
+        val intentConfiguration = makeIntentConfigurationForPayment(
+            setupFutureUse = IntentConfiguration.SetupFutureUse.OffSession,
+        )
+
+        val failure = assertThrows(IllegalArgumentException::class.java) {
+            DeferredIntentValidator.validate(
+                stripeIntent = paymentIntent,
+                intentConfiguration = intentConfiguration,
+            )
+        }
+
+        assertThat(failure).isInstanceOf(IllegalArgumentException::class.java)
+
+        assertThat(failure).hasMessageThat().isEqualTo(
+            "Your PaymentIntent setupFutureUsage (on_session) does not match " +
+                "the PaymentSheet.IntentConfiguration setupFutureUsage (off_session)."
+        )
+    }
+
+    @Test
+    fun `Fails if PaymentIntent has different captureMethod than IntentConfiguration`() {
+        val paymentIntent = PaymentIntentFactory.create()
+        val intentConfiguration = makeIntentConfigurationForPayment(
+            captureMethod = IntentConfiguration.CaptureMethod.Manual,
+        )
+
+        val failure = assertThrows(IllegalArgumentException::class.java) {
+            DeferredIntentValidator.validate(
+                stripeIntent = paymentIntent,
+                intentConfiguration = intentConfiguration,
+            )
+        }
+
+        assertThat(failure).isInstanceOf(IllegalArgumentException::class.java)
+
+        assertThat(failure).hasMessageThat().isEqualTo(
+            "Your PaymentIntent captureMethod (Automatic) does not match " +
+                "the PaymentSheet.IntentConfiguration captureMethod (Manual)."
+        )
+    }
+
+    @Test
+    fun `Fails if SetupIntent is validated against IntentConfiguration in payment mode`() {
+        val paymentIntent = SetupIntentFixtures.SI_SUCCEEDED
+        val intentConfiguration = makeIntentConfigurationForPayment()
+
+        val failure = assertThrows(IllegalArgumentException::class.java) {
+            DeferredIntentValidator.validate(
+                stripeIntent = paymentIntent,
+                intentConfiguration = intentConfiguration,
+            )
+        }
+
+        assertThat(failure).isInstanceOf(IllegalArgumentException::class.java)
+
+        assertThat(failure).hasMessageThat().isEqualTo(
+            "You returned a SetupIntent client secret " +
+                "but used a PaymentSheet.IntentConfiguration in payment mode."
+        )
+    }
+
+    @Test
+    fun `Fails if SetupIntent has different usage than IntentConfiguration`() {
+        val paymentIntent = SetupIntentFixtures.SI_SUCCEEDED
+        val intentConfiguration = makeIntentConfigurationForSetup(
+            usage = IntentConfiguration.SetupFutureUse.OnSession,
+        )
+
+        val failure = assertThrows(IllegalArgumentException::class.java) {
+            DeferredIntentValidator.validate(
+                stripeIntent = paymentIntent,
+                intentConfiguration = intentConfiguration,
+            )
+        }
+
+        assertThat(failure).isInstanceOf(IllegalArgumentException::class.java)
+
+        assertThat(failure).hasMessageThat().isEqualTo(
+            "Your SetupIntent usage (off_session) does not match " +
+                "the PaymentSheet.IntentConfiguration usage (off_session)."
+        )
+    }
+
+    private fun makeIntentConfigurationForPayment(
+        amount: Long = 1000L,
+        currency: String = "usd",
+        setupFutureUse: IntentConfiguration.SetupFutureUse? = null,
+        captureMethod: IntentConfiguration.CaptureMethod = IntentConfiguration.CaptureMethod.Automatic,
+    ): IntentConfiguration {
+        return IntentConfiguration(
+            mode = IntentConfiguration.Mode.Payment(
+                amount = amount,
+                currency = currency,
+                setupFutureUse = setupFutureUse,
+                captureMethod = captureMethod,
+            ),
+        )
+    }
+
+    private fun makeIntentConfigurationForSetup(
+        usage: IntentConfiguration.SetupFutureUse = IntentConfiguration.SetupFutureUse.OffSession,
+    ): IntentConfiguration {
+        return IntentConfiguration(
+            mode = IntentConfiguration.Mode.Setup(
+                setupFutureUse = usage,
+            ),
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DeferredIntentValidatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DeferredIntentValidatorTest.kt
@@ -17,7 +17,7 @@ internal class DeferredIntentValidatorTest {
         val paymentIntent = PaymentIntentFactory.create()
         val intentConfiguration = makeIntentConfigurationForSetup()
 
-        val failure = assertFailsWith(IllegalArgumentException::class) {
+        val failure = assertFailsWith<IllegalArgumentException> {
             DeferredIntentValidator.validate(
                 stripeIntent = paymentIntent,
                 intentConfiguration = intentConfiguration,
@@ -36,7 +36,7 @@ internal class DeferredIntentValidatorTest {
         val paymentIntent = PaymentIntentFactory.create()
         val intentConfiguration = makeIntentConfigurationForPayment(currency = "eur")
 
-        val failure = assertFailsWith(IllegalArgumentException::class) {
+        val failure = assertFailsWith<IllegalArgumentException> {
             DeferredIntentValidator.validate(
                 stripeIntent = paymentIntent,
                 intentConfiguration = intentConfiguration,
@@ -59,7 +59,7 @@ internal class DeferredIntentValidatorTest {
             setupFutureUse = IntentConfiguration.SetupFutureUse.OffSession,
         )
 
-        val failure = assertFailsWith(IllegalArgumentException::class) {
+        val failure = assertFailsWith<IllegalArgumentException> {
             DeferredIntentValidator.validate(
                 stripeIntent = paymentIntent,
                 intentConfiguration = intentConfiguration,
@@ -80,7 +80,7 @@ internal class DeferredIntentValidatorTest {
             captureMethod = IntentConfiguration.CaptureMethod.Manual,
         )
 
-        val failure = assertFailsWith(IllegalArgumentException::class) {
+        val failure = assertFailsWith<IllegalArgumentException> {
             DeferredIntentValidator.validate(
                 stripeIntent = paymentIntent,
                 intentConfiguration = intentConfiguration,
@@ -102,7 +102,7 @@ internal class DeferredIntentValidatorTest {
 
         val intentConfiguration = makeIntentConfigurationForPayment()
 
-        val failure = assertFailsWith(IllegalArgumentException::class) {
+        val failure = assertFailsWith<IllegalArgumentException> {
             DeferredIntentValidator.validate(
                 stripeIntent = paymentIntent,
                 intentConfiguration = intentConfiguration,
@@ -152,7 +152,7 @@ internal class DeferredIntentValidatorTest {
         val setupIntent = SetupIntentFixtures.SI_SUCCEEDED
         val intentConfiguration = makeIntentConfigurationForPayment()
 
-        val failure = assertFailsWith(IllegalArgumentException::class) {
+        val failure = assertFailsWith<IllegalArgumentException> {
             DeferredIntentValidator.validate(
                 stripeIntent = setupIntent,
                 intentConfiguration = intentConfiguration,
@@ -173,7 +173,7 @@ internal class DeferredIntentValidatorTest {
             usage = IntentConfiguration.SetupFutureUse.OnSession,
         )
 
-        val failure = assertFailsWith(IllegalArgumentException::class) {
+        val failure = assertFailsWith<IllegalArgumentException> {
             DeferredIntentValidator.validate(
                 stripeIntent = setupIntent,
                 intentConfiguration = intentConfiguration,

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
@@ -5,9 +5,10 @@ import com.stripe.android.model.ConfirmStripeIntentParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.IntentConfirmationInterceptor
+import com.stripe.android.paymentsheet.PaymentSheet
 import kotlinx.coroutines.channels.Channel
 
-class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor {
+internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor {
 
     private val channel = Channel<IntentConfirmationInterceptor.NextStep>(capacity = 1)
 
@@ -36,7 +37,7 @@ class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor {
     }
 
     override suspend fun intercept(
-        clientSecret: String?,
+        initializationMode: PaymentSheet.InitializationMode,
         paymentMethodCreateParams: PaymentMethodCreateParams,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
         setupForFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage?
@@ -45,7 +46,7 @@ class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor {
     }
 
     override suspend fun intercept(
-        clientSecret: String?,
+        initializationMode: PaymentSheet.InitializationMode,
         paymentMethod: PaymentMethod,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
         setupForFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage?

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
@@ -41,7 +41,6 @@ internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor
         paymentMethodCreateParams: PaymentMethodCreateParams,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
         setupForFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage?,
-        isFlowController: Boolean,
     ): IntentConfirmationInterceptor.NextStep {
         return channel.receive()
     }
@@ -51,7 +50,6 @@ internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor
         paymentMethod: PaymentMethod,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
         setupForFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage?,
-        isFlowController: Boolean,
     ): IntentConfirmationInterceptor.NextStep {
         return channel.receive()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
@@ -40,7 +40,8 @@ internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor
         initializationMode: PaymentSheet.InitializationMode,
         paymentMethodCreateParams: PaymentMethodCreateParams,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
-        setupForFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage?
+        setupForFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage?,
+        isFlowController: Boolean,
     ): IntentConfirmationInterceptor.NextStep {
         return channel.receive()
     }
@@ -49,7 +50,8 @@ internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor
         initializationMode: PaymentSheet.InitializationMode,
         paymentMethod: PaymentMethod,
         shippingValues: ConfirmPaymentIntentParams.Shipping?,
-        setupForFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage?
+        setupForFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage?,
+        isFlowController: Boolean,
     ): IntentConfirmationInterceptor.NextStep {
         return channel.receive()
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds a validator for the deferred intent flow, making sure that the created `PaymentIntent` or `SetupIntent` matches the initially provided `IntentConfiguration`.

It also makes sure that manual capture is only used with `FlowController`.

(cc @yuki-stripe @porter-stripe)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
