### PR TITLE
Restrict Link classes that were never considered public.

### DIFF
--- a/link/api/link.api
+++ b/link/api/link.api
@@ -5,22 +5,6 @@ public final class com/stripe/android/link/BuildConfig {
 	public fun <init> ()V
 }
 
-public final class com/stripe/android/link/LinkActivityContract$Args : com/stripe/android/view/ActivityStarter$Args {
-	public static final field $stable I
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public static final field Companion Lcom/stripe/android/link/LinkActivityContract$Args$Companion;
-	public final fun copy (Lcom/stripe/android/link/LinkConfiguration;Lcom/stripe/android/model/PaymentMethodCreateParams;)Lcom/stripe/android/link/LinkActivityContract$Args;
-	public static synthetic fun copy$default (Lcom/stripe/android/link/LinkActivityContract$Args;Lcom/stripe/android/link/LinkConfiguration;Lcom/stripe/android/model/PaymentMethodCreateParams;ILjava/lang/Object;)Lcom/stripe/android/link/LinkActivityContract$Args;
-	public fun describeContents ()I
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
-public final class com/stripe/android/link/LinkActivityContract$Args$Companion {
-}
-
 public final class com/stripe/android/link/LinkActivityContract$Args$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/LinkActivityContract$Args;
@@ -32,22 +16,6 @@ public final class com/stripe/android/link/LinkActivityContract$Args$Creator : a
 public final class com/stripe/android/link/LinkActivityContract$Companion {
 }
 
-public final class com/stripe/android/link/LinkActivityContract$Result : com/stripe/android/view/ActivityStarter$Result {
-	public static final field $stable I
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (Lcom/stripe/android/link/LinkActivityResult;)V
-	public final fun component1 ()Lcom/stripe/android/link/LinkActivityResult;
-	public final fun copy (Lcom/stripe/android/link/LinkActivityResult;)Lcom/stripe/android/link/LinkActivityContract$Result;
-	public static synthetic fun copy$default (Lcom/stripe/android/link/LinkActivityContract$Result;Lcom/stripe/android/link/LinkActivityResult;ILjava/lang/Object;)Lcom/stripe/android/link/LinkActivityContract$Result;
-	public fun describeContents ()I
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getLinkResult ()Lcom/stripe/android/link/LinkActivityResult;
-	public fun hashCode ()I
-	public fun toBundle ()Landroid/os/Bundle;
-	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
 public final class com/stripe/android/link/LinkActivityContract$Result$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/LinkActivityContract$Result;
@@ -56,34 +24,12 @@ public final class com/stripe/android/link/LinkActivityContract$Result$Creator :
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/link/LinkActivityResult$Canceled : com/stripe/android/link/LinkActivityResult {
-	public static final field $stable I
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (Lcom/stripe/android/link/LinkActivityResult$Canceled$Reason;)V
-	public final fun component1 ()Lcom/stripe/android/link/LinkActivityResult$Canceled$Reason;
-	public final fun copy (Lcom/stripe/android/link/LinkActivityResult$Canceled$Reason;)Lcom/stripe/android/link/LinkActivityResult$Canceled;
-	public static synthetic fun copy$default (Lcom/stripe/android/link/LinkActivityResult$Canceled;Lcom/stripe/android/link/LinkActivityResult$Canceled$Reason;ILjava/lang/Object;)Lcom/stripe/android/link/LinkActivityResult$Canceled;
-	public fun describeContents ()I
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getReason ()Lcom/stripe/android/link/LinkActivityResult$Canceled$Reason;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
 public final class com/stripe/android/link/LinkActivityResult$Canceled$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/LinkActivityResult$Canceled;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/link/LinkActivityResult$Canceled;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
-}
-
-public final class com/stripe/android/link/LinkActivityResult$Canceled$Reason : java/lang/Enum {
-	public static final field BackPressed Lcom/stripe/android/link/LinkActivityResult$Canceled$Reason;
-	public static final field LoggedOut Lcom/stripe/android/link/LinkActivityResult$Canceled$Reason;
-	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/link/LinkActivityResult$Canceled$Reason;
-	public static fun values ()[Lcom/stripe/android/link/LinkActivityResult$Canceled$Reason;
 }
 
 public final class com/stripe/android/link/LinkActivityResult$Completed : com/stripe/android/link/LinkActivityResult {
@@ -102,21 +48,6 @@ public final class com/stripe/android/link/LinkActivityResult$Completed$Creator 
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/link/LinkActivityResult$Failed : com/stripe/android/link/LinkActivityResult {
-	public static final field $stable I
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (Ljava/lang/Throwable;)V
-	public final fun component1 ()Ljava/lang/Throwable;
-	public final fun copy (Ljava/lang/Throwable;)Lcom/stripe/android/link/LinkActivityResult$Failed;
-	public static synthetic fun copy$default (Lcom/stripe/android/link/LinkActivityResult$Failed;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/stripe/android/link/LinkActivityResult$Failed;
-	public fun describeContents ()I
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getError ()Ljava/lang/Throwable;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
 public final class com/stripe/android/link/LinkActivityResult$Failed$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/LinkActivityResult$Failed;
@@ -133,18 +64,6 @@ public final class com/stripe/android/link/LinkConfiguration$Creator : android/o
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/link/LinkPaymentDetails$New : com/stripe/android/link/LinkPaymentDetails {
-	public static final field $stable I
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public fun <init> (Lcom/stripe/android/model/ConsumerPaymentDetails$PaymentDetails;Lcom/stripe/android/model/PaymentMethodCreateParams;Lcom/stripe/android/model/PaymentMethodCreateParams;)V
-	public final fun buildFormValues ()Ljava/util/Map;
-	public fun describeContents ()I
-	public final fun getOriginalParams ()Lcom/stripe/android/model/PaymentMethodCreateParams;
-	public fun getPaymentDetails ()Lcom/stripe/android/model/ConsumerPaymentDetails$PaymentDetails;
-	public fun getPaymentMethodCreateParams ()Lcom/stripe/android/model/PaymentMethodCreateParams;
-	public fun writeToParcel (Landroid/os/Parcel;I)V
-}
-
 public final class com/stripe/android/link/LinkPaymentDetails$New$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/LinkPaymentDetails$New;
@@ -159,16 +78,6 @@ public final class com/stripe/android/link/LinkPaymentDetails$Saved$Creator : an
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/link/LinkPaymentDetails$Saved;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
-}
-
-public final class com/stripe/android/link/model/AccountStatus : java/lang/Enum {
-	public static final field Error Lcom/stripe/android/link/model/AccountStatus;
-	public static final field NeedsVerification Lcom/stripe/android/link/model/AccountStatus;
-	public static final field SignedOut Lcom/stripe/android/link/model/AccountStatus;
-	public static final field VerificationStarted Lcom/stripe/android/link/model/AccountStatus;
-	public static final field Verified Lcom/stripe/android/link/model/AccountStatus;
-	public static fun valueOf (Ljava/lang/String;)Lcom/stripe/android/link/model/AccountStatus;
-	public static fun values ()[Lcom/stripe/android/link/model/AccountStatus;
 }
 
 public final class com/stripe/android/link/ui/ComposableSingletons$PrimaryButtonKt {
@@ -201,41 +110,5 @@ public final class com/stripe/android/link/ui/inline/ComposableSingletons$LinkIn
 	public fun <init> ()V
 	public final fun getLambda-1$link_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-2$link_release ()Lkotlin/jvm/functions/Function2;
-}
-
-public final class com/stripe/android/link/ui/inline/LinkInlineSignedInKt {
-}
-
-public final class com/stripe/android/link/ui/inline/LinkInlineSignupKt {
-}
-
-public final class com/stripe/android/link/ui/inline/UserInput$SignIn : com/stripe/android/link/ui/inline/UserInput {
-	public static final field $stable I
-	public fun <init> (Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/stripe/android/link/ui/inline/UserInput$SignIn;
-	public static synthetic fun copy$default (Lcom/stripe/android/link/ui/inline/UserInput$SignIn;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/link/ui/inline/UserInput$SignIn;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getEmail ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/stripe/android/link/ui/inline/UserInput$SignUp : com/stripe/android/link/ui/inline/UserInput {
-	public static final field $stable I
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/lang/String;
-	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/stripe/android/link/ui/inline/UserInput$SignUp;
-	public static synthetic fun copy$default (Lcom/stripe/android/link/ui/inline/UserInput$SignUp;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/stripe/android/link/ui/inline/UserInput$SignUp;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getCountry ()Ljava/lang/String;
-	public final fun getEmail ()Ljava/lang/String;
-	public final fun getName ()Ljava/lang/String;
-	public final fun getPhone ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 

--- a/link/api/link.api
+++ b/link/api/link.api
@@ -13,9 +13,6 @@ public final class com/stripe/android/link/LinkActivityContract$Args$Creator : a
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
-public final class com/stripe/android/link/LinkActivityContract$Companion {
-}
-
 public final class com/stripe/android/link/LinkActivityContract$Result$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/link/LinkActivityContract$Result;
@@ -30,14 +27,6 @@ public final class com/stripe/android/link/LinkActivityResult$Canceled$Creator :
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/link/LinkActivityResult$Canceled;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
-}
-
-public final class com/stripe/android/link/LinkActivityResult$Completed : com/stripe/android/link/LinkActivityResult {
-	public static final field $stable I
-	public static final field CREATOR Landroid/os/Parcelable$Creator;
-	public static final field INSTANCE Lcom/stripe/android/link/LinkActivityResult$Completed;
-	public fun describeContents ()I
-	public fun writeToParcel (Landroid/os/Parcel;I)V
 }
 
 public final class com/stripe/android/link/LinkActivityResult$Completed$Creator : android/os/Parcelable$Creator {

--- a/link/src/main/java/com/stripe/android/link/LinkActivityContract.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivityContract.kt
@@ -22,11 +22,12 @@ class LinkActivityContract :
     }
 
     @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class Args internal constructor(
         internal val configuration: LinkConfiguration,
         internal val prefilledCardParams: PaymentMethodCreateParams? = null,
     ) : ActivityStarter.Args {
-        companion object {
+        internal companion object {
             internal fun fromIntent(intent: Intent): Args? {
                 return intent.getParcelableExtra(EXTRA_ARGS)
             }
@@ -34,13 +35,14 @@ class LinkActivityContract :
     }
 
     @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class Result(
         val linkResult: LinkActivityResult
     ) : ActivityStarter.Result {
         override fun toBundle() = bundleOf(EXTRA_RESULT to this)
     }
 
-    companion object {
+    internal companion object {
         const val EXTRA_ARGS =
             "com.stripe.android.link.LinkActivityContract.extra_args"
         const val EXTRA_RESULT =

--- a/link/src/main/java/com/stripe/android/link/LinkActivityResult.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivityResult.kt
@@ -13,15 +13,18 @@ sealed class LinkActivityResult(
      * Indicates that the flow was completed successfully and the Stripe Intent was confirmed.
      */
     @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     object Completed : LinkActivityResult(Activity.RESULT_OK)
 
     /**
      * The user cancelled the Link flow without completing it.
      */
     @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class Canceled(
         val reason: Reason
     ) : LinkActivityResult(Activity.RESULT_CANCELED) {
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         enum class Reason {
             BackPressed,
             LoggedOut
@@ -32,6 +35,7 @@ sealed class LinkActivityResult(
      * Something went wrong. See [error] for more information.
      */
     @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class Failed(
         val error: Throwable
     ) : LinkActivityResult(Activity.RESULT_CANCELED)

--- a/link/src/main/java/com/stripe/android/link/LinkPaymentDetails.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkPaymentDetails.kt
@@ -25,6 +25,7 @@ sealed class LinkPaymentDetails(
      * A [ConsumerPaymentDetails.PaymentDetails] that is already saved to the consumer's account.
      */
     @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     internal class Saved(
         override val paymentDetails: ConsumerPaymentDetails.PaymentDetails,
         override val paymentMethodCreateParams: PaymentMethodCreateParams
@@ -36,6 +37,7 @@ sealed class LinkPaymentDetails(
      * fields with the user-entered values.
      */
     @Parcelize
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     class New(
         override val paymentDetails: ConsumerPaymentDetails.PaymentDetails,
         override val paymentMethodCreateParams: PaymentMethodCreateParams,

--- a/link/src/main/java/com/stripe/android/link/model/AccountStatus.kt
+++ b/link/src/main/java/com/stripe/android/link/model/AccountStatus.kt
@@ -1,5 +1,8 @@
 package com.stripe.android.link.model
 
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 enum class AccountStatus {
     Verified, // Customer is signed in
     NeedsVerification, // Customer needs to authenticate

--- a/link/src/main/java/com/stripe/android/link/ui/PrimaryButton.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/PrimaryButton.kt
@@ -1,7 +1,10 @@
+@file:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+
 package com.stripe.android.link.ui
 
 import android.content.res.Resources
 import androidx.annotation.DrawableRes
+import androidx.annotation.RestrictTo
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -70,6 +73,7 @@ internal fun completePaymentButtonLabel(
         requireNotNull(stripeIntent.amount),
         requireNotNull(stripeIntent.currency)
     ).buildPayButtonLabel(resources)
+
     is SetupIntent -> resources.getString(StripeUiCoreR.string.stripe_setup_button_label)
 }
 
@@ -122,6 +126,7 @@ internal fun PrimaryButton(
                         color = MaterialTheme.linkColors.buttonLabel,
                         strokeWidth = 2.dp
                     )
+
                     PrimaryButtonState.Completed -> Icon(
                         painter = painterResource(id = R.drawable.stripe_link_complete),
                         contentDescription = null,
@@ -132,6 +137,7 @@ internal fun PrimaryButton(
                             },
                         tint = MaterialTheme.linkColors.buttonLabel
                     )
+
                     else -> Row(
                         Modifier.fillMaxWidth(),
                         verticalAlignment = Alignment.CenterVertically

--- a/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignedIn.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignedIn.kt
@@ -1,3 +1,5 @@
+@file:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+
 package com.stripe.android.link.ui.inline
 
 import androidx.annotation.RestrictTo
@@ -30,7 +32,6 @@ import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.getBorderStroke
 import com.stripe.android.uicore.stripeColors
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Composable
 fun LinkInlineSignedIn(
     linkConfigurationCoordinator: LinkConfigurationCoordinator,

--- a/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignup.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/LinkInlineSignup.kt
@@ -1,3 +1,5 @@
+@file:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+
 package com.stripe.android.link.ui.inline
 
 import androidx.annotation.RestrictTo
@@ -87,7 +89,6 @@ private fun Preview() {
     }
 }
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun LinkInlineSignup(

--- a/link/src/main/java/com/stripe/android/link/ui/inline/UserInput.kt
+++ b/link/src/main/java/com/stripe/android/link/ui/inline/UserInput.kt
@@ -10,6 +10,7 @@ sealed class UserInput {
     /**
      * Represents an input that is valid for signing in to a link account.
      */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class SignIn(
         val email: String
     ) : UserInput()
@@ -17,6 +18,7 @@ sealed class UserInput {
     /**
      * Represents an input that is valid for signing up to a link account.
      */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class SignUp(
         val email: String,
         val phone: String,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add `@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)` to a bunch of classes that were considered internal, or had parents restricted.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Align the kotlin binary compatibility checker baseline with what we actually consider public. 
Follow up to https://github.com/stripe/stripe-android/pull/6848#discussion_r1224516390
