### PR TITLE
[FC] Remove Toast when no browser installed


### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Financial Connections
 * [FIXED][6836](https://github.com/stripe/stripe-android/pull/6836) Prevents double navigation when tapping too quickly.
-* 
+* [CHANGED][6850](https://github.com/stripe/stripe-android/pull/6850) Removes Toast shown after gracefully failing if no browser installed.
+
 ## 20.25.5 - 2023-06-05
 
 ### PaymentSheet

--- a/financial-connections/res/values/strings.xml
+++ b/financial-connections/res/values/strings.xml
@@ -135,7 +135,6 @@
     <string name="stripe_verification.maxAttemptsExceeded">We\'re experiencing high volumes. Try again in an hour and if you need immediate assistance, please contact us.</string>
     <string name="stripe_verification.unexpectedError">Something went wrong.</string>
     <string name="stripe_link_account_picker_disconnected">Disconnected</string>
-    <string name="stripe_no_browser_installed">No Web browser available to start connecting your accounts. Please install a browser and try again.</string>
     <plurals name="stripe_success_networking_save_to_link_failed">
         <item quantity="one">Your account was connected to %1$s but could not be saved to Link with Stripe at this time.</item>
         <item quantity="other">Your accounts were connected to %1$s but could not be saved to Link with Stripe at this time.</item>

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModel.kt
@@ -140,8 +140,7 @@ internal class FinancialConnectionsSheetViewModel @Inject constructor(
             analyticsTracker.track(Error(Pane.UNEXPECTED_ERROR, error))
             finishWithResult(
                 state = awaitState(),
-                result = Failed(error),
-                finishMessage = R.string.stripe_no_browser_installed
+                result = Failed(error)
             )
         }
     }


### PR DESCRIPTION
# Summary
 Remove Toast shown after gracefully failing the AuthFlow when no browser installed.

# Motivation
:notebook_with_decorative_cover: &nbsp;**[Android] Remove Toast when no browser installed**
:globe_with_meridians: &nbsp;[BANKCON-7114](https://jira.corp.stripe.com/browse/BANKCON-7114)
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified