### PR TITLE
[FC] Add mutex to prevent onNewIntent <> OnResume race condition


### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
@@ -163,7 +163,6 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
         }
     }
 
-
     /**
      *  If activity resumes and we did not receive a callback from the AuthFlow,
      *  then the user hit the back button or closed the custom tabs UI, so return result as
@@ -171,14 +170,12 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
      */
     fun onResume() = viewModelScope.launch {
         mutex.withLock {
-            logger.debug("CONV onResume")
             val state = awaitState()
             if (state.webAuthFlow is Loading) {
                 setState { copy(webAuthFlow = Fail(WebAuthFlowCancelledException())) }
             }
         }
     }
-
 
     fun openPartnerAuthFlowInBrowser(url: String) {
         setState {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
@@ -48,6 +48,8 @@ import com.stripe.android.financialconnections.presentation.FinancialConnections
 import com.stripe.android.financialconnections.ui.TextResource
 import com.stripe.android.financialconnections.utils.UriUtils
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -67,6 +69,8 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
     @Named(APPLICATION_ID) private val applicationId: String,
     initialState: FinancialConnectionsSheetNativeState
 ) : MavericksViewModel<FinancialConnectionsSheetNativeState>(initialState) {
+
+    private val mutex = Mutex()
 
     init {
         setState { copy(firstInit = false) }
@@ -96,8 +100,8 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
      *
      * @param intent the new intent with the redirect URL in the intent data
      */
-    fun handleOnNewIntent(intent: Intent?) {
-        viewModelScope.launch {
+    fun handleOnNewIntent(intent: Intent?) = viewModelScope.launch {
+        mutex.withLock {
             val receivedUrl: String = intent?.data?.toString() ?: ""
             when {
                 receivedUrl.contains("authentication_return", true) -> {
@@ -159,20 +163,22 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
         }
     }
 
+
     /**
      *  If activity resumes and we did not receive a callback from the AuthFlow,
      *  then the user hit the back button or closed the custom tabs UI, so return result as
      *  canceled.
      */
-    fun onResume() {
-        setState {
-            if (webAuthFlow is Loading) {
-                copy(webAuthFlow = Fail(WebAuthFlowCancelledException()))
-            } else {
-                this
+    fun onResume() = viewModelScope.launch {
+        mutex.withLock {
+            logger.debug("CONV onResume")
+            val state = awaitState()
+            if (state.webAuthFlow is Loading) {
+                setState { copy(webAuthFlow = Fail(WebAuthFlowCancelledException())) }
             }
         }
     }
+
 
     fun openPartnerAuthFlowInBrowser(url: String) {
         setState {
@@ -197,6 +203,7 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
                 value = R.string.stripe_close_dialog_networking_desc,
                 args = listOf(businessName)
             )
+
             else -> TextResource.StringId(
                 value = R.string.stripe_close_dialog_desc
             )


### PR DESCRIPTION
# Summary

Here's a rough breakdown of the usual life cycle of the `FinancialConnectionsSheetNativeActivity` 

- `FinancialConnectionsSheetNativeActivity` is in the foreground and it launches the browser.
  - Sets the web flow state to Loading
- The browser takes the foreground, and the Activity goes to the background (**onPause** gets called)
- The browser finishes its flow and triggers a redirect back to the Activity.
  - If the user finishes the flow and the browser triggers a deep link, **onNewIntent** gets called with the deeplink.
    - Sets the web flow state from Loading to Success or Fail depending on the deeplink received from the browser
  - Regardless of the result of the flow, **onResume** gets called (since the activity comes back to the foreground)
- If the web flow state is still Loading, set it to Canceled. This would trigger an AuthSessionEvent.Retry event and call /auth_sessions/cancel.

These two events happen in order, but separated by milliseconds. There’s potentially a race condition where the **onNewIntent** hasn’t yet transitioned the state from Loading when **onResume** checks it, marking the state as Canceled.

# Solution

Knowing that `onNewIntent` gets triggered before `onResume` but that their logic can run in parallel, a mutex within the same coroutine context would prevent race conditions between the two. 

# Motivation
:notebook_with_decorative_cover: &nbsp;**[Android] Add mutex to prevent onNewIntent <> OnResume race condition**
:globe_with_meridians: &nbsp;[BANKCON-7115](https://jira.corp.stripe.com/browse/BANKCON-7115)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [X] Manually verified