### PR TITLE
Explicitly use fade-in to launch sheet activities

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/view/AuthActivityStarterHost.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/AuthActivityStarterHost.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.view
 
+import android.app.Application
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -24,11 +25,15 @@ sealed class AuthActivityStarterHost {
 
     abstract val statusBarColor: Int?
     abstract val lifecycleOwner: LifecycleOwner
+    abstract val application: Application
 
     internal class ActivityHost(
         val activity: ComponentActivity,
         override val statusBarColor: Int?
     ) : AuthActivityStarterHost() {
+
+        override val application: Application
+            get() = activity.application
 
         override val lifecycleOwner: LifecycleOwner = activity
 
@@ -48,6 +53,9 @@ sealed class AuthActivityStarterHost {
         val fragment: Fragment,
         override val statusBarColor: Int?
     ) : AuthActivityStarterHost() {
+
+        override val application: Application
+            get() = fragment.requireActivity().application
 
         override val lifecycleOwner: LifecycleOwner = fragment
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
@@ -1,13 +1,16 @@
 package com.stripe.android.customersheet
 
+import android.app.Application
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultCaller
 import androidx.annotation.RestrictTo
+import androidx.core.app.ActivityOptionsCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import com.stripe.android.customersheet.injection.CustomerSheetComponent
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.utils.AnimationConstants
 import javax.inject.Inject
 
 /**
@@ -19,6 +22,7 @@ import javax.inject.Inject
 @ExperimentalCustomerSheetApi
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class CustomerSheet @Inject internal constructor(
+    private val application: Application,
     activityResultCaller: ActivityResultCaller,
     private val callback: CustomerSheetResultCallback,
 ) {
@@ -33,9 +37,15 @@ class CustomerSheet @Inject internal constructor(
      * are delivered through the callback passed in [CustomerSheet.create].
      */
     fun present() {
-        customerSheetActivityLauncher.launch(
-            CustomerSheetContract.Args
+        val args = CustomerSheetContract.Args
+
+        val options = ActivityOptionsCompat.makeCustomAnimation(
+            application.applicationContext,
+            AnimationConstants.FADE_IN,
+            AnimationConstants.FADE_OUT,
         )
+
+        customerSheetActivityLauncher.launch(args, options)
     }
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultPaymentSheetLauncher.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.ActivityResultRegistry
+import androidx.core.app.ActivityOptionsCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
@@ -14,6 +15,7 @@ import com.stripe.android.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.injection.DaggerPaymentSheetLauncherComponent
 import com.stripe.android.paymentsheet.injection.PaymentSheetLauncherComponent
+import com.stripe.android.utils.AnimationConstants
 import org.jetbrains.annotations.TestOnly
 
 /**
@@ -23,7 +25,7 @@ import org.jetbrains.annotations.TestOnly
 internal class DefaultPaymentSheetLauncher(
     private val activityResultLauncher: ActivityResultLauncher<PaymentSheetContractV2.Args>,
     lifecycleOwner: LifecycleOwner,
-    application: Application,
+    private val application: Application,
 ) : PaymentSheetLauncher {
     @InjectorKey
     private val injectorKey: String =
@@ -100,7 +102,14 @@ internal class DefaultPaymentSheetLauncher(
             config = configuration,
             injectorKey = injectorKey,
         )
-        activityResultLauncher.launch(args)
+
+        val options = ActivityOptionsCompat.makeCustomAnimation(
+            application.applicationContext,
+            AnimationConstants.FADE_IN,
+            AnimationConstants.FADE_OUT,
+        )
+
+        activityResultLauncher.launch(args, options)
     }
 
     private class Injector(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
@@ -1,21 +1,27 @@
 package com.stripe.android.paymentsheet.addresselement
 
+import android.app.Application
 import android.os.Parcelable
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResultLauncher
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.app.ActivityOptionsCompat
 import androidx.fragment.app.Fragment
 import com.stripe.android.core.injection.InjectorKey
 import com.stripe.android.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.addresselement.AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration
+import com.stripe.android.utils.AnimationConstants
 import kotlinx.parcelize.Parcelize
 
 /**
  * A drop-in class that presents a bottom sheet to collect a customer's address.
  */
 class AddressLauncher internal constructor(
+    private val application: Application,
     private val activityResultLauncher: ActivityResultLauncher<AddressElementActivityContract.Args>
 ) {
     @InjectorKey
@@ -32,11 +38,12 @@ class AddressLauncher internal constructor(
         activity: ComponentActivity,
         callback: AddressLauncherResultCallback
     ) : this(
-        activity.registerForActivityResult(
+        application = activity.application,
+        activityResultLauncher = activity.registerForActivityResult(
             AddressElementActivityContract()
         ) {
             callback.onAddressLauncherResult(it)
-        }
+        },
     )
 
     /**
@@ -49,11 +56,12 @@ class AddressLauncher internal constructor(
         fragment: Fragment,
         callback: AddressLauncherResultCallback
     ) : this(
-        fragment.registerForActivityResult(
+        application = fragment.requireActivity().application,
+        activityResultLauncher = fragment.registerForActivityResult(
             AddressElementActivityContract()
         ) {
             callback.onAddressLauncherResult(it)
-        }
+        },
     )
 
     @JvmOverloads
@@ -61,13 +69,19 @@ class AddressLauncher internal constructor(
         publishableKey: String,
         configuration: Configuration = Configuration()
     ) {
-        activityResultLauncher.launch(
-            AddressElementActivityContract.Args(
-                publishableKey,
-                configuration,
-                injectorKey
-            )
+        val args = AddressElementActivityContract.Args(
+            publishableKey,
+            configuration,
+            injectorKey
         )
+
+        val options = ActivityOptionsCompat.makeCustomAnimation(
+            application.applicationContext,
+            AnimationConstants.FADE_IN,
+            AnimationConstants.FADE_OUT,
+        )
+
+        activityResultLauncher.launch(args, options)
     }
 
     /** Configuration for [AddressLauncher] **/
@@ -214,7 +228,12 @@ fun rememberAddressLauncher(
         onResult = callback::onAddressLauncherResult
     )
 
+    val context = LocalContext.current
+
     return remember {
-        AddressLauncher(activityResultLauncher)
+        AddressLauncher(
+            application = context.applicationContext as Application,
+            activityResultLauncher = activityResultLauncher,
+        )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -5,6 +5,7 @@ import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.VisibleForTesting
+import androidx.core.app.ActivityOptionsCompat
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelProvider
@@ -55,6 +56,7 @@ import com.stripe.android.paymentsheet.model.PaymentOptionFactory
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.currency
 import com.stripe.android.paymentsheet.state.PaymentSheetState
+import com.stripe.android.utils.AnimationConstants
 import dagger.Lazy
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
@@ -244,15 +246,21 @@ internal class DefaultFlowController @Inject internal constructor(
             return
         }
 
-        paymentOptionActivityLauncher.launch(
-            PaymentOptionContract.Args(
-                state = state.copy(paymentSelection = viewModel.paymentSelection),
-                statusBarColor = statusBarColor(),
-                injectorKey = injectorKey,
-                enableLogging = enableLogging,
-                productUsage = productUsage,
-            )
+        val args = PaymentOptionContract.Args(
+            state = state.copy(paymentSelection = viewModel.paymentSelection),
+            statusBarColor = statusBarColor(),
+            injectorKey = injectorKey,
+            enableLogging = enableLogging,
+            productUsage = productUsage,
         )
+
+        val options = ActivityOptionsCompat.makeCustomAnimation(
+            viewModel.getApplication(),
+            AnimationConstants.FADE_IN,
+            AnimationConstants.FADE_OUT,
+        )
+
+        paymentOptionActivityLauncher.launch(args, options)
     }
 
     override fun confirm() {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingAuthenticator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingAuthenticator.kt
@@ -3,10 +3,12 @@ package com.stripe.android.paymentsheet.paymentdatacollection.polling
 import androidx.activity.result.ActivityResultCallback
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
+import androidx.core.app.ActivityOptionsCompat
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.PaymentFlowResult
 import com.stripe.android.payments.core.authentication.PaymentAuthenticator
+import com.stripe.android.utils.AnimationConstants
 import com.stripe.android.view.AuthActivityStarterHost
 import javax.inject.Singleton
 
@@ -31,7 +33,14 @@ internal class PollingAuthenticator : PaymentAuthenticator<StripeIntent>() {
             initialDelayInSeconds = UPI_INITIAL_DELAY_IN_SECONDS,
             maxAttempts = UPI_MAX_ATTEMPTS,
         )
-        pollingLauncher?.launch(args)
+
+        val options = ActivityOptionsCompat.makeCustomAnimation(
+            host.application.applicationContext,
+            AnimationConstants.FADE_IN,
+            AnimationConstants.FADE_OUT,
+        )
+
+        pollingLauncher?.launch(args, options)
     }
 
     override fun onNewActivityResultCaller(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -78,6 +78,7 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argWhere
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
@@ -334,7 +335,7 @@ internal class DefaultFlowControllerTest {
             productUsage = PRODUCT_USAGE
         )
 
-        verify(paymentOptionActivityLauncher).launch(eq(expectedArgs))
+        verify(paymentOptionActivityLauncher).launch(eq(expectedArgs), anyOrNull())
     }
 
     @Test
@@ -422,8 +423,8 @@ internal class DefaultFlowControllerTest {
             argWhere {
                 // Make sure that paymentMethods contains the new added payment methods and the initial payment methods.
                 it.state.customerPaymentMethods == initialPaymentMethods
-            }
-
+            },
+            anyOrNull(),
         )
     }
 
@@ -921,9 +922,8 @@ internal class DefaultFlowControllerTest {
         flowController.presentPaymentOptions()
 
         verify(paymentOptionActivityLauncher).launch(
-            argWhere {
-                it.state.paymentSelection == previousPaymentSelection
-            }
+            argWhere { it.state.paymentSelection == previousPaymentSelection },
+            anyOrNull(),
         )
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request explicitly sets fade-in transitions for launching sheet activities. While this seemingly wasn’t necessary up to API 33, running the example app on API 34 shows a bad visual glitch without this tweak.

These include:
- PaymentSheetActivity and PaymentOptionsActivity
- CustomerSheetActivity
- AddressElementActivity
- PollingActivity

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Polish for API 34.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screen recordings

### Before

https://github.com/stripe/stripe-android/assets/110940675/8f800e8e-bef9-42d6-9f57-0ba27f4bf1e4

### After

https://github.com/stripe/stripe-android/assets/110940675/1810ccd3-f140-4bf8-87f9-747906654b60

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
