### PR TITLE
Clean up view models automatically

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
@@ -54,7 +54,11 @@ internal class PaymentLauncherConfirmationActivity : AppCompatActivity() {
         }
 
         viewModel.paymentLauncherResult.observe(this, ::finishWithResult)
-        viewModel.register(this)
+        viewModel.register(
+            activityResultCaller = this,
+            lifecycleOwner = this,
+        )
+
         val host = AuthActivityStarterHost.create(this)
         when (args) {
             is PaymentLauncherContract.Args.IntentConfirmationArgs -> {
@@ -67,11 +71,6 @@ internal class PaymentLauncherConfirmationActivity : AppCompatActivity() {
                 viewModel.handleNextActionForStripeIntent(args.setupIntentClientSecret, host)
             }
         }
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        viewModel.cleanUp()
     }
 
     override fun finish() {

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivityTest.kt
@@ -73,7 +73,7 @@ class PaymentLauncherConfirmationActivityTest {
         ).use {
             it.onActivity {
                 runTest {
-                    verify(viewModel).register(any())
+                    verify(viewModel).register(any(), any())
                 }
             }
         }
@@ -143,7 +143,7 @@ class PaymentLauncherConfirmationActivityTest {
             it.onActivity {
                 runTest {
                     verify(viewModel).handleNextActionForStripeIntent(eq(CLIENT_SECRET), any())
-                    verify(viewModel).register(any())
+                    verify(viewModel).register(any(), any())
                 }
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -47,7 +47,10 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
             return
         }
 
-        viewModel.registerFromActivity(this)
+        viewModel.registerFromActivity(
+            activityResultCaller = this,
+            lifecycleOwner = this,
+        )
 
         viewModel.setupGooglePay(
             lifecycleScope,
@@ -99,13 +102,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
             Activity.RESULT_OK,
             Intent().putExtras(PaymentSheetContractV2.Result(result).toBundle())
         )
-    }
-
-    override fun onDestroy() {
-        if (!earlyExitDueToIllegalState) {
-            viewModel.unregisterFromActivity()
-        }
-        super.onDestroy()
     }
 
     private fun finishWithError(error: Throwable?) {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request removes the need for `onDestroy()` or `cleanup()` methods on our view models. Instead of calling these methods on the view model in the Activity’s `onDestroy()` method, we now observe the `LifecycleOwner` directly inside the view models.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

We no longer need to remember to use `earlyExitDueToIllegalState` in the Activity’s `onDestroy()` to decide whether to call the view model or not. This has caused issues in the past.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
