### PR TITLE
Ignore case when comparing intent and intent configuration currencies

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DeferredIntentValidator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DeferredIntentValidator.kt
@@ -29,9 +29,10 @@ internal object DeferredIntentValidator {
                         "but used a PaymentSheet.IntentConfiguration in setup mode."
                 }
 
-                require(paymentMode.currency == stripeIntent.currency) {
-                    "Your PaymentIntent currency (${stripeIntent.currency}) does not match " +
-                        "the PaymentSheet.IntentConfiguration currency (${paymentMode.currency})."
+                require(paymentMode.currency.lowercase() == stripeIntent.currency?.lowercase()) {
+                    "Your PaymentIntent currency (${stripeIntent.currency?.lowercase()}) does " +
+                        "not match the PaymentSheet.IntentConfiguration currency " +
+                        "(${paymentMode.currency.lowercase()})."
                 }
 
                 require(paymentMode.setupFutureUsage == stripeIntent.setupFutureUsage) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DeferredIntentValidatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DeferredIntentValidatorTest.kt
@@ -136,6 +136,20 @@ internal class DeferredIntentValidatorTest {
     @Test
     fun `Succeeds if PaymentIntent and IntentConfiguration match`() {
         val paymentIntent = PaymentIntentFactory.create()
+        val intentConfiguration = makeIntentConfigurationForPayment()
+
+        val result = DeferredIntentValidator.validate(
+            stripeIntent = paymentIntent,
+            intentConfiguration = intentConfiguration,
+            isFlowController = true,
+        )
+
+        assertThat(result).isEqualTo(paymentIntent)
+    }
+
+    @Test
+    fun `Succeeds if PaymentIntent and IntentConfiguration have same currency but in different case`() {
+        val paymentIntent = PaymentIntentFactory.create()
         val intentConfiguration = makeIntentConfigurationForPayment(
             currency = "USD", // uppercase to test case insensitivity
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DeferredIntentValidatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/DeferredIntentValidatorTest.kt
@@ -136,7 +136,9 @@ internal class DeferredIntentValidatorTest {
     @Test
     fun `Succeeds if PaymentIntent and IntentConfiguration match`() {
         val paymentIntent = PaymentIntentFactory.create()
-        val intentConfiguration = makeIntentConfigurationForPayment()
+        val intentConfiguration = makeIntentConfigurationForPayment(
+            currency = "USD", // uppercase to test case insensitivity
+        )
 
         val result = DeferredIntentValidator.validate(
             stripeIntent = paymentIntent,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request makes the `DeferredIntentValidator` (created [here](https://github.com/stripe/stripe-android/pull/6839)) ignore the case when comparing the currencies of `IntentConfiguration` and the created `StripeIntent`.

(cc @yuki-stripe @porter-stripe)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
