### PR TITLE
Send `deferred_intent_confirmation_type` in payment success event

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -149,7 +149,9 @@ internal class PaymentOptionsViewModel @Inject constructor(
                 eventReporter.onPaymentSuccess(
                     paymentSelection = PaymentSelection.Link,
                     currency = stripeIntent.value?.currency,
-                    isDecoupling = isDecoupling,
+                    // TODO Revisit when integrating the new Link flow. Suspicion is that this will
+                    //  not actually be needed anymore then.
+                    deferredIntentConfirmationType = null,
                 )
                 prefsRepository.savePaymentSelection(PaymentSelection.Link)
                 onPaymentResult(PaymentResult.Completed)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -493,9 +493,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                     onError(nextStep.message)
                 }
                 is IntentConfirmationInterceptor.NextStep.Complete -> {
-                    if (nextStep.isForceSuccess) {
-                        eventReporter.onForceSuccess()
-                    }
                     processPayment(stripeIntent, PaymentResult.Completed)
                 }
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -152,6 +152,8 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
     private var googlePayPaymentMethodLauncher: GooglePayPaymentMethodLauncher? = null
 
+    private var deferredIntentConfirmationType: DeferredIntentConfirmationType? = null
+
     @VisibleForTesting
     internal val googlePayLauncherConfig: GooglePayPaymentMethodLauncher.Config? =
         args.googlePayConfig?.let { config ->
@@ -244,7 +246,9 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                 eventReporter.onPaymentSuccess(
                     paymentSelection = PaymentSelection.Link,
                     currency = stripeIntent.value?.currency,
-                    isDecoupling = isDecoupling,
+                    // TODO Revisit when integrating the new Link flow. Suspicion is that this will
+                    //  not actually be needed anymore then.
+                    deferredIntentConfirmationType = null,
                 )
                 prefsRepository.savePaymentSelection(PaymentSelection.Link)
                 _paymentSheetResult.tryEmit(PaymentSheetResult.Completed)
@@ -479,6 +483,8 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                 shippingValues = args.config?.shippingDetails?.toConfirmPaymentIntentShipping(),
             )
 
+            deferredIntentConfirmationType = nextStep.deferredIntentConfirmationType
+
             when (nextStep) {
                 is IntentConfirmationInterceptor.NextStep.HandleNextAction -> {
                     handleNextAction(
@@ -518,8 +524,11 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                 eventReporter.onPaymentSuccess(
                     paymentSelection = selection.value,
                     currency = stripeIntent.currency,
-                    isDecoupling = isDecoupling,
+                    deferredIntentConfirmationType = deferredIntentConfirmationType,
                 )
+
+                // Reset after sending event
+                deferredIntentConfirmationType = null
 
                 // Default future payments to the selected payment method. New payment methods won't
                 // be the default because we don't know if the user selected save for future use.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.analytics
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
+import com.stripe.android.paymentsheet.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import kotlinx.coroutines.CoroutineScope
@@ -99,7 +100,7 @@ internal class DefaultEventReporter @Inject internal constructor(
     override fun onPaymentSuccess(
         paymentSelection: PaymentSelection?,
         currency: String?,
-        isDecoupling: Boolean,
+        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
     ) {
         // Google Pay is treated as a saved payment method after confirmation, so we need to
         // "reset" to PaymentSelection.GooglePay for accurate reporting
@@ -118,7 +119,8 @@ internal class DefaultEventReporter @Inject internal constructor(
                 durationMillis = durationMillisFrom(paymentSheetShownMillis),
                 result = PaymentSheetEvent.Payment.Result.Success,
                 currency = currency,
-                isDecoupled = isDecoupling,
+                isDecoupled = deferredIntentConfirmationType != null,
+                deferredIntentConfirmationType = deferredIntentConfirmationType,
             )
         )
     }
@@ -136,6 +138,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 result = PaymentSheetEvent.Payment.Result.Failure,
                 currency = currency,
                 isDecoupled = isDecoupling,
+                deferredIntentConfirmationType = null,
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -160,10 +160,6 @@ internal class DefaultEventReporter @Inject internal constructor(
         )
     }
 
-    override fun onForceSuccess() {
-        fireEvent(PaymentSheetEvent.ForceSuccess)
-    }
-
     private fun fireEvent(event: PaymentSheetEvent) {
         CoroutineScope(workContext).launch {
             analyticsRequestExecutor.executeAsync(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -56,8 +56,6 @@ internal interface EventReporter {
         isDecoupling: Boolean,
     )
 
-    fun onForceSuccess()
-
     enum class Mode(val code: String) {
         Complete("complete"),
         Custom("custom");

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.analytics
 
 import androidx.annotation.Keep
+import com.stripe.android.paymentsheet.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 
@@ -38,7 +39,7 @@ internal interface EventReporter {
     fun onPaymentSuccess(
         paymentSelection: PaymentSelection?,
         currency: String?,
-        isDecoupling: Boolean,
+        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
     )
 
     fun onPaymentFailure(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.analytics
 
 import androidx.annotation.Keep
 import com.stripe.android.core.networking.AnalyticsEvent
+import com.stripe.android.paymentsheet.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.uicore.StripeThemeDefaults
@@ -180,15 +181,22 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         paymentSelection: PaymentSelection?,
         currency: String?,
         isDecoupled: Boolean,
+        deferredIntentConfirmationType: DeferredIntentConfirmationType?,
     ) : PaymentSheetEvent() {
+
         override val eventName: String =
             formatEventName(mode, "payment_${analyticsValue(paymentSelection)}_$result")
+
         override val additionalParams: Map<String, Any?> =
             mapOf(
                 "duration" to durationMillis?.div(1000f),
                 "locale" to Locale.getDefault().toString(),
                 "currency" to currency,
                 FIELD_IS_DECOUPLED to isDecoupled,
+            ).plus(
+                deferredIntentConfirmationType?.let {
+                    mapOf(FIELD_DEFERRED_INTENT_CONFIRMATION_TYPE to it.value)
+                }.orEmpty()
             )
 
         enum class Result(private val code: String) {
@@ -258,6 +266,7 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         const val FIELD_BILLING_DETAILS_COLLECTION_CONFIGURATION =
             "billing_details_collection_configuration"
         const val FIELD_IS_DECOUPLED = "is_decoupled"
+        const val FIELD_DEFERRED_INTENT_CONFIRMATION_TYPE = "deferred_intent_confirmation_type"
         const val FIELD_ATTACH_DEFAULTS = "attach_defaults"
         const val FIELD_COLLECT_NAME = "name"
         const val FIELD_COLLECT_EMAIL = "email"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEvent.kt
@@ -224,13 +224,6 @@ internal sealed class PaymentSheetEvent : AnalyticsEvent {
         )
     }
 
-    object ForceSuccess : PaymentSheetEvent() {
-        override val eventName: String = "mc_force_success"
-        override val additionalParams: Map<String, Any?> = mapOf(
-            FIELD_IS_DECOUPLED to true,
-        )
-    }
-
     internal companion object {
         private fun analyticsValue(
             paymentSelection: PaymentSelection?

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -304,6 +304,8 @@ internal class DefaultFlowController @Inject internal constructor(
                 shippingValues = state.config?.shippingDetails?.toConfirmPaymentIntentShipping(),
             )
 
+            viewModel.deferredIntentConfirmationType = nextStep.deferredIntentConfirmationType
+
             when (nextStep) {
                 is IntentConfirmationInterceptor.NextStep.HandleNextAction -> {
                     handleNextAction(
@@ -475,8 +477,9 @@ internal class DefaultFlowController @Inject internal constructor(
                 eventReporter.onPaymentSuccess(
                     paymentSelection = viewModel.paymentSelection,
                     currency = viewModel.state?.stripeIntent?.currency,
-                    isDecoupling = isDecoupling,
+                    deferredIntentConfirmationType = viewModel.deferredIntentConfirmationType,
                 )
+                viewModel.deferredIntentConfirmationType = null
             }
             is PaymentResult.Failed -> {
                 eventReporter.onPaymentFailure(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -322,9 +322,6 @@ internal class DefaultFlowController @Inject internal constructor(
                     )
                 }
                 is IntentConfirmationInterceptor.NextStep.Complete -> {
-                    if (nextStep.isForceSuccess) {
-                        eventReporter.onForceSuccess()
-                    }
                     onPaymentResult(PaymentResult.Completed)
                 }
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.flowcontroller
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.paymentsheet.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 
@@ -29,7 +30,14 @@ internal class FlowControllerViewModel(
             handle[STATE_KEY] = value
         }
 
+    var deferredIntentConfirmationType: DeferredIntentConfirmationType?
+        get() = handle[KEY_DEFERRED_INTENT_CONFIRMATION_TYPE]
+        set(value) {
+            handle[KEY_DEFERRED_INTENT_CONFIRMATION_TYPE] = value
+        }
+
     private companion object {
         private const val STATE_KEY = "state"
+        private const val KEY_DEFERRED_INTENT_CONFIRMATION_TYPE = "KEY_DEFERRED_INTENT_CONFIRMATION_TYPE"
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -72,7 +72,6 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.reset
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
@@ -1311,8 +1310,7 @@ internal class PaymentSheetViewModelTest {
             val isForceSuccess = clientSecret == PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT
             fakeIntentConfirmationInterceptor.enqueueCompleteStep(isForceSuccess)
 
-            verify(eventReporter, verificationMode).onForceSuccess()
-            reset(eventReporter)
+            // TODO Wait for replacement
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -112,7 +112,7 @@ class DefaultEventReporterTest {
         completeEventReporter.onPaymentSuccess(
             paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
             currency = "usd",
-            isDecoupling = false,
+            deferredIntentConfirmationType = null,
         )
         verify(analyticsRequestExecutor).executeAsync(
             argWhere { req ->
@@ -143,7 +143,7 @@ class DefaultEventReporterTest {
                 isGooglePay = true,
             ),
             currency = "usd",
-            isDecoupling = false,
+            deferredIntentConfirmationType = null,
         )
 
         verify(analyticsRequestExecutor).executeAsync(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetEventTest.kt
@@ -62,6 +62,7 @@ class PaymentSheetEventTest {
             result = PaymentSheetEvent.Payment.Result.Success,
             currency = "usd",
             isDecoupled = false,
+            deferredIntentConfirmationType = null,
         )
         assertThat(
             newPMEvent.eventName
@@ -89,6 +90,7 @@ class PaymentSheetEventTest {
             result = PaymentSheetEvent.Payment.Result.Success,
             currency = "usd",
             isDecoupled = false,
+            deferredIntentConfirmationType = null,
         )
         assertThat(
             savedPMEvent.eventName
@@ -116,6 +118,7 @@ class PaymentSheetEventTest {
             result = PaymentSheetEvent.Payment.Result.Success,
             currency = "usd",
             isDecoupled = false,
+            deferredIntentConfirmationType = null,
         )
         assertThat(
             googlePayEvent.eventName
@@ -143,6 +146,7 @@ class PaymentSheetEventTest {
             result = PaymentSheetEvent.Payment.Result.Success,
             currency = "usd",
             isDecoupled = false,
+            deferredIntentConfirmationType = null,
         )
         assertThat(
             linkEvent.eventName
@@ -176,6 +180,7 @@ class PaymentSheetEventTest {
             result = PaymentSheetEvent.Payment.Result.Success,
             currency = "usd",
             isDecoupled = false,
+            deferredIntentConfirmationType = null,
         )
         assertThat(
             inlineLinkEvent.eventName
@@ -207,6 +212,7 @@ class PaymentSheetEventTest {
             result = PaymentSheetEvent.Payment.Result.Failure,
             currency = "usd",
             isDecoupled = false,
+            deferredIntentConfirmationType = null,
         )
         assertThat(
             newPMEvent.eventName
@@ -234,6 +240,7 @@ class PaymentSheetEventTest {
             result = PaymentSheetEvent.Payment.Result.Failure,
             currency = "usd",
             isDecoupled = false,
+            deferredIntentConfirmationType = null,
         )
         assertThat(
             savedPMEvent.eventName
@@ -261,6 +268,7 @@ class PaymentSheetEventTest {
             result = PaymentSheetEvent.Payment.Result.Failure,
             currency = "usd",
             isDecoupled = false,
+            deferredIntentConfirmationType = null,
         )
         assertThat(
             googlePayEvent.eventName
@@ -288,6 +296,7 @@ class PaymentSheetEventTest {
             result = PaymentSheetEvent.Payment.Result.Failure,
             currency = "usd",
             isDecoupled = false,
+            deferredIntentConfirmationType = null,
         )
         assertThat(
             linkEvent.eventName
@@ -321,6 +330,7 @@ class PaymentSheetEventTest {
             result = PaymentSheetEvent.Payment.Result.Failure,
             currency = "usd",
             isDecoupled = false,
+            deferredIntentConfirmationType = null,
         )
         assertThat(
             inlineLinkEvent.eventName

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -40,6 +40,7 @@ import com.stripe.android.payments.paymentlauncher.StripePaymentLauncher
 import com.stripe.android.payments.paymentlauncher.StripePaymentLauncherAssistedFactory
 import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.CreateIntentResult
+import com.stripe.android.paymentsheet.DeferredIntentConfirmationType
 import com.stripe.android.paymentsheet.DelicatePaymentSheetApi
 import com.stripe.android.paymentsheet.ExperimentalPaymentSheetDecouplingApi
 import com.stripe.android.paymentsheet.IntentConfirmationInterceptor
@@ -75,7 +76,6 @@ import kotlinx.coroutines.test.setMain
 import org.junit.Rule
 import org.junit.runner.RunWith
 import org.mockito.Mockito.never
-import org.mockito.Mockito.times
 import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -86,7 +86,6 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.isA
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
@@ -211,7 +210,7 @@ internal class DefaultFlowControllerTest {
             .onPaymentSuccess(
                 paymentSelection = isA<PaymentSelection.New>(),
                 currency = eq("usd"),
-                isDecoupling = eq(false),
+                deferredIntentConfirmationType = isNull(),
             )
     }
 
@@ -1141,29 +1140,113 @@ internal class DefaultFlowControllerTest {
     @Test
     fun `Sends correct analytics event based on force-success usage`() = runTest {
         val clientSecrets = listOf(
-            PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT to times(1),
-            "real_client_secret" to never(),
+            PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT to DeferredIntentConfirmationType.None,
+            "real_client_secret" to DeferredIntentConfirmationType.Server,
         )
 
-        for ((clientSecret, verificationMode) in clientSecrets) {
+        for ((clientSecret, deferredIntentConfirmationType) in clientSecrets) {
             IntentConfirmationInterceptor.createIntentCallback = CreateIntentCallback { _, _ ->
                 CreateIntentResult.Success(clientSecret)
             }
 
             val flowController = createAndConfigureFlowControllerForDeferredIntent()
+            val savedSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
 
             flowController.onPaymentOptionResult(
-                PaymentOptionResult.Succeeded(
-                    PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
-                )
+                PaymentOptionResult.Succeeded(savedSelection)
             )
             flowController.confirm()
 
             val isForceSuccess = clientSecret == PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT
             fakeIntentConfirmationInterceptor.enqueueCompleteStep(isForceSuccess)
 
-            // TODO Wait for replacement
+            verify(eventReporter).onPaymentSuccess(
+                paymentSelection = eq(savedSelection),
+                currency = anyOrNull(),
+                deferredIntentConfirmationType = eq(deferredIntentConfirmationType),
+            )
         }
+    }
+
+    @Test
+    fun `Sends no deferred_intent_confirmation_type for non-deferred intent confirmation`() = runTest {
+        val flowController = createFlowController().apply {
+            configureExpectingSuccess()
+        }
+
+        val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        val savedSelection = PaymentSelection.Saved(paymentMethod)
+
+        flowController.onPaymentOptionResult(
+            PaymentOptionResult.Succeeded(savedSelection)
+        )
+        flowController.confirm()
+
+        val confirmParams = ConfirmPaymentIntentParams.createWithPaymentMethodId(
+            paymentMethodId = paymentMethod.id!!,
+            clientSecret = "pi_123_secret_456",
+        )
+
+        fakeIntentConfirmationInterceptor.enqueueConfirmStep(confirmParams)
+        flowController.onPaymentResult(PaymentResult.Completed)
+
+        verify(eventReporter).onPaymentSuccess(
+            paymentSelection = eq(savedSelection),
+            currency = anyOrNull(),
+            deferredIntentConfirmationType = isNull(),
+        )
+    }
+
+    @Test
+    fun `Sends correct deferred_intent_confirmation_type for client-side confirmation of deferred intent`() = runTest {
+        val flowController = createAndConfigureFlowControllerForDeferredIntent()
+
+        val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        val savedSelection = PaymentSelection.Saved(paymentMethod)
+
+        flowController.onPaymentOptionResult(
+            PaymentOptionResult.Succeeded(savedSelection)
+        )
+        flowController.confirm()
+
+        val confirmParams = ConfirmPaymentIntentParams.createWithPaymentMethodId(
+            paymentMethodId = paymentMethod.id!!,
+            clientSecret = "pi_123_secret_456",
+        )
+
+        fakeIntentConfirmationInterceptor.enqueueConfirmStep(
+            confirmParams = confirmParams,
+            isDeferred = true,
+        )
+        flowController.onPaymentResult(PaymentResult.Completed)
+
+        verify(eventReporter).onPaymentSuccess(
+            paymentSelection = eq(savedSelection),
+            currency = anyOrNull(),
+            deferredIntentConfirmationType = eq(DeferredIntentConfirmationType.Client),
+        )
+    }
+
+    @Test
+    fun `Sends correct deferred_intent_confirmation_type for server-side confirmation of deferred intent`() = runTest {
+        val flowController = createAndConfigureFlowControllerForDeferredIntent()
+
+        val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        val savedSelection = PaymentSelection.Saved(paymentMethod)
+
+        flowController.onPaymentOptionResult(
+            PaymentOptionResult.Succeeded(savedSelection)
+        )
+        flowController.confirm()
+
+        fakeIntentConfirmationInterceptor.enqueueNextActionStep("pi_123_secret_456")
+        flowController.onPaymentResult(PaymentResult.Completed)
+
+        verify(eventReporter).onPaymentSuccess(
+            paymentSelection = eq(savedSelection),
+            currency = anyOrNull(),
+            deferredIntentConfirmationType = eq(DeferredIntentConfirmationType.Server),
+        )
     }
 
     @OptIn(ExperimentalPaymentSheetDecouplingApi::class)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -1162,8 +1162,7 @@ internal class DefaultFlowControllerTest {
             val isForceSuccess = clientSecret == PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT
             fakeIntentConfirmationInterceptor.enqueueCompleteStep(isForceSuccess)
 
-            verify(eventReporter, verificationMode).onForceSuccess()
-            reset(eventReporter)
+            // TODO Wait for replacement
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeIntentConfirmationInterceptor.kt
@@ -12,8 +12,14 @@ internal class FakeIntentConfirmationInterceptor : IntentConfirmationInterceptor
 
     private val channel = Channel<IntentConfirmationInterceptor.NextStep>(capacity = 1)
 
-    fun enqueueConfirmStep(confirmParams: ConfirmStripeIntentParams) {
-        val nextStep = IntentConfirmationInterceptor.NextStep.Confirm(confirmParams)
+    fun enqueueConfirmStep(
+        confirmParams: ConfirmStripeIntentParams,
+        isDeferred: Boolean = false,
+    ) {
+        val nextStep = IntentConfirmationInterceptor.NextStep.Confirm(
+            confirmParams = confirmParams,
+            isDeferred = isDeferred,
+        )
         channel.trySend(nextStep)
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds `deferred_intent_confirmation_type` to the event for successful payments, allowing us to understand if an intent was confirmed on the client, server, or outside of Stripe.

(cc @yuki-stripe @porter-stripe)

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Decoupling GA.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
