### PR TITLE
Handle Link Redirects.

### DIFF
--- a/link/build.gradle
+++ b/link/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     testImplementation testLibs.androidx.core
     testImplementation testLibs.kotlin.coroutines
     testImplementation testLibs.turbine
+    testImplementation testLibs.espresso.intents
 
     androidTestImplementation testLibs.truth
     androidTestImplementation testLibs.androidx.junit

--- a/link/src/main/AndroidManifest.xml
+++ b/link/src/main/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <activity
+            android:name="com.stripe.android.link.LinkForegroundActivity"
+            android:autoRemoveFromRecents="true"
+            android:configChanges="orientation|keyboard|keyboardHidden|screenLayout|screenSize|smallestScreenSize"
+            android:launchMode="singleTop"
+            android:theme="@style/StripeTransparentTheme" />
+
+        <activity
+            android:name="com.stripe.android.link.LinkRedirectHandlerActivity"
+            android:theme="@style/StripeTransparentTheme"
+            android:autoRemoveFromRecents="true"
+            android:launchMode="singleInstance"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="stripesdk"
+                    android:host="link_return_url"
+                    android:path="/${applicationId}" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/link/src/main/java/com/stripe/android/link/LinkActivityContract.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkActivityContract.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.annotation.RestrictTo
-import androidx.browser.customtabs.CustomTabsIntent
-import androidx.core.net.toUri
 import androidx.core.os.bundleOf
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.link.LinkActivityResult.Canceled.Reason.BackPressed
@@ -26,10 +24,7 @@ class LinkActivityContract :
             publishableKey = paymentConfiguration.publishableKey,
             stripeAccount = paymentConfiguration.stripeAccountId,
         )
-        return CustomTabsIntent.Builder()
-            .build()
-            .also { it.intent.data = payload.toUrl().toUri() }
-            .intent
+        return LinkForegroundActivity.createIntent(context, payload.toUrl())
     }
 
     override fun parseResult(resultCode: Int, intent: Intent?): LinkActivityResult {

--- a/link/src/main/java/com/stripe/android/link/LinkForegroundActivity.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkForegroundActivity.kt
@@ -1,0 +1,95 @@
+package com.stripe.android.link
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.core.net.toUri
+
+internal class LinkForegroundActivity : AppCompatActivity() {
+    companion object {
+        const val ACTION_REDIRECT = "LinkForegroundActivity.redirect"
+        const val EXTRA_POPUP_URL = "LinkPopupUrl"
+        const val EXTRA_FAILURE = "LinkFailure"
+        const val RESULT_PAYMENT_METHOD = 49871
+        const val RESULT_FAILURE = 91367
+
+        private const val SAVED_STATE_HAS_LAUNCHED_POPUP = "LinkHasLaunchedPopup"
+
+        fun createIntent(context: Context, popupUrl: String): Intent {
+            return Intent(context, LinkForegroundActivity::class.java)
+                .putExtra(EXTRA_POPUP_URL, popupUrl)
+        }
+
+        fun redirectIntent(context: Context, uri: Uri?): Intent {
+            val intent = Intent(context, LinkForegroundActivity::class.java)
+            intent.action = ACTION_REDIRECT
+            intent.data = uri
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+            return intent
+        }
+    }
+
+    private var hasLaunchedPopup: Boolean = false
+
+    public override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        hasLaunchedPopup = savedInstanceState?.getBoolean(SAVED_STATE_HAS_LAUNCHED_POPUP) ?: false
+
+        handleRedirectIfAvailable(intent)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putBoolean(SAVED_STATE_HAS_LAUNCHED_POPUP, hasLaunchedPopup)
+    }
+
+    public override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        handleRedirectIfAvailable(intent)
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        if (!isFinishing) {
+            if (hasLaunchedPopup) {
+                setResult(Activity.RESULT_CANCELED)
+                finish()
+            } else {
+                launchPopup()
+            }
+        }
+    }
+
+    private fun handleRedirectIfAvailable(intent: Intent) {
+        if (intent.action == ACTION_REDIRECT) {
+            setResult(RESULT_PAYMENT_METHOD, intent)
+            finish()
+        }
+    }
+
+    private fun launchPopup() {
+        hasLaunchedPopup = true
+
+        val popupUri = intent.extras?.getString(EXTRA_POPUP_URL)?.toUri()
+        if (popupUri == null) {
+            setResult(Activity.RESULT_CANCELED)
+            finish()
+            return
+        }
+        try {
+            CustomTabsIntent.Builder()
+                .build()
+                .launchUrl(this, popupUri)
+        } catch (e: ActivityNotFoundException) {
+            setResult(RESULT_FAILURE, Intent().putExtra(EXTRA_FAILURE, e))
+            finish()
+        }
+    }
+}

--- a/link/src/main/java/com/stripe/android/link/LinkRedirectHandlerActivity.kt
+++ b/link/src/main/java/com/stripe/android/link/LinkRedirectHandlerActivity.kt
@@ -1,0 +1,12 @@
+package com.stripe.android.link
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+
+internal class LinkRedirectHandlerActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        startActivity(LinkForegroundActivity.redirectIntent(this, intent.data))
+        finish()
+    }
+}

--- a/link/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.link
 
-import android.content.Intent
 import android.os.Bundle
 import android.os.Parcel
 import androidx.test.core.app.ApplicationProvider
@@ -80,8 +79,8 @@ class LinkActivityContractTest {
         )
         val contract = LinkActivityContract()
         val intent = contract.createIntent(ApplicationProvider.getApplicationContext(), args)
-        assertThat(intent.action).isEqualTo(Intent.ACTION_VIEW)
-        assertThat(intent.data.toString()).isEqualTo(
+        assertThat(intent.component?.className).isEqualTo(LinkForegroundActivity::class.java.name)
+        assertThat(intent.extras?.getString(LinkForegroundActivity.EXTRA_POPUP_URL)).isEqualTo(
             "https://checkout.link.com/link-popup.html#" +
                 "eyJwdWJsaXNoYWJsZUtleSI6InBrX3Rlc3RfYWJjZGVmZyIsInN0cmlwZUFjY291bnQiOm51bGws" +
                 "Im1lcmNoYW50SW5mbyI6eyJidXNpbmVzc05hbWUiOiJNZXJjaGFudCwgSW5jIiwiY291bnRyeSI6" +

--- a/link/src/test/java/com/stripe/android/link/LinkForegroundActivityTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkForegroundActivityTest.kt
@@ -1,0 +1,184 @@
+package com.stripe.android.link
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import androidx.core.net.toUri
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.intent.Intents.assertNoUnverifiedIntents
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.Intents.intending
+import androidx.test.espresso.intent.Intents.times
+import androidx.test.espresso.intent.matcher.IntentMatchers.anyIntent
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasData
+import androidx.test.espresso.intent.rule.IntentsRule
+import com.google.common.truth.Truth.assertThat
+import org.hamcrest.Matchers.allOf
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.shadows.ShadowActivity
+
+@RunWith(RobolectricTestRunner::class)
+internal class LinkForegroundActivityTest {
+    private val popupUrl = "https://checkout.link.com/from_unit_tests"
+    private val redirectUrl = "stripesdk://link_return_url/example.app?payload=foo".toUri()
+
+    @get:Rule
+    val intentsTestRule = IntentsRule()
+
+    @Test
+    fun `finishes with a cancelled result when no popupUrl is passed`() {
+        val intent =
+            Intent(ApplicationProvider.getApplicationContext(), LinkForegroundActivity::class.java)
+
+        val scenario = ActivityScenario.launchActivityForResult<LinkForegroundActivity>(intent)
+        assertThat(scenario.result.resultCode)
+            .isEqualTo(Activity.RESULT_CANCELED)
+        assertNoUnverifiedIntents()
+    }
+
+    @Test
+    fun `finishes with a failure result when activity fails to launch`() {
+        val intent = LinkForegroundActivity.createIntent(
+            context = ApplicationProvider.getApplicationContext(),
+            popupUrl = popupUrl,
+        )
+
+        intending(anyIntent()).respondWithFunction {
+            throw ActivityNotFoundException("From Tests")
+        }
+
+        val scenario = ActivityScenario.launchActivityForResult<LinkForegroundActivity>(intent)
+        assertThat(scenario.result.resultCode)
+            .isEqualTo(LinkForegroundActivity.RESULT_FAILURE)
+    }
+
+    @Test
+    fun `launches chrome custom tabs with url onResume`() {
+        val intent = LinkForegroundActivity.createIntent(
+            context = ApplicationProvider.getApplicationContext(),
+            popupUrl = popupUrl,
+        )
+
+        val scenario = ActivityScenario.launch<LinkForegroundActivity>(intent)
+        intended(
+            allOf(
+                hasAction(Intent.ACTION_VIEW),
+                hasData(popupUrl),
+            )
+        )
+        assertThat(scenario.state).isEquivalentAccordingToCompareTo(Lifecycle.State.RESUMED)
+    }
+
+    @Test
+    fun `closing the browser emits a cancelled result`() {
+        val intent = LinkForegroundActivity.createIntent(
+            context = ApplicationProvider.getApplicationContext(),
+            popupUrl = popupUrl,
+        )
+
+        val scenario = ActivityScenario.launchActivityForResult<LinkForegroundActivity>(intent)
+        intended(
+            allOf(
+                hasAction(Intent.ACTION_VIEW),
+                hasData(popupUrl),
+            )
+        )
+        assertThat(scenario.state).isEquivalentAccordingToCompareTo(Lifecycle.State.RESUMED)
+
+        scenario.moveToState(Lifecycle.State.STARTED).moveToState(Lifecycle.State.RESUMED)
+
+        assertThat(scenario.result.resultCode)
+            .isEqualTo(Activity.RESULT_CANCELED)
+    }
+
+    @Test
+    fun `launches url only once when activity is recreated`() {
+        val intent = LinkForegroundActivity.createIntent(
+            context = ApplicationProvider.getApplicationContext(),
+            popupUrl = popupUrl,
+        )
+
+        val scenario = ActivityScenario.launch<LinkForegroundActivity>(intent)
+        intended(
+            allOf(
+                hasAction(Intent.ACTION_VIEW),
+                hasData(popupUrl),
+            ),
+            times(1)
+        )
+        scenario.recreate()
+        assertNoUnverifiedIntents()
+    }
+
+    @Test
+    fun `launches url only once when activity is resumed after paused`() {
+        val intent = LinkForegroundActivity.createIntent(
+            context = ApplicationProvider.getApplicationContext(),
+            popupUrl = popupUrl,
+        )
+
+        val scenario = ActivityScenario.launch<LinkForegroundActivity>(intent)
+        intended(
+            allOf(
+                hasAction(Intent.ACTION_VIEW),
+                hasData(popupUrl),
+            ),
+            times(1)
+        )
+        scenario.moveToState(Lifecycle.State.STARTED).moveToState(Lifecycle.State.RESUMED)
+        assertNoUnverifiedIntents()
+    }
+
+    @Test
+    fun `handles onNewIntent having intent with redirect action`() {
+        val intent = LinkForegroundActivity.createIntent(
+            context = ApplicationProvider.getApplicationContext(),
+            popupUrl = popupUrl,
+        )
+
+        val scenario = ActivityScenario.launchActivityForResult<LinkForegroundActivity>(intent)
+        scenario.onActivity { activity ->
+            activity.onNewIntent(
+                LinkForegroundActivity.redirectIntent(
+                    activity,
+                    redirectUrl,
+                )
+            )
+        }
+        assertThat(scenario.result.resultCode)
+            .isEqualTo(LinkForegroundActivity.RESULT_PAYMENT_METHOD)
+        assertThat(scenario.result.resultData.data)
+            .isEqualTo(redirectUrl)
+    }
+
+    @Test
+    fun `handles onCreate having intent with redirect action`() {
+        val intent = LinkForegroundActivity.createIntent(
+            context = ApplicationProvider.getApplicationContext(),
+            popupUrl = popupUrl,
+        )
+
+        val controller = Robolectric.buildActivity(LinkForegroundActivity::class.java, intent)
+        controller.create().resume()
+        controller.newIntent(
+            LinkForegroundActivity.redirectIntent(
+                controller.get(),
+                redirectUrl,
+            )
+        )
+        assertThat(controller.get().isFinishing).isTrue()
+        val shadowActivity = Shadows.shadowOf(controller.get()) as ShadowActivity
+        assertThat(shadowActivity.resultCode)
+            .isEqualTo(LinkForegroundActivity.RESULT_PAYMENT_METHOD)
+        assertThat(shadowActivity.resultIntent.data)
+            .isEqualTo(redirectUrl)
+    }
+}

--- a/link/src/test/java/com/stripe/android/link/LinkRedirectHandlerActivityTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkRedirectHandlerActivityTest.kt
@@ -1,0 +1,45 @@
+package com.stripe.android.link
+
+import android.content.Intent
+import android.net.Uri
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasData
+import androidx.test.espresso.intent.rule.IntentsRule
+import com.google.common.truth.Truth.assertThat
+import org.hamcrest.core.AllOf.allOf
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class LinkRedirectHandlerActivityTest {
+    @get:Rule
+    val intentsTestRule = IntentsRule()
+
+    @Test
+    fun `launches LinkForegroundActivity onCreate with url information`() {
+        val uri = Uri.parse("stripesdk://link_return_url/example.app?payload=foo")
+        val intent = Intent(
+            ApplicationProvider.getApplicationContext(),
+            LinkRedirectHandlerActivity::class.java,
+        ).also { intent ->
+            intent.data = uri
+        }
+
+        val scenario = ActivityScenario.launch<LinkRedirectHandlerActivity>(intent)
+        intended(
+            allOf(
+                hasComponent(LinkForegroundActivity::class.java.name),
+                hasAction(LinkForegroundActivity.ACTION_REDIRECT),
+                hasData(uri),
+            )
+        )
+        assertThat(scenario.state).isAtLeast(Lifecycle.State.DESTROYED)
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This is only an iterative step in completing the redirect. This phase only closes the Link popup, as well as allows sending the result back to the SDK. We don't actually consume the result, or complete the payment.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Link redesign.
