### PR TITLE
Fix serialization of defaults in Link PopupPayload.

### DIFF
--- a/link/src/main/java/com/stripe/android/link/serialization/PopupPayload.kt
+++ b/link/src/main/java/com/stripe/android/link/serialization/PopupPayload.kt
@@ -68,12 +68,14 @@ internal data class PopupPayload(
     )
 
     fun toUrl(): String {
-        val json = Json.encodeToString(serializer(), this)
+        val json = PopupPayloadJson.encodeToString(serializer(), this)
         return baseUrl + Base64.encodeToString(json.encodeToByteArray(), Base64.NO_WRAP)
     }
 
     companion object {
         private const val baseUrl: String = "https://checkout.link.com/link-popup.html#"
+
+        val PopupPayloadJson = Json { encodeDefaults = true }
 
         fun create(
             configuration: LinkConfiguration,

--- a/link/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
+++ b/link/src/test/java/com/stripe/android/link/LinkActivityContractTest.kt
@@ -87,7 +87,8 @@ class LinkActivityContractTest {
                 "IlVTIn0sImN1c3RvbWVySW5mbyI6eyJlbWFpbCI6ImN1c3RvbWVyQGVtYWlsLmNvbSIsImNvdW50" +
                 "cnkiOiJVUyJ9LCJwYXltZW50SW5mbyI6eyJjdXJyZW5jeSI6InVzZCIsImFtb3VudCI6MTA5OX0s" +
                 "InJldHVyblVybCI6InN0cmlwZXNkazovL2xpbmtfcmV0dXJuX3VybC9jb20uc3RyaXBlLmFuZHJv" +
-                "aWQubGluay50ZXN0IiwibG9jYWxlIjoiVVMifQ=="
+                "aWQubGluay50ZXN0IiwibG9jYWxlIjoiVVMiLCJwYXRoIjoibW9iaWxlX3BheSIsImludGVncmF0" +
+                "aW9uVHlwZSI6Im1vYmlsZSJ9"
         )
     }
 }

--- a/link/src/test/java/com/stripe/android/link/serialization/PopupPayloadTest.kt
+++ b/link/src/test/java/com/stripe/android/link/serialization/PopupPayloadTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.link.serialization
 
 import com.google.common.truth.Truth.assertThat
-import kotlinx.serialization.json.Json
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -11,13 +10,16 @@ import org.robolectric.RobolectricTestRunner
 internal class PopupPayloadTest {
     @Test
     fun testJsonSerialization() {
-        val json = Json.encodeToString(PopupPayload.serializer(), createPayload())
-        assertThat(json).isEqualTo("""{"publishableKey":"pk_test_abc","stripeAccount":"123","merchantInfo":{"businessName":"Jay's Taco Stand","country":"US"},"customerInfo":{"email":"jaystacostandfake@gmail.com","country":"US"},"paymentInfo":{"currency":"USD","amount":5555},"returnUrl":"stripesdk://link_return_url","locale":"US"}""")
+        val json = PopupPayload.PopupPayloadJson.encodeToString(
+            serializer = PopupPayload.serializer(),
+            value = createPayload(),
+        )
+        assertThat(json).isEqualTo("""{"publishableKey":"pk_test_abc","stripeAccount":"123","merchantInfo":{"businessName":"Jay's Taco Stand","country":"US"},"customerInfo":{"email":"jaystacostandfake@gmail.com","country":"US"},"paymentInfo":{"currency":"USD","amount":5555},"returnUrl":"stripesdk://link_return_url","locale":"US","path":"mobile_pay","integrationType":"mobile"}""")
     }
 
     @Test
     fun testToUrl() {
-        assertThat(createPayload().toUrl()).isEqualTo("https://checkout.link.com/link-popup.html#eyJwdWJsaXNoYWJsZUtleSI6InBrX3Rlc3RfYWJjIiwic3RyaXBlQWNjb3VudCI6IjEyMyIsIm1lcmNoYW50SW5mbyI6eyJidXNpbmVzc05hbWUiOiJKYXkncyBUYWNvIFN0YW5kIiwiY291bnRyeSI6IlVTIn0sImN1c3RvbWVySW5mbyI6eyJlbWFpbCI6ImpheXN0YWNvc3RhbmRmYWtlQGdtYWlsLmNvbSIsImNvdW50cnkiOiJVUyJ9LCJwYXltZW50SW5mbyI6eyJjdXJyZW5jeSI6IlVTRCIsImFtb3VudCI6NTU1NX0sInJldHVyblVybCI6InN0cmlwZXNkazovL2xpbmtfcmV0dXJuX3VybCIsImxvY2FsZSI6IlVTIn0=")
+        assertThat(createPayload().toUrl()).isEqualTo("https://checkout.link.com/link-popup.html#eyJwdWJsaXNoYWJsZUtleSI6InBrX3Rlc3RfYWJjIiwic3RyaXBlQWNjb3VudCI6IjEyMyIsIm1lcmNoYW50SW5mbyI6eyJidXNpbmVzc05hbWUiOiJKYXkncyBUYWNvIFN0YW5kIiwiY291bnRyeSI6IlVTIn0sImN1c3RvbWVySW5mbyI6eyJlbWFpbCI6ImpheXN0YWNvc3RhbmRmYWtlQGdtYWlsLmNvbSIsImNvdW50cnkiOiJVUyJ9LCJwYXltZW50SW5mbyI6eyJjdXJyZW5jeSI6IlVTRCIsImFtb3VudCI6NTU1NX0sInJldHVyblVybCI6InN0cmlwZXNkazovL2xpbmtfcmV0dXJuX3VybCIsImxvY2FsZSI6IlVTIiwicGF0aCI6Im1vYmlsZV9wYXkiLCJpbnRlZ3JhdGlvblR5cGUiOiJtb2JpbGUifQ==")
     }
 
     private fun createPayload(): PopupPayload = PopupPayload(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
I didn't have a way to test this end to end, and I missed this wasn't sending the defaults for the hardcoded JSON items.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Link mobile redesign.
