### PR TITLE
Add `rememberCustomerSheet` method

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/CustomerSheetActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/CustomerSheetActivity.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
+import com.stripe.android.customersheet.rememberCustomerSheet
 import com.stripe.android.paymentsheet.example.R
 import com.stripe.android.paymentsheet.example.samples.ui.shared.PaymentSheetExampleTheme
 
@@ -37,20 +38,20 @@ internal class CustomerSheetActivity : AppCompatActivity() {
 
         supportActionBar?.title = getString(R.string.customer_toolbar_title)
 
-        val customerSheet = CustomerSheet.create(
-            activity = this,
-            configuration = CustomerSheet.Configuration.Builder()
-                .googlePayEnabled(true)
-                .build(),
-            customerAdapter = viewModel.customerAdapter,
-            callback = {
-                Toast.makeText(this, "Got result $it", Toast.LENGTH_LONG).show()
-            }
-        )
-
         setContent {
             PaymentSheetExampleTheme {
+                val customerSheet = rememberCustomerSheet(
+                    customerAdapter = viewModel.customerAdapter,
+                    configuration = CustomerSheet.Configuration.Builder()
+                        .googlePayEnabled(true)
+                        .build(),
+                    callback = {
+                        Toast.makeText(this, "Got result $it", Toast.LENGTH_LONG).show()
+                    },
+                )
+
                 val viewState by viewModel.state.collectAsState()
+
                 Column(
                     modifier = Modifier
                         .fillMaxSize()

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
@@ -7,11 +7,11 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.model.SavedSelection
 
 /**
- * [CustomerAdapter] A bridge to your backend to fetch Customer-related information. Typically,
+ * A bridge to your backend to fetch customer-related information. Typically,
  * you will not need to implement this interface yourself. You should instead use
- * [CustomerAdaper.create], which manages retrieving and updating a Stripe customer for you.
+ * [CustomerAdapter.create], which manages retrieving and updating a Stripe customer for you.
  *
- * The methods in this interface should act on a Stripe [Customer] object.
+ * The methods in this interface should act on a Stripe `Customer` object.
  *
  * Implement this interface if you would prefer retrieving and updating your Stripe customer object
  * via your own backend instead of using the default implementation.

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetCompose.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetCompose.kt
@@ -1,0 +1,48 @@
+@file:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+
+package com.stripe.android.customersheet
+
+import androidx.activity.compose.LocalActivityResultRegistryOwner
+import androidx.annotation.RestrictTo
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+
+/**
+ * Creates a [CustomerSheet] that is remembered across compositions.
+ *
+ * This *must* be called unconditionally, as part of the initialization path.
+ *
+ * @param configuration An optional [CustomerSheet.Configuration]
+ * @param customerAdapter The [CustomerAdapter] to fetch customer-related information
+ * @param callback Called with the result of the operation after [CustomerSheet] is dismissed
+ */
+@ExperimentalCustomerSheetApi
+@Composable
+fun rememberCustomerSheet(
+    configuration: CustomerSheet.Configuration = CustomerSheet.Configuration(),
+    customerAdapter: CustomerAdapter,
+    callback: CustomerSheetResultCallback,
+): CustomerSheet {
+    val viewModelStoreOwner = requireNotNull(LocalViewModelStoreOwner.current) {
+        "CustomerSheet must be created with access to a ViewModelStoreOwner"
+    }
+
+    val activityResultRegistryOwner = requireNotNull(LocalActivityResultRegistryOwner.current) {
+        "CustomerSheet must be created with access to an ActivityResultRegistryOwner"
+    }
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    return remember {
+        CustomerSheet.getInstance(
+            lifecycleOwner = lifecycleOwner,
+            viewModelStoreOwner = viewModelStoreOwner,
+            activityResultRegistryOwner = activityResultRegistryOwner,
+            configuration = configuration,
+            customerAdapter = customerAdapter,
+            callback = callback,
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetComponent.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.customersheet.injection
 
-import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultRegistryOwner
+import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
 import dagger.BindsInstance
@@ -14,8 +15,16 @@ internal interface CustomerSheetComponent {
 
     @Subcomponent.Builder
     interface Builder {
+
         @BindsInstance
-        fun activityResultCaller(activityResultCaller: ActivityResultCaller): Builder
+        fun lifecycleOwner(
+            lifecycleOwner: LifecycleOwner,
+        ): Builder
+
+        @BindsInstance
+        fun activityResultRegistryOwner(
+            activityResultRegistryOwner: ActivityResultRegistryOwner,
+        ): Builder
 
         fun build(): CustomerSheetComponent
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds a `rememberCustomerSheet` method for the new CustomerSheet surface. It follows the pattern in https://github.com/stripe/stripe-android/pull/6583.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Better integration in Compose.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
