### PR TITLE
Add edge-to-edge rendering for Address Element

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -94,6 +94,7 @@ ext.libs = [
                 flowLayout         : "com.google.accompanist:accompanist-flowlayout:${versions.accompanist}",
                 navigationAnimation: "com.google.accompanist:accompanist-navigation-animation:${versions.accompanist}",
                 navigationMaterial : "com.google.accompanist:accompanist-navigation-material:${versions.accompanist}",
+                systemUiController : "com.google.accompanist:accompanist-systemuicontroller:${versions.accompanist}",
                 themeAdapter       : "com.google.accompanist:accompanist-themeadapter-material:${versions.accompanist}",
                 webView            : "com.google.accompanist:accompanist-webview:${versions.accompanist}",
         ],

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -1,3 +1,10 @@
+public final class com/stripe/android/common/ui/ComposableSingletons$BottomSheetKt {
+	public static final field INSTANCE Lcom/stripe/android/common/ui/ComposableSingletons$BottomSheetKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$paymentsheet_release ()Lkotlin/jvm/functions/Function2;
+}
+
 public final class com/stripe/android/customersheet/InternalCustomerSheetResult$Canceled$Creator : android/os/Parcelable$Creator {
 	public fun <init> ()V
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/customersheet/InternalCustomerSheetResult$Canceled;
@@ -1094,10 +1101,8 @@ public abstract interface class com/stripe/android/paymentsheet/addresselement/A
 public final class com/stripe/android/paymentsheet/addresselement/ComposableSingletons$AddressElementActivityKt {
 	public static final field INSTANCE Lcom/stripe/android/paymentsheet/addresselement/ComposableSingletons$AddressElementActivityKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function4;
-	public static field lambda-2 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
 	public final fun getLambda-1$paymentsheet_release ()Lkotlin/jvm/functions/Function4;
-	public final fun getLambda-2$paymentsheet_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class com/stripe/android/paymentsheet/databinding/StripeActivityPaymentOptionsBinding : androidx/viewbinding/ViewBinding {

--- a/paymentsheet/build.gradle
+++ b/paymentsheet/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation libs.compose.navigation
     implementation libs.accompanist.navigationAnimation
     implementation libs.accompanist.navigationMaterial
+    implementation libs.accompanist.systemUiController
 
     // Other
     implementation libs.playServicesWallet

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -40,6 +40,7 @@
     <ID>MagicNumber:PaymentOptionUi.kt$18</ID>
     <ID>MagicNumber:PrimaryButton.kt$PrimaryButton$0.5f</ID>
     <ID>MagicNumber:USBankAccountForm.kt$0.5f</ID>
+    <ID>MatchingDeclarationName:BottomSheet.kt$BottomSheetState</ID>
     <ID>MaxLineLength:BillingAddressViewTest.kt$BillingAddressViewTest$fun</ID>
     <ID>MaxLineLength:DefaultFlowControllerTest.kt$DefaultFlowControllerTest$fun</ID>
     <ID>MaxLineLength:DefaultPaymentSheetLoaderTest.kt$DefaultPaymentSheetLoaderTest$fun</ID>

--- a/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheet.kt
@@ -18,7 +18,10 @@ import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -89,9 +92,14 @@ internal fun BottomSheet(
         label = "StatusBarColorAlpha",
     )
 
+    var isFirstLaunch by rememberSaveable { mutableStateOf(true) }
+
     LaunchedEffect(Unit) {
         state.show()
-        onShow()
+        if (isFirstLaunch) {
+            isFirstLaunch = false
+            onShow()
+        }
 
         state.awaitDismissal()
         onDismissed()

--- a/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheet.kt
@@ -16,7 +16,6 @@ import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.ModalBottomSheetValue.Expanded
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -98,22 +97,18 @@ internal fun BottomSheet(
         onDismissed()
     }
 
-    DisposableEffect(systemUiController, statusBarColorAlpha) {
+    LaunchedEffect(systemUiController, statusBarColorAlpha) {
         systemUiController.setStatusBarColor(
             color = scrimColor.copy(statusBarColorAlpha),
             darkIcons = false,
         )
-
-        onDispose {}
     }
 
-    DisposableEffect(systemUiController) {
+    LaunchedEffect(systemUiController) {
         systemUiController.setNavigationBarColor(
             color = Color.Transparent,
             darkIcons = false,
         )
-
-        onDispose {}
     }
 
     ModalBottomSheetLayout(

--- a/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheet.kt
@@ -61,13 +61,22 @@ internal fun rememberBottomSheetState(
     }
 }
 
+/**
+ * Renders the provided [sheetContent] in a modal bottom sheet.
+ *
+ * @param state The [BottomSheetState] that controls the visibility of the bottom sheet.
+ * @param onShow Called when the bottom sheet is displayed for the first time. This might be used to
+ * navigate to a specific screen.
+ * @param onDismissed Called when the user dismisses the bottom sheet by swiping down. You should
+ * inform your view model about this change.
+ */
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 internal fun BottomSheet(
     state: BottomSheetState,
     modifier: Modifier = Modifier,
+    onDismissed: () -> Unit,
     onShow: () -> Unit = {},
-    onDismissed: () -> Unit = {},
     sheetContent: @Composable ColumnScope.() -> Unit,
 ) {
     val systemUiController = rememberSystemUiController()

--- a/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/ui/BottomSheet.kt
@@ -1,0 +1,119 @@
+package com.stripe.android.common.ui
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ModalBottomSheetDefaults
+import androidx.compose.material.ModalBottomSheetLayout
+import androidx.compose.material.ModalBottomSheetState
+import androidx.compose.material.ModalBottomSheetValue
+import androidx.compose.material.ModalBottomSheetValue.Expanded
+import androidx.compose.material.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import kotlinx.coroutines.flow.first
+
+@OptIn(ExperimentalMaterialApi::class)
+internal class BottomSheetState(
+    val modalBottomSheetState: ModalBottomSheetState,
+) {
+
+    suspend fun show() {
+        modalBottomSheetState.show()
+    }
+
+    suspend fun awaitDismissal() {
+        snapshotFlow { modalBottomSheetState.isVisible }.first { isVisible -> !isVisible }
+    }
+
+    suspend fun hide() {
+        modalBottomSheetState.hide()
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+internal fun rememberBottomSheetState(
+    confirmValueChange: (ModalBottomSheetValue) -> Boolean = { true },
+): BottomSheetState {
+    val modalBottomSheetState = rememberModalBottomSheetState(
+        initialValue = ModalBottomSheetValue.Hidden,
+        confirmValueChange = confirmValueChange,
+        skipHalfExpanded = true,
+        animationSpec = tween(),
+    )
+
+    return remember {
+        BottomSheetState(modalBottomSheetState)
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+internal fun BottomSheet(
+    state: BottomSheetState,
+    modifier: Modifier = Modifier,
+    onShow: () -> Unit = {},
+    onDismissed: () -> Unit = {},
+    sheetContent: @Composable ColumnScope.() -> Unit,
+) {
+    val systemUiController = rememberSystemUiController()
+    val scrimColor = ModalBottomSheetDefaults.scrimColor
+
+    val isExpanded = state.modalBottomSheetState.targetValue == Expanded
+
+    val statusBarColorAlpha by animateFloatAsState(
+        targetValue = if (isExpanded) scrimColor.alpha else 0f,
+        animationSpec = tween(),
+        label = "StatusBarColorAlpha",
+    )
+
+    LaunchedEffect(Unit) {
+        state.show()
+        onShow()
+
+        state.awaitDismissal()
+        onDismissed()
+    }
+
+    DisposableEffect(systemUiController, statusBarColorAlpha) {
+        systemUiController.setStatusBarColor(
+            color = scrimColor.copy(statusBarColorAlpha),
+            darkIcons = false,
+        )
+
+        onDispose {}
+    }
+
+    DisposableEffect(systemUiController) {
+        systemUiController.setNavigationBarColor(
+            color = Color.Transparent,
+            darkIcons = false,
+        )
+
+        onDispose {}
+    }
+
+    ModalBottomSheetLayout(
+        modifier = modifier.statusBarsPadding(),
+        sheetState = state.modalBottomSheetState,
+        sheetContent = {
+            sheetContent()
+            Spacer(modifier = Modifier.windowInsetsBottomHeight(WindowInsets.systemBars))
+        },
+        content = {},
+    )
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivityContract.kt
@@ -1,10 +1,8 @@
 package com.stripe.android.paymentsheet.addresselement
 
-import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
-import androidx.annotation.ColorInt
 import androidx.core.os.bundleOf
 import com.stripe.android.core.injection.DUMMY_INJECTOR_KEY
 import com.stripe.android.core.injection.InjectorKey
@@ -15,9 +13,7 @@ internal class AddressElementActivityContract :
     ActivityResultContract<AddressElementActivityContract.Args, AddressLauncherResult>() {
 
     override fun createIntent(context: Context, input: Args): Intent {
-        val statusBarColor = (context as? Activity)?.window?.statusBarColor
-        return Intent(context, AddressElementActivity::class.java)
-            .putExtra(EXTRA_ARGS, input.copy(statusBarColor = statusBarColor))
+        return Intent(context, AddressElementActivity::class.java).putExtra(EXTRA_ARGS, input)
     }
 
     @Suppress("DEPRECATION")
@@ -38,7 +34,6 @@ internal class AddressElementActivityContract :
         internal val publishableKey: String,
         internal val config: AddressLauncher.Configuration?,
         @InjectorKey internal val injectorKey: String = DUMMY_INJECTOR_KEY,
-        @ColorInt internal val statusBarColor: Int? = null
     ) : ActivityStarter.Args {
 
         internal companion object {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request makes Address Element render edge-to-edge. It does so with a new `BottomSheet` composable, which will also be used for `CustomerSheet` (see [here](https://github.com/stripe/stripe-android/pull/6887)) and eventually also for `PaymentSheet`.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

UX polish.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before | After |
| ------------- | ------------- |
| ![Screenshot_1686950258](https://github.com/stripe/stripe-android/assets/110940675/49b3f5bb-94a9-4334-b564-f0cf9540cf3f) | ![Screenshot_1686949940](https://github.com/stripe/stripe-android/assets/110940675/061f7072-ab34-47bd-9c2b-d43595a4921b) |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
