### PR TITLE
Add edge-to-edge rendering for Payment Sheet

### DIFF
--- a/payments-core/res/values/themes.xml
+++ b/payments-core/res/values/themes.xml
@@ -50,5 +50,7 @@
         <item name="android:windowAnimationStyle">@null</item>
         <item name="colorSurface">@color/stripe_paymentsheet_background</item>
         <item name="actionMenuTextColor">@color/stripe_paymentsheet_toolbar_items_color</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
 </resources>

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
@@ -49,10 +49,6 @@ internal class PaymentLauncherConfirmationActivity : AppCompatActivity() {
             // Prevent back presses while confirming payment
         }
 
-        args.statusBarColor?.let {
-            window.statusBarColor = it
-        }
-
         viewModel.paymentLauncherResult.observe(this, ::finishWithResult)
         viewModel.register(
             activityResultCaller = this,

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivityTest.kt
@@ -29,8 +29,7 @@ class PaymentLauncherConfirmationActivityTest {
     private val testFactory = TestUtils.viewModelFactoryFor(viewModel)
 
     @Test
-    fun `statusBarColor is set on window`() {
-        val color = Color.CYAN
+    fun `statusBarColor is set to transparent on window`() {
         mockViewModelActivityScenario().launch(
             Intent(
                 ApplicationProvider.getApplicationContext(),
@@ -43,12 +42,12 @@ class PaymentLauncherConfirmationActivityTest {
                     false,
                     PRODUCT_USAGE,
                     mock(),
-                    color
+                    Color.CYAN
                 ).toBundle()
             )
         ).use {
-            it.onActivity {
-                assertThat(it.window.statusBarColor).isEqualTo(color)
+            it.onActivity { activity ->
+                assertThat(activity.window.statusBarColor).isEqualTo(Color.TRANSPARENT)
             }
         }
     }

--- a/paymentsheet/detekt-baseline.xml
+++ b/paymentsheet/detekt-baseline.xml
@@ -30,6 +30,7 @@
     <ID>LongMethod:USBankAccountForm.kt$@Composable private fun AccountDetailsForm( formArgs: FormArguments, isProcessing: Boolean, bankName: String?, last4: String?, saveForFutureUseElement: SaveForFutureUseElement, onRemoveAccount: () -> Unit, )</ID>
     <ID>LongMethod:USBankAccountForm.kt$@OptIn(ExperimentalPaymentSheetDecouplingApi::class) @Composable internal fun USBankAccountForm( formArgs: FormArguments, sheetViewModel: BaseSheetViewModel, isProcessing: Boolean, modifier: Modifier = Modifier, )</ID>
     <ID>MagicNumber:AutocompleteScreen.kt$0.07f</ID>
+    <ID>MagicNumber:BaseSheetActivity.kt$BaseSheetActivity$30</ID>
     <ID>MagicNumber:GooglePayButton.kt$GooglePayButton$0.5f</ID>
     <ID>MagicNumber:PaymentMethodsUI.kt$.3f</ID>
     <ID>MagicNumber:PaymentMethodsUI.kt$.4f</ID>

--- a/paymentsheet/res/values/themes.xml
+++ b/paymentsheet/res/values/themes.xml
@@ -26,7 +26,10 @@
         <item name="actionMenuTextColor">@color/stripe_paymentsheet_toolbar_items_color</item>
     </style>
 
-    <style name="StripePaymentSheetDefaultTheme" parent="StripePaymentSheetBaseTheme" />
+    <style name="StripePaymentSheetDefaultTheme" parent="StripePaymentSheetBaseTheme">
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+    </style>
 
     <style name="StripePaymentSheetAddPaymentMethodTheme">
         <item name="colorOnSurface">@color/stripe_paymentsheet_form</item>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -44,9 +44,6 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionResult>()
             return
         }
 
-        starterArgs.statusBarColor?.let {
-            window.statusBarColor = it
-        }
         setContentView(viewBinding.root)
 
         viewModel.paymentOptionResult.launchAndCollectIn(this) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -60,10 +60,6 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
             )
         )
 
-        starterArgs?.statusBarColor?.let {
-            window.statusBarColor = it
-        }
-
         setContentView(viewBinding.root)
 
         viewBinding.content.setContent {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -22,7 +22,6 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat.Type
 import androidx.core.view.updateLayoutParams
 import androidx.core.view.updateMargins
-import androidx.core.view.updatePadding
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.stripe.android.paymentsheet.BottomSheetController
 import com.stripe.android.paymentsheet.LinkHandler
@@ -127,9 +126,6 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
                     top = initialState.top + insets.getInsets(Type.systemBars()).top,
                 )
             }
-
-            // Keyboard inset
-            view.updatePadding(bottom = initialState.bottom + insets.getInsets(Type.ime()).bottom)
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -18,10 +18,16 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat.Type
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updateMargins
+import androidx.core.view.updatePadding
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.stripe.android.paymentsheet.BottomSheetController
 import com.stripe.android.paymentsheet.LinkHandler
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.utils.doOnApplyWindowInsets
 import com.stripe.android.paymentsheet.utils.launchAndCollectIn
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.uicore.isSystemDarkTheme
@@ -62,6 +68,7 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
         }
 
         bottomSheet.layoutTransition.enableTransitionType(LayoutTransition.CHANGING)
+        renderEdgeToEdge()
 
         bottomSheetController.setup(bottomSheet)
 
@@ -104,6 +111,26 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
         // TODO(mlb): Consider if this needs to be an abstract function
         setActivityResult(result)
         bottomSheetController.hide()
+    }
+
+    private fun renderEdgeToEdge() {
+        if (Build.VERSION.SDK_INT < 30) {
+            return
+        }
+
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+
+        bottomSheet.doOnApplyWindowInsets { view, insets, initialState ->
+            // Status bar inset
+            view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                updateMargins(
+                    top = initialState.top + insets.getInsets(Type.systemBars()).top,
+                )
+            }
+
+            // Keyboard inset
+            view.updatePadding(bottom = initialState.bottom + insets.getInsets(Type.ime()).bottom)
+        }
     }
 
     private fun updateRootViewClickHandling(isProcessing: Boolean) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentOptionsScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentOptionsScreen.kt
@@ -1,12 +1,8 @@
 package com.stripe.android.paymentsheet.ui
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredHeight
-import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -22,6 +18,7 @@ import com.stripe.android.paymentsheet.PaymentOptionsViewModel
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.databinding.StripeFragmentPaymentOptionsPrimaryButtonBinding
 import com.stripe.android.paymentsheet.navigation.Content
+import com.stripe.android.paymentsheet.utils.PaymentSheetContentPadding
 import com.stripe.android.ui.core.elements.H4Text
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.text.Html
@@ -48,6 +45,7 @@ internal fun PaymentOptionsScreen(
     )
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun PaymentOptionsScreenContent(
     viewModel: PaymentOptionsViewModel,
@@ -60,7 +58,6 @@ internal fun PaymentOptionsScreenContent(
     val notesText by viewModel.notesText.collectAsState()
 
     val horizontalPadding = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_horizontal)
-    val bottomPadding = dimensionResource(R.dimen.stripe_paymentsheet_button_container_spacing_bottom)
 
     Column(modifier) {
         headerText?.let { text ->
@@ -99,7 +96,6 @@ internal fun PaymentOptionsScreenContent(
             )
         }
 
-        Spacer(modifier = Modifier.requiredHeight(bottomPadding))
-        Spacer(modifier = Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))
+        PaymentSheetContentPadding()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentOptionsScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentOptionsScreen.kt
@@ -1,7 +1,12 @@
 package com.stripe.android.paymentsheet.ui
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -57,9 +62,7 @@ internal fun PaymentOptionsScreenContent(
     val horizontalPadding = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_horizontal)
     val bottomPadding = dimensionResource(R.dimen.stripe_paymentsheet_button_container_spacing_bottom)
 
-    Column(
-        modifier = modifier.padding(bottom = bottomPadding),
-    ) {
+    Column(modifier) {
         headerText?.let { text ->
             H4Text(
                 text = stringResource(text),
@@ -95,5 +98,8 @@ internal fun PaymentOptionsScreenContent(
                     .padding(horizontal = horizontalPadding),
             )
         }
+
+        Spacer(modifier = Modifier.requiredHeight(bottomPadding))
+        Spacer(modifier = Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -4,13 +4,9 @@ package com.stripe.android.paymentsheet.ui
 
 import androidx.annotation.RestrictTo
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
-import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -30,6 +26,7 @@ import com.stripe.android.paymentsheet.PaymentSheetViewModel
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.databinding.StripeFragmentPaymentSheetPrimaryButtonBinding
 import com.stripe.android.paymentsheet.state.WalletsState
+import com.stripe.android.paymentsheet.utils.PaymentSheetContentPadding
 import com.stripe.android.ui.core.elements.H4Text
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.text.Html
@@ -89,10 +86,6 @@ internal fun PaymentSheetScreenContent(
     val currentScreen by viewModel.currentScreen.collectAsState()
     val notes by viewModel.notesText.collectAsState()
 
-    val bottomPadding = dimensionResource(
-        R.dimen.stripe_paymentsheet_button_container_spacing_bottom
-    )
-
     val horizontalPadding = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_horizontal)
 
     Column(modifier) {
@@ -141,8 +134,7 @@ internal fun PaymentSheetScreenContent(
             )
         }
 
-        Spacer(modifier = Modifier.requiredHeight(bottomPadding))
-        Spacer(modifier = Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))
+        PaymentSheetContentPadding()
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -4,9 +4,13 @@ package com.stripe.android.paymentsheet.ui
 
 import androidx.annotation.RestrictTo
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -91,9 +95,7 @@ internal fun PaymentSheetScreenContent(
 
     val horizontalPadding = dimensionResource(R.dimen.stripe_paymentsheet_outer_spacing_horizontal)
 
-    Column(
-        modifier = modifier.padding(bottom = bottomPadding),
-    ) {
+    Column(modifier) {
         headerText?.let { text ->
             H4Text(
                 text = stringResource(text),
@@ -138,6 +140,9 @@ internal fun PaymentSheetScreenContent(
                     .padding(horizontal = horizontalPadding),
             )
         }
+
+        Spacer(modifier = Modifier.requiredHeight(bottomPadding))
+        Spacer(modifier = Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/EdgeToEdge.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/EdgeToEdge.kt
@@ -2,13 +2,25 @@ package com.stripe.android.paymentsheet.utils
 
 import android.view.View
 import android.view.WindowInsets
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.isImeVisible
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.layout.windowInsetsBottomHeight
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
 import androidx.core.view.doOnAttach
+import com.stripe.android.paymentsheet.R
+import androidx.compose.foundation.layout.WindowInsets.Companion as ComposeWindowInsets
 
 // Taken from https://medium.com/androiddevelopers/windowinsets-listeners-to-layouts-8f9ccc8fa4d1
-internal fun View.doOnApplyWindowInsets(f: (View, WindowInsets, InitialPadding) -> Unit) {
+internal fun View.doOnApplyWindowInsets(onApplyInsets: (View, WindowInsets, InitialPadding) -> Unit) {
     val initialPadding = InitialPadding(paddingLeft, paddingTop, paddingRight, paddingBottom)
     setOnApplyWindowInsetsListener { v, insets ->
-        f(v, insets, initialPadding)
+        onApplyInsets(v, insets, initialPadding)
         insets
     }
     requestApplyInsetsWhenAttached()
@@ -24,5 +36,18 @@ internal data class InitialPadding(
 internal fun View.requestApplyInsetsWhenAttached() {
     doOnAttach {
         it.requestApplyInsets()
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun PaymentSheetContentPadding() {
+    val bottomPadding = dimensionResource(R.dimen.stripe_paymentsheet_button_container_spacing_bottom)
+    Spacer(modifier = Modifier.requiredHeight(bottomPadding))
+
+    Spacer(modifier = Modifier.windowInsetsBottomHeight(ComposeWindowInsets.ime))
+
+    if (!ComposeWindowInsets.isImeVisible) {
+        Spacer(modifier = Modifier.windowInsetsBottomHeight(ComposeWindowInsets.navigationBars))
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/EdgeToEdge.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/utils/EdgeToEdge.kt
@@ -1,0 +1,28 @@
+package com.stripe.android.paymentsheet.utils
+
+import android.view.View
+import android.view.WindowInsets
+import androidx.core.view.doOnAttach
+
+// Taken from https://medium.com/androiddevelopers/windowinsets-listeners-to-layouts-8f9ccc8fa4d1
+internal fun View.doOnApplyWindowInsets(f: (View, WindowInsets, InitialPadding) -> Unit) {
+    val initialPadding = InitialPadding(paddingLeft, paddingTop, paddingRight, paddingBottom)
+    setOnApplyWindowInsetsListener { v, insets ->
+        f(v, insets, initialPadding)
+        insets
+    }
+    requestApplyInsetsWhenAttached()
+}
+
+internal data class InitialPadding(
+    val left: Int,
+    val top: Int,
+    val right: Int,
+    val bottom: Int,
+)
+
+internal fun View.requestApplyInsetsWhenAttached() {
+    doOnAttach {
+        it.requestApplyInsets()
+    }
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request makes Payment Sheet render edge-to-edge.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

UX polish.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before | After |
| ------------- | ------------- |
| ![Screenshot_1687012752](https://github.com/stripe/stripe-android/assets/110940675/d3f9cce6-03e3-45f0-87c2-d919edab24ab) | ![Screenshot_1687012932](https://github.com/stripe/stripe-android/assets/110940675/71691f7a-d899-46f9-9c1b-2eba380c3606) |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
