### PR TITLE
Make `PaymentSheetTopBar` use `topBarState` directly

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -114,7 +114,6 @@ internal class CustomerSheetViewModel @Inject constructor(
                     title = configuration.headerTextForSelectionScreen,
                     savedPaymentMethods = savedPaymentMethods,
                     paymentSelection = paymentSelection,
-                    showEditMenu = savedPaymentMethods.isNotEmpty(),
                     isLiveMode = isLiveMode,
                     isProcessing = false,
                     isEditing = false,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
@@ -4,19 +4,31 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
+import com.stripe.android.paymentsheet.ui.PaymentSheetTopBarState
+import com.stripe.android.paymentsheet.ui.PaymentSheetTopBarStateFactory
 import kotlinx.coroutines.flow.Flow
 
 internal sealed class CustomerSheetViewState(
-    open val showEditMenu: Boolean,
+    open val savedPaymentMethods: List<PaymentMethod>,
     open val isLiveMode: Boolean,
     open val isProcessing: Boolean,
     open val isEditing: Boolean,
     open val screen: PaymentSheetScreen,
 ) {
+
+    val topBarState: PaymentSheetTopBarState
+        get() = PaymentSheetTopBarStateFactory.create(
+            screen = screen,
+            paymentMethods = savedPaymentMethods,
+            isLiveMode = isLiveMode,
+            isProcessing = isProcessing,
+            isEditing = isEditing,
+        )
+
     data class Loading(
         override val isLiveMode: Boolean,
     ) : CustomerSheetViewState(
-        showEditMenu = false,
+        savedPaymentMethods = emptyList(),
         isLiveMode = isLiveMode,
         isProcessing = false,
         isEditing = false,
@@ -25,9 +37,8 @@ internal sealed class CustomerSheetViewState(
 
     data class SelectPaymentMethod(
         val title: String?,
-        val savedPaymentMethods: List<PaymentMethod>,
+        override val savedPaymentMethods: List<PaymentMethod>,
         val paymentSelection: PaymentSelection?,
-        override val showEditMenu: Boolean,
         override val isLiveMode: Boolean,
         override val isProcessing: Boolean,
         override val isEditing: Boolean,
@@ -36,7 +47,7 @@ internal sealed class CustomerSheetViewState(
         val primaryButtonEnabled: Boolean,
         val errorMessage: String? = null,
     ) : CustomerSheetViewState(
-        showEditMenu = showEditMenu,
+        savedPaymentMethods = savedPaymentMethods,
         isLiveMode = isLiveMode,
         isProcessing = isProcessing,
         isEditing = isEditing,
@@ -48,7 +59,7 @@ internal sealed class CustomerSheetViewState(
         val enabled: Boolean,
         override val isLiveMode: Boolean,
     ) : CustomerSheetViewState(
-        showEditMenu = false,
+        savedPaymentMethods = emptyList(),
         isLiveMode = isLiveMode,
         isProcessing = false,
         isEditing = false,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -44,11 +44,7 @@ internal fun CustomerSheetScreen(
     PaymentSheetScaffold(
         topBar = {
             PaymentSheetTopBar(
-                screen = viewState.screen,
-                showEditMenu = viewState.showEditMenu,
-                isLiveMode = viewState.isLiveMode,
-                isProcessing = viewState.isProcessing,
-                isEditing = viewState.isEditing,
+                state = viewState.topBarState,
                 handleBackPressed = {
                     viewActionHandler(
                         CustomerSheetViewAction.OnBackPressed

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentOptionsScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentOptionsScreen.kt
@@ -26,20 +26,12 @@ internal fun PaymentOptionsScreen(
     viewModel: PaymentOptionsViewModel,
     modifier: Modifier = Modifier,
 ) {
-    val screen = viewModel.currentScreen.collectAsState().value
-    val paymentMethods = viewModel.paymentMethods.collectAsState().value
-    val isLiveMode = viewModel.stripeIntent.collectAsState().value?.isLiveMode
-    val isProcessing = viewModel.processing.collectAsState().value
-    val isEditing = viewModel.editing.collectAsState().value
+    val topBarState by viewModel.topBarState.collectAsState()
 
     PaymentSheetScaffold(
         topBar = {
             PaymentSheetTopBar(
-                screen = screen,
-                showEditMenu = !paymentMethods.isNullOrEmpty(),
-                isLiveMode = isLiveMode,
-                isProcessing = isProcessing,
-                isEditing = isEditing,
+                state = topBarState,
                 handleBackPressed = viewModel::handleBackPressed,
                 toggleEditing = viewModel::toggleEditing,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -38,22 +38,14 @@ internal fun PaymentSheetScreen(
     val contentVisible by viewModel.contentVisible.collectAsState()
     val processing by viewModel.processing.collectAsState()
 
-    val screen = viewModel.currentScreen.collectAsState().value
-    val paymentMethods = viewModel.paymentMethods.collectAsState().value
-    val isLiveMode = viewModel.stripeIntent.collectAsState().value?.isLiveMode
-    val isProcessing = viewModel.processing.collectAsState().value
-    val isEditing = viewModel.editing.collectAsState().value
+    val topBarState by viewModel.topBarState.collectAsState()
 
     DismissKeyboardOnProcessing(processing)
 
     PaymentSheetScaffold(
         topBar = {
             PaymentSheetTopBar(
-                screen = screen,
-                showEditMenu = !paymentMethods.isNullOrEmpty(),
-                isLiveMode = isLiveMode,
-                isProcessing = isProcessing,
-                isEditing = isEditing,
+                state = topBarState,
                 handleBackPressed = viewModel::handleBackPressed,
                 toggleEditing = viewModel::toggleEditing,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBar.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBar.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.core.content.res.ResourcesCompat
 import com.stripe.android.paymentsheet.R
-import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.StripeThemeDefaults
 import com.stripe.android.uicore.stripeColors
@@ -41,23 +40,11 @@ internal const val SHEET_NAVIGATION_BUTTON_TAG = "SHEET_NAVIGATION_BUTTON_TAG"
 
 @Composable
 internal fun PaymentSheetTopBar(
-    screen: PaymentSheetScreen,
-    showEditMenu: Boolean,
-    isLiveMode: Boolean?,
-    isProcessing: Boolean,
-    isEditing: Boolean,
+    state: PaymentSheetTopBarState,
     handleBackPressed: () -> Unit,
     toggleEditing: () -> Unit,
     elevation: Dp = 0.dp,
 ) {
-    val state = rememberPaymentSheetTopBarState(
-        screen = screen,
-        showEditMenu = showEditMenu,
-        isLiveMode = isLiveMode ?: true,
-        isProcessing = isProcessing,
-        isEditing = isEditing,
-    )
-
     PaymentSheetTopBar(
         state = state,
         elevation = elevation,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarState.kt
@@ -2,8 +2,7 @@ package com.stripe.android.paymentsheet.ui
 
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.R as StripeR
@@ -18,15 +17,15 @@ internal data class PaymentSheetTopBarState(
     val isEnabled: Boolean,
 )
 
-@Composable
-internal fun rememberPaymentSheetTopBarState(
-    screen: PaymentSheetScreen,
-    showEditMenu: Boolean,
-    isLiveMode: Boolean,
-    isProcessing: Boolean,
-    isEditing: Boolean,
-): PaymentSheetTopBarState {
-    return remember(screen, showEditMenu, isLiveMode, isProcessing, isEditing) {
+internal object PaymentSheetTopBarStateFactory {
+
+    fun create(
+        screen: PaymentSheetScreen,
+        paymentMethods: List<PaymentMethod>?,
+        isLiveMode: Boolean,
+        isProcessing: Boolean,
+        isEditing: Boolean,
+    ): PaymentSheetTopBarState {
         val icon = if (screen == PaymentSheetScreen.AddAnotherPaymentMethod) {
             R.drawable.stripe_ic_paymentsheet_back
         } else {
@@ -47,13 +46,23 @@ internal fun rememberPaymentSheetTopBarState(
             StripeR.string.stripe_edit
         }
 
-        PaymentSheetTopBarState(
+        return PaymentSheetTopBarState(
             icon = icon,
             contentDescription = contentDescription,
             showTestModeLabel = !isLiveMode,
-            showEditMenu = showOptionsMenu && showEditMenu,
+            showEditMenu = showOptionsMenu && !paymentMethods.isNullOrEmpty(),
             editMenuLabel = editMenuLabel,
             isEnabled = !isProcessing,
+        )
+    }
+
+    fun createDefault(): PaymentSheetTopBarState {
+        return create(
+            screen = PaymentSheetScreen.Loading,
+            paymentMethods = emptyList(),
+            isLiveMode = true,
+            isProcessing = false,
+            isEditing = false,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -35,6 +35,8 @@ import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.state.GooglePayState
 import com.stripe.android.paymentsheet.toPaymentSelection
 import com.stripe.android.paymentsheet.ui.HeaderTextFactory
+import com.stripe.android.paymentsheet.ui.PaymentSheetTopBarState
+import com.stripe.android.paymentsheet.ui.PaymentSheetTopBarStateFactory
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.forms.resources.LpmRepository
@@ -196,6 +198,19 @@ internal abstract class BaseSheetViewModel(
             started = SharingStarted.WhileSubscribed(),
             initialValue = PaymentOptionsState(),
         )
+
+    val topBarState: StateFlow<PaymentSheetTopBarState> = combine(
+        currentScreen,
+        paymentMethods,
+        stripeIntent.map { it?.isLiveMode ?: true },
+        processing,
+        editing,
+        PaymentSheetTopBarStateFactory::create,
+    ).stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(),
+        initialValue = PaymentSheetTopBarStateFactory.createDefault(),
+    )
 
     init {
         viewModelScope.launch {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
@@ -137,17 +137,6 @@ internal class CustomerSheetActivityTest {
     }
 
     @Test
-    fun `When showEditMenu is true, edit menu is visible`() {
-        runActivityScenario(
-            viewState = createSelectPaymentMethodViewState(
-                showEditMenu = true
-            ),
-        ) {
-            page.waitForText("edit")
-        }
-    }
-
-    @Test
     fun `When isGooglePayEnabled is true, google pay is visible`() {
         runActivityScenario(
             viewState = createSelectPaymentMethodViewState(
@@ -237,7 +226,6 @@ internal class CustomerSheetActivityTest {
         title: String? = null,
         savedPaymentMethods: List<PaymentMethod> = listOf(),
         paymentSelection: PaymentSelection? = null,
-        showEditMenu: Boolean = false,
         isLiveMode: Boolean = false,
         isProcessing: Boolean = false,
         isEditing: Boolean = false,
@@ -249,7 +237,6 @@ internal class CustomerSheetActivityTest {
             title = title,
             savedPaymentMethods = savedPaymentMethods,
             paymentSelection = paymentSelection,
-            showEditMenu = showEditMenu,
             isLiveMode = isLiveMode,
             isProcessing = isProcessing,
             isEditing = isEditing,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -33,9 +33,8 @@ class CustomerSheetScreenshotTest {
             CustomerSheetScreen(
                 viewState = CustomerSheetViewState.SelectPaymentMethod(
                     title = "Screenshot testing",
-                    savedPaymentMethods = listOf(),
+                    savedPaymentMethods = emptyList(),
                     paymentSelection = null,
-                    showEditMenu = false,
                     isLiveMode = false,
                     isProcessing = false,
                     isEditing = false,
@@ -72,7 +71,6 @@ class CustomerSheetScreenshotTest {
                     paymentSelection = PaymentSelection.Saved(
                         savedPaymentMethods.first()
                     ),
-                    showEditMenu = true,
                     isLiveMode = false,
                     isProcessing = false,
                     isEditing = false,
@@ -95,9 +93,8 @@ class CustomerSheetScreenshotTest {
             CustomerSheetScreen(
                 viewState = CustomerSheetViewState.SelectPaymentMethod(
                     title = "Screenshot testing",
-                    savedPaymentMethods = listOf(),
+                    savedPaymentMethods = emptyList(),
                     paymentSelection = PaymentSelection.GooglePay,
-                    showEditMenu = true,
                     isLiveMode = false,
                     isProcessing = false,
                     isEditing = false,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -88,7 +88,6 @@ class CustomerSheetViewModelTest {
                         paymentSelection = PaymentSelection.Saved(
                             paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
                         ),
-                        showEditMenu = true,
                         isLiveMode = false,
                         isProcessing = false,
                         isEditing = false,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarStateFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/PaymentSheetTopBarStateFactoryTest.kt
@@ -1,26 +1,23 @@
 package com.stripe.android.paymentsheet.ui
 
-import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
 import com.stripe.android.R as StripeR
 
 @RunWith(AndroidJUnit4::class)
-class PaymentSheetTopBarStateTest {
-
-    @get:Rule
-    val composeTestRule = createComposeRule()
+class PaymentSheetTopBarStateFactoryTest {
 
     @Test
     fun `SelectSavedPaymentMethods shows correct navigation icon`() {
         val state = buildTopBarState(
             screen = PaymentSheetScreen.SelectSavedPaymentMethods,
-            showEditMenu = false,
+            paymentMethods = emptyList(),
             isLiveMode = false,
             isProcessing = false,
             isEditing = false,
@@ -33,7 +30,7 @@ class PaymentSheetTopBarStateTest {
     fun `AddFirstPaymentMethod shows correct navigation icon`() {
         val state = buildTopBarState(
             screen = PaymentSheetScreen.AddFirstPaymentMethod,
-            showEditMenu = false,
+            paymentMethods = emptyList(),
             isLiveMode = false,
             isProcessing = false,
             isEditing = false,
@@ -46,7 +43,7 @@ class PaymentSheetTopBarStateTest {
     fun `AddAnotherPaymentMethod shows correct navigation icon`() {
         val state = buildTopBarState(
             screen = PaymentSheetScreen.AddAnotherPaymentMethod,
-            showEditMenu = false,
+            paymentMethods = emptyList(),
             isLiveMode = false,
             isProcessing = false,
             isEditing = false,
@@ -59,7 +56,7 @@ class PaymentSheetTopBarStateTest {
     fun `Shows test mode badge if not running in live mode`() {
         val state = buildTopBarState(
             screen = PaymentSheetScreen.AddAnotherPaymentMethod,
-            showEditMenu = false,
+            paymentMethods = emptyList(),
             isLiveMode = false,
             isProcessing = false,
             isEditing = false,
@@ -72,7 +69,7 @@ class PaymentSheetTopBarStateTest {
     fun `Hide test mode badge if running in live mode`() {
         val state = buildTopBarState(
             screen = PaymentSheetScreen.AddAnotherPaymentMethod,
-            showEditMenu = false,
+            paymentMethods = emptyList(),
             isLiveMode = true,
             isProcessing = false,
             isEditing = false,
@@ -85,7 +82,7 @@ class PaymentSheetTopBarStateTest {
     fun `Shows edit menu if displaying customer payment methods`() {
         val state = buildTopBarState(
             screen = PaymentSheetScreen.SelectSavedPaymentMethods,
-            showEditMenu = true,
+            paymentMethods = listOf(mock()),
             isLiveMode = false,
             isProcessing = false,
             isEditing = false,
@@ -98,7 +95,7 @@ class PaymentSheetTopBarStateTest {
     fun `Hides edit menu if customer has no payment methods`() {
         val state = buildTopBarState(
             screen = PaymentSheetScreen.SelectSavedPaymentMethods,
-            showEditMenu = false,
+            paymentMethods = emptyList(),
             isLiveMode = false,
             isProcessing = false,
             isEditing = false,
@@ -111,7 +108,7 @@ class PaymentSheetTopBarStateTest {
     fun `Hides edit menu if not on the saved payment methods screen`() {
         val state = buildTopBarState(
             screen = PaymentSheetScreen.AddAnotherPaymentMethod,
-            showEditMenu = true,
+            paymentMethods = listOf(mock()),
             isLiveMode = false,
             isProcessing = false,
             isEditing = false,
@@ -124,7 +121,7 @@ class PaymentSheetTopBarStateTest {
     fun `Shows correct edit menu label when not in editing mode`() {
         val state = buildTopBarState(
             screen = PaymentSheetScreen.AddAnotherPaymentMethod,
-            showEditMenu = false,
+            paymentMethods = emptyList(),
             isLiveMode = false,
             isProcessing = false,
             isEditing = false,
@@ -137,7 +134,7 @@ class PaymentSheetTopBarStateTest {
     fun `Shows correct edit menu label when in editing mode`() {
         val state = buildTopBarState(
             screen = PaymentSheetScreen.AddAnotherPaymentMethod,
-            showEditMenu = false,
+            paymentMethods = emptyList(),
             isLiveMode = true,
             isProcessing = false,
             isEditing = true,
@@ -150,7 +147,7 @@ class PaymentSheetTopBarStateTest {
     fun `Enables menu when not processing`() {
         val state = buildTopBarState(
             screen = PaymentSheetScreen.AddAnotherPaymentMethod,
-            showEditMenu = false,
+            paymentMethods = emptyList(),
             isLiveMode = false,
             isProcessing = false,
             isEditing = false,
@@ -163,7 +160,7 @@ class PaymentSheetTopBarStateTest {
     fun `Disables menu when processing`() {
         val state = buildTopBarState(
             screen = PaymentSheetScreen.AddAnotherPaymentMethod,
-            showEditMenu = false,
+            paymentMethods = emptyList(),
             isLiveMode = false,
             isProcessing = true,
             isEditing = false,
@@ -174,25 +171,17 @@ class PaymentSheetTopBarStateTest {
 
     private fun buildTopBarState(
         screen: PaymentSheetScreen,
-        showEditMenu: Boolean,
+        paymentMethods: List<PaymentMethod>,
         isLiveMode: Boolean,
         isProcessing: Boolean,
         isEditing: Boolean,
     ): PaymentSheetTopBarState {
-        var state: PaymentSheetTopBarState? = null
-
-        composeTestRule.setContent {
-            state = rememberPaymentSheetTopBarState(
-                screen = screen,
-                showEditMenu = showEditMenu,
-                isLiveMode = isLiveMode,
-                isProcessing = isProcessing,
-                isEditing = isEditing,
-            )
-        }
-
-        return state ?: throw AssertionError(
-            "buildTopBarState should not produce null result"
+        return PaymentSheetTopBarStateFactory.create(
+            screen = screen,
+            paymentMethods = paymentMethods,
+            isLiveMode = isLiveMode,
+            isProcessing = isProcessing,
+            isEditing = isEditing,
         )
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request refactors `PaymentSheetTopBar` to take a `PaymentSheetTopBarState` directly. This cleans up the call-sites.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
