### PR TITLE
[FC] Stop using new `getParcelableExtra` API 33 method.

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/utils/Intent.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/utils/Intent.kt
@@ -1,14 +1,11 @@
 package com.stripe.android.financialconnections.utils
 
 import android.content.Intent
-import android.os.Build.VERSION.SDK_INT
-import android.os.Build.VERSION_CODES.TIRAMISU
 import android.os.Parcelable
 
-internal inline fun <reified T : Parcelable> Intent.parcelable(key: String): T? = when {
-    SDK_INT >= TIRAMISU -> getParcelableExtra(key, T::class.java)
-    else -> {
-        @Suppress("DEPRECATION")
-        getParcelableExtra(key) as? T
-    }
+// The new Intent.getParcelableExtra(String,Class) throws an NPE internally
+// see https://issuetracker.google.com/issues/240585930#comment6
+internal inline fun <reified T : Parcelable> Intent.parcelable(key: String): T? {
+    @Suppress("DEPRECATION")
+    return getParcelableExtra(key) as? T
 }


### PR DESCRIPTION
# Summary
- We're seeing crashes when using the new `getParcelableExtra` method on Android 13 devices
- See https://issuetracker.google.com/issues/240585930#comment6
- Temporary solution listed in the issue tracker: `if you are impacted, the way forward for now is to continue using the older APIs for Android 13 and below. They are marked as @Deprecated, but still work as intended.`

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
