### PR TITLE
Remove AnimatedContent from CustomerSheetScreen

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -1,8 +1,6 @@
 package com.stripe.android.customersheet.ui
 
-import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -31,7 +29,6 @@ import com.stripe.android.paymentsheet.ui.PaymentSheetTopBar
 import com.stripe.android.ui.core.FormUI
 import com.stripe.android.ui.core.elements.H4Text
 
-@OptIn(ExperimentalAnimationApi::class)
 @Composable
 internal fun CustomerSheetScreen(
     viewState: CustomerSheetViewState,
@@ -60,26 +57,22 @@ internal fun CustomerSheetScreen(
             )
         },
         content = {
-            AnimatedContent(
-                targetState = viewState
-            ) { targetState ->
-                when (targetState) {
-                    is CustomerSheetViewState.Loading -> {
-                        Loading()
-                    }
-                    is CustomerSheetViewState.SelectPaymentMethod -> {
-                        SelectPaymentMethod(
-                            viewState = targetState,
-                            viewActionHandler = viewActionHandler,
-                            paymentMethodNameProvider = paymentMethodNameProvider,
-                        )
-                    }
-                    is CustomerSheetViewState.AddPaymentMethod -> {
-                        AddCard(
-                            viewState = targetState,
-                            viewActionHandler = viewActionHandler,
-                        )
-                    }
+            when (viewState) {
+                is CustomerSheetViewState.Loading -> {
+                    Loading()
+                }
+                is CustomerSheetViewState.SelectPaymentMethod -> {
+                    SelectPaymentMethod(
+                        viewState = viewState,
+                        viewActionHandler = viewActionHandler,
+                        paymentMethodNameProvider = paymentMethodNameProvider,
+                    )
+                }
+                is CustomerSheetViewState.AddPaymentMethod -> {
+                    AddCard(
+                        viewState = viewState,
+                        viewActionHandler = viewActionHandler,
+                    )
                 }
             }
         },


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Remove AnimatedContent from CustomerSheetScreen. This was causing janky animations, will need to rethink about animating the content. Perhaps NavHost might work better.

# Screenshots
| Before  | After |
| ------------- | ------------- |
| <img src="https://github.com/stripe/stripe-android/assets/99316447/44c61cfb-e810-4e71-a51e-15468ec886a8" height=400/> | <img src="https://github.com/stripe/stripe-android/assets/99316447/b4775648-90fb-4721-99cb-13731f4ed8a0" height=400/> |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
