### PR TITLE
Allow Long as amount for Google Pay Launcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## XX.XX.XX - 2023-XX-XX
 
+### Payments
+* [ADDED][6912](https://github.com/stripe/stripe-android/pull/6912) `GooglePayPaymentMethodLauncher` can now be presented with an amount of type `Long`. The method to present with an `Int` has been deprecated.
+* [DEPRECATED][6912](https://github.com/stripe/stripe-android/pull/6912) `GooglePayLauncherContract` and `GooglePayPaymentMethodLauncherContract` have been deprecated and will be removed in a future release. Use `GooglePayLauncher` and `GooglePayPaymentMethodLauncher` directly instead.
+
 ## 20.25.8 - 2023-06-26
 
 ### Financial Connections

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,11 @@
 # Migration Guide
 
+## Migrating from versions < 20.26.0
+- Changes to `GooglePayLauncherContract`
+  * The class has been deprecated and will be removed in a future release. Use `GooglePayLauncher` directly.
+- Changes to `GooglePayPaymentMethodLauncherContract`
+  * The class has been deprecated and will be removed in a future release. Use `GooglePayPaymentMethodLauncher` directly.
+
 ## Migrating from versions < 20.5.0
 - Changes to `PaymentSheet.Configuration`
   * `primaryButtonColor` is now deprecated. Please use the new `Appearance` parameter instead:

--- a/example/src/main/java/com/stripe/example/activity/GooglePayPaymentMethodLauncherComposeActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/GooglePayPaymentMethodLauncherComposeActivity.kt
@@ -84,7 +84,7 @@ class GooglePayPaymentMethodLauncherComposeActivity : AppCompatActivity() {
             onLaunchGooglePay = {
                 googlePayLauncher.present(
                     currencyCode = "EUR",
-                    amount = 2500
+                    amount = 2500L,
                 )
             }
         )

--- a/example/src/main/java/com/stripe/example/activity/GooglePayPaymentMethodLauncherIntegrationActivity.kt
+++ b/example/src/main/java/com/stripe/example/activity/GooglePayPaymentMethodLauncherIntegrationActivity.kt
@@ -50,7 +50,7 @@ class GooglePayPaymentMethodLauncherIntegrationActivity : AppCompatActivity() {
 
             googlePayLauncher.present(
                 currencyCode = "EUR",
-                amount = 2500
+                amount = 2500L,
             )
         }
     }

--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -298,7 +298,9 @@ public final class com/stripe/android/GooglePayJsonFactory$TransactionInfo : and
 	public fun <init> (Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$CheckoutOption;)V
 	public synthetic fun <init> (Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$CheckoutOption;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun copy (Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$CheckoutOption;)Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo;
+	public final fun copy (Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$CheckoutOption;)Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo;
 	public static synthetic fun copy$default (Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo;Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$CheckoutOption;ILjava/lang/Object;)Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo;
+	public static synthetic fun copy$default (Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo;Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$TotalPriceStatus;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo$CheckoutOption;ILjava/lang/Object;)Lcom/stripe/android/GooglePayJsonFactory$TransactionInfo;
 	public fun describeContents ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -373,6 +375,7 @@ public final class com/stripe/android/PayWithGoogleUtils {
 	public static final field $stable I
 	public static final field INSTANCE Lcom/stripe/android/PayWithGoogleUtils;
 	public static final fun getPriceString (ILjava/util/Currency;)Ljava/lang/String;
+	public static final fun getPriceString (JLjava/util/Currency;)Ljava/lang/String;
 }
 
 public final class com/stripe/android/PaymentAuthConfig {
@@ -1350,7 +1353,10 @@ public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLa
 	public final fun present (Ljava/lang/String;)V
 	public final fun present (Ljava/lang/String;I)V
 	public final fun present (Ljava/lang/String;ILjava/lang/String;)V
+	public final fun present (Ljava/lang/String;J)V
+	public final fun present (Ljava/lang/String;JLjava/lang/String;)V
 	public static synthetic fun present$default (Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher;Ljava/lang/String;ILjava/lang/String;ILjava/lang/Object;)V
+	public static synthetic fun present$default (Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher;Ljava/lang/String;JLjava/lang/String;ILjava/lang/Object;)V
 }
 
 public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher$BillingAddressConfig : android/os/Parcelable {
@@ -1555,6 +1561,22 @@ public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLa
 	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContract$Args$InjectionParams;
 	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
 	public final fun newArray (I)[Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContract$Args$InjectionParams;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractV2$Args$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractV2$Args;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractV2$Args;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractV2$Args$InjectionParams$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractV2$Args$InjectionParams;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lcom/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractV2$Args$InjectionParams;
 	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 

--- a/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
@@ -3,7 +3,6 @@ package com.stripe.android
 import android.content.Context
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
-import com.stripe.android.GooglePayJsonFactory.TransactionInfo.TotalPriceStatus
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
@@ -300,54 +299,76 @@ class GooglePayJsonFactory constructor(
         }
     }
 
-    /**
-     * [TransactionInfo](https://developers.google.com/pay/api/android/reference/request-objects#TransactionInfo)
-     */
     @Parcelize
-    data class TransactionInfo @JvmOverloads constructor(
-        /**
-         * ISO 4217 alphabetic currency code.
-         */
+    data class TransactionInfo internal constructor(
         internal val currencyCode: String,
-
-        /**
-         * The status of the total price used.
-         */
         internal val totalPriceStatus: TotalPriceStatus,
-
-        /**
-         * ISO 3166-1 alpha-2 country code where the transaction is processed.
-         * This is required for merchants based in European Economic Area (EEA) countries.
-         */
-        internal val countryCode: String? = null,
-
-        /**
-         * A unique ID that identifies a transaction attempt. Merchants may use an existing ID or
-         * generate a specific one for Google Pay transaction attempts. This field is required
-         * when you send callbacks to the Google Transaction Events API.
-         */
-        internal val transactionId: String? = null,
-
-        /**
-         * Total monetary value of the transaction.
-         *
-         * This field is required unless [totalPriceStatus] is set to [TotalPriceStatus.NotCurrentlyKnown].
-         *
-         * The value of this field is represented in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
-         * For example, when [currencyCode] is `"USD"`, a value of `100` represents 100 cents ($1.00).
-         */
-        internal val totalPrice: Int? = null,
-
-        /**
-         * Custom label for the total price within the display items.
-         */
-        internal val totalPriceLabel: String? = null,
-
-        /**
-         * Affects the submit button text displayed in the Google Pay payment sheet.
-         */
-        internal val checkoutOption: CheckoutOption? = null
+        internal val countryCode: String?,
+        internal val transactionId: String?,
+        internal val totalPrice: Long?,
+        internal val totalPriceLabel: String?,
+        internal val checkoutOption: CheckoutOption?,
     ) : Parcelable {
+
+        /**
+         * [TransactionInfo](https://developers.google.com/pay/api/android/reference/request-objects#TransactionInfo)
+         *
+         * @param currencyCode ISO 4217 alphabetic currency code.
+         * @param totalPriceStatus The status of the total price used.
+         * @param countryCode ISO 3166-1 alpha-2 country code where the transaction is processed. This
+         * is required for merchants based in European Economic Area (EEA) countries.
+         * @param transactionId A unique ID that identifies a transaction attempt. Merchants may use an
+         * existing ID or generate a specific one for Google Pay transaction attempts. This field is
+         * required when you send callbacks to the Google Transaction Events API.
+         * @param totalPrice Total monetary value of the transaction. This field is required unless
+         * [totalPriceStatus] is set to [TotalPriceStatus.NotCurrentlyKnown]. The value of this field is
+         * represented in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
+         * For example, when [currencyCode] is `"USD"`, a value of `100` represents 100 cents ($1.00).
+         * @param totalPriceLabel Custom label for the total price within the display items.
+         * @param checkoutOption Affects the submit button text displayed in the Google Pay payment sheet.
+         */
+        @JvmOverloads
+        constructor(
+            currencyCode: String,
+            totalPriceStatus: TotalPriceStatus,
+            countryCode: String? = null,
+            transactionId: String? = null,
+            totalPrice: Int? = null,
+            totalPriceLabel: String? = null,
+            checkoutOption: CheckoutOption? = null,
+        ) : this(
+            currencyCode = currencyCode,
+            totalPriceStatus = totalPriceStatus,
+            countryCode = countryCode,
+            transactionId = transactionId,
+            totalPrice = totalPrice?.toLong(),
+            totalPriceLabel = totalPriceLabel,
+            checkoutOption = checkoutOption,
+        )
+
+        @Deprecated(
+            message = "This method isn't meant for public usage and will be removed in a future release.",
+        )
+        fun copy(
+            currencyCode: String = this.currencyCode,
+            totalPriceStatus: TotalPriceStatus = this.totalPriceStatus,
+            countryCode: String? = this.countryCode,
+            transactionId: String? = this.transactionId,
+            totalPrice: Int? = this.totalPrice?.toInt(),
+            totalPriceLabel: String? = this.totalPriceLabel,
+            checkoutOption: CheckoutOption? = this.checkoutOption,
+        ): TransactionInfo {
+            return copy(
+                currencyCode = currencyCode,
+                totalPriceStatus = totalPriceStatus,
+                countryCode = countryCode,
+                transactionId = transactionId,
+                totalPrice = totalPrice?.toLong(),
+                totalPriceLabel = totalPriceLabel,
+                checkoutOption = checkoutOption,
+            )
+        }
+
         /**
          * The status of the total price used.
          */

--- a/payments-core/src/main/java/com/stripe/android/PayWithGoogleUtils.kt
+++ b/payments-core/src/main/java/com/stripe/android/PayWithGoogleUtils.kt
@@ -18,8 +18,24 @@ object PayWithGoogleUtils {
      * @param currency the [Currency] used to determine how many digits after the decimal
      * @return a String that can be used as a Pay with Google price string
      */
+    @Deprecated(
+        message = "Use getPriceString(Long, Currency) instead.",
+        replaceWith = ReplaceWith("getPriceString(price.toLong(), currency)"),
+    )
     @JvmStatic
     fun getPriceString(price: Int, currency: Currency): String {
+        return getPriceString(price.toLong(), currency)
+    }
+
+    /**
+     * Converts an integer price in the lowest currency denomination to a Google string value.
+     * For instance: (100L, USD) -> "1.00", but (100L, JPY) -> "100".
+     * @param price the price in the lowest available currency denomination
+     * @param currency the [Currency] used to determine how many digits after the decimal
+     * @return a String that can be used as a Pay with Google price string
+     */
+    @JvmStatic
+    fun getPriceString(price: Long, currency: Currency): String {
         val fractionDigits = currency.defaultFractionDigits
         val totalLength = price.toString().length
         val builder = StringBuilder()

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherContract.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherContract.kt
@@ -9,6 +9,10 @@ import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.SetupIntent
 import kotlinx.parcelize.Parcelize
 
+@Deprecated(
+    message = "This class isn't meant for public use and will be removed in a future release. " +
+        "Use GooglePayLauncher directly.",
+)
 class GooglePayLauncherContract :
     ActivityResultContract<GooglePayLauncherContract.Args, GooglePayLauncher.Result>() {
 

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
@@ -137,7 +137,8 @@ internal class GooglePayLauncherViewModel(
                     totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.Final,
                     countryCode = args.config.merchantCountryCode,
                     transactionId = stripeIntent.id,
-                    totalPrice = stripeIntent.amount?.toInt(),
+                    totalPrice = stripeIntent.amount,
+                    totalPriceLabel = null,
                     checkoutOption = GooglePayJsonFactory.TransactionInfo.CheckoutOption.CompleteImmediatePurchase
                 )
             }
@@ -147,7 +148,8 @@ internal class GooglePayLauncherViewModel(
                     totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.Estimated,
                     countryCode = args.config.merchantCountryCode,
                     transactionId = stripeIntent.id,
-                    totalPrice = 0,
+                    totalPrice = 0L,
+                    totalPriceLabel = null,
                     checkoutOption = GooglePayJsonFactory.TransactionInfo.CheckoutOption.Default
                 )
             }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherActivity.kt
@@ -33,14 +33,14 @@ internal class GooglePayPaymentMethodLauncherActivity : AppCompatActivity() {
         GooglePayPaymentMethodLauncherViewModel.Factory(args)
     }
 
-    private lateinit var args: GooglePayPaymentMethodLauncherContract.Args
+    private lateinit var args: GooglePayPaymentMethodLauncherContractV2.Args
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         setFadeAnimations()
 
-        val nullableArgs = GooglePayPaymentMethodLauncherContract.Args.fromIntent(intent)
+        val nullableArgs = GooglePayPaymentMethodLauncherContractV2.Args.fromIntent(intent)
         if (nullableArgs == null) {
             finishWithResult(
                 GooglePayPaymentMethodLauncher.Result.Failed(

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractV2.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractV2.kt
@@ -4,21 +4,19 @@ import android.content.Context
 import android.content.Intent
 import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
+import androidx.annotation.RestrictTo
 import androidx.core.os.bundleOf
 import com.stripe.android.core.injection.InjectorKey
 import com.stripe.android.model.PaymentMethod
 import kotlinx.parcelize.Parcelize
 
-@Deprecated(
-    message = "This class isn't meant for public use and will be removed in a future release. " +
-        "Use GooglePayPaymentMethodLauncher directly.",
-)
-class GooglePayPaymentMethodLauncherContract :
-    ActivityResultContract<GooglePayPaymentMethodLauncherContract.Args, GooglePayPaymentMethodLauncher.Result>() {
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+class GooglePayPaymentMethodLauncherContractV2 :
+    ActivityResultContract<GooglePayPaymentMethodLauncherContractV2.Args, GooglePayPaymentMethodLauncher.Result>() {
 
     override fun createIntent(context: Context, input: Args): Intent {
         return Intent(context, GooglePayPaymentMethodLauncherActivity::class.java)
-            .putExtras(input.toV2().toBundle())
+            .putExtras(input.toBundle())
     }
 
     override fun parseResult(
@@ -42,11 +40,12 @@ class GooglePayPaymentMethodLauncherContract :
      *     existing ID or generate a specific one for Google Pay transaction attempts.
      *     This field is required when you send callbacks to the Google Transaction Events API.
      */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
     data class Args internal constructor(
         internal val config: GooglePayPaymentMethodLauncher.Config,
         internal val currencyCode: String,
-        internal val amount: Int,
+        internal val amount: Long,
         internal val transactionId: String? = null,
         internal val injectionParams: InjectionParams? = null
     ) : Parcelable {
@@ -54,7 +53,7 @@ class GooglePayPaymentMethodLauncherContract :
         constructor(
             config: GooglePayPaymentMethodLauncher.Config,
             currencyCode: String,
-            amount: Int,
+            amount: Long,
             transactionId: String? = null
         ) : this(config, currencyCode, amount, transactionId, null)
 
@@ -81,22 +80,4 @@ class GooglePayPaymentMethodLauncherContract :
     internal companion object {
         internal const val EXTRA_RESULT = "extra_result"
     }
-}
-
-private fun GooglePayPaymentMethodLauncherContract.Args.toV2(): GooglePayPaymentMethodLauncherContractV2.Args {
-    return GooglePayPaymentMethodLauncherContractV2.Args(
-        config = config,
-        currencyCode = currencyCode,
-        amount = amount.toLong(),
-        transactionId = transactionId,
-        injectionParams = injectionParams?.let { params ->
-            GooglePayPaymentMethodLauncherContractV2.Args.InjectionParams(
-                injectorKey = params.injectorKey,
-                productUsage = params.productUsage,
-                enableLogging = params.enableLogging,
-                stripeAccountId = params.stripeAccountId,
-                publishableKey = params.publishableKey,
-            )
-        },
-    )
 }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
@@ -33,7 +33,7 @@ import javax.inject.Inject
 internal class GooglePayPaymentMethodLauncherViewModel @Inject constructor(
     private val paymentsClient: PaymentsClient,
     private val requestOptions: ApiRequest.Options,
-    private val args: GooglePayPaymentMethodLauncherContract.Args,
+    private val args: GooglePayPaymentMethodLauncherContractV2.Args,
     private val stripeRepository: StripeRepository,
     private val googlePayJsonFactory: GooglePayJsonFactory,
     private val googlePayRepository: GooglePayRepository,
@@ -75,7 +75,7 @@ internal class GooglePayPaymentMethodLauncherViewModel @Inject constructor(
 
     @VisibleForTesting
     internal fun createTransactionInfo(
-        args: GooglePayPaymentMethodLauncherContract.Args
+        args: GooglePayPaymentMethodLauncherContractV2.Args
     ): GooglePayJsonFactory.TransactionInfo {
         return GooglePayJsonFactory.TransactionInfo(
             currencyCode = args.currencyCode,
@@ -83,6 +83,7 @@ internal class GooglePayPaymentMethodLauncherViewModel @Inject constructor(
             countryCode = args.config.merchantCountryCode,
             transactionId = args.transactionId,
             totalPrice = args.amount,
+            totalPriceLabel = null,
             checkoutOption = GooglePayJsonFactory.TransactionInfo.CheckoutOption.Default
         )
     }
@@ -125,7 +126,7 @@ internal class GooglePayPaymentMethodLauncherViewModel @Inject constructor(
     }
 
     internal class Factory(
-        private val args: GooglePayPaymentMethodLauncherContract.Args,
+        private val args: GooglePayPaymentMethodLauncherContractV2.Args,
     ) : ViewModelProvider.Factory, Injectable<Factory.FallbackInjectionParams> {
 
         internal data class FallbackInjectionParams(

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherFactory.kt
@@ -3,7 +3,7 @@ package com.stripe.android.googlepaylauncher.injection
 import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.RestrictTo
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
-import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContract
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
 import dagger.assisted.AssistedFactory
 import kotlinx.coroutines.CoroutineScope
 
@@ -14,7 +14,7 @@ interface GooglePayPaymentMethodLauncherFactory {
         lifecycleScope: CoroutineScope,
         config: GooglePayPaymentMethodLauncher.Config,
         readyCallback: GooglePayPaymentMethodLauncher.ReadyCallback,
-        activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContract.Args>,
+        activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>,
         skipReadyCheck: Boolean = false
     ): GooglePayPaymentMethodLauncher
 }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherViewModelSubcomponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherViewModelSubcomponent.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.googlepaylauncher.injection
 
 import androidx.lifecycle.SavedStateHandle
-import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContract
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherViewModel
 import dagger.BindsInstance
 import dagger.Subcomponent
@@ -14,7 +14,7 @@ internal interface GooglePayPaymentMethodLauncherViewModelSubcomponent {
     interface Builder {
 
         @BindsInstance
-        fun args(args: GooglePayPaymentMethodLauncherContract.Args): Builder
+        fun args(args: GooglePayPaymentMethodLauncherContractV2.Args): Builder
 
         @BindsInstance
         fun savedStateHandle(savedStateHandle: SavedStateHandle): Builder

--- a/payments-core/src/test/java/com/stripe/android/GooglePayJsonFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/GooglePayJsonFactoryTest.kt
@@ -144,7 +144,7 @@ class GooglePayJsonFactoryTest {
             transactionInfo = GooglePayJsonFactory.TransactionInfo(
                 currencyCode = "USD",
                 totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.Estimated,
-                totalPrice = 500,
+                totalPrice = 500L,
                 countryCode = "US",
                 transactionId = transactionId,
                 totalPriceLabel = "Your total price",

--- a/payments-core/src/test/java/com/stripe/android/PayWithGoogleUtilsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PayWithGoogleUtilsTest.kt
@@ -19,51 +19,51 @@ class PayWithGoogleUtilsTest {
 
     @Test
     fun getPriceString_whenCurrencyWithDecimals_returnsExpectedValue() {
-        val priceString = getPriceString(100, Currency.getInstance("USD"))
+        val priceString = getPriceString(100L, Currency.getInstance("USD"))
         assertThat(priceString).isEqualTo("1.00")
 
-        val littlePrice = getPriceString(8, Currency.getInstance("EUR"))
+        val littlePrice = getPriceString(8L, Currency.getInstance("EUR"))
         assertThat(littlePrice).isEqualTo("0.08")
 
-        val bigPrice = getPriceString(20000000, Currency.getInstance("GBP"))
+        val bigPrice = getPriceString(20000000L, Currency.getInstance("GBP"))
         assertThat(bigPrice).isEqualTo("200000.00")
     }
 
     @Test
     fun getPriceString_whenLocaleWithCommas_returnsExpectedValue() {
         Locale.setDefault(Locale.FRENCH)
-        val priceString = getPriceString(100, Currency.getInstance("USD"))
+        val priceString = getPriceString(100L, Currency.getInstance("USD"))
         assertThat(priceString).isEqualTo("1.00")
 
-        val littlePrice = getPriceString(8, Currency.getInstance("EUR"))
+        val littlePrice = getPriceString(8L, Currency.getInstance("EUR"))
         assertThat(littlePrice).isEqualTo("0.08")
 
-        val bigPrice = getPriceString(20000000, Currency.getInstance("GBP"))
+        val bigPrice = getPriceString(20000000L, Currency.getInstance("GBP"))
         assertThat(bigPrice).isEqualTo("200000.00")
     }
 
     @Test
     fun getPriceString_whenCurrencyWithoutDecimals_returnsExpectedValue() {
-        val priceString = getPriceString(250, Currency.getInstance("JPY"))
+        val priceString = getPriceString(250L, Currency.getInstance("JPY"))
         assertThat(priceString).isEqualTo("250")
 
-        val bigPrice = getPriceString(250000, Currency.getInstance("KRW"))
+        val bigPrice = getPriceString(250000L, Currency.getInstance("KRW"))
         assertThat(bigPrice).isEqualTo("250000")
 
-        val littlePrice = getPriceString(7, Currency.getInstance("CLP"))
+        val littlePrice = getPriceString(7L, Currency.getInstance("CLP"))
         assertThat(littlePrice).isEqualTo("7")
     }
 
     @Test
     fun getPriceString_whenLocaleWithArabicNumerals_returnsExpectedValue() {
         Locale.setDefault(Locale.Builder().setLanguage("ar").setRegion("AE").build())
-        val priceString = getPriceString(100, Currency.getInstance("USD"))
+        val priceString = getPriceString(100L, Currency.getInstance("USD"))
         assertThat(priceString).isEqualTo("1.00")
 
-        val littlePrice = getPriceString(8, Currency.getInstance("EUR"))
+        val littlePrice = getPriceString(8L, Currency.getInstance("EUR"))
         assertThat(littlePrice).isEqualTo("0.08")
 
-        val bigPrice = getPriceString(20000000, Currency.getInstance("GBP"))
+        val bigPrice = getPriceString(20000000L, Currency.getInstance("GBP"))
         assertThat(bigPrice).isEqualTo("200000.00")
     }
 }

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModelTest.kt
@@ -97,7 +97,7 @@ class GooglePayLauncherViewModelTest {
                     totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.Final,
                     countryCode = "us",
                     transactionId = "pi_1F7J1aCRMbs6FrXfaJcvbxF6",
-                    totalPrice = 1099,
+                    totalPrice = 1099L,
                     totalPriceLabel = null,
                     checkoutOption = GooglePayJsonFactory.TransactionInfo.CheckoutOption.CompleteImmediatePurchase
                 )
@@ -117,7 +117,7 @@ class GooglePayLauncherViewModelTest {
                     totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.Estimated,
                     countryCode = "us",
                     transactionId = "seti_1GSmaFCRMbs",
-                    totalPrice = 0,
+                    totalPrice = 0L,
                     totalPriceLabel = null,
                     checkoutOption = GooglePayJsonFactory.TransactionInfo.CheckoutOption.Default
                 )

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractTest.kt
@@ -1,0 +1,34 @@
+package com.stripe.android.googlepaylauncher
+
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class GooglePayPaymentMethodLauncherContractTest {
+
+    @Test
+    fun `Converts to V2 args internally`() {
+        val contract = GooglePayPaymentMethodLauncherContract()
+
+        val args = GooglePayPaymentMethodLauncherContract.Args(
+            config = GooglePayPaymentMethodLauncher.Config(
+                environment = GooglePayEnvironment.Test,
+                merchantCountryCode = "CA",
+                merchantName = "Till's Shop",
+            ),
+            currencyCode = "CAD",
+            amount = 12345,
+        )
+
+        val intent = contract.createIntent(
+            context = ApplicationProvider.getApplicationContext(),
+            input = args,
+        )
+
+        val v2Args = GooglePayPaymentMethodLauncherContractV2.Args.fromIntent(intent)
+        assertThat(v2Args).isNotNull()
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherTest.kt
@@ -62,7 +62,7 @@ class GooglePayPaymentMethodLauncherTest {
                 CONFIG,
                 readyCallback,
                 fragment.registerForActivityResult(
-                    GooglePayPaymentMethodLauncherContract(),
+                    GooglePayPaymentMethodLauncherContractV2(),
                     FakeActivityResultRegistry(result)
                 ) {
                     resultCallback.onResult(it)
@@ -101,7 +101,7 @@ class GooglePayPaymentMethodLauncherTest {
                 CONFIG,
                 readyCallback,
                 fragment.registerForActivityResult(
-                    GooglePayPaymentMethodLauncherContract(),
+                    GooglePayPaymentMethodLauncherContractV2(),
                     FakeActivityResultRegistry(result)
                 ) {
                     resultCallback.onResult(it)
@@ -129,7 +129,7 @@ class GooglePayPaymentMethodLauncherTest {
                 CONFIG,
                 readyCallback,
                 fragment.registerForActivityResult(
-                    GooglePayPaymentMethodLauncherContract(),
+                    GooglePayPaymentMethodLauncherContractV2(),
                     FakeActivityResultRegistry(
                         GooglePayPaymentMethodLauncher.Result.Completed(
                             PaymentMethodFixtures.CARD_PAYMENT_METHOD
@@ -168,7 +168,7 @@ class GooglePayPaymentMethodLauncherTest {
                 CONFIG,
                 readyCallback,
                 fragment.registerForActivityResult(
-                    GooglePayPaymentMethodLauncherContract(),
+                    GooglePayPaymentMethodLauncherContractV2(),
                     FakeActivityResultRegistry(
                         GooglePayPaymentMethodLauncher.Result.Completed(
                             PaymentMethodFixtures.CARD_PAYMENT_METHOD

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
@@ -163,12 +163,12 @@ class GooglePayPaymentMethodLauncherViewModelTest {
             WeakMapInjectorRegistry.register(injector, injectorKey)
 
             val factory = GooglePayPaymentMethodLauncherViewModel.Factory(
-                GooglePayPaymentMethodLauncherContract.Args(
+                GooglePayPaymentMethodLauncherContractV2.Args(
                     mock(),
                     "usd",
                     1099,
                     null,
-                    GooglePayPaymentMethodLauncherContract.Args.InjectionParams(
+                    GooglePayPaymentMethodLauncherContractV2.Args.InjectionParams(
                         injectorKey,
                         emptySet(),
                         false,
@@ -200,7 +200,7 @@ class GooglePayPaymentMethodLauncherViewModelTest {
             PaymentConfiguration.init(application, publishableKey)
 
             val factory = GooglePayPaymentMethodLauncherViewModel.Factory(
-                GooglePayPaymentMethodLauncherContract.Args(
+                GooglePayPaymentMethodLauncherContractV2.Args(
                     GooglePayPaymentMethodLauncher.Config(
                         GooglePayEnvironment.Test,
                         "US",
@@ -209,7 +209,7 @@ class GooglePayPaymentMethodLauncherViewModelTest {
                     "usd",
                     1099,
                     null,
-                    GooglePayPaymentMethodLauncherContract.Args.InjectionParams(
+                    GooglePayPaymentMethodLauncherContractV2.Args.InjectionParams(
                         DUMMY_INJECTOR_KEY,
                         productUsage,
                         false,
@@ -256,7 +256,7 @@ class GooglePayPaymentMethodLauncherViewModelTest {
     }
 
     private companion object {
-        val ARGS = GooglePayPaymentMethodLauncherContract.Args(
+        val ARGS = GooglePayPaymentMethodLauncherContractV2.Args(
             GooglePayPaymentMethodLauncher.Config(
                 GooglePayEnvironment.Test,
                 merchantCountryCode = "us",

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -8,7 +8,7 @@ import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
-import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContract
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
 import com.stripe.android.paymentsheet.databinding.StripeActivityPaymentSheetBinding
 import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.PaymentSheetScreen
@@ -55,7 +55,7 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
         viewModel.setupGooglePay(
             lifecycleScope,
             registerForActivityResult(
-                GooglePayPaymentMethodLauncherContract(),
+                GooglePayPaymentMethodLauncherContractV2(),
                 viewModel::onGooglePayResult
             )
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -22,7 +22,7 @@ import com.stripe.android.core.injection.Injector
 import com.stripe.android.core.injection.injectWithFallback
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
-import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContract
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.model.ConfirmPaymentIntentParams
@@ -324,7 +324,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
     fun setupGooglePay(
         lifecycleScope: CoroutineScope,
-        activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContract.Args>
+        activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>
     ) {
         googlePayLauncherConfig?.let { config ->
             googlePayPaymentMethodLauncher =
@@ -375,7 +375,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                 googlePayPaymentMethodLauncher?.present(
                     currencyCode = (stripeIntent as? PaymentIntent)?.currency
                         ?: args.googlePayConfig?.currencyCode.orEmpty(),
-                    amount = (stripeIntent as? PaymentIntent)?.amount?.toInt() ?: 0,
+                    amount = (stripeIntent as? PaymentIntent)?.amount ?: 0L,
                     transactionId = stripeIntent.id
                 )
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -18,7 +18,7 @@ import com.stripe.android.core.injection.NonFallbackInjector
 import com.stripe.android.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
-import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContract
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkConfigurationCoordinator
@@ -96,7 +96,7 @@ internal class DefaultFlowController @Inject internal constructor(
 ) : PaymentSheet.FlowController, NonFallbackInjector {
     private val paymentOptionActivityLauncher: ActivityResultLauncher<PaymentOptionContract.Args>
     private val googlePayActivityLauncher:
-        ActivityResultLauncher<GooglePayPaymentMethodLauncherContract.Args>
+        ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>
 
     /**
      * [FlowControllerComponent] is hold to inject into [Activity]s and created
@@ -173,7 +173,7 @@ internal class DefaultFlowController @Inject internal constructor(
             )
         googlePayActivityLauncher =
             activityResultCaller.registerForActivityResult(
-                GooglePayPaymentMethodLauncherContract(),
+                GooglePayPaymentMethodLauncherContractV2(),
                 ::onGooglePayResult
             )
     }
@@ -577,7 +577,7 @@ internal class DefaultFlowController @Inject internal constructor(
         ).present(
             currencyCode = (state.stripeIntent as? PaymentIntent)?.currency
                 ?: googlePayConfig.currencyCode.orEmpty(),
-            amount = (state.stripeIntent as? PaymentIntent)?.amount?.toInt() ?: 0,
+            amount = (state.stripeIntent as? PaymentIntent)?.amount ?: 0L,
             transactionId = state.stripeIntent.id
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/BasePaymentSheetViewModelInjectionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/BasePaymentSheetViewModelInjectionTest.kt
@@ -12,7 +12,7 @@ import com.stripe.android.core.injection.InjectorKey
 import com.stripe.android.core.injection.NonFallbackInjector
 import com.stripe.android.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
-import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContract
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.StripeIntent
@@ -60,7 +60,7 @@ internal open class BasePaymentSheetViewModelInjectionTest {
                 lifecycleScope: CoroutineScope,
                 config: GooglePayPaymentMethodLauncher.Config,
                 readyCallback: GooglePayPaymentMethodLauncher.ReadyCallback,
-                activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContract.Args>,
+                activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>,
                 skipReadyCheck: Boolean
             ): GooglePayPaymentMethodLauncher {
                 val googlePayPaymentMethodLauncher = mock<GooglePayPaymentMethodLauncher>()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -30,7 +30,7 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.WeakMapInjectorRegistry
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
-import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContract
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.model.AccountStatus
@@ -987,7 +987,7 @@ internal class PaymentSheetActivityTest {
                 lifecycleScope: CoroutineScope,
                 config: GooglePayPaymentMethodLauncher.Config,
                 readyCallback: GooglePayPaymentMethodLauncher.ReadyCallback,
-                activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContract.Args>,
+                activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>,
                 skipReadyCheck: Boolean
             ): GooglePayPaymentMethodLauncher {
                 val googlePayPaymentMethodLauncher = mock<GooglePayPaymentMethodLauncher>()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -15,7 +15,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
-import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContract
+import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
 import com.stripe.android.googlepaylauncher.injection.GooglePayPaymentMethodLauncherFactory
 import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.LinkActivityResult
@@ -119,7 +119,7 @@ internal class DefaultFlowControllerTest {
         mock<ActivityResultLauncher<AddressElementActivityContract.Args>>()
 
     private val googlePayActivityLauncher =
-        mock<ActivityResultLauncher<GooglePayPaymentMethodLauncherContract.Args>>()
+        mock<ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>>()
     val googlePayPaymentMethodLauncher = mock<GooglePayPaymentMethodLauncher>()
 
     private val linkActivityResultLauncher =
@@ -159,7 +159,7 @@ internal class DefaultFlowControllerTest {
 
         whenever(
             activityResultCaller.registerForActivityResult(
-                any<GooglePayPaymentMethodLauncherContract>(),
+                any<GooglePayPaymentMethodLauncherContractV2>(),
                 any()
             )
         ).thenReturn(googlePayActivityLauncher)
@@ -810,7 +810,7 @@ internal class DefaultFlowControllerTest {
         )
         flowController.confirm()
 
-        verify(googlePayPaymentMethodLauncher).present("usd", 1099, "pi_1F7J1aCRMbs6FrXfaJcvbxF6")
+        verify(googlePayPaymentMethodLauncher).present("usd", 1099L, "pi_1F7J1aCRMbs6FrXfaJcvbxF6")
     }
 
     @Test
@@ -1407,7 +1407,7 @@ internal class DefaultFlowControllerTest {
                 lifecycleScope: CoroutineScope,
                 config: GooglePayPaymentMethodLauncher.Config,
                 readyCallback: GooglePayPaymentMethodLauncher.ReadyCallback,
-                activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContract.Args>,
+                activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>,
                 skipReadyCheck: Boolean
             ): GooglePayPaymentMethodLauncher {
                 return googlePayPaymentMethodLauncher


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request makes it possible to launch `GooglePayPaymentMethodLauncher` with an amount as a `Long` instead of an `Int`. This is more consistent with the rest of our API.

We deprecate the `present()` method that uses an `Int` and also deprecate `GooglePayLauncherContract` and `GooglePayPaymentMethodLauncherContract` themselves, as we’d want to make them internal. Consumers of the SDK should use the launchers directly.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Consistency and smaller API surface.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

* [ADDED] `GooglePayPaymentMethodLauncher` can now be presented with an amount of type `Long`. The method to present with an `Int` has been deprecated.
* [DEPRECATED] `GooglePayLauncherContract` and `GooglePayPaymentMethodLauncherContract` have been deprecated and will be removed in a future release. Use `GooglePayLauncher` and `GooglePayPaymentMethodLauncher` directly instead.
