### PR TITLE
Add mock network test runners

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -12,12 +12,16 @@ import com.stripe.android.networktesting.RequestMatchers.not
 import com.stripe.android.networktesting.RequestMatchers.path
 import com.stripe.android.networktesting.RequestMatchers.query
 import com.stripe.android.networktesting.testBodyFromFile
+import com.stripe.android.paymentsheet.utils.assertCompleted
+import com.stripe.android.paymentsheet.utils.assertFailed
+import com.stripe.android.paymentsheet.utils.runFlowControllerTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
+@OptIn(ExperimentalPaymentSheetDecouplingApi::class)
 @RunWith(AndroidJUnit4::class)
 internal class FlowControllerTest {
     @get:Rule
@@ -29,7 +33,12 @@ internal class FlowControllerTest {
     val networkRule = NetworkRule()
 
     @Test
-    fun testSuccessfulCardPayment() {
+    fun testSuccessfulCardPayment() = runFlowControllerTest(
+        paymentOptionCallback = { paymentOption ->
+            assertThat(paymentOption?.label).endsWith("4242")
+        },
+        resultCallback = ::assertCompleted,
+    ) { testContext ->
         networkRule.enqueue(
             method("GET"),
             path("/v1/elements/sessions"),
@@ -37,34 +46,14 @@ internal class FlowControllerTest {
             response.testBodyFromFile("elements-sessions-requires_payment_method.json")
         }
 
-        val resultCountDownLatch = CountDownLatch(1)
-        val activityScenarioRule = composeTestRule.activityRule
-        val scenario = activityScenarioRule.scenario
-        scenario.moveToState(Lifecycle.State.CREATED)
-        lateinit var flowController: PaymentSheet.FlowController
-        scenario.onActivity {
-            PaymentConfiguration.init(it, "pk_test_123")
-            flowController = PaymentSheet.FlowController.create(
-                activity = it,
-                paymentOptionCallback = { paymentOption ->
-                    assertThat(paymentOption?.label).endsWith("4242")
-                    flowController.confirm()
-                },
-                paymentResultCallback = { result ->
-                    assertThat(result).isInstanceOf(PaymentSheetResult.Completed::class.java)
-                    resultCountDownLatch.countDown()
-                },
-            )
-        }
-        scenario.moveToState(Lifecycle.State.RESUMED)
-        scenario.onActivity {
-            flowController.configureWithPaymentIntent(
+        testContext.configureFlowController {
+            configureWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
                 configuration = null,
                 callback = { success, error ->
                     assertThat(success).isTrue()
                     assertThat(error).isNull()
-                    flowController.presentPaymentOptions()
+                    presentPaymentOptions()
                 }
             )
         }
@@ -80,12 +69,15 @@ internal class FlowControllerTest {
         }
 
         page.clickPrimaryButton()
-
-        assertThat(resultCountDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
     }
 
     @Test
-    fun testFailedElementsSessionCall() {
+    fun testFailedElementsSessionCall() = runFlowControllerTest(
+        paymentOptionCallback = { paymentOption ->
+            assertThat(paymentOption?.label).endsWith("4242")
+        },
+        resultCallback = ::assertCompleted,
+    ) { testContext ->
         networkRule.enqueue(
             method("GET"),
             path("/v1/elements/sessions"),
@@ -100,34 +92,14 @@ internal class FlowControllerTest {
             response.testBodyFromFile("payment-intent-get-requires_payment_method.json")
         }
 
-        val resultCountDownLatch = CountDownLatch(1)
-        val activityScenarioRule = composeTestRule.activityRule
-        val scenario = activityScenarioRule.scenario
-        scenario.moveToState(Lifecycle.State.CREATED)
-        lateinit var flowController: PaymentSheet.FlowController
-        scenario.onActivity {
-            PaymentConfiguration.init(it, "pk_test_123")
-            flowController = PaymentSheet.FlowController.create(
-                activity = it,
-                paymentOptionCallback = { paymentOption ->
-                    assertThat(paymentOption?.label).endsWith("4242")
-                    flowController.confirm()
-                },
-                paymentResultCallback = { result ->
-                    assertThat(result).isInstanceOf(PaymentSheetResult.Completed::class.java)
-                    resultCountDownLatch.countDown()
-                },
-            )
-        }
-        scenario.moveToState(Lifecycle.State.RESUMED)
-        scenario.onActivity {
-            flowController.configureWithPaymentIntent(
+        testContext.configureFlowController {
+            configureWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
                 configuration = null,
                 callback = { success, error ->
                     assertThat(success).isTrue()
                     assertThat(error).isNull()
-                    flowController.presentPaymentOptions()
+                    presentPaymentOptions()
                 }
             )
         }
@@ -142,12 +114,15 @@ internal class FlowControllerTest {
         }
 
         page.clickPrimaryButton()
-
-        assertThat(resultCountDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
     }
 
     @Test
-    fun testFailedConfirmCall() {
+    fun testFailedConfirmCall() = runFlowControllerTest(
+        paymentOptionCallback = { paymentOption ->
+            assertThat(paymentOption?.label).endsWith("4242")
+        },
+        resultCallback = ::assertFailed,
+    ) { testContext ->
         networkRule.enqueue(
             method("GET"),
             path("/v1/elements/sessions"),
@@ -155,34 +130,14 @@ internal class FlowControllerTest {
             response.testBodyFromFile("elements-sessions-requires_payment_method.json")
         }
 
-        val resultCountDownLatch = CountDownLatch(1)
-        val activityScenarioRule = composeTestRule.activityRule
-        val scenario = activityScenarioRule.scenario
-        scenario.moveToState(Lifecycle.State.CREATED)
-        lateinit var flowController: PaymentSheet.FlowController
-        scenario.onActivity {
-            PaymentConfiguration.init(it, "pk_test_123")
-            flowController = PaymentSheet.FlowController.create(
-                activity = it,
-                paymentOptionCallback = { paymentOption ->
-                    assertThat(paymentOption?.label).endsWith("4242")
-                    flowController.confirm()
-                },
-                paymentResultCallback = { result ->
-                    assertThat(result).isInstanceOf(PaymentSheetResult.Failed::class.java)
-                    resultCountDownLatch.countDown()
-                },
-            )
-        }
-        scenario.moveToState(Lifecycle.State.RESUMED)
-        scenario.onActivity {
-            flowController.configureWithPaymentIntent(
+        testContext.configureFlowController {
+            configureWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
                 configuration = null,
                 callback = { success, error ->
                     assertThat(success).isTrue()
                     assertThat(error).isNull()
-                    flowController.presentPaymentOptions()
+                    presentPaymentOptions()
                 }
             )
         }
@@ -198,10 +153,9 @@ internal class FlowControllerTest {
         }
 
         page.clickPrimaryButton()
-
-        assertThat(resultCountDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
     }
 
+    // TODO This one will be difficult
     @Test
     fun testActivityRecreationDoesNotMakeSubsequentCallsToElementsSession() {
         networkRule.enqueue(
@@ -333,7 +287,13 @@ internal class FlowControllerTest {
 
     @OptIn(ExperimentalPaymentSheetDecouplingApi::class)
     @Test
-    fun testDeferredIntentCardPayment() {
+    fun testDeferredIntentCardPayment() = runFlowControllerTest(
+        createIntentCallback = { _, _ -> CreateIntentResult.Success("pi_example_secret_example") },
+        paymentOptionCallback = { paymentOption ->
+            assertThat(paymentOption?.label).endsWith("4242")
+        },
+        resultCallback = ::assertCompleted,
+    ) { testContext ->
         networkRule.enqueue(
             method("GET"),
             path("/v1/elements/sessions"),
@@ -341,33 +301,8 @@ internal class FlowControllerTest {
             response.testBodyFromFile("elements-sessions-deferred_payment_intent.json")
         }
 
-        val resultCountDownLatch = CountDownLatch(1)
-        val activityScenarioRule = composeTestRule.activityRule
-        val scenario = activityScenarioRule.scenario
-        scenario.moveToState(Lifecycle.State.CREATED)
-        lateinit var flowController: PaymentSheet.FlowController
-        scenario.onActivity {
-            PaymentConfiguration.init(it, "pk_test_123")
-            flowController = PaymentSheet.FlowController.create(
-                activity = it,
-                paymentOptionCallback = { paymentOption ->
-                    assertThat(paymentOption?.label).endsWith("4242")
-                    flowController.confirm()
-                },
-                createIntentCallback = { _, _ ->
-                    CreateIntentResult.Success(
-                        clientSecret = "pi_example_secret_example"
-                    )
-                },
-                paymentResultCallback = { result ->
-                    assertThat(result).isInstanceOf(PaymentSheetResult.Completed::class.java)
-                    resultCountDownLatch.countDown()
-                },
-            )
-        }
-        scenario.moveToState(Lifecycle.State.RESUMED)
-        scenario.onActivity {
-            flowController.configureWithIntentConfiguration(
+        testContext.configureFlowController {
+            configureWithIntentConfiguration(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                         amount = 5099,
@@ -378,7 +313,7 @@ internal class FlowControllerTest {
                 callback = { success, error ->
                     assertThat(success).isTrue()
                     assertThat(error).isNull()
-                    flowController.presentPaymentOptions()
+                    presentPaymentOptions()
                 }
             )
         }
@@ -418,13 +353,26 @@ internal class FlowControllerTest {
         }
 
         page.clickPrimaryButton()
-
-        assertThat(resultCountDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
     }
 
     @OptIn(ExperimentalPaymentSheetDecouplingApi::class)
     @Test
-    fun testDeferredIntentFailedCardPayment() {
+    fun testDeferredIntentFailedCardPayment() = runFlowControllerTest(
+        createIntentCallback = { _, _ ->
+            CreateIntentResult.Failure(
+                cause = Exception("We don't accept visa"),
+                displayMessage = "We don't accept visa"
+            )
+        },
+        paymentOptionCallback = { paymentOption ->
+            assertThat(paymentOption?.label).endsWith("4242")
+        },
+        resultCallback = { result ->
+            assertThat(result).isInstanceOf(PaymentSheetResult.Failed::class.java)
+            assertThat((result as PaymentSheetResult.Failed).error.message)
+                .isEqualTo("We don't accept visa")
+        },
+    ) { testContext ->
         networkRule.enqueue(
             method("GET"),
             path("/v1/elements/sessions"),
@@ -432,36 +380,8 @@ internal class FlowControllerTest {
             response.testBodyFromFile("elements-sessions-deferred_payment_intent.json")
         }
 
-        val resultCountDownLatch = CountDownLatch(1)
-        val activityScenarioRule = composeTestRule.activityRule
-        val scenario = activityScenarioRule.scenario
-        scenario.moveToState(Lifecycle.State.CREATED)
-        lateinit var flowController: PaymentSheet.FlowController
-        var paymentSheetResult: PaymentSheetResult? = null
-        scenario.onActivity {
-            PaymentConfiguration.init(it, "pk_test_123")
-            flowController = PaymentSheet.FlowController.create(
-                activity = it,
-                paymentOptionCallback = { paymentOption ->
-                    assertThat(paymentOption?.label).endsWith("4242")
-                    flowController.confirm()
-                },
-                createIntentCallback = { _, _ ->
-                    CreateIntentResult.Failure(
-                        cause = Exception("We don't accept visa"),
-                        displayMessage = "We don't accept visa"
-                    )
-                },
-                paymentResultCallback = { result ->
-                    assertThat(result).isInstanceOf(PaymentSheetResult.Failed::class.java)
-                    paymentSheetResult = result
-                    resultCountDownLatch.countDown()
-                },
-            )
-        }
-        scenario.moveToState(Lifecycle.State.RESUMED)
-        scenario.onActivity {
-            flowController.configureWithIntentConfiguration(
+        testContext.configureFlowController {
+            configureWithIntentConfiguration(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                         amount = 5099,
@@ -472,7 +392,7 @@ internal class FlowControllerTest {
                 callback = { success, error ->
                     assertThat(success).isTrue()
                     assertThat(error).isNull()
-                    flowController.presentPaymentOptions()
+                    presentPaymentOptions()
                 }
             )
         }
@@ -493,14 +413,20 @@ internal class FlowControllerTest {
 
         page.clickPrimaryButton()
 
-        assertThat(resultCountDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
-        assertThat((paymentSheetResult as PaymentSheetResult.Failed).error.message)
-            .isEqualTo("We don't accept visa")
+        // TODO Wait for text?
     }
 
     @OptIn(ExperimentalPaymentSheetDecouplingApi::class, DelicatePaymentSheetApi::class)
     @Test
-    fun testDeferredIntentCardPaymentWithForcedSuccess() {
+    fun testDeferredIntentCardPaymentWithForcedSuccess() = runFlowControllerTest(
+        createIntentCallback = { _, _ ->
+            CreateIntentResult.Success(PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT)
+        },
+        paymentOptionCallback = { paymentOption ->
+            assertThat(paymentOption?.label).endsWith("4242")
+        },
+        resultCallback = ::assertCompleted,
+    ) { testContext ->
         networkRule.enqueue(
             method("GET"),
             path("/v1/elements/sessions"),
@@ -508,31 +434,8 @@ internal class FlowControllerTest {
             response.testBodyFromFile("elements-sessions-deferred_payment_intent.json")
         }
 
-        val resultCountDownLatch = CountDownLatch(1)
-        val activityScenarioRule = composeTestRule.activityRule
-        val scenario = activityScenarioRule.scenario
-        scenario.moveToState(Lifecycle.State.CREATED)
-        lateinit var flowController: PaymentSheet.FlowController
-        scenario.onActivity {
-            PaymentConfiguration.init(it, "pk_test_123")
-            flowController = PaymentSheet.FlowController.create(
-                activity = it,
-                paymentOptionCallback = { paymentOption ->
-                    assertThat(paymentOption?.label).endsWith("4242")
-                    flowController.confirm()
-                },
-                createIntentCallback = { _, _ ->
-                    CreateIntentResult.Success(PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT)
-                },
-                paymentResultCallback = { result ->
-                    assertThat(result).isInstanceOf(PaymentSheetResult.Completed::class.java)
-                    resultCountDownLatch.countDown()
-                },
-            )
-        }
-        scenario.moveToState(Lifecycle.State.RESUMED)
-        scenario.onActivity {
-            flowController.configureWithIntentConfiguration(
+        testContext.configureFlowController {
+            configureWithIntentConfiguration(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                         amount = 2000,
@@ -543,7 +446,7 @@ internal class FlowControllerTest {
                 callback = { success, error ->
                     assertThat(success).isTrue()
                     assertThat(error).isNull()
-                    flowController.presentPaymentOptions()
+                    presentPaymentOptions()
                 }
             )
         }
@@ -563,13 +466,23 @@ internal class FlowControllerTest {
         }
 
         page.clickPrimaryButton()
-
-        assertThat(resultCountDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
     }
 
     @OptIn(ExperimentalPaymentSheetDecouplingApi::class)
     @Test
-    fun testDeferredIntentCardPaymentWithInvalidStripeIntent() {
+    fun testDeferredIntentCardPaymentWithInvalidStripeIntent() = runFlowControllerTest(
+        createIntentCallback = { _, _ -> CreateIntentResult.Success("pi_example_secret_example") },
+        paymentOptionCallback = { paymentOption ->
+            assertThat(paymentOption?.label).endsWith("4242")
+        },
+        resultCallback = { result ->
+            val failureResult = result as? PaymentSheetResult.Failed
+            assertThat(failureResult?.error?.message).isEqualTo(
+                "Your PaymentIntent currency (usd) does not match " +
+                    "the PaymentSheet.IntentConfiguration currency (cad)."
+            )
+        },
+    ) { testContext ->
         networkRule.enqueue(
             method("GET"),
             path("/v1/elements/sessions"),
@@ -577,35 +490,8 @@ internal class FlowControllerTest {
             response.testBodyFromFile("elements-sessions-deferred_payment_intent.json")
         }
 
-        val resultCountDownLatch = CountDownLatch(1)
-        val activityScenarioRule = composeTestRule.activityRule
-        val scenario = activityScenarioRule.scenario
-        scenario.moveToState(Lifecycle.State.CREATED)
-        lateinit var flowController: PaymentSheet.FlowController
-        scenario.onActivity {
-            PaymentConfiguration.init(it, "pk_test_123")
-            flowController = PaymentSheet.FlowController.create(
-                activity = it,
-                paymentOptionCallback = { paymentOption ->
-                    assertThat(paymentOption?.label).endsWith("4242")
-                    flowController.confirm()
-                },
-                createIntentCallback = { _, _ ->
-                    CreateIntentResult.Success(clientSecret = "pi_example_secret_example")
-                },
-                paymentResultCallback = { result ->
-                    val failureResult = result as? PaymentSheetResult.Failed
-                    assertThat(failureResult?.error?.message).isEqualTo(
-                        "Your PaymentIntent currency (usd) does not match " +
-                            "the PaymentSheet.IntentConfiguration currency (cad)."
-                    )
-                    resultCountDownLatch.countDown()
-                },
-            )
-        }
-        scenario.moveToState(Lifecycle.State.RESUMED)
-        scenario.onActivity {
-            flowController.configureWithIntentConfiguration(
+        testContext.configureFlowController {
+            configureWithIntentConfiguration(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                         // This currency is different from USD in the created intent, which
@@ -618,7 +504,7 @@ internal class FlowControllerTest {
                 callback = { success, error ->
                     assertThat(success).isTrue()
                     assertThat(error).isNull()
-                    flowController.presentPaymentOptions()
+                    presentPaymentOptions()
                 }
             )
         }
@@ -645,7 +531,5 @@ internal class FlowControllerTest {
         }
 
         page.clickPrimaryButton()
-
-        assertThat(resultCountDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -155,7 +155,6 @@ internal class FlowControllerTest {
         page.clickPrimaryButton()
     }
 
-    // TODO This one will be difficult
     @Test
     fun testActivityRecreationDoesNotMakeSubsequentCallsToElementsSession() {
         networkRule.enqueue(
@@ -285,7 +284,6 @@ internal class FlowControllerTest {
         configureFlowController("pi_example2_secret_example2")
     }
 
-    @OptIn(ExperimentalPaymentSheetDecouplingApi::class)
     @Test
     fun testDeferredIntentCardPayment() = runFlowControllerTest(
         createIntentCallback = { _, _ -> CreateIntentResult.Success("pi_example_secret_example") },
@@ -355,7 +353,6 @@ internal class FlowControllerTest {
         page.clickPrimaryButton()
     }
 
-    @OptIn(ExperimentalPaymentSheetDecouplingApi::class)
     @Test
     fun testDeferredIntentFailedCardPayment() = runFlowControllerTest(
         createIntentCallback = { _, _ ->
@@ -412,11 +409,9 @@ internal class FlowControllerTest {
         }
 
         page.clickPrimaryButton()
-
-        // TODO Wait for text?
     }
 
-    @OptIn(ExperimentalPaymentSheetDecouplingApi::class, DelicatePaymentSheetApi::class)
+    @OptIn(DelicatePaymentSheetApi::class)
     @Test
     fun testDeferredIntentCardPaymentWithForcedSuccess() = runFlowControllerTest(
         createIntentCallback = { _, _ ->
@@ -468,7 +463,6 @@ internal class FlowControllerTest {
         page.clickPrimaryButton()
     }
 
-    @OptIn(ExperimentalPaymentSheetDecouplingApi::class)
     @Test
     fun testDeferredIntentCardPaymentWithInvalidStripeIntent() = runFlowControllerTest(
         createIntentCallback = { _, _ -> CreateIntentResult.Success("pi_example_secret_example") },

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -1,22 +1,22 @@
 package com.stripe.android.paymentsheet
 
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.lifecycle.Lifecycle
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.not
 import com.stripe.android.networktesting.RequestMatchers.path
 import com.stripe.android.networktesting.testBodyFromFile
+import com.stripe.android.paymentsheet.utils.assertCompleted
+import com.stripe.android.paymentsheet.utils.assertFailed
+import com.stripe.android.paymentsheet.utils.expectNoResult
+import com.stripe.android.paymentsheet.utils.runPaymentSheetTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 
+@OptIn(ExperimentalPaymentSheetDecouplingApi::class)
 @RunWith(AndroidJUnit4::class)
 internal class PaymentSheetTest {
     @get:Rule
@@ -28,7 +28,9 @@ internal class PaymentSheetTest {
     val networkRule = NetworkRule()
 
     @Test
-    fun testSuccessfulCardPayment() {
+    fun testSuccessfulCardPayment() = runPaymentSheetTest(
+        resultCallback = ::assertCompleted,
+    ) { testContext ->
         networkRule.enqueue(
             method("GET"),
             path("/v1/elements/sessions"),
@@ -36,21 +38,8 @@ internal class PaymentSheetTest {
             response.testBodyFromFile("elements-sessions-requires_payment_method.json")
         }
 
-        val countDownLatch = CountDownLatch(1)
-        val activityScenarioRule = composeTestRule.activityRule
-        val scenario = activityScenarioRule.scenario
-        scenario.moveToState(Lifecycle.State.CREATED)
-        lateinit var paymentSheet: PaymentSheet
-        scenario.onActivity {
-            PaymentConfiguration.init(it, "pk_test_123")
-            paymentSheet = PaymentSheet(it) { result ->
-                assertThat(result).isInstanceOf(PaymentSheetResult.Completed::class.java)
-                countDownLatch.countDown()
-            }
-        }
-        scenario.moveToState(Lifecycle.State.RESUMED)
-        scenario.onActivity {
-            paymentSheet.presentWithPaymentIntent(
+        testContext.presentPaymentSheet {
+            presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
                 configuration = null,
             )
@@ -66,12 +55,12 @@ internal class PaymentSheetTest {
         }
 
         page.clickPrimaryButton()
-
-        assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
     }
 
     @Test
-    fun testSuccessfulDelayedSuccessPayment() {
+    fun testSuccessfulDelayedSuccessPayment() = runPaymentSheetTest(
+        resultCallback = ::assertCompleted,
+    ) { testContext ->
         networkRule.enqueue(
             method("GET"),
             path("/v1/elements/sessions"),
@@ -79,21 +68,8 @@ internal class PaymentSheetTest {
             response.testBodyFromFile("elements-sessions-requires_payment_method.json")
         }
 
-        val countDownLatch = CountDownLatch(1)
-        val activityScenarioRule = composeTestRule.activityRule
-        val scenario = activityScenarioRule.scenario
-        scenario.moveToState(Lifecycle.State.CREATED)
-        lateinit var paymentSheet: PaymentSheet
-        scenario.onActivity {
-            PaymentConfiguration.init(it, "pk_test_123")
-            paymentSheet = PaymentSheet(it) { result ->
-                assertThat(result).isInstanceOf(PaymentSheetResult.Completed::class.java)
-                countDownLatch.countDown()
-            }
-        }
-        scenario.moveToState(Lifecycle.State.RESUMED)
-        scenario.onActivity {
-            paymentSheet.presentWithPaymentIntent(
+        testContext.presentPaymentSheet {
+            presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
                 configuration = null,
             )
@@ -116,12 +92,12 @@ internal class PaymentSheetTest {
         }
 
         page.clickPrimaryButton()
-
-        assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
     }
 
     @Test
-    fun testFailureWhenSetupRequestsFail() {
+    fun testFailureWhenSetupRequestsFail() = runPaymentSheetTest(
+        resultCallback = ::assertFailed,
+    ) { testContext ->
         networkRule.enqueue(
             method("GET"),
             path("/v1/elements/sessions"),
@@ -136,32 +112,20 @@ internal class PaymentSheetTest {
             response.setResponseCode(400)
         }
 
-        val countDownLatch = CountDownLatch(1)
-        val activityScenarioRule = composeTestRule.activityRule
-        val scenario = activityScenarioRule.scenario
-        scenario.moveToState(Lifecycle.State.CREATED)
-        lateinit var paymentSheet: PaymentSheet
-        scenario.onActivity {
-            PaymentConfiguration.init(it, "pk_test_123")
-            paymentSheet = PaymentSheet(it) { result ->
-                assertThat(result).isInstanceOf(PaymentSheetResult.Failed::class.java)
-                countDownLatch.countDown()
-            }
-        }
-        scenario.moveToState(Lifecycle.State.RESUMED)
-        scenario.onActivity {
-            paymentSheet.presentWithPaymentIntent(
+        testContext.presentPaymentSheet {
+            presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
                 configuration = null,
             )
         }
-
-        assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
     }
 
     @OptIn(ExperimentalPaymentSheetDecouplingApi::class)
     @Test
-    fun testDeferredIntentCardPayment() {
+    fun testDeferredIntentCardPayment() = runPaymentSheetTest(
+        createIntentCallback = { _, _ -> CreateIntentResult.Success("pi_example_secret_example") },
+        resultCallback = ::assertCompleted,
+    ) { testContext ->
         networkRule.enqueue(
             method("GET"),
             path("/v1/elements/sessions"),
@@ -169,26 +133,8 @@ internal class PaymentSheetTest {
             response.testBodyFromFile("elements-sessions-deferred_payment_intent.json")
         }
 
-        val countDownLatch = CountDownLatch(1)
-        val activityScenarioRule = composeTestRule.activityRule
-        val scenario = activityScenarioRule.scenario
-        scenario.moveToState(Lifecycle.State.CREATED)
-        lateinit var paymentSheet: PaymentSheet
-        scenario.onActivity {
-            PaymentConfiguration.init(it, "pk_test_123")
-            paymentSheet = PaymentSheet(
-                activity = it,
-                createIntentCallback = { _, _ ->
-                    CreateIntentResult.Success("pi_example_secret_example")
-                }
-            ) { result ->
-                assertThat(result).isInstanceOf(PaymentSheetResult.Completed::class.java)
-                countDownLatch.countDown()
-            }
-        }
-        scenario.moveToState(Lifecycle.State.RESUMED)
-        scenario.onActivity {
-            paymentSheet.presentWithIntentConfiguration(
+        testContext.presentPaymentSheet {
+            presentWithIntentConfiguration(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                         amount = 5099,
@@ -233,13 +179,19 @@ internal class PaymentSheetTest {
         }
 
         page.clickPrimaryButton()
-
-        assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
     }
 
     @OptIn(ExperimentalPaymentSheetDecouplingApi::class)
     @Test
-    fun testDeferredIntentFailedCardPayment() {
+    fun testDeferredIntentFailedCardPayment() = runPaymentSheetTest(
+        createIntentCallback = { _, _ ->
+            CreateIntentResult.Failure(
+                cause = Exception("We don't accept visa"),
+                displayMessage = "We don't accept visa"
+            )
+        },
+        resultCallback = ::expectNoResult,
+    ) { testContext ->
         networkRule.enqueue(
             method("GET"),
             path("/v1/elements/sessions"),
@@ -247,27 +199,8 @@ internal class PaymentSheetTest {
             response.testBodyFromFile("elements-sessions-deferred_payment_intent.json")
         }
 
-        val activityScenarioRule = composeTestRule.activityRule
-        val scenario = activityScenarioRule.scenario
-        scenario.moveToState(Lifecycle.State.CREATED)
-        lateinit var paymentSheet: PaymentSheet
-        scenario.onActivity {
-            PaymentConfiguration.init(it, "pk_test_123")
-            paymentSheet = PaymentSheet(
-                activity = it,
-                createIntentCallback = { _, _ ->
-                    CreateIntentResult.Failure(
-                        cause = Exception("We don't accept visa"),
-                        displayMessage = "We don't accept visa"
-                    )
-                }
-            ) {
-                error("Shouldn't call PaymentSheetResultCallback")
-            }
-        }
-        scenario.moveToState(Lifecycle.State.RESUMED)
-        scenario.onActivity {
-            paymentSheet.presentWithIntentConfiguration(
+        testContext.presentPaymentSheet {
+            presentWithIntentConfiguration(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                         amount = 2000,
@@ -292,12 +225,19 @@ internal class PaymentSheetTest {
         }
 
         page.clickPrimaryButton()
+
         page.waitForText("We don't accept visa")
+        testContext.markTestSucceeded()
     }
 
     @OptIn(ExperimentalPaymentSheetDecouplingApi::class, DelicatePaymentSheetApi::class)
     @Test
-    fun testDeferredIntentCardPaymentWithForcedSuccess() {
+    fun testDeferredIntentCardPaymentWithForcedSuccess() = runPaymentSheetTest(
+        createIntentCallback = { _, _ ->
+            CreateIntentResult.Success(PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT)
+        },
+        resultCallback = ::assertCompleted,
+    ) { testContext ->
         networkRule.enqueue(
             method("GET"),
             path("/v1/elements/sessions"),
@@ -305,26 +245,8 @@ internal class PaymentSheetTest {
             response.testBodyFromFile("elements-sessions-deferred_payment_intent.json")
         }
 
-        val countDownLatch = CountDownLatch(1)
-        val activityScenarioRule = composeTestRule.activityRule
-        val scenario = activityScenarioRule.scenario
-        scenario.moveToState(Lifecycle.State.CREATED)
-        lateinit var paymentSheet: PaymentSheet
-        scenario.onActivity {
-            PaymentConfiguration.init(it, "pk_test_123")
-            paymentSheet = PaymentSheet(
-                activity = it,
-                createIntentCallback = { _, _ ->
-                    CreateIntentResult.Success(PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT)
-                },
-            ) { result ->
-                assertThat(result).isInstanceOf(PaymentSheetResult.Completed::class.java)
-                countDownLatch.countDown()
-            }
-        }
-        scenario.moveToState(Lifecycle.State.RESUMED)
-        scenario.onActivity {
-            paymentSheet.presentWithIntentConfiguration(
+        testContext.presentPaymentSheet {
+            presentWithIntentConfiguration(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
                         amount = 2000,
@@ -349,7 +271,5 @@ internal class PaymentSheetTest {
         }
 
         page.clickPrimaryButton()
-
-        assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -120,7 +120,6 @@ internal class PaymentSheetTest {
         }
     }
 
-    @OptIn(ExperimentalPaymentSheetDecouplingApi::class)
     @Test
     fun testDeferredIntentCardPayment() = runPaymentSheetTest(
         createIntentCallback = { _, _ -> CreateIntentResult.Success("pi_example_secret_example") },
@@ -181,7 +180,6 @@ internal class PaymentSheetTest {
         page.clickPrimaryButton()
     }
 
-    @OptIn(ExperimentalPaymentSheetDecouplingApi::class)
     @Test
     fun testDeferredIntentFailedCardPayment() = runPaymentSheetTest(
         createIntentCallback = { _, _ ->
@@ -230,7 +228,7 @@ internal class PaymentSheetTest {
         testContext.markTestSucceeded()
     }
 
-    @OptIn(ExperimentalPaymentSheetDecouplingApi::class, DelicatePaymentSheetApi::class)
+    @OptIn(DelicatePaymentSheetApi::class)
     @Test
     fun testDeferredIntentCardPaymentWithForcedSuccess() = runPaymentSheetTest(
         createIntentCallback = { _, _ ->

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/FlowControllerTestFactory.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/FlowControllerTestFactory.kt
@@ -1,0 +1,52 @@
+package com.stripe.android.paymentsheet.utils
+
+import androidx.activity.ComponentActivity
+import com.stripe.android.paymentsheet.CreateIntentCallback
+import com.stripe.android.paymentsheet.ExperimentalPaymentSheetDecouplingApi
+import com.stripe.android.paymentsheet.PaymentOptionCallback
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheetResultCallback
+
+@OptIn(ExperimentalPaymentSheetDecouplingApi::class)
+internal class FlowControllerTestFactory(
+    private val integrationType: IntegrationType,
+    private val createIntentCallback: CreateIntentCallback? = null,
+    private val paymentOptionCallback: PaymentOptionCallback,
+    private val resultCallback: PaymentSheetResultCallback,
+) {
+
+    enum class IntegrationType {
+        Activity,
+    }
+
+    fun make(activity: ComponentActivity): PaymentSheet.FlowController {
+        return when (integrationType) {
+            IntegrationType.Activity -> forActivity(activity)
+        }
+    }
+
+    private fun forActivity(activity: ComponentActivity): PaymentSheet.FlowController {
+        lateinit var flowController: PaymentSheet.FlowController
+        flowController = if (createIntentCallback != null) {
+            PaymentSheet.FlowController.create(
+                activity = activity,
+                paymentOptionCallback = { paymentOption ->
+                    paymentOptionCallback.onPaymentOption(paymentOption)
+                    flowController.confirm()
+                },
+                createIntentCallback = createIntentCallback,
+                paymentResultCallback = resultCallback,
+            )
+        } else {
+            PaymentSheet.FlowController.create(
+                activity = activity,
+                paymentOptionCallback = { paymentOption ->
+                    paymentOptionCallback.onPaymentOption(paymentOption)
+                    flowController.confirm()
+                },
+                paymentResultCallback = resultCallback,
+            )
+        }
+        return flowController
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/FlowControllerTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/FlowControllerTestRunner.kt
@@ -1,0 +1,83 @@
+package com.stripe.android.paymentsheet.utils
+
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.paymentsheet.CreateIntentCallback
+import com.stripe.android.paymentsheet.ExperimentalPaymentSheetDecouplingApi
+import com.stripe.android.paymentsheet.MainActivity
+import com.stripe.android.paymentsheet.PaymentOptionCallback
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheetResultCallback
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+internal class FlowControllerTestRunnerContext(
+    private val scenario: ActivityScenario<MainActivity>,
+    private val flowController: PaymentSheet.FlowController,
+) {
+
+    fun configureFlowController(
+        block: PaymentSheet.FlowController.() -> Unit,
+    ) {
+        scenario.onActivity {
+            flowController.block()
+        }
+    }
+}
+
+@OptIn(ExperimentalPaymentSheetDecouplingApi::class)
+internal fun runFlowControllerTest(
+    createIntentCallback: CreateIntentCallback? = null,
+    paymentOptionCallback: PaymentOptionCallback,
+    resultCallback: PaymentSheetResultCallback,
+    block: (FlowControllerTestRunnerContext) -> Unit,
+) {
+    for (integrationType in FlowControllerTestFactory.IntegrationType.values()) {
+        val countDownLatch = CountDownLatch(1)
+
+        val factory = FlowControllerTestFactory(
+            integrationType = integrationType,
+            createIntentCallback = createIntentCallback,
+            paymentOptionCallback = paymentOptionCallback,
+            resultCallback = { result ->
+                resultCallback.onPaymentSheetResult(result)
+                countDownLatch.countDown()
+            }
+        )
+
+        runFlowControllerTest(
+            countDownLatch = countDownLatch,
+            makeFlowController = factory::make,
+            block = block,
+        )
+    }
+}
+
+private fun runFlowControllerTest(
+    countDownLatch: CountDownLatch,
+    makeFlowController: (ComponentActivity) -> PaymentSheet.FlowController,
+    block: (FlowControllerTestRunnerContext) -> Unit,
+) {
+    val scenario = ActivityScenario.launch(MainActivity::class.java)
+    scenario.moveToState(Lifecycle.State.CREATED)
+
+    scenario.onActivity {
+        PaymentConfiguration.init(it, "pk_test_123")
+    }
+
+    lateinit var flowController: PaymentSheet.FlowController
+    scenario.onActivity {
+        flowController = makeFlowController(it)
+    }
+
+    scenario.moveToState(Lifecycle.State.RESUMED)
+
+    val testContext = FlowControllerTestRunnerContext(scenario, flowController)
+    block(testContext)
+
+    assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
+    scenario.close()
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PaymentSheetTestFactory.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PaymentSheetTestFactory.kt
@@ -1,0 +1,33 @@
+package com.stripe.android.paymentsheet.utils
+
+import androidx.activity.ComponentActivity
+import com.stripe.android.paymentsheet.CreateIntentCallback
+import com.stripe.android.paymentsheet.ExperimentalPaymentSheetDecouplingApi
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheetResultCallback
+
+@OptIn(ExperimentalPaymentSheetDecouplingApi::class)
+internal class PaymentSheetTestFactory(
+    private val integrationType: IntegrationType,
+    private val createIntentCallback: CreateIntentCallback? = null,
+    private val resultCallback: PaymentSheetResultCallback,
+) {
+
+    enum class IntegrationType {
+        Activity,
+    }
+
+    fun make(activity: ComponentActivity): PaymentSheet {
+        return when (integrationType) {
+            IntegrationType.Activity -> forActivity(activity)
+        }
+    }
+
+    private fun forActivity(activity: ComponentActivity): PaymentSheet {
+        return if (createIntentCallback != null) {
+            PaymentSheet(activity, createIntentCallback, resultCallback)
+        } else {
+            PaymentSheet(activity, resultCallback)
+        }
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PaymentSheetTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PaymentSheetTestRunner.kt
@@ -27,6 +27,11 @@ internal class PaymentSheetTestRunnerContext(
         }
     }
 
+    /**
+     * Normally we know a test succeeds when it calls [PaymentSheetResultCallback], but some tests
+     * succeed based on other criteria. In these cases, call this method to manually mark a test as
+     * succeeded.
+     */
     fun markTestSucceeded() {
         countDownLatch.countDown()
     }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PaymentSheetTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PaymentSheetTestRunner.kt
@@ -1,0 +1,85 @@
+package com.stripe.android.paymentsheet.utils
+
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.paymentsheet.CreateIntentCallback
+import com.stripe.android.paymentsheet.ExperimentalPaymentSheetDecouplingApi
+import com.stripe.android.paymentsheet.MainActivity
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheetResultCallback
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+internal class PaymentSheetTestRunnerContext(
+    private val scenario: ActivityScenario<MainActivity>,
+    private val paymentSheet: PaymentSheet,
+    private val countDownLatch: CountDownLatch,
+) {
+
+    fun presentPaymentSheet(
+        block: PaymentSheet.() -> Unit,
+    ) {
+        scenario.onActivity {
+            paymentSheet.block()
+        }
+    }
+
+    fun markTestSucceeded() {
+        countDownLatch.countDown()
+    }
+}
+
+@OptIn(ExperimentalPaymentSheetDecouplingApi::class)
+internal fun runPaymentSheetTest(
+    createIntentCallback: CreateIntentCallback? = null,
+    resultCallback: PaymentSheetResultCallback,
+    block: (PaymentSheetTestRunnerContext) -> Unit,
+) {
+    for (integrationType in PaymentSheetTestFactory.IntegrationType.values()) {
+        val countDownLatch = CountDownLatch(1)
+
+        val factory = PaymentSheetTestFactory(
+            integrationType = integrationType,
+            createIntentCallback = createIntentCallback,
+            resultCallback = { result ->
+                resultCallback.onPaymentSheetResult(result)
+                countDownLatch.countDown()
+            }
+        )
+
+        runPaymentSheetTestInternal(
+            countDownLatch = countDownLatch,
+            makePaymentSheet = factory::make,
+            block = block,
+        )
+    }
+}
+
+private fun runPaymentSheetTestInternal(
+    countDownLatch: CountDownLatch,
+    makePaymentSheet: (ComponentActivity) -> PaymentSheet,
+    block: (PaymentSheetTestRunnerContext) -> Unit,
+) {
+    val scenario = ActivityScenario.launch(MainActivity::class.java)
+    scenario.moveToState(Lifecycle.State.CREATED)
+
+    scenario.onActivity {
+        PaymentConfiguration.init(it, "pk_test_123")
+    }
+
+    lateinit var paymentSheet: PaymentSheet
+    scenario.onActivity {
+        paymentSheet = makePaymentSheet(it)
+    }
+
+    scenario.moveToState(Lifecycle.State.RESUMED)
+
+    val testContext = PaymentSheetTestRunnerContext(scenario, paymentSheet, countDownLatch)
+    block(testContext)
+
+    assertThat(countDownLatch.await(5, TimeUnit.SECONDS)).isTrue()
+    scenario.close()
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ResultAssertions.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ResultAssertions.kt
@@ -1,0 +1,17 @@
+package com.stripe.android.paymentsheet.utils
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentsheet.PaymentSheetResult
+
+internal fun assertCompleted(result: PaymentSheetResult) {
+    assertThat(result).isInstanceOf(PaymentSheetResult.Completed::class.java)
+}
+
+internal fun assertFailed(result: PaymentSheetResult) {
+    assertThat(result).isInstanceOf(PaymentSheetResult.Failed::class.java)
+}
+
+@Suppress("UNUSED_PARAMETER")
+internal fun expectNoResult(result: PaymentSheetResult) {
+    error("Shouldn't call PaymentSheetResultCallback")
+}


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds two new test runners for `PaymentSheetTest` and `FlowControllerTest` in preparation of https://github.com/stripe/stripe-android/pull/6583. They’ll allow us to test both the Activity and Compose entry points with a single test.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
