### PR TITLE
Add script to generate PRs for changed screenshots

### DIFF
--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -44,7 +44,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
-          PR_BRANCH: ${{ github.head_ref }}
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 28
@@ -54,7 +53,7 @@ jobs:
           disable-animations: true
           sdcard-path-or-size: 512M
           profile: Nexus 6
-          script: ruby scripts/record_screenshots.rb
+          script: ruby scripts/check_payment_sheet_screenshots.rb
       - uses: actions/upload-artifact@v3
         if: failure()
         with:

--- a/.github/workflows/instrumentation_tests.yml
+++ b/.github/workflows/instrumentation_tests.yml
@@ -41,6 +41,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/stripe_setup
       - name: run tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
+          PR_BRANCH: ${{ github.head_ref }}
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 28
@@ -50,9 +54,7 @@ jobs:
           disable-animations: true
           sdcard-path-or-size: 512M
           profile: Nexus 6
-          # We need to append these weird flags because of a Java 17 bug in Shot
-          # See: https://github.com/pedrovgs/Shot/issues/268
-          script: ./gradlew paymentsheet-example:executeScreenshotTests -Pandroid.testInstrumentationRunnerArguments.package=com.stripe.android.screenshot -Dorg.gradle.jvmargs="--add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/java.nio.channels=ALL-UNNAMED --add-exports java.base/sun.nio.ch=ALL-UNNAMED"
+          script: ruby scripts/record_screenshots.rb
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
@@ -61,6 +63,12 @@ jobs:
             **/build/reports/shot/debug/verification/
             **/tmp/shot/screenshot/
             **/build/reports/androidTests/connected/
+      - uses: peter-evans/create-or-update-comment@v2
+        if: steps.failed-screenshots.outputs.PR_COMMENT
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: ${{ steps.failed-screenshots.outputs.PR_COMMENT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 #       - name: Notify failure endpoint
 #         id: notifyFailureEndpoint
 #         if: failure()

--- a/scripts/record_screenshots.rb
+++ b/scripts/record_screenshots.rb
@@ -1,0 +1,78 @@
+#!/usr/bin/env ruby
+
+require 'open3'
+
+def current_branch
+    pr_branch = ENV['PR_BRANCH']
+    if pr_branch.nil? || pr_branch.empty?
+        'master'
+    else
+        pr_branch
+    end
+end
+
+def create_new_branch_name(current_branch)
+    timestamp = Time.now.strftime("%Y-%m-%d-%H-%M-%S")
+    "ci/updated-screenshots-for-#{current_branch}-#{timestamp}"
+end
+
+def execute_or_fail(command)
+    system(command) or raise "Failed to execute #{command}"
+end
+
+def setup
+    token = ENV['GITHUB_TOKEN']
+    if token.nil?
+        abort("Missing GITHUB_TOKEN environment variable.")
+    end
+
+    repo = ENV['GITHUB_REPOSITORY']
+    if repo.nil?
+        abort("Missing GITHUB_REPOSITORY environment variable.")
+    end
+
+    branch = current_branch
+
+    return token, repo, branch
+end
+
+# ------------------------------
+
+token, repo, base_branch = setup
+
+# Record the screenshots
+record_command = './gradlew paymentsheet-example:executeScreenshotTests -Precord -Pandroid.testInstrumentationRunnerArguments.package=com.stripe.android.screenshot'
+# We need to append these weird flags because of a Java 17 bug in Shot
+# See: https://github.com/pedrovgs/Shot/issues/268
+jdk_17_args = '-Dorg.gradle.jvmargs="--add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/java.nio.channels=ALL-UNNAMED --add-exports java.base/sun.nio.ch=ALL-UNNAMED"'
+system("#{record_command} #{jdk_17_args}")
+
+diff_command = 'git status --porcelain'
+stdout, _, _ = Open3.capture3(diff_command)
+
+if stdout.empty?
+    puts "No differences in screenshots found."
+    exit true
+end
+
+# Commit the changes
+new_branch_name = create_new_branch_name(base_branch)
+execute_or_fail("git checkout -b #{new_branch_name}")
+execute_or_fail("git add .")
+execute_or_fail("git commit -m \"Update screenshots\"")
+
+# Push the changes
+push_url = "https://#{token}@github.com/#{repo}.git"
+execute_or_fail("git push --force #{push_url}")
+
+# Comment on original pull request
+diff_url = "https://github.com/#{repo}/compare/#{base_branch}...#{new_branch_name}"
+
+if base_branch == "master"
+    # If this is a push to master, output the diff URL for later usage
+    puts "Screenshot tests failed.\n\nMerge the screenshot diff here if it's an intentional change: #{diff_url}"
+else
+    # If this is a pull request, comment on it
+    comment = "Screenshot tests failed.\n\n[See differences](#{diff_url})\n\nMerge the branch if it's an intentional change."
+    system("::set-output name=PR_COMMENT::\"#{comment}\"")
+end


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This script changes how we run `TestPaymentSheetScreenshots`. Instead of just validating that the screenshots didn’t change, we immediately record any changed screenshots and make it easy to open a separate pull request with these updated images, which can then be merged into the base branch without having to run these tests locally.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
