### PR TITLE
LinkAccountPicker: first account is still pre-selected when all accounts are disabled


### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModel.kt
@@ -77,8 +77,8 @@ internal class LinkAccountPickerViewModel @Inject constructor(
         onAsync(
             LinkAccountPickerState::payload,
             onSuccess = {
-                // Select first account by default.
-                setState { copy(selectedAccountId = it.accounts.firstOrNull()?.id) }
+                // Select first selectable account by default.
+                setState { copy(selectedAccountId = it.accounts.firstOrNull { it.allowSelection }?.id) }
             },
             onFail = { error ->
                 logger.error("Error fetching payload", error)

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/linkaccountpicker/LinkAccountPickerViewModel.kt
@@ -76,10 +76,6 @@ internal class LinkAccountPickerViewModel @Inject constructor(
     private fun observeAsyncs() {
         onAsync(
             LinkAccountPickerState::payload,
-            onSuccess = {
-                // Select first selectable account by default.
-                setState { copy(selectedAccountId = it.accounts.firstOrNull { it.allowSelection }?.id) }
-            },
             onFail = { error ->
                 logger.error("Error fetching payload", error)
                 eventTracker.track(Error(PANE, error))


### PR DESCRIPTION
# Summary
- Issue: Don't pre-select account when no accounts are selectable.

| After | Before |
|:---:|:---:|
| <img src='https://github.com/stripe/stripe-android/assets/99293320/f19cc20e-1241-4640-921a-881c7e079dd3' width=200px> | <img src='https://github.com/stripe/stripe-android/assets/99293320/2c6b1248-c9d5-45e3-ac2b-da1b5874455d' width=200px> |


# Motivation
:notebook_with_decorative_cover: &nbsp;**[Android] LinkAccountPicker: first account is still pre-selected when all accounts are disabled**
:globe_with_meridians: &nbsp;[BANKCON-7170](https://jira.corp.stripe.com/browse/BANKCON-7170)
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->