### PR TITLE
Add temporary workaround for result

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetActivity.kt
@@ -95,6 +95,7 @@ internal class CustomerSheetActivity : AppCompatActivity() {
 
     private fun finishWithResult(result: InternalCustomerSheetResult) {
         setResult(RESULT_OK, Intent().putExtras(result.toBundle()))
+        viewModel.clear()
         finish()
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -83,6 +83,15 @@ internal class CustomerSheetViewModel @Inject constructor(
         }.orEmpty()
     }
 
+    // TODO (jameswoo) required for now to clear the result. This allows the view model to not enter
+    // a state where the result was already set before. This should be fixed by correctly modeling
+    // the lifecycle of this view model.
+    fun clear() {
+        _result.update {
+            null
+        }
+    }
+
     private fun loadPaymentMethods() {
         viewModelScope.launch {
             var savedPaymentMethods: List<PaymentMethod> = emptyList()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Add temporary workaround for result. This is needed to make sure that the view model is not initialized with a result from a previous invocation of the CustomerSheet.

This will be fixed in a future PR where the activity view model should have a different scope.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

