### PR TITLE
Add loading indicator for primary button

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/ui/PrimaryButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/ui/PrimaryButton.kt
@@ -2,12 +2,16 @@ package com.stripe.android.common.ui
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
@@ -31,6 +35,7 @@ internal fun PrimaryButton(
     isEnabled: Boolean,
     onButtonClick: () -> Unit,
     modifier: Modifier = Modifier,
+    isLoading: Boolean = false,
 ) {
     // We need to use PaymentsTheme.primaryButtonStyle instead of MaterialTheme
     // because of the rules API for primary button.
@@ -70,10 +75,40 @@ internal fun PrimaryButton(
                     disabledBackgroundColor = background
                 )
             ) {
-                Text(
+                PrimaryButtonContent(
                     text = label,
                     color = onBackground.copy(alpha = LocalContentAlpha.current),
-                    style = textStyle
+                    style = textStyle,
+                    isLoading = isLoading,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun PrimaryButtonContent(
+    text: String,
+    color: Color,
+    style: TextStyle,
+    isLoading: Boolean,
+) {
+    BoxWithConstraints(contentAlignment = Alignment.CenterStart) {
+        Text(
+            text = text,
+            color = color,
+            style = style,
+            modifier = Modifier.align(Alignment.Center),
+        )
+        if (isLoading) {
+            Box(
+                modifier = Modifier
+                    .width(maxWidth)
+                    .padding(end = 8.dp)
+            ) {
+                LoadingIndicator(
+                    color = MaterialTheme.colors.onPrimary,
+                    modifier = Modifier.align(Alignment.CenterEnd)
                 )
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -162,6 +162,7 @@ internal class CustomerSheetViewModel @Inject constructor(
                 formViewData = FormViewModel.ViewData(),
                 enabled = true,
                 isLiveMode = isLiveMode,
+                isProcessing = false,
             )
         )
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewState.kt
@@ -57,6 +57,7 @@ internal sealed class CustomerSheetViewState(
         val formViewData: FormViewModel.ViewData,
         val enabled: Boolean,
         override val isLiveMode: Boolean,
+        override val isProcessing: Boolean,
     ) : CustomerSheetViewState(
         savedPaymentMethods = emptyList(),
         isLiveMode = isLiveMode,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/ui/CustomerSheetScreen.kt
@@ -174,6 +174,7 @@ internal fun AddCard(
             // TODO (jameswoo) add to lokalize
             label = "Add",
             isEnabled = true,
+            isLoading = viewState.isProcessing,
             onButtonClick = {
                 viewActionHandler(CustomerSheetViewAction.OnPrimaryButtonPressed)
             },

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetActivityTest.kt
@@ -278,11 +278,13 @@ internal class CustomerSheetActivityTest {
         isLiveMode: Boolean = false,
         formViewData: FormViewModel.ViewData = FormViewModel.ViewData(),
         enabled: Boolean = true,
+        isProcessing: Boolean = false,
     ): CustomerSheetViewState.AddPaymentMethod {
         return CustomerSheetViewState.AddPaymentMethod(
             formViewData = formViewData,
             enabled = enabled,
             isLiveMode = isLiveMode,
+            isProcessing = isProcessing
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -156,6 +156,7 @@ class CustomerSheetScreenshotTest {
                     formViewData = FormViewModel.ViewData(),
                     enabled = true,
                     isLiveMode = false,
+                    isProcessing = false,
                 ),
                 paymentMethodNameProvider = { it!! }
             )


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Add loading indicator for primary button. This matches what iOS has.

https://github.com/stripe/stripe-android/assets/99316447/91eab3ed-b1a4-4f48-9873-932015dc6751

# Screenshots

<img src="https://github.com/stripe/stripe-android/assets/99316447/d55e2fcd-9389-48ee-a3ab-a966584c6829" height=600/>
