### PR TITLE
Inject StripeRepository in CustomerSheetViewModel

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -8,6 +8,7 @@ import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.
 import com.stripe.android.customersheet.injection.CustomerSessionScope
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.forms.FormViewModel
@@ -30,10 +31,12 @@ import javax.inject.Provider
 
 @OptIn(ExperimentalCustomerSheetApi::class)
 @CustomerSessionScope
+@Suppress("unused")
 internal class CustomerSheetViewModel @Inject constructor(
-    paymentConfiguration: PaymentConfiguration,
+    private val paymentConfiguration: PaymentConfiguration,
     private val resources: Resources,
     private val configuration: CustomerSheet.Configuration,
+    private val stripeRepository: StripeRepository,
     private val customerAdapter: CustomerAdapter,
     private val lpmRepository: LpmRepository,
     private val formViewModelSubcomponentBuilderProvider: Provider<FormViewModelSubcomponent.Builder>,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSessionComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSessionComponent.kt
@@ -7,12 +7,18 @@ import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetResultCallback
 import com.stripe.android.customersheet.CustomerSheetViewModel
 import com.stripe.android.customersheet.ExperimentalCustomerSheetApi
+import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import dagger.BindsInstance
 import dagger.Component
 
 @OptIn(ExperimentalCustomerSheetApi::class)
 @CustomerSessionScope
-@Component(modules = [CustomerSheetViewModelModule::class])
+@Component(
+    modules = [
+        CustomerSheetViewModelModule::class,
+        StripeRepositoryModule::class,
+    ]
+)
 internal interface CustomerSessionComponent {
     val customerSheetComponentBuilder: CustomerSheetComponent.Builder
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
@@ -3,13 +3,20 @@ package com.stripe.android.customersheet.injection
 import android.app.Application
 import android.content.Context
 import android.content.res.Resources
+import androidx.core.os.LocaleListCompat
+import com.stripe.android.BuildConfig
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.Logger
+import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
+import com.stripe.android.core.injection.PUBLISHABLE_KEY
+import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.paymentsheet.injection.FormViewModelSubcomponent
 import com.stripe.android.ui.core.forms.resources.LpmRepository
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.Dispatchers
+import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
 
 @Module(
@@ -46,4 +53,26 @@ internal class CustomerSheetViewModelModule {
             LpmRepository.LpmRepositoryArguments(resources)
         )
     }
+
+    @Provides
+    @Named(PUBLISHABLE_KEY)
+    fun publishableKeyProvider(paymentConfiguration: PaymentConfiguration): () -> String {
+        return { paymentConfiguration.publishableKey }
+    }
+
+    @Provides
+    @Named(PRODUCT_USAGE)
+    fun provideProductUsageTokens() = setOf("CustomerSheet")
+
+    @Provides
+    @Named(ENABLE_LOGGING)
+    fun providesEnableLogging(): Boolean = BuildConfig.DEBUG
+
+    @Provides
+    fun provideLogger(@Named(ENABLE_LOGGING) enableLogging: Boolean) =
+        Logger.getInstance(enableLogging)
+
+    @Provides
+    fun provideLocale() =
+        LocaleListCompat.getAdjustedDefault().takeUnless { it.isEmpty }?.get(0)
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.customersheet
 
 import android.app.Application
-import androidx.lifecycle.viewModelScope
 import androidx.test.core.app.ApplicationProvider
 import app.cash.turbine.test
 import app.cash.turbine.testIn
@@ -446,8 +445,8 @@ class CustomerSheetViewModelTest {
                 )
             )
         )
-        val viewStateTurbine = viewModel.viewState.testIn(viewModel.viewModelScope)
-        val resultTurbine = viewModel.result.testIn(viewModel.viewModelScope)
+        val viewStateTurbine = viewModel.viewState.testIn(backgroundScope)
+        val resultTurbine = viewModel.result.testIn(backgroundScope)
 
         assertThat(viewStateTurbine.awaitItem()).isInstanceOf(CustomerSheetViewState.SelectPaymentMethod::class.java)
         assertThat(resultTurbine.awaitItem()).isNull()


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Inject StripeRepository in CustomerSheetViewModel. Will be used to attach payment methods to customers with setup intents.
