### PR TITLE
Add canCreateSetupIntents to CustomerAdapter

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
@@ -21,6 +21,12 @@ import com.stripe.android.paymentsheet.model.SavedSelection
 @ExperimentalCustomerSheetApi
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface CustomerAdapter {
+
+    /**
+     * Whether this backend adapter is able to create setup intents.
+     */
+    val canCreateSetupIntents: Boolean
+
     /**
      * Retrieves a list of payment methods attached to a customer
      * @return a list of [PaymentMethod]s.

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
@@ -38,6 +38,9 @@ internal class StripeCustomerAdapter @Inject constructor(
     @Volatile
     private var cachedCustomerEphemeralKey: CachedCustomerEphemeralKey? = null
 
+    override val canCreateSetupIntents: Boolean
+        get() = setupIntentClientSecretProvider != null
+
     override suspend fun retrievePaymentMethods(): Result<List<PaymentMethod>> {
         return getCustomerEphemeralKey().map { customerEphemeralKey ->
             val paymentMethods = customerRepository.getPaymentMethods(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -395,6 +395,21 @@ class CustomerAdapterTest {
         )
     }
 
+    @Test
+    fun `canCreateSetupIntents should return true if setupIntentClientSecretForCustomerAttach is not null`() {
+        var adapter = createAdapter(
+            setupIntentClientSecretProvider = null,
+        )
+
+        assertThat(adapter.canCreateSetupIntents).isFalse()
+
+        adapter = createAdapter(
+            setupIntentClientSecretProvider = { Result.success("client_secret") },
+        )
+
+        assertThat(adapter.canCreateSetupIntents).isTrue()
+    }
+
     private fun createAdapter(
         customerEphemeralKeyProvider: CustomerEphemeralKeyProvider =
             CustomerEphemeralKeyProvider {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/FakeCustomerAdapter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/FakeCustomerAdapter.kt
@@ -9,6 +9,10 @@ internal class FakeCustomerAdapter(
     private val onSetSelectedPaymentOption: ((paymentOption: CustomerAdapter.PaymentOption?) -> Result<Unit>)? = null,
     private val onDetachPaymentMethod: ((paymentMethodId: String) -> Result<PaymentMethod>)? = null,
 ) : CustomerAdapter {
+
+    override val canCreateSetupIntents: Boolean
+        get() = true
+
     override suspend fun retrievePaymentMethods(): Result<List<PaymentMethod>> {
         return paymentMethods
     }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Add canCreateSetupIntents to CustomerAdapter

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

We need an explicit way to determine if we are attaching the payment method to the customer using setup intents, rather than relying on catching exceptions or Result.failure.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

