### PR TITLE
Update CustomerAdapter Result

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/CustomerSheetExampleViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/CustomerSheetExampleViewModel.kt
@@ -50,7 +50,7 @@ class CustomerSheetExampleViewModel(
                 failure = {
                     CustomerAdapter.Result.failure(
                         it.exception,
-                        "We could\'nt retrieve your information, please try again"
+                        "We could\'nt retrieve your information, please try again."
                     )
                 }
             )
@@ -65,7 +65,7 @@ class CustomerSheetExampleViewModel(
                 failure = {
                     CustomerAdapter.Result.failure(
                         it.exception,
-                        it.message
+                        "We could\'nt retrieve your information, please try again."
                     )
                 }
             )

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/CustomerSheetExampleViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/CustomerSheetExampleViewModel.kt
@@ -50,7 +50,7 @@ class CustomerSheetExampleViewModel(
                 failure = {
                     CustomerAdapter.Result.failure(
                         it.exception,
-                        it.message
+                        "We could\'nt retrieve your information, please try again"
                     )
                 }
             )

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/CustomerSheetExampleViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/customersheet/CustomerSheetExampleViewModel.kt
@@ -40,7 +40,7 @@ class CustomerSheetExampleViewModel(
         customerEphemeralKeyProvider = {
             fetchCustomerEphemeralKey().fold(
                 success = {
-                    Result.success(
+                    CustomerAdapter.Result.success(
                         CustomerEphemeralKey.create(
                             customerId = it.customerId,
                             ephemeralKey = it.customerEphemeralKeySecret
@@ -48,19 +48,25 @@ class CustomerSheetExampleViewModel(
                     )
                 },
                 failure = {
-                    Result.failure(it.exception)
+                    CustomerAdapter.Result.failure(
+                        it.exception,
+                        it.message
+                    )
                 }
             )
         },
         setupIntentClientSecretProvider = { customerId ->
             createSetupIntent(customerId).fold(
                 success = {
-                    Result.success(
+                    CustomerAdapter.Result.success(
                         it.clientSecret
                     )
                 },
                 failure = {
-                    Result.failure(it.exception)
+                    CustomerAdapter.Result.failure(
+                        it.exception,
+                        it.message
+                    )
                 }
             )
         },

--- a/paymentsheet/src/main/java/com/stripe/android/common/exception/ExceptionKt.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/exception/ExceptionKt.kt
@@ -1,0 +1,10 @@
+package com.stripe.android.common.exception
+
+import android.content.Context
+import com.stripe.android.core.exception.StripeException
+import com.stripe.android.paymentsheet.R
+
+internal fun Throwable.stripeErrorMessage(context: Context): String {
+    return (this as? StripeException)?.stripeError?.message
+        ?: context.resources.getString(R.string.stripe_something_went_wrong)
+}

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
@@ -150,26 +150,63 @@ interface CustomerAdapter {
             }
         }
     }
+
+    @ExperimentalCustomerSheetApi
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    @JvmInline
+    value class Result<out T> internal constructor(
+        internal val value: Any?
+    ) {
+
+        val isSuccess: Boolean get() = value !is Failure
+        val isFailure: Boolean get() = value is Failure
+
+        internal data class Failure(
+            val cause: Throwable?,
+            val displayMessage: String? = null
+        )
+
+        @ExperimentalCustomerSheetApi
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        companion object {
+            @ExperimentalCustomerSheetApi
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            fun <T> success(value: T): Result<T> {
+                return Result(value)
+            }
+
+            @ExperimentalCustomerSheetApi
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+            fun <T> failure(cause: Throwable?, displayMessage: String? = null): Result<T> {
+                return Result(createFailure(cause, displayMessage))
+            }
+        }
+    }
 }
 
 /**
  * Callback to provide the customer's ID and an ephemeral key from your server.
+ * Return [CustomerAdapter.Result.failure] with a [CustomerAdapter.Result.Failure.displayMessage]
+ * if something went wrong during the retrieval of the ephemeral key.
  */
 @ExperimentalCustomerSheetApi
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun interface CustomerEphemeralKeyProvider {
 
-    suspend fun provideCustomerEphemeralKey(): Result<CustomerEphemeralKey>
+    suspend fun provideCustomerEphemeralKey(): CustomerAdapter.Result<CustomerEphemeralKey>
 }
 
 /**
  * Callback to provide the [SetupIntent] client secret given a customer ID from your server.
+ * Return [CustomerAdapter.Result.failure] with a with a
+ * [CustomerAdapter.Result.Failure.displayMessage]  if something went wrong during the retrieval of
+ * the [SetupIntent] client secret.
  */
 @ExperimentalCustomerSheetApi
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun interface SetupIntentClientSecretProvider {
 
-    suspend fun provideSetupIntentClientSecret(customerId: String): Result<String>
+    suspend fun provideSetupIntentClientSecret(customerId: String): CustomerAdapter.Result<String>
 }
 
 @ExperimentalCustomerSheetApi

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
@@ -196,7 +196,7 @@ interface CustomerAdapter {
 
             @ExperimentalCustomerSheetApi
             @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-            fun <T> failure(cause: Throwable?, displayMessage: String? = null): Result<T> {
+            fun <T> failure(cause: Throwable?, displayMessage: String?): Result<T> {
                 return Result(createFailure(cause, displayMessage))
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapterResultKt.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapterResultKt.kt
@@ -1,0 +1,95 @@
+@file:Suppress("UNCHECKED_CAST")
+
+package com.stripe.android.customersheet
+
+import com.stripe.android.core.exception.StripeException
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+internal fun createFailure(cause: Throwable?, displayMessage: String? = null): Any {
+    return CustomerAdapter.Result.Failure(cause, displayMessage)
+}
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+internal fun<T> CustomerAdapter.Result<T>.getOrNull(): T? =
+    when {
+        isFailure -> null
+        else -> value as T
+    }
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+internal fun <R, T> CustomerAdapter.Result<T>.flatMap(
+    transform: (T) -> CustomerAdapter.Result<R>
+): CustomerAdapter.Result<R> {
+    return when {
+        isSuccess -> transform(value as T)
+        else -> CustomerAdapter.Result(value)
+    }
+}
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+internal inline fun <R, T> CustomerAdapter.Result<T>.map(
+    transform: (value: T) -> R
+): CustomerAdapter.Result<R> {
+    return when {
+        isSuccess -> CustomerAdapter.Result.success(transform(value as T))
+        else -> CustomerAdapter.Result(value)
+    }
+}
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+internal inline fun <R, T> CustomerAdapter.Result<T>.mapCatching(
+    transform: (value: T) -> R
+): CustomerAdapter.Result<R> {
+    return when {
+        isSuccess -> runCatching { transform(value as T) }
+        else -> CustomerAdapter.Result(value)
+    }
+}
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+@Suppress("TooGenericExceptionCaught")
+internal inline fun <R, T> T.runCatching(block: T.() -> R): CustomerAdapter.Result<R> {
+    return try {
+        CustomerAdapter.Result.success(block())
+    } catch (e: Throwable) {
+        CustomerAdapter.Result.failure(e)
+    }
+}
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+internal inline fun <R, T> CustomerAdapter.Result<T>.fold(
+    onSuccess: (value: T) -> R,
+    onFailure: (cause: Throwable?, displayMessage: String?) -> R
+): R {
+    return when (val failure = value as? CustomerAdapter.Result.Failure) {
+        is CustomerAdapter.Result.Failure -> onFailure(failure.cause, failure.displayMessage)
+        else -> onSuccess(value as T)
+    }
+}
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+internal inline fun <R, T> CustomerAdapter.Result<T>.onSuccess(
+    action: (value: T) -> R
+): CustomerAdapter.Result<T> {
+    if (isSuccess) action(value as T)
+    return this
+}
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+internal inline fun <R, T> CustomerAdapter.Result<T>.onFailure(
+    action: (cause: Throwable?, displayMessage: String?) -> R
+): CustomerAdapter.Result<T> {
+    failureOrNull()?.let {
+        val displayMessage = it.displayMessage
+            ?: (it.cause as? StripeException)?.stripeError?.message
+        action(it.cause, displayMessage)
+    }
+    return this
+}
+
+@OptIn(ExperimentalCustomerSheetApi::class)
+internal fun<T> CustomerAdapter.Result<T>.failureOrNull(): CustomerAdapter.Result.Failure? =
+    when {
+        isFailure -> value as CustomerAdapter.Result.Failure
+        else -> null
+    }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapterResultKt.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapterResultKt.kt
@@ -3,6 +3,7 @@
 package com.stripe.android.customersheet
 
 import com.stripe.android.core.exception.StripeException
+import com.stripe.android.paymentsheet.R
 
 @OptIn(ExperimentalCustomerSheetApi::class)
 internal fun createFailure(cause: Throwable?, displayMessage: String? = null): Any {
@@ -48,11 +49,11 @@ internal inline fun <R, T> CustomerAdapter.Result<T>.mapCatching(
 
 @OptIn(ExperimentalCustomerSheetApi::class)
 @Suppress("TooGenericExceptionCaught")
-internal inline fun <R, T> T.runCatching(block: T.() -> R): CustomerAdapter.Result<R> {
+private inline fun <R, T> T.runCatching(block: T.() -> R): CustomerAdapter.Result<R> {
     return try {
         CustomerAdapter.Result.success(block())
     } catch (e: Throwable) {
-        CustomerAdapter.Result.failure(e)
+        CustomerAdapter.Result.failure(e, null)
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -136,25 +136,6 @@ internal class CustomerSheetViewModel @Inject constructor(
         }
     }
 
-    private fun CustomerAdapter.PaymentOption?.toPaymentSelection(
-        paymentMethodProvider: (paymentMethodId: String) -> PaymentMethod?,
-    ): PaymentSelection? {
-        return when (this) {
-            is CustomerAdapter.PaymentOption.GooglePay -> {
-                PaymentSelection.GooglePay
-            }
-            is CustomerAdapter.PaymentOption.Link -> {
-                PaymentSelection.Link
-            }
-            is CustomerAdapter.PaymentOption.StripeId -> {
-                paymentMethodProvider(id)?.let {
-                    PaymentSelection.Saved(it)
-                }
-            }
-            else -> null
-        }
-    }
-
     private fun onAddCardPressed() {
         val paymentMethodCode = PaymentMethod.Type.Card.code
         val formArguments = FormArguments(
@@ -474,13 +455,13 @@ internal class CustomerSheetViewModel @Inject constructor(
                             label = resources.getString(com.stripe.android.R.string.stripe_google_pay),
                         )
                     )
-                }.onFailure { cause, _ ->
+                }.onFailure { cause, displayMessage ->
                     logger.error(
                         msg = "Failed to persist Google Pay",
                         t = cause,
                     )
                     updateViewState<CustomerSheetViewState.SelectPaymentMethod> {
-                        it.copy(errorMessage = resources.getString(R.string.stripe_something_went_wrong))
+                        it.copy(errorMessage = displayMessage)
                     }
                 }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
-import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toSavedSelection
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PrefsRepository
@@ -66,7 +65,7 @@ internal class StripeCustomerAdapter @Inject constructor(
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,
-                    displayMessage = (it as? StripeException)?.stripeError?.message
+                    displayMessage = it.stripeErrorMessage()
                         ?: context.getString(R.string.stripe_something_went_wrong)
                 )
             }
@@ -86,7 +85,7 @@ internal class StripeCustomerAdapter @Inject constructor(
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,
-                    displayMessage = (it as? StripeException)?.stripeError?.message
+                    displayMessage = it.stripeErrorMessage()
                         ?: context.getString(R.string.stripe_something_went_wrong)
                 )
             }
@@ -167,6 +166,10 @@ internal class StripeCustomerAdapter @Inject constructor(
     internal companion object {
         // 30 minutes, server-side timeout is 60
         internal const val CACHED_CUSTOMER_MAX_AGE_MILLIS = 60 * 30 * 1000L
+
+        fun Throwable.stripeErrorMessage(): String? {
+            return (this as? StripeException)?.stripeError?.message
+        }
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.customersheet
 
 import android.content.Context
-import com.stripe.android.core.exception.StripeException
+import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
 import com.stripe.android.model.PaymentMethod
@@ -65,8 +65,7 @@ internal class StripeCustomerAdapter @Inject constructor(
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,
-                    displayMessage = it.stripeErrorMessage()
-                        ?: context.getString(R.string.stripe_something_went_wrong)
+                    displayMessage = it.stripeErrorMessage(context),
                 )
             }
         }
@@ -85,8 +84,7 @@ internal class StripeCustomerAdapter @Inject constructor(
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,
-                    displayMessage = it.stripeErrorMessage()
-                        ?: context.getString(R.string.stripe_something_went_wrong)
+                    displayMessage = it.stripeErrorMessage(context),
                 )
             }
         }
@@ -166,10 +164,6 @@ internal class StripeCustomerAdapter @Inject constructor(
     internal companion object {
         // 30 minutes, server-side timeout is 60
         internal const val CACHED_CUSTOMER_MAX_AGE_MILLIS = 60 * 30 * 1000L
-
-        fun Throwable.stripeErrorMessage(): String? {
-            return (this as? StripeException)?.stripeError?.message
-        }
     }
 }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -7,7 +7,6 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
-import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toSavedSelection
 import com.stripe.android.customersheet.StripeCustomerAdapter.Companion.CACHED_CUSTOMER_MAX_AGE_MILLIS
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.DefaultPrefsRepository

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.StripeError
+import com.stripe.android.core.exception.APIException
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toSavedSelection
 import com.stripe.android.customersheet.StripeCustomerAdapter.Companion.CACHED_CUSTOMER_MAX_AGE_MILLIS
@@ -21,6 +23,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.lang.IllegalStateException
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertFailsWith
 
@@ -42,7 +45,7 @@ class CustomerAdapterTest {
     @Test
     fun `CustomerAdapter can be created`() {
         val customerEphemeralKeyProvider = CustomerEphemeralKeyProvider {
-            Result.success(
+            CustomerAdapter.Result.success(
                 CustomerEphemeralKey(
                     customerId = "cus_123",
                     ephemeralKey = "ek_123"
@@ -51,7 +54,7 @@ class CustomerAdapterTest {
         }
 
         val setupIntentClientSecretProvider = SetupIntentClientSecretProvider {
-            Result.success("seti_123")
+            CustomerAdapter.Result.success("seti_123")
         }
 
         val adapter = CustomerAdapter.create(
@@ -69,7 +72,7 @@ class CustomerAdapterTest {
         val adapter = createAdapter(
             customerEphemeralKeyProvider = {
                 ephemeralKeyProviderCounter.incrementAndGet()
-                Result.success(
+                CustomerAdapter.Result.success(
                     CustomerEphemeralKey(
                         customerId = testScheduler.currentTime.toString(),
                         ephemeralKey = "ek_123"
@@ -95,7 +98,7 @@ class CustomerAdapterTest {
         val adapter = createAdapter(
             customerEphemeralKeyProvider = {
                 ephemeralKeyProviderCounter.incrementAndGet()
-                Result.success(
+                CustomerAdapter.Result.success(
                     CustomerEphemeralKey(
                         customerId = testScheduler.currentTime.toString(),
                         ephemeralKey = "ek_123"
@@ -136,12 +139,16 @@ class CustomerAdapterTest {
 
     @Test
     fun `retrievePaymentMethods returns failure when customer is not fetched`() = runTest {
-        val error = Result.failure<CustomerEphemeralKey>(Exception("Cannot get customer"))
+        val error = CustomerAdapter.Result.failure<CustomerEphemeralKey>(
+            cause = Exception("Cannot get customer"),
+            displayMessage = "Merchant says cannot get customer"
+        )
         val adapter = createAdapter(
             customerEphemeralKeyProvider = { error }
         )
-        val paymentMethods = adapter.retrievePaymentMethods()
-        assertThat(paymentMethods).isEqualTo(error)
+        val result = adapter.retrievePaymentMethods()
+        assertThat((result.value as CustomerAdapter.Result.Failure).displayMessage)
+            .isEqualTo("Merchant says cannot get customer")
     }
 
     @Test
@@ -158,16 +165,40 @@ class CustomerAdapterTest {
     }
 
     @Test
-    fun `attachPaymentMethod fails when the payment method couldn't be attached`() = runTest {
+    fun `attachPaymentMethod fails with default message when the payment method couldn't be attached`() = runTest {
         val adapter = createAdapter(
             customerRepository = FakeCustomerRepository(
                 onAttachPaymentMethod = {
-                    Result.failure(Exception("could not attach payment method"))
+                    Result.failure(
+                        APIException(
+                            message = "could not attach payment method",
+                        )
+                    )
                 }
             )
         )
         val result = adapter.attachPaymentMethod("pm_1234")
-        assertThat(result.isFailure).isTrue()
+        assertThat((result.value as CustomerAdapter.Result.Failure).displayMessage)
+            .isEqualTo("Something went wrong")
+    }
+
+    @Test
+    fun `attachPaymentMethod fails with Stripe message when the payment method couldn't be attached`() = runTest {
+        val adapter = createAdapter(
+            customerRepository = FakeCustomerRepository(
+                onAttachPaymentMethod = {
+                    Result.failure(
+                        APIException(
+                            message = "could not attach payment method",
+                            stripeError = StripeError(message = "Unable to attach payment method")
+                        )
+                    )
+                }
+            )
+        )
+        val result = adapter.attachPaymentMethod("pm_1234")
+        assertThat((result.value as CustomerAdapter.Result.Failure).displayMessage)
+            .isEqualTo("Unable to attach payment method")
     }
 
     @Test
@@ -184,23 +215,47 @@ class CustomerAdapterTest {
     }
 
     @Test
-    fun `detachPaymentMethod fails when the payment method couldn't be detached`() = runTest {
+    fun `detachPaymentMethod fails with default message when the payment method couldn't be detached`() = runTest {
         val adapter = createAdapter(
             customerRepository = FakeCustomerRepository(
                 onDetachPaymentMethod = {
-                    Result.failure(Exception("could not detach payment method"))
+                    Result.failure(
+                        APIException(
+                            message = "could not detach payment method",
+                        )
+                    )
                 }
             )
         )
         val result = adapter.detachPaymentMethod("pm_1234")
-        assertThat(result.isFailure).isTrue()
+        assertThat((result.value as CustomerAdapter.Result.Failure).displayMessage)
+            .isEqualTo("Something went wrong")
+    }
+
+    @Test
+    fun `detachPaymentMethod fails with Stripe message when the payment method couldn't be detached`() = runTest {
+        val adapter = createAdapter(
+            customerRepository = FakeCustomerRepository(
+                onDetachPaymentMethod = {
+                    Result.failure(
+                        APIException(
+                            message = "could not detach payment method",
+                            stripeError = StripeError(message = "Unable to detach payment method")
+                        )
+                    )
+                }
+            )
+        )
+        val result = adapter.detachPaymentMethod("pm_1234")
+        assertThat((result.value as CustomerAdapter.Result.Failure).displayMessage)
+            .isEqualTo("Unable to detach payment method")
     }
 
     @Test
     fun `setSelectedPaymentMethodOption saves the selected payment method`() = runTest {
         val adapter = createAdapter(
             customerEphemeralKeyProvider = {
-                Result.success(
+                CustomerAdapter.Result.success(
                     CustomerEphemeralKey(
                         customerId = "cus_123",
                         ephemeralKey = "ek_123"
@@ -228,7 +283,7 @@ class CustomerAdapterTest {
     fun `setSelectedPaymentMethodOption clears the saved payment method`() = runTest {
         val adapter = createAdapter(
             customerEphemeralKeyProvider = {
-                Result.success(
+                CustomerAdapter.Result.success(
                     CustomerEphemeralKey(
                         customerId = "cus_123",
                         ephemeralKey = "ek_123"
@@ -265,7 +320,7 @@ class CustomerAdapterTest {
         )
         val adapter = createAdapter(
             customerEphemeralKeyProvider = {
-                Result.success(
+                CustomerAdapter.Result.success(
                     CustomerEphemeralKey(
                         customerId = "cus_123",
                         ephemeralKey = "ek_123"
@@ -291,7 +346,7 @@ class CustomerAdapterTest {
     fun `setSelectedPaymentMethodOption fails when payment selection was unable to be saved`() = runTest {
         val adapter = createAdapter(
             customerEphemeralKeyProvider = {
-                Result.success(
+                CustomerAdapter.Result.success(
                     CustomerEphemeralKey(
                         customerId = "cus_123",
                         ephemeralKey = "ek_123"
@@ -307,15 +362,17 @@ class CustomerAdapterTest {
         val result = adapter.setSelectedPaymentOption(
             paymentOption = CustomerAdapter.PaymentOption.StripeId("pm_1234")
         )
-        assertThat(result.exceptionOrNull()?.message)
-            .isEqualTo("Unable to set the payment option: StripeId(id=pm_1234)")
+        assertThat((result.value as CustomerAdapter.Result.Failure).cause?.message)
+            .isEqualTo("Unable to persist payment option StripeId(id=pm_1234)")
+        assertThat(result.value.displayMessage)
+            .isEqualTo("Something went wrong")
     }
 
     @Test
     fun `setSelectedPaymentMethodOption sets none when there is no selection`() = runTest {
         val adapter = createAdapter(
             customerEphemeralKeyProvider = {
-                Result.success(
+                CustomerAdapter.Result.success(
                     CustomerEphemeralKey(
                         customerId = "cus_123",
                         ephemeralKey = "ek_123"
@@ -361,7 +418,7 @@ class CustomerAdapterTest {
     fun `setupIntentClientSecretForCustomerAttach succeeds`() = runTest {
         val adapter = createAdapter(
             setupIntentClientSecretProvider = {
-                Result.success("seti_123")
+                CustomerAdapter.Result.success("seti_123")
             },
         )
         val result = adapter.setupIntentClientSecretForCustomerAttach()
@@ -370,14 +427,17 @@ class CustomerAdapterTest {
 
     @Test
     fun `setupIntentClientSecretForCustomerAttach fails when client secret cannot be retrieved`() = runTest {
-        val error = Exception("some exception")
         val adapter = createAdapter(
             setupIntentClientSecretProvider = {
-                Result.failure(error)
+                CustomerAdapter.Result.failure(
+                    cause = Exception("some exception"),
+                    displayMessage = "Couldn't get client secret"
+                )
             },
         )
         val result = adapter.setupIntentClientSecretForCustomerAttach()
-        assertThat(result.exceptionOrNull()).isEqualTo(error)
+        assertThat((result.value as CustomerAdapter.Result.Failure).displayMessage)
+            .isEqualTo("Couldn't get client secret")
     }
 
     @Test
@@ -404,16 +464,124 @@ class CustomerAdapterTest {
         assertThat(adapter.canCreateSetupIntents).isFalse()
 
         adapter = createAdapter(
-            setupIntentClientSecretProvider = { Result.success("client_secret") },
+            setupIntentClientSecretProvider = { CustomerAdapter.Result.success("client_secret") },
         )
 
         assertThat(adapter.canCreateSetupIntents).isTrue()
     }
 
+    @Test
+    fun `CustomerAdapter Result can be created using success`() {
+        val result: CustomerAdapter.Result<String> = CustomerAdapter.Result.success("Hello")
+        assertThat(result.value)
+            .isEqualTo("Hello")
+        assertThat(result.getOrNull())
+            .isEqualTo("Hello")
+
+        var newResult = result.map { "world" }
+        assertThat(newResult.value)
+            .isEqualTo("world")
+
+        newResult = newResult.mapCatching { "Hello world" }
+        assertThat(newResult.value)
+            .isEqualTo("Hello world")
+
+        newResult = newResult.fold(
+            onSuccess = {
+                CustomerAdapter.Result.success("Success")
+            },
+            onFailure = { _, _ ->
+                CustomerAdapter.Result.failure(null)
+            }
+        )
+        assertThat(newResult.value)
+            .isEqualTo("Success")
+    }
+
+    @Test
+    fun `CustomerAdapter Result can be created using failure`() {
+        val result: CustomerAdapter.Result<String> = CustomerAdapter.Result.failure(
+            cause = IllegalStateException("Illegal state"),
+            displayMessage = "This is display message",
+        )
+        assertThat((result.value as CustomerAdapter.Result.Failure).displayMessage)
+            .isEqualTo("This is display message")
+        assertThat(result.getOrNull())
+            .isNull()
+
+        var newResult = result.map { "world" }
+        assertThat(newResult.isFailure).isTrue()
+        assertThat((newResult.value as CustomerAdapter.Result.Failure).displayMessage)
+            .isEqualTo("This is display message")
+
+        newResult = newResult.mapCatching { "Hello world" }
+        assertThat(newResult.isFailure).isTrue()
+        assertThat((newResult.value as CustomerAdapter.Result.Failure).displayMessage)
+            .isEqualTo("This is display message")
+
+        newResult = newResult.fold(
+            onSuccess = {
+                CustomerAdapter.Result.success("Success")
+            },
+            onFailure = { _, _ ->
+                CustomerAdapter.Result.failure(
+                    cause = IllegalStateException("Illegal state"),
+                    displayMessage = "This is a new display message",
+                )
+            }
+        )
+        assertThat(newResult.isFailure).isTrue()
+        assertThat((newResult.value as CustomerAdapter.Result.Failure).displayMessage)
+            .isEqualTo("This is a new display message")
+    }
+
+    @Test
+    fun `CustomerAdapter Result is compatible with StripeException`() {
+        val result: CustomerAdapter.Result<String> = CustomerAdapter.Result.failure(
+            cause = APIException(
+                stripeError = StripeError(message = "Some API error")
+            ),
+            displayMessage = "There was a problem with Stripe",
+        )
+        assertThat((result.value as CustomerAdapter.Result.Failure).displayMessage)
+            .isEqualTo("There was a problem with Stripe")
+
+        var newResult = result.map {
+            "New result"
+        }
+        assertThat((newResult.value as CustomerAdapter.Result.Failure).displayMessage)
+            .isEqualTo("There was a problem with Stripe")
+
+        newResult = result.mapCatching {
+            "New result"
+        }
+        assertThat((newResult.value as CustomerAdapter.Result.Failure).displayMessage)
+            .isEqualTo("There was a problem with Stripe")
+
+        var stripeResult: CustomerAdapter.Result<String> = CustomerAdapter.Result.failure(
+            cause = APIException(
+                message = "Unlocalized message",
+                stripeError = null,
+            ),
+            displayMessage = "There was a problem with Stripe",
+        )
+        assertThat((stripeResult.value as CustomerAdapter.Result.Failure).displayMessage)
+            .isEqualTo("There was a problem with Stripe")
+
+        stripeResult = CustomerAdapter.Result.failure(
+            cause = APIException(
+                message = "Unlocalized message"
+            ),
+            displayMessage = null,
+        )
+        assertThat((stripeResult.value as CustomerAdapter.Result.Failure).displayMessage)
+            .isEqualTo(null)
+    }
+
     private fun createAdapter(
         customerEphemeralKeyProvider: CustomerEphemeralKeyProvider =
             CustomerEphemeralKeyProvider {
-                Result.success(
+                CustomerAdapter.Result.success(
                     CustomerEphemeralKey(
                         customerId = "cus_123",
                         ephemeralKey = "ek_123"
@@ -422,7 +590,7 @@ class CustomerAdapterTest {
             },
         setupIntentClientSecretProvider: SetupIntentClientSecretProvider? =
             SetupIntentClientSecretProvider {
-                Result.success("seti_123")
+                CustomerAdapter.Result.success("seti_123")
             },
         timeProvider: () -> Long = { 1L },
         customerRepository: CustomerRepository = FakeCustomerRepository(),

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -490,7 +490,10 @@ class CustomerAdapterTest {
                 CustomerAdapter.Result.success("Success")
             },
             onFailure = { _, _ ->
-                CustomerAdapter.Result.failure(null)
+                CustomerAdapter.Result.failure(
+                    cause = null,
+                    displayMessage = null
+                )
             }
         )
         assertThat(newResult.value)

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -145,25 +145,26 @@ class CustomerSheetViewModelTest {
     fun `When payment methods cannot be loaded, errorMessage is emitted`() = runTest {
         val viewModel = createViewModel(
             customerAdapter = FakeCustomerAdapter(
-                paymentMethods = CustomerAdapter.Result.failure<List<PaymentMethod>>(
+                paymentMethods = CustomerAdapter.Result.failure(
                     cause = APIException(message = "Failed to retrieve payment methods."),
-                    displayMessage = "Failed to retrieve payment methods."
+                    displayMessage = "We could\'nt get your payment methods. Please try again."
                 )
             )
         )
         viewModel.viewState.test {
             assertThat(
                 (awaitItem() as CustomerSheetViewState.SelectPaymentMethod).errorMessage
-            ).isEqualTo("Failed to retrieve payment methods.")
+            ).isEqualTo("We could'nt get your payment methods. Please try again.")
         }
     }
 
     @Test
-    fun `When the selected payment method cannot be loaded, paymentSelection is null`() = runTest {
+    fun `When the selected payment method cannot be loaded, paymentSelection is null and an error message is displayed`() = runTest {
         val viewModel = createViewModel(
             customerAdapter = FakeCustomerAdapter(
-                selectedPaymentOption = CustomerAdapter.Result.failure<CustomerAdapter.PaymentOption?>(
-                    cause = Exception("Failed to retrieve selected payment option.")
+                selectedPaymentOption = CustomerAdapter.Result.failure(
+                    cause = Exception("Failed to retrieve selected payment option."),
+                    displayMessage = null,
                 )
             )
         )
@@ -172,7 +173,7 @@ class CustomerSheetViewModelTest {
             assertThat(viewState.paymentSelection)
                 .isEqualTo(null)
             assertThat(viewState.errorMessage)
-                .isEqualTo(null)
+                .isEqualTo("Something went wrong")
         }
     }
 
@@ -572,7 +573,8 @@ class CustomerSheetViewModelTest {
                 ),
                 onSetSelectedPaymentOption = {
                     CustomerAdapter.Result.failure(
-                        Exception("Unable to set payment option")
+                        cause = Exception("Unable to set payment option"),
+                        displayMessage = "Something went wrong"
                     )
                 }
             )
@@ -915,7 +917,7 @@ class CustomerSheetViewModelTest {
                                 message = "Cannot attach payment method."
                             )
                         ),
-                        displayMessage = "Cannot attach payment method."
+                        displayMessage = "We could not save this payment method. Please try again."
                     )
                 },
             ),
@@ -935,7 +937,7 @@ class CustomerSheetViewModelTest {
             viewState = awaitItem() as CustomerSheetViewState.AddPaymentMethod
             assertThat(viewState.isProcessing).isTrue()
             viewState = awaitItem() as CustomerSheetViewState.AddPaymentMethod
-            assertThat(viewState.errorMessage).isEqualTo("Cannot attach payment method.")
+            assertThat(viewState.errorMessage).isEqualTo("We could not save this payment method. Please try again.")
             assertThat(viewState.isProcessing).isFalse()
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -506,7 +506,7 @@ class CustomerSheetViewModelTest {
                                 message = "Cannot remove this payment method."
                             )
                         ),
-                        displayMessage = "Cannot remove this payment method."
+                        displayMessage = "We were unable to remove this payment method, try again."
                     )
                 }
             )
@@ -525,7 +525,7 @@ class CustomerSheetViewModelTest {
             viewState = awaitItem() as CustomerSheetViewState.SelectPaymentMethod
             assertThat(viewState.savedPaymentMethods).hasSize(1)
             assertThat(viewState.errorMessage)
-                .isEqualTo("Cannot remove this payment method.")
+                .isEqualTo("We were unable to remove this payment method, try again.")
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/FakeCustomerAdapter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/FakeCustomerAdapter.kt
@@ -5,43 +5,49 @@ import com.stripe.android.model.PaymentMethod
 @OptIn(ExperimentalCustomerSheetApi::class)
 internal class FakeCustomerAdapter(
     override var canCreateSetupIntents: Boolean = true,
-    var selectedPaymentOption: Result<CustomerAdapter.PaymentOption?> = Result.success(null),
-    private val paymentMethods: Result<List<PaymentMethod>> = Result.success(listOf()),
-    private val onSetSelectedPaymentOption: ((paymentOption: CustomerAdapter.PaymentOption?) -> Result<Unit>)? = null,
-    private val onAttachPaymentMethod: ((paymentMethodId: String) -> Result<PaymentMethod>)? = null,
-    private val onDetachPaymentMethod: ((paymentMethodId: String) -> Result<PaymentMethod>)? = null,
-    private val onSetupIntentClientSecretForCustomerAttach: (() -> Result<String>)? = null
+    var selectedPaymentOption: CustomerAdapter.Result<CustomerAdapter.PaymentOption?> =
+        CustomerAdapter.Result.success(null),
+    private val paymentMethods: CustomerAdapter.Result<List<PaymentMethod>> =
+        CustomerAdapter.Result.success(listOf()),
+    private val onSetSelectedPaymentOption:
+        ((paymentOption: CustomerAdapter.PaymentOption?) -> CustomerAdapter.Result<Unit>)? = null,
+    private val onAttachPaymentMethod: ((paymentMethodId: String) -> CustomerAdapter.Result<PaymentMethod>)? = null,
+    private val onDetachPaymentMethod: ((paymentMethodId: String) -> CustomerAdapter.Result<PaymentMethod>)? = null,
+    private val onSetupIntentClientSecretForCustomerAttach: (() -> CustomerAdapter.Result<String>)? = null
 ) : CustomerAdapter {
 
-    override suspend fun retrievePaymentMethods(): Result<List<PaymentMethod>> {
+    override suspend fun retrievePaymentMethods(): CustomerAdapter.Result<List<PaymentMethod>> {
         return paymentMethods
     }
 
-    override suspend fun attachPaymentMethod(paymentMethodId: String): Result<PaymentMethod> {
+    override suspend fun attachPaymentMethod(paymentMethodId: String): CustomerAdapter.Result<PaymentMethod> {
         return onAttachPaymentMethod?.invoke(paymentMethodId)
-            ?: Result.success(paymentMethods.getOrNull()?.find { it.id!! == paymentMethodId }!!)
+            ?: CustomerAdapter.Result.success(paymentMethods.getOrNull()?.find { it.id!! == paymentMethodId }!!)
     }
 
-    override suspend fun detachPaymentMethod(paymentMethodId: String): Result<PaymentMethod> {
+    override suspend fun detachPaymentMethod(paymentMethodId: String): CustomerAdapter.Result<PaymentMethod> {
         return onDetachPaymentMethod?.invoke(paymentMethodId)
-            ?: Result.success(paymentMethods.getOrNull()?.find { it.id!! == paymentMethodId }!!)
+            ?: CustomerAdapter.Result.success(paymentMethods.getOrNull()?.find { it.id!! == paymentMethodId }!!)
     }
 
     override suspend fun setSelectedPaymentOption(
         paymentOption: CustomerAdapter.PaymentOption?
-    ): Result<Unit> {
+    ): CustomerAdapter.Result<Unit> {
         return onSetSelectedPaymentOption?.invoke(paymentOption) ?: run {
-            selectedPaymentOption = Result.success(paymentOption)
-            Result.success(Unit)
+            selectedPaymentOption = CustomerAdapter.Result.success(paymentOption)
+            CustomerAdapter.Result.success(Unit)
         }
     }
 
-    override suspend fun retrieveSelectedPaymentOption(): Result<CustomerAdapter.PaymentOption?> {
+    override suspend fun retrieveSelectedPaymentOption(): CustomerAdapter.Result<CustomerAdapter.PaymentOption?> {
         return selectedPaymentOption
     }
 
-    override suspend fun setupIntentClientSecretForCustomerAttach(): Result<String> {
+    override suspend fun setupIntentClientSecretForCustomerAttach(): CustomerAdapter.Result<String> {
         return onSetupIntentClientSecretForCustomerAttach?.invoke()
-            ?: Result.failure(Exception("Provider not implemented"))
+            ?: CustomerAdapter.Result.failure(
+                displayMessage = "Merchant provided error message",
+                cause = Exception("Some error"),
+            )
     }
 }


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

Update errorMessages to forward server side errors. Most errors should be translated from server side. Network errors should be translated on client side, but not the responsibility of `CustomerSheet`.

This PR adds a new exception type for integrators to use: `StripeIntegratorException` (naming TBD)

Proposing a few options @wooj-stripe @jaynewstrom-stripe @tillh-stripe:
1. Update the result types in `CustomerAdapter` from `Result<T>` to `CustomerAdapterResult<T>`, which allows us to specify the failure type to something more specific. (Thank you to Till!)
   
    Pros: 
        - This would be similar to what we are doing in the decoupling case, where we can force users to specify a `displayMessage` and pass that through to the customer.
    
    Cons:
        - This would cause an API change, since we are in beta this would not be breaking. 
        - No longer using generic Result<T> type
        - We would need to pass `StripeRepository` errors through

2. Using the new `StripeIntegratorException`, we can map Stripe and merchant specific errors

    Pros:
        - Simpler and doesn't require API change
        - Handles both Stripe and merchant errors
        - Continue to use Result<T>

    Cons:
        - Not enforced, a merchant can throw a generic exception and we would display "Something went wrong"
        - It is not obvious that you need to use this exception type in order to display error messages to the user, on top of this, the sheet needs to use `Throwable.userFacingErrorMessage` otherwise we won't be able to display the error message from merchant.

3. Pass all exception message through, regardless of type. CustomerSheet won't care where the message is coming from. Or, we could use `localizedMessage` on the Exception (this is what iOS is doing) if it exists, otherwise use `message`.

    Pros:
        - Simplest approach, just get the exception message
        - Makes it clear that CustomerSheet is not responsible for error messages
        - No API changes required

    Cons:
        - Possible footgun, since we don't know where the message is coming from
        - Exception providers are responsible for displaying the proper message and CustomerSheet has no control (imo, CustomerSheet shouldn't have this responsibility anyways)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

