### PR TITLE
[Identity] Remove header when title, timeEstimate and privacyPolicy are null

### DIFF
--- a/identity/detekt-baseline.xml
+++ b/identity/detekt-baseline.xml
@@ -13,6 +13,7 @@
     <ID>LongMethod:AddressSection.kt$@Composable internal fun AddressSection( enabled: Boolean, identityViewModel: IdentityViewModel, addressCountries: List&lt;Country>, addressNotListedText: String, navController: NavController, onAddressCollected: (Resource&lt;RequiredInternationalAddress>) -> Unit )</ID>
     <ID>LongMethod:CameraScreenLaunchedEffect.kt$@Composable internal fun CameraScreenLaunchedEffect( identityViewModel: IdentityViewModel, identityScanViewModel: IdentityScanViewModel, verificationPage: VerificationPage, navController: NavController, cameraManager: IdentityCameraManager, onCameraReady: () -> Unit )</ID>
     <ID>LongMethod:ConfirmationScreen.kt$@Composable internal fun ConfirmationScreen( navController: NavController, identityViewModel: IdentityViewModel, verificationFlowFinishable: VerificationFlowFinishable )</ID>
+    <ID>LongMethod:ConsentScreen.kt$@Composable private fun ConsentHeader( merchantLogoUri: Uri, consentPage: VerificationPageStaticContentConsentPage )</ID>
     <ID>LongMethod:ConsentScreen.kt$@Composable private fun SuccessUI( merchantLogoUri: Uri, verificationPage: VerificationPage, onConsentAgreed: () -> Unit, onConsentDeclined: () -> Unit )</ID>
     <ID>LongMethod:DebugScreen.kt$@Composable internal fun CompleteWithTestDataSection( onClickSubmit: (CompleteOption) -> Unit )</ID>
     <ID>LongMethod:DebugScreen.kt$@Composable internal fun DebugScreen( navController: NavController, identityViewModel: IdentityViewModel, verificationFlowFinishable: VerificationFlowFinishable )</ID>

--- a/identity/detekt-baseline.xml
+++ b/identity/detekt-baseline.xml
@@ -13,7 +13,7 @@
     <ID>LongMethod:AddressSection.kt$@Composable internal fun AddressSection( enabled: Boolean, identityViewModel: IdentityViewModel, addressCountries: List&lt;Country>, addressNotListedText: String, navController: NavController, onAddressCollected: (Resource&lt;RequiredInternationalAddress>) -> Unit )</ID>
     <ID>LongMethod:CameraScreenLaunchedEffect.kt$@Composable internal fun CameraScreenLaunchedEffect( identityViewModel: IdentityViewModel, identityScanViewModel: IdentityScanViewModel, verificationPage: VerificationPage, navController: NavController, cameraManager: IdentityCameraManager, onCameraReady: () -> Unit )</ID>
     <ID>LongMethod:ConfirmationScreen.kt$@Composable internal fun ConfirmationScreen( navController: NavController, identityViewModel: IdentityViewModel, verificationFlowFinishable: VerificationFlowFinishable )</ID>
-    <ID>LongMethod:ConsentScreen.kt$@Composable private fun ConsentHeader( merchantLogoUri: Uri, consentPage: VerificationPageStaticContentConsentPage )</ID>
+    <ID>LongMethod:ConsentScreen.kt$@Composable private fun ConsentHeader( merchantLogoUri: Uri, title: String, privacyPolicy: String, timeEstimate: String )</ID>
     <ID>LongMethod:ConsentScreen.kt$@Composable private fun SuccessUI( merchantLogoUri: Uri, verificationPage: VerificationPage, onConsentAgreed: () -> Unit, onConsentDeclined: () -> Unit )</ID>
     <ID>LongMethod:DebugScreen.kt$@Composable internal fun CompleteWithTestDataSection( onClickSubmit: (CompleteOption) -> Unit )</ID>
     <ID>LongMethod:DebugScreen.kt$@Composable internal fun DebugScreen( navController: NavController, identityViewModel: IdentityViewModel, verificationFlowFinishable: VerificationFlowFinishable )</ID>

--- a/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageStaticContentConsentPage.kt
+++ b/identity/src/main/java/com/stripe/android/identity/networking/models/VerificationPageStaticContentConsentPage.kt
@@ -17,7 +17,7 @@ internal data class VerificationPageStaticContentConsentPage(
     @SerialName("scroll_to_continue_button_text")
     val scrollToContinueButtonText: String,
     @SerialName("title")
-    val title: String,
+    val title: String?,
     @SerialName("privacy_policy")
     val privacyPolicy: String?,
     @SerialName("time_estimate")

--- a/identity/src/main/java/com/stripe/android/identity/ui/ConsentScreen.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/ConsentScreen.kt
@@ -45,7 +45,6 @@ import com.stripe.android.identity.networking.Resource
 import com.stripe.android.identity.networking.models.CollectedDataParam
 import com.stripe.android.identity.networking.models.VerificationPage
 import com.stripe.android.identity.networking.models.VerificationPage.Companion.requireSelfie
-import com.stripe.android.identity.networking.models.VerificationPageStaticContentConsentPage
 import com.stripe.android.identity.utils.isRemote
 import com.stripe.android.identity.utils.urlWithoutQuery
 import com.stripe.android.identity.viewmodel.IdentityViewModel
@@ -151,11 +150,13 @@ private fun SuccessUI(
                     testTag = SCROLLABLE_COLUMN_TAG
                 }
         ) {
-            val shouldShowHeader =
-                consentPage.title != null && consentPage.privacyPolicy != null && consentPage.timeEstimate != null
-
-            if (shouldShowHeader) {
-                ConsentHeader(merchantLogoUri = merchantLogoUri, consentPage = consentPage)
+            if (consentPage.title != null && consentPage.privacyPolicy != null && consentPage.timeEstimate != null) {
+                ConsentHeader(
+                    merchantLogoUri = merchantLogoUri,
+                    title = consentPage.title,
+                    privacyPolicy = consentPage.privacyPolicy,
+                    timeEstimate = consentPage.timeEstimate
+                )
             }
 
             Html(
@@ -220,11 +221,10 @@ private fun SuccessUI(
 @Composable
 private fun ConsentHeader(
     merchantLogoUri: Uri,
-    consentPage: VerificationPageStaticContentConsentPage
+    title: String,
+    privacyPolicy: String,
+    timeEstimate: String
 ) {
-    val title = requireNotNull(consentPage.title)
-    val privacyPolicy = requireNotNull(consentPage.privacyPolicy)
-    val timeEstimate = requireNotNull(consentPage.timeEstimate)
     Row(
         modifier = Modifier
             .fillMaxWidth()

--- a/identity/src/test/java/com/stripe/android/identity/ui/ConsentScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/ConsentScreenTest.kt
@@ -53,7 +53,7 @@ class ConsentScreenTest {
 
     private val mockNavController = mock<NavController>()
 
-    private val verificationPageWithTimeAndPolicy = mock<VerificationPage>().also {
+    private val verificationPageWithTitleTimeAndPolicy = mock<VerificationPage>().also {
         whenever(it.biometricConsent).thenReturn(
             VerificationPageStaticContentConsentPage(
                 acceptButtonText = CONSENT_ACCEPT_TEXT,
@@ -72,11 +72,11 @@ class ConsentScreenTest {
         )
     }
 
-    private val verificationPageWithOutTimeAndPolicy = mock<VerificationPage>().also {
+    private val verificationPageWithOutTitleTimeAndPolicy = mock<VerificationPage>().also {
         whenever(it.biometricConsent).thenReturn(
             VerificationPageStaticContentConsentPage(
                 acceptButtonText = CONSENT_ACCEPT_TEXT,
-                title = CONSENT_TITLE,
+                title = null,
                 privacyPolicy = null,
                 timeEstimate = null,
                 body = CONSENT_BODY,
@@ -92,8 +92,8 @@ class ConsentScreenTest {
     }
 
     @Test
-    fun `when VerificationPage with time and policy UI is bound correctly`() {
-        setComposeTestRuleWith(Resource.success(verificationPageWithTimeAndPolicy)) {
+    fun `when VerificationPage with title time and policy UI is bound correctly`() {
+        setComposeTestRuleWith(Resource.success(verificationPageWithTitleTimeAndPolicy)) {
             onNodeWithTag(LOADING_SCREEN_TAG).assertDoesNotExist()
 
             onNodeWithTag(TITLE_TAG).assertTextEquals(CONSENT_TITLE)
@@ -113,14 +113,15 @@ class ConsentScreenTest {
     }
 
     @Test
-    fun `when VerificationPage without time and policy UI is bound correctly`() {
-        setComposeTestRuleWith(Resource.success(verificationPageWithOutTimeAndPolicy)) {
+    fun `when VerificationPage without title time and policy UI is bound correctly`() {
+        setComposeTestRuleWith(Resource.success(verificationPageWithOutTitleTimeAndPolicy)) {
             onNodeWithTag(LOADING_SCREEN_TAG).assertDoesNotExist()
 
-            onNodeWithTag(TITLE_TAG).assertTextEquals(CONSENT_TITLE)
+            onNodeWithTag(CONSENT_HEADER_TAG).assertDoesNotExist()
             onNodeWithTag(TIME_ESTIMATE_TAG).assertDoesNotExist()
             onNodeWithTag(PRIVACY_POLICY_TAG).assertDoesNotExist()
             onNodeWithTag(DIVIDER_TAG).assertDoesNotExist()
+
             onNodeWithTag(BODY_TAG).assertTextEquals(CONSENT_BODY)
 
             onNodeWithTag(ACCEPT_BUTTON_TAG).onChildAt(0)
@@ -135,7 +136,7 @@ class ConsentScreenTest {
 
     @Test
     fun `when agreed button is clicked correctly navigates`() {
-        setComposeTestRuleWith(Resource.success(verificationPageWithTimeAndPolicy)) {
+        setComposeTestRuleWith(Resource.success(verificationPageWithTitleTimeAndPolicy)) {
             onNodeWithTag(DECLINE_BUTTON_TAG).onChildAt(0).performClick()
             runBlocking {
                 verify(mockIdentityViewModel).postVerificationPageDataAndMaybeNavigate(


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Support fallback document verification, where we don't want to show the title again

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Support document fallback

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
| with title  | without title |
| ------------- | ------------- |
| ![with](https://github.com/stripe/stripe-android/assets/79880926/d84e7228-d88f-47f6-87ab-fd9620cb7f9b) |  ![wihtout](https://github.com/stripe/stripe-android/assets/79880926/a407e568-22a1-4124-abe2-99def0c136af) |







# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
