### PR TITLE
Deterministically regenerate analytics session id.

### DIFF
--- a/payments-core/src/test/java/com/stripe/android/PaymentAnalyticsRequestFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentAnalyticsRequestFactoryTest.kt
@@ -121,7 +121,7 @@ class PaymentAnalyticsRequestFactoryTest {
                 "product_usage" to ATTRIBUTION.toList(),
                 "source_type" to "card",
                 "is_development" to true,
-                "session_id" to analyticsRequestFactory.sessionId
+                "session_id" to AnalyticsRequestFactory.sessionId
             )
         )
     }
@@ -300,7 +300,7 @@ class PaymentAnalyticsRequestFactoryTest {
                 )
             )
         assertThat(analyticsRequest.url)
-            .isEqualTo("https://q.stripe.com?publishable_key=pk_abc123&app_version=0&bindings_version=$sdkVersion&os_version=30&session_id=${analyticsRequestFactory.sessionId}&os_release=11&device_type=robolectric_robolectric_robolectric&source_type=card&app_name=com.stripe.android.test&analytics_ua=analytics.stripe_android-1.0&os_name=REL&event=stripe_android.payment_method_creation&is_development=true")
+            .isEqualTo("https://q.stripe.com?publishable_key=pk_abc123&app_version=0&bindings_version=$sdkVersion&os_version=30&session_id=${AnalyticsRequestFactory.sessionId}&os_release=11&device_type=robolectric_robolectric_robolectric&source_type=card&app_name=com.stripe.android.test&analytics_ua=analytics.stripe_android-1.0&os_name=REL&event=stripe_android.payment_method_creation&is_development=true")
     }
 
     @Test

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -20,6 +20,7 @@ import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.Injectable
 import com.stripe.android.core.injection.Injector
 import com.stripe.android.core.injection.injectWithFallback
+import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
@@ -222,6 +223,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
             }
         }
 
+        AnalyticsRequestFactory.regenerateSessionId()
         eventReporter.onInit(
             configuration = config,
             isDecoupling = isDecoupling,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandler.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.flowcontroller
 
 import com.stripe.android.core.injection.UIContext
+import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.InitializationMode.DeferredIntent
 import com.stripe.android.paymentsheet.analytics.EventReporter
@@ -83,6 +84,7 @@ internal class FlowControllerConfigurationHandler @Inject constructor(
             return
         }
 
+        AnalyticsRequestFactory.regenerateSessionId()
         when (val result = paymentSheetLoader.load(initializationMode, configuration)) {
             is PaymentSheetLoader.Result.Success -> {
                 viewModel.previousConfigureRequest = configureRequest

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -12,6 +12,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
+import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.model.AccountStatus
@@ -138,11 +139,15 @@ internal class PaymentSheetViewModelTest {
 
     @Test
     fun `init should fire analytics event`() {
+        val beforeSessionId = AnalyticsRequestFactory.sessionId
         createViewModel()
         verify(eventReporter).onInit(
             configuration = eq(PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY),
             isDecoupling = eq(false),
         )
+
+        // Creating the view model should regenerate the analytics sessionId.
+        assertThat(beforeSessionId).isNotEqualTo(AnalyticsRequestFactory.sessionId)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerConfigurationHandlerTest.kt
@@ -8,6 +8,7 @@ import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.ExperimentalPaymentSheetDecouplingApi
@@ -80,6 +81,7 @@ class FlowControllerConfigurationHandlerTest {
         val configureErrors = Turbine<Throwable?>()
         val configurationHandler = createConfigurationHandler()
 
+        val beforeSessionId = AnalyticsRequestFactory.sessionId
         configurationHandler.configure(
             scope = this,
             initializationMode = PaymentSheet.InitializationMode.PaymentIntent(
@@ -99,6 +101,8 @@ class FlowControllerConfigurationHandlerTest {
             configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
             isDecoupling = false,
         )
+        // Configure should regenerate the analytics sessionId.
+        assertThat(beforeSessionId).isNotEqualTo(AnalyticsRequestFactory.sessionId)
     }
 
     @Test
@@ -116,6 +120,7 @@ class FlowControllerConfigurationHandlerTest {
         viewModel.previousConfigureRequest = configureRequest
         viewModel.paymentSelection = PaymentSelection.GooglePay
 
+        val beforeSessionId = AnalyticsRequestFactory.sessionId
         configurationHandler.configure(
             scope = this,
             initializationMode = initializationMode,
@@ -134,6 +139,9 @@ class FlowControllerConfigurationHandlerTest {
             configuration = PaymentSheetFixtures.CONFIG_CUSTOMER_WITH_GOOGLEPAY,
             isDecoupling = false,
         )
+
+        // Configure should not regenerate the analytics sessionId when using the same configuration.
+        assertThat(beforeSessionId).isEqualTo(AnalyticsRequestFactory.sessionId)
     }
 
     @Test

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestFactory.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestFactory.kt
@@ -95,7 +95,7 @@ open class AnalyticsRequestFactory(
         const val ANALYTICS_UA = "$ANALYTICS_PREFIX.$ANALYTICS_NAME-$ANALYTICS_VERSION"
 
         fun regenerateSessionId() {
-           sessionId = UUID.randomUUID()
+            sessionId = UUID.randomUUID()
         }
     }
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestFactory.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestFactory.kt
@@ -85,6 +85,7 @@ open class AnalyticsRequestFactory(
         @Volatile
         @VisibleForTesting
         var sessionId: UUID = UUID.randomUUID()
+            private set
 
         private const val ANALYTICS_PREFIX = "analytics"
         private const val ANALYTICS_NAME = "stripe_android"

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestFactory.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/AnalyticsRequestFactory.kt
@@ -17,9 +17,6 @@ open class AnalyticsRequestFactory(
     private val packageName: String,
     private val publishableKeyProvider: Provider<String>
 ) {
-    @VisibleForTesting
-    val sessionId: UUID = UUID.randomUUID()
-
     /**
      * Builds an Analytics request for the given [AnalyticsEvent],
      * including common params + event-specific params defined in [AnalyticsEvent.params]
@@ -85,6 +82,10 @@ open class AnalyticsRequestFactory(
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
+        @Volatile
+        @VisibleForTesting
+        var sessionId: UUID = UUID.randomUUID()
+
         private const val ANALYTICS_PREFIX = "analytics"
         private const val ANALYTICS_NAME = "stripe_android"
         private const val ANALYTICS_VERSION = "1.0"
@@ -92,6 +93,10 @@ open class AnalyticsRequestFactory(
         private val DEVICE_TYPE: String = "${Build.MANUFACTURER}_${Build.BRAND}_${Build.MODEL}"
 
         const val ANALYTICS_UA = "$ANALYTICS_PREFIX.$ANALYTICS_NAME-$ANALYTICS_VERSION"
+
+        fun regenerateSessionId() {
+           sessionId = UUID.randomUUID()
+        }
     }
 }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Rather than rely on the creation of the `AnalyticsRequestFactory` to store the sessionId, store it statically and regenerate it when it needs to be regenerated.

Worth noting that this isn't ideal! And instances like our playground will regenerate twice, and use the same sessionId for both payment sheet and flow controller. Given we don't expect real users to do this, I think this tradeoff of actually having a useful sessionId without MAJOR refactoring is worth it.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Send a sessionId with analytics events.
