### PR TITLE
Update Google Pay launcher tests to test public API

### DIFF
--- a/payments-core/build.gradle
+++ b/payments-core/build.gradle
@@ -42,7 +42,9 @@ dependencies {
     testImplementation testLibs.androidx.archCore
     testImplementation testLibs.androidx.core
     testImplementation testLibs.androidx.fragment
+    testImplementation testLibs.androidx.junit
     testImplementation testLibs.androidx.lifecycle
+    testImplementation testLibs.espresso.intents
     testImplementation testLibs.json
     testImplementation testLibs.junit
     testImplementation testLibs.kotlin.annotations

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
@@ -104,14 +104,13 @@ class GooglePayLauncher internal constructor(
         readyCallback: ReadyCallback,
         resultCallback: ResultCallback
     ) : this(
-        fragment.viewLifecycleOwner.lifecycleScope,
-        config,
-        readyCallback,
-        fragment.registerForActivityResult(
-            GooglePayLauncherContract()
-        ) {
-            resultCallback.onResult(it)
-        },
+        lifecycleScope = fragment.lifecycleScope,
+        config = config,
+        readyCallback = readyCallback,
+        activityResultLauncher = fragment.registerForActivityResult(
+            GooglePayLauncherContract(),
+            resultCallback::onResult,
+        ),
         googlePayRepositoryFactory = {
             DefaultGooglePayRepository(
                 context = fragment.requireActivity().application,
@@ -121,12 +120,12 @@ class GooglePayLauncher internal constructor(
                 allowCreditCards = config.allowCreditCards
             )
         },
-        PaymentAnalyticsRequestFactory(
-            fragment.requireContext(),
-            PaymentConfiguration.getInstance(fragment.requireContext()).publishableKey,
-            setOf(PRODUCT_USAGE)
+        paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
+            context = fragment.requireContext(),
+            publishableKey = PaymentConfiguration.getInstance(fragment.requireContext()).publishableKey,
+            defaultProductUsageTokens = setOf(PRODUCT_USAGE),
         ),
-        DefaultAnalyticsRequestExecutor()
+        analyticsRequestExecutor = DefaultAnalyticsRequestExecutor(),
     )
 
     init {

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayLauncherTest.kt
@@ -1,130 +1,109 @@
 package com.stripe.android.googlepaylauncher
 
-import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
-import android.widget.FrameLayout
-import androidx.activity.result.ActivityResultRegistry
-import androidx.activity.result.contract.ActivityResultContract
-import androidx.core.app.ActivityOptionsCompat
-import androidx.fragment.app.Fragment
-import androidx.fragment.app.testing.launchFragmentInContainer
+import android.app.Activity
+import android.app.Instrumentation
+import android.content.Context
+import android.content.Intent
+import androidx.activity.ComponentActivity
+import androidx.core.os.bundleOf
 import androidx.lifecycle.Lifecycle
-import androidx.test.core.app.ApplicationProvider
+import androidx.lifecycle.lifecycleScope
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.intent.Intents.intending
+import androidx.test.espresso.intent.matcher.IntentMatchers.anyIntent
+import androidx.test.espresso.intent.rule.IntentsTestRule
+import com.google.android.gms.tasks.Tasks
+import com.google.android.gms.wallet.PaymentsClient
+import com.google.android.gms.wallet.Wallet
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
-import com.stripe.android.core.networking.AnalyticsRequestExecutor
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
-import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.Rule
 import org.junit.runner.RunWith
+import org.mockito.Mockito.mockStatic
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isA
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
 @RunWith(RobolectricTestRunner::class)
-class GooglePayLauncherTest {
-    private val testDispatcher = UnconfinedTestDispatcher()
-    private val testScope = TestScope(testDispatcher)
+internal class GooglePayLauncherTest {
 
-    private val scenario = launchFragmentInContainer(initialState = Lifecycle.State.CREATED) {
-        TestFragment()
-    }
-
-    private val readyCallbackInvocations = mutableListOf<Boolean>()
-    private val results = mutableListOf<GooglePayLauncher.Result>()
-
-    private val readyCallback = GooglePayLauncher.ReadyCallback(readyCallbackInvocations::add)
-    private val resultCallback = GooglePayLauncher.ResultCallback(results::add)
-
-    private val analyticsRequestFactory = PaymentAnalyticsRequestFactory(
-        ApplicationProvider.getApplicationContext(),
-        ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
-    )
-    private val firedEvents = mutableListOf<String>()
-    private val analyticsRequestExecutor = AnalyticsRequestExecutor {
-        firedEvents.add(it.params["event"].toString())
-    }
+    @get:Rule
+    val intentsTestRule = IntentsTestRule(ComponentActivity::class.java)
 
     @Test
     fun `presentForPaymentIntent() should successfully return a result when Google Pay is available`() {
-        scenario.onFragment { fragment ->
+        val readyCallback = mock<GooglePayLauncher.ReadyCallback>()
+        val resultCallback = mock<GooglePayLauncher.ResultCallback>()
+
+        runGooglePayLauncherTest { scenario, activity ->
             val launcher = GooglePayLauncher(
-                testScope,
-                CONFIG,
-                readyCallback,
-                fragment.registerForActivityResult(
-                    GooglePayLauncherContract(),
-                    FakeActivityResultRegistry(GooglePayLauncher.Result.Completed)
-                ) {
-                    resultCallback.onResult(it)
-                },
-                { FakeGooglePayRepository(true) },
-                analyticsRequestFactory,
-                analyticsRequestExecutor
+                activity = activity,
+                config = CONFIG,
+                readyCallback = readyCallback,
+                resultCallback = resultCallback,
             )
             scenario.moveToState(Lifecycle.State.RESUMED)
-
-            assertThat(readyCallbackInvocations)
-                .containsExactly(true)
-
             launcher.presentForPaymentIntent("pi_123_secret_456")
-
-            assertThat(results)
-                .containsExactly(GooglePayLauncher.Result.Completed)
         }
+
+        verify(readyCallback).onReady(eq(true))
+        verify(resultCallback).onResult(eq(GooglePayLauncher.Result.Completed))
     }
 
     @Test
     fun `init should fire expected event`() {
-        scenario.onFragment { fragment ->
-            GooglePayLauncher(
-                testScope,
-                CONFIG,
-                readyCallback,
-                fragment.registerForActivityResult(
-                    GooglePayLauncherContract(),
-                    FakeActivityResultRegistry(GooglePayLauncher.Result.Completed)
-                ) {
-                    resultCallback.onResult(it)
-                },
-                { FakeGooglePayRepository(true) },
-                analyticsRequestFactory,
-                analyticsRequestExecutor
-            )
+        val firedEvents = mutableListOf<String>()
 
-            assertThat(firedEvents)
-                .containsExactly("stripe_android.googlepaylauncher_init")
+        runGooglePayLauncherTest { _, activity ->
+            // Have to use the internal constructor here to provide a mock request executor
+            // ¯\_(ツ)_/¯
+            GooglePayLauncher(
+                lifecycleScope = activity.lifecycleScope,
+                config = CONFIG,
+                readyCallback = mock(),
+                activityResultLauncher = mock(),
+                googlePayRepositoryFactory = mock(),
+                paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
+                    context = activity,
+                    publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                ),
+                analyticsRequestExecutor = { firedEvents += it.params["event"].toString() },
+            )
         }
+
+        assertThat(firedEvents).containsExactly("stripe_android.googlepaylauncher_init")
     }
 
     @Test
     fun `presentForPaymentIntent() should throw IllegalStateException when Google Pay is not available`() {
-        scenario.onFragment { fragment ->
-            val launcher = GooglePayLauncher(
-                testScope,
-                CONFIG,
-                readyCallback,
-                fragment.registerForActivityResult(
-                    GooglePayLauncherContract(),
-                    FakeActivityResultRegistry(GooglePayLauncher.Result.Completed)
-                ) {
-                    resultCallback.onResult(it)
-                },
-                { FakeGooglePayRepository(false) },
-                analyticsRequestFactory,
-                analyticsRequestExecutor
-            )
-            scenario.moveToState(Lifecycle.State.RESUMED)
+        val readyCallback = mock<GooglePayLauncher.ReadyCallback>()
+        val resultCallback = mock<GooglePayLauncher.ResultCallback>()
 
-            assertThat(readyCallbackInvocations)
-                .containsExactly(false)
+        runGooglePayLauncherTest(isReady = false) { scenario, activity ->
+            val launcher = GooglePayLauncher(
+                activity = activity,
+                config = CONFIG,
+                readyCallback = readyCallback,
+                resultCallback = resultCallback,
+            )
+
+            scenario.moveToState(Lifecycle.State.RESUMED)
 
             assertFailsWith<IllegalStateException> {
                 launcher.presentForPaymentIntent("pi_123")
             }
         }
+
+        verify(readyCallback).onReady(eq(false))
     }
 
     @Test
@@ -142,28 +121,38 @@ class GooglePayLauncherTest {
         ).isTrue()
     }
 
-    private class FakeActivityResultRegistry(
-        private val result: GooglePayLauncher.Result
-    ) : ActivityResultRegistry() {
-        override fun <I, O> onLaunch(
-            requestCode: Int,
-            contract: ActivityResultContract<I, O>,
-            input: I,
-            options: ActivityOptionsCompat?
-        ) {
-            dispatchResult(
-                requestCode,
-                result
-            )
-        }
-    }
+    private fun runGooglePayLauncherTest(
+        isReady: Boolean = true,
+        result: GooglePayLauncher.Result = GooglePayLauncher.Result.Completed,
+        block: (ActivityScenario<ComponentActivity>, ComponentActivity) -> Unit,
+    ) {
+        mockStatic(Wallet::class.java).use { wallet ->
+            val paymentsClient = mock<PaymentsClient>()
+            whenever(paymentsClient.isReadyToPay(any())).thenReturn(Tasks.forResult(isReady))
 
-    internal class TestFragment : Fragment() {
-        override fun onCreateView(
-            inflater: LayoutInflater,
-            container: ViewGroup?,
-            savedInstanceState: Bundle?
-        ): View = FrameLayout(inflater.context)
+            // Provide a static mock here because DefaultGooglePayRepository calls this static
+            // create method.
+            wallet.`when`<PaymentsClient> {
+                Wallet.getPaymentsClient(isA<Context>(), any())
+            }.thenReturn(paymentsClient)
+
+            // Mock the return value from GooglePayLauncherActivity so that we immediately return
+            val resultData = Intent().putExtras(
+                bundleOf(GooglePayLauncherContract.EXTRA_RESULT to result)
+            )
+            val activityResult = Instrumentation.ActivityResult(Activity.RESULT_OK, resultData)
+            intending(anyIntent()).respondWith(activityResult)
+
+            val scenario = ActivityScenario.launch(ComponentActivity::class.java)
+            scenario.moveToState(Lifecycle.State.CREATED)
+
+            scenario.onActivity { activity ->
+                PaymentConfiguration.init(activity, "pk_test")
+                block(scenario, activity)
+            }
+
+            Espresso.onIdle()
+        }
     }
 
     private companion object {

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherTest.kt
@@ -1,214 +1,155 @@
 package com.stripe.android.googlepaylauncher
 
+import android.app.Activity
+import android.app.Instrumentation
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
-import androidx.activity.result.ActivityResultRegistry
-import androidx.activity.result.contract.ActivityResultContract
-import androidx.core.app.ActivityOptionsCompat
+import androidx.activity.ComponentActivity
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.lifecycle.Lifecycle
-import androidx.test.core.app.ApplicationProvider
+import androidx.lifecycle.lifecycleScope
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.IntentMatchers
+import androidx.test.espresso.intent.rule.IntentsTestRule
+import com.google.android.gms.tasks.Tasks
+import com.google.android.gms.wallet.PaymentsClient
+import com.google.android.gms.wallet.Wallet
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
-import com.stripe.android.core.networking.AnalyticsRequestExecutor
-import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.model.PaymentMethodFixtures.CARD_PAYMENT_METHOD
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
-import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.Rule
 import org.junit.runner.RunWith
+import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isA
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
 @RunWith(RobolectricTestRunner::class)
 class GooglePayPaymentMethodLauncherTest {
-    private val testDispatcher = UnconfinedTestDispatcher()
-    private val testScope = TestScope(testDispatcher)
 
-    private val scenario = launchFragmentInContainer(initialState = Lifecycle.State.CREATED) {
-        TestFragment()
-    }
-
-    private val readyCallbackInvocations = mutableListOf<Boolean>()
-    private val results = mutableListOf<GooglePayPaymentMethodLauncher.Result>()
-
-    private val readyCallback =
-        GooglePayPaymentMethodLauncher.ReadyCallback(readyCallbackInvocations::add)
-    private val resultCallback = GooglePayPaymentMethodLauncher.ResultCallback(results::add)
-
-    val context: Context = ApplicationProvider.getApplicationContext()
-    private val analyticsRequestFactory = PaymentAnalyticsRequestFactory(
-        context,
-        ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
-    )
-    private val firedEvents = mutableListOf<String>()
-    private val analyticsRequestExecutor = AnalyticsRequestExecutor {
-        firedEvents.add(it.params["event"].toString())
-    }
+    @get:Rule
+    val intentsTestRule = IntentsTestRule(ComponentActivity::class.java)
 
     @Test
     fun `present() should successfully return a result when Google Pay is available`() {
-        val result = GooglePayPaymentMethodLauncher.Result.Completed(
-            PaymentMethodFixtures.CARD_PAYMENT_METHOD
-        )
-        scenario.onFragment { fragment ->
+        val result = GooglePayPaymentMethodLauncher.Result.Completed(CARD_PAYMENT_METHOD)
+
+        val readyCallback = mock<GooglePayPaymentMethodLauncher.ReadyCallback>()
+        val resultCallback = mock<GooglePayPaymentMethodLauncher.ResultCallback>()
+
+        runGooglePayPaymentMethodLauncherTest(result) { scenario, activity ->
             val launcher = GooglePayPaymentMethodLauncher(
-                testScope,
-                CONFIG,
-                readyCallback,
-                fragment.registerForActivityResult(
-                    GooglePayPaymentMethodLauncherContractV2(),
-                    FakeActivityResultRegistry(result)
-                ) {
-                    resultCallback.onResult(it)
-                },
-                false,
-                context,
-                { FakeGooglePayRepository(true) },
-                emptySet(),
-                { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
-                { null },
-                paymentAnalyticsRequestFactory = analyticsRequestFactory,
-                analyticsRequestExecutor = analyticsRequestExecutor
+                activity = activity,
+                config = CONFIG,
+                readyCallback = readyCallback,
+                resultCallback = resultCallback,
             )
             scenario.moveToState(Lifecycle.State.RESUMED)
-
-            assertThat(readyCallbackInvocations)
-                .containsExactly(true)
-
-            launcher.present(
-                currencyCode = "usd"
-            )
-
-            assertThat(results)
-                .containsExactly(result)
+            launcher.present(currencyCode = "usd")
         }
+
+        verify(readyCallback).onReady(eq(true))
+        verify(resultCallback).onResult(eq(result))
     }
 
     @Test
     fun `init should fire expected event`() {
-        val result = GooglePayPaymentMethodLauncher.Result.Completed(
-            PaymentMethodFixtures.CARD_PAYMENT_METHOD
-        )
-        scenario.onFragment { fragment ->
-            GooglePayPaymentMethodLauncher(
-                testScope,
-                CONFIG,
-                readyCallback,
-                fragment.registerForActivityResult(
-                    GooglePayPaymentMethodLauncherContractV2(),
-                    FakeActivityResultRegistry(result)
-                ) {
-                    resultCallback.onResult(it)
-                },
-                false,
-                context,
-                { FakeGooglePayRepository(true) },
-                emptySet(),
-                { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
-                { null },
-                paymentAnalyticsRequestFactory = analyticsRequestFactory,
-                analyticsRequestExecutor = analyticsRequestExecutor
-            )
+        val firedEvents = mutableListOf<String>()
+        val result = GooglePayPaymentMethodLauncher.Result.Completed(CARD_PAYMENT_METHOD)
 
-            assertThat(firedEvents)
-                .containsExactly("stripe_android.googlepaypaymentmethodlauncher_init")
+        runGooglePayPaymentMethodLauncherTest(result) { scenario, activity ->
+            val launcher = GooglePayPaymentMethodLauncher(
+                lifecycleScope = activity.lifecycleScope,
+                config = CONFIG,
+                readyCallback = mock(),
+                activityResultLauncher = mock(),
+                skipReadyCheck = true,
+                context = activity,
+                googlePayRepositoryFactory = mock(),
+                productUsage = emptySet(),
+                publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
+                stripeAccountIdProvider = { null },
+                paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
+                    context = activity,
+                    publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                ),
+                analyticsRequestExecutor = { firedEvents += it.params["event"].toString() },
+            )
+            scenario.moveToState(Lifecycle.State.RESUMED)
+            launcher.present(currencyCode = "usd")
         }
+
+        assertThat(firedEvents).containsExactly("stripe_android.googlepaypaymentmethodlauncher_init")
     }
 
     @Test
     fun `present() should throw IllegalStateException when Google Pay is not available`() {
-        scenario.onFragment { fragment ->
-            val launcher = GooglePayPaymentMethodLauncher(
-                testScope,
-                CONFIG,
-                readyCallback,
-                fragment.registerForActivityResult(
-                    GooglePayPaymentMethodLauncherContractV2(),
-                    FakeActivityResultRegistry(
-                        GooglePayPaymentMethodLauncher.Result.Completed(
-                            PaymentMethodFixtures.CARD_PAYMENT_METHOD
-                        )
-                    )
-                ) {
-                    resultCallback.onResult(it)
-                },
-                false,
-                context,
-                { FakeGooglePayRepository(false) },
-                emptySet(),
-                { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
-                { null },
-                paymentAnalyticsRequestFactory = analyticsRequestFactory,
-                analyticsRequestExecutor = analyticsRequestExecutor
-            )
-            scenario.moveToState(Lifecycle.State.RESUMED)
+        val result = GooglePayPaymentMethodLauncher.Result.Completed(CARD_PAYMENT_METHOD)
+        val readyCallback = mock<GooglePayPaymentMethodLauncher.ReadyCallback>()
 
-            assertThat(readyCallbackInvocations)
-                .containsExactly(false)
+        runGooglePayPaymentMethodLauncherTest(isReady = false, result = result) { _, activity ->
+            val launcher = GooglePayPaymentMethodLauncher(
+                activity = activity,
+                config = CONFIG,
+                readyCallback = readyCallback,
+                resultCallback = mock(),
+            )
 
             assertFailsWith<IllegalStateException> {
-                launcher.present(
-                    currencyCode = "usd"
-                )
+                launcher.present(currencyCode = "usd")
             }
         }
+
+        verify(readyCallback).onReady(eq(false))
     }
 
-    @Test
-    fun `when skipReadyCheck should not check if Google Pay is ready`() {
-        scenario.onFragment { fragment ->
-            val launcher = GooglePayPaymentMethodLauncher(
-                testScope,
-                CONFIG,
-                readyCallback,
-                fragment.registerForActivityResult(
-                    GooglePayPaymentMethodLauncherContractV2(),
-                    FakeActivityResultRegistry(
-                        GooglePayPaymentMethodLauncher.Result.Completed(
-                            PaymentMethodFixtures.CARD_PAYMENT_METHOD
-                        )
-                    )
-                ) {
-                    resultCallback.onResult(it)
-                },
-                true,
-                context,
-                { FakeGooglePayRepository(false) },
-                emptySet(),
-                { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
-                { null },
-                paymentAnalyticsRequestFactory = analyticsRequestFactory,
-                analyticsRequestExecutor = analyticsRequestExecutor
+    private fun runGooglePayPaymentMethodLauncherTest(
+        result: GooglePayPaymentMethodLauncher.Result,
+        isReady: Boolean = true,
+        block: (ActivityScenario<ComponentActivity>, ComponentActivity) -> Unit,
+    ) {
+        Mockito.mockStatic(Wallet::class.java).use { wallet ->
+            val paymentsClient = mock<PaymentsClient>()
+            whenever(paymentsClient.isReadyToPay(any())).thenReturn(Tasks.forResult(isReady))
+
+            // Provide a static mock here because DefaultGooglePayRepository calls this static
+            // create method.
+            wallet.`when`<PaymentsClient> {
+                Wallet.getPaymentsClient(isA<Context>(), any())
+            }.thenReturn(paymentsClient)
+
+            // Mock the return value from GooglePayLauncherActivity so that we immediately return
+            val resultData = Intent().putExtras(
+                bundleOf(GooglePayPaymentMethodLauncherContractV2.EXTRA_RESULT to result)
             )
-            scenario.moveToState(Lifecycle.State.RESUMED)
+            val activityResult = Instrumentation.ActivityResult(Activity.RESULT_OK, resultData)
+            Intents.intending(IntentMatchers.anyIntent()).respondWith(activityResult)
 
-            assertThat(readyCallbackInvocations)
-                .isEmpty()
+            val scenario = ActivityScenario.launch(ComponentActivity::class.java)
+            scenario.moveToState(Lifecycle.State.CREATED)
 
-            // Should not throw error
-            launcher.present(currencyCode = "usd")
-        }
-    }
+            scenario.onActivity { activity ->
+                PaymentConfiguration.init(activity, "pk_test")
+                block(scenario, activity)
+            }
 
-    private class FakeActivityResultRegistry(
-        private val result: GooglePayPaymentMethodLauncher.Result
-    ) : ActivityResultRegistry() {
-        override fun <I, O> onLaunch(
-            requestCode: Int,
-            contract: ActivityResultContract<I, O>,
-            input: I,
-            options: ActivityOptionsCompat?
-        ) {
-            dispatchResult(
-                requestCode,
-                result
-            )
+            Espresso.onIdle()
         }
     }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request updates `GooglePayLauncherTest` and `GooglePayPaymentMethodLauncherTest` to use the actual public API instead of the internal constructor.

It means we do have to mock `Wallet.getPaymentsClient()`, but it gives us a more realistic test.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
